### PR TITLE
feat(user): add independent key edit dialog

### DIFF
--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -249,6 +249,7 @@ export async function getUsers(): Promise<UserDisplay[]> {
               // Web UI 登录权限控制
               canLoginWebUi: key.canLoginWebUi,
               // 限额配置
+              cacheTtlPreference: key.cacheTtlPreference ?? "inherit",
               limit5hUsd: key.limit5hUsd,
               limitDailyUsd: key.limitDailyUsd,
               dailyResetMode: key.dailyResetMode,
@@ -400,6 +401,7 @@ export async function getUsersBatch(
               lastProviderName: stats?.lastProviderName ?? null,
               modelStats: stats?.modelStats ?? [],
               canLoginWebUi: key.canLoginWebUi,
+              cacheTtlPreference: key.cacheTtlPreference ?? "inherit",
               limit5hUsd: key.limit5hUsd,
               limitDailyUsd: key.limitDailyUsd,
               dailyResetMode: key.dailyResetMode,

--- a/src/app/[locale]/dashboard/_components/user/user-key-table-row.tsx
+++ b/src/app/[locale]/dashboard/_components/user/user-key-table-row.tsx
@@ -32,7 +32,7 @@ export interface UserKeyTableRowProps {
   onEditUser: (scrollToKeyId?: number) => void;
   onQuickRenew?: (user: UserDisplay) => void;
   optimisticExpiresAt?: Date;
-  currentUser?: { role: string };
+  currentUser?: { id?: number; role: string };
   currencyCode?: string;
   highlightKeyIds?: Set<number>;
   translations: {
@@ -94,6 +94,7 @@ export function UserKeyTableRow({
   onEditUser,
   onQuickRenew,
   optimisticExpiresAt,
+  currentUser,
   currencyCode,
   highlightKeyIds,
   translations,
@@ -377,6 +378,9 @@ export function UserKeyTableRow({
                     status: key.status,
                     modelStats: key.modelStats,
                   }}
+                  fullKeyData={key}
+                  keyOwnerUser={user}
+                  currentUser={currentUser}
                   userProviderGroup={user.providerGroup ?? null}
                   isMultiSelectMode={isMultiSelectMode}
                   isSelected={selectedKeyIds?.has(key.id) ?? false}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -122,6 +122,7 @@ export interface UserKeyDisplay {
   limitConcurrentSessions: number; // 并发 Session 上限
   // Provider group override (null = inherit from user)
   providerGroup?: string | null;
+  cacheTtlPreference?: "inherit" | "5m" | "1h";
 }
 
 /**


### PR DESCRIPTION
## Summary

Add an independent edit dialog for individual API keys, improving efficiency for users with many keys by avoiding full-form updates when editing a single key.

## Problem

For users with many API keys, the current implementation merges user and key editing into one unified dialog. Every submission triggers a full update of all data, causing unnecessary overhead. 

**Fixes #413** - When editing a single key, there should be a separate dialog that only shows and updates that specific key.

**Related to #414** - Builds on the quick toggle and renew functionality recently added for users and keys.

## Solution

- Implement a standalone edit dialog in `KeyRowItem` component that opens when clicking the key edit button
- The dialog only shows the current key's edit form, not other keys or user data
- Only calls `editKey` for the single key being edited, improving efficiency
- User row edit button still opens `UnifiedEditDialog` (existing behavior preserved)

## Changes

### Core Changes
| File | Description |
|------|-------------|
| `src/app/[locale]/dashboard/_components/user/key-row-item.tsx` | Add independent edit dialog with `EditKeyForm`, new props for key/user data |
| `src/app/[locale]/dashboard/_components/user/user-key-table-row.tsx` | Pass `fullKeyData`, `keyOwnerUser`, `currentUser` props to `KeyRowItem` |

### Supporting Changes
| File | Description |
|------|-------------|
| `src/types/user.ts:125` | Add `cacheTtlPreference` field to `UserKeyDisplay` type |
| `src/actions/users.ts:252,404` | Include `cacheTtlPreference` in data building for `getUsers` and `getUsersBatch` |

## Testing

### Automated Tests
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

### Manual Testing
1. Click Key row edit button → Opens independent edit dialog (only shows current key)
2. Modify key attributes → Save → Only updates current key (single `editKey` call)
3. Click User row edit button → Still opens `UnifiedEditDialog` (existing behavior unchanged)
4. Admin can edit `providerGroup`, non-admin cannot
5. Form displays user-level quota hints (e.g., "User limit: $100")

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally

---
*Description enhanced by Claude AI*