### PR TITLE
fix(error): add thinking parameter format error to whitelist

### DIFF
--- a/src/app/v1/_lib/proxy/errors.ts
+++ b/src/app/v1/_lib/proxy/errors.ts
@@ -180,7 +180,7 @@ const NON_RETRYABLE_ERROR_PATTERNS = [
   /prompt is too long: \d+ tokens > \d+ maximum/i,
   /Request blocked by content filter|permission_error.*content filter/i,
   /A maximum of \d+ PDF pages may be provided/i,
-  /Expected.*thinking.*but found|thinking.*must start with a thinking block/i,
+  /thinking.*Input tag.*does not match|Expected.*thinking.*but found|thinking.*must start with a thinking block/i,
   /Field required|required field|missing required/i,
   /非法请求|illegal request|invalid request/i,
 ];
@@ -195,7 +195,10 @@ const NON_RETRYABLE_ERROR_PATTERNS = [
  * 1. Prompt 长度超限：`prompt is too long: {tokens} tokens > {max} maximum`
  * 2. 内容过滤拦截：`Request blocked by content filter` 或 `permission_error.*content filter`
  * 3. PDF 页数限制：`A maximum of {n} PDF pages may be provided`
- * 4. Thinking 格式错误：`Expected.*thinking.*but found` 或 `thinking.*must start with a thinking block`
+ * 4. Thinking 格式错误：
+ *    - `thinking: Input tag 'X' found using 'type' does not match any of the expected tags`
+ *    - `Expected.*thinking.*but found`
+ *    - `thinking.*must start with a thinking block`
  * 5. 参数缺失/验证错误：`Field required`、`required field`、`missing required`
  * 6. 非法请求：`非法请求`、`illegal request`、`invalid request`
  *
@@ -297,7 +300,7 @@ export function isClientAbortError(error: Error): boolean {
  *    → 不应重试（客户端已经不想要结果了）
  *    → 应立即返回错误
  *
- * 2. 不可重试的客户端输入错误（Prompt 超限、内容过滤、PDF 限制、Thinking 格式、参数缺失、非法请求）
+ * 2. 不可重试的客户端输入错误（Prompt 超限、内容过滤、PDF 限制、Thinking 参数格式错误、参数缺失、非法请求）
  *    → 客户端输入违反了 API 的硬性限制或安全策略
  *    → 不应计入熔断器（不是供应商故障）
  *    → 不应重试（重试也会失败）


### PR DESCRIPTION
## 问题描述

当客户端发送的 `thinking` 参数格式不正确时（例如：`'false'` 而非 `'enabled'` 或 `'disabled'`），上游供应商返回 400 错误：

```
thinking: Input tag 'false' found using 'type' does not match any of the expected tags: 'enabled', 'disabled'
```

**当前问题**：
- 该错误返回 400 状态码，但未匹配白名单正则
- 被错误分类为 `PROVIDER_ERROR`（供应商错误）
- 导致健康的供应商被计入熔断器，累计失败次数
- 最终误触发熔断保护，影响正常服务

## 修复方案

将该错误模式加入 `NON_RETRYABLE_CLIENT_ERROR` 白名单：

```diff
-/Expected.*thinking.*but found|thinking.*must start with a thinking block/i,
+/thinking.*Input tag.*does not match|Expected.*thinking.*but found|thinking.*must start with a thinking block/i,
```

**修复后行为**：
- ❌ 不再计入熔断器（避免误熔断）
- ❌ 不会触发供应商切换（切换也无效）
- ✅ 立即返回错误给客户端（提示修正参数）
- ✅ 日志标记为 `client_error_non_retryable`

## 影响范围

- **熔断器准确性提升**：只针对真实的供应商故障触发熔断
- **避免误判**：客户端参数错误不会导致供应商被错误熔断
- **向后兼容**：不影响现有的其他错误处理逻辑

## 测试验证

- [x] TypeScript 类型检查通过
- [x] 正则匹配测试通过
- [x] 文档注释已更新

## 相关 Issue

该修复解决了实际生产环境中遇到的熔断器误触发问题。