### PR TITLE
fix(provider): allow removing custom whitelisted models (#592)

### DIFF
--- a/src/app/[locale]/settings/providers/_components/model-multi-select.tsx
+++ b/src/app/[locale]/settings/providers/_components/model-multi-select.tsx
@@ -58,6 +58,26 @@ export function ModelMultiSelect({
   const [modelSource, setModelSource] = useState<ModelSource>("loading");
   const [customModel, setCustomModel] = useState("");
 
+  const displayedModels = (() => {
+    const seen = new Set<string>();
+    const merged: string[] = [];
+
+    for (const model of availableModels) {
+      if (seen.has(model)) continue;
+      seen.add(model);
+      merged.push(model);
+    }
+
+    // 关键：把已选中但不在远端列表的自定义模型也渲染出来，保证可取消选中
+    for (const model of selectedModels) {
+      if (seen.has(model)) continue;
+      seen.add(model);
+      merged.push(model);
+    }
+
+    return merged;
+  })();
+
   // 供应商类型到显示名称的映射
   const getProviderTypeLabel = (type: string): string => {
     const typeMap: Record<string, string> = {
@@ -267,7 +287,7 @@ export function ModelMultiSelect({
 
                 {/* 模型列表 */}
                 <CommandGroup>
-                  {availableModels.map((model) => (
+                  {displayedModels.map((model) => (
                     <CommandItem
                       key={model}
                       value={model}

--- a/tests/unit/settings/providers/model-multi-select-custom-models-ui.test.tsx
+++ b/tests/unit/settings/providers/model-multi-select-custom-models-ui.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ModelMultiSelect } from "@/app/[locale]/settings/providers/_components/model-multi-select";
+
+const modelPricesActionMocks = vi.hoisted(() => ({
+  getAvailableModelsByProviderType: vi.fn(async () => ["remote-model-1"]),
+}));
+vi.mock("@/actions/model-prices", () => modelPricesActionMocks);
+
+const providersActionMocks = vi.hoisted(() => ({
+  fetchUpstreamModels: vi.fn(async () => ({ ok: false })),
+  getUnmaskedProviderKey: vi.fn(async () => ({ ok: false })),
+}));
+vi.mock("@/actions/providers", () => providersActionMocks);
+
+function loadMessages() {
+  const base = path.join(process.cwd(), "messages/en");
+  const read = (name: string) => JSON.parse(fs.readFileSync(path.join(base, name), "utf8"));
+
+  return {
+    common: read("common.json"),
+    errors: read("errors.json"),
+    ui: read("ui.json"),
+    forms: read("forms.json"),
+    settings: read("settings.json"),
+  };
+}
+
+function render(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(node);
+  });
+
+  return {
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+async function flushTicks(times = 3) {
+  for (let i = 0; i < times; i++) {
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  }
+}
+
+describe("ModelMultiSelect: 自定义白名单模型应可在列表中取消选中", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("已选中但不在 availableModels 的模型应出现在列表中，并可取消选中删除", async () => {
+    const messages = loadMessages();
+    const onChange = vi.fn();
+
+    const { unmount } = render(
+      <NextIntlClientProvider locale="en" messages={messages} timeZone="UTC">
+        <ModelMultiSelect
+          providerType="claude"
+          selectedModels={["custom-model-x"]}
+          onChange={onChange}
+        />
+      </NextIntlClientProvider>
+    );
+
+    await flushTicks(5);
+    expect(modelPricesActionMocks.getAvailableModelsByProviderType).toHaveBeenCalledTimes(1);
+
+    const trigger = document.querySelector("button[role='combobox']") as HTMLButtonElement | null;
+    expect(trigger).toBeTruthy();
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await flushTicks(5);
+
+    // 回归点：custom-model-x 不在 availableModels 时仍应可见，否则用户无法单个删除
+    expect(document.body.textContent || "").toContain("custom-model-x");
+
+    const items = Array.from(document.querySelectorAll("[data-slot='command-item']"));
+    const customItem =
+      items.find((el) => (el.textContent || "").includes("custom-model-x")) ?? null;
+    expect(customItem).toBeTruthy();
+
+    await act(async () => {
+      customItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onChange).toHaveBeenCalled();
+    expect(onChange).toHaveBeenLastCalledWith([]);
+
+    unmount();
+  });
+});


### PR DESCRIPTION
## 问题
当用户通过手动添加模型把模型加入白名单，但该模型不在供应商远端模型列表（availableModels）中时，列表不会渲染该模型，导致无法取消勾选进行单个删除。

**相关 Issue:**
- Fixes #592

## 修复
- 渲染列表合并 availableModels + selectedModels（缺失项追加），保证自定义模型可见且可取消选中。
- 新增单测覆盖该回归场景。

## 变更

### 核心变更
- `model-multi-select.tsx`: 添加 `displayedModels` 计算逻辑，合并 `availableModels` 和 `selectedModels`，确保自定义白名单模型可见且可取消选中

### 测试覆盖
- 新增单元测试 `model-multi-select-custom-models-ui.test.tsx` (112 行)
- 覆盖自定义模型渲染和取消选中场景

## 验证
- [x] bun run test
- [x] bun run test:coverage
- [x] bun run lint
- [x] bun run typecheck
- [x] bun run build

---
*Description enhanced by Claude AI*