### PR TITLE
fix: 修复 CodeRabbit webhook 反馈

### DIFF
--- a/messages/en/settings.json
+++ b/messages/en/settings.json
@@ -429,6 +429,11 @@
     "dingtalkSecretPlaceholder": "Optional, used for signing",
     "customHeaders": "Custom Headers (JSON)",
     "customHeadersPlaceholder": "{\"X-Token\":\"...\"}",
+    "errors": {
+      "headersInvalidJson": "Headers must be valid JSON",
+      "headersMustBeObject": "Headers must be a JSON object",
+      "headersValueMustBeString": "Header values must be strings"
+    },
     "types": {
       "wechat": "WeCom",
       "feishu": "Feishu",

--- a/messages/ja/settings.json
+++ b/messages/ja/settings.json
@@ -420,6 +420,11 @@
     "dingtalkSecretPlaceholder": "任意（署名用）",
     "customHeaders": "カスタムヘッダー（JSON）",
     "customHeadersPlaceholder": "{\"X-Token\":\"...\"}",
+    "errors": {
+      "headersInvalidJson": "Headers は有効な JSON である必要があります",
+      "headersMustBeObject": "Headers は JSON オブジェクトである必要があります",
+      "headersValueMustBeString": "Headers の値は文字列である必要があります"
+    },
     "types": {
       "wechat": "WeCom",
       "feishu": "Feishu",

--- a/messages/ru/settings.json
+++ b/messages/ru/settings.json
@@ -420,6 +420,11 @@
     "dingtalkSecretPlaceholder": "Необязательно, для подписи",
     "customHeaders": "Пользовательские заголовки (JSON)",
     "customHeadersPlaceholder": "{\"X-Token\":\"...\"}",
+    "errors": {
+      "headersInvalidJson": "Заголовки должны быть корректным JSON",
+      "headersMustBeObject": "Заголовки должны быть JSON-объектом",
+      "headersValueMustBeString": "Значения заголовков должны быть строками"
+    },
     "types": {
       "wechat": "WeCom",
       "feishu": "Feishu",

--- a/messages/zh-CN/settings.json
+++ b/messages/zh-CN/settings.json
@@ -1678,6 +1678,11 @@
     "dingtalkSecretPlaceholder": "可选，用于签名",
     "customHeaders": "自定义 Headers（JSON）",
     "customHeadersPlaceholder": "{\"X-Token\":\"...\"}",
+    "errors": {
+      "headersInvalidJson": "Headers 不是有效 JSON",
+      "headersMustBeObject": "Headers 必须是 JSON 对象",
+      "headersValueMustBeString": "Headers 的值必须为字符串"
+    },
     "types": {
       "wechat": "企业微信",
       "feishu": "飞书",

--- a/messages/zh-TW/settings.json
+++ b/messages/zh-TW/settings.json
@@ -420,6 +420,11 @@
     "dingtalkSecretPlaceholder": "可選，用於簽名",
     "customHeaders": "自訂 Headers（JSON）",
     "customHeadersPlaceholder": "{\"X-Token\":\"...\"}",
+    "errors": {
+      "headersInvalidJson": "Headers 不是有效 JSON",
+      "headersMustBeObject": "Headers 必須是 JSON 物件",
+      "headersValueMustBeString": "Headers 的值必須為字串"
+    },
     "types": {
       "wechat": "企業微信",
       "feishu": "飛書",

--- a/src/actions/notifications.ts
+++ b/src/actions/notifications.ts
@@ -11,6 +11,7 @@ import {
   type UpdateNotificationSettingsInput,
   updateNotificationSettings,
 } from "@/repository/notifications";
+import type { ActionResult } from "./types";
 
 /**
  * 获取通知设置
@@ -28,11 +29,11 @@ export async function getNotificationSettingsAction(): Promise<NotificationSetti
  */
 export async function updateNotificationSettingsAction(
   payload: UpdateNotificationSettingsInput
-): Promise<{ success: boolean; data?: NotificationSettings; error?: string }> {
+): Promise<ActionResult<NotificationSettings>> {
   try {
     const session = await getSession();
     if (!session || session.user.role !== "admin") {
-      return { success: false, error: "无权限执行此操作" };
+      return { ok: false, error: "无权限执行此操作" };
     }
 
     const updated = await updateNotificationSettings(payload);
@@ -50,10 +51,10 @@ export async function updateNotificationSettingsAction(
       });
     }
 
-    return { success: true, data: updated };
+    return { ok: true, data: updated };
   } catch (error) {
     return {
-      success: false,
+      ok: false,
       error: error instanceof Error ? error.message : "更新通知设置失败",
     };
   }

--- a/src/app/[locale]/dashboard/_components/webhook-migration-dialog.tsx
+++ b/src/app/[locale]/dashboard/_components/webhook-migration-dialog.tsx
@@ -22,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { logger } from "@/lib/logger";
 import { setOnboardingCompleted, shouldShowOnboarding } from "@/lib/onboarding";
 import { cn } from "@/lib/utils";
 import {
@@ -135,7 +136,7 @@ export function WebhookMigrationDialog() {
         }
       } catch (error) {
         // Don't block user if settings fetch fails, but log for debugging
-        console.warn("[WebhookMigrationDialog] Failed to load notification settings:", error);
+        logger.warn("[WebhookMigrationDialog] Failed to load notification settings", { error });
       }
     };
 

--- a/src/app/api/actions/[...route]/route.ts
+++ b/src/app/api/actions/[...route]/route.ts
@@ -791,12 +791,7 @@ const { route: updateNotificationSettingsRoute, handler: updateNotificationSetti
   createActionRoute(
     "notifications",
     "updateNotificationSettingsAction",
-    async (payload) => {
-      const result = await notificationActions.updateNotificationSettingsAction(payload);
-      return result.success
-        ? { ok: true, data: result.data }
-        : { ok: false, error: result.error || "更新通知设置失败" };
-    },
+    notificationActions.updateNotificationSettingsAction,
     {
       requestSchema: z.object({
         enabled: z.boolean().optional().describe("通知总开关"),
@@ -909,7 +904,10 @@ const WebhookTargetCreateSchema = z.object({
   telegramBotToken: z.string().trim().optional().nullable(),
   telegramChatId: z.string().trim().optional().nullable(),
   dingtalkSecret: z.string().trim().optional().nullable(),
-  customTemplate: z.string().trim().optional().nullable(),
+  customTemplate: z
+    .union([z.string().trim(), z.record(z.string(), z.unknown())])
+    .optional()
+    .nullable(),
   customHeaders: z.record(z.string(), z.string()).optional().nullable(),
   proxyUrl: z.string().trim().optional().nullable(),
   proxyFallbackToDirect: z.boolean().optional(),

--- a/tests/unit/actions/internal-url-allowed.test.ts
+++ b/tests/unit/actions/internal-url-allowed.test.ts
@@ -37,6 +37,7 @@ describe("允许内网地址输入", () => {
   });
 
   test("testWebhookAction 不阻止内网 URL（但会因 hostname 不支持而失败）", async () => {
+    // 该用例验证：输入层允许内网 IP（不会被拦截），但 provider 检测会因 hostname 不受支持而失败
     const { testWebhookAction } = await import("@/actions/notifications");
     const result = await testWebhookAction("http://127.0.0.1:8080/webhook", "cost-alert");
 


### PR DESCRIPTION
## Summary

This PR addresses code quality feedback from CodeRabbit reviews on recent webhook-related PRs, focusing on type safety, i18n consistency, and test documentation.

**Related PRs:**
- Follow-up to #506 - Fixes issues identified in Webhook Onboarding Refactor
- Follow-up to #505 - Fixes issues identified in Enhanced Webhook System
- Related to #485 - Custom Webhook notification feature (completed in #505)

---

## Problem

CodeRabbit identified several code quality and consistency issues in the recent webhook feature implementation:

1. **Inconsistent logging** - Dashboard migration dialog used `console.warn` instead of unified logger
2. **Missing i18n** - Webhook target dialog showed hardcoded error messages instead of translation keys
3. **Type safety issues** - Notification settings action used `as any` and inconsistent return types
4. **Type mismatch** - `customTemplate` had frontend/backend type inconsistency (string vs Record)
5. **Missing test comments** - Unit test intent not clearly documented

---

## Solution

### Fixes Applied

| Issue | Fix | Files Changed |
|-------|-----|---------------|
| Console logging | Replace `console.warn` with unified `logger.warn()` | `webhook-migration-dialog.tsx` |
| Hardcoded errors | Convert to i18n keys, add translations for 5 languages | `webhook-target-dialog.tsx`, `messages/*/settings.json` |
| Type assertions | Remove `as any`, unify `updateNotificationSettingsAction` to return `ActionResult<T>` | `notifications.ts`, `route.ts`, `hooks.ts` |
| Type consistency | Make `customTemplate` accept both `string \| Record<string, unknown>` in server action | `webhook-targets.ts`, `route.ts` |
| Test documentation | Add comment explaining test intent | `internal-url-allowed.test.ts` |

### New i18n Keys

Added to all 5 locales (en/ja/ru/zh-CN/zh-TW):

```json
"notifications.targetDialog.errors": {
  "headersInvalidJson": "Headers must be valid JSON",
  "headersMustBeObject": "Headers must be a JSON object",
  "headersValueMustBeString": "Header values must be strings"
}
```

### Type Safety Improvements

**Before**:
```typescript
// Inconsistent return type
return { success: true, data: result };

// Type assertion
await updateNotificationSettingsAction(payload as any);
```

**After**:
```typescript
// Unified ActionResult<T>
return { ok: true, data: result };

// Properly typed payload
const payload: UpdatePayload = { ... };
await updateNotificationSettingsAction(payload);
```

---

## Changes

### Core Changes
- `src/actions/notifications.ts` - Unify return type to `ActionResult<NotificationSettings>`
- `src/actions/webhook-targets.ts` - Support both string and object for `customTemplate`
- `src/app/[locale]/settings/notifications/_lib/hooks.ts` - Remove `as any`, properly type all callbacks

### Supporting Changes
- `messages/*/settings.json` (5 files) - Add `errors` section for webhook target validation
- `src/app/[locale]/dashboard/_components/webhook-migration-dialog.tsx` - Use unified logger
- `src/app/[locale]/settings/notifications/_components/webhook-target-dialog.tsx` - Use i18n for errors
- `src/app/api/actions/[...route]/route.ts` - Update schema to accept `string | Record` for customTemplate
- `tests/unit/actions/internal-url-allowed.test.ts` - Add test intent comment

---

## Testing

### Validation

```bash
✅ bun run lint          # Biome checks passed
✅ bun run typecheck     # TypeScript checks passed
✅ bun run test          # All tests passed
✅ bun run build         # Production build successful
✅ bun run test --coverage  # Coverage improved
```

### Coverage Improvement

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Statements | 64.97% | 65.03% | +0.06% |
| Branches | 51.00% | 51.14% | +0.14% |
| Functions | 59.80% | 59.95% | +0.15% |
| Lines | 65.81% | 65.88% | +0.07% |

---

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] i18n translations complete (5 languages)
- [x] Type safety improved (removed `as any`)
- [x] Coverage maintained/improved

---

## Original Description (Chinese)

修复点：
- dashboard webhook 迁移弹窗：使用统一 logger（替换 console.warn）。
- Webhook 目标弹窗：Headers 解析错误改为 i18n key，并补齐 5 语言翻译。
- 通知设置 hooks：统一 updateNotificationSettingsAction 返回 ActionResult（ok/data/error），移除 as any 与多处类型断言。
- Webhook target：customTemplate 在前后端统一为 JSON 对象（Record），server action 兼容 string/object 两种输入。
- 单测：按建议补充用例意图注释。

验证：bun run lint/typecheck/test/build/test --coverage
覆盖率：All files（Stmts/Branch/Funcs/Lines）由 64.97/51.00/59.80/65.81 提升到 65.03/51.14/59.95/65.88

---
*Description enhanced by Claude AI*