### PR TITLE
fix: key provider group #281

### DIFF
--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -235,10 +235,38 @@ export async function getProviders(): Promise<ProviderDisplay[]> {
 /**
  * 获取所有可用的供应商分组标签（用于用户表单中的下拉建议）
  */
-export async function getAvailableProviderGroups(): Promise<string[]> {
+/**
+ * 获取所有可用的供应商分组列表
+ * @param userId - 可选的用户ID，用于过滤用户可用的分组
+ * @returns 供应商分组列表
+ */
+export async function getAvailableProviderGroups(userId?: number): Promise<string[]> {
   try {
     const { getDistinctProviderGroups } = await import("@/repository/provider");
-    return await getDistinctProviderGroups();
+    const allGroups = await getDistinctProviderGroups();
+
+    // 如果没有提供 userId，返回所有分组（向后兼容）
+    if (!userId) {
+      return allGroups;
+    }
+
+    // 查询用户配置的 providerGroup
+    const { findUserById } = await import("@/repository/user");
+    const user = await findUserById(userId);
+
+    if (!user || !user.providerGroup) {
+      // 用户未配置 providerGroup，返回所有分组
+      return allGroups;
+    }
+
+    // 解析用户的 providerGroup（逗号分隔）
+    const userGroups = user.providerGroup
+      .split(",")
+      .map((g) => g.trim())
+      .filter(Boolean);
+
+    // 过滤：只返回用户配置的分组
+    return allGroups.filter((group) => userGroups.includes(group));
   } catch (error) {
     logger.error("获取供应商分组失败:", error);
     return [];

--- a/src/app/[locale]/dashboard/_components/user/forms/add-key-form.tsx
+++ b/src/app/[locale]/dashboard/_components/user/forms/add-key-form.tsx
@@ -36,8 +36,12 @@ export function AddKeyForm({ userId, user, onSuccess }: AddKeyFormProps) {
 
   // Load provider group suggestions
   useEffect(() => {
-    getAvailableProviderGroups().then(setProviderGroupSuggestions);
-  }, []);
+    if (user?.id) {
+      getAvailableProviderGroups(user.id).then(setProviderGroupSuggestions);
+    } else {
+      getAvailableProviderGroups().then(setProviderGroupSuggestions);
+    }
+  }, [user?.id]);
 
   const form = useZodForm({
     schema: KeyFormSchema,

--- a/src/app/[locale]/dashboard/_components/user/forms/edit-key-form.tsx
+++ b/src/app/[locale]/dashboard/_components/user/forms/edit-key-form.tsx
@@ -51,8 +51,12 @@ export function EditKeyForm({ keyData, user, onSuccess }: EditKeyFormProps) {
 
   // Load provider group suggestions
   useEffect(() => {
-    getAvailableProviderGroups().then(setProviderGroupSuggestions);
-  }, []);
+    if (user?.id) {
+      getAvailableProviderGroups(user.id).then(setProviderGroupSuggestions);
+    } else {
+      getAvailableProviderGroups().then(setProviderGroupSuggestions);
+    }
+  }, [user?.id]);
 
   const formatExpiresAt = (expiresAt: string) => {
     if (!expiresAt || expiresAt === "永不过期") return "";

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -99,6 +99,8 @@ export interface UserKeyDisplay {
   limitMonthlyUsd: number | null; // 月消费上限（美元）
   limitTotalUsd?: number | null; // 总消费上限（美元）
   limitConcurrentSessions: number; // 并发 Session 上限
+  // Provider group override (null = inherit from user)
+  providerGroup?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes two critical bugs in the key-level provider group feature that was introduced in PR #289.

## Problem

**Related Issues:**
- Fixes #281 - Two bugs reported after initial feature implementation:
  1. **Display Bug**: Key provider group selection was not showing in the UI after saving (though it was correctly saved to database)
  2. **Scope Bug**: Key provider group dropdown was showing all global groups instead of filtering to only the user's configured groups

Additionally, this PR addresses a **cascading update scenario**: when a user's provider groups are reduced, existing keys could still reference removed groups, causing inconsistent routing behavior.

## Solution

### 1. Fix Display Bug
Added missing `providerGroup` field to `UserKeyDisplay` type and included it in `getUsers()` response mapping. This ensures the UI receives and displays the saved provider group value.

**Changed files:**
- `src/types/user.ts` - Added `providerGroup` to `UserKeyDisplay` interface
- `src/actions/users.ts` - Added `providerGroup: key.providerGroup` to user display mapping

### 2. Fix Scope Filtering
Modified `getAvailableProviderGroups()` to accept an optional `userId` parameter and filter groups based on the user's `providerGroup` configuration. Updated key forms to pass user ID for proper filtering.

**Changed files:**
- `src/actions/providers.ts` - Added `userId` parameter and filtering logic
- `src/app/[locale]/dashboard/_components/user/forms/add-key-form.tsx` - Pass `user.id` to filter suggestions
- `src/app/[locale]/dashboard/_components/user/forms/edit-key-form.tsx` - Pass `user.id` to filter suggestions

**Behavior:**
- **Without userId**: Returns all global groups (backward compatibility)
- **With userId**: Returns only groups present in user's `providerGroup` configuration
- **User has no providerGroup set**: Returns all global groups (fallback)

### 3. Implement Cascading Updates
Added logic in `editUser()` to detect when user's provider groups are reduced and cascade the update to all associated keys. This prevents keys from referencing groups that are no longer available to the user.

**Changed files:**
- `src/actions/users.ts` - Added cascading update logic with detection of removed groups

**Cascading Logic:**
1. Compare old vs new user `providerGroup` settings
2. Identify removed groups
3. For each user key that has a `providerGroup` set:
   - Filter out removed groups from key's group list
   - Update key if groups were removed
   - Set to `null` if all groups were removed
4. Skip keys without explicit `providerGroup` (they inherit from user)

**Example Scenario:**
- User initially has groups: `88code,privnode,deepseek`
- User is updated to only: `88code,deepseek`
- Key A has explicit groups: `88code,privnode` → Updated to: `88code`
- Key B has explicit groups: `privnode` → Updated to: `null` (inherits from user)
- Key C has no explicit groups → No change (already inherits from user)

## Changes

### Core Changes
- Added `providerGroup` field to `UserKeyDisplay` type for proper UI display
- Enhanced `getAvailableProviderGroups()` with user-scoped filtering
- Implemented cascading user-to-key provider group updates

### Supporting Changes
- Updated key forms to use filtered provider group suggestions
- Added detailed logging for cascading updates

## Testing

### Automated Tests
- [ ] Unit tests for `getAvailableProviderGroups()` with userId parameter
- [ ] Integration tests for cascading update logic

### Manual Testing
1. **Display Fix Verification:**
   - Create/edit a key with provider group selection
   - Verify the selected group displays correctly in the key list and edit form
   
2. **Scope Filtering Verification:**
   - Configure a user with specific provider groups (e.g., `88code,deepseek`)
   - Open add/edit key form for that user
   - Verify dropdown only shows configured groups, not all global groups

3. **Cascading Update Verification:**
   - Create a user with provider groups: `88code,privnode,deepseek`
   - Create keys with explicit provider groups containing `privnode`
   - Edit user to remove `privnode` from their groups
   - Verify keys are automatically updated to remove `privnode`
   - Check logs for cascading update messages

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Fixes reported bugs from issue #281
- [x] Maintains backward compatibility

---
*Description enhanced by Claude AI*