### PR TITLE
fix(billing): 修复 Gemini 缓存 token 重复计费问题

### DIFF
--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -1200,8 +1200,13 @@ function extractUsageMetrics(value: unknown): UsageMetrics | null {
   }
 
   // Gemini support
+  // 注意：promptTokenCount 包含 cachedContentTokenCount，需要减去以避免重复计费
+  // 计费公式：input = (promptTokenCount - cachedContentTokenCount) × input_price
+  //          cache = cachedContentTokenCount × cache_price
   if (typeof usage.promptTokenCount === "number") {
-    result.input_tokens = usage.promptTokenCount;
+    const cachedTokens =
+      typeof usage.cachedContentTokenCount === "number" ? usage.cachedContentTokenCount : 0;
+    result.input_tokens = Math.max(usage.promptTokenCount - cachedTokens, 0);
     hasAny = true;
   }
   if (typeof usage.candidatesTokenCount === "number") {


### PR DESCRIPTION
## 问题描述

Gemini API 的 `promptTokenCount` 包含了 `cachedContentTokenCount`，但原代码直接使用 `promptTokenCount` 作为 `input_tokens`，导致缓存命中的 token 被重复计费：

- input 成本：按全部 prompt tokens 计费（含缓存部分）
- cache 成本：缓存 tokens 再次按 cache 价格计费

**Related Issues:**
- Related to #325 - 本 PR 是 Gemini 计费改进的一部分，修复缓存 token 重复计费问题
- Follow-up to #327 - 继续完善 Gemini token 计费准确性
- Follow-up to #153 - 延续 Gemini usage 解析的改进工作

## 修复方案

在解析 Gemini usage 时，直接从 `promptTokenCount` 中减去 `cachedContentTokenCount`：

```typescript
// 修复前
result.input_tokens = usage.promptTokenCount;

// 修复后
const cachedTokens = typeof usage.cachedContentTokenCount === "number" 
  ? usage.cachedContentTokenCount : 0;
result.input_tokens = Math.max(usage.promptTokenCount - cachedTokens, 0);
```

## 数据验证

根据 Gemini 官方 API 返回示例：
```
promptTokenCount = 696219
cachedContentTokenCount = 696190
candidatesTokenCount = 214
totalTokenCount = 696433
```

数学验证：`696219 + 214 = 696433` ✅

证明 `promptTokenCount` 确实包含 `cachedContentTokenCount`，修复后：
- `input_tokens = 696219 - 696190 = 29`
- `cache_read_input_tokens = 696190`

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/response-handler.ts`: 在 Gemini usage 解析中减去 `cachedContentTokenCount` 避免重复计费

## 测试

- [x] TypeScript 类型检查通过
- [x] 代码逻辑验证：使用 `Math.max(..., 0)` 确保结果非负

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally

---
*Description enhanced by Claude AI*