### PR TITLE
feat(usage-doc): update OpenCode config example with GPT-5.2 and Gemini v1beta

### DIFF
--- a/messages/en/usage.json
+++ b/messages/en/usage.json
@@ -543,8 +543,8 @@
         "important": "Important",
         "importantPoints": [
           "Create an API key in the cch console and set the CCH_API_KEY environment variable",
-          "All providers use ${resolvedOrigin}/v1 as baseURL (cch v1 API base URL)",
-          "When selecting models, use provider_id/model_id (e.g. cchClaude/claude-sonnet-4-5-20250929)"
+          "cchClaude/openai use ${resolvedOrigin}/v1; cchGemini uses ${resolvedOrigin}/v1beta",
+          "When selecting models, use provider_id/model_id (e.g. openai/gpt-5.2 or cchClaude/claude-sonnet-4-5-20250929)"
         ]
       },
 

--- a/messages/ja/usage.json
+++ b/messages/ja/usage.json
@@ -543,8 +543,8 @@
         "important": "重要",
         "importantPoints": [
           "cch の管理画面で API Key を作成し、環境変数 CCH_API_KEY を設定してください",
-          "3 つの provider すべてで baseURL は ${resolvedOrigin}/v1（cch の v1 API ベース URL）",
-          "モデル選択は provider_id/model_id 形式（例：cchClaude/claude-sonnet-4-5-20250929）"
+          "cchClaude/openai は ${resolvedOrigin}/v1、cchGemini は ${resolvedOrigin}/v1beta を baseURL に使用します",
+          "モデル選択は provider_id/model_id 形式（例：openai/gpt-5.2 または cchClaude/claude-sonnet-4-5-20250929）"
         ]
       },
 

--- a/messages/ru/usage.json
+++ b/messages/ru/usage.json
@@ -543,8 +543,8 @@
         "important": "Важно",
         "importantPoints": [
           "Создайте API key в панели cch и задайте переменную окружения CCH_API_KEY",
-          "Все provider используют ${resolvedOrigin}/v1 как baseURL (базовый URL cch v1 API)",
-          "При выборе модели используйте provider_id/model_id (например, cchClaude/claude-sonnet-4-5-20250929)"
+          "cchClaude/openai используют ${resolvedOrigin}/v1; cchGemini использует ${resolvedOrigin}/v1beta",
+          "При выборе модели используйте provider_id/model_id (например, openai/gpt-5.2 или cchClaude/claude-sonnet-4-5-20250929)"
         ]
       },
 

--- a/messages/zh-CN/usage.json
+++ b/messages/zh-CN/usage.json
@@ -539,8 +539,8 @@
         "important": "重要说明",
         "importantPoints": [
           "请先在 cch 后台创建 API Key，并设置环境变量 CCH_API_KEY",
-          "三个 provider 的 baseURL 都使用 ${resolvedOrigin}/v1（cch v1 API 地址）",
-          "模型选择时使用 provider_id/model_id 格式（例如 cchClaude/claude-sonnet-4-5-20250929）"
+          "cchClaude/openai 使用 ${resolvedOrigin}/v1，cchGemini 使用 ${resolvedOrigin}/v1beta",
+          "模型选择时使用 provider_id/model_id 格式（例如 openai/gpt-5.2 或 cchClaude/claude-sonnet-4-5-20250929）"
         ]
       },
 

--- a/messages/zh-TW/usage.json
+++ b/messages/zh-TW/usage.json
@@ -539,8 +539,8 @@
         "important": "重要說明",
         "importantPoints": [
           "請先在 cch 後台創建 API Key，並設置環境變量 CCH_API_KEY",
-          "三個 provider 的 baseURL 都使用 ${resolvedOrigin}/v1（cch v1 API 地址）",
-          "模型選擇時使用 provider_id/model_id 格式（例如 cchClaude/claude-sonnet-4-5-20250929）"
+          "cchClaude/openai 使用 ${resolvedOrigin}/v1，cchGemini 使用 ${resolvedOrigin}/v1beta",
+          "模型選擇時使用 provider_id/model_id 格式（例如 openai/gpt-5.2 或 cchClaude/claude-sonnet-4-5-20250929）"
         ]
       },
 

--- a/src/app/[locale]/usage-doc/page.tsx
+++ b/src/app/[locale]/usage-doc/page.tsx
@@ -1080,6 +1080,8 @@ gemini`}
         $schema: "https://opencode.ai/config.json",
         theme: "opencode",
         autoupdate: false,
+        model: "openai/gpt-5.2",
+        small_model: "openai/gpt-5.2-small",
         provider: {
           cchClaude: {
             npm: "@ai-sdk/anthropic",
@@ -1100,16 +1102,34 @@ gemini`}
             options: {
               baseURL: `${resolvedOrigin}/v1`,
               apiKey: "{env:CCH_API_KEY}",
+              store: false,
+              setCacheKey: true,
             },
             models: {
-              "gpt-5.2": { name: "GPT-5.2" },
+              "gpt-5.2": {
+                name: "GPT-5.2",
+                options: {
+                  reasoningEffort: "xhigh",
+                  store: false,
+                  include: ["reasoning.encrypted_content"],
+                },
+              },
+              "gpt-5.2-small": {
+                id: "gpt-5.2",
+                name: "GPT-5.2 Small",
+                options: {
+                  reasoningEffort: "medium",
+                  store: false,
+                  include: ["reasoning.encrypted_content"],
+                },
+              },
             },
           },
           cchGemini: {
             npm: "@ai-sdk/google",
             name: "Gemini via cch",
             options: {
-              baseURL: `${resolvedOrigin}/v1`,
+              baseURL: `${resolvedOrigin}/v1beta`,
               apiKey: "{env:CCH_API_KEY}",
             },
             models: {

--- a/tests/unit/usage-doc/opencode-usage-doc.test.tsx
+++ b/tests/unit/usage-doc/opencode-usage-doc.test.tsx
@@ -69,18 +69,28 @@ describe("UsageDoc - OpenCode 配置教程", () => {
     expect(text).toContain('"baseURL": "http://localhost:23000/v1"');
 
     expect(text).toContain('"npm": "@ai-sdk/anthropic"');
-    expect(text).toContain('"npm": "@ai-sdk/openai"');
     expect(text).toContain('"npm": "@ai-sdk/google"');
+    expect(text).not.toContain('"npm": "@ai-sdk/openai"');
     expect(text).not.toContain("@ai-sdk/openai-compatible");
 
     expect(text).toContain("claude-haiku-4-5-20251001");
     expect(text).toContain("claude-sonnet-4-5-20250929");
     expect(text).toContain("claude-opus-4-5-20251101");
 
+    expect(text).toContain('"model": "openai/gpt-5.2"');
+    expect(text).toContain('"small_model": "openai/gpt-5.2-small"');
+
     expect(text).toContain("gpt-5.2");
+    expect(text).toContain("gpt-5.2-small");
+    expect(text).toContain('"reasoningEffort": "xhigh"');
+    expect(text).toContain('"reasoningEffort": "medium"');
+    expect(text).toContain('"store": false');
+    expect(text).toContain('"setCacheKey": true');
+    expect(text).toContain("reasoning.encrypted_content");
 
     expect(text).toContain("gemini-3-pro-preview");
     expect(text).toContain("gemini-3-flash-preview");
+    expect(text).toContain('"baseURL": "http://localhost:23000/v1beta"');
 
     unmount();
   });


### PR DESCRIPTION
## Summary

- Add OpenAI GPT-5.2 model configuration with `reasoningEffort` options
- Add GPT-5.2-small variant using medium reasoning effort
- Fix Gemini baseURL to use `/v1beta` endpoint
- Update i18n strings across 5 languages to reflect different baseURLs per provider

## Test plan

- [ ] Verify usage-doc page renders correctly
- [ ] Check i18n strings display properly in all 5 languages
- [ ] Confirm OpenCode config example is valid JSON

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR updates the OpenCode configuration documentation to add GPT-5.2 model support with reasoning effort options and fix the Gemini baseURL to use the v1beta endpoint. The i18n strings across all 5 languages were updated to reflect that different providers use different baseURL endpoints.

## Changes Made

- **GPT-5.2 Configuration**: Added `gpt-5.2` and `gpt-5.2-small` models with `reasoningEffort` settings ("xhigh" for full model, "medium" for small variant)
- **OpenAI Options**: Added `store: false`, `setCacheKey: true`, and `include: ["reasoning.encrypted_content"]` options
- **Gemini Endpoint**: Updated cchGemini baseURL from `/v1` to `/v1beta` 
- **i18n Updates**: Updated all 5 language files to document separate baseURLs per provider
- **Test Updates**: Enhanced test expectations to validate new configuration features

## Critical Issue Found

The implementation has a **critical logic error** that will cause:
1. **Test failures**: The test expects `"npm": "@ai-sdk/openai"` NOT to appear in output, but the code includes it
2. **Runtime failures**: Models reference `openai/gpt-5.2` but provider is named `cchGPT`, causing model resolution to fail

**Root cause**: The GPT provider at line 1099 of `page.tsx` is named `cchGPT`, but the model references at lines 1083-1084 use `openai/gpt-5.2` format. OpenCode's `provider_id/model_id` pattern requires these to match. The provider should be renamed from `cchGPT` to `openai`.

## Architecture Fit

This change fits into the existing usage documentation pattern of providing complete configuration examples for CLI tools. The addition of GPT-5.2 reasoning models and the Gemini v1beta endpoint correction align with keeping documentation current with evolving API capabilities.

### Confidence Score: 1/5

- This PR has critical bugs that will cause test failures and runtime errors - NOT safe to merge as-is
- Score of 1 reflects critical logic errors found during thorough analysis. The provider naming mismatch (cchGPT vs openai) will cause: (1) test suite to fail on line 73 of opencode-usage-doc.test.tsx which explicitly checks that "@ai-sdk/openai" should NOT be present, (2) OpenCode to fail at runtime when resolving models because "openai/gpt-5.2" references a non-existent provider named "openai". While the i18n translations are correct and the Gemini v1beta change is valid, the core configuration is broken. The fix is straightforward (rename cchGPT to openai) but essential before merge.
- Critical attention needed on src/app/[locale]/usage-doc/page.tsx - provider naming must be fixed before merge. Test file and i18n files are fine.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/app/[locale]/usage-doc/page.tsx | 1/5 | Critical provider name mismatch: provider named `cchGPT` but model references use `openai/` prefix, causing resolution failure and test failures |
| tests/unit/usage-doc/opencode-usage-doc.test.tsx | 5/5 | Test expectations updated correctly to validate new GPT-5.2 config and Gemini v1beta URL, will fail due to code not matching |
| messages/en/usage.json | 5/5 | i18n updated correctly to document separate baseURLs for different providers, consistent with other languages |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant UsageDocPage
    participant UsageDocContent
    participant OpenCodeConfig
    participant i18n

    User->>Browser: Navigate to /usage-doc
    Browser->>UsageDocPage: Render page
    UsageDocPage->>i18n: Load translations (en/ja/ru/zh-CN/zh-TW)
    i18n-->>UsageDocPage: Return usage.json messages
    UsageDocPage->>UsageDocContent: Pass origin and translations
    UsageDocContent->>OpenCodeConfig: Build config JSON
    Note over OpenCodeConfig: provider: cchClaude (v1)<br/>provider: cchGPT (v1) ❌<br/>provider: cchGemini (v1beta)<br/>model: "openai/gpt-5.2" ❌<br/>small_model: "openai/gpt-5.2-small" ❌
    OpenCodeConfig-->>UsageDocContent: Config JSON string
    UsageDocContent->>Browser: Render documentation with config example
    Browser-->>User: Display usage documentation
    
    Note over OpenCodeConfig: ISSUE: Provider "cchGPT" should be "openai"<br/>to match model references
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->