### PR TITLE
fix: 允许 bot 用户触发 Claude AI Assistant workflow

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -187,6 +187,7 @@ jobs:
             --allowedTools "Read,Write,Edit,Bash(gh:*),Bash(git:*),Bash(npm:*),Bash(pnpm:*),Bash(yarn:*),mcp__github_inline_comment__create_inline_comment"
 
           # 其他配置
+          allowed_bots: "*"  # 允许所有 bot 触发 workflow（包括 claude）
           use_commit_signing: true
           # 仅在支持的 PR 事件类型下启用进度追踪 (opened, synchronize, ready_for_review, reopened)
           # 其他事件类型不支持此功能，将自动禁用以确保 workflow 正常执行


### PR DESCRIPTION
## Summary

修复 GitHub Actions workflow 失败问题：添加 `allowed_bots: "*"` 配置以允许 bot 用户（如 claude）触发 workflow。

## 问题描述

当前 workflow 被 bot 用户触发时会失败，错误信息：
> Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

## 解决方案

在 `.github/workflows/claude-assistant.yml` 中添加：
```yaml
allowed_bots: "*"  # 允许所有 bot 触发 workflow（包括 claude）
```

## 测试计划

- [ ] 合并后，bot 用户应该能成功触发 workflow
- [ ] 验证 workflow 的其他功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)