### PR TITLE
Fix #550: Add error rule for tool_use missing tool_result

### DIFF
--- a/src/repository/error-rules.ts
+++ b/src/repository/error-rules.ts
@@ -524,6 +524,25 @@ const DEFAULT_ERROR_RULES = [
       },
     },
   },
+  // Issue #550: tool_use block missing corresponding tool_result in next message (non-retryable)
+  {
+    pattern:
+      "tool_use.*ids were found without.*tool_result.*immediately after|tool_use.*block must have.*corresponding.*tool_result.*block in the next message",
+    category: "validation_error",
+    description: "tool_use block missing corresponding tool_result in next message (client error)",
+    matchType: "regex" as const,
+    isDefault: true,
+    isEnabled: true,
+    priority: 88,
+    overrideResponse: {
+      type: "error",
+      error: {
+        type: "validation_error",
+        message:
+          "tool_use 块缺少对应的 tool_result，请确保每个 tool_use 在下一条消息中有对应的 tool_result 块",
+      },
+    },
+  },
   // Model-related errors (non-retryable)
   {
     pattern: '"actualModel" is null|actualModel.*null',


### PR DESCRIPTION
## Summary
- Add new error rule to handle `tool_use` blocks missing corresponding `tool_result` in next message
- This is the reverse direction of the existing rule for `tool_result` missing `tool_use`

## Problem
Fixes #550

When a request contains a `tool_use` block without a corresponding `tool_result` in the immediately following message, Claude API returns:
```
`tool_use` ids were found without `tool_result` blocks immediately after: tooluse_xxx. 
Each `tool_use` block must have a corresponding `tool_result` block in the next message.
```

This error was not covered by existing rules, causing unnecessary retries and provider switching.

## Solution
Added a new regex error rule with pattern:
```
tool_use.*ids were found without.*tool_result.*immediately after|tool_use.*block must have.*corresponding.*tool_result.*block in the next message
```

This rule:
- Categorizes the error as `validation_error`
- Returns a user-friendly Chinese message explaining the issue
- Has priority 88 (same as other tool validation errors)
- Prevents retry/provider switching since this is a client-side error

## Changes
- `src/repository/error-rules.ts`: Added new error rule for Issue #550

## Testing
- [x] Verified regex pattern is valid
- [x] Tested pattern matches the actual error message from issue
- [ ] Auto-sync on startup will add this rule to database

---
*Created by Claude AI in response to @claude mention*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds a new error rule to handle validation errors when a `tool_use` block is missing its corresponding `tool_result` in the next message. The implementation is clean and follows the existing patterns in the codebase:

- **Pattern matching**: The regex pattern correctly matches both variations of the Claude API error message
- **Categorization**: Properly categorized as `validation_error` (non-retryable client error)
- **Priority**: Set to 88, matching the related `tool_result` validation rule on line 518
- **Message**: Provides clear Chinese error message explaining the issue
- **Placement**: Well-positioned alongside other tool validation rules (lines 423-526)

The implementation is consistent with the reverse error case (line 510-526) and properly prevents unnecessary retries for this client-side validation error.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no concerns
- The change is minimal, well-tested, and follows established patterns. The regex pattern correctly matches the error message from the issue, and the implementation is consistent with similar validation rules in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/repository/error-rules.ts | Added new error rule for `tool_use` missing `tool_result` validation - pattern is correct and consistent with existing rules |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant ErrorDetector
    participant ClaudeAPI
    participant Database
    
    Note over Client,Database: Error Rule Synchronization on Startup
    Client->>Database: syncDefaultErrorRules()
    Database-->>Client: Insert/Update new rule #550
    
    Note over Client,Database: Request Processing Flow
    Client->>ClaudeAPI: Send request with tool_use block
    ClaudeAPI-->>Client: Error: tool_use missing tool_result
    
    Client->>ErrorDetector: Match error message
    ErrorDetector->>Database: Query active error rules (priority 88)
    Database-->>ErrorDetector: Return rule #550 pattern
    
    ErrorDetector->>ErrorDetector: Regex match: tool_use.*ids were found without.*tool_result
    ErrorDetector-->>Client: Override response (validation_error)
    
    Note over Client: No retry - client-side validation error
    Client-->>Client: Return user-friendly Chinese message
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->