### PR TITLE
fix: clarify provider response model label

### DIFF
--- a/messages/en/settings.json
+++ b/messages/en/settings.json
@@ -599,6 +599,7 @@
         "testModel": "Test model",
         "testModelDesc": "Leave empty to use the default model or type one manually",
         "model": "Model",
+        "responseModel": "Response model",
         "responseTime": "Response time",
         "usage": "Token usage",
         "response": "Response preview",

--- a/messages/zh-CN/settings.json
+++ b/messages/zh-CN/settings.json
@@ -233,6 +233,7 @@
         "testModel": "测试模型",
         "testModelDesc": "可手动输入，不填写则使用默认模型",
         "model": "模型",
+        "responseModel": "响应模型",
         "responseTime": "响应时间",
         "usage": "Token 用量",
         "response": "响应内容",

--- a/messages/zh-TW/settings.json
+++ b/messages/zh-TW/settings.json
@@ -591,6 +591,7 @@
         "testModel": "測試模型",
         "testModelDesc": "可手動輸入，留空則使用預設模型",
         "model": "模型",
+        "responseModel": "回應模型",
         "responseTime": "回應時間",
         "usage": "Token 用量",
         "response": "回應內容",

--- a/src/app/[locale]/settings/providers/_components/forms/api-test-button.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/api-test-button.tsx
@@ -253,7 +253,7 @@ export function ApiTestButton({
         const model = details?.model || t("unknown");
 
         toast.success(t("testSuccess"), {
-          description: `${t("model")}: ${model} | ${t("responseTime")}: ${responseTime}`,
+          description: `${t("responseModel")}: ${model} | ${t("responseTime")}: ${responseTime}`,
           duration: API_TEST_UI_CONFIG.TOAST_SUCCESS_DURATION,
         });
       } else {
@@ -316,7 +316,7 @@ export function ApiTestButton({
     const resultText = [
       `测试结果: ${testResult.success ? "成功" : "失败"}`,
       `消息: ${testResult.message}`,
-      testResult.details?.model && `模型: ${testResult.details.model}`,
+      testResult.details?.model && `${t("responseModel")}: ${testResult.details.model}`,
       testResult.details?.responseTime !== undefined &&
         `响应时间: ${testResult.details.responseTime}ms`,
       testResult.details?.usage &&
@@ -579,7 +579,8 @@ export function ApiTestButton({
             <div className="space-y-1 text-xs opacity-80">
               {testResult.details.model && (
                 <div>
-                  <span className="font-medium">{t("model")}:</span> {testResult.details.model}
+                  <span className="font-medium">{t("responseModel")}:</span>{" "}
+                  {testResult.details.model}
                 </div>
               )}
               {testResult.details.responseTime !== undefined && (


### PR DESCRIPTION
## Summary
- 修改模型测试文本，上游供应商可能重定向模型，测试模型与响应模型不一致可能导致混淆
- 为responseModel添加zh-CN、en和zh-TW的翻译条目