### PR TITLE
feat: 添加Linux部署脚本幂等性，更新README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
 
 - ⚠️ 请妥善保存脚本输出的**管理员令牌**（Admin Token），这是登录后台的唯一凭证！
 - ⚠️ Windows 用户：如果未安装 Docker Desktop，脚本会自动打开下载页面
+- ⚠️ 软件更新：请参考 `Docker Compose 启动章节`，deploy脚本仅用于首次部署，并不用于更新软件 (环境限制，目前仅暂在 Linux 安装脚本确保了部署幂等性，未覆盖 Powershell 脚本)
 
 ### 三步启动（Docker Compose）
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -47,6 +47,7 @@ DIR_ARG=""
 DOMAIN_ARG=""
 ENABLE_CADDY=false
 NON_INTERACTIVE=false
+FORCE_REINSTALL=false
 
 show_help() {
     cat << EOF
@@ -62,6 +63,7 @@ Options:
       --domain <domain>      Domain for Caddy HTTPS (enables Caddy automatically)
       --enable-caddy         Enable Caddy reverse proxy without HTTPS (HTTP only)
   -y, --yes                  Non-interactive mode (skip prompts, use defaults)
+  -f, --force                Force reinstall (remove existing installation)
   -h, --help                 Show this help message
 
 Examples:
@@ -126,6 +128,10 @@ parse_args() {
                 ;;
             -y|--yes)
                 NON_INTERACTIVE=true
+                shift
+                ;;
+            -f|--force)
+                FORCE_REINSTALL=true
                 shift
                 ;;
             -h|--help)
@@ -216,6 +222,90 @@ detect_os() {
         exit 1
     fi
     log_info "Detected OS: $OS_TYPE"
+}
+
+check_existing_installation() {
+    log_info "Checking for existing installation..."
+
+    local installation_found=false
+    local existing_containers=()
+
+    # Check if deployment directory exists with key files
+    if [[ -d "$DEPLOY_DIR" ]]; then
+        if [[ -f "$DEPLOY_DIR/docker-compose.yaml" ]] || [[ -f "$DEPLOY_DIR/.env" ]]; then
+            installation_found=true
+            log_warning "Found existing installation at: $DEPLOY_DIR"
+        fi
+    fi
+
+    # Check for running containers with our naming pattern
+    if command -v docker &> /dev/null; then
+        while IFS= read -r container; do
+            existing_containers+=("$container")
+        done < <(docker ps -a --filter "name=claude-code-hub-" --format "{{.Names}}" 2>/dev/null)
+
+        if [[ ${#existing_containers[@]} -gt 0 ]]; then
+            installation_found=true
+            log_warning "Found existing Docker containers:"
+            for container in "${existing_containers[@]}"; do
+                echo "   - $container"
+            done
+        fi
+    fi
+
+    # If installation found and not forcing reinstall, abort
+    if [[ "$installation_found" == true ]] && [[ "$FORCE_REINSTALL" != true ]]; then
+        echo ""
+        log_error "Claude Code Hub is already installed on this system!"
+        echo ""
+        echo -e "${YELLOW}To manage your existing installation:${NC}"
+        echo -e "   View logs:    ${BLUE}cd $DEPLOY_DIR && docker compose logs -f${NC}"
+        echo -e "   Stop:         ${BLUE}cd $DEPLOY_DIR && docker compose down${NC}"
+        echo -e "   Restart:      ${BLUE}cd $DEPLOY_DIR && docker compose restart${NC}"
+        echo ""
+        echo -e "${YELLOW}To completely remove and reinstall:${NC}"
+        echo -e "   1. Stop services:  ${BLUE}cd $DEPLOY_DIR && docker compose down -v${NC}"
+        echo -e "   2. Remove directory: ${BLUE}rm -rf $DEPLOY_DIR${NC}"
+        echo -e "   3. Re-run this script"
+        echo ""
+        echo -e "${YELLOW}Or use the --force flag to automatically remove and reinstall:${NC}"
+        echo -e "   ${BLUE}$0 --force${NC}"
+        echo ""
+        exit 1
+    fi
+
+    # If forcing reinstall, clean up existing installation
+    if [[ "$installation_found" == true ]] && [[ "$FORCE_REINSTALL" == true ]]; then
+        log_warning "Force reinstall enabled. Removing existing installation..."
+
+        # Stop and remove containers
+        if [[ ${#existing_containers[@]} -gt 0 ]]; then
+            log_info "Stopping and removing existing containers..."
+            if [[ -d "$DEPLOY_DIR" ]] && [[ -f "$DEPLOY_DIR/docker-compose.yaml" ]]; then
+                cd "$DEPLOY_DIR"
+                if docker compose version &> /dev/null; then
+                    docker compose down -v 2>/dev/null || true
+                else
+                    docker-compose down -v 2>/dev/null || true
+                fi
+            fi
+
+            # Force remove any remaining containers
+            for container in "${existing_containers[@]}"; do
+                docker rm -f "$container" 2>/dev/null || true
+            done
+        fi
+
+        # Remove deployment directory
+        if [[ -d "$DEPLOY_DIR" ]]; then
+            log_info "Removing deployment directory: $DEPLOY_DIR"
+            rm -rf "$DEPLOY_DIR"
+        fi
+
+        log_success "Existing installation removed successfully"
+    else
+        log_success "No existing installation found. Proceeding with fresh installation..."
+    fi
 }
 
 select_branch() {
@@ -748,10 +838,13 @@ main() {
     print_header
     
     detect_os
-    
+
     # Apply CLI overrides after OS detection (for deploy dir)
     validate_inputs
-    
+
+    # Check for existing installation before proceeding
+    check_existing_installation
+
     if ! check_docker; then
         log_warning "Docker is not installed. Attempting to install..."
         install_docker


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Adds idempotency check to `deploy.sh` that prevents accidental reinstallation by detecting existing installations and requiring a `--force` flag for reinstalls. Updates README.md to clarify that the deploy script is for initial deployment only, with software updates requiring manual Docker Compose commands. The force reinstall functionality removes existing containers and deployment directories to enable clean reinstallation.

### Confidence Score: 2/5

- Concerning data loss risk during force reinstall - existing credentials are not preserved
- The PR introduces a critical logic error in the force reinstall flow. When users run `deploy.sh --force`, the script deletes the deployment directory (line 302) containing the original `.env` file with credentials, then generates completely new random credentials (lines 860-862). This causes users to lose access to their existing database and admin panel. While the idempotency check itself is well-implemented and prevents accidental reinstalls, the force reinstall path has a data loss vulnerability. The README warning is helpful but has minor grammatical issues.
- scripts/deploy.sh requires attention for credential preservation during force reinstall

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| scripts/deploy.sh | 2/5 | Adds idempotency check and force reinstall flag; missing preservation of existing credentials during force reinstall could cause data loss |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Script as deploy.sh
    participant Check as Installation Check
    participant Docker
    participant System as File System

    User->>Script: "Execute deploy.sh [--force]"
    Script->>Script: "Parse arguments & detect OS"
    Script->>Check: "check_existing_installation()"
    Check->>System: "Check if $DEPLOY_DIR exists"
    Check->>Docker: "Check for claude-code-hub-* containers"
    
    alt Installation exists & no --force flag
        Check-->>User: "Error: Already installed + instructions"
        Note over User: Exit with management commands
    else Installation exists & --force flag
        Check->>Docker: "docker compose down -v"
        Check->>Docker: "Remove containers forcefully"
        Check->>System: "rm -rf $DEPLOY_DIR"
        Note over Check: WARNING: Credentials lost here!
        Check->>Script: "Continue with fresh install"
    else No installation found
        Check->>Script: "Proceed with installation"
    end
    
    Script->>Script: "Generate new ADMIN_TOKEN"
    Script->>Script: "Generate new DB_PASSWORD"
    Script->>System: "Create .env with new credentials"
    Script->>Docker: "docker compose up -d"
    Docker-->>User: "Services started"
```