### PR TITLE
Fix #542: Correct Codex model configuration from gpt-5.2-codex to gpt-5.2

### DIFF
--- a/src/app/[locale]/usage-doc/page.tsx
+++ b/src/app/[locale]/usage-doc/page.tsx
@@ -639,7 +639,7 @@ sk_xxxxxxxxxxxxxxxxxx`}
                 <CodeBlock
                   language="toml"
                   code={`model_provider = "cch"
-model = "gpt-5.2-codex"
+model = "gpt-5.2"
 model_reasoning_effort = "xhigh"
 disable_response_storage = true
 sandbox_mode = "workspace-write"
@@ -685,7 +685,7 @@ network_access = true`}
                 <CodeBlock
                   language="toml"
                   code={`model_provider = "cch"
-model = "gpt-5.2-codex"
+model = "gpt-5.2"
 model_reasoning_effort = "xhigh"
 disable_response_storage = true
 sandbox_mode = "workspace-write"


### PR DESCRIPTION
## Summary
Fixed incorrect Codex model name in usage documentation from `gpt-5.2-codex` to `gpt-5.2`.

## Problem
Fixes #542

The usage documentation showed an incorrect model configuration for Codex:
```toml
model = "gpt-5.2-codex"
```

This causes a 400 error:
```
错误: invalid_request_error: Unsupported value: 'high' is not supported with the 'gpt-5.2-codex' model. Supported values are: 'medium'.
```

**Related Issues:**
- Related to #541 - Error rule handling for the same Codex reasoning effort mismatch error
- Related to #544 - Companion PR adding error rule to detect this misconfiguration

**Note:** Issue #542 comment mentioned that CHANGELOG.md (line 359) already documents the correct model name as `gpt-5.2`, confirming this documentation fix aligns with the intended configuration.

## Solution
Changed the model name to the correct value:
```toml
model = "gpt-5.2"
```

## Changes

### Core Changes
- Updated `src/app/[locale]/usage-doc/page.tsx` to use `gpt-5.2` instead of `gpt-5.2-codex` in both the auth.json and env-var configuration examples (2 occurrences)

## Testing
- [x] Verified all instances of `gpt-5.2-codex` have been removed from usage documentation
- [x] Code changes are minimal and focused on documentation
- [x] No functional code changes

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Documentation accuracy verified

---
*Description enhanced by Claude AI*