### PR TITLE
feat: 服务商管理页面中，增加快速克隆服务商按钮

### DIFF
--- a/src/app/settings/providers/_components/forms/provider-form.tsx
+++ b/src/app/settings/providers/_components/forms/provider-form.tsx
@@ -37,6 +37,7 @@ interface ProviderFormProps {
   mode: Mode;
   onSuccess?: () => void;
   provider?: ProviderDisplay; // edit 模式需要，create 可空
+  cloneProvider?: ProviderDisplay; // create 模式用于克隆数据
   enableMultiProviderTypes: boolean;
 }
 
@@ -44,43 +45,53 @@ export function ProviderForm({
   mode,
   onSuccess,
   provider,
+  cloneProvider,
   enableMultiProviderTypes,
 }: ProviderFormProps) {
   const isEdit = mode === "edit";
   const [isPending, startTransition] = useTransition();
 
-  const [name, setName] = useState(isEdit ? (provider?.name ?? "") : "");
-  const [url, setUrl] = useState(isEdit ? (provider?.url ?? "") : "");
+  // 获取初始数据源：编辑模式用 provider，创建模式用 cloneProvider（如果有）
+  const sourceProvider = isEdit ? provider : cloneProvider;
+
+  const [name, setName] = useState(
+    isEdit 
+      ? (provider?.name ?? "") 
+      : cloneProvider 
+        ? `${cloneProvider.name}_Copy` 
+        : ""
+  );
+  const [url, setUrl] = useState(sourceProvider?.url ?? "");
   const [key, setKey] = useState(""); // 编辑时留空代表不更新
   const [providerType, setProviderType] = useState<ProviderType>(
-    isEdit ? (provider?.providerType ?? "claude") : "claude"
+    sourceProvider?.providerType ?? "claude"
   );
   const [modelRedirects, setModelRedirects] = useState<Record<string, string>>(
-    isEdit && provider?.modelRedirects ? provider.modelRedirects : {}
+    sourceProvider?.modelRedirects ?? {}
   );
-  const [priority, setPriority] = useState<number>(isEdit ? (provider?.priority ?? 0) : 0);
-  const [weight, setWeight] = useState<number>(isEdit ? (provider?.weight ?? 1) : 1);
+  const [priority, setPriority] = useState<number>(sourceProvider?.priority ?? 0);
+  const [weight, setWeight] = useState<number>(sourceProvider?.weight ?? 1);
   const [costMultiplier, setCostMultiplier] = useState<number>(
-    isEdit ? (provider?.costMultiplier ?? 1.0) : 1.0
+    sourceProvider?.costMultiplier ?? 1.0
   );
-  const [groupTag, setGroupTag] = useState<string>(isEdit ? (provider?.groupTag ?? "") : "");
+  const [groupTag, setGroupTag] = useState<string>(sourceProvider?.groupTag ?? "");
   const [limit5hUsd, setLimit5hUsd] = useState<number | null>(
-    isEdit ? (provider?.limit5hUsd ?? null) : null
+    sourceProvider?.limit5hUsd ?? null
   );
   const [limitWeeklyUsd, setLimitWeeklyUsd] = useState<number | null>(
-    isEdit ? (provider?.limitWeeklyUsd ?? null) : null
+    sourceProvider?.limitWeeklyUsd ?? null
   );
   const [limitMonthlyUsd, setLimitMonthlyUsd] = useState<number | null>(
-    isEdit ? (provider?.limitMonthlyUsd ?? null) : null
+    sourceProvider?.limitMonthlyUsd ?? null
   );
   const [limitConcurrentSessions, setLimitConcurrentSessions] = useState<number | null>(
-    isEdit ? (provider?.limitConcurrentSessions ?? null) : null
+    sourceProvider?.limitConcurrentSessions ?? null
   );
   const [allowedModels, setAllowedModels] = useState<string[]>(
-    isEdit && provider?.allowedModels ? provider.allowedModels : []
+    sourceProvider?.allowedModels ?? []
   );
   const [joinClaudePool, setJoinClaudePool] = useState<boolean>(
-    isEdit && provider?.joinClaudePool ? provider.joinClaudePool : false
+    sourceProvider?.joinClaudePool ?? false
   );
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/src/app/settings/providers/_components/provider-list-item.tsx
+++ b/src/app/settings/providers/_components/provider-list-item.tsx
@@ -4,10 +4,11 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
-import { Edit, Globe, Key, RotateCcw } from "lucide-react";
+import { Edit, Globe, Key, RotateCcw, Copy, ServerCog } from "lucide-react";
 import type { ProviderDisplay } from "@/types/provider";
 import type { User } from "@/types/user";
 import { ProviderForm } from "./forms/provider-form";
+import { AddProviderDialog } from "./add-provider-dialog";
 import { Switch } from "@/components/ui/switch";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Slider } from "@/components/ui/slider";
@@ -52,6 +53,7 @@ export function ProviderListItem({
 }: ProviderListItemProps) {
   const router = useRouter();
   const [openEdit, setOpenEdit] = useState(false);
+  const [openClone, setOpenClone] = useState(false);
   const [resetPending, startResetTransition] = useTransition();
   const canEdit = currentUser?.role === "admin";
 
@@ -186,35 +188,66 @@ export function ProviderListItem({
               </Badge>
             )}
 
-            {/* 编辑按钮 - 仅管理员可见 */}
+            {/* 编辑和克隆按钮 - 仅管理员可见 */}
             {canEdit && (
-              <Dialog open={openEdit} onOpenChange={setOpenEdit}>
-                <DialogTrigger asChild>
-                  <Button
-                    type="button"
-                    aria-label="编辑服务商"
-                    variant="ghost"
-                    size="icon"
-                    className="h-5 w-5 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
-                  >
-                    <Edit className="h-3.5 w-3.5" />
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
-                  <FormErrorBoundary>
-                    <ProviderForm
-                      mode="edit"
-                      provider={item}
-                      enableMultiProviderTypes={enableMultiProviderTypes}
-                      onSuccess={() => {
-                        setOpenEdit(false);
-                        // 刷新页面数据以同步所有字段
-                        router.refresh();
-                      }}
-                    />
-                  </FormErrorBoundary>
-                </DialogContent>
-              </Dialog>
+              <div className="flex items-center gap-1">
+                {/* 编辑按钮 */}
+                <Dialog open={openEdit} onOpenChange={setOpenEdit}>
+                  <DialogTrigger asChild>
+                    <Button
+                      type="button"
+                      aria-label="编辑服务商"
+                      variant="ghost"
+                      size="icon"
+                      className="h-5 w-5 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                    >
+                      <Edit className="h-3.5 w-3.5" />
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+                    <FormErrorBoundary>
+                      <ProviderForm
+                        mode="edit"
+                        provider={item}
+                        enableMultiProviderTypes={enableMultiProviderTypes}
+                        onSuccess={() => {
+                          setOpenEdit(false);
+                          // 刷新页面数据以同步所有字段
+                          router.refresh();
+                        }}
+                      />
+                    </FormErrorBoundary>
+                  </DialogContent>
+                </Dialog>
+                {/* 克隆按钮 */}
+                <Dialog open={openClone} onOpenChange={setOpenClone}>
+                  <DialogTrigger asChild>
+                    <Button
+                      type="button"
+                      aria-label="克隆服务商"
+                      variant="ghost"
+                      size="icon"
+                      className="h-5 w-5 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+                    <FormErrorBoundary>
+                      <ProviderForm
+                        mode="create"
+                        cloneProvider={item}
+                        enableMultiProviderTypes={enableMultiProviderTypes}
+                        onSuccess={() => {
+                          setOpenClone(false);
+                          // 刷新页面数据以显示新添加的服务商
+                          router.refresh();
+                        }}
+                      />
+                    </FormErrorBoundary>
+                  </DialogContent>
+                </Dialog>
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
在服务商管理页面中，服务商编辑按钮右侧新增了一个克隆按钮，通过该按钮可快速将当前服务商的信息填充至新增页面中，提升操作效率。