### PR TITLE
fix: resolve container name conflicts in multi-user environments

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,5 @@
+name: ${COMPOSE_PROJECT_NAME:-claude-code-hub}
+
 services:
   postgres:
     image: postgres:18


### PR DESCRIPTION
## Summary

Remove hardcoded `container_name` from all services (postgres, redis, app) in docker-compose.yaml to resolve container name conflicts when multiple users share the same Docker daemon.

## Problem

When multiple users share the same Docker daemon and run `docker compose up`, container name conflicts occur because of hardcoded `container_name` values:

- `container_name: claude-code-hub-db`
- `container_name: claude-code-hub-redis`
- `container_name: claude-code-hub-app`

This causes one user's containers to be overwritten or replaced by another user's deployment.

**Related Issues:**
- Closes #624 - Hardcoded container_name causes conflicts in multi-user environments

## Solution

Remove all hardcoded `container_name` values, letting Docker Compose auto-generate names based on the project name. Users can now use the `-p` flag or set `COMPOSE_PROJECT_NAME` in their `.env` file for complete project isolation:

```bash
# Option 1: Use -p flag
docker compose -p my-instance up -d

# Option 2: Set in .env
COMPOSE_PROJECT_NAME=my-instance
docker compose up -d
```

Containers will be automatically named `{project}-postgres-1`, `{project}-redis-1`, `{project}-app-1`.

## Changes

| File | Change |
|------|--------|
| `docker-compose.yaml` | Removed `container_name` from postgres, redis, and app services |

## Testing

### Manual Testing
1. `docker compose up -d` - verify works with default project name
2. `docker compose -p custom-name up -d` - verify containers use custom prefix
3. Two users with different `COMPOSE_PROJECT_NAME` values are fully isolated

---
*Description enhanced by Claude AI*