### PR TITLE
fix: 修复 leaderboard 输出速率计算除以过小值的问题

### DIFF
--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -338,8 +338,9 @@ async function findProviderLeaderboardWithTimezone(
               AND ${messageRequest.durationMs} IS NOT NULL
               AND ${messageRequest.ttfbMs} IS NOT NULL
               AND ${messageRequest.ttfbMs} < ${messageRequest.durationMs}
+              AND (${messageRequest.durationMs} - ${messageRequest.ttfbMs}) >= 100
             THEN (${messageRequest.outputTokens}::double precision)
-              / NULLIF((${messageRequest.durationMs} - ${messageRequest.ttfbMs}) / 1000.0, 0)
+              / ((${messageRequest.durationMs} - ${messageRequest.ttfbMs}) / 1000.0)
           END
         )::double precision,
         0::double precision


### PR DESCRIPTION
## 问题描述 / Problem Description

供应商排行榜的「平均输出速率」计算在某些情况下会出现异常高的值（如 63570.4 tok/s），原因是当 `durationMs - ttfbMs` 值非常小时,除法运算会产生极大的结果。

The provider leaderboard's "Average Output Rate" displays abnormally high values (e.g., 63570.4 tok/s) when `durationMs - ttfbMs` is very small, causing division by near-zero values.

**Related to:** #442 (leaderboard functionality enhancement)  
**Supersedes:** #496 (closed - mixed unrelated features)

## 修复方案 / Solution

1. 添加条件确保 `(durationMs - ttfbMs) >= 100ms`,过滤掉响应时间过短的异常数据
2. 移除 `NULLIF` 包装,因为有了最小值检查后不再需要

1. Add minimum threshold: `(durationMs - ttfbMs) >= 100ms` to filter out anomalous short-duration responses
2. Remove redundant `NULLIF` wrapper since minimum value check prevents division by zero

## Changes

**Core Change:**
- `src/repository/leaderboard.ts` (+2/-1): Fixed output rate calculation with 100ms minimum threshold

## 修复前后对比 / Before/After Comparison

### 修复前（#4 供应商显示 63570.4 tok/s 异常值）

<img width="1082" alt="修复前" src="https://github.com/user-attachments/assets/fe22284f-d840-430c-a638-555d518c1539" />

### 修复后（#4 供应商显示 58.6 tok/s 正常值）

<img width="1070" alt="修复后" src="https://github.com/user-attachments/assets/9a8c19ae-5795-4b34-b7b7-72accb4e3259" />

## Testing / 测试

- [x] 本地验证排行榜数据显示正常
- [x] Local verification of leaderboard data display

## Checklist

- [x] Code follows project conventions
- [x] Self-review completed  
- [x] Tests pass locally

---
*Description enhanced by Claude AI*