### PR TITLE
Fix #541: Add error rule for Codex reasoning effort mismatch

### DIFF
--- a/src/repository/error-rules.ts
+++ b/src/repository/error-rules.ts
@@ -705,6 +705,24 @@ const DEFAULT_ERROR_RULES = [
       },
     },
   },
+  // Issue #541: Codex model reasoning effort mismatch
+  {
+    pattern: "Unsupported value.*is not supported with.*model.*Supported values",
+    category: "thinking_error",
+    description: "Reasoning effort (thinking intensity) not supported by the Codex model",
+    matchType: "regex" as const,
+    isDefault: true,
+    isEnabled: true,
+    priority: 72,
+    overrideResponse: {
+      type: "error",
+      error: {
+        type: "thinking_error",
+        message:
+          "当前思考强度不支持该模型，请调整 reasoning_effort 参数或切换模型（如 'high' 仅支持部分模型）",
+      },
+    },
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Adds a new default error rule to detect and handle Codex API errors when reasoning effort (思考强度) values are incompatible with the selected model
- When triggered, returns a user-friendly Chinese message explaining the issue and suggesting fixes

## Problem
Fixes #541

When using Codex type providers, if the `reasoning_effort` parameter (e.g., `high`) is not supported by the model (e.g., `gpt-5.2-codex` only supports `medium`), the API returns:

```
状态码: 400
错误: invalid_request_error: Unsupported value: 'high' is not supported with the 'gpt-5.2-codex' model. Supported values are: 'medium'.
```

Without an error rule, this cryptic error is passed directly to users.

## Solution
Added a new entry to `DEFAULT_ERROR_RULES` in `src/repository/error-rules.ts`:

- **Pattern**: `Unsupported value.*is not supported with.*model.*Supported values` (regex)
- **Category**: `thinking_error`
- **Priority**: 72 (consistent with other thinking-related errors)
- **Override Response**: 
  ```
  当前思考强度不支持该模型，请调整 reasoning_effort 参数或切换模型（如 'high' 仅支持部分模型）
  ```

## Changes
- `src/repository/error-rules.ts` - Added new error rule for Codex reasoning effort mismatch

## Testing
- [x] Verified regex pattern matches the error message format
- [x] TypeScript typecheck passes
- [x] Biome lint passes
- [x] Unit tests pass

---
*Created by Claude AI in response to @claude mention*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added default error rule to handle Codex API errors when `reasoning_effort` values are incompatible with the model. The rule matches the error pattern "Unsupported value.*is not supported with.*model.*Supported values" and returns a localized Chinese message guiding users to adjust the parameter or switch models. Implementation follows existing patterns with appropriate priority (72) consistent with other thinking-related errors.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change adds a single, well-defined error rule following established patterns. The regex pattern correctly matches the documented error format, priority is consistent with similar rules, and the implementation is isolated with no side effects
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/repository/error-rules.ts | Added new error rule for Codex reasoning effort mismatch with proper pattern, priority, and Chinese error message |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API Gateway
    participant ErrorDetector
    participant ErrorRules
    participant Codex Provider

    Client->>API Gateway: Request with reasoning_effort='high'
    API Gateway->>Codex Provider: Forward request (model=gpt-5.2-codex)
    Codex Provider-->>API Gateway: 400 Error: Unsupported value 'high'
    API Gateway->>ErrorDetector: Process error response
    ErrorDetector->>ErrorRules: Match error pattern
    ErrorRules-->>ErrorDetector: Rule matched (priority 72)
    ErrorDetector->>ErrorDetector: Apply override response
    ErrorDetector-->>Client: User-friendly message in Chinese
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->