### PR TITLE
Fix #518: Add error rule for Invalid signature in thinking block

### DIFF
--- a/src/repository/error-rules.ts
+++ b/src/repository/error-rules.ts
@@ -622,6 +622,25 @@ const DEFAULT_ERROR_RULES = [
       },
     },
   },
+  // Issue #518: Invalid signature in thinking block (cross-channel format incompatibility)
+  {
+    pattern: "Invalid `signature` in `thinking` block",
+    category: "thinking_error",
+    description:
+      "Invalid signature in thinking block (occurs when switching between Anthropic and non-Anthropic channels)",
+    matchType: "contains" as const,
+    isDefault: true,
+    isEnabled: true,
+    priority: 71,
+    overrideResponse: {
+      type: "error",
+      error: {
+        type: "thinking_error",
+        message:
+          "thinking 块签名无效，通常发生在 Anthropic 渠道与非 Anthropic 渠道切换时，请检查请求格式",
+      },
+    },
+  },
   {
     pattern: "Missing required parameter|Extra inputs.*not permitted",
     category: "parameter_error",


### PR DESCRIPTION
## Summary
Added a new error rule to handle "Invalid \`signature\` in \`thinking\` block" error that commonly occurs when switching between Anthropic and non-Anthropic channels.

## Problem
Fixes #518

The error "Invalid \`signature\` in \`thinking\` block" was not matched by existing error rules, causing unclear error messages for users. This error commonly occurs when requests alternate between Anthropic channels and non-Anthropic channels.

## Solution
Added a new error rule in `src/repository/error-rules.ts`:

- **Pattern**: `Invalid \`signature\` in \`thinking\` block`
- **Match Type**: `contains` (for precise matching)
- **Category**: `thinking_error`
- **Priority**: 71 (higher than the generic thinking error rule at priority 70)
- **Error Message**: Clear Chinese explanation about the cross-channel incompatibility

## Changes
- Updated `DEFAULT_ERROR_RULES` array in `/src/repository/error-rules.ts:625-643`
- Added comprehensive description linking to issue #518

## Testing
- [x] TypeScript compilation passed
- [x] Biome lint check passed
- [x] Error rule follows existing pattern structure

## Notes
This rule will be automatically synced to the database when the application starts or when users refresh the error rules cache.

---
*Created by Claude AI in response to @claude mention*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added a new error rule to handle "Invalid `signature` in `thinking` block" errors that occur when switching between Anthropic and non-Anthropic channels. The implementation correctly:

- Uses `matchType: "contains"` for precise string matching
- Provides a clear Chinese error message explaining the cross-channel incompatibility
- Sets `category: "thinking_error"` to group with related errors
- Includes proper documentation linking to issue #518
- Follows the existing error rule structure and formatting

The rule will be automatically synced to the database on application startup via `syncDefaultErrorRules()`. The pattern is specific enough that it won't conflict with the generic thinking error rule at priority 70.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk
- The change is a simple addition of a new error rule that follows established patterns. The implementation is correct and won't conflict with existing rules. The only minor improvement would be adjusting the priority number for better performance, but this doesn't affect correctness.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/repository/error-rules.ts | Added new error rule for Invalid signature in thinking block with correct pattern and format, though priority could be optimized |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant ProxyServer
    participant ErrorDetector
    participant Database
    participant AnthropicAPI as Anthropic/Non-Anthropic API
    
    Note over ProxyServer: Application Startup
    ProxyServer->>Database: syncDefaultErrorRules()
    Database-->>ProxyServer: New rule inserted/updated
    ProxyServer->>ErrorDetector: reload() triggered
    ErrorDetector->>Database: getActiveErrorRules()
    Database-->>ErrorDetector: All enabled rules (sorted by priority)
    ErrorDetector->>ErrorDetector: Parse rules into containsPatterns
    Note over ErrorDetector: New rule added to cache at priority 71
    
    Note over Client: Runtime Error Occurs
    Client->>ProxyServer: API Request
    ProxyServer->>AnthropicAPI: Forward request
    AnthropicAPI-->>ProxyServer: Error: Invalid `signature` in `thinking` block
    ProxyServer->>ErrorDetector: detectAsync(errorMessage)
    ErrorDetector->>ErrorDetector: Iterate through containsPatterns (priority order)
    ErrorDetector->>ErrorDetector: Check generic thinking rule (priority 70) - no match
    ErrorDetector->>ErrorDetector: Check signature thinking rule (priority 71) - MATCH!
    ErrorDetector-->>ProxyServer: Return overrideResponse
    ProxyServer->>ProxyServer: Replace error message with Chinese translation
    ProxyServer-->>Client: Friendly error: "thinking 块签名无效..."
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->