### PR TITLE
fix: 修复排行榜 Tab 切换无限循环问题, close #177

### DIFF
--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
@@ -45,7 +45,9 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     if (normalizedPeriod !== period) {
       setPeriod(normalizedPeriod);
     }
-  }, [isAdmin, searchParams, scope, period]);
+    // 移除 scope 和 period 从依赖数组，避免无限循环
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAdmin, searchParams]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## Summary
修复排行榜页面 Tab 切换时触发无限循环导致页面卡死的问题。

## Problem
PR #168 (commit 281ed80) 引入了一个 bug：在 `useEffect` 依赖数组中包含了 `scope` 和 `period` 状态变量。当这些状态被更新时，会重新触发 useEffect，而 useEffect 内部又会检查并更新这些状态，导致无限循环。

## Solution
从 `useEffect` 依赖数组中移除 `scope` 和 `period`，因为：
- 这两个变量仅在 effect 内部作为比较目标使用
- 真正需要响应的变化来源是 `searchParams`
- 添加了 `eslint-disable` 注释说明原因

## Changes
- `src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx`
  - 移除 `scope` 和 `period` 从 useEffect 依赖数组
  - 添加注释说明修改原因

## Testing
- [x] Manual testing performed - 验证 Tab 切换不再触发无限循环
- [x] No breaking changes

## Related Issues
Closes #177