### PR TITLE
🤖 Auto-fix CI failures for PR #251

### DIFF
--- a/drizzle/0024_request-filters.sql
+++ b/drizzle/0024_request-filters.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "request_filters" (
+CREATE TABLE IF NOT EXISTS "request_filters" (
 	"id" serial PRIMARY KEY NOT NULL,
 	"name" varchar(100) NOT NULL,
 	"description" text,
@@ -13,6 +13,6 @@ CREATE TABLE "request_filters" (
 	"updated_at" timestamp with time zone DEFAULT now()
 );
 --> statement-breakpoint
-CREATE INDEX "idx_request_filters_enabled" ON "request_filters" USING btree ("is_enabled","priority");--> statement-breakpoint
-CREATE INDEX "idx_request_filters_scope" ON "request_filters" USING btree ("scope");--> statement-breakpoint
-CREATE INDEX "idx_request_filters_action" ON "request_filters" USING btree ("action");
+CREATE INDEX IF NOT EXISTS "idx_request_filters_enabled" ON "request_filters" USING btree ("is_enabled","priority");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_request_filters_scope" ON "request_filters" USING btree ("scope");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_request_filters_action" ON "request_filters" USING btree ("action");


### PR DESCRIPTION
## Auto-fix CI Failures

Original PR: #251
Failed CI: [PR Build Check](https://github.com/ding113/claude-code-hub/actions/runs/19849053595)

### Fixes Applied:

**Migration Idempotency Fix** (`drizzle/0024_request-filters.sql`)

The migration file was missing `IF NOT EXISTS` clauses which caused the `validate:migrations` script to fail. Added:
- `CREATE TABLE IF NOT EXISTS` for the `request_filters` table
- `CREATE INDEX IF NOT EXISTS` for all 3 indexes:
  - `idx_request_filters_enabled`
  - `idx_request_filters_scope`  
  - `idx_request_filters_action`

This ensures the migration is idempotent and can be re-run safely without errors.

---
🤖 *Auto-generated by Claude AI*