### PR TITLE
fix: Key 清除到期时间序列化更稳

### DIFF
--- a/src/app/[locale]/dashboard/_components/user/forms/edit-key-form.tsx
+++ b/src/app/[locale]/dashboard/_components/user/forms/edit-key-form.tsx
@@ -103,7 +103,8 @@ export function EditKeyForm({ keyData, user, isAdmin = false, onSuccess }: EditK
         try {
           const res = await editKey(keyData.id, {
             name: data.name,
-            expiresAt: data.expiresAt || undefined,
+            // 重要：清除到期时间时用空字符串表达，避免 undefined 在 Server Action 序列化时被丢弃
+            expiresAt: data.expiresAt ?? "",
             canLoginWebUi: data.canLoginWebUi,
             cacheTtlPreference: data.cacheTtlPreference,
             limit5hUsd: data.limit5hUsd,

--- a/src/app/[locale]/dashboard/_components/user/unified-edit-dialog.tsx
+++ b/src/app/[locale]/dashboard/_components/user/unified-edit-dialog.tsx
@@ -442,7 +442,8 @@ function UnifiedEditDialogInner({
                 const keyRes = await addKey({
                   userId: user.id,
                   name: key.name,
-                  expiresAt: key.expiresAt || undefined,
+                  // 重要：清除到期时间时用空字符串表达，避免 undefined 在 Server Action 序列化时被丢弃
+                  expiresAt: key.expiresAt ?? "",
                   isEnabled: key.isEnabled,
                   canLoginWebUi: key.canLoginWebUi,
                   providerGroup: normalizeProviderGroup(key.providerGroup),
@@ -466,7 +467,8 @@ function UnifiedEditDialogInner({
                 // Existing key - edit it
                 const keyRes = await editKey(key.id, {
                   name: key.name,
-                  expiresAt: key.expiresAt || undefined,
+                  // 重要：清除到期时间时用空字符串表达，避免 undefined 在 Server Action 序列化时被丢弃
+                  expiresAt: key.expiresAt ?? "",
                   canLoginWebUi: key.canLoginWebUi,
                   isEnabled: key.isEnabled,
                   providerGroup: normalizeProviderGroup(key.providerGroup),

--- a/tests/unit/actions/keys-edit-key-expires-at-clear.test.ts
+++ b/tests/unit/actions/keys-edit-key-expires-at-clear.test.ts
@@ -120,6 +120,21 @@ describe("editKey: expiresAt 清除/不更新语义", () => {
     );
   });
 
+  test('携带 expiresAt="" 时应清除 expires_at（写入 null）', async () => {
+    const { editKey } = await import("@/actions/keys");
+
+    const res = await editKey(1, { name: "k2", expiresAt: "" });
+
+    expect(res.ok).toBe(true);
+    expect(updateKeyMock).toHaveBeenCalledTimes(1);
+    expect(updateKeyMock).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        expires_at: null,
+      })
+    );
+  });
+
   test("携带 expiresAt=YYYY-MM-DD 时应写入对应 Date", async () => {
     const { editKey } = await import("@/actions/keys");
 

--- a/tests/unit/dashboard/edit-key-form-expiry-clear-ui.test.tsx
+++ b/tests/unit/dashboard/edit-key-form-expiry-clear-ui.test.tsx
@@ -129,7 +129,7 @@ describe("EditKeyForm: 清除 expiresAt 后应携带 expiresAt 字段提交（�
     expect(keysActionMocks.editKey).toHaveBeenCalledTimes(1);
     const [, payload] = keysActionMocks.editKey.mock.calls[0] as [number, any];
 
-    // 关键点：必须显式携带 expiresAt 字段（即使为 undefined），后端才会识别为“清除”
+    // 关键点：必须显式携带 expiresAt 字段（清除时通常为 ""），后端才会识别为“清除”
     expect(Object.hasOwn(payload, "expiresAt")).toBe(true);
 
     unmount();


### PR DESCRIPTION
## Summary

Improves the robustness of clearing Key expiration dates by using empty string `""` instead of `undefined` for the clear semantic on the frontend.

改进清除密钥到期时间的稳定性，前端使用空字符串 `""` 代替 `undefined` 来传递"清除"语义。

## Problem

After PR #533 fixed the backend to properly handle expiration date clearing, a potential edge case remained: when clearing a Key's expiration date, the frontend used `undefined` to represent "clear". However, `undefined` fields may be dropped during Next.js Server Action serialization across the client/server boundary, causing the backend to potentially not recognize the clear intent.

**Follow-up to:**
- PR #533 - Fixed the core issue of expiration dates not persisting after clear

## Solution

Changed the frontend to use empty string `""` instead of `undefined` when clearing expiration dates:

1. **edit-key-form.tsx**: Changed `data.expiresAt || undefined` to `data.expiresAt ?? ""`
2. **unified-edit-dialog.tsx**: Same change for both `addKey` and `editKey` calls

The KeyFormSchema already handles empty string → undefined conversion via `preprocess`, so this change ensures the field is always present in the serialized payload while maintaining the same backend behavior.

## Changes

### Core Changes
- `src/app/[locale]/dashboard/_components/user/forms/edit-key-form.tsx` (+2/-1): Use empty string for clear semantic
- `src/app/[locale]/dashboard/_components/user/unified-edit-dialog.tsx` (+4/-2): Same change for add/edit key operations

### Test Updates
- `tests/unit/actions/keys-edit-key-expires-at-clear.test.ts` (+15/-0): Added test case for `expiresAt=""` clear semantic
- `tests/unit/dashboard/edit-key-form-expiry-clear-ui.test.tsx` (+1/-1): Updated comment to reflect new behavior

## Testing

### Automated Tests
- [x] Unit test added for `expiresAt=""` case
- [x] Existing test comments updated

### Local Verification
All checks passed:
```bash
bun run lint && bun run typecheck && bun run test && bun run test:coverage && bun run build
```

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] Builds successfully

---
*Description enhanced by Claude AI*