### PR TITLE
Fix #274: Use millisecond timestamps for date filtering to fix timezone issue

### DIFF
--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
@@ -30,10 +30,10 @@ interface UsageLogsFiltersProps {
     userId?: number;
     keyId?: number;
     providerId?: number;
-    /** 本地时间字符串，格式: "YYYY-MM-DDTHH:mm" */
-    startDateLocal?: string;
-    /** 本地时间字符串，格式: "YYYY-MM-DDTHH:mm" */
-    endDateLocal?: string;
+    /** 开始时间戳（毫秒，浏览器本地时区的 00:00:00） */
+    startTime?: number;
+    /** 结束时间戳（毫秒，浏览器本地时区的次日 00:00:00，用于 < 比较） */
+    endTime?: number;
     statusCode?: number;
     excludeStatusCode200?: boolean;
     model?: string;
@@ -141,35 +141,66 @@ export function UsageLogsFilters({
     onReset();
   };
 
-  // Memoized endDate calculation: endDateLocal is next day 00:00, subtract 1 day to show correct end date
+  // Helper: convert timestamp to display date string (YYYY-MM-DD)
+  const timestampToDateString = useCallback((timestamp: number): string => {
+    const date = new Date(timestamp);
+    return format(date, "yyyy-MM-dd");
+  }, []);
+
+  // Helper: parse date string to timestamp (start of day in browser timezone)
+  const dateStringToTimestamp = useCallback((dateStr: string): number => {
+    const [year, month, day] = dateStr.split("-").map(Number);
+    return new Date(year, month - 1, day, 0, 0, 0, 0).getTime();
+  }, []);
+
+  // Memoized startDate for display (from timestamp)
+  const displayStartDate = useMemo(() => {
+    if (!localFilters.startTime) return undefined;
+    return timestampToDateString(localFilters.startTime);
+  }, [localFilters.startTime, timestampToDateString]);
+
+  // Memoized endDate calculation: endTime is next day 00:00, subtract 1 day to show correct end date
   const displayEndDate = useMemo(() => {
-    if (!localFilters.endDateLocal) return undefined;
-    const endDateStr = localFilters.endDateLocal.split("T")[0];
-    const endDate = parse(endDateStr, "yyyy-MM-dd", new Date());
-    return format(addDays(endDate, -1), "yyyy-MM-dd");
-  }, [localFilters.endDateLocal]);
+    if (!localFilters.endTime) return undefined;
+    // endTime is next day 00:00, so subtract 1 day to get actual end date
+    const actualEndDate = new Date(localFilters.endTime - 24 * 60 * 60 * 1000);
+    return format(actualEndDate, "yyyy-MM-dd");
+  }, [localFilters.endTime]);
 
   // Memoized callback for date range changes
-  const handleDateRangeChange = useCallback((range: { startDate?: string; endDate?: string }) => {
-    if (range.startDate && range.endDate) {
-      // Convert to backend format:
-      // startDateLocal: "YYYY-MM-DDT00:00" (start of day)
-      // endDateLocal: "YYYY-MM-(DD+1)T00:00" (start of next day, for < comparison)
-      const endDate = parse(range.endDate, "yyyy-MM-dd", new Date());
-      const nextDay = addDays(endDate, 1);
-      setLocalFilters((prev) => ({
-        ...prev,
-        startDateLocal: `${range.startDate}T00:00`,
-        endDateLocal: `${format(nextDay, "yyyy-MM-dd")}T00:00`,
-      }));
-    } else {
-      setLocalFilters((prev) => ({
-        ...prev,
-        startDateLocal: undefined,
-        endDateLocal: undefined,
-      }));
-    }
-  }, []);
+  const handleDateRangeChange = useCallback(
+    (range: { startDate?: string; endDate?: string }) => {
+      if (range.startDate && range.endDate) {
+        // Convert to millisecond timestamps:
+        // startTime: start of selected start date (00:00:00.000 in browser timezone)
+        // endTime: start of day AFTER selected end date (for < comparison)
+        const startTimestamp = dateStringToTimestamp(range.startDate);
+        const endDate = parse(range.endDate, "yyyy-MM-dd", new Date());
+        const nextDay = addDays(endDate, 1);
+        const endTimestamp = new Date(
+          nextDay.getFullYear(),
+          nextDay.getMonth(),
+          nextDay.getDate(),
+          0,
+          0,
+          0,
+          0
+        ).getTime();
+        setLocalFilters((prev) => ({
+          ...prev,
+          startTime: startTimestamp,
+          endTime: endTimestamp,
+        }));
+      } else {
+        setLocalFilters((prev) => ({
+          ...prev,
+          startTime: undefined,
+          endTime: undefined,
+        }));
+      }
+    },
+    [dateStringToTimestamp]
+  );
 
   return (
     <div className="space-y-4">
@@ -178,9 +209,7 @@ export function UsageLogsFilters({
         <div className="space-y-2 lg:col-span-4">
           <Label>{t("logs.filters.dateRange")}</Label>
           <LogsDateRangePicker
-            startDate={
-              localFilters.startDateLocal ? localFilters.startDateLocal.split("T")[0] : undefined
-            }
+            startDate={displayStartDate}
             endDate={displayEndDate}
             onDateRangeChange={handleDateRangeChange}
           />

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-view.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-view.tsx
@@ -52,13 +52,13 @@ export function UsageLogsView({
   const previousParamsRef = useRef<string>("");
 
   // 从 URL 参数解析筛选条件
-  // 注意：时间使用字符串传递，避免 Date 序列化导致的时区问题
+  // 使用毫秒时间戳传递时间，避免时区问题
   const filters: {
     userId?: number;
     keyId?: number;
     providerId?: number;
-    startDateLocal?: string;
-    endDateLocal?: string;
+    startTime?: number;
+    endTime?: number;
     statusCode?: number;
     excludeStatusCode200?: boolean;
     model?: string;
@@ -71,9 +71,9 @@ export function UsageLogsView({
     providerId: searchParams.providerId
       ? parseInt(searchParams.providerId as string, 10)
       : undefined,
-    // 直接传递本地时间字符串，不转换为 Date
-    startDateLocal: searchParams.startDate as string | undefined,
-    endDateLocal: searchParams.endDate as string | undefined,
+    // 使用毫秒时间戳，无时区歧义
+    startTime: searchParams.startTime ? parseInt(searchParams.startTime as string, 10) : undefined,
+    endTime: searchParams.endTime ? parseInt(searchParams.endTime as string, 10) : undefined,
     statusCode:
       searchParams.statusCode && searchParams.statusCode !== "!200"
         ? parseInt(searchParams.statusCode as string, 10)
@@ -174,9 +174,9 @@ export function UsageLogsView({
     if (newFilters.userId) query.set("userId", newFilters.userId.toString());
     if (newFilters.keyId) query.set("keyId", newFilters.keyId.toString());
     if (newFilters.providerId) query.set("providerId", newFilters.providerId.toString());
-    // 时间直接使用字符串格式（datetime-local 返回的格式）
-    if (newFilters.startDateLocal) query.set("startDate", newFilters.startDateLocal);
-    if (newFilters.endDateLocal) query.set("endDate", newFilters.endDateLocal);
+    // 使用毫秒时间戳传递时间，无时区歧义
+    if (newFilters.startTime) query.set("startTime", newFilters.startTime.toString());
+    if (newFilters.endTime) query.set("endTime", newFilters.endTime.toString());
     if (newFilters.excludeStatusCode200) {
       query.set("statusCode", "!200");
     } else if (newFilters.statusCode !== undefined) {


### PR DESCRIPTION
## Summary

Fixes the timezone inconsistency issue in usage logs date filtering reported in #274.

**Root cause:** Date filters were passed as local time strings (e.g., `"2025-12-06T00:00"`) which caused different interpretations between browser and server timezones.

**Solution:** Use millisecond timestamps (Unix epoch) for frontend-backend communication, eliminating timezone ambiguity.

## Changes

- **`usage-logs-filters.tsx`**: Convert selected date ranges to millisecond timestamps
- **`usage-logs-view.tsx`**: Parse/pass timestamps via URL params (`startTime`/`endTime`)
- **`usage-logs.ts` (repository)**: Accept timestamps and convert to ISO strings for PostgreSQL

## Technical Details

Before:
```
Browser (UTC+8): selects "2025-12-06" → sends "2025-12-06T00:00"
Server (UTC+8): interprets as "2025-12-06 00:00 Asia/Shanghai"
Problem: If browser is in different timezone, wrong data is returned
```

After:
```
Browser (UTC+8): selects "2025-12-06" → sends timestamp 1733414400000
Server: converts to ISO "2025-12-05T16:00:00.000Z" → compares with DB
Result: Consistent behavior regardless of browser/server timezone mismatch
```

## Test Plan

- [ ] Select a date range in usage logs filter
- [ ] Verify URL params show `startTime` and `endTime` as millisecond timestamps
- [ ] Verify correct records are returned regardless of browser timezone
- [ ] Test at midnight boundary (e.g., Beijing time 00:00-01:00)

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)