### PR TITLE
fix: Set HOSTNAME environment variable in Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -32,6 +32,7 @@ FROM node:trixie-slim AS runner
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOST=0.0.0.0
+ENV HOSTNAME=0.0.0.0
 WORKDIR /app
 
 # 安装 PostgreSQL 18 客户端工具（用于数据库备份/恢复功能）和 curl（用于健康检查）


### PR DESCRIPTION
## Summary

Adds the `HOSTNAME` environment variable to the Dockerfile to fix container accessibility issues on Windows with Docker Compose.

## Problem

When running the container on Windows with Docker Compose, the Next.js standalone server listens on the container's hostname instead of `0.0.0.0`, making the application inaccessible from the host network.

**Related Issues:**
- Fixes #621 - Windows Docker Compose container listens on hostname instead of 0.0.0.0

## Solution

Add `ENV HOSTNAME=0.0.0.0` to the Dockerfile runner stage. Next.js standalone server reads the `HOSTNAME` environment variable (not `HOST`) to determine the binding address. Without this, the server falls back to default behavior which causes binding issues on Windows.

## Changes

### Core Changes
- `deploy/Dockerfile`: Added `ENV HOSTNAME=0.0.0.0` environment variable alongside the existing `HOST` variable

## Technical Details

Next.js standalone mode uses `process.env.HOSTNAME` to determine the server binding address:
```javascript
const hostname = process.env.HOSTNAME || '0.0.0.0'
```

The existing `ENV HOST=0.0.0.0` is not used by Next.js standalone server, so `HOSTNAME` must be explicitly set for proper container networking.

## Testing

### Manual Testing
1. Build the Docker image with the updated Dockerfile
2. Run with `docker compose up` on Windows
3. Verify the application is accessible from the host at `localhost:3000`

---
*Description enhanced by Claude AI*