### PR TITLE
fix: 用户每日消费按重置配置统计

### DIFF
--- a/tests/unit/lib/rate-limit/user-daily-reset.test.ts
+++ b/tests/unit/lib/rate-limit/user-daily-reset.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let redisClient: { status: string } | null = null;
+
+vi.mock("@/lib/redis", () => ({
+  getRedisClient: () => redisClient,
+}));
+
+const statisticsMock = {
+  sumKeyTotalCost: vi.fn(async () => 0),
+  sumUserTotalCost: vi.fn(async () => 0),
+  sumUserCostToday: vi.fn(async () => 0),
+  sumUserCostInTimeRange: vi.fn(async () => 0),
+  sumKeyCostInTimeRange: vi.fn(async () => 0),
+  sumProviderCostInTimeRange: vi.fn(async () => 0),
+  findKeyCostEntriesInTimeRange: vi.fn(async () => []),
+  findProviderCostEntriesInTimeRange: vi.fn(async () => []),
+  findUserCostEntriesInTimeRange: vi.fn(async () => []),
+};
+
+vi.mock("@/repository/statistics", () => statisticsMock);
+
+describe("RateLimitService.checkUserDailyCost - dailyResetTime/dailyResetMode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    redisClient = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fixed 模式：当前时间在重置点之前时，应从昨天重置点开始统计", async () => {
+    // Asia/Shanghai: 2026-01-02 17:00 => 2026-01-02T09:00:00.000Z
+    vi.setSystemTime(new Date(Date.UTC(2026, 0, 2, 9, 0, 0)));
+    statisticsMock.sumUserCostInTimeRange.mockResolvedValueOnce(1.23);
+
+    const { RateLimitService } = await import("@/lib/rate-limit");
+    const result = await RateLimitService.checkUserDailyCost(123, 10, "18:00", "fixed");
+
+    expect(result.allowed).toBe(true);
+    expect(result.current).toBeCloseTo(1.23, 10);
+
+    expect(statisticsMock.sumUserCostInTimeRange).toHaveBeenCalledTimes(1);
+    const [, startTime, endTime] = statisticsMock.sumUserCostInTimeRange.mock.calls[0];
+
+    // 2026-01-01 18:00 Asia/Shanghai => 2026-01-01T10:00:00.000Z
+    expect((startTime as Date).toISOString()).toBe("2026-01-01T10:00:00.000Z");
+    expect((endTime as Date).toISOString()).toBe("2026-01-02T09:00:00.000Z");
+    expect(statisticsMock.sumUserCostToday).not.toHaveBeenCalled();
+  });
+
+  it("fixed 模式：当前时间在重置点之后时，应从今天重置点开始统计", async () => {
+    // Asia/Shanghai: 2026-01-02 20:00 => 2026-01-02T12:00:00.000Z
+    vi.setSystemTime(new Date(Date.UTC(2026, 0, 2, 12, 0, 0)));
+    statisticsMock.sumUserCostInTimeRange.mockResolvedValueOnce(2);
+
+    const { RateLimitService } = await import("@/lib/rate-limit");
+    const result = await RateLimitService.checkUserDailyCost(123, 10, "18:00", "fixed");
+
+    expect(result.allowed).toBe(true);
+    expect(result.current).toBeCloseTo(2, 10);
+
+    const [, startTime] = statisticsMock.sumUserCostInTimeRange.mock.calls[0];
+    // 2026-01-02 18:00 Asia/Shanghai => 2026-01-02T10:00:00.000Z
+    expect((startTime as Date).toISOString()).toBe("2026-01-02T10:00:00.000Z");
+    expect(statisticsMock.sumUserCostToday).not.toHaveBeenCalled();
+  });
+
+  it("rolling 模式：Redis 不可用时应使用过去 24 小时窗口统计", async () => {
+    const now = new Date(Date.UTC(2026, 0, 2, 12, 0, 0));
+    vi.setSystemTime(now);
+    statisticsMock.sumUserCostInTimeRange.mockResolvedValueOnce(3);
+
+    const { RateLimitService } = await import("@/lib/rate-limit");
+    const result = await RateLimitService.checkUserDailyCost(123, 10, "18:00", "rolling");
+
+    expect(result.allowed).toBe(true);
+    expect(result.current).toBeCloseTo(3, 10);
+
+    const [, startTime, endTime] = statisticsMock.sumUserCostInTimeRange.mock.calls[0];
+    expect((endTime as Date).toISOString()).toBe(now.toISOString());
+    expect((startTime as Date).toISOString()).toBe(
+      new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString()
+    );
+    expect(statisticsMock.sumUserCostToday).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 背景
个人页面中,Key 层级 daily 已用使用 dailyResetTime/dailyResetMode 计算窗口;用户层级 daily 已用仍按自然日统计,导致展示不一致,并在 Redis 不可用/缓存缺失时可能误判用户日限额。

## 相关工作

**Follow-up to:**
- #507 - 修复用户层级和Key层级每日限额时区判断不一致问题 (本PR继续完善相同区域的限额统计逻辑)

**Related to:**
- #339 - 余额的周限滚动窗口功能需求 (本PR处理的 rolling mode 是该需求的实现基础)
- #161 - 每日消费限额功能的原始实现

## 变更
- 个人页:用户 daily 已用改为基于用户 dailyResetTime/dailyResetMode 计算时间窗口并按 createdAt range 聚合。
- 限额校验:checkUserDailyCost 在 fixed/rolling 模式下的 DB 回退统一使用同一窗口(不再按自然日)。
- 管理端:getUserLimitUsage 的 dailyCost 与 resetAt 按用户配置计算(rolling 模式 resetAt 使用 24h fallback)。

## 核心变更

### 1. src/actions/my-usage.ts (getMyQuota)
- 替换 `sumUserCostToday()` 为 `sumUserCostInTimeRange()` 
- 使用 `getTimeRangeForPeriodWithMode()` 根据用户的 dailyResetTime/dailyResetMode 计算时间窗口

### 2. src/actions/users.ts (getUserLimitUsage)
- 替换 `sumUserCostToday()` 为 `sumUserCostInTimeRange()`
- 使用 `getResetInfoWithMode()` 计算 resetAt,确保与前端展示一致

### 3. src/lib/rate-limit/service.ts (checkUserDailyCost)
- Redis 降级路径(Slow Path)改用 `sumUserCostInTimeRange()` 并传入正确的时间窗口
- Cache Miss 路径同样使用时间窗口查询
- **影响**: fixed 模式下回退不再按 CURRENT_DATE 自然日,而是按配置的重置点

### 4. 新增单元测试
- tests/unit/lib/rate-limit/user-daily-reset.test.ts
- 覆盖 fixed/rolling 两种模式的时间窗口计算逻辑

## 影响范围

| 模块 | 影响 | 变更类型 |
|------|------|----------|
| 个人页用量展示 | 用户层级 daily 已用计算逻辑变化 | 修复 |
| 管理端用户限额查询 | resetAt 计算方式变化 | 修复 |
| 限额校验(Redis降级) | 使用时间窗口而非自然日 | 修复 |

## 兼容性

✅ **无破坏性变更**
- `sumUserCostToday` 仍然存在于 statistics.ts,未删除(其他代码可能仍在使用)
- 仅替换了 3 处调用点为 `sumUserCostInTimeRange`
- API 签名未变化

## 测试

### 自动化测试
- ✅ bun run lint
- ✅ bun run typecheck  
- ✅ bun run test
- ✅ bun run build
- ✅ 新增单测:tests/unit/lib/rate-limit/user-daily-reset.test.ts
  - fixed 模式:当前时间在重置点之前/之后的窗口计算
  - rolling 模式:Redis 不可用时使用过去 24 小时窗口

### 测试场景

**场景 1: fixed 模式,dailyResetTime="18:00"**
- 当前时间: 2026-01-02 17:00 (Asia/Shanghai)
- 预期窗口: [2026-01-01 18:00, 2026-01-02 17:00)
- 验证: ✅ 单测覆盖

**场景 2: rolling 模式,Redis 不可用**
- 当前时间: 2026-01-02 12:00 UTC
- 预期窗口: [2026-01-01 12:00, 2026-01-02 12:00)
- 验证: ✅ 单测覆盖

## 覆盖率

对比报告:All files lines 8.83% -> 8.92% (/tmp/cch-coverage-before.txt vs /tmp/cch-coverage-after.txt)

---
*Description enhanced by Claude AI*