### PR TITLE
fix(proxy): preserve User-Agent for gemini providers (fix #515)

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -848,26 +848,6 @@ export class ProxyForwarder {
       const accessToken = await GeminiAuth.getAccessToken(provider.key);
       const isApiKey = GeminiAuth.isApiKey(provider.key);
 
-      const headers = new Headers();
-      headers.set("Content-Type", "application/json");
-
-      // ⭐ 统一禁用 gzip 压缩（不仅限于流式请求）
-      // 原因：undici（Node.js fetch）在连接提前关闭时会对不完整的 gzip 流抛出 "TypeError: terminated"
-      // Bun 的 fetch 实现更宽松，不会报错，这导致 bun dev 正常但 Docker 构建后失败
-      // 参考：Gunzip.emit → emitErrorNT → emitErrorCloseNT 错误链
-      headers.set("accept-encoding", "identity");
-
-      if (isApiKey) {
-        headers.set(GEMINI_PROTOCOL.HEADERS.API_KEY, accessToken);
-      } else {
-        headers.set("Authorization", `Bearer ${accessToken}`);
-      }
-
-      // CLI specific headers
-      if (provider.providerType === "gemini-cli") {
-        headers.set(GEMINI_PROTOCOL.HEADERS.API_CLIENT, "GeminiCLI/1.0");
-      }
-
       // 3. 直接透传：使用 buildProxyUrl() 拼接原始路径和查询参数
       const baseUrl =
         provider.url ||
@@ -876,7 +856,16 @@ export class ProxyForwarder {
           : GEMINI_PROTOCOL.CLI_ENDPOINT);
 
       proxyUrl = buildProxyUrl(baseUrl, session.requestUrl);
-      processedHeaders = headers;
+
+      // 4. Headers 处理：默认透传 session.headers（含请求过滤器修改），但移除代理认证头并覆盖上游鉴权
+      // 说明：之前 Gemini 分支使用 new Headers() 重建 headers，会导致 user-agent 丢失且过滤器不生效
+      processedHeaders = ProxyForwarder.buildGeminiHeaders(
+        session,
+        provider,
+        baseUrl,
+        accessToken,
+        isApiKey
+      );
 
       if (session.sessionId) {
         void SessionManager.storeSessionUpstreamRequestMeta(
@@ -1802,6 +1791,51 @@ export class ProxyForwarder {
 
     const headerProcessor = HeaderProcessor.createForProxy({
       blacklist: ["content-length", "connection"], // 删除 content-length（动态计算）和 connection（undici 自动管理）
+      preserveClientIpHeaders: preserveClientIp,
+      overrides,
+    });
+
+    return headerProcessor.process(session.headers);
+  }
+
+  private static buildGeminiHeaders(
+    session: ProxySession,
+    provider: NonNullable<typeof session.provider>,
+    baseUrl: string,
+    accessToken: string,
+    isApiKey: boolean
+  ): Headers {
+    const preserveClientIp = provider.preserveClientIp ?? false;
+    const { clientIp, xForwardedFor } = ProxyForwarder.resolveClientIp(session.headers);
+
+    const overrides: Record<string, string> = {
+      host: HeaderProcessor.extractHost(baseUrl),
+      "content-type": "application/json",
+      "accept-encoding": "identity",
+      "user-agent": session.headers.get("user-agent") ?? session.userAgent ?? "claude-code-hub",
+    };
+
+    if (isApiKey) {
+      overrides[GEMINI_PROTOCOL.HEADERS.API_KEY] = accessToken;
+    } else {
+      overrides.authorization = `Bearer ${accessToken}`;
+    }
+
+    if (provider.providerType === "gemini-cli") {
+      overrides[GEMINI_PROTOCOL.HEADERS.API_CLIENT] = "GeminiCLI/1.0";
+    }
+
+    if (preserveClientIp) {
+      if (xForwardedFor) {
+        overrides["x-forwarded-for"] = xForwardedFor;
+      }
+      if (clientIp) {
+        overrides["x-real-ip"] = clientIp;
+      }
+    }
+
+    const headerProcessor = HeaderProcessor.createForProxy({
+      blacklist: ["content-length", "connection", "x-api-key", GEMINI_PROTOCOL.HEADERS.API_KEY],
       preserveClientIpHeaders: preserveClientIp,
       overrides,
     });

--- a/tests/unit/proxy/proxy-forwarder.test.ts
+++ b/tests/unit/proxy/proxy-forwarder.test.ts
@@ -59,6 +59,15 @@ function createCodexProvider(): Provider {
   } as unknown as Provider;
 }
 
+function createGeminiProvider(providerType: "gemini" | "gemini-cli"): Provider {
+  return {
+    providerType,
+    url: "https://generativelanguage.googleapis.com/v1beta",
+    key: "test-outbound-key",
+    preserveClientIp: false,
+  } as unknown as Provider;
+}
+
 describe("ProxyForwarder - buildHeaders User-Agent resolution", () => {
   it("应该优先使用过滤器修改的 user-agent（Codex provider）", () => {
     const session = createSession({
@@ -145,5 +154,159 @@ describe("ProxyForwarder - buildHeaders User-Agent resolution", () => {
 
     // 空字符串应该被保留（使用 ?? 而非 ||）
     expect(resultHeaders.get("user-agent")).toBe("");
+  });
+});
+
+describe("ProxyForwarder - buildGeminiHeaders headers passthrough", () => {
+  it("应该透传 user-agent，并覆盖上游 x-goog-api-key（API key 模式）", () => {
+    const session = createSession({
+      userAgent: "Original-UA/1.0",
+      headers: new Headers([
+        ["user-agent", "Original-UA/1.0"],
+        ["x-api-key", "proxy-user-key-should-not-leak"],
+        ["x-goog-api-key", "proxy-user-key-google-should-not-leak"],
+        ["authorization", "Bearer proxy-user-bearer-should-not-leak"],
+      ]),
+    });
+
+    const provider = createGeminiProvider("gemini");
+    const { buildGeminiHeaders } = ProxyForwarder as unknown as {
+      buildGeminiHeaders: (
+        session: ProxySession,
+        provider: Provider,
+        baseUrl: string,
+        accessToken: string,
+        isApiKey: boolean
+      ) => Headers;
+    };
+    const resultHeaders = buildGeminiHeaders(
+      session,
+      provider,
+      "https://generativelanguage.googleapis.com/v1beta",
+      "upstream-api-key",
+      true
+    );
+
+    expect(resultHeaders.get("user-agent")).toBe("Original-UA/1.0");
+    expect(resultHeaders.get("x-api-key")).toBeNull();
+    expect(resultHeaders.get("authorization")).toBeNull();
+    expect(resultHeaders.get("x-goog-api-key")).toBe("upstream-api-key");
+    expect(resultHeaders.get("accept-encoding")).toBe("identity");
+    expect(resultHeaders.get("content-type")).toBe("application/json");
+    expect(resultHeaders.get("host")).toBe("generativelanguage.googleapis.com");
+  });
+
+  it("应该允许过滤器修改 user-agent（Gemini provider）", () => {
+    const session = createSession({
+      userAgent: "Original-UA/1.0",
+      headers: new Headers([["user-agent", "Filtered-UA/2.0"]]),
+    });
+    (session as any).originalHeaders = new Headers([["user-agent", "Original-UA/1.0"]]);
+
+    const provider = createGeminiProvider("gemini");
+    const { buildGeminiHeaders } = ProxyForwarder as unknown as {
+      buildGeminiHeaders: (
+        session: ProxySession,
+        provider: Provider,
+        baseUrl: string,
+        accessToken: string,
+        isApiKey: boolean
+      ) => Headers;
+    };
+    const resultHeaders = buildGeminiHeaders(
+      session,
+      provider,
+      "https://generativelanguage.googleapis.com/v1beta",
+      "upstream-api-key",
+      true
+    );
+
+    expect(resultHeaders.get("user-agent")).toBe("Filtered-UA/2.0");
+  });
+
+  it("应该在过滤器删除 user-agent 时回退到原始 userAgent（Gemini provider）", () => {
+    const session = createSession({
+      userAgent: "Original-UA/1.0",
+      headers: new Headers(), // user-agent 被删除
+    });
+    (session as any).originalHeaders = new Headers([["user-agent", "Original-UA/1.0"]]);
+
+    const provider = createGeminiProvider("gemini");
+    const { buildGeminiHeaders } = ProxyForwarder as unknown as {
+      buildGeminiHeaders: (
+        session: ProxySession,
+        provider: Provider,
+        baseUrl: string,
+        accessToken: string,
+        isApiKey: boolean
+      ) => Headers;
+    };
+    const resultHeaders = buildGeminiHeaders(
+      session,
+      provider,
+      "https://generativelanguage.googleapis.com/v1beta",
+      "upstream-api-key",
+      true
+    );
+
+    expect(resultHeaders.get("user-agent")).toBe("Original-UA/1.0");
+  });
+
+  it("应该使用 Authorization Bearer（OAuth 模式）并移除 x-goog-api-key", () => {
+    const session = createSession({
+      userAgent: "Original-UA/1.0",
+      headers: new Headers([
+        ["user-agent", "Original-UA/1.0"],
+        ["x-goog-api-key", "proxy-user-key-google-should-not-leak"],
+      ]),
+    });
+
+    const provider = createGeminiProvider("gemini");
+    const { buildGeminiHeaders } = ProxyForwarder as unknown as {
+      buildGeminiHeaders: (
+        session: ProxySession,
+        provider: Provider,
+        baseUrl: string,
+        accessToken: string,
+        isApiKey: boolean
+      ) => Headers;
+    };
+    const resultHeaders = buildGeminiHeaders(
+      session,
+      provider,
+      "https://generativelanguage.googleapis.com/v1beta",
+      "upstream-oauth-token",
+      false
+    );
+
+    expect(resultHeaders.get("authorization")).toBe("Bearer upstream-oauth-token");
+    expect(resultHeaders.get("x-goog-api-key")).toBeNull();
+  });
+
+  it("gemini-cli 应该注入 x-goog-api-client 头", () => {
+    const session = createSession({
+      userAgent: "Original-UA/1.0",
+      headers: new Headers([["user-agent", "Original-UA/1.0"]]),
+    });
+
+    const provider = createGeminiProvider("gemini-cli");
+    const { buildGeminiHeaders } = ProxyForwarder as unknown as {
+      buildGeminiHeaders: (
+        session: ProxySession,
+        provider: Provider,
+        baseUrl: string,
+        accessToken: string,
+        isApiKey: boolean
+      ) => Headers;
+    };
+    const resultHeaders = buildGeminiHeaders(
+      session,
+      provider,
+      "https://cloudcode-pa.googleapis.com/v1internal",
+      "upstream-oauth-token",
+      false
+    );
+
+    expect(resultHeaders.get("x-goog-api-client")).toBe("GeminiCLI/1.0");
   });
 });


### PR DESCRIPTION
## Summary

Fixes User-Agent header loss in Gemini provider forwarding, which caused Cloudflare to block requests. This PR implements header passthrough for Gemini providers similar to the approach used in PR #465 for Codex.

修复 Gemini 供应商转发时 User-Agent 请求头丢失的问题，该问题导致 Cloudflare 拦截请求。此 PR 为 Gemini 供应商实现了类似 PR #465 中 Codex 的请求头透传机制。

## Problem

**Related Issues:**
- Fixes #515 - CCH 转发 Gemini 会被 Cloudflare 拦截 (CCH forwarding Gemini requests blocked by Cloudflare)
- Related to #457 - 请求过滤器中 set header 疑似未生效 (Request filter header modifications not working)
- Follow-up to #465 - Applied similar header passthrough pattern from Codex to Gemini providers

**Root Cause:**

In the Gemini/Gemini-CLI forwarding branch, the code used `new Headers()` to rebuild request headers from scratch, which caused:

1. **User-Agent loss**: Original user-agent header was not preserved, causing Cloudflare to block requests
2. **Filter bypass**: Request filter and provider filter modifications to headers were not applied
3. **Inconsistent behavior**: Different from other provider types (Claude, OpenAI, Codex)

Gemini/Gemini-CLI 转发分支使用 `new Headers()` 重建请求头，导致：
1. User-Agent 丢失，被 Cloudflare 拦截
2. 请求过滤器/供应商过滤器对 header 的修改不生效
3. 与其他供应商类型（Claude、OpenAI、Codex）行为不一致

## Solution

Changed Gemini branch to use header passthrough based on `session.headers` with unified filtering/override via `HeaderProcessor`:

1. **New `buildGeminiHeaders()` method**: Centralized header processing for Gemini providers
2. **Header passthrough**: Base headers on `session.headers` (includes filter modifications)
3. **Security**: Explicit blacklist to remove proxy authentication headers (`authorization`, `x-api-key`, `x-goog-api-key`) to prevent leaking proxy user keys to upstream
4. **User-Agent priority**:
   - First: Filter-modified `session.headers["user-agent"]`
   - Fallback: Original `session.userAgent`
   - Last resort: `"claude-code-hub"`
5. **Upstream authentication override**: Set `x-goog-api-key` (API key mode) or `Authorization: Bearer` (OAuth mode) for upstream

修改 Gemini 分支改为基于 `session.headers` 进行透传，使用 `HeaderProcessor` 统一过滤/覆盖：
1. 新增 `buildGeminiHeaders()` 方法统一处理 Gemini 供应商请求头
2. 请求头透传：基于 `session.headers`（包含过滤器修改）
3. 安全性：显式黑名单移除代理认证头避免泄露
4. User-Agent 优先级：过滤器 → 原始 → 兜底
5. 上游鉴权覆盖：根据模式设置正确的认证头

## Changes

### Core Changes (src/app/v1/_lib/proxy/forwarder.ts)

- **Removed** hardcoded `new Headers()` logic in Gemini forwarding branch (lines 851-872)
- **Added** `buildGeminiHeaders()` private method (+51 lines):
  - Implements header passthrough with `HeaderProcessor`
  - Explicit authentication header blacklist for security
  - User-agent resolution with 3-tier fallback
  - Support for `preserveClientIp` (X-Forwarded-For, X-Real-IP)
  - Gemini-CLI specific headers (`x-goog-api-client`)

### Test Coverage (tests/unit/proxy/proxy-forwarder.test.ts)

Added 5 comprehensive test cases for `buildGeminiHeaders()` (+163 lines):

1. ✅ User-agent passthrough with upstream authentication override (API key mode)
2. ✅ Request filter modifications to user-agent are respected
3. ✅ Fallback to original `userAgent` when filter deletes user-agent
4. ✅ OAuth mode uses `Authorization: Bearer` and removes `x-goog-api-key`
5. ✅ Gemini-CLI injects `x-goog-api-client` header

## Breaking Changes

None. This is a bug fix that aligns Gemini provider behavior with other provider types.

## Testing

### Automated Tests

- ✅ Unit tests added (5 new tests for header passthrough)
- ✅ bun run test
- ✅ bun run typecheck
- ✅ bun run lint
- ✅ bun run build

### Manual Testing Needed

To verify the fix for #515:

1. Configure a Gemini provider with a custom request filter that sets `user-agent`
2. Send a request through the proxy
3. Verify Cloudflare does not block the request
4. Check session details to confirm user-agent is present and matches filter settings

## Architecture Note

This PR applies the same header modification tracking pattern introduced in #465 (for Codex) to Gemini providers, ensuring consistent header handling across all provider types:

- **Codex**: Uses `buildHeaders()` with modification tracking (#465)
- **Claude/OpenAI**: Uses `buildHeaders()` with `HeaderProcessor`
- **Gemini**: Now uses `buildGeminiHeaders()` with same `HeaderProcessor` pattern ✨

## Checklist

- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally (5 new unit tests)
- [x] No documentation changes needed (internal fix)
- [x] Security: Proxy authentication headers properly blacklisted

---

🤖 *Description enhanced by Claude AI*
