### PR TITLE
fix: 增强隐私保护，扩展请求头黑名单过滤范围

### DIFF
--- a/src/app/v1/_lib/headers.ts
+++ b/src/app/v1/_lib/headers.ts
@@ -21,11 +21,47 @@ export class HeaderProcessor {
 
   constructor(config: HeaderProcessorConfig = {}) {
     // 初始化黑名单（默认包含代理相关的 headers）
+    // 目的：保护客户端隐私，避免真实 IP 和来源信息泄露给上游供应商
     const defaultBlacklist = [
-      "x-forwarded-for",
-      "x-forwarded-host",
-      "x-forwarded-port",
-      "x-forwarded-proto",
+      // 标准代理转发头
+      "x-forwarded-for", // 客户端真实 IP 链
+      "x-forwarded-host", // 原始请求 Host
+      "x-forwarded-port", // 原始请求端口
+      "x-forwarded-proto", // 原始请求协议 (http/https)
+      "forwarded", // RFC 7239 标准转发头
+
+      // 真实 IP 相关
+      "x-real-ip", // Nginx 常用的真实 IP 头
+      "x-client-ip", // 部分代理使用
+      "x-originating-ip", // Microsoft 相关服务
+      "x-remote-ip", // 部分代理使用
+      "x-remote-addr", // 部分代理使用
+
+      // CDN/云服务商特定头
+      "cf-connecting-ip", // Cloudflare 客户端 IP
+      "cf-ipcountry", // Cloudflare 客户端国家
+      "cf-ray", // Cloudflare 请求追踪 ID
+      "cf-visitor", // Cloudflare 访问者信息
+      "true-client-ip", // Cloudflare Enterprise / Akamai
+      "x-cluster-client-ip", // 部分负载均衡器
+      "fastly-client-ip", // Fastly CDN
+      "x-azure-clientip", // Azure
+      "x-azure-fdid", // Azure Front Door ID
+      "x-azure-ref", // Azure 请求追踪
+      "akamai-origin-hop", // Akamai
+      "x-akamai-config-log-detail", // Akamai 配置日志
+
+      // 请求追踪和关联头
+      "x-request-id", // 请求追踪 ID
+      "x-correlation-id", // 关联 ID
+      "x-trace-id", // 追踪 ID
+      "x-amzn-trace-id", // AWS X-Ray 追踪
+      "x-b3-traceid", // Zipkin 追踪
+      "x-b3-spanid", // Zipkin span
+      "x-b3-parentspanid", // Zipkin parent span
+      "x-b3-sampled", // Zipkin 采样标记
+      "traceparent", // W3C Trace Context
+      "tracestate", // W3C Trace Context 状态
     ];
 
     // 如果不保留 authorization，添加到黑名单


### PR DESCRIPTION
## 修改内容

在 `src/app/v1/_lib/headers.ts` 中扩展了请求头黑名单，新增以下类型的过滤：

### 1. 标准代理头
- `forwarded` (RFC 7239 标准)

### 2. 真实 IP 相关头 (新增 5 个)
- `x-real-ip` (Nginx 常用)
- `x-client-ip`
- `x-originating-ip` (Microsoft)
- `x-remote-ip`
- `x-remote-addr`

### 3. CDN/云服务商特定头 (新增 12 个)
- Cloudflare: `cf-connecting-ip`, `cf-ipcountry`, `cf-ray`, `cf-visitor`, `true-client-ip`
- Fastly: `fastly-client-ip`
- Azure: `x-azure-clientip`, `x-azure-fdid`, `x-azure-ref`
- Akamai: `akamai-origin-hop`, `x-akamai-config-log-detail`
- 负载均衡器: `x-cluster-client-ip`

### 4. 请求追踪和关联头 (新增 11 个)
- 通用追踪: `x-request-id`, `x-correlation-id`, `x-trace-id`
- AWS X-Ray: `x-amzn-trace-id`
- Zipkin: `x-b3-traceid`, `x-b3-spanid`, `x-b3-parentspanid`, `x-b3-sampled`
- W3C Trace Context: `traceparent`, `tracestate`

## 修改目的

1. **保护客户端隐私**: 防止真实 IP 地址泄露给上游供应商
2. **统一行为**: 无论请求来自 CDN/云服务商，都统一过滤
3. **增强安全性**: 避免上游供应商通过追踪头识别用户来源和行为模式
4. **符合代理服务最佳实践**: 参考 Nginx、HAProxy 等成熟代理的默认行为

## 影响范围

- 所有通过 `ProxyForwarder` 转发的请求
- 不影响响应头处理
- 已有的 4 个 `x-forwarded-*` 头保持不变
- 向后兼容，不破坏现有功能