### PR TITLE
fix: 调整为不同API提供商添加特定User-Agent，避免统一使用claude-cli/2.0.33

### DIFF
--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -2104,7 +2104,7 @@ export async function testProviderOpenAIResponses(
         },
       ],
     }),
-    userAgent: "codex_cli_rs/0.63.0 (Mac OS 26.1.0; arm64) Apple_Terminal/455.1",
+    userAgent: "codex_cli_rs/0.63.0",
     successMessage: "OpenAI Responses API 测试成功",
     extract: (result) => ({
       model: "model" in result ? result.model : undefined,


### PR DESCRIPTION
## Summary / 摘要

Add provider-specific User-Agent headers for API testing to avoid Cloudflare Bot detection and improve test success rates.

为 API 测试添加渠道特定的 User-Agent 头，避免被 Cloudflare Bot 检测系统拦截，提高 API 测试成功率。

## Problem / 问题

The previous implementation used a hardcoded generic User-Agent (`claude-cli/2.0.33`) for all provider API tests. This approach:
- Triggered Cloudflare Bot detection for non-Anthropic providers
- Caused API tests to fail with 520 errors
- Did not accurately represent the actual client behavior

## Solution / 解决方案

Added a `userAgent` parameter to the `executeProviderApiTest` interface and configured provider-specific User-Agent headers:

| Provider | User-Agent |
|----------|------------|
| Anthropic Messages API | `claude-cli/2.0.50 (external, cli)` |
| OpenAI Chat Completions API | `OpenAI/NodeJS/3.2.1` |
| OpenAI Responses API (Codex) | `codex_cli_rs/0.63.0` |
| Gemini API | `GeminiCLI/v0.17.1` |

## Changes / 变更

- Added `userAgent` field to the test options interface in `executeProviderApiTest`
- Updated Anthropic Messages API test with Claude CLI User-Agent
- Updated OpenAI Chat Completions API test with OpenAI SDK User-Agent
- Updated OpenAI Responses API test with Codex CLI User-Agent
- Updated Gemini API test with Gemini CLI User-Agent
- Removed hardcoded generic User-Agent from the request building logic

## Files Changed / 文件变更

- `src/actions/providers.ts` - Core changes to provider API testing

## Testing / 测试

- [x] Manual testing performed
- [x] No breaking changes
- [x] Existing API test functionality preserved