### PR TITLE
fix: improve mobile layout for provider list

### DIFF
--- a/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
@@ -345,7 +345,7 @@ export function ProviderRichListItem({
 
   return (
     <>
-      <div className="flex items-center gap-4 py-3 px-4 border-b hover:bg-muted/50 transition-colors">
+      <div className="flex flex-wrap items-start gap-2 py-3 px-4 border-b hover:bg-muted/50 transition-colors md:flex-nowrap md:items-center md:gap-4">
         {/* 左侧：状态和类型图标 */}
         <div className="flex items-center gap-2">
           {/* 启用状态指示器 */}
@@ -366,7 +366,7 @@ export function ProviderRichListItem({
         </div>
 
         {/* 中间：名称、URL、官网、tag、熔断状态 */}
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 min-w-0 w-full md:w-auto">
           <div className="flex items-center gap-2 flex-wrap">
             {/* Favicon */}
             {provider.faviconUrl && (
@@ -382,7 +382,7 @@ export function ProviderRichListItem({
             )}
 
             {/* 名称 */}
-            <span className="font-semibold truncate">{provider.name}</span>
+            <span className="font-semibold md:truncate">{provider.name}</span>
 
             {/* Group Tags (supports comma-separated values) */}
             {(provider.groupTag
@@ -556,8 +556,61 @@ export function ProviderRichListItem({
           )}
         </div>
 
+        {/* 移动端：指标快速编辑 */}
+        <div className="grid grid-cols-3 gap-4 text-center w-full md:hidden">
+          <div>
+            <div className="text-xs text-muted-foreground">{tList("priority")}</div>
+            <div className="font-medium">
+              {canEdit ? (
+                <InlineEditPopover
+                  value={provider.priority}
+                  label={tInline("priorityLabel")}
+                  type="integer"
+                  validator={validatePriority}
+                  onSave={handleSavePriority}
+                />
+              ) : (
+                <span>{provider.priority}</span>
+              )}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">{tList("weight")}</div>
+            <div className="font-medium">
+              {canEdit ? (
+                <InlineEditPopover
+                  value={provider.weight}
+                  label={tInline("weightLabel")}
+                  type="integer"
+                  validator={validateWeight}
+                  onSave={handleSaveWeight}
+                />
+              ) : (
+                <span>{provider.weight}</span>
+              )}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">{tList("costMultiplier")}</div>
+            <div className="font-medium">
+              {canEdit ? (
+                <InlineEditPopover
+                  value={provider.costMultiplier}
+                  label={tInline("costMultiplierLabel")}
+                  validator={validateCostMultiplier}
+                  onSave={handleSaveCostMultiplier}
+                  suffix="x"
+                  type="number"
+                />
+              ) : (
+                <span>{provider.costMultiplier}x</span>
+              )}
+            </div>
+          </div>
+        </div>
+
         {/* 操作按钮 */}
-        <div className="flex items-center gap-1 flex-shrink-0">
+        <div className="flex items-center gap-3 flex-shrink-0 w-full justify-end pt-2 border-t border-border/30 md:gap-1 md:w-auto md:pt-0 md:border-t-0">
           {/* 启用/禁用切换 */}
           {canEdit && (
             <Switch


### PR DESCRIPTION
## Summary

- Optimize provider list layout for mobile devices
- Add inline editing for priority/weight/cost multiplier on mobile (previously desktop-only)
- Improve touch target spacing for better mobile UX

## Screenshots

### Before
![微信图片_20260115092831_205_3](https://github.com/user-attachments/assets/52160d67-4eef-4bf0-8ba8-28712d94810a)


### After
<img width="227" height="437" alt="Snipaste_2026-01-15_09-32-26" src="https://github.com/user-attachments/assets/fc038358-d052-4bec-8ae2-687b67b392ca" />


## Changes

- Use `flex-wrap` on mobile, `flex-nowrap` on desktop to allow natural content flow
- Remove name truncation on mobile for better readability
- Add mobile-specific metrics editing row with same `InlineEditPopover` as desktop
- Increase action button spacing (`gap-3`) for touch-friendly interaction
- Add visual separator (border-top) between content and actions on mobile

## Test plan

- [x] Test on mobile device or browser dev tools (< 768px width)
- [x] Verify provider name displays fully on mobile
- [x] Verify priority/weight/cost multiplier can be edited on mobile
- [x] Verify desktop layout remains unchanged

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR improves mobile UX for the provider list by adding responsive layout improvements and inline editing capabilities on mobile devices. The changes include:

- Convert layout from fixed flex to responsive flex-wrap on mobile and flex-nowrap on desktop
- Remove name truncation on mobile for better readability
- Add mobile-specific metrics editing row (`priority`, `weight`, `cost_multiplier`) using the existing `InlineEditPopover` component
- Increase action button spacing and add visual separator (border-top) between content and actions on mobile
- Improve touch target spacing with `gap-3` instead of `gap-1`

The functionality remains intact and existing components are reused appropriately. However, the metrics editing section duplicates 51 lines of code between desktop and mobile views, which should be refactored into a shared component to improve maintainability.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge. The responsive layout changes are well-structured using Tailwind's responsive utilities, and the feature additions are backwards-compatible with existing functionality.
- Score of 4 reflects that the PR implements the intended features correctly and maintains backward compatibility. The layout improvements use established patterns (flex-wrap, responsive gap/display utilities) without introducing new risks. The main concern is code duplication between desktop and mobile metrics sections (51 lines), which is a maintainability issue rather than a functional bug. The `InlineEditPopover` component is already tested and reused, so adding it to mobile is low-risk. The changes align with the PR description and testing checklist items are clearly defined.
- Consider refactoring the duplicated metrics editing section into a separate component for better code maintainability, though this is not blocking for merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx | Mobile layout improvements with responsive grid changes, flex wrapping, and inline editing on mobile. Key issue: significant code duplication between desktop and mobile metrics sections (51 lines duplicated exactly). |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User as Mobile User
    participant UI as Provider List Item
    participant Popover as InlineEditPopover
    participant Provider as editProvider Action
    participant Toast as Toast Notification

    Note over User,Toast: Mobile Layout Flow (< 768px)
    
    User->>UI: View provider on mobile
    Note over UI: Layout wraps with flex-wrap<br/>Name displays fully (no truncate)<br/>Metrics visible in 3-col grid
    
    User->>UI: Tap metrics editing (priority/weight/cost)
    UI->>Popover: Open InlineEditPopover for field
    Popover->>User: Show input with validation
    
    User->>Popover: Enter new value
    Popover->>Popover: Validate input
    
    alt Validation passes
        User->>Popover: Tap Save
        Popover->>Provider: Call editProvider(id, {field: value})
        Provider->>Provider: Update provider on server
        Provider-->>Popover: Return success/error
        Popover->>Toast: Show success message
        Popover->>UI: Close and refresh
    else Validation fails
        Popover->>User: Show error message
    end
    
    User->>UI: Tap action buttons
    Note over UI: Full width buttons with<br/>increased gap (gap-3)<br/>Bordered separator on mobile
    UI->>UI: Toggle/Edit/Clone/Delete provider

    Note over User,Toast: Desktop Layout Flow (>= 768px)
    User->>UI: View provider on desktop
    Note over UI: Layout stays compact (flex-nowrap)<br/>Name truncates<br/>Metrics in compact column layout
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->