### PR TITLE
fix: 修复数据库迁移枚举类型重复创建错误

### DIFF
--- a/drizzle/0022_simple_stardust.sql
+++ b/drizzle/0022_simple_stardust.sql
@@ -1,4 +1,10 @@
-CREATE TYPE "public"."daily_reset_mode" AS ENUM('fixed', 'rolling');--> statement-breakpoint
+-- 安全创建枚举类型 (如果不存在则创建)
+DO $$ BEGIN
+    CREATE TYPE "public"."daily_reset_mode" AS ENUM('fixed', 'rolling');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
 ALTER TABLE "keys" ALTER COLUMN "daily_reset_mode" SET DEFAULT 'fixed'::"public"."daily_reset_mode";--> statement-breakpoint
 ALTER TABLE "keys" ALTER COLUMN "daily_reset_mode" SET DATA TYPE "public"."daily_reset_mode" USING "daily_reset_mode"::"public"."daily_reset_mode";--> statement-breakpoint
 ALTER TABLE "providers" ALTER COLUMN "daily_reset_mode" SET DEFAULT 'fixed'::"public"."daily_reset_mode";--> statement-breakpoint


### PR DESCRIPTION
## Summary
修复数据库迁移过程中 `daily_reset_mode` 枚举类型重复创建导致的错误。

## Changes
- 在 `drizzle/0022_simple_stardust.sql` 中添加异常处理逻辑
- 使用 `DO $$ BEGIN ... EXCEPTION` 块安全创建枚举类型
- 确保迁移脚本的幂等性，避免 "type already exists" 错误

## Background
项目中存在两个迁移文件尝试创建相同的枚举类型：
- `0021_daily_cost_limits.sql` - 已有异常处理 ✅
- `0022_simple_stardust.sql` - 缺少异常处理 ❌（本次修复）

当数据库中已存在该枚举类型时，直接使用 `CREATE TYPE` 会导致迁移失败。

## Solution
将原来的：
```sql
CREATE TYPE "public"."daily_reset_mode" AS ENUM('fixed', 'rolling');
```

修改为：
```sql
DO $$ BEGIN
    CREATE TYPE "public"."daily_reset_mode" AS ENUM('fixed', 'rolling');
EXCEPTION
    WHEN duplicate_object THEN null;
END $$;
```

## Test Plan
- [x] 本地开发环境测试
- [x] Docker 环境测试
- [x] 验证迁移脚本幂等性

## Impact
- ✅ 修复 Docker 部署时的迁移失败问题
- ✅ 确保 `AUTO_MIGRATE=true` 环境下的稳定性
- ✅ 兼容已存在和不存在枚举类型的两种场景

🤖 Generated with [Claude Code](https://claude.com/claude-code)