### PR TITLE
test(models): 为 /v1/models 端点添加单元测试

### DIFF
--- a/src/app/v1/_lib/models/available-models.ts
+++ b/src/app/v1/_lib/models/available-models.ts
@@ -10,7 +10,7 @@ import { ProxyProviderResolver } from "../proxy/provider-selector";
 
 type ResponseFormat = "openai" | "anthropic" | "gemini" | "codex";
 
-interface FetchedModel {
+export interface FetchedModel {
   id: string;
   displayName?: string;
   createdAt?: string;
@@ -125,7 +125,7 @@ function mapResponseFormatToClientFormat(format: ResponseFormat): ClientFormat {
 /**
  * 根据模型 ID 推断所有者
  */
-function inferOwner(modelId: string): string {
+export function inferOwner(modelId: string): string {
   if (modelId.startsWith("claude-")) return "anthropic";
   if (modelId.startsWith("gpt-") || modelId.startsWith("o1") || modelId.startsWith("o3"))
     return "openai";
@@ -256,7 +256,7 @@ async function fetchModelsFromProvider(provider: Provider): Promise<FetchedModel
 /**
  * 根据客户端格式获取需要决策的 providerType 列表
  */
-function getProviderTypesForFormat(clientFormat: ClientFormat): Provider["providerType"][] {
+export function getProviderTypesForFormat(clientFormat: ClientFormat): Provider["providerType"][] {
   switch (clientFormat) {
     case "claude":
       return ["claude", "claude-auth"];
@@ -298,7 +298,7 @@ async function getAvailableModels(
 /**
  * 格式化为 OpenAI 响应
  */
-function formatOpenAIResponse(models: FetchedModel[]): object {
+export function formatOpenAIResponse(models: FetchedModel[]): object {
   const now = Math.floor(Date.now() / 1000);
   const data = models.map((m) => ({
     id: m.id,
@@ -313,7 +313,7 @@ function formatOpenAIResponse(models: FetchedModel[]): object {
 /**
  * 格式化为 Anthropic 响应
  */
-function formatAnthropicResponse(models: FetchedModel[]): object {
+export function formatAnthropicResponse(models: FetchedModel[]): object {
   const now = new Date().toISOString();
   const data = models.map((m) => ({
     id: m.id,
@@ -328,7 +328,7 @@ function formatAnthropicResponse(models: FetchedModel[]): object {
 /**
  * 格式化为 Gemini 响应
  */
-function formatGeminiResponse(models: FetchedModel[]): object {
+export function formatGeminiResponse(models: FetchedModel[]): object {
   const geminiModels = models.map((m) => ({
     name: `models/${m.id}`,
     displayName: m.displayName || m.id,

--- a/tests/unit/proxy/available-models.test.ts
+++ b/tests/unit/proxy/available-models.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test } from "vitest";
+import {
+  formatAnthropicResponse,
+  formatGeminiResponse,
+  formatOpenAIResponse,
+  getProviderTypesForFormat,
+  inferOwner,
+  type FetchedModel,
+} from "@/app/v1/_lib/models/available-models";
+
+describe("inferOwner - 根据模型 ID 推断所有者", () => {
+  describe("Anthropic 模型", () => {
+    test("claude-* 模型应返回 anthropic", () => {
+      expect(inferOwner("claude-3-opus-20240229")).toBe("anthropic");
+      expect(inferOwner("claude-3-sonnet-20240229")).toBe("anthropic");
+      expect(inferOwner("claude-3-haiku-20240307")).toBe("anthropic");
+      expect(inferOwner("claude-2.1")).toBe("anthropic");
+      expect(inferOwner("claude-instant-1.2")).toBe("anthropic");
+    });
+  });
+
+  describe("OpenAI 模型", () => {
+    test("gpt-* 模型应返回 openai", () => {
+      expect(inferOwner("gpt-4")).toBe("openai");
+      expect(inferOwner("gpt-4-turbo")).toBe("openai");
+      expect(inferOwner("gpt-3.5-turbo")).toBe("openai");
+      expect(inferOwner("gpt-4o")).toBe("openai");
+    });
+
+    test("o1* 模型应返回 openai", () => {
+      expect(inferOwner("o1-preview")).toBe("openai");
+      expect(inferOwner("o1-mini")).toBe("openai");
+      expect(inferOwner("o1")).toBe("openai");
+    });
+
+    test("o3* 模型应返回 openai", () => {
+      expect(inferOwner("o3-mini")).toBe("openai");
+      expect(inferOwner("o3")).toBe("openai");
+    });
+  });
+
+  describe("Google 模型", () => {
+    test("gemini-* 模型应返回 google", () => {
+      expect(inferOwner("gemini-pro")).toBe("google");
+      expect(inferOwner("gemini-1.5-pro")).toBe("google");
+      expect(inferOwner("gemini-1.5-flash")).toBe("google");
+      expect(inferOwner("gemini-2.0-flash-exp")).toBe("google");
+    });
+  });
+
+  describe("DeepSeek 模型", () => {
+    test("deepseek* 模型应返回 deepseek", () => {
+      expect(inferOwner("deepseek-chat")).toBe("deepseek");
+      expect(inferOwner("deepseek-coder")).toBe("deepseek");
+      expect(inferOwner("deepseek-v3")).toBe("deepseek");
+    });
+  });
+
+  describe("Alibaba 模型", () => {
+    test("qwen* 模型应返回 alibaba", () => {
+      expect(inferOwner("qwen-turbo")).toBe("alibaba");
+      expect(inferOwner("qwen-plus")).toBe("alibaba");
+      expect(inferOwner("qwen-max")).toBe("alibaba");
+    });
+  });
+
+  describe("未知模型", () => {
+    test("无法识别的模型应返回 unknown", () => {
+      expect(inferOwner("llama-2-70b")).toBe("unknown");
+      expect(inferOwner("mistral-7b")).toBe("unknown");
+      expect(inferOwner("custom-model")).toBe("unknown");
+    });
+  });
+});
+
+describe("getProviderTypesForFormat - 客户端格式到 Provider 类型映射", () => {
+  test("claude 格式应返回 claude 和 claude-auth 类型", () => {
+    expect(getProviderTypesForFormat("claude")).toEqual(["claude", "claude-auth"]);
+  });
+
+  test("openai 格式应返回 codex 和 openai-compatible 类型", () => {
+    expect(getProviderTypesForFormat("openai")).toEqual(["codex", "openai-compatible"]);
+  });
+
+  test("gemini 格式应返回 gemini 和 gemini-cli 类型", () => {
+    expect(getProviderTypesForFormat("gemini")).toEqual(["gemini", "gemini-cli"]);
+  });
+
+  test("gemini-cli 格式应返回 gemini 和 gemini-cli 类型", () => {
+    expect(getProviderTypesForFormat("gemini-cli")).toEqual(["gemini", "gemini-cli"]);
+  });
+
+  test("response 格式应仅返回 codex 类型", () => {
+    expect(getProviderTypesForFormat("response")).toEqual(["codex"]);
+  });
+});
+
+describe("formatOpenAIResponse - OpenAI 格式响应", () => {
+  test("空模型列表应返回空 data 数组", () => {
+    const result = formatOpenAIResponse([]) as { object: string; data: unknown[] };
+    expect(result.object).toBe("list");
+    expect(result.data).toEqual([]);
+  });
+
+  test("应正确格式化模型列表", () => {
+    const models: FetchedModel[] = [
+      { id: "gpt-4" },
+      { id: "claude-3-opus-20240229" },
+      { id: "gemini-pro" },
+    ];
+
+    const result = formatOpenAIResponse(models) as {
+      object: string;
+      data: Array<{ id: string; object: string; created: number; owned_by: string }>;
+    };
+
+    expect(result.object).toBe("list");
+    expect(result.data).toHaveLength(3);
+
+    expect(result.data[0].id).toBe("gpt-4");
+    expect(result.data[0].object).toBe("model");
+    expect(result.data[0].owned_by).toBe("openai");
+    expect(typeof result.data[0].created).toBe("number");
+
+    expect(result.data[1].id).toBe("claude-3-opus-20240229");
+    expect(result.data[1].owned_by).toBe("anthropic");
+
+    expect(result.data[2].id).toBe("gemini-pro");
+    expect(result.data[2].owned_by).toBe("google");
+  });
+
+  test("created 时间戳应为当前时间（秒）", () => {
+    const before = Math.floor(Date.now() / 1000);
+    const result = formatOpenAIResponse([{ id: "test" }]) as {
+      data: Array<{ created: number }>;
+    };
+    const after = Math.floor(Date.now() / 1000);
+
+    expect(result.data[0].created).toBeGreaterThanOrEqual(before);
+    expect(result.data[0].created).toBeLessThanOrEqual(after);
+  });
+});
+
+describe("formatAnthropicResponse - Anthropic 格式响应", () => {
+  test("空模型列表应返回空 data 数组", () => {
+    const result = formatAnthropicResponse([]) as { data: unknown[]; has_more: boolean };
+    expect(result.data).toEqual([]);
+    expect(result.has_more).toBe(false);
+  });
+
+  test("应正确格式化模型列表", () => {
+    const models: FetchedModel[] = [
+      { id: "claude-3-opus-20240229", displayName: "Claude 3 Opus", createdAt: "2024-02-29T00:00:00Z" },
+      { id: "claude-3-sonnet-20240229" },
+    ];
+
+    const result = formatAnthropicResponse(models) as {
+      data: Array<{ id: string; type: string; display_name: string; created_at: string }>;
+      has_more: boolean;
+    };
+
+    expect(result.has_more).toBe(false);
+    expect(result.data).toHaveLength(2);
+
+    expect(result.data[0].id).toBe("claude-3-opus-20240229");
+    expect(result.data[0].type).toBe("model");
+    expect(result.data[0].display_name).toBe("Claude 3 Opus");
+    expect(result.data[0].created_at).toBe("2024-02-29T00:00:00Z");
+
+    expect(result.data[1].id).toBe("claude-3-sonnet-20240229");
+    expect(result.data[1].display_name).toBe("claude-3-sonnet-20240229");
+    expect(result.data[1].created_at).toBeDefined();
+  });
+
+  test("缺少 displayName 时应使用 id 作为 display_name", () => {
+    const result = formatAnthropicResponse([{ id: "test-model" }]) as {
+      data: Array<{ display_name: string }>;
+    };
+    expect(result.data[0].display_name).toBe("test-model");
+  });
+});
+
+describe("formatGeminiResponse - Gemini 格式响应", () => {
+  test("空模型列表应返回空 models 数组", () => {
+    const result = formatGeminiResponse([]) as { models: unknown[] };
+    expect(result.models).toEqual([]);
+  });
+
+  test("应正确格式化模型列表", () => {
+    const models: FetchedModel[] = [
+      { id: "gemini-pro", displayName: "Gemini Pro" },
+      { id: "gemini-1.5-flash" },
+    ];
+
+    const result = formatGeminiResponse(models) as {
+      models: Array<{
+        name: string;
+        displayName: string;
+        supportedGenerationMethods: string[];
+      }>;
+    };
+
+    expect(result.models).toHaveLength(2);
+
+    expect(result.models[0].name).toBe("models/gemini-pro");
+    expect(result.models[0].displayName).toBe("Gemini Pro");
+    expect(result.models[0].supportedGenerationMethods).toEqual(["generateContent"]);
+
+    expect(result.models[1].name).toBe("models/gemini-1.5-flash");
+    expect(result.models[1].displayName).toBe("gemini-1.5-flash");
+  });
+
+  test("模型名称应添加 models/ 前缀", () => {
+    const result = formatGeminiResponse([{ id: "test-model" }]) as {
+      models: Array<{ name: string }>;
+    };
+    expect(result.models[0].name).toBe("models/test-model");
+  });
+
+  test("缺少 displayName 时应使用 id", () => {
+    const result = formatGeminiResponse([{ id: "test-model" }]) as {
+      models: Array<{ displayName: string }>;
+    };
+    expect(result.models[0].displayName).toBe("test-model");
+  });
+});


### PR DESCRIPTION
## 概述

为 PR #517 引入的模型列表功能补充单元测试。

## 测试覆盖

| 函数 | 测试数 | 说明 |
|------|--------|------|
| `inferOwner` | 8 | 模型所有者推断（Anthropic/OpenAI/Google/DeepSeek/Alibaba/未知） |
| `getProviderTypesForFormat` | 5 | 客户端格式到 Provider 类型映射 |
| `formatOpenAIResponse` | 3 | OpenAI 格式响应 |
| `formatAnthropicResponse` | 3 | Anthropic 格式响应 |
| `formatGeminiResponse` | 4 | Gemini 格式响应 |

**共 23 个测试用例，全部通过。**

## 变更内容

- **`src/app/v1/_lib/models/available-models.ts`**: 导出纯函数以便测试
- **`tests/unit/proxy/available-models.test.ts`**: 新增测试文件

## 测试结果

```
✓ tests/unit/proxy/available-models.test.ts (23 tests)
Test Files  1 passed (1)
Tests       23 passed (23)
```

## 关联

Related to #517

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds comprehensive unit tests for the `/v1/models` endpoint functionality introduced in PR #517. The PR exports 5 pure functions from `available-models.ts` to enable testing and creates 23 test cases covering:

- **Model owner inference** (8 tests): Validates identification of Anthropic, OpenAI, Google, DeepSeek, Alibaba models, plus unknown fallback
- **Provider type mapping** (5 tests): Verifies correct mapping from client formats to provider types
- **Response formatting** (10 tests): Tests OpenAI, Anthropic, and Gemini response formatting with various edge cases

All changes are purely additive - the main file only adds `export` keywords to existing functions without modifying logic. Test coverage is thorough with proper edge case handling (empty arrays, missing optional fields, timestamp validation).

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk - it only adds test coverage without modifying production logic
- Score reflects that this is a pure testing PR with zero changes to production code logic. Only `export` keywords were added to enable unit testing. All 23 tests are well-structured with proper edge case coverage and no security or logical concerns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/unit/proxy/available-models.test.ts | Adds comprehensive unit tests (23 cases) covering model inference, format mapping, and response formatting |
| src/app/v1/_lib/models/available-models.ts | Exports pure functions (`inferOwner`, `formatOpenAIResponse`, etc.) for unit testing, no logic changes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Suite
    participant Module as available-models.ts
    
    Note over Test,Module: Test Execution Flow
    
    Test->>Module: inferOwner(modelId)
    Module-->>Test: Return owner (anthropic/openai/google/etc.)
    
    Test->>Module: getProviderTypesForFormat(clientFormat)
    Module-->>Test: Return providerTypes array
    
    Test->>Module: formatOpenAIResponse(models)
    Module-->>Test: Return OpenAI format {object, data}
    
    Test->>Module: formatAnthropicResponse(models)
    Module-->>Test: Return Anthropic format {data, has_more}
    
    Test->>Module: formatGeminiResponse(models)
    Module-->>Test: Return Gemini format {models}
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->