### PR TITLE
update workflow

### DIFF
--- a/.github/workflows/claude-issue-auto-response.yml
+++ b/.github/workflows/claude-issue-auto-response.yml
@@ -8,7 +8,7 @@ jobs:
   check-codex-status:
     runs-on: ubuntu-latest
     outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
+      should_run: ${{ steps.check.outputs.should_run || steps.perm_check.outputs.should_run }}
     steps:
       - name: Check if Codex workflow succeeded for this issue
         id: check

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -12,7 +12,7 @@ jobs:
       !endsWith(github.actor, '[bot]')
     runs-on: ubuntu-latest
     outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
+      should_run: ${{ steps.check.outputs.should_run || steps.perm_check.outputs.should_run }}
     steps:
       - name: Check if Codex workflow succeeded for this PR
         id: check


### PR DESCRIPTION
## Summary
Adds fallback mechanism for `should_run` output in Claude auto-response and PR review workflows to handle cases where permission checks override the default Codex workflow status check.

## Problem
The `should_run` job output in both `claude-issue-auto-response.yml` and `claude-pr-review.yml` workflows was only populated from the Codex status check step. In certain scenarios (likely related to permission/authorization edge cases), this output could be undefined, causing downstream job execution logic to fail unexpectedly.

## Solution
Adds a logical OR fallback to the job output expression:
```yaml
should_run: ${{ steps.check.outputs.should_run || steps.perm_check.outputs.should_run }}
```

This ensures that if the Codex workflow status check (`steps.check.outputs.should_run`) is not set, the workflow will fall back to using the permission check output (`steps.perm_check.outputs.should_run`).

## Changes

### Core Changes
- `.github/workflows/claude-issue-auto-response.yml` - Added `perm_check.outputs.should_run` fallback to job output
- `.github/workflows/claude-pr-review.yml` - Added `perm_check.outputs.should_run` fallback to job output

## Testing
- [ ] Manual testing: Verify workflows execute correctly in permission-edge-case scenarios
- [ ] Verify job outputs are populated correctly in both normal and fallback conditions

## Related
- Related to PR #16 - "允许 bot 用户触发 Claude AI Assistant workflow"
- Related to PR #244 - "add workflow" (workflow improvements)

---
*Description enhanced by Claude AI*