### PR TITLE
fix: 故障转移后无条件更新 Session 绑定

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -149,12 +149,13 @@ export class ProxyForwarder {
 
           // ⭐ 成功后绑定 session 到供应商（智能绑定策略）
           if (session.sessionId) {
-            // 使用智能绑定策略（主备模式 + 健康自动回迁）
+            // 使用智能绑定策略（故障转移优先 + 稳定性优化）
             const result = await SessionManager.updateSessionBindingSmart(
               session.sessionId,
               currentProvider.id,
               currentProvider.priority || 0,
-              totalProvidersAttempted === 1 && attemptCount === 1 // isFirstAttempt
+              totalProvidersAttempted === 1 && attemptCount === 1, // isFirstAttempt
+              totalProvidersAttempted > 1 // isFailoverSuccess: 切换过供应商
             );
 
             if (result.updated) {


### PR DESCRIPTION
## Summary

修复 Session 故障转移后绑定未更新的问题，确保故障转移成功后无条件更新 Session 绑定。

## Problem

当 Session 发生故障转移（Provider A 失败 → Provider B 成功）后，由于原供应商熔断器未触发，Session 绑定不会更新到 B，导致：
- 后续请求仍优先尝试已失败的 Provider A
- 缓存重复创建
- 不必要的供应商切换

## Solution

新增 `isFailoverSuccess` 参数，用于标识是否发生了供应商切换（`totalProvidersAttempted > 1`）。当故障转移成功后，无条件更新 Session 绑定到新供应商，避免后续请求再次尝试失败的供应商。

## Changes

- **`src/app/v1/_lib/proxy/forwarder.ts`**: 传递 `isFailoverSuccess` 参数，标识是否切换过供应商
- **`src/lib/session-manager.ts`**: 
  - `updateSessionBindingSmart` 新增 `isFailoverSuccess` 参数
  - 故障转移成功时无条件更新绑定（优先于其他策略）
  - 简化函数文档注释

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] No breaking changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)