### PR TITLE
fix: provider list not refreshing after adding new provider

### DIFF
--- a/src/app/[locale]/dashboard/providers/page.tsx
+++ b/src/app/[locale]/dashboard/providers/page.tsx
@@ -1,6 +1,5 @@
 import { BarChart3 } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { AddProviderDialog } from "@/app/[locale]/settings/providers/_components/add-provider-dialog";
 import { ProviderManagerLoader } from "@/app/[locale]/settings/providers/_components/provider-manager-loader";
 import { SchedulingRulesDialog } from "@/app/[locale]/settings/providers/_components/scheduling-rules-dialog";
 import { Section } from "@/components/section";
@@ -52,7 +51,6 @@ export default async function DashboardProvidersPage({
               </Link>
             </Button>
             <SchedulingRulesDialog />
-            <AddProviderDialog enableMultiProviderTypes={enableMultiProviderTypes} />
           </>
         }
       >

--- a/src/app/[locale]/settings/providers/_components/provider-manager-loader.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-manager-loader.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
-import type { ReactNode } from "react";
 import { getProviders, getProvidersHealthStatus } from "@/actions/providers";
 import type { CurrencyCode } from "@/lib/utils/currency";
 import type { ProviderDisplay } from "@/types/provider";
 import type { User } from "@/types/user";
+import { AddProviderDialog } from "./add-provider-dialog";
 import { ProviderManager } from "./provider-manager";
 
 type ProviderHealthStatus = Record<
@@ -39,13 +39,11 @@ async function fetchSystemSettings(): Promise<{ currencyDisplay: CurrencyCode }>
 interface ProviderManagerLoaderProps {
   currentUser?: User;
   enableMultiProviderTypes: boolean;
-  addDialogSlot?: ReactNode;
 }
 
 function ProviderManagerLoaderContent({
   currentUser,
   enableMultiProviderTypes,
-  addDialogSlot,
 }: ProviderManagerLoaderProps) {
   const {
     data: providers = [],
@@ -87,7 +85,7 @@ function ProviderManagerLoaderContent({
       enableMultiProviderTypes={enableMultiProviderTypes}
       loading={loading}
       refreshing={refreshing}
-      addDialogSlot={addDialogSlot}
+      addDialogSlot={<AddProviderDialog enableMultiProviderTypes={enableMultiProviderTypes} />}
     />
   );
 }

--- a/src/app/[locale]/settings/providers/page.tsx
+++ b/src/app/[locale]/settings/providers/page.tsx
@@ -6,7 +6,6 @@ import { Link } from "@/i18n/routing";
 import { getSession } from "@/lib/auth";
 import { getEnvConfig } from "@/lib/config/env.schema";
 import { SettingsPageHeader } from "../_components/settings-page-header";
-import { AddProviderDialog } from "./_components/add-provider-dialog";
 import { ProviderManagerLoader } from "./_components/provider-manager-loader";
 import { SchedulingRulesDialog } from "./_components/scheduling-rules-dialog";
 
@@ -41,7 +40,6 @@ export default async function SettingsProvidersPage() {
         <ProviderManagerLoader
           currentUser={session?.user}
           enableMultiProviderTypes={enableMultiProviderTypes}
-          addDialogSlot={<AddProviderDialog enableMultiProviderTypes={enableMultiProviderTypes} />}
         />
       </Section>
     </>


### PR DESCRIPTION
## Summary

- Fix provider list not refreshing after adding a new provider
- Move `AddProviderDialog` creation from Server Component to Client Component (`ProviderManagerLoaderContent`)
- Ensure `useQueryClient()` correctly accesses the `QueryClient` instance within `QueryClientProvider`

## Root Cause

`AddProviderDialog` was previously created in Server Components (`page.tsx`) and passed as a slot prop. Due to React Server/Client Component boundary handling, `useQueryClient()` could not correctly access the same `queryClient` instance, causing `invalidateQueries()` calls to fail to trigger data refetch.

## Changes

| File | Change |
|------|--------|
| `provider-manager-loader.tsx` | Create `AddProviderDialog` internally instead of receiving via prop |
| `settings/providers/page.tsx` | Remove `addDialogSlot` prop |
| `dashboard/providers/page.tsx` | Remove duplicate `AddProviderDialog` from `Section.actions` |

## Test plan

- [x] Add a new provider on `/settings/providers` page
- [x] Verify the provider list refreshes immediately after creation
- [x] Add a new provider on `/dashboard/providers` page
- [x] Verify the provider list refreshes immediately after creation
- [x] Verify only one "Add Provider" button appears on each page

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes the provider list not refreshing after adding a new provider by correctly managing React Server/Client Component boundaries. The root cause was that `AddProviderDialog` was being instantiated in Server Components and passed as a prop, which broke the `QueryClientProvider` context needed for `useQueryClient()` to work correctly.

**Changes Made:**
- Moved `AddProviderDialog` instantiation from Server Components (`page.tsx` files) into the Client Component `ProviderManagerLoaderContent`, which is wrapped by `QueryClientProvider`
- Removed the `addDialogSlot` prop from `ProviderManagerLoader` since the dialog is now created internally
- Eliminated duplicate `AddProviderDialog` instantiation in `/dashboard/providers`, ensuring a single source of truth for dialog management
- The dialog can now correctly call `queryClient.invalidateQueries()` on successful provider creation, triggering the expected data refetch

All changes follow proper Next.js App Router patterns by keeping query client operations within the Client Component boundary where `QueryClientProvider` is available.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with high confidence - it correctly addresses the React Server/Client boundary issue without introducing any side effects or regressions.
- Score of 5 is justified because: (1) The changes are surgical and focused on fixing a specific bug - moving component instantiation to the correct context boundary; (2) All three files maintain backward compatibility - the public API of `ProviderManagerLoader` is simplified but functional; (3) The fix directly addresses the root cause - `useQueryClient()` can now access the same `QueryClient` instance within the provider boundary; (4) No new dependencies or complex logic was introduced; (5) The pattern aligns with React and Next.js best practices for handling Client Components within Server Components.
- No files require special attention - all changes are minimal, focused, and correct.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/settings/providers/_components/provider-manager-loader.tsx | Correctly moved `AddProviderDialog` instantiation from Server Components into this Client Component. Now the dialog is created inside `QueryClientProvider`, ensuring `useQueryClient()` has access to the correct context instance. Removed `addDialogSlot` prop and imports. This fixes the core issue where query invalidation wasn't working. |
| src/app/[locale]/settings/providers/page.tsx | Correctly removed the `AddProviderDialog` import and `addDialogSlot` prop from `ProviderManagerLoader`. This Server Component no longer needs to instantiate the dialog. Changes align with the fix to move dialog creation to the Client Component boundary. |
| src/app/[locale]/dashboard/providers/page.tsx | Correctly removed duplicate `AddProviderDialog` import and instantiation from `Section.actions`. The dialog is now consistently managed only by `ProviderManagerLoader`, preventing duplicate buttons and ensuring a single source of truth for dialog state and query invalidation. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SC as Server Component<br/>(page.tsx)
    participant QCP as QueryClientProvider
    participant CC as ProviderManagerLoaderContent<br/>(Client Component)
    participant APD as AddProviderDialog<br/>(Client Component)
    participant QC as QueryClient

    rect rgb(200, 220, 255)
    Note over SC,QC: BEFORE FIX: AddProviderDialog created in Server Component
    SC->>SC: Create AddProviderDialog instance
    SC->>QCP: Pass addDialogSlot prop
    Note over APD: useQueryClient() fails - outside QueryClientProvider context
    end

    rect rgb(200, 255, 220)
    Note over SC,QC: AFTER FIX: AddProviderDialog created inside Client Component
    SC->>QCP: Render QueryClientProvider
    QCP->>CC: Render ProviderManagerLoaderContent
    CC->>APD: Create AddProviderDialog (inside QueryClientProvider context)
    APD->>QC: useQueryClient() now has access
    APD->>APD: onSuccess: invalidateQueries(['providers'])
    QC->>CC: Refetch data
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->