### PR TITLE
fix: 补全 Session 详情请求响应记录

### DIFF
--- a/src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-details-tabs.tsx
+++ b/src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-details-tabs.tsx
@@ -8,47 +8,116 @@ import { isSSEText } from "@/lib/utils/sse";
 
 export type SessionMessages = Record<string, unknown> | Record<string, unknown>[];
 
-function formatHeaders(headers: Record<string, string> | null): string | null {
-  if (!headers || Object.keys(headers).length === 0) return null;
-  return Object.entries(headers)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join("\n");
+function formatHeaders(
+  headers: Record<string, string> | null,
+  preambleLines?: string[]
+): string | null {
+  const normalizedPreamble = (preambleLines ?? []).map((line) => line.trim()).filter(Boolean);
+  const preamble = normalizedPreamble.length > 0 ? normalizedPreamble.join("\n") : null;
+
+  const headerLines =
+    headers && Object.keys(headers).length > 0
+      ? Object.entries(headers)
+          .map(([key, value]) => `${key}: ${value}`)
+          .join("\n")
+      : null;
+
+  const combined = [preamble, headerLines].filter(Boolean).join("\n\n");
+  return combined.length > 0 ? combined : null;
 }
 
 interface SessionMessagesDetailsTabsProps {
+  requestBody: unknown | null;
   messages: SessionMessages | null;
   requestHeaders: Record<string, string> | null;
   responseHeaders: Record<string, string> | null;
   response: string | null;
+  requestMeta: { clientUrl: string | null; upstreamUrl: string | null; method: string | null };
+  responseMeta: { upstreamUrl: string | null; statusCode: number | null };
 }
 
 export function SessionMessagesDetailsTabs({
+  requestBody,
   messages,
   response,
   requestHeaders,
   responseHeaders,
+  requestMeta,
+  responseMeta,
 }: SessionMessagesDetailsTabsProps) {
   const t = useTranslations("dashboard.sessions");
   const codeExpandedMaxHeight = "calc(100vh - 260px)";
 
   const requestBodyContent = useMemo(() => {
+    if (requestBody === null) return null;
+    return JSON.stringify(requestBody, null, 2);
+  }, [requestBody]);
+
+  const requestMessagesContent = useMemo(() => {
     if (messages === null) return null;
     return JSON.stringify(messages, null, 2);
   }, [messages]);
 
-  const formattedRequestHeaders = useMemo(() => formatHeaders(requestHeaders), [requestHeaders]);
-  const formattedResponseHeaders = useMemo(() => formatHeaders(responseHeaders), [responseHeaders]);
+  const requestHeadersPreamble = useMemo(() => {
+    const lines: string[] = [];
+    const method = requestMeta.method?.trim() || null;
+
+    if (requestMeta.upstreamUrl) {
+      lines.push(
+        method
+          ? `UPSTREAM: ${method} ${requestMeta.upstreamUrl}`
+          : `UPSTREAM: ${requestMeta.upstreamUrl}`
+      );
+    }
+    if (requestMeta.clientUrl) {
+      lines.push(
+        method ? `CLIENT: ${method} ${requestMeta.clientUrl}` : `CLIENT: ${requestMeta.clientUrl}`
+      );
+    }
+
+    return lines;
+  }, [requestMeta.clientUrl, requestMeta.method, requestMeta.upstreamUrl]);
+
+  const responseHeadersPreamble = useMemo(() => {
+    const lines: string[] = [];
+
+    if (responseMeta.statusCode !== null && responseMeta.upstreamUrl) {
+      lines.push(`UPSTREAM: HTTP ${responseMeta.statusCode} ${responseMeta.upstreamUrl}`);
+      return lines;
+    }
+    if (responseMeta.statusCode !== null) {
+      lines.push(`UPSTREAM: HTTP ${responseMeta.statusCode}`);
+      return lines;
+    }
+    if (responseMeta.upstreamUrl) {
+      lines.push(`UPSTREAM: ${responseMeta.upstreamUrl}`);
+    }
+
+    return lines;
+  }, [responseMeta.statusCode, responseMeta.upstreamUrl]);
+
+  const formattedRequestHeaders = useMemo(
+    () => formatHeaders(requestHeaders, requestHeadersPreamble),
+    [requestHeaders, requestHeadersPreamble]
+  );
+  const formattedResponseHeaders = useMemo(
+    () => formatHeaders(responseHeaders, responseHeadersPreamble),
+    [responseHeaders, responseHeadersPreamble]
+  );
 
   const responseLanguage = response && isSSEText(response) ? "sse" : "json";
 
   return (
     <Tabs defaultValue="requestBody" className="w-full" data-testid="session-details-tabs">
-      <TabsList className="grid w-full grid-cols-4">
+      <TabsList className="grid w-full grid-cols-5">
         <TabsTrigger value="requestHeaders" data-testid="session-tab-trigger-request-headers">
           {t("details.requestHeaders")}
         </TabsTrigger>
         <TabsTrigger value="requestBody" data-testid="session-tab-trigger-request-body">
           {t("details.requestBody")}
+        </TabsTrigger>
+        <TabsTrigger value="requestMessages" data-testid="session-tab-trigger-request-messages">
+          {t("details.requestMessages")}
         </TabsTrigger>
         <TabsTrigger value="responseHeaders" data-testid="session-tab-trigger-response-headers">
           {t("details.responseHeaders")}
@@ -81,6 +150,21 @@ export function SessionMessagesDetailsTabs({
             content={requestBodyContent}
             language="json"
             fileName="request.json"
+            maxHeight="600px"
+            defaultExpanded
+            expandedMaxHeight={codeExpandedMaxHeight}
+          />
+        )}
+      </TabsContent>
+
+      <TabsContent value="requestMessages" data-testid="session-tab-request-messages">
+        {requestMessagesContent === null ? (
+          <div className="text-muted-foreground p-4">{t("details.noData")}</div>
+        ) : (
+          <CodeDisplay
+            content={requestMessagesContent}
+            language="json"
+            fileName="request.messages.json"
             maxHeight="600px"
             defaultExpanded
             expandedMaxHeight={codeExpandedMaxHeight}

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -879,6 +879,12 @@ export class ProxyForwarder {
       processedHeaders = headers;
 
       if (session.sessionId) {
+        void SessionManager.storeSessionUpstreamRequestMeta(
+          session.sessionId,
+          { url: proxyUrl, method: session.method },
+          session.requestSequence
+        ).catch((err) => logger.error("Failed to store upstream request meta:", err));
+
         void SessionManager.storeSessionRequestHeaders(
           session.sessionId,
           processedHeaders,
@@ -1099,6 +1105,14 @@ export class ProxyForwarder {
         mcpPassthroughType: provider.mcpPassthroughType,
         usedBaseUrl: effectiveBaseUrl,
       });
+
+      if (session.sessionId) {
+        void SessionManager.storeSessionUpstreamRequestMeta(
+          session.sessionId,
+          { url: proxyUrl, method: session.method },
+          session.requestSequence
+        ).catch((err) => logger.error("Failed to store upstream request meta:", err));
+      }
 
       const hasBody = session.method !== "GET" && session.method !== "HEAD";
 
@@ -1899,6 +1913,12 @@ export class ProxyForwarder {
         responseHeaders,
         session.requestSequence
       ).catch((err) => logger.error("Failed to store response headers:", err));
+
+      void SessionManager.storeSessionUpstreamResponseMeta(
+        session.sessionId,
+        { url, statusCode: undiciRes.statusCode },
+        session.requestSequence
+      ).catch((err) => logger.error("Failed to store upstream response meta:", err));
     }
 
     // 检测响应是否为 gzip 压缩


### PR DESCRIPTION
## 背景
Session 详情页此前仅展示 request 的 messages/input 子集，导致根级字段（如 model/instructions）丢失；同时 request/response headers 缺少端点与响应状态码，排查链路不完整。

**相关 PR:**
- Follow-up to #469 - Session 详情页综合显示增强
- Follow-up to #465 - Request Filter 头部修改追踪修复  
- Follow-up to #420 - Request/Response Headers 记录功能

## 变更
- Redis 临时记录（5 分钟 TTL）：新增完整 requestBody 与请求/响应元信息（端点、方法、statusCode）。
- Session 详情页：
  - 请求体展示完整 JSON（不再只是 messages）。
  - 增加 "请求 Messages" Tab 保留原有 messages 视图。
  - 请求头/响应头顶部增加 preamble（CLIENT/UPSTREAM 端点与响应状态码）。

## 影响范围
- 仅影响 Session 详情调试数据记录与展示；不改变代理转发逻辑与业务语义。
- Header 仍沿用既有脱敏策略（authorization/x-api-key 等遮罩）。

## 核心文件变更

### Session 管理 (3 files)
- `src/lib/session-manager.ts` - 新增 requestBody 及元信息存储/获取方法（+240/-1）
- `src/app/v1/_lib/proxy/session-guard.ts` - 在格式转换前存储完整请求体（+31/-8）
- `src/app/v1/_lib/proxy/forwarder.ts` - 记录上游请求/响应元信息（+20/-0）

### UI 展示 (3 files)  
- `src/actions/active-sessions.ts` - 扩展 getSessionDetails 返回完整数据（+33/-2）
- `session-details-tabs.tsx` - 新增 requestBody Tab 与 preamble 显示（+92/-8）
- `session-messages-client.tsx` - 状态管理与数据传递（+23/-0）

### 测试 (1 file)
- `session-messages-client.test.tsx` - 验证新增 Tab 与元信息渲染（+38/-0）

## 验证

### 自动化检查
- [x] bun run lint  
- [x] bun run typecheck
- [x] bun run test
- [x] bun run build

### 手动测试步骤
1. 发送包含 `model` 和 `instructions` 的请求
2. 进入 Session 详情页
3. 验证 "请求体" Tab 显示完整 JSON（包含 model/instructions）
4. 验证 "请求 Messages" Tab 保留原有 messages 视图
5. 验证请求头/响应头顶部显示端点与状态码

## 备注
bun run test:coverage 当前因仓库全局覆盖率阈值不满足而失败（非本 PR 引入的问题）。

---
*Description enhanced by Claude AI*