### PR TITLE
fix(logs): improve cache tooltip display when 5m/1h breakdown unavail…

### DIFF
--- a/src/app/[locale]/dashboard/logs/_components/error-details-dialog.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/error-details-dialog.tsx
@@ -47,6 +47,7 @@ interface ErrorDetailsDialogProps {
   // 计费详情
   inputTokens?: number | null;
   outputTokens?: number | null;
+  cacheCreationInputTokens?: number | null; // 缓存创建总量
   cacheCreation5mInputTokens?: number | null;
   cacheCreation1hInputTokens?: number | null;
   cacheReadInputTokens?: number | null;
@@ -77,6 +78,7 @@ export function ErrorDetailsDialog({
   billingModelSource = "original",
   inputTokens,
   outputTokens,
+  cacheCreationInputTokens,
   cacheCreation5mInputTokens,
   cacheCreation1hInputTokens,
   cacheReadInputTokens,
@@ -421,25 +423,35 @@ export function ErrorDetailsDialog({
                             {formatTokenAmount(outputTokens)} tokens
                           </span>
                         </div>
-                        {(cacheCreation5mInputTokens ?? 0) > 0 && (
+                        {((cacheCreation5mInputTokens ?? 0) > 0 ||
+                          ((cacheCreationInputTokens ?? 0) > 0 && cacheTtlApplied !== "1h")) && (
                           <div className="flex justify-between">
                             <span className="text-muted-foreground">
                               {t("logs.billingDetails.cacheWrite5m")}:
                             </span>
                             <span className="font-mono">
-                              {formatTokenAmount(cacheCreation5mInputTokens)} tokens{" "}
-                              <span className="text-orange-600">(1.25x)</span>
+                              {formatTokenAmount(
+                                (cacheCreation5mInputTokens ?? 0) > 0
+                                  ? cacheCreation5mInputTokens
+                                  : cacheCreationInputTokens
+                              )}{" "}
+                              tokens <span className="text-orange-600">(1.25x)</span>
                             </span>
                           </div>
                         )}
-                        {(cacheCreation1hInputTokens ?? 0) > 0 && (
+                        {((cacheCreation1hInputTokens ?? 0) > 0 ||
+                          ((cacheCreationInputTokens ?? 0) > 0 && cacheTtlApplied === "1h")) && (
                           <div className="flex justify-between">
                             <span className="text-muted-foreground">
                               {t("logs.billingDetails.cacheWrite1h")}:
                             </span>
                             <span className="font-mono">
-                              {formatTokenAmount(cacheCreation1hInputTokens)} tokens{" "}
-                              <span className="text-orange-600">(2x)</span>
+                              {formatTokenAmount(
+                                (cacheCreation1hInputTokens ?? 0) > 0
+                                  ? cacheCreation1hInputTokens
+                                  : cacheCreationInputTokens
+                              )}{" "}
+                              tokens <span className="text-orange-600">(2x)</span>
                             </span>
                           </div>
                         )}

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
@@ -252,10 +252,24 @@ export function UsageLogsTable({
                           <TooltipContent align="end" className="text-xs space-y-1">
                             <div className="font-medium">{t("logs.columns.cacheWrite")}</div>
                             <div className="pl-2">
-                              5m: {formatTokenAmount(log.cacheCreation5mInputTokens)}
+                              5m:{" "}
+                              {formatTokenAmount(
+                                (log.cacheCreation5mInputTokens ?? 0) > 0
+                                  ? log.cacheCreation5mInputTokens
+                                  : log.cacheTtlApplied !== "1h"
+                                    ? log.cacheCreationInputTokens
+                                    : 0
+                              )}
                             </div>
                             <div className="pl-2">
-                              1h: {formatTokenAmount(log.cacheCreation1hInputTokens)}
+                              1h:{" "}
+                              {formatTokenAmount(
+                                (log.cacheCreation1hInputTokens ?? 0) > 0
+                                  ? log.cacheCreation1hInputTokens
+                                  : log.cacheTtlApplied === "1h"
+                                    ? log.cacheCreationInputTokens
+                                    : 0
+                              )}
                             </div>
                             <div className="font-medium mt-1">{t("logs.columns.cacheRead")}</div>
                             <div className="pl-2">
@@ -425,6 +439,7 @@ export function UsageLogsTable({
                         billingModelSource={billingModelSource}
                         inputTokens={log.inputTokens}
                         outputTokens={log.outputTokens}
+                        cacheCreationInputTokens={log.cacheCreationInputTokens}
                         cacheCreation5mInputTokens={log.cacheCreation5mInputTokens}
                         cacheCreation1hInputTokens={log.cacheCreation1hInputTokens}
                         cacheReadInputTokens={log.cacheReadInputTokens}

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -428,10 +428,24 @@ export function VirtualizedLogsTable({
                         <TooltipContent align="end" className="text-xs space-y-1">
                           <div className="font-medium">{t("logs.columns.cacheWrite")}</div>
                           <div className="pl-2">
-                            5m: {formatTokenAmount(log.cacheCreation5mInputTokens)}
+                            5m:{" "}
+                            {formatTokenAmount(
+                              (log.cacheCreation5mInputTokens ?? 0) > 0
+                                ? log.cacheCreation5mInputTokens
+                                : log.cacheTtlApplied !== "1h"
+                                  ? log.cacheCreationInputTokens
+                                  : 0
+                            )}
                           </div>
                           <div className="pl-2">
-                            1h: {formatTokenAmount(log.cacheCreation1hInputTokens)}
+                            1h:{" "}
+                            {formatTokenAmount(
+                              (log.cacheCreation1hInputTokens ?? 0) > 0
+                                ? log.cacheCreation1hInputTokens
+                                : log.cacheTtlApplied === "1h"
+                                  ? log.cacheCreationInputTokens
+                                  : 0
+                            )}
                           </div>
                           <div className="font-medium mt-1">{t("logs.columns.cacheRead")}</div>
                           <div className="pl-2">{formatTokenAmount(log.cacheReadInputTokens)}</div>
@@ -555,6 +569,7 @@ export function VirtualizedLogsTable({
                       billingModelSource={billingModelSource}
                       inputTokens={log.inputTokens}
                       outputTokens={log.outputTokens}
+                      cacheCreationInputTokens={log.cacheCreationInputTokens}
                       cacheCreation5mInputTokens={log.cacheCreation5mInputTokens}
                       cacheCreation1hInputTokens={log.cacheCreation1hInputTokens}
                       cacheReadInputTokens={log.cacheReadInputTokens}


### PR DESCRIPTION
## Summary

Improves cache tooltip display in the logs page when the 5-minute/1-hour cache token breakdown is unavailable, using smart inference based on `cacheTtlApplied` to provide meaningful data.

## Problem

When upstream providers return only `cache_creation_input_tokens` without the detailed breakdown (`cache_creation.ephemeral_5m_input_tokens` or `ephemeral_1h_input_tokens`), the tooltip displays "5m: 0" and "1h: 0" even though there are actual cache creation tokens recorded.

**Related Issues:**
- Fixes #444 - Tooltip not displaying cache creation tokens properly
- Follow-up to #278 - Original differentiated cache billing implementation
- Follow-up to #310 - Database fix for saving cache 5m/1h tokens

## Solution

Implement smart inference for cache creation display based on `cacheTtlApplied`:
- When only total `cacheCreationInputTokens` is available (no 5m/1h breakdown), display the total under the appropriate category (5m or 1h) based on the applied TTL
- If TTL is "1h", show total under 1h cache; otherwise show under 5m cache
- When specific 5m/1h values exist, use those values (existing behavior preserved)

## Changes

### Core Changes
| File | Purpose |
|------|---------|
| `usage-logs-table.tsx` | Add smart cache token inference to tooltip display |
| `virtualized-logs-table.tsx` | Same tooltip logic for virtualized table variant |
| `error-details-dialog.tsx` | Add `cacheCreationInputTokens` prop and inference logic for billing details modal |

### Logic Applied
```tsx
// For 5m display:
(cacheCreation5mInputTokens ?? 0) > 0
  ? cacheCreation5mInputTokens
  : cacheTtlApplied !== "1h"
    ? cacheCreationInputTokens  // Use total when TTL is not 1h
    : 0

// For 1h display:
(cacheCreation1hInputTokens ?? 0) > 0
  ? cacheCreation1hInputTokens
  : cacheTtlApplied === "1h"
    ? cacheCreationInputTokens  // Use total when TTL is 1h
    : 0
```

## Screenshots
<img width="419" height="291" alt="image" src="https://github.com/user-attachments/assets/29796885-68e4-4129-a16b-c7c8bcfcb6f6" />
<img width="440" height="283" alt="image" src="https://github.com/user-attachments/assets/d741ff83-b99c-4174-89c4-9f5b9f72e2b7" />
<img width="557" height="302" alt="image" src="https://github.com/user-attachments/assets/7992d681-353b-4bfd-b167-5c3c54b8d211" />
<img width="603" height="240" alt="image" src="https://github.com/user-attachments/assets/e6a7b8ee-0318-448b-87c4-ad55f3c611e4" />


## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] No breaking changes
- [x] Both virtualized and non-virtualized table variants updated
- [x] Billing details dialog updated for consistency

---
*Description enhanced by Claude AI*