### PR TITLE
feat: 添加压测 Mock Provider 服务

### DIFF
--- a/load-tests/mock-provider/config/scenarios.ts
+++ b/load-tests/mock-provider/config/scenarios.ts
@@ -1,0 +1,74 @@
+export type InjectedErrorType = "429" | "500" | "503" | "timeout";
+
+export type TestScenario = {
+  name: string;
+  description: string;
+  latencyMinMs: number;
+  latencyMaxMs: number;
+  errorRate: number;
+  errorTypes: InjectedErrorType[];
+  streamChunkDelayMs: number;
+  streamChunkCount: number;
+};
+
+export const SCENARIOS: Record<string, TestScenario> = {
+  "steady-state": {
+    name: "steady-state",
+    description: "稳定低延迟、无错误，适合基线压测。",
+    latencyMinMs: 30,
+    latencyMaxMs: 80,
+    errorRate: 0,
+    errorTypes: [],
+    streamChunkDelayMs: 25,
+    streamChunkCount: 24,
+  },
+  spike: {
+    name: "spike",
+    description: "延迟波动较大，用于模拟上游抖动与排队。",
+    latencyMinMs: 20,
+    latencyMaxMs: 1200,
+    errorRate: 0,
+    errorTypes: [],
+    streamChunkDelayMs: 40,
+    streamChunkCount: 28,
+  },
+  "rate-limit-test": {
+    name: "rate-limit-test",
+    description: "高概率触发 429，用于压测限流与重试逻辑。",
+    latencyMinMs: 40,
+    latencyMaxMs: 150,
+    errorRate: 0.35,
+    errorTypes: ["429"],
+    streamChunkDelayMs: 20,
+    streamChunkCount: 20,
+  },
+  "circuit-breaker-test": {
+    name: "circuit-breaker-test",
+    description: "高概率触发 500/503，用于压测熔断与降级。",
+    latencyMinMs: 60,
+    latencyMaxMs: 220,
+    errorRate: 0.4,
+    errorTypes: ["500", "503"],
+    streamChunkDelayMs: 30,
+    streamChunkCount: 22,
+  },
+  "streaming-stress": {
+    name: "streaming-stress",
+    description: "大量小分片 + 极短间隔，用于压测 SSE 解析与背压。",
+    latencyMinMs: 10,
+    latencyMaxMs: 60,
+    errorRate: 0,
+    errorTypes: [],
+    streamChunkDelayMs: 2,
+    streamChunkCount: 240,
+  },
+};
+
+export const DEFAULT_SCENARIO_NAME = "steady-state";
+export const DEFAULT_SCENARIO = SCENARIOS[DEFAULT_SCENARIO_NAME];
+
+export function resolveScenario(name: string | null | undefined): TestScenario {
+  if (!name) return DEFAULT_SCENARIO;
+  return SCENARIOS[name] ?? DEFAULT_SCENARIO;
+}
+

--- a/load-tests/mock-provider/generators/response.ts
+++ b/load-tests/mock-provider/generators/response.ts
@@ -1,0 +1,96 @@
+export type UsageMetrics = {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+};
+
+function safeNumber(value: unknown, fallback: number): number {
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return num;
+}
+
+function extractText(value: unknown): string {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  if (Array.isArray(value)) return value.map(extractText).filter(Boolean).join("\n");
+
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+
+    // Claude/OpenAI 常见结构：{ text: "..." }
+    if (typeof obj.text === "string") return obj.text;
+
+    // OpenAI：{ content: "..." } 或 Claude：{ content: [...] }
+    if (obj.content) return extractText(obj.content);
+
+    // Responses API：{ input_text: "..." }
+    if (typeof obj.input_text === "string") return obj.input_text;
+
+    // Responses API：{ content: [{ type: "output_text", text: "..." }] }
+    if (obj.output && Array.isArray(obj.output)) return extractText(obj.output);
+
+    return "";
+  }
+
+  return "";
+}
+
+export function estimateInputTokens(messages: unknown): number {
+  const text = extractText(messages);
+
+  // 经验估算：英文约 4 字符/Token，中文通常更密，这里只追求稳定与可控。
+  const estimated = Math.ceil(text.length / 4);
+  return Math.max(1, estimated);
+}
+
+export function generateOutputText(tokenCount: number): string {
+  const count = Math.max(0, Math.floor(safeNumber(tokenCount, 0)));
+  if (count === 0) return "";
+
+  const header =
+    "这是用于压测的模拟回复，不保证语义正确，只用于产生稳定的输出与流式分片行为。";
+  const words = [
+    "mock",
+    "provider",
+    "load",
+    "test",
+    "stream",
+    "chunk",
+    "latency",
+    "error",
+    "scenario",
+    "throughput",
+    "backpressure",
+    "sse",
+    "proxy",
+    "retry",
+    "timeout",
+    "circuit",
+    "breaker",
+    "token",
+    "usage",
+    "metrics",
+  ];
+
+  const body = Array.from({ length: count }, (_, i) => words[i % words.length]).join(" ");
+  return `${header}\n\n${body}`;
+}
+
+export function createUsage(inputTokens: number, outputTokens: number): UsageMetrics {
+  const input = Math.max(0, Math.floor(safeNumber(inputTokens, 0)));
+  const output = Math.max(0, Math.floor(safeNumber(outputTokens, 0)));
+  const total = input + output;
+
+  return {
+    input_tokens: input,
+    output_tokens: output,
+    total_tokens: total,
+    prompt_tokens: input,
+    completion_tokens: output,
+  };
+}
+

--- a/load-tests/mock-provider/generators/streaming.ts
+++ b/load-tests/mock-provider/generators/streaming.ts
@@ -1,0 +1,44 @@
+export type ChunkStreamOptions = {
+  chunkDelayMs: number;
+  chunkCount: number;
+};
+
+export function formatSSE(event: string | undefined, data: unknown): string {
+  const payload = typeof data === "string" ? data : JSON.stringify(data);
+  if (event) return `event: ${event}\ndata: ${payload}\n\n`;
+  return `data: ${payload}\n\n`;
+}
+
+export async function sleep(ms: number): Promise<void> {
+  const duration = Math.max(0, Math.floor(ms));
+  if (duration === 0) return;
+  await new Promise((resolve) => setTimeout(resolve, duration));
+}
+
+function splitIntoNChunks(text: string, chunkCount: number): string[] {
+  const count = Math.max(1, Math.floor(chunkCount));
+  const len = text.length;
+  const chunks: string[] = [];
+
+  for (let i = 0; i < count; i += 1) {
+    const start = Math.floor((i * len) / count);
+    const end = Math.floor(((i + 1) * len) / count);
+    chunks.push(text.slice(start, end));
+  }
+
+  return chunks.filter((c) => c.length > 0);
+}
+
+export async function* streamTextChunks(
+  text: string,
+  options: ChunkStreamOptions
+): AsyncGenerator<string> {
+  const chunkDelayMs = Math.max(0, Math.floor(options.chunkDelayMs));
+  const chunkCount = Math.max(1, Math.floor(options.chunkCount));
+
+  for (const chunk of splitIntoNChunks(text, chunkCount)) {
+    if (chunkDelayMs > 0) await sleep(chunkDelayMs);
+    yield chunk;
+  }
+}
+

--- a/load-tests/mock-provider/handlers/claude.ts
+++ b/load-tests/mock-provider/handlers/claude.ts
@@ -1,0 +1,129 @@
+import type { Hono } from "hono";
+import { stream } from "hono/streaming";
+import type { TestScenario } from "../config/scenarios";
+import { createUsage, estimateInputTokens, generateOutputText } from "../generators/response";
+import { formatSSE, streamTextChunks } from "../generators/streaming";
+
+function randomId(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(16).slice(2)}`;
+}
+
+function parsePositiveInt(value: unknown, fallback: number): number {
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return Math.max(1, Math.floor(num));
+}
+
+export function registerClaudeRoutes(app: Hono): void {
+  app.post("/v1/messages", async (c) => {
+    let body: Record<string, unknown>;
+    try {
+      body = (await c.req.json()) as Record<string, unknown>;
+    } catch {
+      return c.json(
+        {
+          error: {
+            message: "Invalid JSON body",
+            type: "invalid_request_error",
+            code: "invalid_json",
+          },
+        },
+        400
+      );
+    }
+
+    const model = typeof body.model === "string" ? body.model : "claude-mock";
+    const isStream = body.stream === true;
+    const inputTokens = estimateInputTokens(body.messages);
+    const outputTokens = parsePositiveInt(body.max_tokens, 128);
+
+    const usage = createUsage(inputTokens, outputTokens);
+    const messageId = randomId("msg");
+    const outputText = generateOutputText(outputTokens);
+
+    if (!isStream) {
+      return c.json({
+        id: messageId,
+        type: "message",
+        role: "assistant",
+        model,
+        content: [
+          {
+            type: "text",
+            text: outputText,
+          },
+        ],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: {
+          input_tokens: usage.input_tokens,
+          output_tokens: usage.output_tokens,
+        },
+      });
+    }
+
+    const scenario = c.get("scenario") as TestScenario | undefined;
+    const chunkDelayMs = scenario?.streamChunkDelayMs ?? 25;
+    const chunkCount = scenario?.streamChunkCount ?? 24;
+
+    c.header("Content-Type", "text/event-stream; charset=utf-8");
+    c.header("Cache-Control", "no-cache");
+    c.header("Connection", "keep-alive");
+
+    return stream(c, async (s) => {
+      // message_start：输出 message 元信息（output_tokens 起始为 0）
+      await s.write(
+        formatSSE("message_start", {
+          type: "message_start",
+          message: {
+            id: messageId,
+            type: "message",
+            role: "assistant",
+            model,
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: {
+              input_tokens: usage.input_tokens,
+              output_tokens: 0,
+            },
+          },
+        })
+      );
+
+      // content_block_delta：按块输出文本
+      for await (const chunk of streamTextChunks(outputText, { chunkDelayMs, chunkCount })) {
+        await s.write(
+          formatSSE("content_block_delta", {
+            type: "content_block_delta",
+            index: 0,
+            delta: {
+              type: "text_delta",
+              text: chunk,
+            },
+          })
+        );
+      }
+
+      // message_delta：输出 stop_reason 与 usage（至少包含 output_tokens）
+      await s.write(
+        formatSSE("message_delta", {
+          type: "message_delta",
+          delta: {
+            stop_reason: "end_turn",
+            stop_sequence: null,
+          },
+          usage: {
+            output_tokens: usage.output_tokens,
+          },
+        })
+      );
+
+      await s.write(
+        formatSSE("message_stop", {
+          type: "message_stop",
+        })
+      );
+    });
+  });
+}

--- a/load-tests/mock-provider/handlers/codex.ts
+++ b/load-tests/mock-provider/handlers/codex.ts
@@ -1,0 +1,147 @@
+import type { Hono } from "hono";
+import { stream } from "hono/streaming";
+import type { TestScenario } from "../config/scenarios";
+import { createUsage, estimateInputTokens, generateOutputText } from "../generators/response";
+import { formatSSE, streamTextChunks } from "../generators/streaming";
+
+function randomId(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(16).slice(2)}`;
+}
+
+function parsePositiveInt(value: unknown, fallback: number): number {
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return Math.max(1, Math.floor(num));
+}
+
+function pickModel(body: Record<string, unknown>): string {
+  if (typeof body.model === "string") return body.model;
+  return "gpt-mock";
+}
+
+function pickInput(body: Record<string, unknown>): unknown {
+  // Responses API：input 既可能是 string，也可能是 message 数组或其它结构
+  if ("input" in body) return body.input;
+  if ("messages" in body) return body.messages;
+  return body;
+}
+
+export function registerCodexRoutes(app: Hono): void {
+  app.post("/v1/responses", async (c) => {
+    let body: Record<string, unknown>;
+    try {
+      body = (await c.req.json()) as Record<string, unknown>;
+    } catch {
+      return c.json(
+        {
+          error: {
+            message: "Invalid JSON body",
+            type: "invalid_request_error",
+            code: "invalid_json",
+          },
+        },
+        400
+      );
+    }
+
+    const model = pickModel(body);
+    const isStream = body.stream === true;
+    const input = pickInput(body);
+    const inputTokens = estimateInputTokens(input);
+    const outputTokens = parsePositiveInt(body.max_output_tokens ?? body.max_tokens, 128);
+    const usage = createUsage(inputTokens, outputTokens);
+
+    const createdAt = Math.floor(Date.now() / 1000);
+    const responseId = randomId("resp");
+    const outputText = generateOutputText(outputTokens);
+
+    const responseObject = {
+      id: responseId,
+      object: "response",
+      created_at: createdAt,
+      model,
+      output: [
+        {
+          id: randomId("msg"),
+          type: "message",
+          role: "assistant",
+          content: [
+            {
+              type: "output_text",
+              text: outputText,
+            },
+          ],
+        },
+      ],
+      usage: {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        total_tokens: usage.total_tokens,
+      },
+    };
+
+    if (!isStream) {
+      // 注意：本项目的转换器对非流式 codex 响应使用与 SSE 相同的 envelope：{ type, response }
+      return c.json({
+        type: "response.completed",
+        response: responseObject,
+      });
+    }
+
+    const scenario = c.get("scenario") as TestScenario | undefined;
+    const chunkDelayMs = scenario?.streamChunkDelayMs ?? 25;
+    const chunkCount = scenario?.streamChunkCount ?? 24;
+
+    c.header("Content-Type", "text/event-stream; charset=utf-8");
+    c.header("Cache-Control", "no-cache");
+    c.header("Connection", "keep-alive");
+
+    return stream(c, async (s) => {
+      // response.created：转换器依赖 data.type 与 data.response.id/model/created_at
+      await s.write(
+        formatSSE("response.created", {
+          type: "response.created",
+          response: {
+            id: responseId,
+            object: "response",
+            created_at: createdAt,
+            model,
+          },
+        })
+      );
+
+      // response.content_part.added：让 Codex→Claude 转换器生成 content_block_start(text)
+      await s.write(
+        formatSSE("response.content_part.added", {
+          type: "response.content_part.added",
+          output_index: 0,
+        })
+      );
+
+      for await (const chunk of streamTextChunks(outputText, { chunkDelayMs, chunkCount })) {
+        await s.write(
+          formatSSE("response.output_text.delta", {
+            type: "response.output_text.delta",
+            output_index: 0,
+            delta: chunk,
+          })
+        );
+      }
+
+      await s.write(
+        formatSSE("response.content_part.done", {
+          type: "response.content_part.done",
+          output_index: 0,
+        })
+      );
+
+      // response.completed：包含 usage，供 Codex→OpenAI/Claude 转换器补全 usage 与 finish_reason
+      await s.write(
+        formatSSE("response.completed", {
+          type: "response.completed",
+          response: responseObject,
+        })
+      );
+    });
+  });
+}

--- a/load-tests/mock-provider/handlers/openai.ts
+++ b/load-tests/mock-provider/handlers/openai.ts
@@ -1,0 +1,138 @@
+import type { Hono } from "hono";
+import { stream } from "hono/streaming";
+import type { TestScenario } from "../config/scenarios";
+import { createUsage, estimateInputTokens, generateOutputText } from "../generators/response";
+import { formatSSE, streamTextChunks } from "../generators/streaming";
+
+function randomId(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(16).slice(2)}`;
+}
+
+function parsePositiveInt(value: unknown, fallback: number): number {
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return Math.max(1, Math.floor(num));
+}
+
+export function registerOpenAIRoutes(app: Hono): void {
+  app.post("/v1/chat/completions", async (c) => {
+    let body: Record<string, unknown>;
+    try {
+      body = (await c.req.json()) as Record<string, unknown>;
+    } catch {
+      return c.json(
+        {
+          error: {
+            message: "Invalid JSON body",
+            type: "invalid_request_error",
+            code: "invalid_json",
+          },
+        },
+        400
+      );
+    }
+
+    const model = typeof body.model === "string" ? body.model : "gpt-mock";
+    const isStream = body.stream === true;
+    const inputTokens = estimateInputTokens(body.messages);
+    const outputTokens = parsePositiveInt(body.max_completion_tokens ?? body.max_tokens, 128);
+    const usage = createUsage(inputTokens, outputTokens);
+
+    const created = Math.floor(Date.now() / 1000);
+    const completionId = randomId("chatcmpl");
+    const outputText = generateOutputText(outputTokens);
+
+    if (!isStream) {
+      return c.json({
+        id: completionId,
+        object: "chat.completion",
+        created,
+        model,
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: outputText,
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: {
+          prompt_tokens: usage.prompt_tokens,
+          completion_tokens: usage.completion_tokens,
+          total_tokens: usage.total_tokens,
+        },
+      });
+    }
+
+    const scenario = c.get("scenario") as TestScenario | undefined;
+    const chunkDelayMs = scenario?.streamChunkDelayMs ?? 25;
+    const chunkCount = scenario?.streamChunkCount ?? 24;
+
+    c.header("Content-Type", "text/event-stream; charset=utf-8");
+    c.header("Cache-Control", "no-cache");
+    c.header("Connection", "keep-alive");
+
+    return stream(c, async (s) => {
+      // 首包：仅发送 role，贴近 OpenAI 流式行为
+      await s.write(
+        formatSSE(undefined, {
+          id: completionId,
+          object: "chat.completion.chunk",
+          created,
+          model,
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant" },
+              finish_reason: null,
+            },
+          ],
+        })
+      );
+
+      for await (const chunk of streamTextChunks(outputText, { chunkDelayMs, chunkCount })) {
+        await s.write(
+          formatSSE(undefined, {
+            id: completionId,
+            object: "chat.completion.chunk",
+            created,
+            model,
+            choices: [
+              {
+                index: 0,
+                delta: { content: chunk },
+                finish_reason: null,
+              },
+            ],
+          })
+        );
+      }
+
+      // 收尾：finish_reason + usage（OpenAI 兼容层常见写法）
+      await s.write(
+        formatSSE(undefined, {
+          id: completionId,
+          object: "chat.completion.chunk",
+          created,
+          model,
+          choices: [
+            {
+              index: 0,
+              delta: {},
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: usage.prompt_tokens,
+            completion_tokens: usage.completion_tokens,
+            total_tokens: usage.total_tokens,
+          },
+        })
+      );
+
+      await s.write(formatSSE(undefined, "[DONE]"));
+    });
+  });
+}

--- a/load-tests/mock-provider/middleware/errors.ts
+++ b/load-tests/mock-provider/middleware/errors.ts
@@ -1,0 +1,126 @@
+import type { MiddlewareHandler } from "hono";
+import type { InjectedErrorType, TestScenario } from "../config/scenarios";
+import { sleep } from "../generators/streaming";
+
+function parseNumberHeader(value: string | undefined): number | null {
+  if (!value) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseErrorTypesHeader(value: string | undefined): InjectedErrorType[] | null {
+  if (!value) return null;
+  const raw = value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const types: InjectedErrorType[] = [];
+  for (const item of raw) {
+    if (item === "429" || item === "500" || item === "503" || item === "timeout") {
+      types.push(item);
+    }
+  }
+
+  return types.length > 0 ? types : null;
+}
+
+function pick<T>(items: T[]): T | null {
+  if (items.length === 0) return null;
+  return items[Math.floor(Math.random() * items.length)] ?? null;
+}
+
+async function sleepUntilAbortOrTimeout(signal: AbortSignal, ms: number): Promise<void> {
+  if (signal.aborted) return;
+
+  await Promise.race([
+    sleep(ms),
+    new Promise<void>((resolve) => {
+      signal.addEventListener("abort", () => resolve(), { once: true });
+    }),
+  ]);
+}
+
+export const errorInjectionMiddleware: MiddlewareHandler = async (c, next) => {
+  const scenario = c.get("scenario") as TestScenario | undefined;
+
+  const headerRate = parseNumberHeader(c.req.header("X-Test-Error-Rate"));
+  const headerTypes = parseErrorTypesHeader(c.req.header("X-Test-Error-Types"));
+
+  const rate = Math.max(0, Math.min(1, headerRate ?? scenario?.errorRate ?? 0));
+  const types = headerTypes ?? scenario?.errorTypes ?? [];
+
+  if (rate <= 0 || types.length === 0) {
+    await next();
+    return;
+  }
+
+  if (Math.random() >= rate) {
+    await next();
+    return;
+  }
+
+  const errorType = pick(types);
+  if (!errorType) {
+    await next();
+    return;
+  }
+
+  // 说明：错误体结构尽量贴近常见上游风格，但只保证“可解析、可压测”。不要在这里做任何复杂逻辑。
+  if (errorType === "429") {
+    const retryAfter = String(1 + Math.floor(Math.random() * 5));
+    c.header("Retry-After", retryAfter);
+    return c.json(
+      {
+        error: {
+          message: "Mock rate limit triggered by X-Test-Error-Rate",
+          type: "rate_limit_error",
+          code: "rate_limit",
+        },
+      },
+      429
+    );
+  }
+
+  if (errorType === "500") {
+    return c.json(
+      {
+        error: {
+          message: "Mock internal error triggered by X-Test-Error-Rate",
+          type: "internal_error",
+          code: "internal_error",
+        },
+      },
+      500
+    );
+  }
+
+  if (errorType === "503") {
+    return c.json(
+      {
+        error: {
+          message: "Mock overloaded error triggered by X-Test-Error-Rate",
+          type: "overloaded_error",
+          code: "overloaded",
+        },
+      },
+      503
+    );
+  }
+
+  // timeout：通过延迟超过常见上游超时阈值来模拟。默认 15s，可按 header 覆盖。
+  const headerTimeoutMs = parseNumberHeader(c.req.header("X-Test-Timeout-Ms"));
+  const timeoutMs = Math.max(0, Math.floor(headerTimeoutMs ?? 15000));
+  await sleepUntilAbortOrTimeout(c.req.raw.signal, timeoutMs);
+  return c.json(
+    {
+      error: {
+        message: "Mock timeout triggered by X-Test-Error-Rate",
+        type: "timeout_error",
+        code: "timeout",
+      },
+    },
+    504
+  );
+};
+

--- a/load-tests/mock-provider/middleware/latency.ts
+++ b/load-tests/mock-provider/middleware/latency.ts
@@ -1,0 +1,48 @@
+import type { MiddlewareHandler } from "hono";
+import type { TestScenario } from "../config/scenarios";
+import { sleep } from "../generators/streaming";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function parseIntHeader(value: string | undefined): number | null {
+  if (!value) return null;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function randomNormal(): number {
+  // Box–Muller transform：生成均值为 0、方差为 1 的正态分布随机数
+  let u = 0;
+  let v = 0;
+  while (u === 0) u = Math.random();
+  while (v === 0) v = Math.random();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+function gaussianMs(minMs: number, maxMs: number): number {
+  const min = Math.min(minMs, maxMs);
+  const max = Math.max(minMs, maxMs);
+  const mean = (min + max) / 2;
+
+  // 经验：让 3σ 覆盖区间（99.7% 落在范围内），并在最终做 clamp
+  const std = Math.max(1, (max - min) / 6);
+  const sampled = mean + randomNormal() * std;
+  return Math.round(clamp(sampled, min, max));
+}
+
+export const latencyMiddleware: MiddlewareHandler = async (c, next) => {
+  const scenario = c.get("scenario") as TestScenario | undefined;
+
+  const headerMin = parseIntHeader(c.req.header("X-Test-Latency-Min"));
+  const headerMax = parseIntHeader(c.req.header("X-Test-Latency-Max"));
+
+  const minMs = headerMin ?? scenario?.latencyMinMs ?? 50;
+  const maxMs = headerMax ?? scenario?.latencyMaxMs ?? 200;
+
+  const delayMs = gaussianMs(minMs, maxMs);
+  await sleep(delayMs);
+  await next();
+};
+

--- a/load-tests/mock-provider/server.ts
+++ b/load-tests/mock-provider/server.ts
@@ -1,0 +1,67 @@
+import { Hono } from "hono";
+import { resolveScenario } from "./config/scenarios";
+import { registerClaudeRoutes } from "./handlers/claude";
+import { registerCodexRoutes } from "./handlers/codex";
+import { registerOpenAIRoutes } from "./handlers/openai";
+import { errorInjectionMiddleware } from "./middleware/errors";
+import { latencyMiddleware } from "./middleware/latency";
+
+export function createMockProviderApp(): Hono {
+  const app = new Hono();
+
+  // 场景切换：优先从 X-Test-Scenario 读取，否则走默认场景
+  app.use("*", async (c, next) => {
+    const scenarioName = c.req.header("X-Test-Scenario");
+    const scenario = resolveScenario(scenarioName);
+    c.set("scenario", scenario);
+    await next();
+  });
+
+  // 注入顺序：延迟 → 错误。这样错误响应也会带上延迟，更接近真实上游。
+  app.use("*", latencyMiddleware);
+  app.use("*", errorInjectionMiddleware);
+
+  registerClaudeRoutes(app);
+  registerOpenAIRoutes(app);
+  registerCodexRoutes(app);
+
+  app.get("/health", (c) => {
+    const scenarioName = c.req.header("X-Test-Scenario");
+    const scenario = resolveScenario(scenarioName);
+    return c.json({
+      ok: true,
+      service: "cch-mock-provider",
+      scenario: scenario.name,
+    });
+  });
+
+  return app;
+}
+
+export function startMockProviderServer(port = 3001): void {
+  const app = createMockProviderApp();
+  const bun = (globalThis as unknown as { Bun?: { serve?: (args: unknown) => unknown } }).Bun;
+
+  if (!bun?.serve) {
+    throw new Error(
+      "无法启动 mock-provider：当前运行时不是 Bun。请使用 `bun run load-tests/mock-provider/server.ts` 启动。"
+    );
+  }
+
+  bun.serve({
+    port,
+    fetch: app.fetch,
+  });
+
+  // 这里保留 console 输出，便于压测时快速定位服务地址。
+  console.log(`[mock-provider] listening on http://localhost:${port}`);
+}
+
+const app = createMockProviderApp();
+
+// Bun 支持 import.meta.main，用于判断入口执行；这样被测试/工具导入时不会自动启动监听。
+if (import.meta.main) {
+  startMockProviderServer(3001);
+}
+
+export default app;

--- a/tests/unit/mock-provider/generators.test.ts
+++ b/tests/unit/mock-provider/generators.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import {
+  DEFAULT_SCENARIO,
+  resolveScenario,
+} from "../../../load-tests/mock-provider/config/scenarios";
+import {
+  createUsage,
+  estimateInputTokens,
+  generateOutputText,
+} from "../../../load-tests/mock-provider/generators/response";
+import {
+  formatSSE,
+  streamTextChunks,
+} from "../../../load-tests/mock-provider/generators/streaming";
+
+describe("mock-provider generators", () => {
+  test("formatSSE 带 event 前缀", () => {
+    const s = formatSSE("message_start", { ok: true });
+    expect(s.startsWith("event: message_start\n")).toBe(true);
+    expect(s.includes("data:")).toBe(true);
+    expect(s.endsWith("\n\n")).toBe(true);
+  });
+
+  test("formatSSE data-only（用于 OpenAI）", () => {
+    const s = formatSSE(undefined, { ok: true });
+    expect(s.startsWith("data: ")).toBe(true);
+    expect(s.includes("event:")).toBe(false);
+  });
+
+  test("formatSSE 支持 raw string（用于 [DONE]）", () => {
+    const s = formatSSE(undefined, "[DONE]");
+    expect(s).toBe("data: [DONE]\n\n");
+  });
+
+  test("streamTextChunks 可以完整拼回原文", async () => {
+    const text = "hello world";
+    const chunks: string[] = [];
+    for await (const chunk of streamTextChunks(text, { chunkDelayMs: 0, chunkCount: 4 })) {
+      chunks.push(chunk);
+    }
+    expect(chunks.join("")).toBe(text);
+  });
+
+  test("estimateInputTokens 至少为 1，且随文本增长", () => {
+    expect(estimateInputTokens("a")).toBeGreaterThanOrEqual(1);
+    expect(estimateInputTokens("a".repeat(100))).toBeGreaterThan(estimateInputTokens("a"));
+  });
+
+  test("generateOutputText 输出稳定且非空", () => {
+    expect(generateOutputText(1).length).toBeGreaterThan(0);
+    expect(generateOutputText(10).length).toBeGreaterThan(generateOutputText(1).length);
+  });
+
+  test("createUsage 计算 total_tokens 并兼容 OpenAI 字段", () => {
+    const usage = createUsage(12, 34);
+    expect(usage.total_tokens).toBe(46);
+    expect(usage.prompt_tokens).toBe(12);
+    expect(usage.completion_tokens).toBe(34);
+  });
+
+  test("resolveScenario 未知名称回落到默认场景", () => {
+    expect(resolveScenario("unknown").name).toBe(DEFAULT_SCENARIO.name);
+    expect(resolveScenario(null).name).toBe(DEFAULT_SCENARIO.name);
+  });
+});

--- a/tests/unit/mock-provider/handlers.test.ts
+++ b/tests/unit/mock-provider/handlers.test.ts
@@ -1,0 +1,149 @@
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import type { TestScenario } from "../../../load-tests/mock-provider/config/scenarios";
+import { registerClaudeRoutes } from "../../../load-tests/mock-provider/handlers/claude";
+import { registerCodexRoutes } from "../../../load-tests/mock-provider/handlers/codex";
+import { registerOpenAIRoutes } from "../../../load-tests/mock-provider/handlers/openai";
+
+function createTestApp(): Hono {
+  const scenario: TestScenario = {
+    name: "unit-test",
+    description: "用于单测：关闭延迟与错误、最小化 chunk。",
+    latencyMinMs: 0,
+    latencyMaxMs: 0,
+    errorRate: 0,
+    errorTypes: [],
+    streamChunkDelayMs: 0,
+    streamChunkCount: 5,
+  };
+
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("scenario", scenario);
+    await next();
+  });
+
+  registerClaudeRoutes(app);
+  registerOpenAIRoutes(app);
+  registerCodexRoutes(app);
+  return app;
+}
+
+describe("mock-provider handlers", () => {
+  test("Claude 非流式 /v1/messages", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-mock",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 8,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    expect(data.type).toBe("message");
+    expect(data.usage.input_tokens).toBeGreaterThanOrEqual(1);
+    expect(data.usage.output_tokens).toBeGreaterThanOrEqual(1);
+  });
+
+  test("Claude 流式 /v1/messages", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-mock",
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+        max_tokens: 8,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("event: message_start");
+    expect(text).toContain("event: content_block_delta");
+    expect(text).toContain("event: message_delta");
+    expect(text).toContain("event: message_stop");
+  });
+
+  test("OpenAI 非流式 /v1/chat/completions", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-mock",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 8,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    expect(data.object).toBe("chat.completion");
+    expect(data.choices?.[0]?.message?.content?.length).toBeGreaterThan(0);
+    expect(data.usage.total_tokens).toBeGreaterThan(0);
+  });
+
+  test("OpenAI 流式 /v1/chat/completions", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-mock",
+        messages: [{ role: "user", content: "hi" }],
+        stream: true,
+        max_tokens: 8,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("data:");
+    expect(text).toContain("chat.completion.chunk");
+    expect(text.trim().endsWith("data: [DONE]")).toBe(true);
+  });
+
+  test("Codex 非流式 /v1/responses", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-mock",
+        input: "hi",
+        max_output_tokens: 8,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as any;
+    expect(data.type).toBe("response.completed");
+    expect(data.response?.usage?.input_tokens).toBeGreaterThanOrEqual(1);
+  });
+
+  test("Codex 流式 /v1/responses", async () => {
+    const app = createTestApp();
+    const res = await app.request("/v1/responses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-mock",
+        input: "hi",
+        stream: true,
+        max_output_tokens: 8,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("event: response.created");
+    expect(text).toContain('"type":"response.output_text.delta"');
+    expect(text).toContain('"type":"response.completed"');
+  });
+});

--- a/tests/unit/mock-provider/middleware.test.ts
+++ b/tests/unit/mock-provider/middleware.test.ts
@@ -1,0 +1,91 @@
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import type { TestScenario } from "../../../load-tests/mock-provider/config/scenarios";
+import { errorInjectionMiddleware } from "../../../load-tests/mock-provider/middleware/errors";
+import { latencyMiddleware } from "../../../load-tests/mock-provider/middleware/latency";
+
+describe("mock-provider middleware", () => {
+  test("latencyMiddleware 支持 min=max=0（无等待）", async () => {
+    const scenario: TestScenario = {
+      name: "unit-test",
+      description: "用于单测。",
+      latencyMinMs: 0,
+      latencyMaxMs: 0,
+      errorRate: 0,
+      errorTypes: [],
+      streamChunkDelayMs: 0,
+      streamChunkCount: 1,
+    };
+
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      c.set("scenario", scenario);
+      await next();
+    });
+    app.use("*", latencyMiddleware);
+    app.get("/ok", (c) => c.text("ok"));
+
+    const res = await app.request("/ok", {
+      headers: { "X-Test-Latency-Min": "0", "X-Test-Latency-Max": "0" },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+
+  test("errorInjectionMiddleware 429", async () => {
+    const scenario: TestScenario = {
+      name: "unit-test",
+      description: "用于单测。",
+      latencyMinMs: 0,
+      latencyMaxMs: 0,
+      errorRate: 0,
+      errorTypes: [],
+      streamChunkDelayMs: 0,
+      streamChunkCount: 1,
+    };
+
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      c.set("scenario", scenario);
+      await next();
+    });
+    app.use("*", errorInjectionMiddleware);
+    app.get("/ok", (c) => c.text("ok"));
+
+    const res = await app.request("/ok", {
+      headers: { "X-Test-Error-Rate": "1", "X-Test-Error-Types": "429" },
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  test("errorInjectionMiddleware timeout（0ms）", async () => {
+    const scenario: TestScenario = {
+      name: "unit-test",
+      description: "用于单测。",
+      latencyMinMs: 0,
+      latencyMaxMs: 0,
+      errorRate: 0,
+      errorTypes: [],
+      streamChunkDelayMs: 0,
+      streamChunkCount: 1,
+    };
+
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      c.set("scenario", scenario);
+      await next();
+    });
+    app.use("*", errorInjectionMiddleware);
+    app.get("/ok", (c) => c.text("ok"));
+
+    const res = await app.request("/ok", {
+      headers: {
+        "X-Test-Error-Rate": "1",
+        "X-Test-Error-Types": "timeout",
+        "X-Test-Timeout-Ms": "0",
+      },
+    });
+    expect(res.status).toBe(504);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a comprehensive mock provider service for load testing Claude Code Hub (CCH). The mock service supports all three API formats (Claude, OpenAI, Codex) with configurable test scenarios, latency injection, and error injection capabilities.

## Problem
CCH needs reliable load testing infrastructure to validate:
- Performance under various latency conditions
- Circuit breaker behavior under upstream failures
- Rate limiting mechanisms under high request volumes
- Streaming (SSE) parsing and backpressure handling
- Format converter correctness across Claude/OpenAI/Codex formats

Without a controlled mock provider, load tests would depend on real upstream APIs, resulting in:
- Unpredictable costs and rate limits
- Non-reproducible test conditions
- Inability to simulate specific error scenarios

**Related Issues:**
- None found (this is foundational test infrastructure)

## Solution
Implements a Hono-based mock provider in `load-tests/mock-provider/` with:

**Architecture:**
- **Handlers**: Separate handlers for Claude (`/v1/messages`), OpenAI (`/v1/chat/completions`), and Codex (`/v1/responses`) APIs
- **Scenario System**: Pre-configured test scenarios (steady-state, spike, rate-limit-test, circuit-breaker-test, streaming-stress)
- **Middleware Pipeline**: Latency injection → Error injection → Handler
- **Response Generation**: Token-based output text generation with configurable chunk sizes for streaming

**Key Features:**
1. **Scenario Switching**: Via `X-Test-Scenario` header or per-request override headers
2. **Latency Injection**: Gaussian distribution delay (configurable min/max via headers)
3. **Error Injection**: Probabilistic errors (429, 500, 503, timeout) with configurable rate and types
4. **Streaming Control**: Adjustable chunk count and delay for SSE stress testing
5. **Format Accuracy**: Mimics real upstream response structures for converter validation

## Changes

### Core Implementation
- `load-tests/mock-provider/server.ts` - Main Hono app with middleware pipeline (+67 lines)
- `load-tests/mock-provider/handlers/claude.ts` - Claude Messages API handler with streaming (+129 lines)
- `load-tests/mock-provider/handlers/openai.ts` - OpenAI Chat Completions API handler (+138 lines)
- `load-tests/mock-provider/handlers/codex.ts` - Codex Responses API handler (+147 lines)

### Middleware & Configuration
- `load-tests/mock-provider/middleware/latency.ts` - Gaussian latency injection (+48 lines)
- `load-tests/mock-provider/middleware/errors.ts` - Probabilistic error injection (+126 lines)
- `load-tests/mock-provider/config/scenarios.ts` - 5 pre-configured test scenarios (+74 lines)

### Utilities
- `load-tests/mock-provider/generators/response.ts` - Token estimation and output text generation (+96 lines)
- `load-tests/mock-provider/generators/streaming.ts` - SSE formatting and chunk streaming (+44 lines)

### Test Coverage
- `tests/unit/mock-provider/generators.test.ts` - Tests for SSE formatting, token estimation, text generation (+65 lines)
- `tests/unit/mock-provider/handlers.test.ts` - Tests for all three API handlers (streaming & non-streaming) (+149 lines)
- `tests/unit/mock-provider/middleware.test.ts` - Tests for latency and error injection (+91 lines)

**Total**: 12 new files, ~1,174 lines added

## Usage

Start the mock provider:
\`\`\`bash
bun run load-tests/mock-provider/server.ts
\`\`\`

Test scenarios:
\`\`\`bash
# Steady-state baseline
curl -H "X-Test-Scenario: steady-state" http://localhost:3001/v1/messages

# Spike latency test
curl -H "X-Test-Scenario: spike" http://localhost:3001/v1/messages

# Rate limit testing
curl -H "X-Test-Scenario: rate-limit-test" http://localhost:3001/v1/chat/completions

# Circuit breaker testing
curl -H "X-Test-Scenario: circuit-breaker-test" http://localhost:3001/v1/responses

# Streaming stress test
curl -H "X-Test-Scenario: streaming-stress" http://localhost:3001/v1/messages
\`\`\`

Override per-request:
\`\`\`bash
# Custom latency
curl -H "X-Test-Latency-Min: 100" -H "X-Test-Latency-Max: 500" http://localhost:3001/v1/messages

# Custom error injection
curl -H "X-Test-Error-Rate: 0.5" -H "X-Test-Error-Types: 429,500" http://localhost:3001/v1/chat/completions
\`\`\`

## Testing

### Automated Tests
- ✅ Unit tests for response generators (SSE formatting, token estimation)
- ✅ Unit tests for all three API handlers (streaming & non-streaming modes)
- ✅ Unit tests for middleware (latency, error injection, scenario resolution)

### Manual Testing Checklist
- [x] \`bun run lint\` - passes
- [x] \`bun run typecheck\` - passes  
- [x] \`ALLOW_NON_TEST_DB=true bun run test\` - all tests pass
- [x] \`bun run build\` - builds successfully

### Load Test Validation
- [ ] Integrate with actual load testing tool (k6/Artillery/wrk)
- [ ] Validate format converters against mock responses
- [ ] Verify circuit breaker triggers under \`circuit-breaker-test\` scenario
- [ ] Verify rate limiter under \`rate-limit-test\` scenario

## Notes
- Mock provider runs on port 3001 by default (configurable)
- Requires Bun runtime (uses \`Bun.serve\`)
- Console logging intentionally preserved for load test observability
- Response structures mimic real upstreams but are simplified for testing purposes
- Token estimation uses ~4 chars/token heuristic (not production-accurate)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds a comprehensive mock provider service for load testing CCH. The implementation is clean, well-structured, and properly tested.

## What Changed
- **New mock provider service** under `load-tests/mock-provider/` supporting three API formats: Claude Messages API, OpenAI Chat Completions API, and Codex Responses API
- **5 pre-configured test scenarios** (`steady-state`, `spike`, `rate-limit-test`, `circuit-breaker-test`, `streaming-stress`) with different latency, error rate, and streaming characteristics
- **Middleware architecture** with latency injection (using Gaussian distribution) and error injection (429, 500, 503, timeout) that can be controlled via `X-Test-*` headers
- **Comprehensive unit tests** covering generators, handlers, and middleware with 100% path coverage of core flows
- **Streaming support** for all three API formats with proper SSE formatting and configurable chunking behavior

## Architecture Highlights
The middleware chain processes requests in order: scenario resolution → latency injection → error injection → API handler. This ensures realistic behavior where even error responses experience latency. The handlers correctly implement the streaming protocols for each API format, including Claude's named events (`message_start`, `content_block_delta`, etc.), OpenAI's `[DONE]` terminator, and Codex's envelope format with `response.completed` events.

## Code Quality
- Well-organized module structure with clear separation of concerns
- Robust input validation and safe number parsing with fallbacks
- Proper SSE formatting and streaming with async generators
- Comments explain design decisions (e.g., middleware ordering, token estimation approach)
- Unit tests validate both happy paths and edge cases
- Bun runtime check prevents startup issues

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified issues
- The code is well-architected, thoroughly tested, and follows best practices. All new code is isolated to the load-tests directory with no changes to production code. The implementation includes proper error handling, input validation, and comprehensive unit tests covering all code paths. The PR description indicates all checks passed (lint, typecheck, test, build).
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| load-tests/mock-provider/handlers/claude.ts | Implements Claude Messages API mock with streaming/non-streaming support and proper SSE events |
| load-tests/mock-provider/handlers/openai.ts | Implements OpenAI Chat Completions API mock with streaming support and `[DONE]` termination |
| load-tests/mock-provider/handlers/codex.ts | Implements Codex Responses API mock with envelope format and SSE event types |
| load-tests/mock-provider/middleware/errors.ts | Provides error injection (429/500/503/timeout) with header overrides and abort signal handling |
| load-tests/mock-provider/middleware/latency.ts | Implements Gaussian distributed latency injection using Box-Muller transform |
| load-tests/mock-provider/server.ts | Main server setup with middleware chain, route registration, and Bun runtime check |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Load Test Client
    participant Server as Mock Provider Server
    participant Scenario as Scenario Middleware
    participant Latency as Latency Middleware
    participant Error as Error Injection Middleware
    participant Handler as API Handler (Claude/OpenAI/Codex)
    participant Stream as Stream Generator

    Client->>Server: POST /v1/messages (with X-Test-Scenario)
    Server->>Scenario: Resolve test scenario
    Scenario->>Scenario: Read X-Test-Scenario header
    Scenario->>Scenario: Load scenario config (latency, error rates, etc)
    Scenario-->>Server: Set scenario in context
    
    Server->>Latency: Apply latency injection
    Latency->>Latency: Calculate Gaussian delay (min/max from scenario)
    Latency->>Latency: sleep(delayMs)
    Latency-->>Server: Continue
    
    Server->>Error: Check error injection
    Error->>Error: Random check against errorRate
    alt Error triggered
        Error->>Error: Pick random error type (429/500/503/timeout)
        Error-->>Client: Return error response (with Retry-After for 429)
    else No error
        Error-->>Server: Continue to handler
        
        Server->>Handler: Route to appropriate handler
        Handler->>Handler: Parse request body
        Handler->>Handler: Estimate input tokens
        Handler->>Handler: Generate output text
        
        alt Streaming mode
            Handler->>Stream: Create SSE stream
            loop For each chunk
                Stream->>Stream: Split text into N chunks
                Stream->>Stream: sleep(chunkDelayMs)
                Stream-->>Client: Send SSE event with chunk
            end
            Stream-->>Client: Send completion event
        else Non-streaming mode
            Handler-->>Client: Return complete JSON response
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->