### PR TITLE
fix(pagination): resolve PR review issues - timezone and performance

### DIFF
--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
@@ -105,6 +105,13 @@ export function UsageLogsFilters({
     return dynamicOnly;
   }, [dynamicStatusCodes]);
 
+  const userMap = useMemo(() => new Map(users.map((user) => [user.id, user.name])), [users]);
+
+  const providerMap = useMemo(
+    () => new Map(providers.map((provider) => [provider.id, provider.name])),
+    [providers]
+  );
+
   const [keys, setKeys] = useState<Key[]>(initialKeys);
   const [localFilters, setLocalFilters] = useState(filters);
   const [isExporting, setIsExporting] = useState(false);
@@ -285,8 +292,7 @@ export function UsageLogsFilters({
                   className="w-full justify-between"
                 >
                   {localFilters.userId ? (
-                    (users.find((user) => user.id === localFilters.userId)?.name ??
-                    localFilters.userId.toString())
+                    (userMap.get(localFilters.userId) ?? localFilters.userId.toString())
                   ) : (
                     <span className="text-muted-foreground">
                       {isUsersLoading ? t("logs.stats.loading") : t("logs.filters.allUsers")}
@@ -392,8 +398,7 @@ export function UsageLogsFilters({
                   className="w-full justify-between"
                 >
                   {localFilters.providerId ? (
-                    (providers.find((provider) => provider.id === localFilters.providerId)?.name ??
-                    localFilters.providerId.toString())
+                    (providerMap.get(localFilters.providerId) ?? localFilters.providerId.toString())
                   ) : (
                     <span className="text-muted-foreground">
                       {isProvidersLoading

--- a/src/repository/usage-logs.ts
+++ b/src/repository/usage-logs.ts
@@ -184,7 +184,7 @@ export async function findUsageLogsBatch(
     .select({
       id: messageRequest.id,
       createdAt: messageRequest.createdAt,
-      createdAtRaw: sql<string>`to_char(${messageRequest.createdAt}, 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+      createdAtRaw: sql<string>`to_char(${messageRequest.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
       sessionId: messageRequest.sessionId,
       requestSequence: messageRequest.requestSequence,
       userName: users.name,

--- a/src/repository/user.ts
+++ b/src/repository/user.ts
@@ -186,7 +186,7 @@ export async function findUserListBatch(
       providerGroup: users.providerGroup,
       tags: users.tags,
       createdAt: users.createdAt,
-      createdAtRaw: sql<string>`to_char(${users.createdAt}, 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+      createdAtRaw: sql<string>`to_char(${users.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
       updatedAt: users.updatedAt,
       deletedAt: users.deletedAt,
       limit5hUsd: users.limit5hUsd,


### PR DESCRIPTION
## Summary
Addresses PR #436 review feedback with critical fixes for timezone handling and performance optimization.

## Problem
**Related Issues:**
- Related to #428 - Filter dropdown unusable with 100+ users (original fix in PR #436, this PR optimizes performance)
- Related to #429 - Pagination shows duplicate records (original fix in PR #436, this PR fixes timezone bug)
- Follow-up to #436 - Resolves review feedback on that PR

PR #436 introduced a critical bug in the cursor pagination: `to_char(timestamptz, ...)` formats timestamps using the database session timezone but appends `Z` (UTC) suffix. In non-UTC deployments, this causes cursor mismatch and pagination can skip/duplicate rows.

Additionally, the filter dropdown lookup was using `Array.find()` on every render, which is O(n) and inefficient for large user/provider lists.

## Solution

### Critical: Timezone Fix
Added `AT TIME ZONE 'UTC'` to `to_char()` calls to ensure timestamps are always formatted in UTC before appending the `Z` suffix:
- `src/repository/user.ts:189`
- `src/repository/usage-logs.ts:187`

### Medium: Performance Optimization  
Replaced O(n) `Array.find()` lookups with O(1) `Map.get()` using memoized Maps:
- Added `userMap` and `providerMap` with `useMemo`
- Benefits scenarios with 100+ users/providers

## Changes

### Core Changes
| File | Change |
|------|--------|
| `src/repository/user.ts:189` | Add `AT TIME ZONE 'UTC'` to cursor timestamp |
| `src/repository/usage-logs.ts:187` | Add `AT TIME ZONE 'UTC'` to cursor timestamp |
| `src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx` | Add useMemo Maps for O(1) lookup |

## Testing

### Automated Tests
- [x] `bun run typecheck` passed
- [x] `bun run lint` passed

### Manual Testing
1. Deploy in non-UTC timezone environment
2. Verify pagination does not skip/duplicate records when scrolling through users
3. Verify filter dropdown performance with 100+ users/providers

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] 5/5 code review agents passed (3 Opus + 2 Codex)

---
*Description enhanced by Claude AI*