### PR TITLE
Fix cors preflight

### DIFF
--- a/src/app/v1/[...route]/route.ts
+++ b/src/app/v1/[...route]/route.ts
@@ -2,6 +2,7 @@ import "@/lib/polyfills/file";
 import { Hono } from "hono";
 import { handle } from "hono/vercel";
 import { handleChatCompletions } from "@/app/v1/_lib/codex/chat-completions-handler";
+import { registerCors } from "@/app/v1/_lib/cors";
 import { handleProxyRequest } from "@/app/v1/_lib/proxy-handler";
 import { logger } from "@/lib/logger";
 import { sensitiveWordDetector } from "@/lib/sensitive-word-detector";
@@ -20,6 +21,8 @@ sensitiveWordDetector.reload().catch((err) => {
 });
 
 const app = new Hono().basePath("/v1");
+
+registerCors(app);
 
 // OpenAI Compatible API 路由
 app.post("/chat/completions", handleChatCompletions);

--- a/src/app/v1/_lib/cors.ts
+++ b/src/app/v1/_lib/cors.ts
@@ -1,0 +1,94 @@
+import type { Context, Hono } from "hono";
+
+const DEFAULT_ALLOW_HEADERS =
+  "authorization,x-api-key,x-goog-api-key,content-type,anthropic-version,x-session-id,x-client-version";
+
+const DEFAULT_CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
+  "Access-Control-Allow-Headers": DEFAULT_ALLOW_HEADERS,
+  "Access-Control-Expose-Headers":
+    "x-request-id,x-ratelimit-limit,x-ratelimit-remaining,x-ratelimit-reset,retry-after",
+  "Access-Control-Max-Age": "86400", // 24 hours
+};
+
+/**
+ * 动态构建 CORS 响应头
+ */
+function buildCorsHeaders(options: { origin?: string | null; requestHeaders?: string | null }) {
+  const headers = new Headers(DEFAULT_CORS_HEADERS);
+
+  if (options.origin) {
+    headers.set("Access-Control-Allow-Origin", options.origin);
+    headers.append("Vary", "Origin");
+  }
+
+  if (options.requestHeaders) {
+    headers.set("Access-Control-Allow-Headers", options.requestHeaders);
+    headers.append("Vary", "Access-Control-Request-Headers");
+  }
+
+  if (headers.get("Access-Control-Allow-Origin") !== "*") {
+    headers.set("Access-Control-Allow-Credentials", "true");
+  }
+
+  return headers;
+}
+
+/**
+ * 为响应添加 CORS 头
+ */
+export function applyCors(
+  res: Response,
+  ctx: { origin?: string | null; requestHeaders?: string | null }
+): Response {
+  const corsHeaders = buildCorsHeaders(ctx);
+  const headers = res.headers;
+
+  if (!headers || typeof headers.set !== "function") {
+    const safeStatus =
+      typeof res.status === "number" && res.status >= 200 && res.status <= 599 ? res.status : 200;
+    return new Response(res.body, { status: safeStatus, headers: corsHeaders });
+  }
+
+  corsHeaders.forEach((value, key) => {
+    if (key === "vary") {
+      headers.append(key, value);
+    } else {
+      headers.set(key, value);
+    }
+  });
+  return res;
+}
+
+/**
+ * 构建预检请求响应
+ */
+export function buildPreflightResponse(options: {
+  origin?: string | null;
+  requestHeaders?: string | null;
+}): Response {
+  return new Response(null, { status: 204, headers: buildCorsHeaders(options) });
+}
+
+export const CORS_HEADERS = DEFAULT_CORS_HEADERS;
+
+/**
+ * 注册 CORS 中间件
+ */
+export function registerCors(app: Hono): void {
+  app.use("*", async (c, next) => {
+    await next();
+    return applyCors(c.res, {
+      origin: c.req.header("origin"),
+      requestHeaders: c.req.header("access-control-request-headers"),
+    });
+  });
+
+  app.options("*", (c: Context) =>
+    buildPreflightResponse({
+      origin: c.req.header("origin"),
+      requestHeaders: c.req.header("access-control-request-headers"),
+    })
+  );
+}

--- a/src/app/v1beta/[...route]/route.ts
+++ b/src/app/v1beta/[...route]/route.ts
@@ -1,12 +1,15 @@
 import "@/lib/polyfills/file";
 import { Hono } from "hono";
 import { handle } from "hono/vercel";
+import { registerCors } from "@/app/v1/_lib/cors";
 import { handleProxyRequest } from "@/app/v1/_lib/proxy-handler";
 
 export const runtime = "nodejs";
 
 // Gemini API 路由处理器（/v1beta/models/{model}:generateContent）
 const app = new Hono().basePath("/v1beta");
+
+registerCors(app);
 
 // 所有 Gemini API 请求都通过 proxy handler 处理
 // 格式检测会自动识别 Gemini 请求体中的 contents 字段


### PR DESCRIPTION

## 问题背景

在 Obsidian（基于 Electron）或浏览器环境中调用 `/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse` 时，客户端会先发送 OPTIONS 预检请求。由于预检请求不携带认证头，导致以下问题：

1. **401 错误**：预检请求被认证守卫拦截
2. **500 错误**：流式响应尝试追加 CORS 头时，因 `headers` 不可变抛出异常

## 解决方案

在路由层统一处理 CORS，避免预检请求进入业务守卫链。

### 新增 `src/app/v1/_lib/cors.ts`

- 动态回显 `Origin` 和 `Access-Control-Request-Headers`
- 预检请求直接返回 `204 No Content`
- 添加 `Access-Control-Expose-Headers` 暴露 `x-request-id`、`x-ratelimit-*` 等响应头
- Vary 头用 `append` 追加，避免覆盖已有值

### 路由层集成

- `/v1` 和 `/v1beta` 路由统一调用 `registerCors(app)`
- 业务请求（POST/GET 等）仍完整走鉴权/限流/代理链

## 技术细节

**为什么需要处理 OPTIONS？**

Electron 应用和浏览器对跨域请求会自动发送 OPTIONS 预检。当请求携带自定义头（`Authorization`、`x-api-key`、`anthropic-version` 等）时触发。若预检被拒绝，实际业务请求不会发送。

**当前配置**：
```typescript
"Access-Control-Allow-Origin": "*"  // 允许所有来源
```

## 安全考虑

**安全性未降低**：
- 预检请求放行 ≠ 业务请求放行
- 实际 API 调用仍需有效的 API Key
- 原有认证/限流/会话守卫链完全不变

## 变更文件

- ✨ 新增：`src/app/v1/_lib/cors.ts`
- 🔧 修改：`src/app/v1/[...route]/route.ts`
- 🔧 修改：`src/app/v1beta/[...route]/route.ts`

## 验证

```bash
bun run typecheck  # ✅ 通过
bun run lint       # ✅ 通过
```

## Checklist

- [x] 目标分支为 `dev`
- [ ] 所有状态检查（Docker Build Test）已通过
- [x] 与 `main` 无直接冲突

