### PR TITLE
fix(rectifier): detect 'signature: Field required' error and trigger rectifier

### DIFF
--- a/src/app/v1/_lib/proxy/thinking-signature-rectifier.ts
+++ b/src/app/v1/_lib/proxy/thinking-signature-rectifier.ts
@@ -50,6 +50,16 @@ export function detectThinkingSignatureRectifierTrigger(
     return "invalid_signature_in_thinking_block";
   }
 
+  // 检测：signature 字段缺失（Claude API 返回 "xxx.signature: Field required"）
+  // 场景：请求体中存在 thinking block 但缺少 signature 字段
+  // 常见于从非 Anthropic 渠道切换到 Anthropic 渠道时，历史 thinking block 未包含 signature
+  const looksLikeMissingSignatureField =
+    lower.includes("signature") && lower.includes("field required");
+
+  if (looksLikeMissingSignatureField) {
+    return "invalid_signature_in_thinking_block"; // 复用现有触发类型，整流逻辑相同
+  }
+
   // 与默认错误规则保持一致（Issue #432 / Rule 6）
   if (/非法请求|illegal request|invalid request/i.test(errorMessage)) {
     return "invalid_request";

--- a/src/repository/error-rules.ts
+++ b/src/repository/error-rules.ts
@@ -735,6 +735,27 @@ const DEFAULT_ERROR_RULES = [
       },
     },
   },
+  // Issue #xxx: Missing signature field in thinking block
+  {
+    pattern: "signature.*Field required",
+    category: "thinking_error",
+    description: "Missing signature field in thinking block (cross-channel format incompatibility)",
+    matchType: "regex" as const,
+    isDefault: true,
+    isEnabled: true,
+    priority: 72,
+    overrideResponse: {
+      type: "error",
+      error: {
+        type: "thinking_error",
+        message:
+          "thinking block 缺少必需的 signature 字段。" +
+          "该问题通常发生在从非 Anthropic 渠道切换到 Anthropic 渠道时。" +
+          "请确保 tool_result 续写请求中原样回传上一轮 assistant 的 thinking/redacted_thinking 块（含 signature/data），" +
+          "或关闭 thinking 后重试。",
+      },
+    },
+  },
   {
     pattern: "Missing required parameter|Extra inputs.*not permitted",
     category: "parameter_error",


### PR DESCRIPTION
## Summary

- Extend `detectThinkingSignatureRectifierTrigger` to match `signature: Field required` error
- Add Rule 72 for friendly error message when signature field is missing in thinking block
- Add comprehensive test cases for the new detection logic

## Problem

When switching from non-Anthropic to Anthropic channels, thinking blocks may lack the required `signature` field, causing Claude API to return:

```
{"type":"error","error":{"type":"invalid_request_error","message":"***.***.***.***.***.signature: Field required"}}
```

Previously, this error was not detected by the thinking signature rectifier, so:
1. No automatic retry with rectification was triggered
2. No friendly error message was provided

**Related Issues:**
- Follow-up to #518 - Extends the original "Invalid `signature` in `thinking` block" error handling to also cover the missing signature case
- Builds on PR #576 - Extends the thinking signature rectifier feature to detect additional error patterns
- Related to PR #577 - Similar category of cross-channel thinking block compatibility fixes

## Solution

1. **Extend rectifier detection** (thinking-signature-rectifier.ts:53-61):
   - Add detection for `signature` + `field required` pattern
   - Reuse existing trigger type `invalid_signature_in_thinking_block`
   - Rectification removes thinking blocks and disables thinking on retry

2. **Add error rule** (error-rules.ts: Rule 72):
   - Pattern: `signature.*Field required`
   - Provides user-friendly Chinese error message explaining the issue

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/thinking-signature-rectifier.ts` - Add detection for missing signature field pattern
- `src/repository/error-rules.ts` - Add Rule 72 for friendly error message

### Supporting Changes
- `src/app/v1/_lib/proxy/thinking-signature-rectifier.test.ts` - Comprehensive tests for the new detection logic

## Testing

### Automated Tests
- [x] Unit tests added (11 tests, all passing)
- [x] TypeScript type check passes
- [x] Biome lint check passes
- [x] Production build succeeds

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No breaking changes

---
*Description enhanced by Claude AI*