### PR TITLE
fix: 改进 prompt_limit 错误规则的正则匹配

### DIFF
--- a/src/repository/error-rules.ts
+++ b/src/repository/error-rules.ts
@@ -179,7 +179,7 @@ export async function deleteErrorRule(id: number): Promise<boolean> {
  */
 const DEFAULT_ERROR_RULES = [
   {
-    pattern: "prompt is too long.*maximum.*tokens",
+    pattern: "prompt is too long.*(tokens.*maximum|maximum.*tokens)",
     category: "prompt_limit",
     description: "Prompt token limit exceeded",
     matchType: "regex" as const,


### PR DESCRIPTION
## Summary
- 修复 prompt_limit 错误规则的正则表达式，使其能同时匹配两种格式：
  - `prompt is too long...tokens...maximum`
  - `prompt is too long...maximum...tokens`

## Changes
将原来的 `prompt is too long.*maximum.*tokens` 改为 `prompt is too long.*(tokens.*maximum|maximum.*tokens)`，以覆盖不同 API 返回的错误消息格式。

## Test plan
- [ ] 验证正则表达式能正确匹配两种格式的错误消息

🤖 Generated with [Claude Code](https://claude.com/claude-code)