### PR TITLE
Fix #432: Add error rule for empty message content validation

### DIFF
--- a/src/repository/error-rules.ts
+++ b/src/repository/error-rules.ts
@@ -437,6 +437,23 @@ const DEFAULT_ERROR_RULES = [
       },
     },
   },
+  // Issue #432: Empty message content validation error (non-retryable)
+  {
+    pattern: "all messages must have non-empty content",
+    category: "validation_error",
+    description: "Message content is empty (client error)",
+    matchType: "contains" as const,
+    isDefault: true,
+    isEnabled: true,
+    priority: 89,
+    overrideResponse: {
+      type: "error",
+      error: {
+        type: "validation_error",
+        message: "消息内容不能为空，请确保所有消息都有有效内容（最后一条 assistant 消息除外）",
+      },
+    },
+  },
   // Issue #366: Tool names must be unique (MCP server configuration error)
   {
     pattern: "Tool names must be unique",


### PR DESCRIPTION
## Summary
- Add a new default error rule to detect and properly handle the "all messages must have non-empty content except for the optional final assistant message" validation error from Claude API

## Problem
Fixes #432

When Claude API returns this validation error, it was not being classified as a non-retryable error, potentially causing unnecessary retry attempts.

## Solution
Added a new error rule with the following configuration:
- **Pattern**: `all messages must have non-empty content` (contains match)
- **Category**: `validation_error`
- **Priority**: 89 (same as other validation errors)
- **Override Response**: Returns a user-friendly Chinese error message explaining that message content cannot be empty

## Changes
- Added new error rule to `DEFAULT_ERROR_RULES` in `src/repository/error-rules.ts`

## Testing
- [x] TypeScript typecheck passes
- [x] Lint check passes
- [x] New rule follows existing patterns for validation errors

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)