### PR TITLE
feat: allow costMultiplier to be set to 0 for cost-exempt providers

### DIFF
--- a/src/app/[locale]/settings/providers/_components/forms/provider-form.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/provider-form.tsx
@@ -804,7 +804,12 @@ export function ProviderForm({
                       value={costMultiplier}
                       onChange={(e) => {
                         const value = e.target.value;
-                        setCostMultiplier(value === "" ? 1.0 : parseFloat(value));
+                        if (value === "") {
+                          setCostMultiplier(1.0);
+                          return;
+                        }
+                        const num = parseFloat(value);
+                        setCostMultiplier(Number.isNaN(num) ? 1.0 : num);
                       }}
                       onFocus={(e) => e.target.select()}
                       placeholder={t("sections.routing.scheduleParams.costMultiplier.placeholder")}


### PR DESCRIPTION
close #239

## Summary

- Fix onChange handler in provider form to distinguish between empty string and 0 value
- Add onFocus handler to auto-select input content for better UX when editing

## Changes

**`src/app/[locale]/settings/providers/_components/forms/provider-form.tsx`:**

- Changed `onChange` from `parseFloat(e.target.value) || 1.0` to properly handle 0:
  ```tsx
  onChange={(e) => {
    const value = e.target.value;
    setCostMultiplier(value === "" ? 1.0 : parseFloat(value));
  }}
  ```
- Added `onFocus={(e) => e.target.select()}` to auto-select content when focused

## Use Cases

Setting `costMultiplier = 0` is useful for:
- Free trial providers
- Internal test providers  
- Fixed-cost providers (monthly/yearly billing, not usage-based)
- Debug/development providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)