### PR TITLE
feat: implement vendor-endpoint architecture for multi-endpoint provider support

### DIFF
--- a/drizzle/0055_bumpy_mojo.sql
+++ b/drizzle/0055_bumpy_mojo.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS "provider_endpoint_probe_events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"endpoint_id" integer NOT NULL,
+	"source" varchar(20) DEFAULT 'active_probe' NOT NULL,
+	"result" varchar(10) NOT NULL,
+	"status_code" integer,
+	"latency_ms" integer,
+	"error_type" varchar(50),
+	"error_message" text,
+	"checked_at" timestamp with time zone DEFAULT now(),
+	"created_at" timestamp with time zone DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "provider_endpoints" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"vendor_id" integer NOT NULL,
+	"provider_type" varchar(20) NOT NULL,
+	"base_url" varchar(512) NOT NULL,
+	"is_enabled" boolean DEFAULT true NOT NULL,
+	"priority" integer DEFAULT 0 NOT NULL,
+	"weight" integer DEFAULT 1 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "provider_vendors" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"vendor_key" varchar(255) NOT NULL,
+	"display_name" varchar(100) NOT NULL,
+	"website_url" text,
+	"favicon_url" text,
+	"is_enabled" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now(),
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "providers" ADD COLUMN IF NOT EXISTS "vendor_id" integer;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_probe_events_endpoint_time" ON "provider_endpoint_probe_events" USING btree ("endpoint_id","checked_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_probe_events_checked_at" ON "provider_endpoint_probe_events" USING btree ("checked_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_provider_endpoints_vendor_type" ON "provider_endpoints" USING btree ("vendor_id","provider_type") WHERE "provider_endpoints"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_provider_endpoints_enabled_priority" ON "provider_endpoints" USING btree ("is_enabled","vendor_id","provider_type","priority","weight") WHERE "provider_endpoints"."deleted_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uniq_provider_endpoints_vendor_type_base_url" ON "provider_endpoints" USING btree ("vendor_id","provider_type","base_url");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_provider_endpoints_created_at" ON "provider_endpoints" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_provider_endpoints_deleted_at" ON "provider_endpoints" USING btree ("deleted_at");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uniq_provider_vendors_vendor_key" ON "provider_vendors" USING btree ("vendor_key");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_provider_vendors_created_at" ON "provider_vendors" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_provider_vendors_deleted_at" ON "provider_vendors" USING btree ("deleted_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_providers_vendor" ON "providers" USING btree ("vendor_id") WHERE "providers"."deleted_at" IS NULL;

--- a/drizzle/meta/0055_snapshot.json
+++ b/drizzle/meta/0055_snapshot.json
@@ -1,0 +1,2837 @@
+{
+  "id": "a2c936db-a4b3-4514-8031-b26e356eb104",
+  "prevId": "36887729-08df-4af3-98fe-d4fa87c7c5c7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.error_rules": {
+      "name": "error_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regex'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_response": {
+          "name": "override_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_status_code": {
+          "name": "override_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_rules_enabled": {
+          "name": "idx_error_rules_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_pattern": {
+          "name": "unique_pattern",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_category": {
+          "name": "idx_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_match_type": {
+          "name": "idx_match_type",
+          "columns": [
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_login_web_ui": {
+          "name": "can_login_web_ui",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_keys_user_id": {
+          "name": "idx_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_created_at": {
+          "name": "idx_keys_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_deleted_at": {
+          "name": "idx_keys_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_request": {
+      "name": "message_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "provider_chain": {
+          "name": "provider_chain",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "special_settings": {
+          "name": "special_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_cause": {
+          "name": "error_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages_count": {
+          "name": "messages_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_message_request_user_date_cost": {
+          "name": "idx_message_request_user_date_cost",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_query": {
+          "name": "idx_message_request_user_query",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_id": {
+          "name": "idx_message_request_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_seq": {
+          "name": "idx_message_request_session_seq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_endpoint": {
+          "name": "idx_message_request_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_blocked_by": {
+          "name": "idx_message_request_blocked_by",
+          "columns": [
+            {
+              "expression": "blocked_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_id": {
+          "name": "idx_message_request_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_id": {
+          "name": "idx_message_request_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key": {
+          "name": "idx_message_request_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_created_at": {
+          "name": "idx_message_request_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_deleted_at": {
+          "name": "idx_message_request_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_prices": {
+      "name": "model_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_data": {
+          "name": "price_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'litellm'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_prices_latest": {
+          "name": "idx_model_prices_latest",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_model_name": {
+          "name": "idx_model_prices_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_created_at": {
+          "name": "idx_model_prices_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_source": {
+          "name": "idx_model_prices_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_legacy_mode": {
+          "name": "use_legacy_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_enabled": {
+          "name": "circuit_breaker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_webhook": {
+          "name": "circuit_breaker_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_enabled": {
+          "name": "daily_leaderboard_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "daily_leaderboard_webhook": {
+          "name": "daily_leaderboard_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_time": {
+          "name": "daily_leaderboard_time",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'09:00'"
+        },
+        "daily_leaderboard_top_n": {
+          "name": "daily_leaderboard_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cost_alert_enabled": {
+          "name": "cost_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cost_alert_webhook": {
+          "name": "cost_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_alert_threshold": {
+          "name": "cost_alert_threshold",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.80'"
+        },
+        "cost_alert_check_interval": {
+          "name": "cost_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_target_bindings": {
+      "name": "notification_target_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule_cron": {
+          "name": "schedule_cron",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_timezone": {
+          "name": "schedule_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Asia/Shanghai'"
+        },
+        "template_override": {
+          "name": "template_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_notification_target_binding": {
+          "name": "unique_notification_target_binding",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_type": {
+          "name": "idx_notification_bindings_type",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_target": {
+          "name": "idx_notification_bindings_target",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_target_bindings_target_id_webhook_targets_id_fk": {
+          "name": "notification_target_bindings_target_id_webhook_targets_id_fk",
+          "tableFrom": "notification_target_bindings",
+          "tableTo": "webhook_targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoint_probe_events": {
+      "name": "provider_endpoint_probe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active_probe'"
+        },
+        "result": {
+          "name": "result",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_probe_events_endpoint_time": {
+          "name": "idx_probe_events_endpoint_time",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_probe_events_checked_at": {
+          "name": "idx_probe_events_checked_at",
+          "columns": [
+            {
+              "expression": "checked_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoints": {
+      "name": "provider_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_provider_endpoints_vendor_type": {
+          "name": "idx_provider_endpoints_vendor_type",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_enabled_priority": {
+          "name": "idx_provider_endpoints_enabled_priority",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_provider_endpoints_vendor_type_base_url": {
+          "name": "uniq_provider_endpoints_vendor_type_base_url",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_created_at": {
+          "name": "idx_provider_endpoints_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_deleted_at": {
+          "name": "idx_provider_endpoints_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_vendors": {
+      "name": "provider_vendors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vendor_key": {
+          "name": "vendor_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uniq_provider_vendors_vendor_key": {
+          "name": "uniq_provider_vendors_vendor_key",
+          "columns": [
+            {
+              "expression": "vendor_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_vendors_created_at": {
+          "name": "idx_provider_vendors_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_vendors_deleted_at": {
+          "name": "idx_provider_vendors_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.0'"
+        },
+        "group_tag": {
+          "name": "group_tag",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "preserve_client_ip": {
+          "name": "preserve_client_ip",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_redirects": {
+          "name": "model_redirects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "join_claude_pool": {
+          "name": "join_claude_pool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "codex_instructions_strategy": {
+          "name": "codex_instructions_strategy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "mcp_passthrough_type": {
+          "name": "mcp_passthrough_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "mcp_passthrough_url": {
+          "name": "mcp_passthrough_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost_reset_at": {
+          "name": "total_cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_retry_attempts": {
+          "name": "max_retry_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circuit_breaker_failure_threshold": {
+          "name": "circuit_breaker_failure_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "circuit_breaker_open_duration": {
+          "name": "circuit_breaker_open_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1800000
+        },
+        "circuit_breaker_half_open_success_threshold": {
+          "name": "circuit_breaker_half_open_success_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "first_byte_timeout_streaming_ms": {
+          "name": "first_byte_timeout_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "streaming_idle_timeout_ms": {
+          "name": "streaming_idle_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_timeout_non_streaming_ms": {
+          "name": "request_timeout_non_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_preference": {
+          "name": "context_1m_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_effort_preference": {
+          "name": "codex_reasoning_effort_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_summary_preference": {
+          "name": "codex_reasoning_summary_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_text_verbosity_preference": {
+          "name": "codex_text_verbosity_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_parallel_tool_calls_preference": {
+          "name": "codex_parallel_tool_calls_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tpm": {
+          "name": "tpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpm": {
+          "name": "rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpd": {
+          "name": "rpd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cc": {
+          "name": "cc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_providers_enabled_priority": {
+          "name": "idx_providers_enabled_priority",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_group": {
+          "name": "idx_providers_group",
+          "columns": [
+            {
+              "expression": "group_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_vendor": {
+          "name": "idx_providers_vendor",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_created_at": {
+          "name": "idx_providers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_deleted_at": {
+          "name": "idx_providers_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_filters": {
+      "name": "request_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement": {
+          "name": "replacement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "provider_ids": {
+          "name": "provider_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_tags": {
+          "name": "group_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_request_filters_enabled": {
+          "name": "idx_request_filters_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_scope": {
+          "name": "idx_request_filters_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_action": {
+          "name": "idx_request_filters_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_binding": {
+          "name": "idx_request_filters_binding",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sensitive_words": {
+      "name": "sensitive_words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contains'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sensitive_words_enabled": {
+          "name": "idx_sensitive_words_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sensitive_words_created_at": {
+          "name": "idx_sensitive_words_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_title": {
+          "name": "site_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Claude Code Hub'"
+        },
+        "allow_global_usage_view": {
+          "name": "allow_global_usage_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "currency_display": {
+          "name": "currency_display",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "billing_model_source": {
+          "name": "billing_model_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'original'"
+        },
+        "enable_auto_cleanup": {
+          "name": "enable_auto_cleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cleanup_retention_days": {
+          "name": "cleanup_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cleanup_schedule": {
+          "name": "cleanup_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 2 * * *'"
+        },
+        "cleanup_batch_size": {
+          "name": "cleanup_batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10000
+        },
+        "enable_client_version_check": {
+          "name": "enable_client_version_check",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verbose_provider_error": {
+          "name": "verbose_provider_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_http2": {
+          "name": "enable_http2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "intercept_anthropic_warmup_requests": {
+          "name": "intercept_anthropic_warmup_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_thinking_signature_rectifier": {
+          "name": "enable_thinking_signature_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_codex_session_id_completion": {
+          "name": "enable_codex_session_id_completion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_response_fixer": {
+          "name": "enable_response_fixer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "response_fixer_config": {
+          "name": "response_fixer_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"fixTruncatedJson\":true,\"fixSseFormat\":true,\"fixEncoding\":true,\"maxJsonDepth\":200,\"maxFixSize\":1048576}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "rpm_limit": {
+          "name": "rpm_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_limit_usd": {
+          "name": "daily_limit_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_active_role_sort": {
+          "name": "idx_users_active_role_sort",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_enabled_expires_at": {
+          "name": "idx_users_enabled_expires_at",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_deleted_at": {
+          "name": "idx_users_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_targets": {
+      "name": "webhook_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "webhook_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_bot_token": {
+          "name": "telegram_bot_token",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dingtalk_secret": {
+          "name": "dingtalk_secret",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_template": {
+          "name": "custom_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_test_at": {
+          "name": "last_test_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_result": {
+          "name": "last_test_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.daily_reset_mode": {
+      "name": "daily_reset_mode",
+      "schema": "public",
+      "values": [
+        "fixed",
+        "rolling"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "circuit_breaker",
+        "daily_leaderboard",
+        "cost_alert"
+      ]
+    },
+    "public.webhook_provider_type": {
+      "name": "webhook_provider_type",
+      "schema": "public",
+      "values": [
+        "wechat",
+        "feishu",
+        "dingtalk",
+        "telegram",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1768240715707,
       "tag": "0054_tidy_winter_soldier",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1768303107027,
+      "tag": "0055_bumpy_mojo",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/en/dashboard.json
+++ b/messages/en/dashboard.json
@@ -1014,7 +1014,9 @@
       "minutes": "min",
       "requests": "requests",
       "noData": "No Data",
-      "noRequests": "No Requests"
+      "noRequests": "No Requests",
+      "probes": "probes",
+      "noProbes": "No Probes"
     },
     "toast": {
       "refreshSuccess": "Availability data refreshed",

--- a/messages/en/settings/providers/tabs.json
+++ b/messages/en/settings/providers/tabs.json
@@ -1,0 +1,6 @@
+{
+  "title": "Provider Settings",
+  "description": "Manage AI providers, vendors, and API quotas",
+  "providers": "Providers",
+  "vendors": "Vendors"
+}

--- a/messages/en/settings/providers/vendors.json
+++ b/messages/en/settings/providers/vendors.json
@@ -1,0 +1,53 @@
+{
+  "title": "Vendors",
+  "description": "Manage AI model vendors and their API endpoints",
+  "searchPlaceholder": "Search vendors...",
+  "empty": {
+    "title": "No vendors found",
+    "description": "Try adjusting your search terms"
+  },
+  "stats": {
+    "providers": "Providers",
+    "endpoints": "Endpoints"
+  },
+  "actions": {
+    "configure": "Configure",
+    "updated": "Vendor updated successfully",
+    "saving": "Saving...",
+    "save": "Save Changes"
+  },
+  "edit": {
+    "title": "Edit Vendor",
+    "description": "Update vendor details and manage API endpoints"
+  },
+  "fields": {
+    "name": "Display Name",
+    "website": "Website URL",
+    "enabled": "Enabled"
+  },
+  "endpoints": {
+    "title": "API Endpoints",
+    "count": "Total endpoints",
+    "add": "Add Endpoint",
+    "empty": "No endpoints configured",
+    "baseUrl": "Base URL",
+    "priority": "Priority",
+    "weight": "Weight",
+    "createSuccess": "Endpoint created successfully",
+    "addTitle": "Add Endpoint",
+    "addDescription": "Add a new API endpoint for this vendor",
+    "fields": {
+      "type": "Provider Type",
+      "baseUrl": "Base URL",
+      "priority": "Priority",
+      "weight": "Weight"
+    },
+    "actions": {
+      "create": "Create"
+    },
+    "errors": {
+      "conflict": "Endpoint already exists",
+      "createFailed": "Failed to create endpoint"
+    }
+  }
+}

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -1119,7 +1119,9 @@
       "minutes": "分钟",
       "requests": "请求",
       "noData": "无数据",
-      "noRequests": "无请求"
+      "noRequests": "无请求",
+      "probes": "探测",
+      "noProbes": "无探测"
     },
     "toast": {
       "refreshSuccess": "可用性数据已刷新",
@@ -1197,7 +1199,7 @@
         "limit5h": "5 小时",
         "limitDaily": "每日",
         "limitWeekly": "每周",
-        "limitMonthly": "每月",
+        "limitMonthly": "月",
         "limitTotal": "总计",
         "limitSessions": "并发"
       }

--- a/messages/zh-CN/settings/providers/tabs.json
+++ b/messages/zh-CN/settings/providers/tabs.json
@@ -1,0 +1,6 @@
+{
+  "title": "供应商设置",
+  "description": "管理 AI 供应商、厂商和 API 配额",
+  "providers": "供应商列表",
+  "vendors": "厂商管理"
+}

--- a/messages/zh-CN/settings/providers/vendors.json
+++ b/messages/zh-CN/settings/providers/vendors.json
@@ -1,0 +1,53 @@
+{
+  "title": "厂商管理",
+  "description": "管理 AI 模型厂商及其 API 端点配置",
+  "searchPlaceholder": "搜索厂商...",
+  "empty": {
+    "title": "未找到厂商",
+    "description": "请尝试调整搜索关键词"
+  },
+  "stats": {
+    "providers": "个供应商",
+    "endpoints": "个端点"
+  },
+  "actions": {
+    "configure": "配置",
+    "updated": "厂商更新成功",
+    "saving": "保存中...",
+    "save": "保存更改"
+  },
+  "edit": {
+    "title": "编辑厂商",
+    "description": "更新厂商详情并管理 API 端点"
+  },
+  "fields": {
+    "name": "显示名称",
+    "website": "官网链接",
+    "enabled": "启用"
+  },
+  "endpoints": {
+    "title": "API 端点",
+    "count": "个端点",
+    "add": "添加端点",
+    "empty": "暂无配置端点",
+    "baseUrl": "基础 URL",
+    "priority": "优先级",
+    "weight": "权重",
+    "createSuccess": "端点创建成功",
+    "addTitle": "添加端点",
+    "addDescription": "为此厂商添加新的 API 端点",
+    "fields": {
+      "type": "供应商类型",
+      "baseUrl": "基础 URL",
+      "priority": "优先级",
+      "weight": "权重"
+    },
+    "actions": {
+      "create": "创建"
+    },
+    "errors": {
+      "conflict": "端点已存在",
+      "createFailed": "创建端点失败"
+    }
+  }
+}

--- a/src/actions/provider-endpoints.ts
+++ b/src/actions/provider-endpoints.ts
@@ -1,0 +1,212 @@
+"use server";
+
+import { getTranslations } from "next-intl/server";
+import { getSession } from "@/lib/auth";
+import { logger } from "@/lib/logger";
+import { ERROR_CODES } from "@/lib/utils/error-messages";
+import {
+  createProviderEndpoint,
+  deleteProviderEndpoint,
+  findProviderEndpointById,
+  findProviderEndpointsByVendorIds,
+  findProviderEndpointsByVendorType,
+  updateProviderEndpoint,
+} from "@/repository/provider-endpoint";
+import type { ProviderEndpoint, ProviderType } from "@/types/provider";
+import type { ActionResult } from "./types";
+
+function isAdmin(session: Awaited<ReturnType<typeof getSession>>): boolean {
+  return !!session && session.user.role === "admin";
+}
+
+export async function getProviderEndpointsByVendors(args: {
+  vendorIds: number[];
+}): Promise<ProviderEndpoint[]> {
+  try {
+    const session = await getSession();
+    if (!isAdmin(session)) {
+      return [];
+    }
+
+    return await findProviderEndpointsByVendorIds(args.vendorIds);
+  } catch (error) {
+    logger.error("[ProviderEndpointsAction] Failed to list endpoints", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+export async function getProviderEndpointsByVendorTypeAction(args: {
+  vendorId: number;
+  providerType: ProviderType;
+}): Promise<ProviderEndpoint[]> {
+  try {
+    const session = await getSession();
+    if (!isAdmin(session)) {
+      return [];
+    }
+
+    return await findProviderEndpointsByVendorType(args.vendorId, args.providerType);
+  } catch (error) {
+    logger.error("[ProviderEndpointsAction] Failed to list endpoints by vendor/type", {
+      vendorId: args.vendorId,
+      providerType: args.providerType,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+export async function createProviderEndpointAction(data: {
+  vendorId: number;
+  providerType: ProviderType;
+  baseUrl: string;
+  isEnabled?: boolean;
+  priority?: number;
+  weight?: number;
+}): Promise<ActionResult<ProviderEndpoint>> {
+  const tError = await getTranslations("errors");
+
+  const session = await getSession();
+  if (!session) {
+    return { ok: false, error: tError("UNAUTHORIZED"), errorCode: ERROR_CODES.UNAUTHORIZED };
+  }
+  if (!isAdmin(session)) {
+    return {
+      ok: false,
+      error: tError("PERMISSION_DENIED"),
+      errorCode: ERROR_CODES.PERMISSION_DENIED,
+    };
+  }
+
+  try {
+    const created = await createProviderEndpoint({
+      vendorId: data.vendorId,
+      providerType: data.providerType,
+      baseUrl: data.baseUrl,
+      isEnabled: data.isEnabled,
+      priority: data.priority,
+      weight: data.weight,
+    });
+
+    return { ok: true, data: created };
+  } catch (error) {
+    logger.error("[ProviderEndpointsAction] Failed to create endpoint", {
+      vendorId: data.vendorId,
+      providerType: data.providerType,
+      baseUrl: data.baseUrl,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    const message = error instanceof Error ? error.message : "";
+    const isUniqueViolation =
+      message.includes("uniq_provider_endpoints_vendor_type_base_url") ||
+      message.toLowerCase().includes("duplicate");
+
+    if (isUniqueViolation) {
+      return { ok: false, error: tError("CONFLICT"), errorCode: ERROR_CODES.CONFLICT };
+    }
+
+    return {
+      ok: false,
+      error: tError("CREATE_FAILED"),
+      errorCode: ERROR_CODES.CREATE_FAILED,
+    };
+  }
+}
+
+export async function updateProviderEndpointAction(
+  endpointId: number,
+  patch: {
+    baseUrl?: string;
+    isEnabled?: boolean;
+    priority?: number;
+    weight?: number;
+  }
+): Promise<ActionResult<ProviderEndpoint>> {
+  const tError = await getTranslations("errors");
+
+  const session = await getSession();
+  if (!session) {
+    return { ok: false, error: tError("UNAUTHORIZED"), errorCode: ERROR_CODES.UNAUTHORIZED };
+  }
+  if (!isAdmin(session)) {
+    return {
+      ok: false,
+      error: tError("PERMISSION_DENIED"),
+      errorCode: ERROR_CODES.PERMISSION_DENIED,
+    };
+  }
+
+  try {
+    const updated = await updateProviderEndpoint(endpointId, patch);
+    if (!updated) {
+      return { ok: false, error: tError("NOT_FOUND"), errorCode: ERROR_CODES.NOT_FOUND };
+    }
+
+    return { ok: true, data: updated };
+  } catch (error) {
+    logger.error("[ProviderEndpointsAction] Failed to update endpoint", {
+      endpointId,
+      patch,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    const message = error instanceof Error ? error.message : "";
+    const isUniqueViolation =
+      message.includes("uniq_provider_endpoints_vendor_type_base_url") ||
+      message.toLowerCase().includes("duplicate");
+
+    if (isUniqueViolation) {
+      return { ok: false, error: tError("CONFLICT"), errorCode: ERROR_CODES.CONFLICT };
+    }
+
+    return {
+      ok: false,
+      error: tError("UPDATE_FAILED"),
+      errorCode: ERROR_CODES.UPDATE_FAILED,
+    };
+  }
+}
+
+export async function deleteProviderEndpointAction(endpointId: number): Promise<ActionResult> {
+  const tError = await getTranslations("errors");
+
+  const session = await getSession();
+  if (!session) {
+    return { ok: false, error: tError("UNAUTHORIZED"), errorCode: ERROR_CODES.UNAUTHORIZED };
+  }
+  if (!isAdmin(session)) {
+    return {
+      ok: false,
+      error: tError("PERMISSION_DENIED"),
+      errorCode: ERROR_CODES.PERMISSION_DENIED,
+    };
+  }
+
+  try {
+    const endpoint = await findProviderEndpointById(endpointId);
+    if (!endpoint) {
+      return { ok: false, error: tError("NOT_FOUND"), errorCode: ERROR_CODES.NOT_FOUND };
+    }
+
+    const ok = await deleteProviderEndpoint(endpointId);
+    if (!ok) {
+      return { ok: false, error: tError("DELETE_FAILED"), errorCode: ERROR_CODES.DELETE_FAILED };
+    }
+
+    return { ok: true };
+  } catch (error) {
+    logger.error("[ProviderEndpointsAction] Failed to delete endpoint", {
+      endpointId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    return {
+      ok: false,
+      error: tError("DELETE_FAILED"),
+      errorCode: ERROR_CODES.DELETE_FAILED,
+    };
+  }
+}

--- a/src/actions/provider-vendors.ts
+++ b/src/actions/provider-vendors.ts
@@ -1,0 +1,219 @@
+"use server";
+
+import { getTranslations } from "next-intl/server";
+import { getSession } from "@/lib/auth";
+import { logger } from "@/lib/logger";
+import { ERROR_CODES } from "@/lib/utils/error-messages";
+import { normalizeVendorKeyFromUrl } from "@/lib/utils/vendor-key";
+import {
+  findProviderVendorSummaries,
+  type MergeProviderVendorsResult,
+  mergeProviderVendors,
+  type ProviderVendorSummary,
+  splitProviderVendor,
+  updateProviderVendor,
+} from "@/repository/provider-vendor";
+import type { ProviderVendor } from "@/types/provider";
+import type { ActionResult } from "./types";
+
+function isAdmin(session: Awaited<ReturnType<typeof getSession>>): boolean {
+  return !!session && session.user.role === "admin";
+}
+
+export async function getProviderVendors(): Promise<ProviderVendorSummary[]> {
+  try {
+    const session = await getSession();
+    if (!isAdmin(session)) {
+      return [];
+    }
+
+    return await findProviderVendorSummaries();
+  } catch (error) {
+    logger.error("[ProviderVendorsAction] Failed to list vendors", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+export async function editProviderVendor(
+  vendorId: number,
+  patch: {
+    displayName?: string;
+    websiteUrl?: string | null;
+    faviconUrl?: string | null;
+    isEnabled?: boolean;
+  }
+): Promise<ActionResult<ProviderVendor>> {
+  const tError = await getTranslations("errors");
+
+  const session = await getSession();
+  if (!session) {
+    return { ok: false, error: tError("UNAUTHORIZED"), errorCode: ERROR_CODES.UNAUTHORIZED };
+  }
+  if (!isAdmin(session)) {
+    return {
+      ok: false,
+      error: tError("PERMISSION_DENIED"),
+      errorCode: ERROR_CODES.PERMISSION_DENIED,
+    };
+  }
+
+  try {
+    const updated = await updateProviderVendor(vendorId, patch);
+    if (!updated) {
+      return { ok: false, error: tError("NOT_FOUND"), errorCode: ERROR_CODES.NOT_FOUND };
+    }
+
+    return { ok: true, data: updated };
+  } catch (error) {
+    logger.error("[ProviderVendorsAction] Failed to update vendor", {
+      vendorId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    return {
+      ok: false,
+      error: tError("UPDATE_FAILED"),
+      errorCode: ERROR_CODES.UPDATE_FAILED,
+    };
+  }
+}
+
+export async function mergeProviderVendorsAction(args: {
+  targetVendorId: number;
+  sourceVendorIds: number[];
+}): Promise<ActionResult<MergeProviderVendorsResult>> {
+  const tError = await getTranslations("errors");
+
+  const session = await getSession();
+  if (!session) {
+    return { ok: false, error: tError("UNAUTHORIZED"), errorCode: ERROR_CODES.UNAUTHORIZED };
+  }
+  if (!isAdmin(session)) {
+    return {
+      ok: false,
+      error: tError("PERMISSION_DENIED"),
+      errorCode: ERROR_CODES.PERMISSION_DENIED,
+    };
+  }
+
+  if (!Number.isFinite(args.targetVendorId) || args.targetVendorId <= 0) {
+    return {
+      ok: false,
+      error: tError("INVALID_FORMAT"),
+      errorCode: ERROR_CODES.INVALID_FORMAT,
+    };
+  }
+
+  try {
+    const result = await mergeProviderVendors({
+      targetVendorId: args.targetVendorId,
+      sourceVendorIds: args.sourceVendorIds,
+    });
+
+    return { ok: true, data: result };
+  } catch (error) {
+    logger.error("[ProviderVendorsAction] Failed to merge vendors", {
+      targetVendorId: args.targetVendorId,
+      sourceVendorIds: args.sourceVendorIds,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("not found")) {
+      return { ok: false, error: tError("NOT_FOUND"), errorCode: ERROR_CODES.NOT_FOUND };
+    }
+
+    return {
+      ok: false,
+      error: tError("OPERATION_FAILED"),
+      errorCode: ERROR_CODES.OPERATION_FAILED,
+    };
+  }
+}
+
+export type SplitProviderVendorActionResult = {
+  sourceVendorId: number;
+  newVendor: ProviderVendor;
+  movedProviderIds: number[];
+};
+
+export async function splitProviderVendorAction(args: {
+  sourceVendorId: number;
+  newVendorWebsiteUrlOrHost: string;
+  newDisplayName: string;
+  providerIdsToMove: number[];
+  websiteUrl?: string | null;
+  faviconUrl?: string | null;
+}): Promise<ActionResult<SplitProviderVendorActionResult>> {
+  const tError = await getTranslations("errors");
+
+  const session = await getSession();
+  if (!session) {
+    return { ok: false, error: tError("UNAUTHORIZED"), errorCode: ERROR_CODES.UNAUTHORIZED };
+  }
+  if (!isAdmin(session)) {
+    return {
+      ok: false,
+      error: tError("PERMISSION_DENIED"),
+      errorCode: ERROR_CODES.PERMISSION_DENIED,
+    };
+  }
+
+  const vendorKey = normalizeVendorKeyFromUrl(args.newVendorWebsiteUrlOrHost);
+  if (!vendorKey) {
+    return {
+      ok: false,
+      error: tError("INVALID_URL"),
+      errorCode: ERROR_CODES.INVALID_URL,
+    };
+  }
+
+  try {
+    const result = await splitProviderVendor({
+      sourceVendorId: args.sourceVendorId,
+      newVendorKey: vendorKey,
+      newDisplayName: args.newDisplayName,
+      websiteUrl: args.websiteUrl ?? null,
+      faviconUrl: args.faviconUrl ?? null,
+      providerIdsToMove: args.providerIdsToMove,
+    });
+
+    return {
+      ok: true,
+      data: {
+        sourceVendorId: result.sourceVendorId,
+        newVendor: result.newVendor,
+        movedProviderIds: result.movedProviderIds,
+      },
+    };
+  } catch (error) {
+    logger.error("[ProviderVendorsAction] Failed to split vendor", {
+      sourceVendorId: args.sourceVendorId,
+      vendorKey,
+      providerIdsToMove: args.providerIdsToMove,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    const message = error instanceof Error ? error.message : "";
+    const isUniqueViolation =
+      message.includes("uniq_provider_vendors_vendor_key") ||
+      message.includes("provider_vendors_vendor_key") ||
+      message.toLowerCase().includes("duplicate");
+
+    if (message.includes("source vendor not found")) {
+      return { ok: false, error: tError("NOT_FOUND"), errorCode: ERROR_CODES.NOT_FOUND };
+    }
+
+    if (isUniqueViolation) {
+      return { ok: false, error: tError("CONFLICT"), errorCode: ERROR_CODES.CONFLICT };
+    }
+
+    return {
+      ok: false,
+      error: tError("OPERATION_FAILED"),
+      errorCode: ERROR_CODES.OPERATION_FAILED,
+    };
+  }
+}

--- a/src/app/[locale]/dashboard/availability/_components/availability-providers-view.tsx
+++ b/src/app/[locale]/dashboard/availability/_components/availability-providers-view.tsx
@@ -1,0 +1,530 @@
+"use client";
+
+import { Activity, CheckCircle2, HelpCircle, RefreshCw, XCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import type {
+  AvailabilityQueryResult,
+  ProviderAvailabilitySummary,
+  TimeBucketMetrics,
+} from "@/lib/availability";
+import { cn } from "@/lib/utils";
+
+type TimeRangeOption = "15min" | "1h" | "6h" | "24h" | "7d";
+type SortOption = "availability" | "name" | "requests";
+
+// Target number of buckets to fill the heatmap width consistently
+const TARGET_BUCKETS = 60;
+
+const TIME_RANGE_MAP: Record<TimeRangeOption, number> = {
+  "15min": 15 * 60 * 1000,
+  "1h": 60 * 60 * 1000,
+  "6h": 6 * 60 * 60 * 1000,
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Calculate bucket size to achieve target bucket count
+ */
+function calculateBucketSize(timeRangeMs: number): number {
+  const bucketSizeMs = timeRangeMs / TARGET_BUCKETS;
+  const bucketSizeMinutes = bucketSizeMs / (60 * 1000);
+  // Round to reasonable precision (0.25 min = 15 seconds minimum)
+  return Math.max(0.25, Math.round(bucketSizeMinutes * 4) / 4);
+}
+
+/**
+ * Get color class based on availability score
+ * Simple gradient: gray(no data) -> red -> green
+ */
+function getAvailabilityColor(score: number, hasData: boolean): string {
+  if (!hasData) return "bg-slate-300 dark:bg-slate-600"; // Gray = no data
+
+  if (score < 0.5) return "bg-red-500";
+  if (score < 0.8) return "bg-orange-500";
+  if (score < 0.95) return "bg-lime-500";
+  return "bg-green-500";
+}
+
+/**
+ * Format bucket time for display in tooltip
+ */
+function formatBucketTime(isoString: string, bucketSizeMinutes: number): string {
+  const date = new Date(isoString);
+  if (bucketSizeMinutes >= 1440) {
+    // Daily buckets: show date
+    return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  }
+  if (bucketSizeMinutes >= 60) {
+    // Hourly buckets: show date + hour
+    return date.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+  // Sub-hour buckets: show full time with seconds for precision
+  if (bucketSizeMinutes < 1) {
+    return date.toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  }
+  // Minute buckets: show time
+  return date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+}
+
+/**
+ * Format bucket size for display
+ */
+function _formatBucketSizeDisplay(minutes: number): string {
+  if (minutes >= 60) {
+    const hours = minutes / 60;
+    return hours === 1 ? "1 hour" : `${Number(hours).toFixed(1)} hours`;
+  }
+  if (minutes >= 1) {
+    return `${Math.round(minutes)} min`;
+  }
+  const seconds = Math.round(minutes * 60);
+  return `${seconds} sec`;
+}
+
+export function AvailabilityProvidersView() {
+  const t = useTranslations("dashboard.availability");
+  const [data, setData] = useState<AvailabilityQueryResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [timeRange, setTimeRange] = useState<TimeRangeOption>("24h");
+  const [sortBy, setSortBy] = useState<SortOption>("availability");
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setRefreshing(true);
+      const now = new Date();
+      const timeRangeMs = TIME_RANGE_MAP[timeRange];
+      const startTime = new Date(now.getTime() - timeRangeMs);
+      const bucketSizeMinutes = calculateBucketSize(timeRangeMs);
+
+      const params = new URLSearchParams({
+        startTime: startTime.toISOString(),
+        endTime: now.toISOString(),
+        bucketSizeMinutes: bucketSizeMinutes.toString(),
+        maxBuckets: TARGET_BUCKETS.toString(),
+      });
+
+      const res = await fetch(`/api/availability?${params}`);
+      if (!res.ok) {
+        throw new Error(t("states.fetchFailed"));
+      }
+
+      const result: AvailabilityQueryResult = await res.json();
+      setData(result);
+      setError(null);
+    } catch (err) {
+      console.error("Failed to fetch availability data:", err);
+      setError(err instanceof Error ? err.message : t("states.fetchFailed"));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [timeRange, t]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Generate unified time buckets for all providers
+  const unifiedBuckets = useMemo(() => {
+    if (!data) return [];
+
+    const startTime = new Date(data.startTime);
+    const endTime = new Date(data.endTime);
+    const bucketSizeMs = data.bucketSizeMinutes * 60 * 1000;
+
+    const buckets: string[] = [];
+    let current = new Date(Math.floor(startTime.getTime() / bucketSizeMs) * bucketSizeMs);
+
+    while (current.getTime() < endTime.getTime()) {
+      buckets.push(current.toISOString());
+      current = new Date(current.getTime() + bucketSizeMs);
+    }
+
+    return buckets;
+  }, [data]);
+
+  // Sort providers based on selected option
+  const sortedProviders = useMemo(() => {
+    if (!data?.providers) return [];
+
+    return [...data.providers].sort((a, b) => {
+      switch (sortBy) {
+        case "availability":
+          // Unknown status (no data) goes to the end
+          if (a.currentStatus === "unknown" && b.currentStatus !== "unknown") return 1;
+          if (b.currentStatus === "unknown" && a.currentStatus !== "unknown") return -1;
+          // Sort by availability descending (best first)
+          return b.currentAvailability - a.currentAvailability;
+        case "name":
+          return a.providerName.localeCompare(b.providerName);
+        case "requests":
+          // Sort by requests descending (most active first)
+          return b.totalRequests - a.totalRequests;
+        default:
+          return 0;
+      }
+    });
+  }, [data?.providers, sortBy]);
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case "green":
+        return <CheckCircle2 className="h-4 w-4 text-green-500" />;
+      case "red":
+        return <XCircle className="h-4 w-4 text-red-500" />;
+      case "unknown":
+        return <HelpCircle className="h-4 w-4 text-slate-400" />;
+      default:
+        return <Activity className="h-4 w-4 text-muted-foreground" />;
+    }
+  };
+
+  const getStatusBadge = (status: string) => {
+    const statusKey = status as "green" | "red" | "unknown";
+
+    // 采用与请求日志相同的配色方案
+    const getStatusClassName = () => {
+      switch (status) {
+        case "green":
+          // 成功 - 绿色
+          return "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700";
+        case "red":
+          // 错误 - 红色
+          return "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700";
+        default:
+          // 未知 - 灰色
+          return "bg-gray-100 text-gray-700 border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600";
+      }
+    };
+
+    return (
+      <Badge variant="outline" className={`gap-1 ${getStatusClassName()}`}>
+        {getStatusIcon(status)}
+        {t(`status.${statusKey}`)}
+      </Badge>
+    );
+  };
+
+  const formatLatency = (ms: number) => {
+    if (ms < 1000) return `${Math.round(ms)}ms`;
+    return `${(Number(ms) / 1000).toFixed(2)}s`;
+  };
+
+  const formatPercentage = (value: number) => `${(Number(value) * 100).toFixed(1)}%`;
+
+  // Summary counts
+  const getSummaryCounts = () => {
+    if (!data?.providers) return { healthy: 0, unhealthy: 0, unknown: 0, total: 0 };
+    return {
+      healthy: data.providers.filter((p) => p.currentStatus === "green").length,
+      unhealthy: data.providers.filter((p) => p.currentStatus === "red").length,
+      unknown: data.providers.filter((p) => p.currentStatus === "unknown").length,
+      total: data.providers.length,
+    };
+  };
+
+  const summary = getSummaryCounts();
+
+  // Get bucket data for a provider at a specific time
+  const getBucketData = (
+    provider: ProviderAvailabilitySummary,
+    bucketStart: string
+  ): TimeBucketMetrics | null => {
+    return provider.timeBuckets.find((b) => b.bucketStart === bucketStart) || null;
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-4">
+          {[...Array(4)].map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="pb-2">
+                <Skeleton className="h-4 w-24" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-8 w-16" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        <Card>
+          <CardContent className="py-8">
+            <div className="text-center text-muted-foreground">{t("states.loading")}</div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="py-8">
+          <div className="text-center text-destructive">{error}</div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <div className="space-y-6">
+        {/* Summary Cards */}
+        <div className="grid gap-4 md:grid-cols-4">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                {t("metrics.systemAvailability")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">
+                {formatPercentage(data?.systemAvailability ?? 0)}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-green-600 flex items-center gap-1">
+                <CheckCircle2 className="h-4 w-4" />
+                {t("summary.healthyProviders")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold text-green-600">{summary.healthy}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-red-600 flex items-center gap-1">
+                <XCircle className="h-4 w-4" />
+                {t("summary.unhealthyProviders")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold text-red-600">{summary.unhealthy}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-slate-500 flex items-center gap-1">
+                <HelpCircle className="h-4 w-4" />
+                {t("summary.unknownProviders")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold text-slate-500">{summary.unknown}</div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Controls */}
+        <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
+          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-4 w-full sm:w-auto">
+            <Select value={timeRange} onValueChange={(v) => setTimeRange(v as TimeRangeOption)}>
+              <SelectTrigger className="w-full sm:w-[180px]">
+                <SelectValue placeholder={t("timeRange.label")} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="15min">{t("timeRange.last15min")}</SelectItem>
+                <SelectItem value="1h">{t("timeRange.last1h")}</SelectItem>
+                <SelectItem value="6h">{t("timeRange.last6h")}</SelectItem>
+                <SelectItem value="24h">{t("timeRange.last24h")}</SelectItem>
+                <SelectItem value="7d">{t("timeRange.last7d")}</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={sortBy} onValueChange={(v) => setSortBy(v as SortOption)}>
+              <SelectTrigger className="w-full sm:w-[160px]">
+                <SelectValue placeholder={t("sort.label")} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="availability">{t("sort.availability")}</SelectItem>
+                <SelectItem value="name">{t("sort.name")}</SelectItem>
+                <SelectItem value="requests">{t("sort.requests")}</SelectItem>
+              </SelectContent>
+            </Select>
+            {data && (
+              <span className="text-sm text-muted-foreground">
+                {t("heatmap.bucketSize")}: {data.bucketSizeMinutes} {t("heatmap.minutes")}
+              </span>
+            )}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={fetchData}
+            disabled={refreshing}
+            className="w-full sm:w-auto"
+          >
+            <RefreshCw className={cn("h-4 w-4 mr-2", refreshing && "animate-spin")} />
+            {refreshing ? t("actions.refreshing") : t("actions.refresh")}
+          </Button>
+        </div>
+
+        {/* Heatmap */}
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("chart.title")}</CardTitle>
+            <CardDescription>{t("chart.description")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {!sortedProviders.length ? (
+              <div className="text-center text-muted-foreground py-8">
+                {t("states.noProviders")}
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {/* Provider rows with heatmap */}
+                {sortedProviders.map((provider) => (
+                  <div
+                    key={provider.providerId}
+                    className="flex flex-col sm:flex-row sm:items-center gap-3"
+                  >
+                    {/* Provider name and summary - on same row for mobile */}
+                    <div className="flex items-center justify-between sm:contents">
+                      <div className="w-auto sm:w-32 md:w-40 shrink-0 flex items-center gap-2">
+                        <span
+                          className="font-medium truncate text-sm"
+                          title={provider.providerName}
+                        >
+                          {provider.providerName}
+                        </span>
+                        {getStatusBadge(provider.currentStatus)}
+                      </div>
+
+                      {/* Summary stats - shown on right for mobile, at end for desktop */}
+                      <div className="w-auto sm:w-20 md:w-24 lg:w-28 shrink-0 text-right text-sm sm:order-last">
+                        <div className="font-mono">
+                          {provider.currentStatus === "unknown"
+                            ? t("heatmap.noData")
+                            : formatPercentage(provider.currentAvailability)}
+                        </div>
+                        <div className="text-muted-foreground text-xs">
+                          {provider.totalRequests > 0
+                            ? `${provider.totalRequests.toLocaleString()} ${t("heatmap.requests")}`
+                            : t("heatmap.noRequests")}
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Heatmap cells - wrappable grid with auto-fill */}
+                    <div className="w-full sm:flex-1 sm:min-w-0">
+                      <div className="grid gap-1 grid-cols-[repeat(auto-fill,minmax(12px,1fr))] sm:gap-px">
+                        {unifiedBuckets.map((bucketStart) => {
+                          const bucket = getBucketData(provider, bucketStart);
+                          const hasData = bucket !== null && bucket.totalRequests > 0;
+                          const score = hasData ? bucket.availabilityScore : 0;
+
+                          return (
+                            <Tooltip key={bucketStart}>
+                              <TooltipTrigger asChild>
+                                <div
+                                  className={cn(
+                                    "h-6 rounded-[2px] cursor-pointer transition-opacity hover:opacity-80",
+                                    getAvailabilityColor(score, hasData)
+                                  )}
+                                />
+                              </TooltipTrigger>
+                              <TooltipContent side="top" className="max-w-xs">
+                                <div className="text-sm space-y-1">
+                                  <div className="font-medium">
+                                    {formatBucketTime(bucketStart, data?.bucketSizeMinutes ?? 5)}
+                                  </div>
+                                  {hasData && bucket ? (
+                                    <>
+                                      <div>
+                                        {t("heatmap.requests")}: {bucket.totalRequests}
+                                      </div>
+                                      <div>
+                                        {t("columns.availability")}:{" "}
+                                        {formatPercentage(bucket.availabilityScore)}
+                                      </div>
+                                      <div>
+                                        {t("columns.avgLatency")}:{" "}
+                                        {formatLatency(bucket.avgLatencyMs)}
+                                      </div>
+                                      <div className="flex gap-2 text-xs">
+                                        <span className="text-green-500">
+                                          {t("details.greenCount")}: {bucket.greenCount}
+                                        </span>
+                                        <span className="text-red-500">
+                                          {t("details.redCount")}: {bucket.redCount}
+                                        </span>
+                                      </div>
+                                    </>
+                                  ) : (
+                                    <div className="text-muted-foreground">
+                                      {t("heatmap.noData")}
+                                    </div>
+                                  )}
+                                </div>
+                              </TooltipContent>
+                            </Tooltip>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Legend */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex flex-wrap gap-3 sm:gap-4 md:gap-6 text-sm">
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-sm bg-green-500" />
+                <span className="text-muted-foreground">{t("legend.green")}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-sm bg-lime-500" />
+                <span className="text-muted-foreground">{t("legend.lime")}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-sm bg-orange-500" />
+                <span className="text-muted-foreground">{t("legend.orange")}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-sm bg-red-500" />
+                <span className="text-muted-foreground">{t("legend.red")}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded-sm bg-slate-300 dark:bg-slate-600" />
+                <span className="text-muted-foreground">{t("legend.noData")}</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/app/[locale]/dashboard/availability/page.tsx
+++ b/src/app/[locale]/dashboard/availability/page.tsx
@@ -4,35 +4,38 @@ import { Suspense } from "react";
 import { Section } from "@/components/section";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { getSession } from "@/lib/auth";
+import { AvailabilityEndpointsView } from "./_components/availability-endpoints-view";
+import { AvailabilityProvidersView } from "./_components/availability-providers-view";
 import { AvailabilityViewSkeleton } from "./_components/availability-skeleton";
-import { AvailabilityView } from "./_components/availability-view";
 
 export const dynamic = "force-dynamic";
 
 export default async function AvailabilityPage() {
-  const t = await getTranslations("dashboard");
+  const t = await getTranslations("dashboard.availability");
   const session = await getSession();
 
   // Only admin can access availability monitoring
   const isAdmin = session?.user.role === "admin";
 
   if (!isAdmin) {
+    const tPerm = await getTranslations("dashboard.leaderboard.permission");
     return (
       <div className="space-y-6">
-        <Section title={t("availability.title")} description={t("availability.description")}>
+        <Section title={t("title")} description={t("description")}>
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <AlertCircle className="h-5 w-5 text-muted-foreground" />
-                {t("leaderboard.permission.title")}
+                {tPerm("title")}
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <Alert>
                 <AlertCircle className="h-4 w-4" />
-                <AlertTitle>{t("leaderboard.permission.restricted")}</AlertTitle>
-                <AlertDescription>{t("leaderboard.permission.userAction")}</AlertDescription>
+                <AlertTitle>{tPerm("restricted")}</AlertTitle>
+                <AlertDescription>{tPerm("userAction")}</AlertDescription>
               </Alert>
             </CardContent>
           </Card>
@@ -43,10 +46,23 @@ export default async function AvailabilityPage() {
 
   return (
     <div className="space-y-6">
-      <Section title={t("availability.title")} description={t("availability.description")}>
-        <Suspense fallback={<AvailabilityViewSkeleton />}>
-          <AvailabilityView />
-        </Suspense>
+      <Section title={t("title")} description={t("description")}>
+        <Tabs defaultValue="providers" className="w-full">
+          <TabsList>
+            <TabsTrigger value="providers">{t("tabs.providers")}</TabsTrigger>
+            <TabsTrigger value="endpoints">{t("tabs.endpoints")}</TabsTrigger>
+          </TabsList>
+          <TabsContent value="providers" className="mt-4">
+            <Suspense fallback={<AvailabilityViewSkeleton />}>
+              <AvailabilityProvidersView />
+            </Suspense>
+          </TabsContent>
+          <TabsContent value="endpoints" className="mt-4">
+            <Suspense fallback={<AvailabilityViewSkeleton />}>
+              <AvailabilityEndpointsView />
+            </Suspense>
+          </TabsContent>
+        </Tabs>
       </Section>
     </div>
   );

--- a/src/app/[locale]/settings/providers/_components/providers-tabs.tsx
+++ b/src/app/[locale]/settings/providers/_components/providers-tabs.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useSelectedLayoutSegment } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Link } from "@/i18n/routing";
+
+export function ProvidersTabs({ children }: { children: React.ReactNode }) {
+  const segment = useSelectedLayoutSegment();
+  const t = useTranslations("settings.providers.tabs");
+
+  const activeTab = segment === "vendors" ? "vendors" : "providers";
+
+  return (
+    <Tabs value={activeTab} className="space-y-4">
+      <TabsList>
+        <Link href="/settings/providers">
+          <TabsTrigger value="providers">{t("providers")}</TabsTrigger>
+        </Link>
+        <Link href="/settings/providers/vendors">
+          <TabsTrigger value="vendors">{t("vendors")}</TabsTrigger>
+        </Link>
+      </TabsList>
+      {children}
+    </Tabs>
+  );
+}

--- a/src/app/[locale]/settings/providers/_components/vendors/endpoint-add-dialog.tsx
+++ b/src/app/[locale]/settings/providers/_components/vendors/endpoint-add-dialog.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import * as z from "zod";
+import { createProviderEndpointAction } from "@/actions/provider-endpoints";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { ProviderType } from "@/types/provider";
+
+const formSchema = z.object({
+  providerType: z.enum([
+    "claude",
+    "claude-auth",
+    "codex",
+    "gemini",
+    "gemini-cli",
+    "openai-compatible",
+  ]),
+  baseUrl: z.string().url(),
+  priority: z.number().int(),
+  weight: z.number().int().min(1),
+  isEnabled: z.boolean(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface EndpointAddDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  vendorId: number;
+}
+
+export function EndpointAddDialog({ open, onOpenChange, vendorId }: EndpointAddDialogProps) {
+  const t = useTranslations("settings.providers.vendors.endpoints");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const queryClient = useQueryClient();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+    reset,
+    setError,
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      providerType: "openai-compatible",
+      baseUrl: "",
+      priority: 0,
+      weight: 1,
+      isEnabled: true,
+    },
+  });
+
+  const onSubmit = async (values: FormValues) => {
+    setIsSubmitting(true);
+    try {
+      const result = await createProviderEndpointAction({
+        vendorId,
+        providerType: values.providerType as ProviderType,
+        baseUrl: values.baseUrl,
+        priority: values.priority,
+        weight: values.weight,
+        isEnabled: values.isEnabled,
+      });
+
+      if (result.ok) {
+        toast.success(t("createSuccess"));
+        queryClient.invalidateQueries({ queryKey: ["provider-endpoints"] });
+        queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
+        onOpenChange(false);
+        reset();
+      } else {
+        if (result.errorCode === "CONFLICT") {
+          setError("baseUrl", { message: t("errors.conflict") });
+        } else {
+          toast.error(result.error || t("errors.createFailed"));
+        }
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>{t("addTitle")}</DialogTitle>
+          <DialogDescription>{t("addDescription")}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="providerType">{t("fields.type")}</Label>
+            <Controller
+              control={control}
+              name="providerType"
+              render={({ field }) => (
+                <Select onValueChange={field.onChange} defaultValue={field.value}>
+                  <SelectTrigger id="providerType">
+                    <SelectValue placeholder="Select type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="openai-compatible">OpenAI Compatible</SelectItem>
+                    <SelectItem value="claude">Claude</SelectItem>
+                    <SelectItem value="claude-auth">Claude Auth</SelectItem>
+                    <SelectItem value="gemini">Gemini</SelectItem>
+                    <SelectItem value="gemini-cli">Gemini CLI</SelectItem>
+                    <SelectItem value="codex">Codex</SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+            {errors.providerType && (
+              <p className="text-sm text-destructive">{errors.providerType.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="baseUrl">{t("fields.baseUrl")}</Label>
+            <Controller
+              control={control}
+              name="baseUrl"
+              render={({ field }) => (
+                <Input id="baseUrl" placeholder="https://api.example.com/v1" {...field} />
+              )}
+            />
+            {errors.baseUrl && <p className="text-sm text-destructive">{errors.baseUrl.message}</p>}
+          </div>
+
+          <div className="flex gap-4">
+            <div className="space-y-2 flex-1">
+              <Label htmlFor="priority">{t("fields.priority")}</Label>
+              <Controller
+                control={control}
+                name="priority"
+                render={({ field }) => (
+                  <Input
+                    id="priority"
+                    type="number"
+                    {...field}
+                    onChange={(e) => field.onChange(e.target.valueAsNumber)}
+                  />
+                )}
+              />
+              {errors.priority && (
+                <p className="text-sm text-destructive">{errors.priority.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2 flex-1">
+              <Label htmlFor="weight">{t("fields.weight")}</Label>
+              <Controller
+                control={control}
+                name="weight"
+                render={({ field }) => (
+                  <Input
+                    id="weight"
+                    type="number"
+                    min={1}
+                    {...field}
+                    onChange={(e) => field.onChange(e.target.valueAsNumber)}
+                  />
+                )}
+              />
+              {errors.weight && <p className="text-sm text-destructive">{errors.weight.message}</p>}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {t("actions.create")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/[locale]/settings/providers/_components/vendors/endpoint-list-item.tsx
+++ b/src/app/[locale]/settings/providers/_components/vendors/endpoint-list-item.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { deleteProviderEndpointAction } from "@/actions/provider-endpoints";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { ProviderEndpoint } from "@/types/provider";
+
+export function EndpointListItem({ endpoint }: { endpoint: ProviderEndpoint }) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const queryClient = useQueryClient();
+
+  const handleDelete = async () => {
+    if (!confirm("Are you sure you want to delete this endpoint?")) return;
+
+    setIsDeleting(true);
+    try {
+      const result = await deleteProviderEndpointAction(endpoint.id);
+      if (result.ok) {
+        queryClient.invalidateQueries({ queryKey: ["provider-endpoints"] });
+        toast.success("Endpoint deleted");
+      } else {
+        toast.error("Failed to delete endpoint");
+      }
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between rounded-md border p-3 text-sm">
+      <div className="flex flex-col gap-1 overflow-hidden">
+        <div className="font-mono truncate" title={endpoint.baseUrl}>
+          {endpoint.baseUrl}
+        </div>
+        <div className="flex gap-2">
+          <Badge variant="outline" className="text-[10px] h-5">
+            P{endpoint.priority}
+          </Badge>
+          <Badge variant="outline" className="text-[10px] h-5">
+            W{endpoint.weight}
+          </Badge>
+        </div>
+      </div>
+      <Button variant="ghost" size="icon" onClick={handleDelete} disabled={isDeleting}>
+        {isDeleting ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Trash2 className="h-4 w-4 text-destructive" />
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/src/app/[locale]/settings/providers/_components/vendors/vendor-card.tsx
+++ b/src/app/[locale]/settings/providers/_components/vendors/vendor-card.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { Globe, Settings2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { toast } from "sonner";
+import { editProviderVendor } from "@/actions/provider-vendors";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import type { ProviderVendorSummary } from "@/repository/provider-vendor";
+import { VendorEditSheet } from "./vendor-edit-sheet";
+
+export function VendorCard({ vendor }: { vendor: ProviderVendorSummary }) {
+  const t = useTranslations("settings.providers.vendors");
+  const [isEditOpen, setIsEditOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const handleToggle = async (enabled: boolean) => {
+    const result = await editProviderVendor(vendor.id, { isEnabled: enabled });
+    if (result.ok) {
+      queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
+      toast.success(t("actions.updated"));
+    } else {
+      toast.error(t("errors.updateFailed"));
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <div className="flex items-center gap-2">
+          {vendor.faviconUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={vendor.faviconUrl} alt="" className="h-5 w-5 rounded-sm" />
+          ) : (
+            <Globe className="h-5 w-5 text-muted-foreground" />
+          )}
+          <span className="font-semibold">{vendor.displayName}</span>
+        </div>
+        <Switch checked={vendor.isEnabled} onCheckedChange={handleToggle} />
+      </CardHeader>
+      <CardContent className="space-y-2 pb-2">
+        <div className="flex gap-2">
+          <Badge variant="secondary">
+            {vendor.providerCount} {t("stats.providers")}
+          </Badge>
+          <Badge variant="outline">
+            {vendor.endpointCount} {t("stats.endpoints")}
+          </Badge>
+        </div>
+      </CardContent>
+      <CardFooter className="pt-2">
+        <Button variant="ghost" size="sm" className="w-full" onClick={() => setIsEditOpen(true)}>
+          <Settings2 className="mr-2 h-4 w-4" />
+          {t("actions.configure")}
+        </Button>
+        <VendorEditSheet open={isEditOpen} onOpenChange={setIsEditOpen} vendor={vendor} />
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/app/[locale]/settings/providers/_components/vendors/vendor-edit-sheet.tsx
+++ b/src/app/[locale]/settings/providers/_components/vendors/vendor-edit-sheet.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { toast } from "sonner";
+import { editProviderVendor } from "@/actions/provider-vendors";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import type { ProviderVendorSummary } from "@/repository/provider-vendor";
+import { VendorEndpointsManager } from "./vendor-endpoints-manager";
+
+interface VendorEditSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  vendor: ProviderVendorSummary;
+}
+
+export function VendorEditSheet({ open, onOpenChange, vendor }: VendorEditSheetProps) {
+  const t = useTranslations("settings.providers.vendors");
+  const [displayName, setDisplayName] = useState(vendor.displayName);
+  const [websiteUrl, setWebsiteUrl] = useState(vendor.websiteUrl || "");
+  const [isSaving, setIsSaving] = useState(false);
+  const queryClient = useQueryClient();
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      const result = await editProviderVendor(vendor.id, {
+        displayName,
+        websiteUrl: websiteUrl || null,
+      });
+
+      if (result.ok) {
+        queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
+        toast.success(t("actions.updated"));
+        onOpenChange(false);
+      } else {
+        toast.error(t("errors.updateFailed"));
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="sm:max-w-xl overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>{t("edit.title")}</SheetTitle>
+          <SheetDescription>{t("edit.description")}</SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-6 space-y-6">
+          <div className="space-y-4 rounded-lg border p-4">
+            <div className="grid gap-2">
+              <Label htmlFor="name">{t("fields.name")}</Label>
+              <Input
+                id="name"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="website">{t("fields.website")}</Label>
+              <Input
+                id="website"
+                value={websiteUrl}
+                onChange={(e) => setWebsiteUrl(e.target.value)}
+              />
+            </div>
+            <Button onClick={handleSave} disabled={isSaving} className="w-full">
+              {isSaving ? t("actions.saving") : t("actions.save")}
+            </Button>
+          </div>
+
+          <div className="space-y-4">
+            <h3 className="text-lg font-semibold">{t("endpoints.title")}</h3>
+            <VendorEndpointsManager vendorId={vendor.id} />
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/app/[locale]/settings/providers/_components/vendors/vendor-endpoints-manager.tsx
+++ b/src/app/[locale]/settings/providers/_components/vendors/vendor-endpoints-manager.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, Loader2, Plus, Server } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { getProviderEndpointsByVendors } from "@/actions/provider-endpoints";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import type { ProviderType } from "@/types/provider";
+import { EndpointAddDialog } from "./endpoint-add-dialog";
+import { EndpointListItem } from "./endpoint-list-item";
+
+export function VendorEndpointsManager({ vendorId }: { vendorId: number }) {
+  const t = useTranslations("settings.providers.vendors.endpoints");
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [openTypes, setOpenTypes] = useState<Record<string, boolean>>({});
+
+  const { data: endpoints, isLoading } = useQuery({
+    queryKey: ["provider-endpoints", vendorId],
+    queryFn: () => getProviderEndpointsByVendors({ vendorIds: [vendorId] }),
+  });
+
+  if (isLoading) {
+    return <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />;
+  }
+
+  const groupedEndpoints = (endpoints || []).reduce(
+    (acc, endpoint) => {
+      if (!acc[endpoint.providerType]) acc[endpoint.providerType] = [];
+      acc[endpoint.providerType]?.push(endpoint);
+      return acc;
+    },
+    {} as Record<ProviderType, typeof endpoints>
+  );
+
+  const types = Object.keys(groupedEndpoints) as ProviderType[];
+
+  const toggleType = (type: string) => {
+    setOpenTypes((prev) => ({ ...prev, [type]: !prev[type] }));
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <p className="text-sm text-muted-foreground">
+          {endpoints?.length || 0} {t("count")}
+        </p>
+        <Button size="sm" variant="outline" onClick={() => setIsAddOpen(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          {t("add")}
+        </Button>
+      </div>
+
+      <EndpointAddDialog open={isAddOpen} onOpenChange={setIsAddOpen} vendorId={vendorId} />
+
+      {endpoints?.length === 0 ? (
+        <div className="flex h-32 flex-col items-center justify-center rounded-lg border border-dashed bg-muted/50">
+          <Server className="mb-2 h-8 w-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">{t("empty")}</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {types.map((type) => {
+            const typeEndpoints = groupedEndpoints[type] || [];
+            const isOpen = openTypes[type] ?? true;
+
+            return (
+              <Collapsible
+                key={type}
+                open={isOpen}
+                onOpenChange={() => toggleType(type)}
+                className="border rounded-md"
+              >
+                <CollapsibleTrigger asChild>
+                  <button className="flex w-full items-center justify-between p-3 hover:bg-muted/50 transition-colors">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-sm uppercase">{type}</span>
+                      <Badge variant="secondary" className="text-xs">
+                        {typeEndpoints.length}
+                      </Badge>
+                    </div>
+                    <ChevronDown
+                      className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+                    />
+                  </button>
+                </CollapsibleTrigger>
+                <CollapsibleContent className="p-3 pt-0 space-y-2">
+                  {typeEndpoints.map((endpoint) => (
+                    <EndpointListItem key={endpoint.id} endpoint={endpoint} />
+                  ))}
+                </CollapsibleContent>
+              </Collapsible>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/settings/providers/_components/vendors/vendor-list.tsx
+++ b/src/app/[locale]/settings/providers/_components/vendors/vendor-list.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { PackageOpen } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { ProviderVendorSummary } from "@/repository/provider-vendor";
+import { VendorCard } from "./vendor-card";
+
+interface VendorListProps {
+  vendors: ProviderVendorSummary[];
+}
+
+export function VendorList({ vendors }: VendorListProps) {
+  const t = useTranslations("settings.providers.vendors");
+
+  if (vendors.length === 0) {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center rounded-lg border border-dashed text-center">
+        <PackageOpen className="mb-4 h-10 w-10 text-muted-foreground" />
+        <h3 className="text-lg font-medium">{t("empty.title")}</h3>
+        <p className="text-sm text-muted-foreground">{t("empty.description")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {vendors.map((vendor) => (
+        <VendorCard key={vendor.id} vendor={vendor} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/[locale]/settings/providers/_components/vendors/vendors-manager-loader.tsx
+++ b/src/app/[locale]/settings/providers/_components/vendors/vendors-manager-loader.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { getProviderVendors } from "@/actions/provider-vendors";
+import { VendorsManager } from "./vendors-manager";
+
+export function VendorsManagerLoader() {
+  const { data: vendors, isLoading } = useQuery({
+    queryKey: ["provider-vendors"],
+    queryFn: () => getProviderVendors(),
+    staleTime: 30_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return <VendorsManager initialVendors={vendors || []} />;
+}

--- a/src/app/[locale]/settings/providers/_components/vendors/vendors-manager.tsx
+++ b/src/app/[locale]/settings/providers/_components/vendors/vendors-manager.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import type { ProviderVendorSummary } from "@/repository/provider-vendor";
+import { VendorList } from "./vendor-list";
+
+interface VendorsManagerProps {
+  initialVendors: ProviderVendorSummary[];
+}
+
+export function VendorsManager({ initialVendors }: VendorsManagerProps) {
+  const t = useTranslations("settings.providers.vendors");
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const filteredVendors = initialVendors.filter(
+    (vendor) =>
+      vendor.displayName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      vendor.vendorKey.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <div className="relative flex-1">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder={t("searchPlaceholder")}
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+      </div>
+
+      <VendorList vendors={filteredVendors} />
+    </div>
+  );
+}

--- a/src/app/[locale]/settings/providers/layout.tsx
+++ b/src/app/[locale]/settings/providers/layout.tsx
@@ -1,0 +1,19 @@
+import { getTranslations } from "next-intl/server";
+import { ProvidersTabs } from "./_components/providers-tabs";
+
+export default async function ProvidersLayout({ children }: { children: React.ReactNode }) {
+  const t = await getTranslations("settings.providers.tabs");
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight">{t("title")}</h2>
+          <p className="text-muted-foreground">{t("description")}</p>
+        </div>
+      </div>
+
+      <ProvidersTabs>{children}</ProvidersTabs>
+    </div>
+  );
+}

--- a/src/app/[locale]/settings/providers/page.tsx
+++ b/src/app/[locale]/settings/providers/page.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/routing";
 import { getSession } from "@/lib/auth";
 import { getEnvConfig } from "@/lib/config/env.schema";
-import { SettingsPageHeader } from "../_components/settings-page-header";
 import { AutoSortPriorityDialog } from "./_components/auto-sort-priority-dialog";
 import { ProviderManagerLoader } from "./_components/provider-manager-loader";
 import { SchedulingRulesDialog } from "./_components/scheduling-rules-dialog";
@@ -20,30 +19,26 @@ export default async function SettingsProvidersPage() {
   const enableMultiProviderTypes = getEnvConfig().ENABLE_MULTI_PROVIDER_TYPES;
 
   return (
-    <>
-      <SettingsPageHeader title={t("providers.title")} description={t("providers.description")} />
-
-      <Section
-        title={t("providers.section.title")}
-        description={t("providers.section.description")}
-        actions={
-          <>
-            <Button asChild variant="outline">
-              <Link href="/dashboard/leaderboard?scope=provider">
-                <BarChart3 className="h-4 w-4" />
-                {t("providers.section.leaderboard")}
-              </Link>
-            </Button>
-            <AutoSortPriorityDialog />
-            <SchedulingRulesDialog />
-          </>
-        }
-      >
-        <ProviderManagerLoader
-          currentUser={session?.user}
-          enableMultiProviderTypes={enableMultiProviderTypes}
-        />
-      </Section>
-    </>
+    <Section
+      title={t("providers.section.title")}
+      description={t("providers.section.description")}
+      actions={
+        <>
+          <Button asChild variant="outline">
+            <Link href="/dashboard/leaderboard?scope=provider">
+              <BarChart3 className="h-4 w-4" />
+              {t("providers.section.leaderboard")}
+            </Link>
+          </Button>
+          <AutoSortPriorityDialog />
+          <SchedulingRulesDialog />
+        </>
+      }
+    >
+      <ProviderManagerLoader
+        currentUser={session?.user}
+        enableMultiProviderTypes={enableMultiProviderTypes}
+      />
+    </Section>
   );
 }

--- a/src/app/[locale]/settings/providers/vendors/page.tsx
+++ b/src/app/[locale]/settings/providers/vendors/page.tsx
@@ -1,0 +1,13 @@
+import { getTranslations } from "next-intl/server";
+import { Section } from "@/components/section";
+import { VendorsManagerLoader } from "../_components/vendors/vendors-manager-loader";
+
+export default async function VendorsPage() {
+  const t = await getTranslations("settings.providers.vendors");
+
+  return (
+    <Section title={t("title")} description={t("description")}>
+      <VendorsManagerLoader />
+    </Section>
+  );
+}

--- a/src/app/api/availability/endpoints/current/route.ts
+++ b/src/app/api/availability/endpoints/current/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { getCurrentEndpointStatus } from "@/lib/endpoint-availability";
+
+export async function GET() {
+  const session = await getSession();
+  if (!session || session.user.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await getCurrentEndpointStatus();
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Current endpoint availability API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/availability/endpoints/events/route.ts
+++ b/src/app/api/availability/endpoints/events/route.ts
@@ -1,0 +1,43 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { findProviderEndpointProbeEvents } from "@/repository/provider-endpoint-probe-event";
+
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  if (!session || session.user.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+
+    const endpointIdRaw = searchParams.get("endpointId");
+    const endpointId = endpointIdRaw ? parseInt(endpointIdRaw, 10) : NaN;
+
+    if (!Number.isFinite(endpointId) || endpointId <= 0) {
+      return NextResponse.json({ error: "Invalid endpointId" }, { status: 400 });
+    }
+
+    const limitRaw = searchParams.get("limit");
+    const limitParsed = limitRaw ? parseInt(limitRaw, 10) : NaN;
+    const limit = Number.isFinite(limitParsed) ? Math.min(Math.max(limitParsed, 1), 500) : 100;
+
+    const startTimeRaw = searchParams.get("startTime");
+    const endTimeRaw = searchParams.get("endTime");
+
+    const startTime = startTimeRaw ? new Date(startTimeRaw) : undefined;
+    const endTime = endTimeRaw ? new Date(endTimeRaw) : undefined;
+
+    const events = await findProviderEndpointProbeEvents({
+      endpointId,
+      startTime: startTime && Number.isFinite(startTime.getTime()) ? startTime : undefined,
+      endTime: endTime && Number.isFinite(endTime.getTime()) ? endTime : undefined,
+      limit,
+    });
+
+    return NextResponse.json(events);
+  } catch (error) {
+    console.error("Endpoint probe events API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/availability/endpoints/route.ts
+++ b/src/app/api/availability/endpoints/route.ts
@@ -1,0 +1,76 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import {
+  type EndpointAvailabilityQueryOptions,
+  queryEndpointAvailability,
+} from "@/lib/endpoint-availability";
+import type { ProviderType } from "@/types/provider";
+
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  if (!session || session.user.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+
+    const options: EndpointAvailabilityQueryOptions = {};
+
+    const startTime = searchParams.get("startTime");
+    if (startTime) {
+      options.startTime = startTime;
+    }
+
+    const endTime = searchParams.get("endTime");
+    if (endTime) {
+      options.endTime = endTime;
+    }
+
+    const endpointIds = searchParams.get("endpointIds");
+    if (endpointIds) {
+      options.endpointIds = endpointIds
+        .split(",")
+        .map((id) => parseInt(id.trim(), 10))
+        .filter((id) => !Number.isNaN(id));
+    }
+
+    const vendorIds = searchParams.get("vendorIds");
+    if (vendorIds) {
+      options.vendorIds = vendorIds
+        .split(",")
+        .map((id) => parseInt(id.trim(), 10))
+        .filter((id) => !Number.isNaN(id));
+    }
+
+    const providerTypes = searchParams.get("providerTypes");
+    if (providerTypes) {
+      options.providerTypes = providerTypes
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0) as ProviderType[];
+    }
+
+    const bucketSizeMinutes = searchParams.get("bucketSizeMinutes");
+    if (bucketSizeMinutes) {
+      const parsed = parseFloat(bucketSizeMinutes);
+      options.bucketSizeMinutes = Number.isNaN(parsed) ? 0.25 : Math.max(0.25, parsed);
+    }
+
+    const includeDisabled = searchParams.get("includeDisabled");
+    if (includeDisabled) {
+      options.includeDisabled = includeDisabled === "true";
+    }
+
+    const maxBuckets = searchParams.get("maxBuckets");
+    if (maxBuckets) {
+      options.maxBuckets = parseInt(maxBuckets, 10);
+    }
+
+    const result = await queryEndpointAvailability(options);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Endpoint availability API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/v1/_lib/proxy/endpoint-resolver.ts
+++ b/src/app/v1/_lib/proxy/endpoint-resolver.ts
@@ -1,0 +1,144 @@
+import "server-only";
+
+import { isEndpointCircuitOpen, openVendorTypeFuse } from "@/lib/endpoint-circuit-breaker";
+import { logger } from "@/lib/logger";
+import { findProviderEndpointsByVendorType } from "@/repository/provider-endpoint";
+import type { Provider, ProviderEndpoint } from "@/types/provider";
+import type { ProxySession } from "./session";
+
+const ENDPOINTS_CACHE_TTL_MS = 30_000;
+
+type EndpointsCacheEntry = {
+  expiresAt: number;
+  endpoints: ProviderEndpoint[];
+};
+
+const endpointsCache = new Map<string, EndpointsCacheEntry>();
+
+function getCacheKey(vendorId: number, providerType: Provider["providerType"]): string {
+  return `${vendorId}:${providerType}`;
+}
+
+function isValidBaseUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+async function getEndpointsCached(
+  vendorId: number,
+  providerType: Provider["providerType"]
+): Promise<ProviderEndpoint[]> {
+  const now = Date.now();
+  const key = getCacheKey(vendorId, providerType);
+  const cached = endpointsCache.get(key);
+  if (cached && cached.expiresAt > now) {
+    return cached.endpoints;
+  }
+
+  const endpoints = await findProviderEndpointsByVendorType(vendorId, providerType);
+  endpointsCache.set(key, { expiresAt: now + ENDPOINTS_CACHE_TTL_MS, endpoints });
+  return endpoints;
+}
+
+function weightedRandom(endpoints: ProviderEndpoint[]): ProviderEndpoint {
+  const totalWeight = endpoints.reduce((sum, e) => sum + (e.weight ?? 0), 0);
+
+  if (totalWeight <= 0) {
+    const index = Math.floor(Math.random() * endpoints.length);
+    return endpoints[Math.max(0, Math.min(index, endpoints.length - 1))];
+  }
+
+  const random = Math.random() * totalWeight;
+  let cumulativeWeight = 0;
+
+  for (const endpoint of endpoints) {
+    cumulativeWeight += endpoint.weight ?? 0;
+    if (random < cumulativeWeight) {
+      return endpoint;
+    }
+  }
+
+  return endpoints[endpoints.length - 1];
+}
+
+export class EndpointResolutionError extends Error {
+  constructor(
+    message: string,
+    public readonly vendorId: number,
+    public readonly providerType: Provider["providerType"]
+  ) {
+    super(message);
+    this.name = "EndpointResolutionError";
+  }
+}
+
+export type EndpointResolverSession = Pick<ProxySession, "setProviderEndpoint">;
+
+export class EndpointResolver {
+  static async resolve(session: EndpointResolverSession, provider: Provider): Promise<string> {
+    const fallback = provider.url;
+
+    if (!provider.vendorId) {
+      session.setProviderEndpoint(null);
+      return fallback;
+    }
+
+    const vendorId = provider.vendorId;
+    const providerType = provider.providerType;
+
+    const allEndpoints = await getEndpointsCached(vendorId, providerType);
+
+    if (allEndpoints.length === 0) {
+      session.setProviderEndpoint(null);
+      return fallback;
+    }
+
+    const enabledEndpoints = allEndpoints.filter((e) => e.isEnabled);
+    const validEnabledEndpoints = enabledEndpoints.filter((e) => isValidBaseUrl(e.baseUrl));
+
+    if (enabledEndpoints.length > 0 && validEnabledEndpoints.length === 0) {
+      logger.warn("[EndpointResolver] All enabled endpoints have invalid baseUrl", {
+        vendorId,
+        providerType,
+        enabledCount: enabledEndpoints.length,
+      });
+    }
+
+    if (validEnabledEndpoints.length === 0) {
+      session.setProviderEndpoint(null);
+      openVendorTypeFuse({ vendorId, providerType, reason: "no_enabled_endpoints" });
+      throw new EndpointResolutionError("No enabled endpoints", vendorId, providerType);
+    }
+
+    const healthyEndpoints = validEnabledEndpoints.filter((e) => !isEndpointCircuitOpen(e.id));
+
+    if (healthyEndpoints.length === 0) {
+      session.setProviderEndpoint(null);
+      openVendorTypeFuse({ vendorId, providerType, reason: "all_endpoints_unhealthy" });
+      throw new EndpointResolutionError("All endpoints unhealthy", vendorId, providerType);
+    }
+
+    const minPriority = Math.min(...healthyEndpoints.map((e) => e.priority ?? 0));
+    const topPriority = healthyEndpoints.filter((e) => (e.priority ?? 0) === minPriority);
+
+    const selected = weightedRandom(topPriority);
+
+    session.setProviderEndpoint(selected);
+
+    logger.debug("[EndpointResolver] Selected endpoint", {
+      vendorId,
+      providerType,
+      endpointId: selected.id,
+      baseUrl: selected.baseUrl,
+      priority: selected.priority,
+      weight: selected.weight,
+      candidateCount: topPriority.length,
+    });
+
+    return selected.baseUrl;
+  }
+}

--- a/src/app/v1/_lib/proxy/session.ts
+++ b/src/app/v1/_lib/proxy/session.ts
@@ -9,7 +9,7 @@ import type { CacheTtlResolved } from "@/types/cache";
 import type { Key } from "@/types/key";
 import type { ProviderChainItem } from "@/types/message";
 import type { ModelPriceData } from "@/types/model-price";
-import type { Provider, ProviderType } from "@/types/provider";
+import type { Provider, ProviderEndpoint, ProviderType } from "@/types/provider";
 import type { SpecialSetting } from "@/types/special-settings";
 import type { User } from "@/types/user";
 import { ProxyError } from "./errors";
@@ -63,6 +63,7 @@ export class ProxySession {
   userName: string;
   authState: AuthState | null;
   provider: Provider | null;
+  providerEndpoint: ProviderEndpoint | null;
   messageContext: MessageContext | null;
 
   // Time To First Byte (ms). Streaming: first chunk. Non-stream: equals durationMs.
@@ -146,6 +147,7 @@ export class ProxySession {
     this.userName = "unknown";
     this.authState = null;
     this.provider = null;
+    this.providerEndpoint = null;
     this.messageContext = null;
     this.sessionId = null;
     this.providerChain = [];
@@ -248,9 +250,18 @@ export class ProxySession {
 
   setProvider(provider: Provider | null): void {
     this.provider = provider;
+    this.providerEndpoint = null;
     if (provider) {
       this.providerType = provider.providerType as ProviderType;
     }
+  }
+
+  setProviderEndpoint(endpoint: ProviderEndpoint | null): void {
+    this.providerEndpoint = endpoint;
+  }
+
+  getProviderEndpoint(): ProviderEndpoint | null {
+    return this.providerEndpoint;
   }
 
   setCacheTtlResolved(ttl: CacheTtlResolved | null): void {

--- a/src/lib/endpoint-availability/endpoint-availability-service.ts
+++ b/src/lib/endpoint-availability/endpoint-availability-service.ts
@@ -1,0 +1,371 @@
+import { and, asc, desc, eq, gte, inArray, isNull, lte } from "drizzle-orm";
+import { db } from "@/drizzle/db";
+import { providerEndpointProbeEvents, providerEndpoints, providerVendors } from "@/drizzle/schema";
+import { calculateAvailabilityScore, determineOptimalBucketSize } from "@/lib/availability";
+import { logger } from "@/lib/logger";
+import type { ProviderType } from "@/types/provider";
+import type {
+  EndpointAvailabilityQueryOptions,
+  EndpointAvailabilityQueryResult,
+  EndpointAvailabilitySummary,
+  EndpointTimeBucketMetrics,
+} from "./types";
+
+const MAX_EVENTS_PER_QUERY = 100000;
+
+function calculatePercentile(sortedValues: number[], percentile: number): number {
+  if (sortedValues.length === 0) return 0;
+  const index = Math.ceil((percentile / 100) * sortedValues.length) - 1;
+  return sortedValues[Math.max(0, Math.min(index, sortedValues.length - 1))];
+}
+
+export async function queryEndpointAvailability(
+  options: EndpointAvailabilityQueryOptions = {}
+): Promise<EndpointAvailabilityQueryResult> {
+  const now = new Date();
+  const {
+    startTime = new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    endTime = now,
+    endpointIds = [],
+    vendorIds = [],
+    providerTypes = [],
+    bucketSizeMinutes: explicitBucketSize,
+    includeDisabled = false,
+    maxBuckets = 100,
+  } = options;
+
+  const startDate = typeof startTime === "string" ? new Date(startTime) : startTime;
+  const endDate = typeof endTime === "string" ? new Date(endTime) : endTime;
+  const timeRangeMinutes = (endDate.getTime() - startDate.getTime()) / (1000 * 60);
+
+  const endpointConditions = [isNull(providerEndpoints.deletedAt)];
+  if (!includeDisabled) {
+    endpointConditions.push(eq(providerEndpoints.isEnabled, true));
+  }
+  if (endpointIds.length > 0) {
+    endpointConditions.push(inArray(providerEndpoints.id, endpointIds));
+  }
+  if (vendorIds.length > 0) {
+    endpointConditions.push(inArray(providerEndpoints.vendorId, vendorIds));
+  }
+  if (providerTypes.length > 0) {
+    endpointConditions.push(inArray(providerEndpoints.providerType, providerTypes));
+  }
+
+  const endpointList = await db
+    .select({
+      id: providerEndpoints.id,
+      vendorId: providerEndpoints.vendorId,
+      providerType: providerEndpoints.providerType,
+      baseUrl: providerEndpoints.baseUrl,
+      isEnabled: providerEndpoints.isEnabled,
+      vendorName: providerVendors.displayName,
+    })
+    .from(providerEndpoints)
+    .leftJoin(
+      providerVendors,
+      and(eq(providerEndpoints.vendorId, providerVendors.id), isNull(providerVendors.deletedAt))
+    )
+    .where(and(...endpointConditions))
+    .orderBy(
+      asc(providerEndpoints.vendorId),
+      asc(providerEndpoints.providerType),
+      asc(providerEndpoints.priority),
+      asc(providerEndpoints.id)
+    );
+
+  if (endpointList.length === 0) {
+    return {
+      queriedAt: now.toISOString(),
+      startTime: startDate.toISOString(),
+      endTime: endDate.toISOString(),
+      bucketSizeMinutes: explicitBucketSize ?? 60,
+      endpoints: [],
+      systemAvailability: 0,
+    };
+  }
+
+  const endpointIdList = endpointList.map((e) => e.id);
+
+  const events = await db
+    .select({
+      endpointId: providerEndpointProbeEvents.endpointId,
+      result: providerEndpointProbeEvents.result,
+      latencyMs: providerEndpointProbeEvents.latencyMs,
+      checkedAt: providerEndpointProbeEvents.checkedAt,
+    })
+    .from(providerEndpointProbeEvents)
+    .where(
+      and(
+        inArray(providerEndpointProbeEvents.endpointId, endpointIdList),
+        gte(providerEndpointProbeEvents.checkedAt, startDate),
+        lte(providerEndpointProbeEvents.checkedAt, endDate)
+      )
+    )
+    .orderBy(asc(providerEndpointProbeEvents.checkedAt))
+    .limit(MAX_EVENTS_PER_QUERY);
+
+  if (events.length === MAX_EVENTS_PER_QUERY) {
+    logger.warn("[EndpointAvailability] Query hit max events limit, results may be incomplete", {
+      limit: MAX_EVENTS_PER_QUERY,
+      startTime: startDate.toISOString(),
+      endTime: endDate.toISOString(),
+    });
+  }
+
+  const rawBucketSize =
+    explicitBucketSize ?? determineOptimalBucketSize(events.length, timeRangeMinutes);
+  const bucketSizeMinutes = Number.isNaN(rawBucketSize)
+    ? determineOptimalBucketSize(events.length, timeRangeMinutes)
+    : Math.max(0.25, rawBucketSize);
+  const bucketSizeMs = bucketSizeMinutes * 60 * 1000;
+
+  const endpointBuckets = new Map<
+    number,
+    Map<
+      string,
+      {
+        greenCount: number;
+        redCount: number;
+        latencies: number[];
+      }
+    >
+  >();
+
+  for (const endpoint of endpointList) {
+    endpointBuckets.set(endpoint.id, new Map());
+  }
+
+  for (const evt of events) {
+    if (!evt.checkedAt) continue;
+
+    const bucketStart = new Date(Math.floor(evt.checkedAt.getTime() / bucketSizeMs) * bucketSizeMs);
+    const bucketKey = bucketStart.toISOString();
+
+    const endpointData = endpointBuckets.get(evt.endpointId);
+    if (!endpointData) continue;
+
+    if (!endpointData.has(bucketKey)) {
+      endpointData.set(bucketKey, {
+        greenCount: 0,
+        redCount: 0,
+        latencies: [],
+      });
+    }
+
+    const bucket = endpointData.get(bucketKey);
+    if (!bucket) continue;
+
+    if (evt.result === "success") {
+      bucket.greenCount++;
+    } else {
+      bucket.redCount++;
+    }
+
+    if (evt.latencyMs !== null) {
+      bucket.latencies.push(evt.latencyMs);
+    }
+  }
+
+  const endpointSummaries: EndpointAvailabilitySummary[] = [];
+
+  for (const endpoint of endpointList) {
+    const bucketData = endpointBuckets.get(endpoint.id);
+    const timeBuckets: EndpointTimeBucketMetrics[] = [];
+
+    let totalGreen = 0;
+    let totalRed = 0;
+    const allLatencies: number[] = [];
+    let lastProbeAt: string | null = null;
+
+    const sortedBucketKeys = Array.from(bucketData?.keys() ?? [])
+      .sort()
+      .slice(-maxBuckets);
+
+    for (const bucketKey of sortedBucketKeys) {
+      const bucket = bucketData?.get(bucketKey);
+      if (!bucket) continue;
+
+      const bucketStart = new Date(bucketKey);
+      const bucketEnd = new Date(bucketStart.getTime() + bucketSizeMs);
+
+      totalGreen += bucket.greenCount;
+      totalRed += bucket.redCount;
+
+      allLatencies.push(...bucket.latencies);
+
+      const sortedLatencies = [...bucket.latencies].sort((a, b) => a - b);
+      const total = bucket.greenCount + bucket.redCount;
+
+      timeBuckets.push({
+        bucketStart: bucketStart.toISOString(),
+        bucketEnd: bucketEnd.toISOString(),
+        totalProbes: total,
+        greenCount: bucket.greenCount,
+        redCount: bucket.redCount,
+        availabilityScore: calculateAvailabilityScore(bucket.greenCount, bucket.redCount),
+        avgLatencyMs:
+          sortedLatencies.length > 0
+            ? sortedLatencies.reduce((a, b) => a + b, 0) / sortedLatencies.length
+            : 0,
+        p50LatencyMs: calculatePercentile(sortedLatencies, 50),
+        p95LatencyMs: calculatePercentile(sortedLatencies, 95),
+        p99LatencyMs: calculatePercentile(sortedLatencies, 99),
+      });
+
+      if (total > 0) {
+        lastProbeAt = bucketEnd.toISOString();
+      }
+    }
+
+    const totalProbes = totalGreen + totalRed;
+    const sortedAllLatencies = allLatencies.sort((a, b) => a - b);
+
+    let currentStatus: EndpointAvailabilitySummary["currentStatus"] = "unknown";
+    if (timeBuckets.length > 0) {
+      const recentBuckets = timeBuckets.slice(-3);
+      const recentScore =
+        recentBuckets.reduce((sum, b) => sum + b.availabilityScore, 0) / recentBuckets.length;
+
+      currentStatus = recentScore >= 0.5 ? "green" : "red";
+    }
+
+    endpointSummaries.push({
+      endpointId: endpoint.id,
+      vendorId: endpoint.vendorId,
+      vendorName: endpoint.vendorName ?? "",
+      providerType: (endpoint.providerType || "claude") as ProviderType,
+      baseUrl: endpoint.baseUrl,
+      isEnabled: endpoint.isEnabled ?? true,
+      currentStatus,
+      currentAvailability: calculateAvailabilityScore(totalGreen, totalRed),
+      totalProbes,
+      successRate: totalProbes > 0 ? totalGreen / totalProbes : 0,
+      avgLatencyMs:
+        sortedAllLatencies.length > 0
+          ? sortedAllLatencies.reduce((a, b) => a + b, 0) / sortedAllLatencies.length
+          : 0,
+      lastProbeAt,
+      timeBuckets,
+    });
+  }
+
+  const totalSystemProbes = endpointSummaries.reduce((sum, e) => sum + e.totalProbes, 0);
+  const weightedSystemAvailability =
+    totalSystemProbes > 0
+      ? endpointSummaries.reduce((sum, e) => sum + e.currentAvailability * e.totalProbes, 0) /
+        totalSystemProbes
+      : 0;
+
+  return {
+    queriedAt: now.toISOString(),
+    startTime: startDate.toISOString(),
+    endTime: endDate.toISOString(),
+    bucketSizeMinutes,
+    endpoints: endpointSummaries,
+    systemAvailability: weightedSystemAvailability,
+  };
+}
+
+export async function getCurrentEndpointStatus(): Promise<
+  Array<{
+    endpointId: number;
+    vendorId: number;
+    vendorName: string;
+    providerType: ProviderType;
+    baseUrl: string;
+    status: EndpointAvailabilitySummary["currentStatus"];
+    availability: number;
+    probeCount: number;
+    lastProbeAt: string | null;
+  }>
+> {
+  const now = new Date();
+  const fifteenMinutesAgo = new Date(now.getTime() - 15 * 60 * 1000);
+
+  const endpointList = await db
+    .select({
+      id: providerEndpoints.id,
+      vendorId: providerEndpoints.vendorId,
+      providerType: providerEndpoints.providerType,
+      baseUrl: providerEndpoints.baseUrl,
+      vendorName: providerVendors.displayName,
+    })
+    .from(providerEndpoints)
+    .leftJoin(
+      providerVendors,
+      and(eq(providerEndpoints.vendorId, providerVendors.id), isNull(providerVendors.deletedAt))
+    )
+    .where(and(eq(providerEndpoints.isEnabled, true), isNull(providerEndpoints.deletedAt)));
+
+  if (endpointList.length === 0) {
+    return [];
+  }
+
+  const endpointIdList = endpointList.map((e) => e.id);
+
+  const events = await db
+    .select({
+      endpointId: providerEndpointProbeEvents.endpointId,
+      result: providerEndpointProbeEvents.result,
+      checkedAt: providerEndpointProbeEvents.checkedAt,
+    })
+    .from(providerEndpointProbeEvents)
+    .where(
+      and(
+        inArray(providerEndpointProbeEvents.endpointId, endpointIdList),
+        gte(providerEndpointProbeEvents.checkedAt, fifteenMinutesAgo),
+        lte(providerEndpointProbeEvents.checkedAt, now)
+      )
+    )
+    .orderBy(desc(providerEndpointProbeEvents.checkedAt));
+
+  const endpointStats = new Map<
+    number,
+    {
+      greenCount: number;
+      redCount: number;
+      lastProbeAt: string | null;
+    }
+  >();
+
+  for (const endpoint of endpointList) {
+    endpointStats.set(endpoint.id, { greenCount: 0, redCount: 0, lastProbeAt: null });
+  }
+
+  for (const evt of events) {
+    const stats = endpointStats.get(evt.endpointId);
+    if (!stats) continue;
+
+    if (!stats.lastProbeAt && evt.checkedAt) {
+      stats.lastProbeAt = evt.checkedAt.toISOString();
+    }
+
+    if (evt.result === "success") {
+      stats.greenCount++;
+    } else {
+      stats.redCount++;
+    }
+  }
+
+  return endpointList.map((endpoint) => {
+    const stats = endpointStats.get(endpoint.id);
+    const green = stats?.greenCount ?? 0;
+    const red = stats?.redCount ?? 0;
+    const total = green + red;
+
+    const availability = calculateAvailabilityScore(green, red);
+
+    return {
+      endpointId: endpoint.id,
+      vendorId: endpoint.vendorId,
+      vendorName: endpoint.vendorName ?? "",
+      providerType: (endpoint.providerType || "claude") as ProviderType,
+      baseUrl: endpoint.baseUrl,
+      status: total === 0 ? "unknown" : availability >= 0.5 ? "green" : "red",
+      availability,
+      probeCount: total,
+      lastProbeAt: stats?.lastProbeAt ?? null,
+    };
+  });
+}

--- a/src/lib/endpoint-availability/index.ts
+++ b/src/lib/endpoint-availability/index.ts
@@ -1,0 +1,5 @@
+export {
+  getCurrentEndpointStatus,
+  queryEndpointAvailability,
+} from "./endpoint-availability-service";
+export * from "./types";

--- a/src/lib/endpoint-availability/types.ts
+++ b/src/lib/endpoint-availability/types.ts
@@ -1,0 +1,51 @@
+import type { AvailabilityStatus } from "@/lib/availability";
+import type { ProviderType } from "@/types/provider";
+
+export interface EndpointAvailabilityQueryOptions {
+  startTime?: Date | string;
+  endTime?: Date | string;
+  endpointIds?: number[];
+  vendorIds?: number[];
+  providerTypes?: ProviderType[];
+  bucketSizeMinutes?: number;
+  includeDisabled?: boolean;
+  maxBuckets?: number;
+}
+
+export interface EndpointTimeBucketMetrics {
+  bucketStart: string;
+  bucketEnd: string;
+  totalProbes: number;
+  greenCount: number;
+  redCount: number;
+  availabilityScore: number;
+  avgLatencyMs: number;
+  p50LatencyMs: number;
+  p95LatencyMs: number;
+  p99LatencyMs: number;
+}
+
+export interface EndpointAvailabilitySummary {
+  endpointId: number;
+  vendorId: number;
+  vendorName: string;
+  providerType: ProviderType;
+  baseUrl: string;
+  isEnabled: boolean;
+  currentStatus: AvailabilityStatus;
+  currentAvailability: number;
+  totalProbes: number;
+  successRate: number;
+  avgLatencyMs: number;
+  lastProbeAt: string | null;
+  timeBuckets: EndpointTimeBucketMetrics[];
+}
+
+export interface EndpointAvailabilityQueryResult {
+  queriedAt: string;
+  startTime: string;
+  endTime: string;
+  bucketSizeMinutes: number;
+  endpoints: EndpointAvailabilitySummary[];
+  systemAvailability: number;
+}

--- a/src/lib/endpoint-circuit-breaker.ts
+++ b/src/lib/endpoint-circuit-breaker.ts
@@ -1,0 +1,191 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import type { ProviderType } from "@/types/provider";
+
+export type EndpointCircuitState = "closed" | "open" | "half-open";
+
+export interface EndpointHealth {
+  failureCount: number;
+  lastFailureTime: number | null;
+  circuitState: EndpointCircuitState;
+  circuitOpenUntil: number | null;
+  halfOpenSuccessCount: number;
+}
+
+type VendorTypeFuseKey = string;
+
+type VendorTypeFuseState = {
+  openUntil: number;
+  openedAt: number;
+  lastReason: string;
+};
+
+function parsePositiveInt(input: string | undefined, fallback: number): number {
+  if (!input) return fallback;
+  const parsed = Number.parseInt(input, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+const ENDPOINT_FAILURE_THRESHOLD = parsePositiveInt(
+  process.env.ENDPOINT_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+  3
+);
+const ENDPOINT_OPEN_DURATION_MS = parsePositiveInt(
+  process.env.ENDPOINT_CIRCUIT_BREAKER_OPEN_DURATION_MS,
+  5 * 60 * 1000
+);
+const ENDPOINT_HALF_OPEN_SUCCESS_THRESHOLD = parsePositiveInt(
+  process.env.ENDPOINT_CIRCUIT_BREAKER_HALF_OPEN_SUCCESS_THRESHOLD,
+  2
+);
+
+const VENDOR_TYPE_FUSE_OPEN_DURATION_MS = parsePositiveInt(
+  process.env.VENDOR_TYPE_FUSE_OPEN_DURATION_MS,
+  60 * 1000
+);
+
+const endpointHealthMap = new Map<number, EndpointHealth>();
+const vendorTypeFuseMap = new Map<VendorTypeFuseKey, VendorTypeFuseState>();
+
+function getOrCreateEndpointHealth(endpointId: number): EndpointHealth {
+  const existing = endpointHealthMap.get(endpointId);
+  if (existing) return existing;
+
+  const health: EndpointHealth = {
+    failureCount: 0,
+    lastFailureTime: null,
+    circuitState: "closed",
+    circuitOpenUntil: null,
+    halfOpenSuccessCount: 0,
+  };
+
+  endpointHealthMap.set(endpointId, health);
+  return health;
+}
+
+function getVendorTypeFuseKey(vendorId: number, providerType: ProviderType): VendorTypeFuseKey {
+  return `${vendorId}:${providerType}`;
+}
+
+export function getEndpointCircuitState(endpointId: number): EndpointCircuitState {
+  return getOrCreateEndpointHealth(endpointId).circuitState;
+}
+
+export function isEndpointCircuitOpen(endpointId: number): boolean {
+  const health = getOrCreateEndpointHealth(endpointId);
+
+  if (health.circuitState !== "open") {
+    return false;
+  }
+
+  if (!health.circuitOpenUntil) {
+    return true;
+  }
+
+  const now = Date.now();
+  if (now <= health.circuitOpenUntil) {
+    return true;
+  }
+
+  health.circuitState = "half-open";
+  health.circuitOpenUntil = null;
+  health.halfOpenSuccessCount = 0;
+
+  return false;
+}
+
+export function recordEndpointFailure(endpointId: number, error: Error): void {
+  const health = getOrCreateEndpointHealth(endpointId);
+
+  if (health.circuitState === "half-open") {
+    health.circuitState = "open";
+    health.failureCount = ENDPOINT_FAILURE_THRESHOLD;
+    health.lastFailureTime = Date.now();
+    health.circuitOpenUntil = Date.now() + ENDPOINT_OPEN_DURATION_MS;
+    health.halfOpenSuccessCount = 0;
+
+    logger.warn("[EndpointCircuitBreaker] Half-open failure, reopening", {
+      endpointId,
+      errorName: error.name,
+    });
+
+    return;
+  }
+
+  health.failureCount += 1;
+  health.lastFailureTime = Date.now();
+
+  if (ENDPOINT_FAILURE_THRESHOLD > 0 && health.failureCount >= ENDPOINT_FAILURE_THRESHOLD) {
+    health.circuitState = "open";
+    health.circuitOpenUntil = Date.now() + ENDPOINT_OPEN_DURATION_MS;
+    health.halfOpenSuccessCount = 0;
+
+    logger.warn("[EndpointCircuitBreaker] Circuit opened", {
+      endpointId,
+      failureCount: health.failureCount,
+      threshold: ENDPOINT_FAILURE_THRESHOLD,
+      errorName: error.name,
+    });
+  }
+}
+
+export function recordEndpointSuccess(endpointId: number): void {
+  const health = getOrCreateEndpointHealth(endpointId);
+
+  if (health.circuitState === "half-open") {
+    health.halfOpenSuccessCount += 1;
+
+    if (health.halfOpenSuccessCount >= ENDPOINT_HALF_OPEN_SUCCESS_THRESHOLD) {
+      health.circuitState = "closed";
+      health.failureCount = 0;
+      health.lastFailureTime = null;
+      health.circuitOpenUntil = null;
+      health.halfOpenSuccessCount = 0;
+    }
+
+    return;
+  }
+
+  if (health.circuitState === "closed" && health.failureCount > 0) {
+    health.failureCount = 0;
+    health.lastFailureTime = null;
+  }
+}
+
+export function openVendorTypeFuse(options: {
+  vendorId: number;
+  providerType: ProviderType;
+  reason: string;
+}): void {
+  const now = Date.now();
+  const key = getVendorTypeFuseKey(options.vendorId, options.providerType);
+
+  vendorTypeFuseMap.set(key, {
+    openUntil: now + VENDOR_TYPE_FUSE_OPEN_DURATION_MS,
+    openedAt: now,
+    lastReason: options.reason,
+  });
+
+  logger.warn("[EndpointCircuitBreaker] Vendor+type fuse opened", {
+    vendorId: options.vendorId,
+    providerType: options.providerType,
+    reason: options.reason,
+    openDurationMs: VENDOR_TYPE_FUSE_OPEN_DURATION_MS,
+  });
+}
+
+export function isVendorTypeFuseOpen(vendorId: number, providerType: ProviderType): boolean {
+  const key = getVendorTypeFuseKey(vendorId, providerType);
+  const state = vendorTypeFuseMap.get(key);
+  if (!state) return false;
+
+  const now = Date.now();
+  if (now <= state.openUntil) {
+    return true;
+  }
+
+  vendorTypeFuseMap.delete(key);
+  return false;
+}

--- a/src/lib/endpoint-probe-scheduler.ts
+++ b/src/lib/endpoint-probe-scheduler.ts
@@ -1,0 +1,374 @@
+import "server-only";
+
+import { recordEndpointFailure, recordEndpointSuccess } from "@/lib/endpoint-circuit-breaker";
+import { logger } from "@/lib/logger";
+import { executeProviderTest } from "@/lib/provider-testing/test-service";
+import { findAllProvidersFresh } from "@/repository/provider";
+import { findProviderEndpointsByVendorIds } from "@/repository/provider-endpoint";
+import {
+  createProviderEndpointProbeEvent,
+  deleteProviderEndpointProbeEventsOlderThan,
+} from "@/repository/provider-endpoint-probe-event";
+import type { Provider, ProviderType } from "@/types/provider";
+
+type ProbeTarget = {
+  endpointId: number;
+  vendorId: number;
+  providerType: ProviderType;
+  baseUrl: string;
+  apiKey: string;
+};
+
+function parsePositiveInt(input: string | undefined, fallback: number): number {
+  if (!input) return fallback;
+  const parsed = Number.parseInt(input, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+const ENABLE_ENDPOINT_PROBING = process.env.ENABLE_ENDPOINT_PROBING === "true";
+const ENDPOINT_PROBE_INTERVAL_MS = parsePositiveInt(
+  process.env.ENDPOINT_PROBE_INTERVAL_MS,
+  300_000
+);
+const ENDPOINT_PROBE_TIMEOUT_MS = parsePositiveInt(process.env.ENDPOINT_PROBE_TIMEOUT_MS, 5_000);
+const ENDPOINT_PROBE_MAX_PER_CYCLE = parsePositiveInt(process.env.ENDPOINT_PROBE_MAX_PER_CYCLE, 20);
+const ENDPOINT_PROBE_CONCURRENCY = parsePositiveInt(process.env.ENDPOINT_PROBE_CONCURRENCY, 5);
+const ENDPOINT_PROBE_RETENTION_DAYS = parsePositiveInt(
+  process.env.ENDPOINT_PROBE_RETENTION_DAYS,
+  7
+);
+const ENDPOINT_PROBE_CLEANUP_INTERVAL_MS = parsePositiveInt(
+  process.env.ENDPOINT_PROBE_CLEANUP_INTERVAL_MS,
+  24 * 60 * 60 * 1000
+);
+
+const CONFIG_CACHE_TTL_MS = 60_000;
+
+const schedulerState = globalThis as unknown as {
+  __CCH_ENDPOINT_PROBE_INTERVAL_ID__?: ReturnType<typeof setInterval> | null;
+  __CCH_ENDPOINT_PROBE_CLEANUP_INTERVAL_ID__?: ReturnType<typeof setInterval> | null;
+  __CCH_ENDPOINT_PROBE_CURSOR__?: number;
+};
+
+let isProbing = false;
+let targetsCache: { expiresAt: number; targets: ProbeTarget[] } | null = null;
+
+function isValidBaseUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function keyOf(vendorId: number, providerType: Provider["providerType"]): string {
+  return `${vendorId}:${providerType}`;
+}
+
+function pickTargetsRoundRobin(targets: ProbeTarget[]): ProbeTarget[] {
+  if (targets.length <= ENDPOINT_PROBE_MAX_PER_CYCLE) {
+    return targets;
+  }
+
+  const cursor = schedulerState.__CCH_ENDPOINT_PROBE_CURSOR__ ?? 0;
+  const sorted = [...targets].sort((a, b) => a.endpointId - b.endpointId);
+
+  const picked: ProbeTarget[] = [];
+  for (let i = 0; i < ENDPOINT_PROBE_MAX_PER_CYCLE; i++) {
+    const index = (cursor + i) % sorted.length;
+    picked.push(sorted[index]);
+  }
+
+  schedulerState.__CCH_ENDPOINT_PROBE_CURSOR__ = (cursor + picked.length) % sorted.length;
+  return picked;
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>
+): Promise<void> {
+  const pending = new Set<Promise<void>>();
+
+  for (const item of items) {
+    let taskPromise: Promise<void>;
+    taskPromise = fn(item).finally(() => {
+      pending.delete(taskPromise);
+    });
+
+    pending.add(taskPromise);
+
+    if (pending.size >= concurrency) {
+      await Promise.race(pending);
+    }
+  }
+
+  await Promise.allSettled(pending);
+}
+
+async function loadTargetsCached(): Promise<ProbeTarget[]> {
+  const now = Date.now();
+  if (targetsCache && targetsCache.expiresAt > now) {
+    return targetsCache.targets;
+  }
+
+  const providers = await findAllProvidersFresh();
+
+  const enabledProviders = providers
+    .filter((p) => p.isEnabled && Number.isFinite(p.vendorId ?? NaN) && !!p.key)
+    .sort((a, b) => {
+      const aPriority = a.priority ?? 0;
+      const bPriority = b.priority ?? 0;
+      if (aPriority !== bPriority) return aPriority - bPriority;
+      return a.id - b.id;
+    });
+
+  const vendorTypeKeyToApiKey = new Map<string, string>();
+  const vendorIds: number[] = [];
+
+  for (const p of enabledProviders) {
+    if (!p.vendorId) continue;
+
+    const key = keyOf(p.vendorId, p.providerType);
+    if (!vendorTypeKeyToApiKey.has(key)) {
+      vendorTypeKeyToApiKey.set(key, p.key);
+    }
+
+    vendorIds.push(p.vendorId);
+  }
+
+  const uniqueVendorIds = Array.from(new Set(vendorIds));
+  if (uniqueVendorIds.length === 0) {
+    targetsCache = { expiresAt: now + CONFIG_CACHE_TTL_MS, targets: [] };
+    return [];
+  }
+
+  const endpoints = await findProviderEndpointsByVendorIds(uniqueVendorIds);
+
+  const targets: ProbeTarget[] = [];
+
+  for (const endpoint of endpoints) {
+    if (!endpoint.isEnabled) continue;
+    if (!isValidBaseUrl(endpoint.baseUrl)) continue;
+
+    const apiKey = vendorTypeKeyToApiKey.get(keyOf(endpoint.vendorId, endpoint.providerType));
+    if (!apiKey) {
+      continue;
+    }
+
+    targets.push({
+      endpointId: endpoint.id,
+      vendorId: endpoint.vendorId,
+      providerType: endpoint.providerType,
+      baseUrl: endpoint.baseUrl,
+      apiKey,
+    });
+  }
+
+  targetsCache = { expiresAt: now + CONFIG_CACHE_TTL_MS, targets };
+  return targets;
+}
+
+async function probeTarget(target: ProbeTarget): Promise<void> {
+  const checkedAt = new Date();
+
+  try {
+    const result = await executeProviderTest({
+      providerUrl: target.baseUrl,
+      apiKey: target.apiKey,
+      providerType: target.providerType,
+      timeoutMs: ENDPOINT_PROBE_TIMEOUT_MS,
+    });
+
+    if (result.success) {
+      recordEndpointSuccess(target.endpointId);
+
+      await createProviderEndpointProbeEvent({
+        endpointId: target.endpointId,
+        source: "active_probe",
+        result: "success",
+        statusCode: result.httpStatusCode ?? null,
+        latencyMs: result.latencyMs ?? null,
+        checkedAt,
+      });
+
+      return;
+    }
+
+    const error = new Error(result.errorMessage ?? "Endpoint probe failed");
+    if (result.errorType) {
+      error.name = result.errorType;
+    }
+
+    recordEndpointFailure(target.endpointId, error);
+
+    await createProviderEndpointProbeEvent({
+      endpointId: target.endpointId,
+      source: "active_probe",
+      result: "fail",
+      statusCode: result.httpStatusCode ?? null,
+      latencyMs: result.latencyMs ?? null,
+      errorType: result.errorType ?? null,
+      errorMessage: result.errorMessage ?? null,
+      checkedAt,
+    });
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+
+    recordEndpointFailure(target.endpointId, err);
+
+    await createProviderEndpointProbeEvent({
+      endpointId: target.endpointId,
+      source: "active_probe",
+      result: "fail",
+      statusCode: null,
+      latencyMs: null,
+      errorType: err.name,
+      errorMessage: err.message,
+      checkedAt,
+    });
+  }
+}
+
+export async function runEndpointProbeCycleOnce(): Promise<void> {
+  if (isProbing) {
+    logger.debug("[EndpointProbe] Skipping cycle, previous cycle still running");
+    return;
+  }
+
+  isProbing = true;
+
+  try {
+    const targets = await loadTargetsCached();
+    if (targets.length === 0) {
+      logger.debug("[EndpointProbe] No endpoints available for probing");
+      return;
+    }
+
+    const selected = pickTargetsRoundRobin(targets);
+
+    logger.info("[EndpointProbe] Starting probe cycle", {
+      totalTargets: targets.length,
+      selectedTargets: selected.length,
+      timeoutMs: ENDPOINT_PROBE_TIMEOUT_MS,
+      concurrency: ENDPOINT_PROBE_CONCURRENCY,
+    });
+
+    let succeeded = 0;
+    let failed = 0;
+
+    await runWithConcurrency(selected, ENDPOINT_PROBE_CONCURRENCY, async (target) => {
+      try {
+        await probeTarget(target);
+        succeeded++;
+      } catch {
+        failed++;
+      }
+    });
+
+    logger.info("[EndpointProbe] Probe cycle completed", {
+      attempted: selected.length,
+      succeeded,
+      failed,
+    });
+  } catch (error) {
+    logger.warn("[EndpointProbe] Probe cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    isProbing = false;
+  }
+}
+
+export async function cleanupEndpointProbeEventsOnce(): Promise<number> {
+  try {
+    const deleted = await deleteProviderEndpointProbeEventsOlderThan({
+      days: ENDPOINT_PROBE_RETENTION_DAYS,
+    });
+
+    if (deleted > 0) {
+      logger.info("[EndpointProbe] Old probe events cleaned", {
+        deleted,
+        retentionDays: ENDPOINT_PROBE_RETENTION_DAYS,
+      });
+    }
+
+    return deleted;
+  } catch (error) {
+    logger.warn("[EndpointProbe] Failed to cleanup old probe events", {
+      error: error instanceof Error ? error.message : String(error),
+      retentionDays: ENDPOINT_PROBE_RETENTION_DAYS,
+    });
+
+    return 0;
+  }
+}
+
+export function startEndpointProbeScheduler(): void {
+  if (!ENABLE_ENDPOINT_PROBING) {
+    logger.info("[EndpointProbe] Endpoint probing is disabled");
+    return;
+  }
+
+  if (schedulerState.__CCH_ENDPOINT_PROBE_INTERVAL_ID__) {
+    return;
+  }
+
+  void runEndpointProbeCycleOnce();
+  void cleanupEndpointProbeEventsOnce();
+
+  schedulerState.__CCH_ENDPOINT_PROBE_INTERVAL_ID__ = setInterval(() => {
+    void runEndpointProbeCycleOnce();
+  }, ENDPOINT_PROBE_INTERVAL_MS);
+
+  schedulerState.__CCH_ENDPOINT_PROBE_CLEANUP_INTERVAL_ID__ = setInterval(() => {
+    void cleanupEndpointProbeEventsOnce();
+  }, ENDPOINT_PROBE_CLEANUP_INTERVAL_MS);
+
+  logger.info("[EndpointProbe] Scheduler started", {
+    intervalSeconds: Math.round(ENDPOINT_PROBE_INTERVAL_MS / 1000),
+    timeoutMs: ENDPOINT_PROBE_TIMEOUT_MS,
+    maxPerCycle: ENDPOINT_PROBE_MAX_PER_CYCLE,
+    retentionDays: ENDPOINT_PROBE_RETENTION_DAYS,
+  });
+}
+
+export function stopEndpointProbeScheduler(): void {
+  if (schedulerState.__CCH_ENDPOINT_PROBE_INTERVAL_ID__) {
+    clearInterval(schedulerState.__CCH_ENDPOINT_PROBE_INTERVAL_ID__);
+    schedulerState.__CCH_ENDPOINT_PROBE_INTERVAL_ID__ = null;
+  }
+
+  if (schedulerState.__CCH_ENDPOINT_PROBE_CLEANUP_INTERVAL_ID__) {
+    clearInterval(schedulerState.__CCH_ENDPOINT_PROBE_CLEANUP_INTERVAL_ID__);
+    schedulerState.__CCH_ENDPOINT_PROBE_CLEANUP_INTERVAL_ID__ = null;
+  }
+
+  logger.info("[EndpointProbe] Scheduler stopped");
+}
+
+export function isEndpointProbingEnabled(): boolean {
+  return ENABLE_ENDPOINT_PROBING;
+}
+
+export function getEndpointProbeSchedulerStatus(): {
+  enabled: boolean;
+  running: boolean;
+  intervalMs: number;
+  timeoutMs: number;
+  maxPerCycle: number;
+  concurrency: number;
+  retentionDays: number;
+} {
+  return {
+    enabled: ENABLE_ENDPOINT_PROBING,
+    running: !!schedulerState.__CCH_ENDPOINT_PROBE_INTERVAL_ID__,
+    intervalMs: ENDPOINT_PROBE_INTERVAL_MS,
+    timeoutMs: ENDPOINT_PROBE_TIMEOUT_MS,
+    maxPerCycle: ENDPOINT_PROBE_MAX_PER_CYCLE,
+    concurrency: ENDPOINT_PROBE_CONCURRENCY,
+    retentionDays: ENDPOINT_PROBE_RETENTION_DAYS,
+  };
+}

--- a/src/lib/utils/vendor-key.ts
+++ b/src/lib/utils/vendor-key.ts
@@ -1,0 +1,11 @@
+export function normalizeVendorKeyFromUrl(rawUrl: string): string | null {
+  if (!rawUrl) return null;
+
+  try {
+    const url = new URL(rawUrl);
+    const hostname = url.hostname.toLowerCase();
+    return hostname.startsWith("www.") ? hostname.slice(4) : hostname;
+  } catch {
+    return null;
+  }
+}

--- a/src/repository/_shared/transformers.ts
+++ b/src/repository/_shared/transformers.ts
@@ -2,7 +2,12 @@ import { formatCostForStorage } from "@/lib/utils/currency";
 import type { Key } from "@/types/key";
 import type { MessageRequest } from "@/types/message";
 import type { ModelPrice } from "@/types/model-price";
-import type { Provider } from "@/types/provider";
+import type {
+  Provider,
+  ProviderEndpoint,
+  ProviderEndpointProbeEvent,
+  ProviderVendor,
+} from "@/types/provider";
 import type { ResponseFixerConfig, SystemSettings } from "@/types/system-config";
 import type { User } from "@/types/user";
 
@@ -71,6 +76,7 @@ export function toProvider(dbProvider: any): Provider {
     priority: dbProvider?.priority ?? 0,
     costMultiplier: dbProvider?.costMultiplier ? parseFloat(dbProvider.costMultiplier) : 1.0,
     groupTag: dbProvider?.groupTag ?? null,
+    vendorId: dbProvider?.vendorId ?? null,
     providerType: dbProvider?.providerType ?? "claude",
     preserveClientIp: dbProvider?.preserveClientIp ?? false,
     modelRedirects: dbProvider?.modelRedirects ?? null,
@@ -114,6 +120,53 @@ export function toProvider(dbProvider: any): Provider {
     cc: dbProvider?.cc ?? null,
     createdAt: dbProvider?.createdAt ? new Date(dbProvider.createdAt) : new Date(),
     updatedAt: dbProvider?.updatedAt ? new Date(dbProvider.updatedAt) : new Date(),
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function toProviderVendor(dbVendor: any): ProviderVendor {
+  return {
+    ...dbVendor,
+    vendorKey: dbVendor?.vendorKey ?? "",
+    displayName: dbVendor?.displayName ?? dbVendor?.vendorKey ?? "",
+    websiteUrl: dbVendor?.websiteUrl ?? null,
+    faviconUrl: dbVendor?.faviconUrl ?? null,
+    isEnabled: dbVendor?.isEnabled ?? true,
+    createdAt: dbVendor?.createdAt ? new Date(dbVendor.createdAt) : new Date(),
+    updatedAt: dbVendor?.updatedAt ? new Date(dbVendor.updatedAt) : new Date(),
+    deletedAt: dbVendor?.deletedAt ? new Date(dbVendor.deletedAt) : undefined,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function toProviderEndpoint(dbEndpoint: any): ProviderEndpoint {
+  return {
+    ...dbEndpoint,
+    vendorId: dbEndpoint?.vendorId ?? 0,
+    providerType: dbEndpoint?.providerType ?? "claude",
+    baseUrl: dbEndpoint?.baseUrl ?? "",
+    isEnabled: dbEndpoint?.isEnabled ?? true,
+    priority: dbEndpoint?.priority ?? 0,
+    weight: dbEndpoint?.weight ?? 1,
+    createdAt: dbEndpoint?.createdAt ? new Date(dbEndpoint.createdAt) : new Date(),
+    updatedAt: dbEndpoint?.updatedAt ? new Date(dbEndpoint.updatedAt) : new Date(),
+    deletedAt: dbEndpoint?.deletedAt ? new Date(dbEndpoint.deletedAt) : undefined,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function toProviderEndpointProbeEvent(dbEvent: any): ProviderEndpointProbeEvent {
+  return {
+    ...dbEvent,
+    endpointId: dbEvent?.endpointId ?? 0,
+    source: dbEvent?.source ?? "active_probe",
+    result: dbEvent?.result ?? "fail",
+    statusCode: dbEvent?.statusCode ?? null,
+    latencyMs: dbEvent?.latencyMs ?? null,
+    errorType: dbEvent?.errorType ?? null,
+    errorMessage: dbEvent?.errorMessage ?? null,
+    checkedAt: dbEvent?.checkedAt ? new Date(dbEvent.checkedAt) : null,
+    createdAt: dbEvent?.createdAt ? new Date(dbEvent.createdAt) : new Date(),
   };
 }
 

--- a/src/repository/provider-endpoint-probe-event.ts
+++ b/src/repository/provider-endpoint-probe-event.ts
@@ -1,0 +1,92 @@
+"use server";
+
+import { and, desc, eq, gte, lt, lte } from "drizzle-orm";
+import { db } from "@/drizzle/db";
+import { providerEndpointProbeEvents } from "@/drizzle/schema";
+import type {
+  ProviderEndpointProbeEvent,
+  ProviderEndpointProbeResult,
+  ProviderEndpointProbeSource,
+} from "@/types/provider";
+import { toProviderEndpointProbeEvent } from "./_shared/transformers";
+
+const PROBE_EVENT_SELECT = {
+  id: providerEndpointProbeEvents.id,
+  endpointId: providerEndpointProbeEvents.endpointId,
+  source: providerEndpointProbeEvents.source,
+  result: providerEndpointProbeEvents.result,
+  statusCode: providerEndpointProbeEvents.statusCode,
+  latencyMs: providerEndpointProbeEvents.latencyMs,
+  errorType: providerEndpointProbeEvents.errorType,
+  errorMessage: providerEndpointProbeEvents.errorMessage,
+  checkedAt: providerEndpointProbeEvents.checkedAt,
+  createdAt: providerEndpointProbeEvents.createdAt,
+} as const;
+
+export async function createProviderEndpointProbeEvent(data: {
+  endpointId: number;
+  source: ProviderEndpointProbeSource;
+  result: ProviderEndpointProbeResult;
+  statusCode?: number | null;
+  latencyMs?: number | null;
+  errorType?: string | null;
+  errorMessage?: string | null;
+  checkedAt?: Date;
+}): Promise<ProviderEndpointProbeEvent> {
+  const [row] = await db
+    .insert(providerEndpointProbeEvents)
+    .values({
+      endpointId: data.endpointId,
+      source: data.source,
+      result: data.result,
+      statusCode: data.statusCode ?? null,
+      latencyMs: data.latencyMs ?? null,
+      errorType: data.errorType ?? null,
+      errorMessage: data.errorMessage ?? null,
+      checkedAt: data.checkedAt ?? new Date(),
+    })
+    .returning(PROBE_EVENT_SELECT);
+
+  return toProviderEndpointProbeEvent(row);
+}
+
+export async function deleteProviderEndpointProbeEventsOlderThan(args: {
+  days: number;
+  now?: Date;
+}): Promise<number> {
+  const now = args.now ?? new Date();
+  const cutoff = new Date(now.getTime() - args.days * 24 * 60 * 60 * 1000);
+
+  const rows = await db
+    .delete(providerEndpointProbeEvents)
+    .where(lt(providerEndpointProbeEvents.checkedAt, cutoff))
+    .returning({ id: providerEndpointProbeEvents.id });
+
+  return rows.length;
+}
+
+export async function findProviderEndpointProbeEvents(args: {
+  endpointId: number;
+  startTime?: Date;
+  endTime?: Date;
+  limit?: number;
+}): Promise<ProviderEndpointProbeEvent[]> {
+  const limit = args.limit ?? 100;
+
+  const conditions = [eq(providerEndpointProbeEvents.endpointId, args.endpointId)];
+  if (args.startTime) {
+    conditions.push(gte(providerEndpointProbeEvents.checkedAt, args.startTime));
+  }
+  if (args.endTime) {
+    conditions.push(lte(providerEndpointProbeEvents.checkedAt, args.endTime));
+  }
+
+  const rows = await db
+    .select(PROBE_EVENT_SELECT)
+    .from(providerEndpointProbeEvents)
+    .where(and(...conditions))
+    .orderBy(desc(providerEndpointProbeEvents.checkedAt))
+    .limit(limit);
+
+  return rows.map(toProviderEndpointProbeEvent);
+}

--- a/src/repository/provider-endpoint.ts
+++ b/src/repository/provider-endpoint.ts
@@ -1,0 +1,156 @@
+"use server";
+
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
+import { db } from "@/drizzle/db";
+import { providerEndpoints } from "@/drizzle/schema";
+import type { ProviderEndpoint, ProviderType } from "@/types/provider";
+import { toProviderEndpoint } from "./_shared/transformers";
+
+const ENDPOINT_SELECT = {
+  id: providerEndpoints.id,
+  vendorId: providerEndpoints.vendorId,
+  providerType: providerEndpoints.providerType,
+  baseUrl: providerEndpoints.baseUrl,
+  isEnabled: providerEndpoints.isEnabled,
+  priority: providerEndpoints.priority,
+  weight: providerEndpoints.weight,
+  createdAt: providerEndpoints.createdAt,
+  updatedAt: providerEndpoints.updatedAt,
+  deletedAt: providerEndpoints.deletedAt,
+} as const;
+
+export async function findProviderEndpointById(id: number): Promise<ProviderEndpoint | null> {
+  const [row] = await db
+    .select(ENDPOINT_SELECT)
+    .from(providerEndpoints)
+    .where(and(eq(providerEndpoints.id, id), isNull(providerEndpoints.deletedAt)));
+
+  return row ? toProviderEndpoint(row) : null;
+}
+
+export async function findProviderEndpointsByVendorIds(
+  vendorIds: number[]
+): Promise<ProviderEndpoint[]> {
+  if (vendorIds.length === 0) return [];
+
+  const rows = await db
+    .select(ENDPOINT_SELECT)
+    .from(providerEndpoints)
+    .where(and(inArray(providerEndpoints.vendorId, vendorIds), isNull(providerEndpoints.deletedAt)))
+    .orderBy(
+      asc(providerEndpoints.vendorId),
+      asc(providerEndpoints.providerType),
+      asc(providerEndpoints.priority)
+    );
+
+  return rows.map(toProviderEndpoint);
+}
+
+export async function findProviderEndpointsByVendorType(
+  vendorId: number,
+  providerType: ProviderType
+): Promise<ProviderEndpoint[]> {
+  const rows = await db
+    .select(ENDPOINT_SELECT)
+    .from(providerEndpoints)
+    .where(
+      and(
+        eq(providerEndpoints.vendorId, vendorId),
+        eq(providerEndpoints.providerType, providerType),
+        isNull(providerEndpoints.deletedAt)
+      )
+    )
+    .orderBy(asc(providerEndpoints.priority), asc(providerEndpoints.id));
+
+  return rows.map(toProviderEndpoint);
+}
+
+export async function createProviderEndpoint(data: {
+  vendorId: number;
+  providerType: ProviderType;
+  baseUrl: string;
+  isEnabled?: boolean;
+  priority?: number;
+  weight?: number;
+}): Promise<ProviderEndpoint> {
+  const [row] = await db
+    .insert(providerEndpoints)
+    .values({
+      vendorId: data.vendorId,
+      providerType: data.providerType,
+      baseUrl: data.baseUrl,
+      isEnabled: data.isEnabled ?? true,
+      priority: data.priority ?? 0,
+      weight: data.weight ?? 1,
+    })
+    .returning(ENDPOINT_SELECT);
+
+  return toProviderEndpoint(row);
+}
+
+export async function updateProviderEndpoint(
+  id: number,
+  patch: {
+    baseUrl?: string;
+    isEnabled?: boolean;
+    priority?: number;
+    weight?: number;
+  }
+): Promise<ProviderEndpoint | null> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dbPatch: any = { updatedAt: new Date() };
+  if (patch.baseUrl !== undefined) dbPatch.baseUrl = patch.baseUrl;
+  if (patch.isEnabled !== undefined) dbPatch.isEnabled = patch.isEnabled;
+  if (patch.priority !== undefined) dbPatch.priority = patch.priority;
+  if (patch.weight !== undefined) dbPatch.weight = patch.weight;
+
+  const [row] = await db
+    .update(providerEndpoints)
+    .set(dbPatch)
+    .where(and(eq(providerEndpoints.id, id), isNull(providerEndpoints.deletedAt)))
+    .returning(ENDPOINT_SELECT);
+
+  return row ? toProviderEndpoint(row) : null;
+}
+
+export async function deleteProviderEndpoint(id: number): Promise<boolean> {
+  const [row] = await db
+    .update(providerEndpoints)
+    .set({
+      deletedAt: new Date(),
+      isEnabled: false,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(providerEndpoints.id, id), isNull(providerEndpoints.deletedAt)))
+    .returning({ id: providerEndpoints.id });
+
+  return !!row;
+}
+
+export async function ensureProviderEndpoint(input: {
+  vendorId: number;
+  providerType: ProviderType;
+  baseUrl: string;
+}): Promise<ProviderEndpoint> {
+  await db
+    .insert(providerEndpoints)
+    .values({
+      vendorId: input.vendorId,
+      providerType: input.providerType,
+      baseUrl: input.baseUrl,
+      isEnabled: true,
+      priority: 0,
+      weight: 1,
+    })
+    .onConflictDoNothing();
+
+  const rows = await findProviderEndpointsByVendorType(input.vendorId, input.providerType);
+  const matched = rows.find((r) => r.baseUrl === input.baseUrl);
+  if (matched) return matched;
+
+  return await createProviderEndpoint({
+    vendorId: input.vendorId,
+    providerType: input.providerType,
+    baseUrl: input.baseUrl,
+  });
+}

--- a/src/repository/provider-vendor.ts
+++ b/src/repository/provider-vendor.ts
@@ -1,0 +1,492 @@
+"use server";
+
+import { and, asc, count, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+import { db } from "@/drizzle/db";
+import {
+  providerEndpointProbeEvents,
+  providerEndpoints,
+  providers,
+  providerVendors,
+} from "@/drizzle/schema";
+import { logger } from "@/lib/logger";
+import type { ProviderType, ProviderVendor } from "@/types/provider";
+import { toProviderVendor } from "./_shared/transformers";
+
+export async function findProviderVendorById(id: number): Promise<ProviderVendor | null> {
+  const [row] = await db
+    .select({
+      id: providerVendors.id,
+      vendorKey: providerVendors.vendorKey,
+      displayName: providerVendors.displayName,
+      websiteUrl: providerVendors.websiteUrl,
+      faviconUrl: providerVendors.faviconUrl,
+      isEnabled: providerVendors.isEnabled,
+      createdAt: providerVendors.createdAt,
+      updatedAt: providerVendors.updatedAt,
+      deletedAt: providerVendors.deletedAt,
+    })
+    .from(providerVendors)
+    .where(and(eq(providerVendors.id, id), isNull(providerVendors.deletedAt)));
+
+  return row ? toProviderVendor(row) : null;
+}
+
+export async function findProviderVendorByVendorKey(
+  vendorKey: string
+): Promise<ProviderVendor | null> {
+  const [row] = await db
+    .select({
+      id: providerVendors.id,
+      vendorKey: providerVendors.vendorKey,
+      displayName: providerVendors.displayName,
+      websiteUrl: providerVendors.websiteUrl,
+      faviconUrl: providerVendors.faviconUrl,
+      isEnabled: providerVendors.isEnabled,
+      createdAt: providerVendors.createdAt,
+      updatedAt: providerVendors.updatedAt,
+      deletedAt: providerVendors.deletedAt,
+    })
+    .from(providerVendors)
+    .where(and(eq(providerVendors.vendorKey, vendorKey), isNull(providerVendors.deletedAt)));
+
+  return row ? toProviderVendor(row) : null;
+}
+
+export async function findAllProviderVendors(): Promise<ProviderVendor[]> {
+  const rows = await db
+    .select({
+      id: providerVendors.id,
+      vendorKey: providerVendors.vendorKey,
+      displayName: providerVendors.displayName,
+      websiteUrl: providerVendors.websiteUrl,
+      faviconUrl: providerVendors.faviconUrl,
+      isEnabled: providerVendors.isEnabled,
+      createdAt: providerVendors.createdAt,
+      updatedAt: providerVendors.updatedAt,
+      deletedAt: providerVendors.deletedAt,
+    })
+    .from(providerVendors)
+    .where(isNull(providerVendors.deletedAt))
+    .orderBy(asc(providerVendors.displayName));
+
+  return rows.map(toProviderVendor);
+}
+
+export type ProviderVendorSummary = ProviderVendor & {
+  providerCount: number;
+  endpointCount: number;
+};
+
+export async function findProviderVendorSummaries(): Promise<ProviderVendorSummary[]> {
+  const vendors = await findAllProviderVendors();
+  if (vendors.length === 0) return [];
+
+  const vendorIds = vendors.map((v) => v.id);
+
+  const providerCounts = await db
+    .select({
+      vendorId: providers.vendorId,
+      providerCount: count(providers.id),
+    })
+    .from(providers)
+    .where(
+      and(
+        inArray(providers.vendorId, vendorIds),
+        isNull(providers.deletedAt),
+        isNotNull(providers.vendorId)
+      )
+    )
+    .groupBy(providers.vendorId);
+
+  const endpointCounts = await db
+    .select({
+      vendorId: providerEndpoints.vendorId,
+      endpointCount: count(providerEndpoints.id),
+    })
+    .from(providerEndpoints)
+    .where(and(inArray(providerEndpoints.vendorId, vendorIds), isNull(providerEndpoints.deletedAt)))
+    .groupBy(providerEndpoints.vendorId);
+
+  const providerCountMap = new Map<number, number>();
+  for (const row of providerCounts) {
+    if (row.vendorId !== null) providerCountMap.set(row.vendorId, row.providerCount);
+  }
+
+  const endpointCountMap = new Map<number, number>();
+  for (const row of endpointCounts) {
+    endpointCountMap.set(row.vendorId, row.endpointCount);
+  }
+
+  return vendors.map((v) => ({
+    ...v,
+    providerCount: providerCountMap.get(v.id) ?? 0,
+    endpointCount: endpointCountMap.get(v.id) ?? 0,
+  }));
+}
+
+export async function createProviderVendor(data: {
+  vendorKey: string;
+  displayName: string;
+  websiteUrl?: string | null;
+  faviconUrl?: string | null;
+  isEnabled?: boolean;
+}): Promise<ProviderVendor> {
+  const [row] = await db
+    .insert(providerVendors)
+    .values({
+      vendorKey: data.vendorKey,
+      displayName: data.displayName,
+      websiteUrl: data.websiteUrl ?? null,
+      faviconUrl: data.faviconUrl ?? null,
+      isEnabled: data.isEnabled ?? true,
+    })
+    .returning({
+      id: providerVendors.id,
+      vendorKey: providerVendors.vendorKey,
+      displayName: providerVendors.displayName,
+      websiteUrl: providerVendors.websiteUrl,
+      faviconUrl: providerVendors.faviconUrl,
+      isEnabled: providerVendors.isEnabled,
+      createdAt: providerVendors.createdAt,
+      updatedAt: providerVendors.updatedAt,
+      deletedAt: providerVendors.deletedAt,
+    });
+
+  return toProviderVendor(row);
+}
+
+export async function updateProviderVendor(
+  id: number,
+  patch: {
+    displayName?: string;
+    websiteUrl?: string | null;
+    faviconUrl?: string | null;
+    isEnabled?: boolean;
+  }
+): Promise<ProviderVendor | null> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dbPatch: any = { updatedAt: new Date() };
+  if (patch.displayName !== undefined) dbPatch.displayName = patch.displayName;
+  if (patch.websiteUrl !== undefined) dbPatch.websiteUrl = patch.websiteUrl;
+  if (patch.faviconUrl !== undefined) dbPatch.faviconUrl = patch.faviconUrl;
+  if (patch.isEnabled !== undefined) dbPatch.isEnabled = patch.isEnabled;
+
+  const [row] = await db
+    .update(providerVendors)
+    .set(dbPatch)
+    .where(and(eq(providerVendors.id, id), isNull(providerVendors.deletedAt)))
+    .returning({
+      id: providerVendors.id,
+      vendorKey: providerVendors.vendorKey,
+      displayName: providerVendors.displayName,
+      websiteUrl: providerVendors.websiteUrl,
+      faviconUrl: providerVendors.faviconUrl,
+      isEnabled: providerVendors.isEnabled,
+      createdAt: providerVendors.createdAt,
+      updatedAt: providerVendors.updatedAt,
+      deletedAt: providerVendors.deletedAt,
+    });
+
+  return row ? toProviderVendor(row) : null;
+}
+
+export async function ensureProviderVendor(input: {
+  vendorKey: string;
+  websiteUrl?: string | null;
+  faviconUrl?: string | null;
+}): Promise<ProviderVendor> {
+  const existing = await findProviderVendorByVendorKey(input.vendorKey);
+  if (existing) {
+    const shouldPatchWebsite = !existing.websiteUrl && input.websiteUrl;
+    const shouldPatchFavicon = !existing.faviconUrl && input.faviconUrl;
+
+    if (shouldPatchWebsite || shouldPatchFavicon) {
+      const updated = await updateProviderVendor(existing.id, {
+        websiteUrl: shouldPatchWebsite ? (input.websiteUrl ?? null) : undefined,
+        faviconUrl: shouldPatchFavicon ? (input.faviconUrl ?? null) : undefined,
+      });
+
+      if (updated) {
+        return updated;
+      }
+
+      logger.warn("ensureProviderVendor: failed to patch vendor metadata", {
+        vendorId: existing.id,
+        vendorKey: input.vendorKey,
+      });
+    }
+
+    return existing;
+  }
+
+  return createProviderVendor({
+    vendorKey: input.vendorKey,
+    displayName: input.vendorKey,
+    websiteUrl: input.websiteUrl ?? null,
+    faviconUrl: input.faviconUrl ?? null,
+    isEnabled: true,
+  });
+}
+
+export type MergeProviderVendorsResult = {
+  targetVendorId: number;
+  sourceVendorIds: number[];
+  movedProviders: number;
+  movedEndpoints: number;
+  dedupedEndpoints: number;
+  reattachedProbeEvents: number;
+  deletedVendors: number;
+};
+
+export async function mergeProviderVendors(input: {
+  targetVendorId: number;
+  sourceVendorIds: number[];
+}): Promise<MergeProviderVendorsResult> {
+  const normalizedSources = Array.from(
+    new Set(input.sourceVendorIds.filter((id) => id !== input.targetVendorId))
+  );
+
+  if (normalizedSources.length === 0) {
+    return {
+      targetVendorId: input.targetVendorId,
+      sourceVendorIds: [],
+      movedProviders: 0,
+      movedEndpoints: 0,
+      dedupedEndpoints: 0,
+      reattachedProbeEvents: 0,
+      deletedVendors: 0,
+    };
+  }
+
+  const now = new Date();
+
+  return await db.transaction(async (tx) => {
+    const [targetVendor] = await tx
+      .select({ id: providerVendors.id })
+      .from(providerVendors)
+      .where(and(eq(providerVendors.id, input.targetVendorId), isNull(providerVendors.deletedAt)))
+      .limit(1);
+
+    if (!targetVendor) {
+      throw new Error("target vendor not found");
+    }
+
+    const existingSourceVendors = await tx
+      .select({ id: providerVendors.id })
+      .from(providerVendors)
+      .where(
+        and(inArray(providerVendors.id, normalizedSources), isNull(providerVendors.deletedAt))
+      );
+
+    const existingSourceIds = existingSourceVendors.map((v) => v.id);
+
+    if (existingSourceIds.length === 0) {
+      return {
+        targetVendorId: input.targetVendorId,
+        sourceVendorIds: [],
+        movedProviders: 0,
+        movedEndpoints: 0,
+        dedupedEndpoints: 0,
+        reattachedProbeEvents: 0,
+        deletedVendors: 0,
+      };
+    }
+
+    const movedProviders = await tx
+      .update(providers)
+      .set({ vendorId: input.targetVendorId, updatedAt: now })
+      .where(and(inArray(providers.vendorId, existingSourceIds), isNull(providers.deletedAt)))
+      .returning({ id: providers.id });
+
+    const sourceEndpoints = await tx
+      .select({
+        id: providerEndpoints.id,
+        vendorId: providerEndpoints.vendorId,
+        providerType: providerEndpoints.providerType,
+        baseUrl: providerEndpoints.baseUrl,
+      })
+      .from(providerEndpoints)
+      .where(
+        and(
+          inArray(providerEndpoints.vendorId, existingSourceIds),
+          isNull(providerEndpoints.deletedAt)
+        )
+      );
+
+    const targetEndpoints = await tx
+      .select({
+        id: providerEndpoints.id,
+        providerType: providerEndpoints.providerType,
+        baseUrl: providerEndpoints.baseUrl,
+      })
+      .from(providerEndpoints)
+      .where(
+        and(
+          eq(providerEndpoints.vendorId, input.targetVendorId),
+          isNull(providerEndpoints.deletedAt)
+        )
+      );
+
+    const keyOf = (p: { providerType: ProviderType; baseUrl: string }) =>
+      `${p.providerType}|${p.baseUrl}`;
+
+    const endpointKeyToId = new Map<string, number>();
+    for (const e of targetEndpoints) {
+      endpointKeyToId.set(
+        keyOf({ providerType: e.providerType as ProviderType, baseUrl: e.baseUrl }),
+        e.id
+      );
+    }
+
+    let movedEndpointsCount = 0;
+    let dedupedEndpointsCount = 0;
+    let reattachedProbeEventsCount = 0;
+
+    for (const endpoint of sourceEndpoints) {
+      const endpointKey = keyOf({
+        providerType: endpoint.providerType as ProviderType,
+        baseUrl: endpoint.baseUrl,
+      });
+      const existingTargetEndpointId = endpointKeyToId.get(endpointKey);
+
+      if (existingTargetEndpointId) {
+        const updatedEvents = await tx
+          .update(providerEndpointProbeEvents)
+          .set({ endpointId: existingTargetEndpointId })
+          .where(eq(providerEndpointProbeEvents.endpointId, endpoint.id))
+          .returning({ id: providerEndpointProbeEvents.id });
+
+        reattachedProbeEventsCount += updatedEvents.length;
+
+        await tx
+          .update(providerEndpoints)
+          .set({ deletedAt: now, isEnabled: false, updatedAt: now })
+          .where(and(eq(providerEndpoints.id, endpoint.id), isNull(providerEndpoints.deletedAt)));
+
+        dedupedEndpointsCount++;
+        continue;
+      }
+
+      await tx
+        .update(providerEndpoints)
+        .set({ vendorId: input.targetVendorId, updatedAt: now })
+        .where(and(eq(providerEndpoints.id, endpoint.id), isNull(providerEndpoints.deletedAt)));
+
+      endpointKeyToId.set(endpointKey, endpoint.id);
+      movedEndpointsCount++;
+    }
+
+    const deletedVendors = await tx
+      .update(providerVendors)
+      .set({ deletedAt: now, isEnabled: false, updatedAt: now })
+      .where(and(inArray(providerVendors.id, existingSourceIds), isNull(providerVendors.deletedAt)))
+      .returning({ id: providerVendors.id });
+
+    return {
+      targetVendorId: input.targetVendorId,
+      sourceVendorIds: existingSourceIds,
+      movedProviders: movedProviders.length,
+      movedEndpoints: movedEndpointsCount,
+      dedupedEndpoints: dedupedEndpointsCount,
+      reattachedProbeEvents: reattachedProbeEventsCount,
+      deletedVendors: deletedVendors.length,
+    };
+  });
+}
+
+export type SplitProviderVendorResult = {
+  sourceVendorId: number;
+  newVendor: ProviderVendor;
+  movedProviderIds: number[];
+  ensuredEndpoints: number;
+};
+
+export async function splitProviderVendor(input: {
+  sourceVendorId: number;
+  newVendorKey: string;
+  newDisplayName: string;
+  websiteUrl?: string | null;
+  faviconUrl?: string | null;
+  providerIdsToMove: number[];
+}): Promise<SplitProviderVendorResult> {
+  const providerIdsToMove = Array.from(new Set(input.providerIdsToMove));
+  const now = new Date();
+
+  return await db.transaction(async (tx) => {
+    const [sourceVendor] = await tx
+      .select({ id: providerVendors.id })
+      .from(providerVendors)
+      .where(and(eq(providerVendors.id, input.sourceVendorId), isNull(providerVendors.deletedAt)))
+      .limit(1);
+
+    if (!sourceVendor) {
+      throw new Error("source vendor not found");
+    }
+
+    const [createdVendorRow] = await tx
+      .insert(providerVendors)
+      .values({
+        vendorKey: input.newVendorKey,
+        displayName: input.newDisplayName,
+        websiteUrl: input.websiteUrl ?? null,
+        faviconUrl: input.faviconUrl ?? null,
+        isEnabled: true,
+      })
+      .returning({
+        id: providerVendors.id,
+        vendorKey: providerVendors.vendorKey,
+        displayName: providerVendors.displayName,
+        websiteUrl: providerVendors.websiteUrl,
+        faviconUrl: providerVendors.faviconUrl,
+        isEnabled: providerVendors.isEnabled,
+        createdAt: providerVendors.createdAt,
+        updatedAt: providerVendors.updatedAt,
+        deletedAt: providerVendors.deletedAt,
+      });
+
+    const newVendor = toProviderVendor(createdVendorRow);
+
+    const movedProviders = providerIdsToMove.length
+      ? await tx
+          .update(providers)
+          .set({ vendorId: newVendor.id, updatedAt: now })
+          .where(
+            and(
+              inArray(providers.id, providerIdsToMove),
+              eq(providers.vendorId, input.sourceVendorId),
+              isNull(providers.deletedAt)
+            )
+          )
+          .returning({
+            id: providers.id,
+            url: providers.url,
+            providerType: providers.providerType,
+          })
+      : [];
+
+    let ensuredEndpoints = 0;
+
+    for (const p of movedProviders) {
+      await tx
+        .insert(providerEndpoints)
+        .values({
+          vendorId: newVendor.id,
+          providerType: (p.providerType || "claude") as ProviderType,
+          baseUrl: p.url,
+          isEnabled: true,
+          priority: 0,
+          weight: 1,
+        })
+        .onConflictDoNothing();
+
+      ensuredEndpoints++;
+    }
+
+    return {
+      sourceVendorId: input.sourceVendorId,
+      newVendor,
+      movedProviderIds: movedProviders.map((p) => p.id),
+      ensuredEndpoints,
+    };
+  });
+}

--- a/src/repository/provider.ts
+++ b/src/repository/provider.ts
@@ -20,6 +20,7 @@ export async function createProvider(providerData: CreateProviderData): Promise<
     costMultiplier:
       providerData.cost_multiplier != null ? providerData.cost_multiplier.toString() : "1.0",
     groupTag: providerData.group_tag,
+    vendorId: providerData.vendor_id ?? null,
     providerType: providerData.provider_type,
     preserveClientIp: providerData.preserve_client_ip ?? false,
     modelRedirects: providerData.model_redirects,
@@ -74,6 +75,7 @@ export async function createProvider(providerData: CreateProviderData): Promise<
     priority: providers.priority,
     costMultiplier: providers.costMultiplier,
     groupTag: providers.groupTag,
+    vendorId: providers.vendorId,
     providerType: providers.providerType,
     preserveClientIp: providers.preserveClientIp,
     modelRedirects: providers.modelRedirects,
@@ -135,6 +137,7 @@ export async function findProviderList(
       priority: providers.priority,
       costMultiplier: providers.costMultiplier,
       groupTag: providers.groupTag,
+      vendorId: providers.vendorId,
       providerType: providers.providerType,
       preserveClientIp: providers.preserveClientIp,
       modelRedirects: providers.modelRedirects,
@@ -210,6 +213,7 @@ export async function findAllProvidersFresh(): Promise<Provider[]> {
       priority: providers.priority,
       costMultiplier: providers.costMultiplier,
       groupTag: providers.groupTag,
+      vendorId: providers.vendorId,
       providerType: providers.providerType,
       preserveClientIp: providers.preserveClientIp,
       modelRedirects: providers.modelRedirects,
@@ -289,6 +293,7 @@ export async function findProviderById(id: number): Promise<Provider | null> {
       priority: providers.priority,
       costMultiplier: providers.costMultiplier,
       groupTag: providers.groupTag,
+      vendorId: providers.vendorId,
       providerType: providers.providerType,
       preserveClientIp: providers.preserveClientIp,
       modelRedirects: providers.modelRedirects,
@@ -360,6 +365,7 @@ export async function updateProvider(
     dbData.costMultiplier =
       providerData.cost_multiplier != null ? providerData.cost_multiplier.toString() : "1.0";
   if (providerData.group_tag !== undefined) dbData.groupTag = providerData.group_tag;
+  if (providerData.vendor_id !== undefined) dbData.vendorId = providerData.vendor_id;
   if (providerData.provider_type !== undefined) dbData.providerType = providerData.provider_type;
   if (providerData.preserve_client_ip !== undefined)
     dbData.preserveClientIp = providerData.preserve_client_ip;
@@ -448,6 +454,7 @@ export async function updateProvider(
       priority: providers.priority,
       costMultiplier: providers.costMultiplier,
       groupTag: providers.groupTag,
+      vendorId: providers.vendorId,
       providerType: providers.providerType,
       preserveClientIp: providers.preserveClientIp,
       modelRedirects: providers.modelRedirects,

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -51,6 +51,9 @@ export interface Provider {
   costMultiplier: number;
   groupTag: string | null;
 
+  // 供应商聚合 ID（为空表示尚未归类）
+  vendorId: number | null;
+
   // 供应商类型：扩展支持 4 种类型
   providerType: ProviderType;
   // 是否透传客户端 IP
@@ -153,6 +156,8 @@ export interface ProviderDisplay {
   priority: number;
   costMultiplier: number;
   groupTag: string | null;
+  // 供应商聚合 ID（为空表示尚未归类）
+  vendorId: number | null;
   // 供应商类型
   providerType: ProviderType;
   // 是否透传客户端 IP
@@ -242,6 +247,9 @@ export interface CreateProviderData {
   cost_multiplier?: number;
   group_tag?: string | null;
 
+  // 供应商聚合 ID（由服务端根据 website_url.host 计算并写入）
+  vendor_id?: number | null;
+
   // 供应商类型和模型配置
   provider_type?: ProviderType;
   preserve_client_ip?: boolean;
@@ -312,6 +320,9 @@ export interface UpdateProviderData {
   cost_multiplier?: number;
   group_tag?: string | null;
 
+  // 供应商聚合 ID（由服务端根据 website_url.host 计算并写入）
+  vendor_id?: number | null;
+
   // 供应商类型和模型配置
   provider_type?: ProviderType;
   preserve_client_ip?: boolean;
@@ -366,4 +377,46 @@ export interface UpdateProviderData {
   rpd?: number | null;
   // CC (Concurrent Connections/Requests): 同一时刻能同时处理的请求数量
   cc?: number | null;
+}
+
+export interface ProviderVendor {
+  id: number;
+  vendorKey: string;
+  displayName: string;
+  websiteUrl: string | null;
+  faviconUrl: string | null;
+  isEnabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date;
+}
+
+export interface ProviderEndpoint {
+  id: number;
+  vendorId: number;
+  providerType: ProviderType;
+  baseUrl: string;
+  isEnabled: boolean;
+  priority: number;
+  weight: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt?: Date;
+}
+
+export type ProviderEndpointProbeSource = "active_probe" | "passive_traffic";
+
+export type ProviderEndpointProbeResult = "success" | "fail";
+
+export interface ProviderEndpointProbeEvent {
+  id: number;
+  endpointId: number;
+  source: ProviderEndpointProbeSource;
+  result: ProviderEndpointProbeResult;
+  statusCode: number | null;
+  latencyMs: number | null;
+  errorType: string | null;
+  errorMessage: string | null;
+  checkedAt: Date | null;
+  createdAt: Date;
 }

--- a/tests/unit/actions/providers.test.ts
+++ b/tests/unit/actions/providers.test.ts
@@ -3,11 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const getSessionMock = vi.fn();
 
 const findAllProvidersFreshMock = vi.fn();
+const findProviderByIdMock = vi.fn();
 const getProviderStatisticsMock = vi.fn();
 const createProviderMock = vi.fn();
 const updateProviderMock = vi.fn();
 const deleteProviderMock = vi.fn();
 const updateProviderPrioritiesBatchMock = vi.fn();
+
+const ensureProviderVendorMock = vi.fn();
+const ensureProviderEndpointMock = vi.fn();
+const normalizeVendorKeyFromUrlMock = vi.fn();
 
 const publishProviderCacheInvalidationMock = vi.fn();
 const saveProviderCircuitConfigMock = vi.fn();
@@ -21,12 +26,24 @@ vi.mock("@/lib/auth", () => ({
   getSession: getSessionMock,
 }));
 
+vi.mock("@/lib/utils/vendor-key", () => ({
+  normalizeVendorKeyFromUrl: normalizeVendorKeyFromUrlMock,
+}));
+
+vi.mock("@/repository/provider-vendor", () => ({
+  ensureProviderVendor: ensureProviderVendorMock,
+}));
+
+vi.mock("@/repository/provider-endpoint", () => ({
+  ensureProviderEndpoint: ensureProviderEndpointMock,
+}));
+
 vi.mock("@/repository/provider", () => ({
   createProvider: createProviderMock,
   deleteProvider: deleteProviderMock,
   findAllProviders: vi.fn(async () => []),
   findAllProvidersFresh: findAllProvidersFreshMock,
-  findProviderById: vi.fn(async () => null),
+  findProviderById: findProviderByIdMock,
   getProviderStatistics: getProviderStatisticsMock,
   resetProviderTotalCostResetAt: vi.fn(async () => {}),
   updateProvider: updateProviderMock,
@@ -89,6 +106,62 @@ describe("Provider Actions - Async Optimization", () => {
 
     getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
 
+    normalizeVendorKeyFromUrlMock.mockReturnValue("api.example.com");
+    ensureProviderVendorMock.mockResolvedValue({ id: 99 });
+    ensureProviderEndpointMock.mockResolvedValue(undefined);
+
+    findProviderByIdMock.mockResolvedValue({
+      id: 1,
+      name: "p1",
+      url: "https://api.example.com",
+      key: "sk-test-1234567890",
+      isEnabled: true,
+      weight: 1,
+      priority: 0,
+      costMultiplier: 1,
+      groupTag: "default",
+      vendorId: 99,
+      providerType: "claude",
+      preserveClientIp: false,
+      modelRedirects: null,
+      allowedModels: null,
+      joinClaudePool: false,
+      codexInstructionsStrategy: "inherit",
+      mcpPassthroughType: "none",
+      mcpPassthroughUrl: null,
+      limit5hUsd: null,
+      limitDailyUsd: null,
+      dailyResetMode: "fixed",
+      dailyResetTime: "00:00",
+      limitWeeklyUsd: null,
+      limitMonthlyUsd: null,
+      limitTotalUsd: null,
+      limitConcurrentSessions: 0,
+      maxRetryAttempts: null,
+      circuitBreakerFailureThreshold: 5,
+      circuitBreakerOpenDuration: 1800000,
+      circuitBreakerHalfOpenSuccessThreshold: 2,
+      proxyUrl: null,
+      proxyFallbackToDirect: false,
+      firstByteTimeoutStreamingMs: null,
+      streamingIdleTimeoutMs: null,
+      requestTimeoutNonStreamingMs: null,
+      websiteUrl: null,
+      faviconUrl: null,
+      cacheTtlPreference: "inherit",
+      context1mPreference: "inherit",
+      codexReasoningEffortPreference: "inherit",
+      codexReasoningSummaryPreference: "inherit",
+      codexTextVerbosityPreference: "inherit",
+      codexParallelToolCallsPreference: "inherit",
+      tpm: null,
+      rpm: null,
+      rpd: null,
+      cc: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
     findAllProvidersFreshMock.mockResolvedValue([
       {
         id: 1,
@@ -100,6 +173,7 @@ describe("Provider Actions - Async Optimization", () => {
         priority: 0,
         costMultiplier: 1,
         groupTag: "default",
+        vendorId: 99,
         providerType: "claude",
         preserveClientIp: false,
         modelRedirects: null,
@@ -146,6 +220,9 @@ describe("Provider Actions - Async Optimization", () => {
 
     createProviderMock.mockResolvedValue({
       id: 123,
+      vendorId: 99,
+      providerType: "claude",
+      url: "https://api.example.com",
       circuitBreakerFailureThreshold: 5,
       circuitBreakerOpenDuration: 1800000,
       circuitBreakerHalfOpenSuccessThreshold: 2,
@@ -153,6 +230,9 @@ describe("Provider Actions - Async Optimization", () => {
 
     updateProviderMock.mockResolvedValue({
       id: 1,
+      vendorId: 99,
+      providerType: "claude",
+      url: "https://api.example.com",
       circuitBreakerFailureThreshold: 5,
       circuitBreakerOpenDuration: 1800000,
       circuitBreakerHalfOpenSuccessThreshold: 2,

--- a/tests/unit/lib/endpoint-availability.test.ts
+++ b/tests/unit/lib/endpoint-availability.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test, vi } from "vitest";
+
+function makeQuery(result: unknown) {
+  const promise = Promise.resolve(result) as unknown as {
+    from: () => unknown;
+    leftJoin: () => unknown;
+    where: () => unknown;
+    orderBy: () => unknown;
+    limit: () => unknown;
+  };
+
+  const chain = () => promise;
+
+  promise.from = chain;
+  promise.leftJoin = chain;
+  promise.where = chain;
+  promise.orderBy = chain;
+  promise.limit = chain;
+
+  return promise;
+}
+
+describe("endpoint-availability", () => {
+  test("queryEndpointAvailability: aggregates probe events into buckets and statuses", async () => {
+    vi.resetModules();
+
+    const start = new Date("2026-01-01T00:00:00.000Z");
+    const end = new Date("2026-01-01T01:00:00.000Z");
+
+    const selectResults: unknown[] = [
+      [
+        {
+          id: 1,
+          vendorId: 10,
+          providerType: "claude",
+          baseUrl: "https://a.example",
+          isEnabled: true,
+          vendorName: "Vendor A",
+        },
+        {
+          id: 2,
+          vendorId: 10,
+          providerType: "claude",
+          baseUrl: "https://b.example",
+          isEnabled: true,
+          vendorName: "Vendor A",
+        },
+      ],
+      [
+        {
+          endpointId: 1,
+          result: "success",
+          latencyMs: 100,
+          checkedAt: new Date("2026-01-01T00:10:00.000Z"),
+        },
+        {
+          endpointId: 1,
+          result: "success",
+          latencyMs: 200,
+          checkedAt: new Date("2026-01-01T00:20:00.000Z"),
+        },
+        {
+          endpointId: 1,
+          result: "fail",
+          latencyMs: 300,
+          checkedAt: new Date("2026-01-01T00:30:00.000Z"),
+        },
+      ],
+    ];
+
+    const db = {
+      select: vi.fn(() => makeQuery(selectResults.shift() ?? [])),
+    };
+
+    vi.doMock("@/drizzle/db", () => ({ db }));
+
+    vi.doMock("@/lib/logger", () => ({
+      logger: {
+        warn: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+      },
+    }));
+
+    const { queryEndpointAvailability } = await import("@/lib/endpoint-availability");
+
+    const result = await queryEndpointAvailability({
+      startTime: start,
+      endTime: end,
+      bucketSizeMinutes: 60,
+      maxBuckets: 10,
+    });
+
+    expect(result.startTime).toBe(start.toISOString());
+    expect(result.endTime).toBe(end.toISOString());
+    expect(result.endpoints).toHaveLength(2);
+
+    const endpoint1 = result.endpoints.find((e) => e.endpointId === 1);
+    const endpoint2 = result.endpoints.find((e) => e.endpointId === 2);
+
+    expect(endpoint1?.totalProbes).toBe(3);
+    expect(endpoint1?.currentAvailability).toBeCloseTo(2 / 3, 5);
+    expect(endpoint1?.currentStatus).toBe("green");
+    expect(endpoint1?.timeBuckets).toHaveLength(1);
+
+    expect(endpoint2?.totalProbes).toBe(0);
+    expect(endpoint2?.currentStatus).toBe("unknown");
+
+    expect(result.systemAvailability).toBeCloseTo(2 / 3, 5);
+  });
+});

--- a/tests/unit/lib/endpoint-circuit-breaker.test.ts
+++ b/tests/unit/lib/endpoint-circuit-breaker.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+describe("endpoint-circuit-breaker", () => {
+  test("opens circuit after threshold and transitions to half-open after open duration", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    vi.resetModules();
+    const mod = await import("@/lib/endpoint-circuit-breaker");
+
+    const endpointId = 1;
+
+    expect(mod.isEndpointCircuitOpen(endpointId)).toBe(false);
+
+    mod.recordEndpointFailure(endpointId, new Error("fail-1"));
+    mod.recordEndpointFailure(endpointId, new Error("fail-2"));
+    mod.recordEndpointFailure(endpointId, new Error("fail-3"));
+
+    expect(mod.getEndpointCircuitState(endpointId)).toBe("open");
+    expect(mod.isEndpointCircuitOpen(endpointId)).toBe(true);
+
+    vi.setSystemTime(new Date("2026-01-01T00:10:00.000Z"));
+
+    expect(mod.isEndpointCircuitOpen(endpointId)).toBe(false);
+    expect(mod.getEndpointCircuitState(endpointId)).toBe("half-open");
+
+    vi.useRealTimers();
+  });
+
+  test("half-open successes close the circuit", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    vi.resetModules();
+    const mod = await import("@/lib/endpoint-circuit-breaker");
+
+    const endpointId = 2;
+
+    mod.recordEndpointFailure(endpointId, new Error("fail-1"));
+    mod.recordEndpointFailure(endpointId, new Error("fail-2"));
+    mod.recordEndpointFailure(endpointId, new Error("fail-3"));
+
+    vi.setSystemTime(new Date("2026-01-01T00:10:00.000Z"));
+    expect(mod.isEndpointCircuitOpen(endpointId)).toBe(false);
+    expect(mod.getEndpointCircuitState(endpointId)).toBe("half-open");
+
+    mod.recordEndpointSuccess(endpointId);
+    expect(mod.getEndpointCircuitState(endpointId)).toBe("half-open");
+
+    mod.recordEndpointSuccess(endpointId);
+    expect(mod.getEndpointCircuitState(endpointId)).toBe("closed");
+
+    vi.useRealTimers();
+  });
+
+  test("vendor+type fuse opens and expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    vi.resetModules();
+    const mod = await import("@/lib/endpoint-circuit-breaker");
+
+    mod.openVendorTypeFuse({
+      vendorId: 10,
+      providerType: "claude",
+      reason: "all_endpoints_unhealthy",
+    });
+
+    expect(mod.isVendorTypeFuseOpen(10, "claude")).toBe(true);
+
+    vi.setSystemTime(new Date("2026-01-01T00:10:00.000Z"));
+
+    expect(mod.isVendorTypeFuseOpen(10, "claude")).toBe(false);
+
+    vi.useRealTimers();
+  });
+});

--- a/tests/unit/lib/endpoint-probe-scheduler.test.ts
+++ b/tests/unit/lib/endpoint-probe-scheduler.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { Provider, ProviderEndpoint } from "@/types/provider";
+
+const findAllProvidersFreshMock = vi.hoisted(() => vi.fn<[], Promise<Provider[]>>());
+
+vi.mock("@/repository/provider", () => ({
+  findAllProvidersFresh: findAllProvidersFreshMock,
+}));
+
+const findProviderEndpointsByVendorIdsMock = vi.hoisted(() =>
+  vi.fn<[vendorIds: number[]], Promise<ProviderEndpoint[]>>()
+);
+
+vi.mock("@/repository/provider-endpoint", () => ({
+  findProviderEndpointsByVendorIds: findProviderEndpointsByVendorIdsMock,
+}));
+
+const createProviderEndpointProbeEventMock = vi.hoisted(() => vi.fn());
+const deleteProviderEndpointProbeEventsOlderThanMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/repository/provider-endpoint-probe-event", () => ({
+  createProviderEndpointProbeEvent: createProviderEndpointProbeEventMock,
+  deleteProviderEndpointProbeEventsOlderThan: deleteProviderEndpointProbeEventsOlderThanMock,
+}));
+
+const executeProviderTestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/provider-testing/test-service", () => ({
+  executeProviderTest: executeProviderTestMock,
+}));
+
+const recordEndpointSuccessMock = vi.hoisted(() => vi.fn());
+const recordEndpointFailureMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/endpoint-circuit-breaker", () => ({
+  recordEndpointSuccess: recordEndpointSuccessMock,
+  recordEndpointFailure: recordEndpointFailureMock,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+describe("endpoint-probe-scheduler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const state = globalThis as unknown as {
+      __CCH_ENDPOINT_PROBE_CURSOR__?: number;
+      __CCH_ENDPOINT_PROBE_INTERVAL_ID__?: ReturnType<typeof setInterval> | null;
+      __CCH_ENDPOINT_PROBE_CLEANUP_INTERVAL_ID__?: ReturnType<typeof setInterval> | null;
+    };
+
+    state.__CCH_ENDPOINT_PROBE_CURSOR__ = 0;
+    state.__CCH_ENDPOINT_PROBE_INTERVAL_ID__ = null;
+    state.__CCH_ENDPOINT_PROBE_CLEANUP_INTERVAL_ID__ = null;
+
+    process.env.ENABLE_ENDPOINT_PROBING = "true";
+    process.env.ENDPOINT_PROBE_MAX_PER_CYCLE = "10";
+    process.env.ENDPOINT_PROBE_CONCURRENCY = "2";
+    process.env.ENDPOINT_PROBE_TIMEOUT_MS = "5000";
+    process.env.ENDPOINT_PROBE_RETENTION_DAYS = "7";
+  });
+
+  test("runEndpointProbeCycleOnce: success probes record success and event", async () => {
+    vi.resetModules();
+
+    findAllProvidersFreshMock.mockResolvedValue([
+      {
+        id: 1,
+        name: "p1",
+        url: "https://provider.example",
+        key: "sk-test",
+        isEnabled: true,
+        vendorId: 10,
+        providerType: "claude",
+        priority: 0,
+      } as unknown as Provider,
+    ]);
+
+    findProviderEndpointsByVendorIdsMock.mockResolvedValue([
+      {
+        id: 100,
+        vendorId: 10,
+        providerType: "claude",
+        baseUrl: "https://endpoint.example",
+        isEnabled: true,
+        priority: 0,
+        weight: 1,
+      } as unknown as ProviderEndpoint,
+    ]);
+
+    executeProviderTestMock.mockResolvedValue({
+      success: true,
+      latencyMs: 123,
+      httpStatusCode: 200,
+    } as unknown);
+
+    createProviderEndpointProbeEventMock.mockResolvedValue({ id: 1 });
+
+    const { runEndpointProbeCycleOnce } = await import("@/lib/endpoint-probe-scheduler");
+
+    await runEndpointProbeCycleOnce();
+
+    expect(executeProviderTestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerUrl: "https://endpoint.example",
+        apiKey: "sk-test",
+        providerType: "claude",
+        timeoutMs: 5000,
+      })
+    );
+
+    expect(recordEndpointSuccessMock).toHaveBeenCalledWith(100);
+    expect(recordEndpointFailureMock).not.toHaveBeenCalled();
+
+    expect(createProviderEndpointProbeEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointId: 100,
+        source: "active_probe",
+        result: "success",
+        statusCode: 200,
+        latencyMs: 123,
+      })
+    );
+  });
+
+  test("runEndpointProbeCycleOnce: failure probes record failure and event", async () => {
+    vi.resetModules();
+
+    findAllProvidersFreshMock.mockResolvedValue([
+      {
+        id: 1,
+        name: "p1",
+        url: "https://provider.example",
+        key: "sk-test",
+        isEnabled: true,
+        vendorId: 10,
+        providerType: "claude",
+        priority: 0,
+      } as unknown as Provider,
+    ]);
+
+    findProviderEndpointsByVendorIdsMock.mockResolvedValue([
+      {
+        id: 200,
+        vendorId: 10,
+        providerType: "claude",
+        baseUrl: "https://endpoint.example",
+        isEnabled: true,
+        priority: 0,
+        weight: 1,
+      } as unknown as ProviderEndpoint,
+    ]);
+
+    executeProviderTestMock.mockResolvedValue({
+      success: false,
+      latencyMs: 5010,
+      errorType: "timeout",
+      errorMessage: "Request timed out",
+    } as unknown);
+
+    createProviderEndpointProbeEventMock.mockResolvedValue({ id: 1 });
+
+    const { runEndpointProbeCycleOnce } = await import("@/lib/endpoint-probe-scheduler");
+
+    await runEndpointProbeCycleOnce();
+
+    expect(recordEndpointFailureMock).toHaveBeenCalledTimes(1);
+    const error = recordEndpointFailureMock.mock.calls[0]?.[1];
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe("timeout");
+    expect((error as Error).message).toBe("Request timed out");
+
+    expect(createProviderEndpointProbeEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointId: 200,
+        source: "active_probe",
+        result: "fail",
+        statusCode: null,
+        latencyMs: 5010,
+        errorType: "timeout",
+        errorMessage: "Request timed out",
+      })
+    );
+  });
+
+  test("cleanupEndpointProbeEventsOnce: calls delete with retention days", async () => {
+    vi.resetModules();
+
+    deleteProviderEndpointProbeEventsOlderThanMock.mockResolvedValue(12);
+
+    const { cleanupEndpointProbeEventsOnce } = await import("@/lib/endpoint-probe-scheduler");
+
+    const deleted = await cleanupEndpointProbeEventsOnce();
+
+    expect(deleteProviderEndpointProbeEventsOlderThanMock).toHaveBeenCalledWith({ days: 7 });
+    expect(deleted).toBe(12);
+  });
+});

--- a/tests/unit/lib/vendor-key.test.ts
+++ b/tests/unit/lib/vendor-key.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+import { normalizeVendorKeyFromUrl } from "@/lib/utils/vendor-key";
+
+describe("normalizeVendorKeyFromUrl", () => {
+  test("应从 https URL 提取并归一化 hostname（去掉 www.）", () => {
+    expect(normalizeVendorKeyFromUrl("https://www.Example.com/path")).toBe("example.com");
+  });
+
+  test("应保留子域名（仅去掉最前缀 www.）", () => {
+    expect(normalizeVendorKeyFromUrl("https://www.api.example.com")).toBe("api.example.com");
+    expect(normalizeVendorKeyFromUrl("https://api.example.com")).toBe("api.example.com");
+  });
+
+  test("包含端口时应忽略端口，仅使用 hostname", () => {
+    expect(normalizeVendorKeyFromUrl("https://api.example.com:8443/v1")).toBe("api.example.com");
+  });
+
+  test("无效 URL 应返回 null", () => {
+    expect(normalizeVendorKeyFromUrl("not-a-url")).toBeNull();
+  });
+});

--- a/tests/unit/proxy/endpoint-resolver.test.ts
+++ b/tests/unit/proxy/endpoint-resolver.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { Provider, ProviderEndpoint } from "@/types/provider";
+
+const findProviderEndpointsByVendorTypeMock = vi.hoisted(() =>
+  vi.fn<[vendorId: number, providerType: Provider["providerType"]], Promise<ProviderEndpoint[]>>()
+);
+
+vi.mock("@/repository/provider-endpoint", () => ({
+  findProviderEndpointsByVendorType: findProviderEndpointsByVendorTypeMock,
+}));
+
+const endpointCircuitBreakerMocks = vi.hoisted(() => ({
+  isEndpointCircuitOpen: vi.fn((_: number) => false),
+  openVendorTypeFuse: vi.fn(),
+}));
+
+vi.mock("@/lib/endpoint-circuit-breaker", () => endpointCircuitBreakerMocks);
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+function makeProvider(partial: Partial<Provider>): Provider {
+  return {
+    url: "https://provider.example",
+    providerType: "claude",
+    vendorId: null,
+    ...partial,
+  } as unknown as Provider;
+}
+
+function makeEndpoint(partial: Partial<ProviderEndpoint>): ProviderEndpoint {
+  return {
+    id: 1,
+    vendorId: 10,
+    providerType: "claude",
+    baseUrl: "https://endpoint.example",
+    isEnabled: true,
+    priority: 0,
+    weight: 1,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...partial,
+  } as unknown as ProviderEndpoint;
+}
+
+describe("EndpointResolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    endpointCircuitBreakerMocks.isEndpointCircuitOpen.mockImplementation(() => false);
+  });
+
+  test("无 vendorId 时应回退到 provider.url，并清空 session endpoint", async () => {
+    vi.resetModules();
+
+    const { EndpointResolver } = await import("@/app/v1/_lib/proxy/endpoint-resolver");
+
+    const setProviderEndpoint = vi.fn();
+    const session = {
+      setProviderEndpoint,
+    } satisfies {
+      setProviderEndpoint: (endpoint: ProviderEndpoint | null) => void;
+    };
+
+    const provider = makeProvider({
+      url: "https://fallback.example",
+      vendorId: null,
+      providerType: "claude",
+    });
+
+    const resolved = await EndpointResolver.resolve(session, provider);
+
+    expect(resolved).toBe("https://fallback.example");
+    expect(setProviderEndpoint).toHaveBeenCalledWith(null);
+    expect(findProviderEndpointsByVendorTypeMock).not.toHaveBeenCalled();
+    expect(endpointCircuitBreakerMocks.openVendorTypeFuse).not.toHaveBeenCalled();
+  });
+
+  test("vendorId 存在但无 endpoints 时应回退到 provider.url", async () => {
+    vi.resetModules();
+
+    findProviderEndpointsByVendorTypeMock.mockResolvedValue([]);
+
+    const { EndpointResolver } = await import("@/app/v1/_lib/proxy/endpoint-resolver");
+
+    const setProviderEndpoint = vi.fn();
+    const session = {
+      setProviderEndpoint,
+    } satisfies {
+      setProviderEndpoint: (endpoint: ProviderEndpoint | null) => void;
+    };
+
+    const provider = makeProvider({
+      url: "https://fallback.example",
+      vendorId: 10,
+      providerType: "claude",
+    });
+
+    const resolved = await EndpointResolver.resolve(session, provider);
+
+    expect(resolved).toBe("https://fallback.example");
+    expect(setProviderEndpoint).toHaveBeenCalledWith(null);
+    expect(findProviderEndpointsByVendorTypeMock).toHaveBeenCalledWith(10, "claude");
+    expect(endpointCircuitBreakerMocks.openVendorTypeFuse).not.toHaveBeenCalled();
+  });
+
+  test("所有 endpoints 不可用时应打开 vendor+type fuse 并抛出异常", async () => {
+    vi.resetModules();
+
+    findProviderEndpointsByVendorTypeMock.mockResolvedValue([
+      makeEndpoint({ id: 1, isEnabled: false, baseUrl: "https://a.example" }),
+      makeEndpoint({ id: 2, isEnabled: false, baseUrl: "https://b.example" }),
+    ]);
+
+    const { EndpointResolver, EndpointResolutionError } = await import(
+      "@/app/v1/_lib/proxy/endpoint-resolver"
+    );
+
+    const setProviderEndpoint = vi.fn();
+    const session = {
+      setProviderEndpoint,
+    } satisfies {
+      setProviderEndpoint: (endpoint: ProviderEndpoint | null) => void;
+    };
+
+    const provider = makeProvider({ vendorId: 10, providerType: "claude" });
+
+    await expect(EndpointResolver.resolve(session, provider)).rejects.toBeInstanceOf(
+      EndpointResolutionError
+    );
+
+    expect(setProviderEndpoint).toHaveBeenCalledWith(null);
+    expect(endpointCircuitBreakerMocks.openVendorTypeFuse).toHaveBeenCalledWith({
+      vendorId: 10,
+      providerType: "claude",
+      reason: "no_enabled_endpoints",
+    });
+  });
+
+  test("所有 endpoints 熔断时应打开 vendor+type fuse 并抛出异常", async () => {
+    vi.resetModules();
+
+    findProviderEndpointsByVendorTypeMock.mockResolvedValue([
+      makeEndpoint({ id: 1, isEnabled: true, baseUrl: "https://a.example" }),
+      makeEndpoint({ id: 2, isEnabled: true, baseUrl: "https://b.example" }),
+    ]);
+
+    endpointCircuitBreakerMocks.isEndpointCircuitOpen.mockImplementation(() => true);
+
+    const { EndpointResolver, EndpointResolutionError } = await import(
+      "@/app/v1/_lib/proxy/endpoint-resolver"
+    );
+
+    const setProviderEndpoint = vi.fn();
+    const session = {
+      setProviderEndpoint,
+    } satisfies {
+      setProviderEndpoint: (endpoint: ProviderEndpoint | null) => void;
+    };
+
+    const provider = makeProvider({ vendorId: 10, providerType: "claude" });
+
+    await expect(EndpointResolver.resolve(session, provider)).rejects.toBeInstanceOf(
+      EndpointResolutionError
+    );
+
+    expect(setProviderEndpoint).toHaveBeenCalledWith(null);
+    expect(endpointCircuitBreakerMocks.openVendorTypeFuse).toHaveBeenCalledWith({
+      vendorId: 10,
+      providerType: "claude",
+      reason: "all_endpoints_unhealthy",
+    });
+  });
+
+  test("应在最优先级 endpoints 中按 weight 选择，并写入 session endpoint", async () => {
+    vi.resetModules();
+
+    const endpoints = [
+      makeEndpoint({ id: 1, baseUrl: "https://a.example", priority: 0, weight: 1 }),
+      makeEndpoint({ id: 2, baseUrl: "https://b.example", priority: 0, weight: 9 }),
+      makeEndpoint({ id: 3, baseUrl: "https://c.example", priority: 1, weight: 999 }),
+    ];
+
+    findProviderEndpointsByVendorTypeMock.mockResolvedValue(endpoints);
+
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.95);
+
+    const { EndpointResolver } = await import("@/app/v1/_lib/proxy/endpoint-resolver");
+
+    const setProviderEndpoint = vi.fn();
+    const session = {
+      setProviderEndpoint,
+    } satisfies {
+      setProviderEndpoint: (endpoint: ProviderEndpoint | null) => void;
+    };
+
+    const provider = makeProvider({ vendorId: 10, providerType: "claude" });
+
+    const resolved = await EndpointResolver.resolve(session, provider);
+
+    expect(resolved).toBe("https://b.example");
+    expect(setProviderEndpoint).toHaveBeenCalledWith(expect.objectContaining({ id: 2 }));
+
+    randomSpy.mockRestore();
+  });
+});

--- a/tests/unit/proxy/provider-selector-vendor-fuse.test.ts
+++ b/tests/unit/proxy/provider-selector-vendor-fuse.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test, vi } from "vitest";
+import type { Provider } from "@/types/provider";
+
+const circuitBreakerMocks = vi.hoisted(() => ({
+  isCircuitOpen: vi.fn(async () => false),
+  getCircuitState: vi.fn(() => "closed"),
+}));
+
+vi.mock("@/lib/circuit-breaker", () => circuitBreakerMocks);
+
+const rateLimitMocks = vi.hoisted(() => ({
+  RateLimitService: {
+    checkCostLimits: vi.fn(async () => ({ allowed: true })),
+    checkTotalCostLimit: vi.fn(async () => ({ allowed: true, current: 0 })),
+  },
+}));
+
+vi.mock("@/lib/rate-limit", () => rateLimitMocks);
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+describe("ProxyProviderResolver.filterByLimits - vendor+type fuse", () => {
+  test("filters out providers when vendor+type fuse is open", async () => {
+    vi.resetModules();
+
+    const { openVendorTypeFuse } = await import("@/lib/endpoint-circuit-breaker");
+    openVendorTypeFuse({ vendorId: 10, providerType: "claude", reason: "test" });
+
+    const { ProxyProviderResolver } = await import("@/app/v1/_lib/proxy/provider-selector");
+
+    const providers: Provider[] = [
+      {
+        id: 1,
+        name: "p1",
+        isEnabled: true,
+        vendorId: 10,
+        providerType: "claude",
+        groupTag: null,
+        weight: 1,
+        priority: 0,
+        costMultiplier: 1,
+        limit5hUsd: null,
+        limitDailyUsd: null,
+        dailyResetMode: "fixed",
+        dailyResetTime: "00:00",
+        limitWeeklyUsd: null,
+        limitMonthlyUsd: null,
+        limitTotalUsd: null,
+        totalCostResetAt: null,
+        limitConcurrentSessions: 0,
+      } as unknown as Provider,
+      {
+        id: 2,
+        name: "p2",
+        isEnabled: true,
+        vendorId: 11,
+        providerType: "claude",
+        groupTag: null,
+        weight: 1,
+        priority: 0,
+        costMultiplier: 1,
+        limit5hUsd: null,
+        limitDailyUsd: null,
+        dailyResetMode: "fixed",
+        dailyResetTime: "00:00",
+        limitWeeklyUsd: null,
+        limitMonthlyUsd: null,
+        limitTotalUsd: null,
+        totalCostResetAt: null,
+        limitConcurrentSessions: 0,
+      } as unknown as Provider,
+    ];
+
+    const filtered = await (ProxyProviderResolver as any).filterByLimits(providers);
+    expect(filtered.map((p: Provider) => p.id)).toEqual([2]);
+  });
+});

--- a/tests/unit/repository/provider-vendor.test.ts
+++ b/tests/unit/repository/provider-vendor.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test, vi } from "vitest";
+
+function makeQuery(result: unknown) {
+  const promise = Promise.resolve(result) as any;
+
+  const chain = () => promise;
+
+  promise.from = chain;
+  promise.where = chain;
+  promise.limit = chain;
+  promise.orderBy = chain;
+  promise.groupBy = chain;
+  promise.set = chain;
+  promise.values = chain;
+  promise.returning = chain;
+  promise.onConflictDoNothing = chain;
+
+  return promise;
+}
+
+describe("provider-vendor repository - merge/split", () => {
+  test("mergeProviderVendors: moves providers and dedupes endpoints", async () => {
+    vi.resetModules();
+
+    const selectResults: unknown[] = [
+      [{ id: 10 }],
+      [{ id: 2 }, { id: 3 }],
+      [
+        { id: 100, vendorId: 2, providerType: "claude", baseUrl: "https://a.example" },
+        { id: 101, vendorId: 2, providerType: "claude", baseUrl: "https://b.example" },
+        { id: 102, vendorId: 3, providerType: "claude", baseUrl: "https://a.example" },
+      ],
+      [{ id: 200, providerType: "claude", baseUrl: "https://a.example" }],
+    ];
+
+    const updateResults: unknown[] = [
+      [{ id: 11 }, { id: 12 }, { id: 13 }],
+      [{ id: 1 }, { id: 2 }],
+      [],
+      [],
+      [{ id: 3 }],
+      [],
+      [{ id: 2 }, { id: 3 }],
+    ];
+
+    const tx = {
+      select: vi.fn(() => makeQuery(selectResults.shift() ?? [])),
+      update: vi.fn(() => makeQuery(updateResults.shift() ?? [])),
+      insert: vi.fn(() => makeQuery([])),
+    };
+
+    vi.doMock("@/drizzle/db", () => ({
+      db: {
+        transaction: async (fn: (txArg: typeof tx) => Promise<unknown>) => fn(tx),
+      },
+    }));
+
+    vi.doMock("@/lib/logger", () => ({
+      logger: {
+        warn: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+      },
+    }));
+
+    const { mergeProviderVendors } = await import("@/repository/provider-vendor");
+
+    const result = await mergeProviderVendors({
+      targetVendorId: 10,
+      sourceVendorIds: [2, 3, 10],
+    });
+
+    expect(result.targetVendorId).toBe(10);
+    expect(result.sourceVendorIds).toEqual([2, 3]);
+    expect(result.movedProviders).toBe(3);
+    expect(result.movedEndpoints).toBe(1);
+    expect(result.dedupedEndpoints).toBe(2);
+    expect(result.reattachedProbeEvents).toBe(3);
+    expect(result.deletedVendors).toBe(2);
+  });
+
+  test("splitProviderVendor: creates vendor, moves providers, ensures endpoints", async () => {
+    vi.resetModules();
+
+    const selectResults: unknown[] = [[{ id: 1 }]];
+
+    const insertResults: unknown[] = [
+      [
+        {
+          id: 50,
+          vendorKey: "new.example",
+          displayName: "New Vendor",
+          websiteUrl: null,
+          faviconUrl: null,
+          isEnabled: true,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+          deletedAt: null,
+        },
+      ],
+      [],
+      [],
+    ];
+
+    const updateResults: unknown[] = [
+      [
+        { id: 1001, url: "https://p1.example", providerType: "claude" },
+        { id: 1002, url: "https://p2.example", providerType: "codex" },
+      ],
+    ];
+
+    const tx = {
+      select: vi.fn(() => makeQuery(selectResults.shift() ?? [])),
+      update: vi.fn(() => makeQuery(updateResults.shift() ?? [])),
+      insert: vi.fn(() => makeQuery(insertResults.shift() ?? [])),
+    };
+
+    vi.doMock("@/drizzle/db", () => ({
+      db: {
+        transaction: async (fn: (txArg: typeof tx) => Promise<unknown>) => fn(tx),
+      },
+    }));
+
+    vi.doMock("@/lib/logger", () => ({
+      logger: {
+        warn: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+      },
+    }));
+
+    const { splitProviderVendor } = await import("@/repository/provider-vendor");
+
+    const result = await splitProviderVendor({
+      sourceVendorId: 1,
+      newVendorKey: "new.example",
+      newDisplayName: "New Vendor",
+      providerIdsToMove: [1001, 1002],
+      websiteUrl: null,
+      faviconUrl: null,
+    });
+
+    expect(result.sourceVendorId).toBe(1);
+    expect(result.newVendor.id).toBe(50);
+    expect(result.newVendor.vendorKey).toBe("new.example");
+    expect(result.movedProviderIds).toEqual([1001, 1002]);
+    expect(result.ensuredEndpoints).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive vendor-endpoint architecture that enables providers to have multiple endpoints with intelligent routing and circuit breaker support.

## Problem

Currently, providers are limited to a single endpoint configuration. This creates limitations for:
- High availability scenarios requiring multiple endpoints per provider
- Load balancing across different API endpoints
- Automatic failover when endpoints become unhealthy

## Solution

Implement a vendor-endpoint architecture that allows:
- Multiple endpoints per provider type (e.g., multiple Claude API endpoints)
- Intelligent endpoint selection based on health status and priority
- Circuit breaker pattern for automatic failover
- Real-time health monitoring with probe scheduling

## Changes

### Database Schema
- Added `provider_vendors` table for vendor management
- Added `provider_endpoints` table with circuit breaker state tracking
- Added `provider_endpoint_probe_events` table for health monitoring history
- Added `vendor_id` foreign key to `providers` table

### Core Services
- **Endpoint Availability Service** (`src/lib/endpoint-availability/`): Health monitoring with configurable probe scheduling
- **Endpoint Circuit Breaker** (`src/lib/endpoint-circuit-breaker.ts`): Automatic failover on endpoint failures
- **Endpoint Probe Scheduler** (`src/lib/endpoint-probe-scheduler.ts`): Background health checks
- **Endpoint Resolver** (`src/app/v1/_lib/proxy/endpoint-resolver.ts`): Smart endpoint selection based on availability

### Proxy Pipeline Integration
- Updated `forwarder.ts` to support endpoint-level routing
- Updated `provider-selector.ts` with vendor fuse integration
- Updated `response-handler.ts` for endpoint-aware error handling
- Updated `session.ts` with endpoint context

### Management UI
- New vendors management page (`/settings/providers/vendors`)
- Vendor card, edit sheet, and endpoints manager components
- Endpoint add dialog and list item components
- Full i18n support (en, zh-CN)

### Dashboard Views
- Split availability dashboard into provider-level and endpoint-level views
- New endpoint availability view with health status visualization
- Real-time SSE updates for endpoint status

### API Endpoints
- `GET /api/availability/endpoints` - List endpoint availability
- `GET /api/availability/endpoints/current` - Current endpoint status
- `GET /api/availability/endpoints/events` - SSE for real-time updates

## Breaking Changes

| Change | Impact | Migration |
|--------|--------|-----------|
| New database tables | Requires migration | Run `bun run db:migrate` or enable `AUTO_MIGRATE=true` |
| `providers` table has new `vendor_id` column | Existing providers will have `NULL` vendor_id | No action needed - backward compatible |

## Testing

### Automated Tests
- [x] Unit tests for endpoint-resolver (`tests/unit/proxy/endpoint-resolver.test.ts`)
- [x] Unit tests for circuit-breaker (`tests/unit/lib/endpoint-circuit-breaker.test.ts`)
- [x] Unit tests for probe-scheduler (`tests/unit/lib/endpoint-probe-scheduler.test.ts`)
- [x] Unit tests for endpoint-availability (`tests/unit/lib/endpoint-availability.test.ts`)
- [x] Unit tests for vendor-key utilities (`tests/unit/lib/vendor-key.test.ts`)
- [x] Repository tests for provider-vendor (`tests/unit/repository/provider-vendor.test.ts`)
- [x] Provider selector vendor fuse tests (`tests/unit/proxy/provider-selector-vendor-fuse.test.ts`)

### Manual Testing
1. Create a new vendor in Settings > Providers > Vendors
2. Add multiple endpoints to the vendor
3. Verify endpoint health monitoring in Dashboard > Availability > Endpoints
4. Test failover by disabling an endpoint

## Files Changed

- 57 files changed, 8073 insertions(+), 71 deletions(-)

## Checklist

- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] i18n strings added for en and zh-CN
- [x] Database migration generated via `bun run db:generate`

---
*Description enhanced by Claude AI*