### PR TITLE
修复OpenAI Responses API供应商模型测试400问题

### DIFF
--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -1262,7 +1262,7 @@ export async function testProviderOpenAIResponses(
     }),
     body: (model) => ({
       model,
-      max_tokens: API_TEST_CONFIG.TEST_MAX_TOKENS,
+      max_output_tokens: API_TEST_CONFIG.TEST_MAX_TOKENS,
       input: "讲一个简短的故事",
     }),
     successMessage: "OpenAI Responses API 测试成功",


### PR DESCRIPTION
根据 OpenAI Responses API 的规范，max_tokens 参数应该为 max_output_tokens

  原因:
  - 在 47930ed 提交后，代码为所有 API 测试函数统一添加了 max_tokens 字段
  - 但 OpenAI Responses API (/v1/responses) 不支持 max_tokens 参数
  - 上游供应商（privnode.com）收到不符合规范的请求后返回 400 错误："Input must be a list"

  修复方案:
  - 从 testProviderOpenAIResponses 函数的请求体中移除 max_tokens 字段
  - 保持请求体只包含 model 和 input 两个字段，符合 Responses API 规范
  - 或保留 token 限制配置，则需要符合 Responses API 的规范

修改:
  - ❌ max_tokens: API_TEST_CONFIG.TEST_MAX_TOKENS
  - ✅ max_output_tokens: API_TEST_CONFIG.TEST_MAX_TOKENS