### PR TITLE
fix(ui): 修复供应商可用性监控页面排序顺序

### DIFF
--- a/src/app/[locale]/dashboard/availability/_components/availability-view.tsx
+++ b/src/app/[locale]/dashboard/availability/_components/availability-view.tsx
@@ -178,8 +178,8 @@ export function AvailabilityView() {
           // Unknown status (no data) goes to the end
           if (a.currentStatus === "unknown" && b.currentStatus !== "unknown") return 1;
           if (b.currentStatus === "unknown" && a.currentStatus !== "unknown") return -1;
-          // Sort by availability ascending (worst first for monitoring)
-          return a.currentAvailability - b.currentAvailability;
+          // Sort by availability descending (best first)
+          return b.currentAvailability - a.currentAvailability;
         case "name":
           return a.providerName.localeCompare(b.providerName);
         case "requests":


### PR DESCRIPTION
## Summary
修复供应商可用性监控页面按可用性排序时的排序顺序，使高可用性供应商正确排在前面。

## Problem
在供应商可用性监控页面中，当用户选择按"可用性"排序时，排序逻辑是按升序排列（低可用性在前），这不符合用户的直觉预期。通常用户希望看到高可用性的供应商排在前面。

## Solution
将可用性排序逻辑从升序改为降序：
- **修改前**: `a.currentAvailability - b.currentAvailability` (升序，低可用性在前)
- **修改后**: `b.currentAvailability - a.currentAvailability` (降序，高可用性在前)

## Changes
- `src/app/[locale]/dashboard/availability/_components/availability-view.tsx`: 修改可用性排序比较函数，改为降序排列

## Testing
- [ ] 手动测试：验证按可用性排序时，高可用性供应商排在前面
- [x] 无破坏性变更

🤖 Generated with [Claude Code](https://claude.com/claude-code)