### PR TITLE
feat(error-rules): add Gemini non-streaming error rule

### DIFF
--- a/src/repository/error-rules.ts
+++ b/src/repository/error-rules.ts
@@ -302,8 +302,8 @@ const DEFAULT_ERROR_RULES = [
       error: {
         code: 400,
         status: "INVALID_ARGUMENT",
-        message: "当前中转站不支持 Gemini generateContent 端点"
-      }
+        message: "当前中转站不支持 Gemini generateContent 端点",
+      },
     },
   },
   {


### PR DESCRIPTION
部分服务商仅支持流式的 gemini 请求, 这种情况下需要返回 400 状态码, 以便 gemini 检测到 generateContent 不可用时, 自动切换到 streamGenerateContent

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds a new default error rule to handle Gemini API's non-streaming request limitation. The rule matches the error message "Missing or invalid 'alt' query parameter. Expected 'alt=sse'" and returns a 400 INVALID_ARGUMENT response, allowing clients to automatically fall back from the `generateContent` endpoint to `streamGenerateContent` for providers that only support streaming.

**Key Changes:**
- Added new error rule at priority 105 (highest priority) to handle Gemini non-streaming errors
- Uses substring matching for reliable pattern detection
- Returns properly formatted Gemini error response with HTTP 400 status code
- Includes Chinese user-friendly error message
- Integrates with existing error rule system without code changes to core logic

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified issues - it adds a configuration entry to an existing system with well-tested infrastructure.
- The change is minimal, non-invasive, and purely additive: it adds one new error rule to the DEFAULT_ERROR_RULES array. The rule follows the exact same pattern, format, and validation as the existing 30+ error rules already in the system. The error pattern is specific and precise (substring matching), reducing false positives. The priority (105) is intentionally highest to ensure this rule is checked first. The override response format is validated and matches the Gemini API error structure defined in the codebase. The sync mechanism automatically handles database persistence. No code changes were made to core logic, reducing regression risk. The feature directly addresses a real provider limitation with a well-documented solution.
- No files require special attention - the change is confined to adding a single configuration entry.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/repository/error-rules.ts | Added a new default error rule (priority 105) to handle Gemini non-streaming request errors. The rule matches the pattern "Missing or invalid 'alt' query parameter. Expected 'alt=sse'" using substring matching (contains), and returns a 400 INVALID_ARGUMENT error with Chinese error message. This enables automatic fallback from generateContent to streamGenerateContent for providers that only support streaming. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Client
    participant ProxyServer as Proxy Server
    participant Gemini as Gemini API
    participant ErrorDetector as Error Detector
    participant Repo as Error Rules Repo

    Client->>ProxyServer: Request to /v1/messages with model=gemini-*
    ProxyServer->>Gemini: Forward request to generateContent endpoint
    Gemini->>Gemini: Check if non-streaming request
    Gemini-->>ProxyServer: 400 Error: "Missing or invalid 'alt' query parameter. Expected 'alt=sse'"
    ProxyServer->>ErrorDetector: Detect error pattern
    ErrorDetector->>Repo: Load active error rules (priority 105 rule first)
    Repo-->>ErrorDetector: Return Gemini non-streaming rule
    ErrorDetector->>ErrorDetector: Match pattern using "contains" method
    ErrorDetector-->>ProxyServer: Match found with override response
    ProxyServer->>ProxyServer: Apply override: Return 400 with Gemini error format
    ProxyServer-->>Client: 400 INVALID_ARGUMENT response
    Client->>Client: Auto-retry with streamGenerateContent
    Client->>ProxyServer: Retry request with stream=true
    ProxyServer->>Gemini: Forward to streamGenerateContent endpoint
    Gemini-->>ProxyServer: 200 Streaming response
    ProxyServer-->>Client: Stream response back to client
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->