### PR TITLE
fix: save cache creation 5m/1h tokens and TTL to database, fix React …

### DIFF
--- a/src/app/[locale]/dashboard/logs/_components/error-details-dialog.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/error-details-dialog.tsx
@@ -380,7 +380,7 @@ export function ErrorDetailsDialog({
                     </span>
                     <span className="font-mono">{formatTokenAmount(outputTokens)} tokens</span>
                   </div>
-                  {cacheCreation5mInputTokens && cacheCreation5mInputTokens > 0 && (
+                  {(cacheCreation5mInputTokens ?? 0) > 0 && (
                     <div className="flex justify-between">
                       <span className="text-muted-foreground">
                         {t("logs.billingDetails.cacheWrite5m")}:
@@ -391,7 +391,7 @@ export function ErrorDetailsDialog({
                       </span>
                     </div>
                   )}
-                  {cacheCreation1hInputTokens && cacheCreation1hInputTokens > 0 && (
+                  {(cacheCreation1hInputTokens ?? 0) > 0 && (
                     <div className="flex justify-between">
                       <span className="text-muted-foreground">
                         {t("logs.billingDetails.cacheWrite1h")}:
@@ -402,7 +402,7 @@ export function ErrorDetailsDialog({
                       </span>
                     </div>
                   )}
-                  {cacheReadInputTokens && cacheReadInputTokens > 0 && (
+                  {(cacheReadInputTokens ?? 0) > 0 && (
                     <div className="flex justify-between">
                       <span className="text-muted-foreground">
                         {t("logs.billingDetails.cacheRead")}:

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
@@ -277,22 +277,19 @@ export function UsageLogsTable({
                                 {t("logs.billingDetails.output")}:{" "}
                                 {formatTokenAmount(log.outputTokens)} tokens
                               </div>
-                              {log.cacheCreation5mInputTokens &&
-                                log.cacheCreation5mInputTokens > 0 && (
-                                  <div>
-                                    {t("logs.billingDetails.cacheWrite5m")}:{" "}
-                                    {formatTokenAmount(log.cacheCreation5mInputTokens)} tokens
-                                    (1.25x)
-                                  </div>
-                                )}
-                              {log.cacheCreation1hInputTokens &&
-                                log.cacheCreation1hInputTokens > 0 && (
-                                  <div>
-                                    {t("logs.billingDetails.cacheWrite1h")}:{" "}
-                                    {formatTokenAmount(log.cacheCreation1hInputTokens)} tokens (2x)
-                                  </div>
-                                )}
-                              {log.cacheReadInputTokens && log.cacheReadInputTokens > 0 && (
+                              {(log.cacheCreation5mInputTokens ?? 0) > 0 && (
+                                <div>
+                                  {t("logs.billingDetails.cacheWrite5m")}:{" "}
+                                  {formatTokenAmount(log.cacheCreation5mInputTokens)} tokens (1.25x)
+                                </div>
+                              )}
+                              {(log.cacheCreation1hInputTokens ?? 0) > 0 && (
+                                <div>
+                                  {t("logs.billingDetails.cacheWrite1h")}:{" "}
+                                  {formatTokenAmount(log.cacheCreation1hInputTokens)} tokens (2x)
+                                </div>
+                              )}
+                              {(log.cacheReadInputTokens ?? 0) > 0 && (
                                 <div>
                                   {t("logs.billingDetails.cacheRead")}:{" "}
                                   {formatTokenAmount(log.cacheReadInputTokens)} tokens (0.1x)

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -353,6 +353,9 @@ export class ProxyResponseHandler {
             outputTokens: usageMetrics?.output_tokens,
             cacheCreationInputTokens: usageMetrics?.cache_creation_input_tokens,
             cacheReadInputTokens: usageMetrics?.cache_read_input_tokens,
+            cacheCreation5mInputTokens: usageMetrics?.cache_creation_5m_input_tokens,
+            cacheCreation1hInputTokens: usageMetrics?.cache_creation_1h_input_tokens,
+            cacheTtlApplied: usageMetrics?.cache_ttl ?? null,
             providerChain: session.getProviderChain(),
             model: session.getCurrentModel() ?? undefined, // ⭐ 更新重定向后的模型
             providerId: session.provider?.id, // ⭐ 更新最终供应商ID（重试切换后）
@@ -897,6 +900,9 @@ export class ProxyResponseHandler {
           outputTokens: usageForCost?.output_tokens,
           cacheCreationInputTokens: usageForCost?.cache_creation_input_tokens,
           cacheReadInputTokens: usageForCost?.cache_read_input_tokens,
+          cacheCreation5mInputTokens: usageForCost?.cache_creation_5m_input_tokens,
+          cacheCreation1hInputTokens: usageForCost?.cache_creation_1h_input_tokens,
+          cacheTtlApplied: usageForCost?.cache_ttl ?? null,
           providerChain: session.getProviderChain(),
           model: session.getCurrentModel() ?? undefined, // ⭐ 更新重定向后的模型
           providerId: session.provider?.id, // ⭐ 更新最终供应商ID（重试切换后）
@@ -1107,7 +1113,10 @@ export class ProxyResponseHandler {
         try {
           reader.releaseLock();
         } catch (releaseError) {
-          logger.warn("Failed to release reader lock", { taskId, releaseError });
+          logger.warn("Failed to release reader lock", {
+            taskId,
+            releaseError,
+          });
         }
         AsyncTaskManager.cleanup(taskId);
       }
@@ -1422,7 +1431,9 @@ async function updateRequestCostFromUsage(
   costMultiplier: number = 1.0
 ): Promise<void> {
   if (!usage) {
-    logger.warn("[CostCalculation] No usage data, skipping cost update", { messageId });
+    logger.warn("[CostCalculation] No usage data, skipping cost update", {
+      messageId,
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary

Fix missing cache token fields in database updates and React rendering bugs in billing tooltips.

## Problem

After the differentiated cache billing feature was implemented (#277/#278), two bugs were discovered:

1. **Missing database fields**: The `updateMessageRequestDetails` calls in `handleNonStream` and `finalizeStream` were not saving the new cache fields (`cacheCreation5mInputTokens`, `cacheCreation1hInputTokens`, `cacheTtlApplied`), causing cache token data to be lost.

2. **React short-circuit rendering bug**: Conditional renders using `x && x > 0 && <Component />` would render a literal `0` when `x = 0` due to JavaScript's short-circuit evaluation behavior. This affected billing tooltips in the logs UI.

**Related Issues:**
- Follow-up to #277 - Original feature request for differentiated cache billing support
- Follow-up to #278 - Original implementation PR (closed)

## Solution

### Database Fix
Added the missing fields to `updateMessageRequestDetails` calls in both `handleNonStream` and `finalizeStream` functions:
- `cacheCreation5mInputTokens`
- `cacheCreation1hInputTokens`
- `cacheTtlApplied`

### React Rendering Fix
Changed conditional rendering pattern from:
```jsx
{x && x > 0 && <Component />}
```
to:
```jsx
{(x ?? 0) > 0 && <Component />}
```

This ensures `0` is never passed to the JSX expression, preventing the literal `0` from being rendered.

## Changes

| File | Purpose |
|------|---------|
| `src/app/v1/_lib/proxy/response-handler.ts` | Add missing cache fields to database updates |
| `src/app/[locale]/dashboard/logs/_components/error-details-dialog.tsx` | Fix conditional rendering for cache tokens |
| `src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx` | Fix conditional rendering for cache tokens |

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] No breaking changes

---
*Description enhanced by Claude AI*