### PR TITLE
Fix #368: Remove forced stream=true for Codex requests

### DIFF
--- a/src/app/v1/_lib/codex/utils/request-sanitizer.ts
+++ b/src/app/v1/_lib/codex/utils/request-sanitizer.ts
@@ -225,9 +225,9 @@ export async function sanitizeCodexRequest(
 
   // 步骤 3: 确保必需字段
   // Codex API 的默认行为
-  if (output.stream === undefined) {
-    output.stream = true; // Codex 默认流式
-  }
+  // 注意：不再强制设置 stream = true，因为 /v1/responses/compact 端点不支持 stream 参数
+  // 如果客户端未指定 stream，则保持 undefined，由上游 API 决定默认行为
+  // 参考：https://github.com/ding113/claude-code-hub/issues/368
   output.store = false; // Codex 不存储对话历史
   output.parallel_tool_calls = true; // Codex 支持并行工具调用
 


### PR DESCRIPTION
## Summary
- Fixed the `/v1/responses/compact` endpoint returning "unknown_parameter: stream" error
- Removed the forced `stream = true` assignment in `sanitizeCodexRequest()` function

## Problem
Fixes #368

When using the Codex native `/v1/responses/compact` endpoint, requests were failing with:
```json
{
  "error": {
    "code": "unknown_parameter",
    "type": "invalid_request_error",
    "param": "stream",
    "message": "Unknown parameter: 'stream'."
  }
}
```

The root cause was in `src/app/v1/_lib/codex/utils/request-sanitizer.ts` (lines 226-230), where the sanitizer forcibly set `stream = true` when the parameter was undefined. The `/v1/responses/compact` endpoint is specifically designed for non-streaming responses and does NOT support the `stream` parameter at all.

## Solution
Removed the forced `stream = true` assignment. Now the sanitizer preserves the original `stream` value (or keeps it `undefined`), allowing the upstream API to handle the default behavior appropriately.

## Changes
- `src/app/v1/_lib/codex/utils/request-sanitizer.ts`: Removed the conditional that set `stream = true` when undefined

## Testing
- [ ] Verified that `/v1/responses/compact` endpoint works without the stream error
- [ ] Verified that regular `/v1/responses` streaming still works as expected

---
*Created by Claude AI in response to @claude mention*