### PR TITLE
fix: remove duplicate description text in data import component

### DIFF
--- a/src/app/[locale]/settings/data/_components/database-import.tsx
+++ b/src/app/[locale]/settings/data/_components/database-import.tsx
@@ -171,8 +171,6 @@ export function DatabaseImport() {
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="text-sm text-muted-foreground">{t("descriptionFull")}</p>
-
       {/* File selection */}
       <div className="flex flex-col gap-2">
         <Label htmlFor="backup-file">{t("selectFileLabel")}</Label>


### PR DESCRIPTION
## Summary
Removes duplicate description text in the database import component to eliminate redundant display with the Section-level description.

## Problem
The database import UI was showing the same description text twice:
1. At the Section component level via `t("data.section.import.description")`
2. Inside the `DatabaseImport` component via `t("descriptionFull")`

Both display essentially the same text: "Restore database from backup file. Supports PostgreSQL custom format (.dump) backup files."

**Screenshot of the issue:**
<img width="1061" height="136" alt="Duplicate description issue" src="https://github.com/user-attachments/assets/930955b2-24c9-4d01-a7a1-26f48983c2f7" />

## Solution
Remove the internal `descriptionFull` paragraph from the `DatabaseImport` component, as the description is already displayed at the Section wrapper level in the parent page.

## Changes

### Core Changes
- `src/app/[locale]/settings/data/_components/database-import.tsx`: Remove redundant description paragraph element

## Testing

### Manual Testing
1. Navigate to Settings → Data Management
2. Scroll to the "Data Import" section
3. Verify only one description line appears below the section title
4. Confirm the description text matches the section description

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] No breaking changes

---
*Description enhanced by Claude AI*