### PR TITLE
Feat/dashboard UI improvements

### DIFF
--- a/drizzle/0057_conscious_quicksilver.sql
+++ b/drizzle/0057_conscious_quicksilver.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "message_request" ALTER COLUMN "input_tokens" SET DATA TYPE bigint;--> statement-breakpoint
+ALTER TABLE "message_request" ALTER COLUMN "output_tokens" SET DATA TYPE bigint;--> statement-breakpoint
+ALTER TABLE "message_request" ALTER COLUMN "cache_creation_input_tokens" SET DATA TYPE bigint;--> statement-breakpoint
+ALTER TABLE "message_request" ALTER COLUMN "cache_read_input_tokens" SET DATA TYPE bigint;--> statement-breakpoint
+ALTER TABLE "message_request" ALTER COLUMN "cache_creation_5m_input_tokens" SET DATA TYPE bigint;--> statement-breakpoint
+ALTER TABLE "message_request" ALTER COLUMN "cache_creation_1h_input_tokens" SET DATA TYPE bigint;

--- a/drizzle/meta/0057_snapshot.json
+++ b/drizzle/meta/0057_snapshot.json
@@ -1,0 +1,2890 @@
+{
+  "id": "734153dd-5481-44cd-a7c6-7adfbc027232",
+  "prevId": "75eef188-0cac-4ae8-9deb-9b0db4f046c2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.error_rules": {
+      "name": "error_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regex'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_response": {
+          "name": "override_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_status_code": {
+          "name": "override_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_rules_enabled": {
+          "name": "idx_error_rules_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_pattern": {
+          "name": "unique_pattern",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_category": {
+          "name": "idx_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_match_type": {
+          "name": "idx_match_type",
+          "columns": [
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_login_web_ui": {
+          "name": "can_login_web_ui",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_keys_user_id": {
+          "name": "idx_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_created_at": {
+          "name": "idx_keys_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_deleted_at": {
+          "name": "idx_keys_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_request": {
+      "name": "message_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "provider_chain": {
+          "name": "provider_chain",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "special_settings": {
+          "name": "special_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_cause": {
+          "name": "error_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages_count": {
+          "name": "messages_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_message_request_user_date_cost": {
+          "name": "idx_message_request_user_date_cost",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_query": {
+          "name": "idx_message_request_user_query",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_id": {
+          "name": "idx_message_request_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_id_prefix": {
+          "name": "idx_message_request_session_id_prefix",
+          "columns": [
+            {
+              "expression": "\"session_id\" varchar_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_seq": {
+          "name": "idx_message_request_session_seq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_endpoint": {
+          "name": "idx_message_request_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_blocked_by": {
+          "name": "idx_message_request_blocked_by",
+          "columns": [
+            {
+              "expression": "blocked_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_id": {
+          "name": "idx_message_request_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_id": {
+          "name": "idx_message_request_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key": {
+          "name": "idx_message_request_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_created_at": {
+          "name": "idx_message_request_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_deleted_at": {
+          "name": "idx_message_request_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_prices": {
+      "name": "model_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_data": {
+          "name": "price_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'litellm'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_prices_latest": {
+          "name": "idx_model_prices_latest",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_model_name": {
+          "name": "idx_model_prices_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_created_at": {
+          "name": "idx_model_prices_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_source": {
+          "name": "idx_model_prices_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_legacy_mode": {
+          "name": "use_legacy_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_enabled": {
+          "name": "circuit_breaker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_webhook": {
+          "name": "circuit_breaker_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_enabled": {
+          "name": "daily_leaderboard_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "daily_leaderboard_webhook": {
+          "name": "daily_leaderboard_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_time": {
+          "name": "daily_leaderboard_time",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'09:00'"
+        },
+        "daily_leaderboard_top_n": {
+          "name": "daily_leaderboard_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cost_alert_enabled": {
+          "name": "cost_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cost_alert_webhook": {
+          "name": "cost_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_alert_threshold": {
+          "name": "cost_alert_threshold",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.80'"
+        },
+        "cost_alert_check_interval": {
+          "name": "cost_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_target_bindings": {
+      "name": "notification_target_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule_cron": {
+          "name": "schedule_cron",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_timezone": {
+          "name": "schedule_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Asia/Shanghai'"
+        },
+        "template_override": {
+          "name": "template_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_notification_target_binding": {
+          "name": "unique_notification_target_binding",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_type": {
+          "name": "idx_notification_bindings_type",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_target": {
+          "name": "idx_notification_bindings_target",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_target_bindings_target_id_webhook_targets_id_fk": {
+          "name": "notification_target_bindings_target_id_webhook_targets_id_fk",
+          "tableFrom": "notification_target_bindings",
+          "tableTo": "webhook_targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoint_probe_logs": {
+      "name": "provider_endpoint_probe_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_endpoint_probe_logs_endpoint_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_endpoint_created_at",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoint_probe_logs_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk": {
+          "name": "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk",
+          "tableFrom": "provider_endpoint_probe_logs",
+          "tableTo": "provider_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoints": {
+      "name": "provider_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_probed_at": {
+          "name": "last_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_ok": {
+          "name": "last_probe_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_status_code": {
+          "name": "last_probe_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_latency_ms": {
+          "name": "last_probe_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_type": {
+          "name": "last_probe_error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_message": {
+          "name": "last_probe_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uniq_provider_endpoints_vendor_type_url": {
+          "name": "uniq_provider_endpoints_vendor_type_url",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_vendor_type": {
+          "name": "idx_provider_endpoints_vendor_type",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_enabled": {
+          "name": "idx_provider_endpoints_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_created_at": {
+          "name": "idx_provider_endpoints_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_deleted_at": {
+          "name": "idx_provider_endpoints_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoints_vendor_id_provider_vendors_id_fk": {
+          "name": "provider_endpoints_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "provider_endpoints",
+          "tableTo": "provider_vendors",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_vendors": {
+      "name": "provider_vendors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "website_domain": {
+          "name": "website_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_provider_vendors_website_domain": {
+          "name": "uniq_provider_vendors_website_domain",
+          "columns": [
+            {
+              "expression": "website_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_vendors_created_at": {
+          "name": "idx_provider_vendors_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_vendor_id": {
+          "name": "provider_vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.0'"
+        },
+        "group_tag": {
+          "name": "group_tag",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "preserve_client_ip": {
+          "name": "preserve_client_ip",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_redirects": {
+          "name": "model_redirects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "join_claude_pool": {
+          "name": "join_claude_pool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "codex_instructions_strategy": {
+          "name": "codex_instructions_strategy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "mcp_passthrough_type": {
+          "name": "mcp_passthrough_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "mcp_passthrough_url": {
+          "name": "mcp_passthrough_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost_reset_at": {
+          "name": "total_cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_retry_attempts": {
+          "name": "max_retry_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circuit_breaker_failure_threshold": {
+          "name": "circuit_breaker_failure_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "circuit_breaker_open_duration": {
+          "name": "circuit_breaker_open_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1800000
+        },
+        "circuit_breaker_half_open_success_threshold": {
+          "name": "circuit_breaker_half_open_success_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "first_byte_timeout_streaming_ms": {
+          "name": "first_byte_timeout_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "streaming_idle_timeout_ms": {
+          "name": "streaming_idle_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_timeout_non_streaming_ms": {
+          "name": "request_timeout_non_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_preference": {
+          "name": "context_1m_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_effort_preference": {
+          "name": "codex_reasoning_effort_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_summary_preference": {
+          "name": "codex_reasoning_summary_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_text_verbosity_preference": {
+          "name": "codex_text_verbosity_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_parallel_tool_calls_preference": {
+          "name": "codex_parallel_tool_calls_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tpm": {
+          "name": "tpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpm": {
+          "name": "rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpd": {
+          "name": "rpd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cc": {
+          "name": "cc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_providers_enabled_priority": {
+          "name": "idx_providers_enabled_priority",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_group": {
+          "name": "idx_providers_group",
+          "columns": [
+            {
+              "expression": "group_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_created_at": {
+          "name": "idx_providers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_deleted_at": {
+          "name": "idx_providers_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_vendor_type": {
+          "name": "idx_providers_vendor_type",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "providers_provider_vendor_id_provider_vendors_id_fk": {
+          "name": "providers_provider_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "provider_vendors",
+          "columnsFrom": [
+            "provider_vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_filters": {
+      "name": "request_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement": {
+          "name": "replacement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "provider_ids": {
+          "name": "provider_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_tags": {
+          "name": "group_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_request_filters_enabled": {
+          "name": "idx_request_filters_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_scope": {
+          "name": "idx_request_filters_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_action": {
+          "name": "idx_request_filters_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_binding": {
+          "name": "idx_request_filters_binding",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sensitive_words": {
+      "name": "sensitive_words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contains'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sensitive_words_enabled": {
+          "name": "idx_sensitive_words_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sensitive_words_created_at": {
+          "name": "idx_sensitive_words_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_title": {
+          "name": "site_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Claude Code Hub'"
+        },
+        "allow_global_usage_view": {
+          "name": "allow_global_usage_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "currency_display": {
+          "name": "currency_display",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "billing_model_source": {
+          "name": "billing_model_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'original'"
+        },
+        "enable_auto_cleanup": {
+          "name": "enable_auto_cleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cleanup_retention_days": {
+          "name": "cleanup_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cleanup_schedule": {
+          "name": "cleanup_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 2 * * *'"
+        },
+        "cleanup_batch_size": {
+          "name": "cleanup_batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10000
+        },
+        "enable_client_version_check": {
+          "name": "enable_client_version_check",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verbose_provider_error": {
+          "name": "verbose_provider_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_http2": {
+          "name": "enable_http2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "intercept_anthropic_warmup_requests": {
+          "name": "intercept_anthropic_warmup_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_thinking_signature_rectifier": {
+          "name": "enable_thinking_signature_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_codex_session_id_completion": {
+          "name": "enable_codex_session_id_completion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_response_fixer": {
+          "name": "enable_response_fixer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "response_fixer_config": {
+          "name": "response_fixer_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"fixTruncatedJson\":true,\"fixSseFormat\":true,\"fixEncoding\":true,\"maxJsonDepth\":200,\"maxFixSize\":1048576}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "rpm_limit": {
+          "name": "rpm_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_limit_usd": {
+          "name": "daily_limit_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_active_role_sort": {
+          "name": "idx_users_active_role_sort",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_enabled_expires_at": {
+          "name": "idx_users_enabled_expires_at",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_deleted_at": {
+          "name": "idx_users_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_targets": {
+      "name": "webhook_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "webhook_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_bot_token": {
+          "name": "telegram_bot_token",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dingtalk_secret": {
+          "name": "dingtalk_secret",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_template": {
+          "name": "custom_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_test_at": {
+          "name": "last_test_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_result": {
+          "name": "last_test_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.daily_reset_mode": {
+      "name": "daily_reset_mode",
+      "schema": "public",
+      "values": [
+        "fixed",
+        "rolling"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "circuit_breaker",
+        "daily_leaderboard",
+        "cost_alert"
+      ]
+    },
+    "public.webhook_provider_type": {
+      "name": "webhook_provider_type",
+      "schema": "public",
+      "values": [
+        "wechat",
+        "feishu",
+        "dingtalk",
+        "telegram",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1769008812140,
       "tag": "0056_tidy_quasar",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1769446927761,
+      "tag": "0057_conscious_quicksilver",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/en/provider-chain.json
+++ b/messages/en/provider-chain.json
@@ -54,6 +54,11 @@
     "rate_limited": "Rate Limited",
     "circuit_open": "Circuit Open",
     "disabled": "Disabled",
+    "excluded": "Excluded",
+    "format_type_mismatch": "Format Type Mismatch",
+    "type_mismatch": "Type Mismatch",
+    "model_not_allowed": "Model Not Allowed",
+    "context_1m_disabled": "1M Context Disabled",
     "model_not_supported": "Model Not Supported",
     "group_mismatch": "Group Mismatch",
     "health_check_failed": "Health Check Failed"

--- a/messages/en/settings/providers/strings.json
+++ b/messages/en/settings/providers/strings.json
@@ -65,6 +65,7 @@
   "circuitStatus": "Circuit Status",
   "vendorTypeCircuit": "Vendor Type Circuit",
   "vendorFallbackName": "Vendor #{id}",
+  "vendorAggregationRule": "Grouped by website domain.",
   "orphanedProviders": "Unknown Vendor",
   "vendorTypeCircuitUpdated": "Vendor type circuit updated",
   "noEndpoints": "No endpoints configured",

--- a/messages/en/settings/providers/strings.json
+++ b/messages/en/settings/providers/strings.json
@@ -65,7 +65,7 @@
   "circuitStatus": "Circuit Status",
   "vendorTypeCircuit": "Vendor Type Circuit",
   "vendorFallbackName": "Vendor #{id}",
-  "vendorAggregationRule": "Grouped by website domain.",
+  "vendorAggregationRule": "Grouped by website domain",
   "orphanedProviders": "Unknown Vendor",
   "vendorTypeCircuitUpdated": "Vendor type circuit updated",
   "noEndpoints": "No endpoints configured",

--- a/messages/ja/provider-chain.json
+++ b/messages/ja/provider-chain.json
@@ -54,6 +54,11 @@
     "rate_limited": "レート制限",
     "circuit_open": "サーキットオープン",
     "disabled": "無効",
+    "excluded": "除外済み",
+    "format_type_mismatch": "フォーマット不一致",
+    "type_mismatch": "タイプ不一致",
+    "model_not_allowed": "モデル不許可",
+    "context_1m_disabled": "1Mコンテキスト無効",
     "model_not_supported": "モデル非対応",
     "group_mismatch": "グループ不一致",
     "health_check_failed": "ヘルスチェック失敗"

--- a/messages/ja/settings/providers/strings.json
+++ b/messages/ja/settings/providers/strings.json
@@ -65,6 +65,7 @@
   "circuitStatus": "回路状態",
   "vendorTypeCircuit": "ベンダー種別回路",
   "vendorFallbackName": "ベンダー #{id}",
+  "vendorAggregationRule": "公式ドメインで集約",
   "orphanedProviders": "不明なベンダー",
   "vendorTypeCircuitUpdated": "ベンダータイプサーキットが更新されました",
   "noEndpoints": "エンドポイントが設定されていません",

--- a/messages/ru/provider-chain.json
+++ b/messages/ru/provider-chain.json
@@ -54,6 +54,11 @@
     "rate_limited": "Ограничение скорости",
     "circuit_open": "Автомат открыт",
     "disabled": "Отключен",
+    "excluded": "Исключен",
+    "format_type_mismatch": "Несоответствие формата",
+    "type_mismatch": "Несоответствие типа",
+    "model_not_allowed": "Модель не разрешена",
+    "context_1m_disabled": "1M контекст отключен",
     "model_not_supported": "Модель не поддерживается",
     "group_mismatch": "Несоответствие группы",
     "health_check_failed": "Проверка состояния не пройдена"

--- a/messages/ru/settings/providers/strings.json
+++ b/messages/ru/settings/providers/strings.json
@@ -65,6 +65,7 @@
   "circuitStatus": "Состояние цепи",
   "vendorTypeCircuit": "Цепь по типу провайдера",
   "vendorFallbackName": "Поставщик #{id}",
+  "vendorAggregationRule": "Группировка по домену сайта",
   "orphanedProviders": "Неизвестный поставщик",
   "vendorTypeCircuitUpdated": "Цепь типа поставщика обновлена",
   "noEndpoints": "Эндпоинты не настроены",

--- a/messages/zh-CN/provider-chain.json
+++ b/messages/zh-CN/provider-chain.json
@@ -54,6 +54,11 @@
     "rate_limited": "速率限制",
     "circuit_open": "熔断器打开",
     "disabled": "已禁用",
+    "excluded": "已排除",
+    "format_type_mismatch": "请求格式不兼容",
+    "type_mismatch": "类型不匹配",
+    "model_not_allowed": "模型不允许",
+    "context_1m_disabled": "1M上下文已禁用",
     "model_not_supported": "不支持该模型",
     "group_mismatch": "分组不匹配",
     "health_check_failed": "健康检查失败"

--- a/messages/zh-CN/settings/providers/strings.json
+++ b/messages/zh-CN/settings/providers/strings.json
@@ -65,6 +65,7 @@
   "circuitStatus": "熔断状态",
   "vendorTypeCircuit": "服务商类型熔断",
   "vendorFallbackName": "服务商 #{id}",
+  "vendorAggregationRule": "按官网域名聚合",
   "orphanedProviders": "未知服务商",
   "vendorTypeCircuitUpdated": "已更新服务商类型熔断器",
   "noEndpoints": "暂无端点配置",

--- a/messages/zh-TW/provider-chain.json
+++ b/messages/zh-TW/provider-chain.json
@@ -54,6 +54,11 @@
     "rate_limited": "速率限制",
     "circuit_open": "熔斷器開啟",
     "disabled": "已停用",
+    "excluded": "已排除",
+    "format_type_mismatch": "請求格式不相容",
+    "type_mismatch": "類型不匹配",
+    "model_not_allowed": "模型不允許",
+    "context_1m_disabled": "1M上下文已停用",
     "model_not_supported": "不支援該模型",
     "group_mismatch": "分組不匹配",
     "health_check_failed": "健康檢查失敗"

--- a/messages/zh-TW/settings/providers/strings.json
+++ b/messages/zh-TW/settings/providers/strings.json
@@ -65,6 +65,7 @@
   "circuitStatus": "熔斷狀態",
   "vendorTypeCircuit": "供應商類型熔斷",
   "vendorFallbackName": "服務商 #{id}",
+  "vendorAggregationRule": "按官方網站網域聚合",
   "orphanedProviders": "未知服務商",
   "vendorTypeCircuitUpdated": "已更新服務商類型熔斷器",
   "noEndpoints": "尚未設定端點",

--- a/src/actions/my-usage.ts
+++ b/src/actions/my-usage.ts
@@ -354,8 +354,8 @@ export async function getMyTodayStats(): Promise<ActionResult<MyTodayStats>> {
     const [aggregate] = await db
       .select({
         calls: sql<number>`count(*)::int`,
-        inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::int`,
-        outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::int`,
+        inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::double precision`,
+        outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::double precision`,
         costUsd: sql<string>`COALESCE(sum(${messageRequest.costUsd}), 0)`,
       })
       .from(messageRequest)
@@ -375,8 +375,8 @@ export async function getMyTodayStats(): Promise<ActionResult<MyTodayStats>> {
         originalModel: messageRequest.originalModel,
         calls: sql<number>`count(*)::int`,
         costUsd: sql<string>`COALESCE(sum(${messageRequest.costUsd}), 0)`,
-        inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::int`,
-        outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::int`,
+        inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::double precision`,
+        outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::double precision`,
       })
       .from(messageRequest)
       .where(
@@ -604,10 +604,10 @@ export async function getMyStatsSummary(
         model: messageRequest.model,
         requests: sql<number>`count(*)::int`,
         cost: sql<string>`COALESCE(sum(${messageRequest.costUsd}), 0)`,
-        inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::int`,
-        outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::int`,
-        cacheCreationTokens: sql<number>`COALESCE(sum(${messageRequest.cacheCreationInputTokens}), 0)::int`,
-        cacheReadTokens: sql<number>`COALESCE(sum(${messageRequest.cacheReadInputTokens}), 0)::int`,
+        inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::double precision`,
+        outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::double precision`,
+        cacheCreationTokens: sql<number>`COALESCE(sum(${messageRequest.cacheCreationInputTokens}), 0)::double precision`,
+        cacheReadTokens: sql<number>`COALESCE(sum(${messageRequest.cacheReadInputTokens}), 0)::double precision`,
       })
       .from(messageRequest)
       .where(
@@ -628,10 +628,10 @@ export async function getMyStatsSummary(
         model: messageRequest.model,
         requests: sql<number>`count(*)::int`,
         cost: sql<string>`COALESCE(sum(${messageRequest.costUsd}), 0)`,
-        inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::int`,
-        outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::int`,
-        cacheCreationTokens: sql<number>`COALESCE(sum(${messageRequest.cacheCreationInputTokens}), 0)::int`,
-        cacheReadTokens: sql<number>`COALESCE(sum(${messageRequest.cacheReadInputTokens}), 0)::int`,
+        inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::double precision`,
+        outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::double precision`,
+        cacheCreationTokens: sql<number>`COALESCE(sum(${messageRequest.cacheCreationInputTokens}), 0)::double precision`,
+        cacheReadTokens: sql<number>`COALESCE(sum(${messageRequest.cacheReadInputTokens}), 0)::double precision`,
       })
       .from(messageRequest)
       .where(

--- a/src/actions/system-config.ts
+++ b/src/actions/system-config.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth";
-import { invalidateSystemSettingsCache } from "@/lib/config";
+import { getEnvConfig, invalidateSystemSettingsCache } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { UpdateSystemSettingsSchema } from "@/lib/validation/schemas";
 import { getSystemSettings, updateSystemSettings } from "@/repository/system-config";
@@ -21,6 +21,21 @@ export async function fetchSystemSettings(): Promise<ActionResult<SystemSettings
   } catch (error) {
     logger.error("获取系统设置失败:", error);
     return { ok: false, error: "获取系统设置失败" };
+  }
+}
+
+export async function getServerTimeZone(): Promise<ActionResult<{ timeZone: string }>> {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return { ok: false, error: "未授权" };
+    }
+
+    const { TZ } = getEnvConfig();
+    return { ok: true, data: { timeZone: TZ } };
+  } catch (error) {
+    logger.error("获取时区失败:", error);
+    return { ok: false, error: "获取时区失败" };
   }
 }
 

--- a/src/app/[locale]/dashboard/_components/bento/dashboard-bento.tsx
+++ b/src/app/[locale]/dashboard/_components/bento/dashboard-bento.tsx
@@ -9,6 +9,7 @@ import type { OverviewData } from "@/actions/overview";
 import { getOverviewData } from "@/actions/overview";
 import { getUserStatistics } from "@/actions/statistics";
 import type { CurrencyCode } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import type {
   LeaderboardEntry,
@@ -202,127 +203,111 @@ export function DashboardBento({
 
   return (
     <div className="space-y-6">
-      {/* Top Section: Metrics + Live Sessions */}
+      {/* Section 1: Metrics (Admin only) */}
       {isAdmin && (
-        <div className="mx-auto w-full max-w-7xl">
-          <BentoGrid>
-            {/* Metric Cards */}
-            <BentoMetricCard
-              title={t("metrics.concurrent")}
-              value={metrics.concurrentSessions}
-              icon={Activity}
-              accentColor="emerald"
-              className="min-h-[120px]"
-              comparisons={[
-                {
-                  value: metrics.recentMinuteRequests,
-                  label: t("metrics.rpm"),
-                  isPercentage: false,
-                },
-              ]}
-            />
-            <BentoMetricCard
-              title={t("metrics.todayRequests")}
-              value={metrics.todayRequests}
-              icon={TrendingUp}
-              accentColor="blue"
-              className="min-h-[120px]"
-              comparisons={[{ value: requestsChange, label: t("metrics.vsYesterday") }]}
-            />
-            <BentoMetricCard
-              title={t("metrics.todayCost")}
-              value={formatCurrency(metrics.todayCost, currencyCode)}
-              icon={DollarSign}
-              accentColor="amber"
-              className="min-h-[120px]"
-              comparisons={[{ value: costChange, label: t("metrics.vsYesterday") }]}
-            />
-            <BentoMetricCard
-              title={t("metrics.avgResponse")}
-              value={metrics.avgResponseTime}
-              icon={Clock}
-              formatter={formatResponseTime}
-              accentColor="purple"
-              className="min-h-[120px]"
-              comparisons={[{ value: -responseTimeChange, label: t("metrics.vsYesterday") }]}
-            />
-          </BentoGrid>
-        </div>
+        <BentoGrid>
+          <BentoMetricCard
+            title={t("metrics.concurrent")}
+            value={metrics.concurrentSessions}
+            icon={Activity}
+            accentColor="emerald"
+            className="min-h-[120px]"
+            comparisons={[
+              {
+                value: metrics.recentMinuteRequests,
+                label: t("metrics.rpm"),
+                isPercentage: false,
+              },
+            ]}
+          />
+          <BentoMetricCard
+            title={t("metrics.todayRequests")}
+            value={metrics.todayRequests}
+            icon={TrendingUp}
+            accentColor="blue"
+            className="min-h-[120px]"
+            comparisons={[{ value: requestsChange, label: t("metrics.vsYesterday") }]}
+          />
+          <BentoMetricCard
+            title={t("metrics.todayCost")}
+            value={formatCurrency(metrics.todayCost, currencyCode)}
+            icon={DollarSign}
+            accentColor="amber"
+            className="min-h-[120px]"
+            comparisons={[{ value: costChange, label: t("metrics.vsYesterday") }]}
+          />
+          <BentoMetricCard
+            title={t("metrics.avgResponse")}
+            value={metrics.avgResponseTime}
+            icon={Clock}
+            formatter={formatResponseTime}
+            accentColor="purple"
+            className="min-h-[120px]"
+            comparisons={[{ value: -responseTimeChange, label: t("metrics.vsYesterday") }]}
+          />
+        </BentoGrid>
       )}
 
-      {/* Middle Section: Statistics Chart + Leaderboards (+ Live Sessions sidebar for admin) */}
-      <div
-        data-testid={isAdmin ? "dashboard-home-layout" : undefined}
-        className={
-          isAdmin ? "grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_300px]" : undefined
-        }
-      >
-        <div className="min-w-0">
-          <div
-            className={[
-              "grid gap-4 md:gap-6",
-              "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
-              "auto-rows-[minmax(140px,auto)]",
-            ].join(" ")}
-          >
-            {statistics && (
-              <StatisticsChartCard
-                data={statistics}
-                onTimeRangeChange={setTimeRange}
-                currencyCode={currencyCode}
-                colSpan={3}
-              />
-            )}
+      {/* Section 2: Statistics Chart - Full width */}
+      {statistics && (
+        <StatisticsChartCard
+          data={statistics}
+          onTimeRangeChange={setTimeRange}
+          currencyCode={currencyCode}
+        />
+      )}
 
-            {canViewLeaderboard && (
-              <LeaderboardCard
-                title={tl("userRankings")}
-                entries={userLeaderboard}
-                currencyCode={currencyCode}
-                isLoading={userLeaderboardLoading}
-                emptyText={tl("noData")}
-                viewAllHref="/dashboard/leaderboard"
-                maxItems={3}
-                accentColor="primary"
-              />
-            )}
-            {canViewLeaderboard && (
-              <LeaderboardCard
-                title={tl("providerRankings")}
-                entries={providerLeaderboard}
-                currencyCode={currencyCode}
-                isLoading={providerLeaderboardLoading}
-                emptyText={tl("noData")}
-                viewAllHref="/dashboard/leaderboard"
-                maxItems={3}
-                accentColor="purple"
-              />
-            )}
-            {canViewLeaderboard && (
-              <LeaderboardCard
-                title={tl("modelRankings")}
-                entries={modelLeaderboard}
-                currencyCode={currencyCode}
-                isLoading={modelLeaderboardLoading}
-                emptyText={tl("noData")}
-                viewAllHref="/dashboard/leaderboard"
-                maxItems={3}
-                accentColor="blue"
-              />
-            )}
-          </div>
-        </div>
+      {/* Section 3: Leaderboards + Live Sessions */}
+      {canViewLeaderboard && (
+        <div
+          data-testid={isAdmin ? "dashboard-home-layout" : undefined}
+          className={cn(
+            "grid gap-6",
+            isAdmin
+              ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-[1fr_1fr_1fr_280px]"
+              : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+          )}
+        >
+          <LeaderboardCard
+            title={tl("userRankings")}
+            entries={userLeaderboard}
+            currencyCode={currencyCode}
+            isLoading={userLeaderboardLoading}
+            emptyText={tl("noData")}
+            viewAllHref="/dashboard/leaderboard"
+            maxItems={3}
+            accentColor="primary"
+          />
+          <LeaderboardCard
+            title={tl("providerRankings")}
+            entries={providerLeaderboard}
+            currencyCode={currencyCode}
+            isLoading={providerLeaderboardLoading}
+            emptyText={tl("noData")}
+            viewAllHref="/dashboard/leaderboard"
+            maxItems={3}
+            accentColor="purple"
+          />
+          <LeaderboardCard
+            title={tl("modelRankings")}
+            entries={modelLeaderboard}
+            currencyCode={currencyCode}
+            isLoading={modelLeaderboardLoading}
+            emptyText={tl("noData")}
+            viewAllHref="/dashboard/leaderboard"
+            maxItems={3}
+            accentColor="blue"
+          />
 
-        {isAdmin && (
-          <aside data-testid="dashboard-home-sidebar" className="hidden lg:block">
+          {isAdmin && (
             <LiveSessionsPanel
+              data-testid="dashboard-home-sidebar"
               sessions={sessionsWithActivity}
               isLoading={sessionsLoading}
-              className="h-full"
             />
-          </aside>
-        )}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/[locale]/dashboard/_components/bento/dashboard-bento.tsx
+++ b/src/app/[locale]/dashboard/_components/bento/dashboard-bento.tsx
@@ -204,101 +204,125 @@ export function DashboardBento({
     <div className="space-y-6">
       {/* Top Section: Metrics + Live Sessions */}
       {isAdmin && (
-        <BentoGrid>
-          {/* Metric Cards */}
-          <BentoMetricCard
-            title={t("metrics.concurrent")}
-            value={metrics.concurrentSessions}
-            icon={Activity}
-            accentColor="emerald"
-            className="min-h-[120px]"
-            comparisons={[
-              { value: metrics.recentMinuteRequests, label: t("metrics.rpm"), isPercentage: false },
-            ]}
-          />
-          <BentoMetricCard
-            title={t("metrics.todayRequests")}
-            value={metrics.todayRequests}
-            icon={TrendingUp}
-            accentColor="blue"
-            className="min-h-[120px]"
-            comparisons={[{ value: requestsChange, label: t("metrics.vsYesterday") }]}
-          />
-          <BentoMetricCard
-            title={t("metrics.todayCost")}
-            value={formatCurrency(metrics.todayCost, currencyCode)}
-            icon={DollarSign}
-            accentColor="amber"
-            className="min-h-[120px]"
-            comparisons={[{ value: costChange, label: t("metrics.vsYesterday") }]}
-          />
-          <BentoMetricCard
-            title={t("metrics.avgResponse")}
-            value={metrics.avgResponseTime}
-            icon={Clock}
-            formatter={formatResponseTime}
-            accentColor="purple"
-            className="min-h-[120px]"
-            comparisons={[{ value: -responseTimeChange, label: t("metrics.vsYesterday") }]}
-          />
-        </BentoGrid>
+        <div className="mx-auto w-full max-w-7xl">
+          <BentoGrid>
+            {/* Metric Cards */}
+            <BentoMetricCard
+              title={t("metrics.concurrent")}
+              value={metrics.concurrentSessions}
+              icon={Activity}
+              accentColor="emerald"
+              className="min-h-[120px]"
+              comparisons={[
+                {
+                  value: metrics.recentMinuteRequests,
+                  label: t("metrics.rpm"),
+                  isPercentage: false,
+                },
+              ]}
+            />
+            <BentoMetricCard
+              title={t("metrics.todayRequests")}
+              value={metrics.todayRequests}
+              icon={TrendingUp}
+              accentColor="blue"
+              className="min-h-[120px]"
+              comparisons={[{ value: requestsChange, label: t("metrics.vsYesterday") }]}
+            />
+            <BentoMetricCard
+              title={t("metrics.todayCost")}
+              value={formatCurrency(metrics.todayCost, currencyCode)}
+              icon={DollarSign}
+              accentColor="amber"
+              className="min-h-[120px]"
+              comparisons={[{ value: costChange, label: t("metrics.vsYesterday") }]}
+            />
+            <BentoMetricCard
+              title={t("metrics.avgResponse")}
+              value={metrics.avgResponseTime}
+              icon={Clock}
+              formatter={formatResponseTime}
+              accentColor="purple"
+              className="min-h-[120px]"
+              comparisons={[{ value: -responseTimeChange, label: t("metrics.vsYesterday") }]}
+            />
+          </BentoGrid>
+        </div>
       )}
 
-      {/* Middle Section: Statistics Chart + Live Sessions (Admin) */}
-      <BentoGrid>
-        {/* Statistics Chart - 3 columns for admin, 4 columns for non-admin */}
-        {statistics && (
-          <StatisticsChartCard
-            data={statistics}
-            onTimeRangeChange={setTimeRange}
-            currencyCode={currencyCode}
-            colSpan={isAdmin ? 3 : 4}
-          />
-        )}
+      {/* Middle Section: Statistics Chart + Leaderboards (+ Live Sessions sidebar for admin) */}
+      <div
+        data-testid={isAdmin ? "dashboard-home-layout" : undefined}
+        className={
+          isAdmin ? "grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_300px]" : undefined
+        }
+      >
+        <div className="min-w-0">
+          <div
+            className={[
+              "grid gap-4 md:gap-6",
+              "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+              "auto-rows-[minmax(140px,auto)]",
+            ].join(" ")}
+          >
+            {statistics && (
+              <StatisticsChartCard
+                data={statistics}
+                onTimeRangeChange={setTimeRange}
+                currencyCode={currencyCode}
+                colSpan={3}
+              />
+            )}
 
-        {/* Live Sessions Panel - Right sidebar, spans 2 rows */}
+            {canViewLeaderboard && (
+              <LeaderboardCard
+                title={tl("userRankings")}
+                entries={userLeaderboard}
+                currencyCode={currencyCode}
+                isLoading={userLeaderboardLoading}
+                emptyText={tl("noData")}
+                viewAllHref="/dashboard/leaderboard"
+                maxItems={3}
+                accentColor="primary"
+              />
+            )}
+            {canViewLeaderboard && (
+              <LeaderboardCard
+                title={tl("providerRankings")}
+                entries={providerLeaderboard}
+                currencyCode={currencyCode}
+                isLoading={providerLeaderboardLoading}
+                emptyText={tl("noData")}
+                viewAllHref="/dashboard/leaderboard"
+                maxItems={3}
+                accentColor="purple"
+              />
+            )}
+            {canViewLeaderboard && (
+              <LeaderboardCard
+                title={tl("modelRankings")}
+                entries={modelLeaderboard}
+                currencyCode={currencyCode}
+                isLoading={modelLeaderboardLoading}
+                emptyText={tl("noData")}
+                viewAllHref="/dashboard/leaderboard"
+                maxItems={3}
+                accentColor="blue"
+              />
+            )}
+          </div>
+        </div>
+
         {isAdmin && (
-          <LiveSessionsPanel sessions={sessionsWithActivity} isLoading={sessionsLoading} />
+          <aside data-testid="dashboard-home-sidebar" className="hidden lg:block">
+            <LiveSessionsPanel
+              sessions={sessionsWithActivity}
+              isLoading={sessionsLoading}
+              className="h-full"
+            />
+          </aside>
         )}
-
-        {/* Leaderboard Cards - Below chart, 3 columns */}
-        {canViewLeaderboard && (
-          <LeaderboardCard
-            title={tl("userRankings")}
-            entries={userLeaderboard}
-            currencyCode={currencyCode}
-            isLoading={userLeaderboardLoading}
-            emptyText={tl("noData")}
-            viewAllHref="/dashboard/leaderboard"
-            maxItems={3}
-            accentColor="primary"
-          />
-        )}
-        {canViewLeaderboard && (
-          <LeaderboardCard
-            title={tl("providerRankings")}
-            entries={providerLeaderboard}
-            currencyCode={currencyCode}
-            isLoading={providerLeaderboardLoading}
-            emptyText={tl("noData")}
-            viewAllHref="/dashboard/leaderboard"
-            maxItems={3}
-            accentColor="purple"
-          />
-        )}
-        {canViewLeaderboard && (
-          <LeaderboardCard
-            title={tl("modelRankings")}
-            entries={modelLeaderboard}
-            currencyCode={currencyCode}
-            isLoading={modelLeaderboardLoading}
-            emptyText={tl("noData")}
-            viewAllHref="/dashboard/leaderboard"
-            maxItems={3}
-            accentColor="blue"
-          />
-        )}
-      </BentoGrid>
+      </div>
     </div>
   );
 }

--- a/src/app/[locale]/dashboard/_components/bento/leaderboard-card.tsx
+++ b/src/app/[locale]/dashboard/_components/bento/leaderboard-card.tsx
@@ -166,7 +166,7 @@ export function LeaderboardCard({
   const maxCost = Math.max(...entries.map((e) => e.totalCost), 0);
 
   return (
-    <BentoCard className={cn("flex flex-col", className)}>
+    <BentoCard className={cn("flex flex-col min-h-[280px]", className)}>
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
         <h4 className="text-sm font-semibold">{title}</h4>

--- a/src/app/[locale]/dashboard/_components/bento/statistics-chart-card.tsx
+++ b/src/app/[locale]/dashboard/_components/bento/statistics-chart-card.tsx
@@ -29,7 +29,6 @@ export interface StatisticsChartCardProps {
   data: UserStatisticsData;
   onTimeRangeChange?: (timeRange: TimeRange) => void;
   currencyCode?: CurrencyCode;
-  colSpan?: 3 | 4;
   className?: string;
 }
 
@@ -37,7 +36,6 @@ export function StatisticsChartCard({
   data,
   onTimeRangeChange,
   currencyCode = "USD",
-  colSpan = 4,
   className,
 }: StatisticsChartCardProps) {
   const t = useTranslations("dashboard.statistics");
@@ -175,11 +173,7 @@ export function StatisticsChartCard({
   };
 
   return (
-    <BentoCard
-      colSpan={colSpan}
-      rowSpan={2}
-      className={cn("flex flex-col p-0 overflow-hidden", className)}
-    >
+    <BentoCard className={cn("flex flex-col p-0 overflow-hidden", className)}>
       {/* Header */}
       <div className="flex items-center justify-between border-b border-border/50 dark:border-white/[0.06]">
         <div className="flex items-center gap-4 p-4">

--- a/src/app/[locale]/dashboard/_components/dashboard-main.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-main.tsx
@@ -19,15 +19,8 @@ export function DashboardMain({ children }: DashboardMainProps) {
   const isSessionMessagesPage =
     normalizedPathname.includes("/dashboard/sessions/") && normalizedPathname.endsWith("/messages");
 
-  const isDashboardHomePage =
-    normalizedPathname === "/dashboard" || normalizedPathname.endsWith("/dashboard");
-
   if (isSessionMessagesPage) {
     return <main className="h-[calc(100vh-64px)] w-full overflow-hidden">{children}</main>;
-  }
-
-  if (isDashboardHomePage) {
-    return <main className="mx-auto w-full max-w-7xl px-6 py-8">{children}</main>;
   }
 
   return <main className="mx-auto w-full max-w-7xl px-6 py-8">{children}</main>;

--- a/src/app/[locale]/dashboard/_components/dashboard-main.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-main.tsx
@@ -10,15 +10,24 @@ interface DashboardMainProps {
 export function DashboardMain({ children }: DashboardMainProps) {
   const pathname = usePathname();
 
+  const normalizedPathname = pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+
   // Pattern to match /dashboard/sessions/[id]/messages
   // The usePathname hook from next-intl/routing might return the path without locale prefix if configured that way,
   // or we just check for the suffix.
   // Let's be safe and check if it includes "/dashboard/sessions/" and ends with "/messages"
   const isSessionMessagesPage =
-    pathname.includes("/dashboard/sessions/") && pathname.endsWith("/messages");
+    normalizedPathname.includes("/dashboard/sessions/") && normalizedPathname.endsWith("/messages");
+
+  const isDashboardHomePage =
+    normalizedPathname === "/dashboard" || normalizedPathname.endsWith("/dashboard");
 
   if (isSessionMessagesPage) {
     return <main className="h-[calc(100vh-64px)] w-full overflow-hidden">{children}</main>;
+  }
+
+  if (isDashboardHomePage) {
+    return <main className="w-full px-6 py-8">{children}</main>;
   }
 
   return <main className="mx-auto w-full max-w-7xl px-6 py-8">{children}</main>;

--- a/src/app/[locale]/dashboard/_components/dashboard-main.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-main.tsx
@@ -27,7 +27,7 @@ export function DashboardMain({ children }: DashboardMainProps) {
   }
 
   if (isDashboardHomePage) {
-    return <main className="w-full px-6 py-8">{children}</main>;
+    return <main className="mx-auto w-full max-w-7xl px-6 py-8">{children}</main>;
   }
 
   return <main className="mx-auto w-full max-w-7xl px-6 py-8">{children}</main>;

--- a/src/app/[locale]/dashboard/availability/_components/availability-dashboard.tsx
+++ b/src/app/[locale]/dashboard/availability/_components/availability-dashboard.tsx
@@ -165,7 +165,6 @@ export function AvailabilityDashboard() {
           <EndpointTab />
         </TabsContent>
       </Tabs>
-
     </div>
   );
 }

--- a/src/app/[locale]/dashboard/availability/_components/availability-dashboard.tsx
+++ b/src/app/[locale]/dashboard/availability/_components/availability-dashboard.tsx
@@ -8,7 +8,6 @@ import { cn } from "@/lib/utils";
 import { EndpointTab } from "./endpoint/endpoint-tab";
 import { OverviewSection } from "./overview/overview-section";
 import { ProviderTab } from "./provider/provider-tab";
-import { FloatingProbeButton } from "./shared/floating-probe-button";
 
 export type TimeRangeOption = "15min" | "1h" | "6h" | "24h" | "7d";
 
@@ -167,8 +166,6 @@ export function AvailabilityDashboard() {
         </TabsContent>
       </Tabs>
 
-      {/* Floating Probe Button */}
-      <FloatingProbeButton onProbeComplete={fetchData} />
     </div>
   );
 }

--- a/src/app/[locale]/dashboard/logs/_components/active-sessions-skeleton.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/active-sessions-skeleton.tsx
@@ -1,47 +1,32 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-
-function CardSkeleton() {
-  return (
-    <Card className="w-[280px] shrink-0">
-      <CardContent className="p-4 space-y-3">
-        <div className="flex items-center justify-between">
-          <Skeleton className="h-5 w-24" />
-          <Skeleton className="h-5 w-16" />
-        </div>
-        <Skeleton className="h-4 w-40" />
-        <Skeleton className="h-4 w-32" />
-        <div className="flex items-center justify-between pt-2 border-t">
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-16" />
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
 
 export function ActiveSessionsSkeleton() {
   return (
-    <Card className="border-border/50">
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Skeleton className="h-8 w-8 rounded-lg" />
-            <div className="space-y-1">
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-3 w-40" />
-            </div>
-          </div>
-          <Skeleton className="h-4 w-20" />
+    <div className="border rounded-lg bg-card">
+      <div className="px-4 py-3 border-b flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-4" />
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-3 w-40" />
         </div>
-      </CardHeader>
-      <CardContent className="pt-0">
-        <div className="flex gap-3 pb-3 overflow-hidden">
-          {[1, 2, 3].map((i) => (
-            <CardSkeleton key={i} />
+        <Skeleton className="h-3 w-20" />
+      </div>
+
+      <div style={{ maxHeight: "200px" }} className="overflow-y-auto">
+        <div className="divide-y">
+          {Array.from({ length: 5 }).map((_, idx) => (
+            <div key={idx} className="px-3 py-2">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-3.5 w-3.5 rounded-full" />
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-3 w-28" />
+                <Skeleton className="h-3 w-10 ml-auto" />
+              </div>
+            </div>
           ))}
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/LogicTraceTab.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/LogicTraceTab.tsx
@@ -216,7 +216,7 @@ export function LogicTraceTab({
                       <Database className="h-3 w-3" />
                       <span className="font-medium">{t("logicTrace.sessionInfo")}</span>
                     </div>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 pl-4">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 pl-4 min-w-0">
                       {sessionReuseContext?.sessionId && (
                         <div className="flex items-center gap-2">
                           <span className="text-muted-foreground">
@@ -252,14 +252,14 @@ export function LogicTraceTab({
                       <Server className="h-3 w-3" />
                       <span className="font-medium">{t("logicTrace.reusedProvider")}</span>
                     </div>
-                    <div className="grid grid-cols-2 gap-1.5 pl-4">
-                      <div>
+                    <div className="grid grid-cols-2 gap-1.5 pl-4 min-w-0">
+                      <div className="min-w-0">
                         <span className="text-muted-foreground">Provider:</span>{" "}
-                        <span className="font-medium">{sessionReuseProvider.name}</span>
+                        <span className="font-medium break-all">{sessionReuseProvider.name}</span>
                       </div>
-                      <div>
+                      <div className="min-w-0">
                         <span className="text-muted-foreground">ID:</span>{" "}
-                        <span className="font-mono">{sessionReuseProvider.id}</span>
+                        <span className="font-mono break-all">{sessionReuseProvider.id}</span>
                       </div>
                       {sessionReuseProvider.priority !== undefined && (
                         <div>
@@ -301,23 +301,23 @@ export function LogicTraceTab({
               subtitle={`${decisionContext.totalProviders} -> ${decisionContext.afterModelFilter || decisionContext.afterHealthCheck}`}
               status="success"
               details={
-                <div className="grid grid-cols-2 gap-2 text-xs">
-                  <div>
+                <div className="grid grid-cols-2 gap-2 text-xs min-w-0">
+                  <div className="min-w-0">
                     <span className="text-muted-foreground">Total:</span>{" "}
                     <span className="font-mono">{decisionContext.totalProviders}</span>
                   </div>
-                  <div>
+                  <div className="min-w-0">
                     <span className="text-muted-foreground">Enabled:</span>{" "}
                     <span className="font-mono">{decisionContext.enabledProviders}</span>
                   </div>
                   {decisionContext.afterGroupFilter !== undefined && (
-                    <div>
+                    <div className="min-w-0">
                       <span className="text-muted-foreground">After Group:</span>{" "}
                       <span className="font-mono">{decisionContext.afterGroupFilter}</span>
                     </div>
                   )}
                   {decisionContext.afterModelFilter !== undefined && (
-                    <div>
+                    <div className="min-w-0">
                       <span className="text-muted-foreground">After Model:</span>{" "}
                       <span className="font-mono">{decisionContext.afterModelFilter}</span>
                     </div>
@@ -336,14 +336,24 @@ export function LogicTraceTab({
               subtitle={`${filteredProviders.length} providers filtered`}
               status="warning"
               details={
-                <div className="space-y-1">
+                <div className="space-y-1 min-w-0">
                   {filteredProviders.map((p, idx) => (
-                    <div key={`${p.id}-${idx}`} className="flex items-center gap-2 text-xs">
-                      <Badge variant="outline" className="text-[10px]">
+                    <div
+                      key={`${p.id}-${idx}`}
+                      className="flex items-center gap-2 text-xs flex-wrap min-w-0"
+                    >
+                      <Badge
+                        variant="outline"
+                        className="text-[10px] shrink-0 max-w-[120px] truncate"
+                      >
                         {p.name}
                       </Badge>
-                      <span className="text-rose-600">{tChain(`filterReasons.${p.reason}`)}</span>
-                      {p.details && <span className="text-muted-foreground">({p.details})</span>}
+                      <span className="text-rose-600 break-all">
+                        {tChain(`filterReasons.${p.reason}`)}
+                      </span>
+                      {p.details && (
+                        <span className="text-muted-foreground break-all">({p.details})</span>
+                      )}
                     </div>
                   ))}
                 </div>
@@ -468,13 +478,13 @@ export function LogicTraceTab({
                           <Link2 className="h-3 w-3" />
                           <span className="font-medium">{t("logicTrace.sessionReuseTitle")}</span>
                         </div>
-                        <div className="grid grid-cols-1 gap-1.5">
+                        <div className="grid grid-cols-1 gap-1.5 min-w-0">
                           {item.decisionContext.sessionId && (
-                            <div className="flex items-center gap-2">
-                              <span className="text-muted-foreground">
+                            <div className="flex items-center gap-2 min-w-0 flex-wrap">
+                              <span className="text-muted-foreground shrink-0">
                                 {tChain("timeline.sessionId", { id: "" }).replace(": ", ":")}
                               </span>
-                              <code className="text-[10px] px-1.5 py-0.5 bg-violet-100 dark:bg-violet-900/30 rounded font-mono">
+                              <code className="text-[10px] px-1.5 py-0.5 bg-violet-100 dark:bg-violet-900/30 rounded font-mono break-all">
                                 {item.decisionContext.sessionId}
                               </code>
                             </div>
@@ -487,23 +497,23 @@ export function LogicTraceTab({
                     )}
 
                     {/* Basic Info */}
-                    <div className="grid grid-cols-2 gap-2">
-                      <div>
+                    <div className="grid grid-cols-2 gap-2 min-w-0">
+                      <div className="min-w-0">
                         <span className="text-muted-foreground">Provider ID:</span>{" "}
-                        <span className="font-mono">{item.id}</span>
+                        <span className="font-mono break-all">{item.id}</span>
                       </div>
                       {item.selectionMethod && !isSessionReuse && (
-                        <div>
+                        <div className="min-w-0">
                           <span className="text-muted-foreground">
                             {tChain("details.selectionMethod")}:
                           </span>{" "}
-                          <span className="font-mono">{item.selectionMethod}</span>
+                          <span className="font-mono break-all">{item.selectionMethod}</span>
                         </div>
                       )}
                       {isSessionReuse && (
-                        <div>
+                        <div className="min-w-0">
                           <span className="text-muted-foreground">Provider:</span>{" "}
-                          <span className="font-mono">{item.name}</span>
+                          <span className="font-mono break-all">{item.name}</span>
                         </div>
                       )}
                     </div>

--- a/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/StepCard.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/StepCard.tsx
@@ -173,7 +173,9 @@ export function StepCard({
 
           {/* Expandable details */}
           {hasDetails && isExpanded && (
-            <div className="mt-3 pt-3 border-t border-current/10">{details}</div>
+            <div className="mt-3 pt-3 border-t border-current/10 overflow-hidden min-w-0">
+              {details}
+            </div>
           )}
         </div>
       </div>

--- a/src/app/[locale]/dashboard/logs/_components/filters/time-filters.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/filters/time-filters.tsx
@@ -24,13 +24,16 @@ export function TimeFilters({ filters, onFiltersChange, serverTimeZone }: TimeFi
   const t = useTranslations("dashboard.logs.filters");
 
   // Helper: convert timestamp to display date string (YYYY-MM-DD)
-  const timestampToDateString = useCallback((timestamp: number): string => {
-    const date = new Date(timestamp);
-    if (serverTimeZone) {
-      return formatInTimeZone(date, serverTimeZone, "yyyy-MM-dd");
-    }
-    return format(date, "yyyy-MM-dd");
-  }, [serverTimeZone]);
+  const timestampToDateString = useCallback(
+    (timestamp: number): string => {
+      const date = new Date(timestamp);
+      if (serverTimeZone) {
+        return formatInTimeZone(date, serverTimeZone, "yyyy-MM-dd");
+      }
+      return format(date, "yyyy-MM-dd");
+    },
+    [serverTimeZone]
+  );
 
   // Memoized startDate for display (from timestamp)
   const displayStartDate = useMemo(() => {

--- a/src/app/[locale]/dashboard/logs/_components/provider-chain-popover.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/provider-chain-popover.test.tsx
@@ -205,6 +205,56 @@ describe("provider-chain-popover probability formatting", () => {
   });
 });
 
+describe("provider-chain-popover group badges", () => {
+  test("renders multiple deduped group badges with tooltip content", () => {
+    const html = renderWithIntl(
+      <ProviderChainPopover
+        chain={[
+          {
+            id: 1,
+            name: "p1",
+            reason: "initial_selection",
+            decisionContext: {
+              totalProviders: 1,
+              enabledProviders: 1,
+              targetType: "claude",
+              groupFilterApplied: false,
+              beforeHealthCheck: 1,
+              afterHealthCheck: 1,
+              priorityLevels: [1],
+              selectedPriority: 1,
+              candidatesAtPriority: [{ id: 1, name: "p1", weight: 100, costMultiplier: 1 }],
+            },
+          },
+          {
+            id: 2,
+            name: "p1",
+            reason: "retry_failed",
+            statusCode: 500,
+          },
+          {
+            id: 3,
+            name: "p1",
+            reason: "request_success",
+            statusCode: 200,
+            groupTag: "alpha, beta, alpha",
+          },
+        ]}
+        finalProvider="p1"
+      />
+    );
+
+    const document = parseHtml(html);
+    const badgeTexts = Array.from(document.querySelectorAll("[data-slot='badge']")).map(
+      (node) => node.textContent
+    );
+    expect(badgeTexts.filter((text) => text === "alpha").length).toBe(1);
+    expect(badgeTexts.filter((text) => text === "beta").length).toBe(1);
+    expect(document.body.textContent).toContain("alpha");
+    expect(document.body.textContent).toContain("beta");
+  });
+});
+
 describe("provider-chain-popover layout", () => {
   test("requestCount<=1 branch keeps truncation container shrinkable", () => {
     const html = renderWithIntl(

--- a/src/app/[locale]/dashboard/logs/_components/provider-chain-popover.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/provider-chain-popover.tsx
@@ -38,6 +38,19 @@ function isActualRequest(item: ProviderChainItem): boolean {
   return false;
 }
 
+function parseGroupTags(groupTag?: string | null): string[] {
+  if (!groupTag) return [];
+  const seen = new Set<string>();
+  const groups: string[] = [];
+  for (const raw of groupTag.split(",")) {
+    const trimmed = raw.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    groups.push(trimmed);
+  }
+  return groups;
+}
+
 /**
  * Get status icon and color for a provider chain item
  */
@@ -279,6 +292,7 @@ export function ProviderChainPopover({
     .find((item) => item.reason === "request_success" || item.reason === "retry_success");
   const finalCostMultiplier = successfulProvider?.costMultiplier;
   const finalGroupTag = successfulProvider?.groupTag;
+  const finalGroupTags = parseGroupTags(finalGroupTag);
   const hasFinalCostBadge =
     finalCostMultiplier !== undefined &&
     finalCostMultiplier !== null &&
@@ -318,15 +332,22 @@ export function ProviderChainPopover({
                 x{finalCostMultiplier.toFixed(2)}
               </Badge>
             )}
-            {/* Group tag badge (if present) */}
-            {finalGroupTag && (
-              <Badge
-                variant="outline"
-                className="text-[10px] px-1 py-0 shrink-0 bg-slate-50 text-slate-600 border-slate-200 dark:bg-slate-900/30 dark:text-slate-400 dark:border-slate-700"
-              >
-                {finalGroupTag}
-              </Badge>
-            )}
+            {/* Group tag badges (if present) */}
+            {finalGroupTags.map((group) => (
+              <TooltipProvider key={group}>
+                <Tooltip delayDuration={200}>
+                  <TooltipTrigger asChild>
+                    <Badge
+                      variant="outline"
+                      className="text-[10px] px-1 py-0 shrink-0 bg-slate-50 text-slate-600 border-slate-200 dark:bg-slate-900/30 dark:text-slate-400 dark:border-slate-700 max-w-[120px] truncate"
+                    >
+                      {group}
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent>{group}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ))}
             {/* Info icon */}
             <InfoIcon className="h-3 w-3 text-muted-foreground shrink-0" aria-hidden="true" />
           </span>

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
@@ -52,6 +52,7 @@ interface UsageLogsFiltersProps {
   filters: UsageLogFilters;
   onChange: (filters: UsageLogFilters) => void;
   onReset: () => void;
+  serverTimeZone?: string;
 }
 
 export function UsageLogsFilters({
@@ -63,6 +64,7 @@ export function UsageLogsFilters({
   filters,
   onChange,
   onReset,
+  serverTimeZone,
 }: UsageLogsFiltersProps) {
   const t = useTranslations("dashboard");
 
@@ -259,7 +261,11 @@ export function UsageLogsFilters({
           activeCount={timeActiveCount}
           defaultOpen={true}
         >
-          <TimeFilters filters={localFilters} onFiltersChange={setLocalFilters} />
+          <TimeFilters
+            filters={localFilters}
+            onFiltersChange={setLocalFilters}
+            serverTimeZone={serverTimeZone}
+          />
         </FilterSection>
 
         {/* Identity Section (Admin only for User, all for Key) */}

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
@@ -1,5 +1,5 @@
 import { cache } from "react";
-import { ActiveSessionsCards } from "@/components/customs/active-sessions-cards";
+import { ActiveSessionsList } from "@/components/customs/active-sessions-list";
 import { getEnvConfig } from "@/lib/config";
 import { getSystemSettings } from "@/repository/system-config";
 import { UsageLogsViewVirtualized } from "./usage-logs-view-virtualized";
@@ -14,7 +14,13 @@ interface UsageLogsDataSectionProps {
 
 export async function UsageLogsActiveSessionsSection() {
   const systemSettings = await getCachedSystemSettings();
-  return <ActiveSessionsCards currencyCode={systemSettings.currencyDisplay} />;
+  return (
+    <ActiveSessionsList
+      currencyCode={systemSettings.currencyDisplay}
+      maxHeight="200px"
+      showTokensCost={false}
+    />
+  );
 }
 
 export async function UsageLogsDataSection({

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
@@ -1,5 +1,6 @@
 import { cache } from "react";
 import { ActiveSessionsCards } from "@/components/customs/active-sessions-cards";
+import { getEnvConfig } from "@/lib/config";
 import { getSystemSettings } from "@/repository/system-config";
 import { UsageLogsViewVirtualized } from "./usage-logs-view-virtualized";
 
@@ -22,12 +23,14 @@ export async function UsageLogsDataSection({
   searchParams,
 }: UsageLogsDataSectionProps) {
   const resolvedSearchParams = await searchParams;
+  const { TZ } = getEnvConfig();
 
   return (
     <UsageLogsViewVirtualized
       isAdmin={isAdmin}
       userId={userId}
       searchParams={resolvedSearchParams}
+      serverTimeZone={TZ}
     />
   );
 }

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
@@ -287,16 +287,16 @@ export function UsageLogsTable({
                       <TooltipProvider>
                         <Tooltip delayDuration={250}>
                           <TooltipTrigger asChild>
-                            <div className="flex items-center justify-end gap-1 cursor-help">
-                              <span>
-                                {formatTokenAmount(log.cacheCreationInputTokens)} /{" "}
-                                {formatTokenAmount(log.cacheReadInputTokens)}
-                              </span>
+                            <div className="flex items-center gap-2 w-full cursor-help">
                               {log.cacheTtlApplied ? (
                                 <Badge variant="outline" className="text-[10px] leading-tight px-1">
                                   {log.cacheTtlApplied}
                                 </Badge>
                               ) : null}
+                              <span className="ml-auto">
+                                {formatTokenAmount(log.cacheCreationInputTokens)} /{" "}
+                                {formatTokenAmount(log.cacheReadInputTokens)}
+                              </span>
                             </div>
                           </TooltipTrigger>
                           <TooltipContent align="end" className="text-xs space-y-1">

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx
@@ -43,6 +43,7 @@ interface UsageLogsViewVirtualizedProps {
   searchParams: { [key: string]: string | string[] | undefined };
   currencyCode?: CurrencyCode;
   billingModelSource?: BillingModelSource;
+  serverTimeZone?: string;
 }
 
 async function fetchSystemSettings(): Promise<SystemSettings> {
@@ -69,6 +70,7 @@ function UsageLogsViewContent({
   searchParams,
   currencyCode = "USD",
   billingModelSource = "original",
+  serverTimeZone,
 }: UsageLogsViewVirtualizedProps) {
   const t = useTranslations("dashboard");
   const tc = useTranslations("customs");
@@ -311,6 +313,7 @@ function UsageLogsViewContent({
               onReset={() => router.push("/dashboard/logs")}
               isProvidersLoading={isProvidersLoading}
               isKeysLoading={isKeysLoading}
+              serverTimeZone={serverTimeZone}
             />
           </CardContent>
         </Card>

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-view.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-view.tsx
@@ -25,6 +25,7 @@ interface UsageLogsViewProps {
   searchParams: { [key: string]: string | string[] | undefined };
   currencyCode?: CurrencyCode;
   billingModelSource?: BillingModelSource;
+  serverTimeZone?: string;
 }
 
 export function UsageLogsView({
@@ -34,6 +35,7 @@ export function UsageLogsView({
   searchParams,
   currencyCode = "USD",
   billingModelSource = "original",
+  serverTimeZone,
 }: UsageLogsViewProps) {
   const t = useTranslations("dashboard");
   const router = useRouter();
@@ -183,14 +185,15 @@ export function UsageLogsView({
           <CardTitle>{t("title.filterCriteria")}</CardTitle>
         </CardHeader>
         <CardContent>
-          <UsageLogsFilters
-            isAdmin={isAdmin}
-            providers={providers}
-            initialKeys={initialKeys}
-            filters={filters}
-            onChange={handleFilterChange}
-            onReset={() => router.push("/dashboard/logs")}
-          />
+        <UsageLogsFilters
+          isAdmin={isAdmin}
+          providers={providers}
+          initialKeys={initialKeys}
+          filters={filters}
+          onChange={handleFilterChange}
+          onReset={() => router.push("/dashboard/logs")}
+          serverTimeZone={serverTimeZone}
+        />
         </CardContent>
       </Card>
 

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-view.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-view.tsx
@@ -185,15 +185,15 @@ export function UsageLogsView({
           <CardTitle>{t("title.filterCriteria")}</CardTitle>
         </CardHeader>
         <CardContent>
-        <UsageLogsFilters
-          isAdmin={isAdmin}
-          providers={providers}
-          initialKeys={initialKeys}
-          filters={filters}
-          onChange={handleFilterChange}
-          onReset={() => router.push("/dashboard/logs")}
-          serverTimeZone={serverTimeZone}
-        />
+          <UsageLogsFilters
+            isAdmin={isAdmin}
+            providers={providers}
+            initialKeys={initialKeys}
+            filters={filters}
+            onChange={handleFilterChange}
+            onReset={() => router.push("/dashboard/logs")}
+            serverTimeZone={serverTimeZone}
+          />
         </CardContent>
       </Card>
 

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -527,8 +527,8 @@ export function VirtualizedLogsTable({
                         <TooltipProvider>
                           <Tooltip delayDuration={250}>
                             <TooltipTrigger asChild>
-                              <div className="cursor-help flex flex-col items-end leading-tight tabular-nums">
-                                <div className="flex items-center gap-1">
+                              <div className="cursor-help flex flex-col w-full leading-tight tabular-nums">
+                                <div className="flex items-center gap-1 w-full">
                                   {log.cacheTtlApplied ? (
                                     <Badge
                                       variant="outline"
@@ -537,9 +537,11 @@ export function VirtualizedLogsTable({
                                       {log.cacheTtlApplied}
                                     </Badge>
                                   ) : null}
-                                  <span>{formatTokenAmount(log.cacheCreationInputTokens)}</span>
+                                  <span className="ml-auto text-right">
+                                    {formatTokenAmount(log.cacheCreationInputTokens)}
+                                  </span>
                                 </div>
-                                <span className="text-muted-foreground">
+                                <span className="text-muted-foreground text-right">
                                   {formatTokenAmount(log.cacheReadInputTokens)}
                                 </span>
                               </div>

--- a/src/app/[locale]/dashboard/logs/_utils/time-range.ts
+++ b/src/app/[locale]/dashboard/logs/_utils/time-range.ts
@@ -1,3 +1,6 @@
+import { format, subDays } from "date-fns";
+import { formatInTimeZone, fromZonedTime, toZonedTime } from "date-fns-tz";
+
 export interface ClockParts {
   hours: number;
   minutes: number;
@@ -18,8 +21,9 @@ export function parseClockString(clockStr: string): ClockParts {
   };
 }
 
-export function formatClockFromTimestamp(timestamp: number): string {
-  const date = new Date(timestamp);
+export function formatClockFromTimestamp(timestamp: number, timeZone?: string): string {
+  const baseDate = new Date(timestamp);
+  const date = timeZone ? toZonedTime(baseDate, timeZone) : baseDate;
   const hh = `${date.getHours()}`.padStart(2, "0");
   const mm = `${date.getMinutes()}`.padStart(2, "0");
   const ss = `${date.getSeconds()}`.padStart(2, "0");
@@ -28,22 +32,71 @@ export function formatClockFromTimestamp(timestamp: number): string {
 
 export function dateStringWithClockToTimestamp(
   dateStr: string,
-  clockStr: string
+  clockStr: string,
+  timeZone?: string
 ): number | undefined {
   const [year, month, day] = dateStr.split("-").map(Number);
   const { hours, minutes, seconds } = parseClockString(clockStr);
 
-  const date = new Date(year, month - 1, day, hours, minutes, seconds, 0);
+  const baseDate = new Date(year, month - 1, day, hours, minutes, seconds, 0);
+  const date = timeZone ? fromZonedTime(baseDate, timeZone) : baseDate;
   const timestamp = date.getTime();
   if (!Number.isFinite(timestamp)) return undefined;
 
-  if (date.getFullYear() !== year) return undefined;
-  if (date.getMonth() !== month - 1) return undefined;
-  if (date.getDate() !== day) return undefined;
+  const validationDate = timeZone ? toZonedTime(date, timeZone) : date;
+  if (validationDate.getFullYear() !== year) return undefined;
+  if (validationDate.getMonth() !== month - 1) return undefined;
+  if (validationDate.getDate() !== day) return undefined;
 
   return timestamp;
 }
 
 export function inclusiveEndTimestampFromExclusive(endExclusiveTimestamp: number): number {
   return Math.max(0, endExclusiveTimestamp - 1000);
+}
+
+export type QuickPeriod = "today" | "yesterday" | "last7days" | "last30days";
+
+function formatDateInTimeZone(date: Date, timeZone?: string): string {
+  if (timeZone) {
+    return formatInTimeZone(date, timeZone, "yyyy-MM-dd");
+  }
+  return format(date, "yyyy-MM-dd");
+}
+
+export function getQuickDateRange(
+  period: QuickPeriod,
+  timeZone?: string,
+  now: Date = new Date()
+): { startDate: string; endDate: string } {
+  const baseDate = timeZone ? toZonedTime(now, timeZone) : now;
+  switch (period) {
+    case "today":
+      return {
+        startDate: formatDateInTimeZone(baseDate, timeZone),
+        endDate: formatDateInTimeZone(baseDate, timeZone),
+      };
+    case "yesterday": {
+      const yesterday = subDays(baseDate, 1);
+      return {
+        startDate: formatDateInTimeZone(yesterday, timeZone),
+        endDate: formatDateInTimeZone(yesterday, timeZone),
+      };
+    }
+    case "last7days":
+      return {
+        startDate: formatDateInTimeZone(subDays(baseDate, 6), timeZone),
+        endDate: formatDateInTimeZone(baseDate, timeZone),
+      };
+    case "last30days":
+      return {
+        startDate: formatDateInTimeZone(subDays(baseDate, 29), timeZone),
+        endDate: formatDateInTimeZone(baseDate, timeZone),
+      };
+    default:
+      return {
+        startDate: formatDateInTimeZone(baseDate, timeZone),
+        endDate: formatDateInTimeZone(baseDate, timeZone),
+      };
+  }
 }

--- a/src/app/[locale]/my-usage/_components/statistics-summary-card.tsx
+++ b/src/app/[locale]/my-usage/_components/statistics-summary-card.tsx
@@ -28,11 +28,13 @@ import { LogsDateRangePicker } from "../../dashboard/logs/_components/logs-date-
 interface StatisticsSummaryCardProps {
   className?: string;
   autoRefreshSeconds?: number;
+  serverTimeZone?: string;
 }
 
 export function StatisticsSummaryCard({
   className,
   autoRefreshSeconds = 30,
+  serverTimeZone,
 }: StatisticsSummaryCardProps) {
   const t = useTranslations("myUsage.stats");
   const [stats, setStats] = useState<MyStatsSummary | null>(null);
@@ -128,6 +130,7 @@ export function StatisticsSummaryCard({
             startDate={dateRange.startDate}
             endDate={dateRange.endDate}
             onDateRangeChange={handleDateRangeChange}
+            serverTimeZone={serverTimeZone}
           />
           <Button
             size="sm"

--- a/src/app/[locale]/my-usage/_components/usage-logs-section.tsx
+++ b/src/app/[locale]/my-usage/_components/usage-logs-section.tsx
@@ -30,6 +30,7 @@ interface UsageLogsSectionProps {
   loading?: boolean;
   autoRefreshSeconds?: number;
   defaultOpen?: boolean;
+  serverTimeZone?: string;
 }
 
 interface Filters {
@@ -48,6 +49,7 @@ export function UsageLogsSection({
   loading = false,
   autoRefreshSeconds,
   defaultOpen = false,
+  serverTimeZone,
 }: UsageLogsSectionProps) {
   const t = useTranslations("myUsage.logs");
   const tCollapsible = useTranslations("myUsage.logsCollapsible");
@@ -375,6 +377,7 @@ export function UsageLogsSection({
                   startDate={draftFilters.startDate}
                   endDate={draftFilters.endDate}
                   onDateRangeChange={handleDateRangeChange}
+                  serverTimeZone={serverTimeZone}
                 />
               </div>
               <div className="space-y-1.5 lg:col-span-4">

--- a/src/app/[locale]/my-usage/_components/usage-logs-table.tsx
+++ b/src/app/[locale]/my-usage/_components/usage-logs-table.tsx
@@ -105,8 +105,7 @@ export function UsageLogsTable({
                     <TooltipProvider>
                       <Tooltip delayDuration={250}>
                         <TooltipTrigger asChild>
-                          <div className="flex items-center justify-end gap-1 cursor-help">
-                            <span>{formatTokenAmount(log.cacheCreationInputTokens)}</span>
+                          <div className="flex items-center gap-2 w-full cursor-help">
                             {log.cacheCreationInputTokens &&
                             log.cacheCreationInputTokens > 0 &&
                             log.cacheTtlApplied ? (
@@ -114,6 +113,9 @@ export function UsageLogsTable({
                                 {log.cacheTtlApplied}
                               </Badge>
                             ) : null}
+                            <span className="ml-auto">
+                              {formatTokenAmount(log.cacheCreationInputTokens)}
+                            </span>
                           </div>
                         </TooltipTrigger>
                         <TooltipContent align="end" className="text-xs space-y-1">

--- a/src/app/[locale]/my-usage/page.tsx
+++ b/src/app/[locale]/my-usage/page.tsx
@@ -7,6 +7,7 @@ import {
   type MyUsageLogsResult,
   type MyUsageQuota,
 } from "@/actions/my-usage";
+import { getServerTimeZone } from "@/actions/system-config";
 import { useRouter } from "@/i18n/routing";
 import { CollapsibleQuotaCard } from "./_components/collapsible-quota-card";
 import { ExpirationInfo } from "./_components/expiration-info";
@@ -22,6 +23,7 @@ export default function MyUsagePage() {
   const [logsData, setLogsData] = useState<MyUsageLogsResult | null>(null);
   const [isQuotaLoading, setIsQuotaLoading] = useState(true);
   const [isLogsLoading, setIsLogsLoading] = useState(true);
+  const [serverTimeZone, setServerTimeZone] = useState<string | undefined>(undefined);
 
   const loadInitial = useCallback(() => {
     setIsQuotaLoading(true);
@@ -38,6 +40,10 @@ export default function MyUsagePage() {
         if (logsResult.ok) setLogsData(logsResult.data ?? null);
       })
       .finally(() => setIsLogsLoading(false));
+
+    void getServerTimeZone().then((tzResult) => {
+      if (tzResult.ok) setServerTimeZone(tzResult.data.timeZone);
+    });
   }, []);
 
   useEffect(() => {
@@ -76,9 +82,14 @@ export default function MyUsagePage() {
 
       <CollapsibleQuotaCard quota={quota} loading={isQuotaLoading} />
 
-      <StatisticsSummaryCard />
+      <StatisticsSummaryCard serverTimeZone={serverTimeZone} />
 
-      <UsageLogsSection initialData={logsData} loading={isLogsLoading} autoRefreshSeconds={30} />
+      <UsageLogsSection
+        initialData={logsData}
+        loading={isLogsLoading}
+        autoRefreshSeconds={30}
+        serverTimeZone={serverTimeZone}
+      />
     </div>
   );
 }

--- a/src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx
@@ -216,7 +216,10 @@ function VendorCard({
                   <TooltipProvider>
                     <Tooltip delayDuration={200}>
                       <TooltipTrigger asChild>
-                        <button type="button" className="text-muted-foreground hover:text-foreground">
+                        <button
+                          type="button"
+                          className="text-muted-foreground hover:text-foreground"
+                        >
                           <InfoIcon className="h-3.5 w-3.5" aria-hidden="true" />
                         </button>
                       </TooltipTrigger>

--- a/src/components/customs/active-sessions-list.tsx
+++ b/src/components/customs/active-sessions-list.tsx
@@ -2,9 +2,9 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Activity, Loader2 } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { getActiveSessions } from "@/actions/active-sessions";
+import { useRouter } from "@/i18n/routing";
 import type { CurrencyCode } from "@/lib/utils/currency";
 import type { ActiveSessionInfo } from "@/types/session";
 import { SessionListItem } from "./session-list-item";
@@ -28,6 +28,8 @@ interface ActiveSessionsListProps {
   showHeader?: boolean;
   /** 容器最大高度 */
   maxHeight?: string;
+  /** 是否显示 Token/成本（默认显示） */
+  showTokensCost?: boolean;
   /** 自定义类名 */
   className?: string;
 }
@@ -43,6 +45,7 @@ export function ActiveSessionsList({
   maxItems,
   showHeader = true,
   maxHeight = "200px",
+  showTokensCost = true,
   className = "",
 }: ActiveSessionsListProps) {
   const router = useRouter();
@@ -103,6 +106,7 @@ export function ActiveSessionsList({
                 key={session.sessionId}
                 session={session}
                 currencyCode={currencyCode}
+                showTokensCost={showTokensCost}
               />
             ))}
           </div>

--- a/src/components/customs/session-list-item.tsx
+++ b/src/components/customs/session-list-item.tsx
@@ -41,13 +41,17 @@ function getStatusIcon(status: "in_progress" | "completed" | "error", statusCode
  * 简洁的 Session 列表项
  * 可复用组件，用于活跃 Session 列表的单项展示
  */
+export interface SessionListItemProps {
+  session: ActiveSessionInfo;
+  currencyCode?: CurrencyCode;
+  showTokensCost?: boolean;
+}
+
 export function SessionListItem({
   session,
   currencyCode = "USD",
-}: {
-  session: ActiveSessionInfo;
-  currencyCode?: CurrencyCode;
-}) {
+  showTokensCost = true,
+}: SessionListItemProps) {
   const statusInfo = getStatusIcon(session.status, session.statusCode);
   const StatusIcon = statusInfo.icon;
   const inputTokensDisplay =
@@ -106,18 +110,22 @@ export function SessionListItem({
         </div>
 
         {/* Token 和成本 */}
-        <div className="flex items-center gap-2 text-xs font-mono flex-shrink-0">
-          {(inputTokensDisplay || outputTokensDisplay) && (
-            <span className="text-muted-foreground">
-              {inputTokensDisplay && `↑${inputTokensDisplay}`}
-              {inputTokensDisplay && outputTokensDisplay && " "}
-              {outputTokensDisplay && `↓${outputTokensDisplay}`}
-            </span>
-          )}
-          {session.costUsd && (
-            <span className="font-medium">{formatCurrency(session.costUsd, currencyCode, 4)}</span>
-          )}
-        </div>
+        {showTokensCost && (
+          <div className="flex items-center gap-2 text-xs font-mono flex-shrink-0">
+            {(inputTokensDisplay || outputTokensDisplay) && (
+              <span className="text-muted-foreground">
+                {inputTokensDisplay && `↑${inputTokensDisplay}`}
+                {inputTokensDisplay && outputTokensDisplay && " "}
+                {outputTokensDisplay && `↓${outputTokensDisplay}`}
+              </span>
+            )}
+            {session.costUsd && (
+              <span className="font-medium">
+                {formatCurrency(session.costUsd, currencyCode, 4)}
+              </span>
+            )}
+          </div>
+        )}
       </div>
     </Link>
   );

--- a/src/components/ui/__tests__/tag-input-dialog.test.tsx
+++ b/src/components/ui/__tests__/tag-input-dialog.test.tsx
@@ -7,7 +7,13 @@ import { useState } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, test, afterEach } from "vitest";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { TagInput } from "@/components/ui/tag-input";
 
 function render(node: ReactNode) {

--- a/src/components/ui/__tests__/tag-input-dialog.test.tsx
+++ b/src/components/ui/__tests__/tag-input-dialog.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, test, afterEach } from "vitest";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { TagInput } from "@/components/ui/tag-input";
+
+function render(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(node);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+afterEach(() => {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+function DialogTagInput() {
+  const [value, setValue] = useState<string[]>([]);
+
+  return (
+    <Dialog open>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Tag Input</DialogTitle>
+          <DialogDescription>Tag input dialog test</DialogDescription>
+        </DialogHeader>
+        <TagInput
+          value={value}
+          onChange={setValue}
+          suggestions={[
+            { value: "tag1", label: "Tag 1" },
+            { value: "tag2", label: "Tag 2" },
+          ]}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+describe("TagInput inside Dialog", () => {
+  test("renders suggestions under dialog content and supports click selection", async () => {
+    const { container, unmount } = render(<DialogTagInput />);
+
+    const input = document.querySelector("input");
+    expect(input).not.toBeNull();
+
+    await act(async () => {
+      input?.focus();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    const dialogContent = document.querySelector('[data-slot="dialog-content"]');
+    expect(dialogContent).not.toBeNull();
+    const suggestionButton = Array.from(dialogContent?.querySelectorAll("button") ?? []).find(
+      (button) => button.textContent === "Tag 1"
+    );
+
+    expect(suggestionButton).not.toBeNull();
+    expect(suggestionButton?.closest('[data-slot="dialog-content"]')).not.toBeNull();
+
+    await act(async () => {
+      suggestionButton?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+
+    const dialogContentAfterClick = document.querySelector('[data-slot="dialog-content"]');
+    expect(dialogContentAfterClick?.textContent).toContain("tag1");
+
+    unmount();
+  });
+
+  test("supports keyboard selection within dialog", async () => {
+    const { container, unmount } = render(<DialogTagInput />);
+
+    const input = document.querySelector("input");
+    expect(input).not.toBeNull();
+
+    await act(async () => {
+      input?.focus();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    await act(async () => {
+      input?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await act(async () => {
+      input?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const dialogContentAfterKey = document.querySelector('[data-slot="dialog-content"]');
+    expect(dialogContentAfterKey?.textContent).toContain("tag1");
+
+    unmount();
+  });
+});

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -6,6 +6,7 @@ import {
   timestamp,
   boolean,
   integer,
+  bigint,
   numeric,
   jsonb,
   index,
@@ -151,9 +152,11 @@ export const providers = pgTable('providers', {
   description: text('description'),
   url: varchar('url').notNull(),
   key: varchar('key').notNull(),
-  providerVendorId: integer('provider_vendor_id').references(() => providerVendors.id, {
-    onDelete: 'restrict',
-  }),
+  providerVendorId: integer('provider_vendor_id')
+    .notNull()
+    .references(() => providerVendors.id, {
+      onDelete: 'restrict',
+    }),
   isEnabled: boolean('is_enabled').notNull().default(true),
   weight: integer('weight').notNull().default(1),
 
@@ -397,13 +400,13 @@ export const messageRequest = pgTable('message_request', {
   originalModel: varchar('original_model', { length: 128 }),
 
   // Token 使用信息
-  inputTokens: integer('input_tokens'),
-  outputTokens: integer('output_tokens'),
+  inputTokens: bigint('input_tokens', { mode: 'number' }),
+  outputTokens: bigint('output_tokens', { mode: 'number' }),
   ttfbMs: integer('ttfb_ms'),
-  cacheCreationInputTokens: integer('cache_creation_input_tokens'),
-  cacheReadInputTokens: integer('cache_read_input_tokens'),
-  cacheCreation5mInputTokens: integer('cache_creation_5m_input_tokens'),
-  cacheCreation1hInputTokens: integer('cache_creation_1h_input_tokens'),
+  cacheCreationInputTokens: bigint('cache_creation_input_tokens', { mode: 'number' }),
+  cacheReadInputTokens: bigint('cache_read_input_tokens', { mode: 'number' }),
+  cacheCreation5mInputTokens: bigint('cache_creation_5m_input_tokens', { mode: 'number' }),
+  cacheCreation1hInputTokens: bigint('cache_creation_1h_input_tokens', { mode: 'number' }),
   cacheTtlApplied: varchar('cache_ttl_applied', { length: 10 }),
 
   // 1M Context Window 应用状态

--- a/src/repository/key.ts
+++ b/src/repository/key.ts
@@ -335,11 +335,11 @@ export async function findKeyUsageTodayBatch(
       keyId: keys.id,
       totalCost: sum(messageRequest.costUsd),
       totalTokens: sql<number>`COALESCE(SUM(
-        COALESCE(${messageRequest.inputTokens}, 0) +
-        COALESCE(${messageRequest.outputTokens}, 0) +
-        COALESCE(${messageRequest.cacheCreationInputTokens}, 0) +
-        COALESCE(${messageRequest.cacheReadInputTokens}, 0)
-      ), 0)::int`,
+        COALESCE(${messageRequest.inputTokens}, 0)::double precision +
+        COALESCE(${messageRequest.outputTokens}, 0)::double precision +
+        COALESCE(${messageRequest.cacheCreationInputTokens}, 0)::double precision +
+        COALESCE(${messageRequest.cacheReadInputTokens}, 0)::double precision
+      ), 0::double precision)`,
     })
     .from(keys)
     .leftJoin(
@@ -622,10 +622,10 @@ export async function findKeysWithStatistics(userId: number): Promise<KeyStatist
         model: messageRequest.model,
         callCount: sql<number>`count(*)::int`,
         totalCost: sum(messageRequest.costUsd),
-        inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::int`,
-        outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::int`,
-        cacheCreationTokens: sql<number>`COALESCE(sum(${messageRequest.cacheCreationInputTokens}), 0)::int`,
-        cacheReadTokens: sql<number>`COALESCE(sum(${messageRequest.cacheReadInputTokens}), 0)::int`,
+        inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::double precision`,
+        outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::double precision`,
+        cacheCreationTokens: sql<number>`COALESCE(sum(${messageRequest.cacheCreationInputTokens}), 0)::double precision`,
+        cacheReadTokens: sql<number>`COALESCE(sum(${messageRequest.cacheReadInputTokens}), 0)::double precision`,
       })
       .from(messageRequest)
       .where(
@@ -771,10 +771,10 @@ export async function findKeysWithStatisticsBatch(
       model: messageRequest.model,
       callCount: sql<number>`count(*)::int`,
       totalCost: sum(messageRequest.costUsd),
-      inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::int`,
-      outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::int`,
-      cacheCreationTokens: sql<number>`COALESCE(sum(${messageRequest.cacheCreationInputTokens}), 0)::int`,
-      cacheReadTokens: sql<number>`COALESCE(sum(${messageRequest.cacheReadInputTokens}), 0)::int`,
+      inputTokens: sql<number>`COALESCE(sum(${messageRequest.inputTokens}), 0)::double precision`,
+      outputTokens: sql<number>`COALESCE(sum(${messageRequest.outputTokens}), 0)::double precision`,
+      cacheCreationTokens: sql<number>`COALESCE(sum(${messageRequest.cacheCreationInputTokens}), 0)::double precision`,
+      cacheReadTokens: sql<number>`COALESCE(sum(${messageRequest.cacheReadInputTokens}), 0)::double precision`,
     })
     .from(messageRequest)
     .where(

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -439,9 +439,9 @@ async function findProviderCacheHitRateLeaderboardWithTimezone(
   providerType?: ProviderType
 ): Promise<ProviderCacheHitRateLeaderboardEntry[]> {
   const totalInputTokensExpr = sql<number>`(
-    COALESCE(${messageRequest.inputTokens}, 0) +
-    COALESCE(${messageRequest.cacheCreationInputTokens}, 0) +
-    COALESCE(${messageRequest.cacheReadInputTokens}, 0)
+    COALESCE(${messageRequest.inputTokens}, 0)::double precision +
+    COALESCE(${messageRequest.cacheCreationInputTokens}, 0)::double precision +
+    COALESCE(${messageRequest.cacheReadInputTokens}, 0)::double precision
   )`;
 
   const cacheRequiredCondition = sql`(

--- a/src/repository/provider-endpoints.ts
+++ b/src/repository/provider-endpoints.ts
@@ -232,7 +232,10 @@ export async function getOrCreateProviderVendorIdFromUrls(input: {
  * 例如: anthropic.com -> Anthropic, api.openai.com -> OpenAI
  */
 export function deriveDisplayNameFromDomain(domain: string): string {
-  const parts = domain.split(".").map((part) => part.trim()).filter(Boolean);
+  const parts = domain
+    .split(".")
+    .map((part) => part.trim())
+    .filter(Boolean);
   if (parts.length === 0) return "";
   if (parts.length === 1) {
     const name = parts[0];

--- a/src/repository/provider-endpoints.ts
+++ b/src/repository/provider-endpoints.ts
@@ -231,7 +231,7 @@ export async function getOrCreateProviderVendorIdFromUrls(input: {
  * 从域名派生显示名称（直接使用域名的中间部分）
  * 例如: anthropic.com -> Anthropic, api.openai.com -> OpenAI
  */
-export function deriveDisplayNameFromDomain(domain: string): string {
+export async function deriveDisplayNameFromDomain(domain: string): Promise<string> {
   const parts = domain
     .split(".")
     .map((part) => part.trim())
@@ -311,7 +311,7 @@ export async function backfillProviderVendorsFromProviders(): Promise<{
       }
 
       try {
-        const displayName = deriveDisplayNameFromDomain(domain);
+        const displayName = await deriveDisplayNameFromDomain(domain);
         const vendorId = await getOrCreateProviderVendorIdFromUrls({
           providerUrl: row.url,
           websiteUrl: row.websiteUrl ?? null,

--- a/src/repository/provider-endpoints.ts
+++ b/src/repository/provider-endpoints.ts
@@ -242,9 +242,13 @@ export async function deriveDisplayNameFromDomain(domain: string): Promise<strin
     return name.charAt(0).toUpperCase() + name.slice(1);
   }
 
+  const apiPrefixes = new Set(["api", "v1", "v2", "v3", "www"]);
   let name = parts[parts.length - 2];
-  if (name === "api" && parts.length >= 3) {
+  if (apiPrefixes.has(name) && parts.length >= 3) {
     name = parts[parts.length - 3];
+  }
+  if (apiPrefixes.has(name) && parts.length >= 4) {
+    name = parts[parts.length - 4];
   }
   return name.charAt(0).toUpperCase() + name.slice(1);
 }

--- a/src/repository/provider-endpoints.ts
+++ b/src/repository/provider-endpoints.ts
@@ -231,9 +231,18 @@ export async function getOrCreateProviderVendorIdFromUrls(input: {
  * 从域名派生显示名称（直接使用域名的中间部分）
  * 例如: anthropic.com -> Anthropic, api.openai.com -> OpenAI
  */
-function deriveDisplayNameFromDomain(domain: string): string {
-  const parts = domain.split(".");
-  const name = parts[0] === "api" && parts[1] ? parts[1] : parts[0];
+export function deriveDisplayNameFromDomain(domain: string): string {
+  const parts = domain.split(".").map((part) => part.trim()).filter(Boolean);
+  if (parts.length === 0) return "";
+  if (parts.length === 1) {
+    const name = parts[0];
+    return name.charAt(0).toUpperCase() + name.slice(1);
+  }
+
+  let name = parts[parts.length - 2];
+  if (name === "api" && parts.length >= 3) {
+    name = parts[parts.length - 3];
+  }
   return name.charAt(0).toUpperCase() + name.slice(1);
 }
 

--- a/tests/unit/actions/my-usage-token-aggregation.test.ts
+++ b/tests/unit/actions/my-usage-token-aggregation.test.ts
@@ -206,4 +206,3 @@ describe("my-usage token aggregation", () => {
     }
   });
 });
-

--- a/tests/unit/actions/my-usage-token-aggregation.test.ts
+++ b/tests/unit/actions/my-usage-token-aggregation.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test, vi } from "vitest";
+
+// 禁用 tests/setup.ts 中基于 DSN/Redis 的默认同步与清理协调，避免无关依赖引入。
+process.env.DSN = "";
+process.env.AUTO_CLEANUP_TEST_DATA = "false";
+
+function sqlToString(sqlObj: unknown): string {
+  const visited = new Set<unknown>();
+
+  const walk = (node: unknown): string => {
+    if (!node || visited.has(node)) return "";
+    visited.add(node);
+
+    if (typeof node === "string") return node;
+
+    if (typeof node === "object") {
+      const anyNode = node as any;
+      if (Array.isArray(anyNode)) {
+        return anyNode.map(walk).join("");
+      }
+
+      if (anyNode.value) {
+        if (Array.isArray(anyNode.value)) {
+          return anyNode.value.map(String).join("");
+        }
+        return String(anyNode.value);
+      }
+
+      if (anyNode.queryChunks) {
+        return walk(anyNode.queryChunks);
+      }
+    }
+
+    return "";
+  };
+
+  return walk(sqlObj);
+}
+
+function createThenableQuery<T>(result: T) {
+  const query: any = Promise.resolve(result);
+
+  query.from = vi.fn(() => query);
+  query.innerJoin = vi.fn(() => query);
+  query.leftJoin = vi.fn(() => query);
+  query.where = vi.fn(() => query);
+  query.groupBy = vi.fn(() => query);
+  query.orderBy = vi.fn(() => query);
+  query.limit = vi.fn(() => query);
+  query.offset = vi.fn(() => query);
+
+  return query;
+}
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getSystemSettings: vi.fn(),
+  getEnvConfig: vi.fn(),
+  getTimeRangeForPeriodWithMode: vi.fn(),
+  findUsageLogsStats: vi.fn(),
+  select: vi.fn(),
+  execute: vi.fn(async () => ({ count: 0 })),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSession: mocks.getSession,
+}));
+
+vi.mock("@/repository/system-config", () => ({
+  getSystemSettings: mocks.getSystemSettings,
+}));
+
+vi.mock("@/lib/config", () => ({
+  getEnvConfig: mocks.getEnvConfig,
+}));
+
+vi.mock("@/lib/rate-limit/time-utils", () => ({
+  getTimeRangeForPeriodWithMode: mocks.getTimeRangeForPeriodWithMode,
+}));
+
+vi.mock("@/repository/usage-logs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/repository/usage-logs")>();
+  return {
+    ...actual,
+    findUsageLogsStats: mocks.findUsageLogsStats,
+  };
+});
+
+vi.mock("@/drizzle/db", () => ({
+  db: {
+    select: mocks.select,
+    execute: mocks.execute,
+  },
+}));
+
+function expectNoIntTokenSum(selection: Record<string, unknown>, field: string) {
+  const tokenSql = sqlToString(selection[field]).toLowerCase();
+  expect(tokenSql).toContain("sum");
+  expect(tokenSql).not.toContain("::int");
+  expect(tokenSql).not.toContain("::int4");
+  expect(tokenSql).toContain("double precision");
+}
+
+describe("my-usage token aggregation", () => {
+  test("getMyTodayStats: token sum 不应使用 ::int", async () => {
+    vi.resetModules();
+
+    const capturedSelections: Array<Record<string, unknown>> = [];
+    const selectQueue: any[] = [];
+    selectQueue.push(
+      createThenableQuery([
+        {
+          calls: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          costUsd: "0",
+        },
+      ])
+    );
+    selectQueue.push(createThenableQuery([]));
+
+    mocks.select.mockImplementation((selection: unknown) => {
+      capturedSelections.push(selection as Record<string, unknown>);
+      return selectQueue.shift() ?? createThenableQuery([]);
+    });
+
+    mocks.getTimeRangeForPeriodWithMode.mockReturnValue({
+      startTime: new Date("2024-01-01T00:00:00.000Z"),
+      endTime: new Date("2024-01-02T00:00:00.000Z"),
+    });
+
+    mocks.getSession.mockResolvedValue({
+      key: {
+        id: 1,
+        key: "k",
+        dailyResetTime: "00:00",
+        dailyResetMode: "fixed",
+      },
+      user: { id: 1 },
+    });
+
+    mocks.getSystemSettings.mockResolvedValue({
+      currencyDisplay: "USD",
+      billingModelSource: "original",
+    });
+
+    const { getMyTodayStats } = await import("@/actions/my-usage");
+    const res = await getMyTodayStats();
+    expect(res.ok).toBe(true);
+
+    expect(capturedSelections.length).toBeGreaterThanOrEqual(2);
+    expectNoIntTokenSum(capturedSelections[0], "inputTokens");
+    expectNoIntTokenSum(capturedSelections[0], "outputTokens");
+    expectNoIntTokenSum(capturedSelections[1], "inputTokens");
+    expectNoIntTokenSum(capturedSelections[1], "outputTokens");
+  });
+
+  test("getMyStatsSummary: token sum 不应使用 ::int", async () => {
+    vi.resetModules();
+
+    const capturedSelections: Array<Record<string, unknown>> = [];
+    const selectQueue: any[] = [];
+    selectQueue.push(createThenableQuery([]));
+    selectQueue.push(createThenableQuery([]));
+
+    mocks.select.mockImplementation((selection: unknown) => {
+      capturedSelections.push(selection as Record<string, unknown>);
+      return selectQueue.shift() ?? createThenableQuery([]);
+    });
+
+    mocks.getEnvConfig.mockReturnValue({ TZ: "UTC" });
+
+    mocks.getSession.mockResolvedValue({
+      key: { id: 1, key: "k" },
+      user: { id: 1 },
+    });
+
+    mocks.getSystemSettings.mockResolvedValue({
+      currencyDisplay: "USD",
+      billingModelSource: "original",
+    });
+
+    mocks.findUsageLogsStats.mockResolvedValue({
+      totalRequests: 0,
+      totalCost: 0,
+      totalTokens: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCacheCreationTokens: 0,
+      totalCacheReadTokens: 0,
+      totalCacheCreation5mTokens: 0,
+      totalCacheCreation1hTokens: 0,
+    });
+
+    const { getMyStatsSummary } = await import("@/actions/my-usage");
+    const res = await getMyStatsSummary({ startDate: "2024-01-01", endDate: "2024-01-01" });
+    expect(res.ok).toBe(true);
+
+    expect(capturedSelections).toHaveLength(2);
+
+    for (const selection of capturedSelections) {
+      expectNoIntTokenSum(selection, "inputTokens");
+      expectNoIntTokenSum(selection, "outputTokens");
+      expectNoIntTokenSum(selection, "cacheCreationTokens");
+      expectNoIntTokenSum(selection, "cacheReadTokens");
+    }
+  });
+});
+

--- a/tests/unit/components/session-list-item.test.tsx
+++ b/tests/unit/components/session-list-item.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test, vi } from "vitest";
+import { SessionListItem } from "@/components/customs/session-list-item";
+import type { CurrencyCode } from "@/lib/utils/currency";
+import type { ActiveSessionInfo } from "@/types/session";
+
+vi.mock("@/i18n/routing", () => ({
+  Link: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/utils/currency", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/utils/currency")>("@/lib/utils/currency");
+  return {
+    ...actual,
+    formatCurrency: () => "__COST__",
+  };
+});
+
+const UP_ARROW = "\u2191";
+const DOWN_ARROW = "\u2193";
+const COST_SENTINEL = "__COST__";
+
+type SessionListItemProps = {
+  session: ActiveSessionInfo;
+  currencyCode?: CurrencyCode;
+  showTokensCost?: boolean;
+};
+
+const SessionListItemTest = SessionListItem as unknown as (
+  props: SessionListItemProps
+) => JSX.Element;
+
+const baseSession: ActiveSessionInfo = {
+  sessionId: "session-1",
+  userName: "alice",
+  userId: 1,
+  keyId: 2,
+  keyName: "key-1",
+  providerId: 3,
+  providerName: "openai",
+  model: "gpt-4.1",
+  apiType: "chat",
+  startTime: 1700000000000,
+  status: "completed",
+  durationMs: 1500,
+  inputTokens: 100,
+  outputTokens: 50,
+  costUsd: "0.0123",
+};
+
+function renderTextContent(options?: {
+  showTokensCost?: boolean;
+  sessionOverrides?: Partial<ActiveSessionInfo>;
+}) {
+  const session = { ...baseSession, ...(options?.sessionOverrides ?? {}) };
+  const html = renderToStaticMarkup(
+    <SessionListItemTest session={session} showTokensCost={options?.showTokensCost} />
+  );
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  return container.textContent ?? "";
+}
+
+describe("SessionListItem showTokensCost", () => {
+  test("hides tokens and cost when disabled but keeps core fields", () => {
+    const text = renderTextContent({ showTokensCost: false });
+
+    expect(text).not.toContain(`${UP_ARROW}100`);
+    expect(text).not.toContain(`${DOWN_ARROW}50`);
+    expect(text).not.toContain(COST_SENTINEL);
+
+    expect(text).toContain("alice");
+    expect(text).toContain("key-1");
+    expect(text).toContain("gpt-4.1");
+    expect(text).toContain("@ openai");
+    expect(text).toContain("1.5s");
+  });
+
+  test("shows tokens and cost by default", () => {
+    const text = renderTextContent();
+
+    expect(text).toContain(`${UP_ARROW}100`);
+    expect(text).toContain(`${DOWN_ARROW}50`);
+    expect(text).toContain(COST_SENTINEL);
+  });
+});

--- a/tests/unit/dashboard-logs-time-range-utils.test.ts
+++ b/tests/unit/dashboard-logs-time-range-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   dateStringWithClockToTimestamp,
   formatClockFromTimestamp,
+  getQuickDateRange,
   inclusiveEndTimestampFromExclusive,
   parseClockString,
 } from "@/app/[locale]/dashboard/logs/_utils/time-range";
@@ -42,5 +43,19 @@ describe("dashboard logs time range utils", () => {
   test("formatClockFromTimestamp uses HH:MM:SS", () => {
     const ts = new Date(2026, 0, 1, 1, 2, 3, 0).getTime();
     expect(formatClockFromTimestamp(ts)).toBe("01:02:03");
+  });
+
+  test("getQuickDateRange uses server timezone for today/yesterday", () => {
+    const now = new Date("2024-01-02T02:00:00Z");
+    const tz = "America/Los_Angeles";
+
+    expect(getQuickDateRange("today", tz, now)).toEqual({
+      startDate: "2024-01-01",
+      endDate: "2024-01-01",
+    });
+    expect(getQuickDateRange("yesterday", tz, now)).toEqual({
+      startDate: "2023-12-31",
+      endDate: "2023-12-31",
+    });
   });
 });

--- a/tests/unit/dashboard-logs-virtualized-special-settings-ui.test.tsx
+++ b/tests/unit/dashboard-logs-virtualized-special-settings-ui.test.tsx
@@ -41,11 +41,11 @@ vi.mock("@/actions/usage-logs", () => ({
           statusCode: 200,
           inputTokens: 1,
           outputTokens: 1,
-          cacheCreationInputTokens: 0,
-          cacheReadInputTokens: 0,
-          cacheCreation5mInputTokens: 0,
+          cacheCreationInputTokens: 10,
+          cacheReadInputTokens: 5,
+          cacheCreation5mInputTokens: 10,
           cacheCreation1hInputTokens: 0,
-          cacheTtlApplied: null,
+          cacheTtlApplied: "1h",
           totalTokens: 2,
           costUsd: "0.000001",
           costMultiplier: null,
@@ -156,6 +156,22 @@ describe("VirtualizedLogsTable - specialSettings display", () => {
     await waitForText(container, "Loaded 1 records");
 
     expect(container.textContent).not.toContain(dashboardMessages.logs.table.specialSettings);
+
+    unmount();
+  });
+});
+
+describe("VirtualizedLogsTable - cache badge alignment", () => {
+  test("badge renders left while numbers stay right", async () => {
+    const { container, unmount } = renderWithIntl(
+      <VirtualizedLogsTable filters={{}} autoRefreshEnabled={false} />
+    );
+
+    await flushMicrotasks();
+    await waitForText(container, "Loaded 1 records");
+
+    expect(container.innerHTML).toContain("1h");
+    expect(container.innerHTML).toContain("ml-auto");
 
     unmount();
   });

--- a/tests/unit/dashboard-logs-warmup-ui.test.tsx
+++ b/tests/unit/dashboard-logs-warmup-ui.test.tsx
@@ -102,3 +102,56 @@ describe("UsageLogsTable - warmup 跳过展示", () => {
     unmount();
   });
 });
+
+describe("UsageLogsTable - cache badge alignment", () => {
+  test("badge renders before numbers and keeps right-aligned tokens", () => {
+    const cacheLog: UsageLogRow = {
+      id: 2,
+      createdAt: new Date(),
+      sessionId: "session_cache",
+      requestSequence: 1,
+      userName: "user",
+      keyName: "key",
+      providerName: "provider",
+      model: "claude-sonnet-4-5-20250929",
+      originalModel: "claude-sonnet-4-5-20250929",
+      endpoint: "/v1/messages",
+      statusCode: 200,
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheCreationInputTokens: 10,
+      cacheReadInputTokens: 5,
+      cacheCreation5mInputTokens: 10,
+      cacheCreation1hInputTokens: 0,
+      cacheTtlApplied: "1h",
+      totalTokens: 15,
+      costUsd: "0.000001",
+      costMultiplier: null,
+      durationMs: 10,
+      ttfbMs: 5,
+      errorMessage: null,
+      providerChain: null,
+      blockedBy: null,
+      blockedReason: null,
+      userAgent: "claude_cli/1.0",
+      messagesCount: 1,
+      context1mApplied: false,
+    };
+
+    const { container, unmount } = renderWithIntl(
+      <UsageLogsTable
+        logs={[cacheLog]}
+        total={1}
+        page={1}
+        pageSize={50}
+        onPageChange={() => {}}
+        isPending={false}
+      />
+    );
+
+    expect(container.innerHTML).toContain("1h");
+    expect(container.innerHTML).toContain("ml-auto");
+
+    unmount();
+  });
+});

--- a/tests/unit/dashboard/availability/availability-dashboard-ui.test.tsx
+++ b/tests/unit/dashboard/availability/availability-dashboard-ui.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, test, vi } from "vitest";
+import { AvailabilityDashboard } from "@/app/[locale]/dashboard/availability/_components/availability-dashboard";
+
+vi.mock(
+  "@/app/[locale]/dashboard/availability/_components/overview/overview-section",
+  () => ({
+    OverviewSection: () => <div data-testid="overview-section" />,
+  })
+);
+vi.mock(
+  "@/app/[locale]/dashboard/availability/_components/provider/provider-tab",
+  () => ({
+    ProviderTab: () => <div data-testid="provider-tab" />,
+  })
+);
+vi.mock(
+  "@/app/[locale]/dashboard/availability/_components/endpoint/endpoint-tab",
+  () => ({
+    EndpointTab: () => <div data-testid="endpoint-tab" />,
+  })
+);
+
+function renderWithIntl(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <NextIntlClientProvider
+        locale="en"
+        timeZone="UTC"
+        messages={{
+          dashboard: {
+            availability: {
+              tabs: { provider: "Provider", endpoint: "Endpoint" },
+              states: { fetchFailed: "Fetch failed" },
+              actions: {
+                probeAll: "Probe All",
+                probing: "Probing",
+                probeSuccess: "Probe success",
+                probeFailed: "Probe failed",
+              },
+            },
+          },
+        }}
+      >
+        {node}
+      </NextIntlClientProvider>
+    );
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("AvailabilityDashboard UI", () => {
+  test("does not render Probe All floating button", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ providers: [], systemAvailability: 0 }),
+      }))
+    );
+
+    const { container, unmount } = renderWithIntl(<AvailabilityDashboard />);
+
+    expect(container.textContent).not.toContain("Probe All");
+
+    unmount();
+  });
+});

--- a/tests/unit/dashboard/availability/availability-dashboard-ui.test.tsx
+++ b/tests/unit/dashboard/availability/availability-dashboard-ui.test.tsx
@@ -9,24 +9,15 @@ import { NextIntlClientProvider } from "next-intl";
 import { describe, expect, test, vi } from "vitest";
 import { AvailabilityDashboard } from "@/app/[locale]/dashboard/availability/_components/availability-dashboard";
 
-vi.mock(
-  "@/app/[locale]/dashboard/availability/_components/overview/overview-section",
-  () => ({
-    OverviewSection: () => <div data-testid="overview-section" />,
-  })
-);
-vi.mock(
-  "@/app/[locale]/dashboard/availability/_components/provider/provider-tab",
-  () => ({
-    ProviderTab: () => <div data-testid="provider-tab" />,
-  })
-);
-vi.mock(
-  "@/app/[locale]/dashboard/availability/_components/endpoint/endpoint-tab",
-  () => ({
-    EndpointTab: () => <div data-testid="endpoint-tab" />,
-  })
-);
+vi.mock("@/app/[locale]/dashboard/availability/_components/overview/overview-section", () => ({
+  OverviewSection: () => <div data-testid="overview-section" />,
+}));
+vi.mock("@/app/[locale]/dashboard/availability/_components/provider/provider-tab", () => ({
+  ProviderTab: () => <div data-testid="provider-tab" />,
+}));
+vi.mock("@/app/[locale]/dashboard/availability/_components/endpoint/endpoint-tab", () => ({
+  EndpointTab: () => <div data-testid="endpoint-tab" />,
+}));
 
 function renderWithIntl(node: ReactNode) {
   const container = document.createElement("div");

--- a/tests/unit/dashboard/dashboard-home-layout.test.tsx
+++ b/tests/unit/dashboard/dashboard-home-layout.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import fs from "node:fs";
+import path from "node:path";
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NextIntlClientProvider } from "next-intl";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { DashboardBento } from "@/app/[locale]/dashboard/_components/bento/dashboard-bento";
+import { DashboardMain } from "@/app/[locale]/dashboard/_components/dashboard-main";
+import type { OverviewData } from "@/actions/overview";
+import type { UserStatisticsData } from "@/types/statistics";
+
+const routingMocks = vi.hoisted(() => ({
+  usePathname: vi.fn(),
+}));
+vi.mock("@/i18n/routing", () => ({
+  usePathname: routingMocks.usePathname,
+}));
+
+const overviewMocks = vi.hoisted(() => ({
+  getOverviewData: vi.fn(),
+}));
+vi.mock("@/actions/overview", () => overviewMocks);
+
+const activeSessionsMocks = vi.hoisted(() => ({
+  getActiveSessions: vi.fn(),
+}));
+vi.mock("@/actions/active-sessions", () => activeSessionsMocks);
+
+const statisticsMocks = vi.hoisted(() => ({
+  getUserStatistics: vi.fn(),
+}));
+vi.mock("@/actions/statistics", () => statisticsMocks);
+
+vi.mock("@/app/[locale]/dashboard/_components/bento/live-sessions-panel", () => ({
+  LiveSessionsPanel: () => <div data-testid="live-sessions-panel" />,
+}));
+
+vi.mock("@/app/[locale]/dashboard/_components/bento/leaderboard-card", () => ({
+  LeaderboardCard: () => <div data-testid="leaderboard-card" />,
+}));
+
+vi.mock("@/app/[locale]/dashboard/_components/bento/statistics-chart-card", () => ({
+  StatisticsChartCard: () => <div data-testid="statistics-chart-card" />,
+}));
+
+const customsMessages = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), "messages/en/customs.json"), "utf8")
+);
+const dashboardMessages = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), "messages/en/dashboard.json"), "utf8")
+);
+
+const mockOverviewData: OverviewData = {
+  concurrentSessions: 2,
+  todayRequests: 12,
+  todayCost: 1.23,
+  avgResponseTime: 456,
+  todayErrorRate: 0.1,
+  yesterdaySamePeriodRequests: 10,
+  yesterdaySamePeriodCost: 1.01,
+  yesterdaySamePeriodAvgResponseTime: 500,
+  recentMinuteRequests: 3,
+};
+
+const mockStatisticsData: UserStatisticsData = {
+  chartData: [],
+  users: [],
+  timeRange: "today",
+  resolution: "hour",
+  mode: "users",
+};
+
+function renderSimple(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(node);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function renderWithProviders(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+
+  act(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <NextIntlClientProvider
+          locale="en"
+          messages={{ customs: customsMessages, dashboard: dashboardMessages }}
+          timeZone="UTC"
+        >
+          {node}
+        </NextIntlClientProvider>
+      </QueryClientProvider>
+    );
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function findByClassToken(root: ParentNode, token: string) {
+  return Array.from(root.querySelectorAll<HTMLElement>("*")).find((el) =>
+    el.classList.contains(token)
+  );
+}
+
+function findClosestWithClasses(element: Element | null, classes: string[]) {
+  let current = element?.parentElement ?? null;
+  while (current) {
+    const hasAll = classes.every((cls) => current.classList.contains(cls));
+    if (hasAll) return current;
+    current = current.parentElement;
+  }
+  return null;
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = "";
+  overviewMocks.getOverviewData.mockResolvedValue({ ok: true, data: mockOverviewData });
+  activeSessionsMocks.getActiveSessions.mockResolvedValue({ ok: true, data: [] });
+  statisticsMocks.getUserStatistics.mockResolvedValue({ ok: true, data: mockStatisticsData });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => [],
+    }))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("DashboardMain layout classes", () => {
+  test("pathname /dashboard removes max-w-7xl but keeps px-6", () => {
+    routingMocks.usePathname.mockReturnValue("/dashboard");
+    const { container, unmount } = renderSimple(
+      <DashboardMain>
+        <div data-testid="content" />
+      </DashboardMain>
+    );
+
+    const main = container.querySelector("main");
+    expect(main).toBeTruthy();
+    expect(main?.className).toContain("px-6");
+    expect(main?.className).not.toContain("max-w-7xl");
+
+    unmount();
+  });
+
+  test("pathname /dashboard/logs keeps max-w-7xl", () => {
+    routingMocks.usePathname.mockReturnValue("/dashboard/logs");
+    const { container, unmount } = renderSimple(
+      <DashboardMain>
+        <div data-testid="content" />
+      </DashboardMain>
+    );
+
+    const main = container.querySelector("main");
+    expect(main).toBeTruthy();
+    expect(main?.className).toContain("max-w-7xl");
+
+    unmount();
+  });
+});
+
+describe("DashboardBento admin layout", () => {
+  test("renders two-column layout with right sidebar LiveSessionsPanel", async () => {
+    const { container, unmount } = renderWithProviders(
+      <DashboardBento
+        isAdmin={true}
+        currencyCode="USD"
+        allowGlobalUsageView={false}
+        initialStatistics={mockStatisticsData}
+      />
+    );
+    await flushPromises();
+
+    const grid = findByClassToken(container, "lg:grid-cols-[minmax(0,1fr)_300px]");
+    expect(grid).toBeTruthy();
+
+    const livePanel = container.querySelector('[data-testid="live-sessions-panel"]');
+    expect(livePanel).toBeTruthy();
+
+    const sidebar = findClosestWithClasses(livePanel, ["hidden", "lg:block"]);
+    expect(sidebar).toBeTruthy();
+    expect(grid?.contains(sidebar as HTMLElement)).toBe(true);
+
+    unmount();
+  });
+});

--- a/tests/unit/dashboard/dashboard-home-layout.test.tsx
+++ b/tests/unit/dashboard/dashboard-home-layout.test.tsx
@@ -171,7 +171,7 @@ afterEach(() => {
 });
 
 describe("DashboardMain layout classes", () => {
-  test("pathname /dashboard removes max-w-7xl but keeps px-6", () => {
+  test("pathname /dashboard has max-w-7xl and px-6", () => {
     routingMocks.usePathname.mockReturnValue("/dashboard");
     const { container, unmount } = renderSimple(
       <DashboardMain>
@@ -182,7 +182,7 @@ describe("DashboardMain layout classes", () => {
     const main = container.querySelector("main");
     expect(main).toBeTruthy();
     expect(main?.className).toContain("px-6");
-    expect(main?.className).not.toContain("max-w-7xl");
+    expect(main?.className).toContain("max-w-7xl");
 
     unmount();
   });
@@ -204,7 +204,7 @@ describe("DashboardMain layout classes", () => {
 });
 
 describe("DashboardBento admin layout", () => {
-  test("renders two-column layout with right sidebar LiveSessionsPanel", async () => {
+  test("renders four-column layout with LiveSessionsPanel in last column", async () => {
     const { container, unmount } = renderWithProviders(
       <DashboardBento
         isAdmin={true}
@@ -215,15 +215,13 @@ describe("DashboardBento admin layout", () => {
     );
     await flushPromises();
 
-    const grid = findByClassToken(container, "lg:grid-cols-[minmax(0,1fr)_300px]");
+    const grid = findByClassToken(container, "lg:grid-cols-[1fr_1fr_1fr_280px]");
     expect(grid).toBeTruthy();
 
     const livePanel = container.querySelector('[data-testid="live-sessions-panel"]');
     expect(livePanel).toBeTruthy();
 
-    const sidebar = findClosestWithClasses(livePanel, ["hidden", "lg:block"]);
-    expect(sidebar).toBeTruthy();
-    expect(grid?.contains(sidebar as HTMLElement)).toBe(true);
+    expect(grid?.contains(livePanel as HTMLElement)).toBe(true);
 
     unmount();
   });

--- a/tests/unit/repository/key-usage-token-overflow.test.ts
+++ b/tests/unit/repository/key-usage-token-overflow.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test, vi } from "vitest";
+
+// 禁用 tests/setup.ts 中基于 DSN/Redis 的默认同步与清理协调，避免无关依赖引入。
+process.env.DSN = "";
+process.env.AUTO_CLEANUP_TEST_DATA = "false";
+
+function sqlToString(sqlObj: unknown): string {
+  const visited = new Set<unknown>();
+
+  const walk = (node: unknown): string => {
+    if (!node || visited.has(node)) return "";
+    visited.add(node);
+
+    if (typeof node === "string") return node;
+
+    if (typeof node === "object") {
+      const anyNode = node as any;
+      if (Array.isArray(anyNode)) {
+        return anyNode.map(walk).join("");
+      }
+
+      if (anyNode.value) {
+        if (Array.isArray(anyNode.value)) {
+          return anyNode.value.map(String).join("");
+        }
+        return String(anyNode.value);
+      }
+
+      if (anyNode.queryChunks) {
+        return walk(anyNode.queryChunks);
+      }
+    }
+
+    return "";
+  };
+
+  return walk(sqlObj);
+}
+
+function createThenableQuery<T>(result: T) {
+  const query: any = Promise.resolve(result);
+
+  query.from = vi.fn(() => query);
+  query.leftJoin = vi.fn(() => query);
+  query.innerJoin = vi.fn(() => query);
+  query.where = vi.fn(() => query);
+  query.groupBy = vi.fn(() => query);
+  query.orderBy = vi.fn(() => query);
+  query.limit = vi.fn(() => query);
+  query.offset = vi.fn(() => query);
+
+  return query;
+}
+
+describe("Key usage token aggregation overflow", () => {
+  test("findKeyUsageTodayBatch: token sum 不应使用 ::int", async () => {
+    vi.resetModules();
+
+    const selectArgs: unknown[] = [];
+    const selectMock = vi.fn((selection: unknown) => {
+      selectArgs.push(selection);
+      return createThenableQuery([]);
+    });
+
+    vi.doMock("@/drizzle/db", () => ({
+      db: {
+        select: selectMock,
+        // 给 tests/setup.ts 的 afterAll 清理逻辑一个可用的 execute
+        execute: vi.fn(async () => ({ count: 0 })),
+      },
+    }));
+
+    const { findKeyUsageTodayBatch } = await import("@/repository/key");
+    await findKeyUsageTodayBatch([1]);
+
+    expect(selectArgs).toHaveLength(1);
+    const selection = selectArgs[0] as Record<string, unknown>;
+    const totalTokensSql = sqlToString(selection.totalTokens).toLowerCase();
+
+    expect(totalTokensSql).not.toContain("::int");
+    expect(totalTokensSql).not.toContain("::int4");
+    expect(totalTokensSql).toContain("double precision");
+  });
+
+  test("findKeysWithStatisticsBatch: modelStats token sum 不应使用 ::int", async () => {
+    vi.resetModules();
+
+    const selectArgs: unknown[] = [];
+    const selectQueue: any[] = [];
+
+    selectQueue.push(
+      createThenableQuery([
+        {
+          id: 10,
+          userId: 1,
+          key: "k",
+          name: "n",
+          isEnabled: true,
+          expiresAt: null,
+          canLoginWebUi: true,
+          limit5hUsd: null,
+          limitDailyUsd: null,
+          dailyResetMode: "fixed",
+          dailyResetTime: "00:00",
+          limitWeeklyUsd: null,
+          limitMonthlyUsd: null,
+          limitTotalUsd: null,
+          limitConcurrentSessions: 0,
+          providerGroup: null,
+          cacheTtlPreference: null,
+          createdAt: new Date("2024-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+          deletedAt: null,
+        },
+      ])
+    );
+    selectQueue.push(createThenableQuery([]));
+    selectQueue.push(createThenableQuery([]));
+
+    const fallbackSelect = createThenableQuery<unknown[]>([]);
+    const selectMock = vi.fn((selection: unknown) => {
+      selectArgs.push(selection);
+      return selectQueue.shift() ?? fallbackSelect;
+    });
+
+    const selectDistinctOnMock = vi.fn(() => createThenableQuery([]));
+
+    vi.doMock("@/drizzle/db", () => ({
+      db: {
+        select: selectMock,
+        selectDistinctOn: selectDistinctOnMock,
+        execute: vi.fn(async () => ({ count: 0 })),
+      },
+    }));
+
+    const { findKeysWithStatisticsBatch } = await import("@/repository/key");
+    await findKeysWithStatisticsBatch([1]);
+
+    const selection = selectArgs.find((s): s is Record<string, unknown> => {
+      if (!s || typeof s !== "object") return false;
+      return "inputTokens" in s && "cacheReadTokens" in s;
+    });
+    expect(selection).toBeTruthy();
+
+    for (const field of ["inputTokens", "outputTokens", "cacheCreationTokens", "cacheReadTokens"]) {
+      const tokenSql = sqlToString(selection?.[field]).toLowerCase();
+      expect(tokenSql).not.toContain("::int");
+      expect(tokenSql).not.toContain("::int4");
+      expect(tokenSql).toContain("double precision");
+    }
+  });
+});

--- a/tests/unit/repository/provider-endpoints-display-name.test.ts
+++ b/tests/unit/repository/provider-endpoints-display-name.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import { deriveDisplayNameFromDomain } from "@/repository/provider-endpoints";
+
+describe("deriveDisplayNameFromDomain", () => {
+  test("uses second-level label before suffix", () => {
+    expect(deriveDisplayNameFromDomain("co.yes.vg")).toBe("Yes");
+  });
+
+  test("keeps api prefix handling and capitalization", () => {
+    expect(deriveDisplayNameFromDomain("api.openai.com")).toBe("Openai");
+  });
+
+  test("falls back to first label when single part", () => {
+    expect(deriveDisplayNameFromDomain("localhost")).toBe("Localhost");
+  });
+});

--- a/tests/unit/repository/provider-endpoints-display-name.test.ts
+++ b/tests/unit/repository/provider-endpoints-display-name.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, test } from "vitest";
 import { deriveDisplayNameFromDomain } from "@/repository/provider-endpoints";
 
 describe("deriveDisplayNameFromDomain", () => {
-  test("uses second-level label before suffix", () => {
-    expect(deriveDisplayNameFromDomain("co.yes.vg")).toBe("Yes");
+  test("uses second-level label before suffix", async () => {
+    expect(await deriveDisplayNameFromDomain("co.yes.vg")).toBe("Yes");
   });
 
-  test("keeps api prefix handling and capitalization", () => {
-    expect(deriveDisplayNameFromDomain("api.openai.com")).toBe("Openai");
+  test("keeps api prefix handling and capitalization", async () => {
+    expect(await deriveDisplayNameFromDomain("api.openai.com")).toBe("Openai");
   });
 
-  test("falls back to first label when single part", () => {
-    expect(deriveDisplayNameFromDomain("localhost")).toBe("Localhost");
+  test("falls back to first label when single part", async () => {
+    expect(await deriveDisplayNameFromDomain("localhost")).toBe("Localhost");
   });
 });

--- a/tests/unit/repository/provider-endpoints-display-name.test.ts
+++ b/tests/unit/repository/provider-endpoints-display-name.test.ts
@@ -13,4 +13,15 @@ describe("deriveDisplayNameFromDomain", () => {
   test("falls back to first label when single part", async () => {
     expect(await deriveDisplayNameFromDomain("localhost")).toBe("Localhost");
   });
+
+  test("handles common API prefixes correctly", async () => {
+    expect(await deriveDisplayNameFromDomain("v1.api.anthropic.com")).toBe("Anthropic");
+    expect(await deriveDisplayNameFromDomain("www.example.com")).toBe("Example");
+    expect(await deriveDisplayNameFromDomain("api.anthropic.com")).toBe("Anthropic");
+  });
+
+  test("handles standard domains without prefixes", async () => {
+    expect(await deriveDisplayNameFromDomain("anthropic.com")).toBe("Anthropic");
+    expect(await deriveDisplayNameFromDomain("openai.com")).toBe("Openai");
+  });
 });


### PR DESCRIPTION
## Summary

This PR enhances the dashboard UI with multiple improvements including server timezone support for logs filtering, provider chain display enhancements, TagInput dropdown positioning fixes inside dialogs, and provider vendor view UX improvements.

## Changes

### Core Changes

#### Server Timezone Support for Logs Filtering
- Added `getServerTimeZone()` server action to expose the server's `TZ` environment variable
- Updated time range utilities to support timezone-aware date/time conversions using `date-fns-tz`
- Propagated `serverTimeZone` prop through logs filter components (`TimeFilters`, `LogsDateRangePicker`, `UsageLogsFilters`)
- Ensures date filtering in logs dashboard uses server timezone for accurate "today", "yesterday", etc. calculations

#### Provider Chain Popover Improvements
- Added 5 new i18n strings for provider exclusion reasons: `excluded`, `format_type_mismatch`, `type_mismatch`, `model_not_allowed`, `context_1m_disabled`
- Improved group tag badge display: now parses comma-separated tags, deduplicates them, and renders each as a separate badge with tooltip
- Added `vendorAggregationRule` i18n string explaining vendor grouping logic

#### TagInput Dropdown Positioning Fix
- Fixed dropdown positioning when TagInput is rendered inside a Dialog component
- Detects if TagInput is inside a `[data-slot="dialog-content"]` container
- Uses absolute positioning relative to dialog content instead of fixed viewport positioning
- Properly handles scroll events within the dialog container

#### Provider Vendor View Enhancements
- Added inline Switch toggle for enabling/disabling endpoints directly in the table row
- Removed endpoint label field from add/edit forms (simplified UX)
- Added info tooltip explaining vendor aggregation rule ("Grouped by website domain")
- Hide vendor cards that have zero providers associated
- Fixed `deriveDisplayNameFromDomain` to properly extract display name from domains like `co.yes.vg`

#### Cache Badge Alignment Fix
- Moved cache TTL badge (`1h`, `5m`) to the left side of the cell
- Token numbers remain right-aligned with `ml-auto` class
- Applied consistently across `UsageLogsTable`, `VirtualizedLogsTable`, and my-usage table

#### Availability Dashboard Cleanup
- Removed `FloatingProbeButton` component from availability dashboard

### Supporting Changes

#### i18n Updates (5 languages: en, ja, ru, zh-CN, zh-TW)
- Added provider chain exclusion reason translations
- Added `vendorAggregationRule` translation for provider settings

#### Test Coverage
- `provider-chain-popover.test.tsx`: Added test for multiple deduped group badges
- `tag-input-dialog.test.tsx`: New test file for TagInput inside Dialog scenarios
- `dashboard-logs-time-range-utils.test.ts`: Added test for timezone-aware quick date ranges
- `dashboard-logs-virtualized-special-settings-ui.test.tsx`: Added cache badge alignment test
- `dashboard-logs-warmup-ui.test.tsx`: Added cache badge alignment test
- `availability-dashboard-ui.test.tsx`: New test verifying probe button removal
- `provider-endpoints-display-name.test.ts`: New test for domain name derivation
- `provider-vendor-view-circuit-ui.test.tsx`: Added tests for vendor list filtering and endpoint toggle

## Breaking Changes

None. All changes are backward compatible.

## Testing

### Automated Tests
- [x] Unit tests added for all new functionality
- [x] Existing tests updated where needed

### Manual Testing
1. **Timezone filtering**: Set server `TZ` to a different timezone, verify "Today" filter shows correct date
2. **TagInput in Dialog**: Open a dialog with TagInput, verify dropdown appears correctly positioned
3. **Provider endpoint toggle**: Toggle endpoint enabled/disabled via inline switch
4. **Cache badge alignment**: Verify TTL badge appears on left, numbers on right in logs tables

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] i18n strings added for all 5 supported languages

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enhances the dashboard UI with multiple well-implemented improvements focused on internationalization, timezone handling, and UX refinements.

## Key Changes

- **Server Timezone Support**: Added timezone-aware date/time conversion using `date-fns-tz` for accurate logs filtering. The implementation properly uses `toZonedTime` and `fromZonedTime` to handle server timezone differences, ensuring "Today" and "Yesterday" filters work correctly regardless of server location.

- **TagInput Dialog Positioning Fix**: Solved dropdown positioning issues when TagInput is rendered inside Dialog components by detecting the dialog container and switching from fixed to absolute positioning with proper scroll event handling.

- **Domain Name Derivation Improvement**: Enhanced `deriveDisplayNameFromDomain` to handle complex TLDs (like `co.yes.vg`) by parsing from right-to-left and supporting multiple API prefix patterns (`api`, `v1`, `v2`, `v3`, `www`). Test coverage confirms backward compatibility with existing domains.

- **Token Overflow Prevention**: Changed token count columns from `integer` to `bigint` to prevent overflow for large token values, addressing a real production concern for high-volume usage.

- **Provider Vendor UX**: Added inline endpoint toggle switches, removed unnecessary label fields, added vendor aggregation tooltips, and hide empty vendor cards for cleaner UI.

- **Cache Badge Alignment**: Improved visual consistency by moving TTL badges to the left with token numbers right-aligned.

- **i18n Coverage**: Added translations for 5 new provider exclusion reasons across all 5 supported languages.

## Test Coverage

Excellent test coverage with new test files for all major changes:
- `tag-input-dialog.test.tsx` - Dialog positioning scenarios
- `provider-endpoints-display-name.test.ts` - Domain derivation logic
- `dashboard-logs-time-range-utils.test.ts` - Timezone-aware date ranges
- Token aggregation and overflow tests
- Cache badge alignment tests

All changes are backward compatible with no breaking changes.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- Score reflects comprehensive test coverage, backward-compatible changes, and well-thought-out implementations. All major changes (timezone support, TagInput positioning, domain derivation, token overflow prevention) have corresponding test coverage. The schema change for providerVendorId.notNull() matches existing database state. Only minor style improvement suggested.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/repository/provider-endpoints.ts | Improved domain name derivation logic to handle complex TLDs like co.yes.vg by checking from right to left and handling multiple API prefixes |
| src/components/ui/tag-input.tsx | Fixed dropdown positioning when TagInput is inside Dialog by detecting dialog container and using absolute positioning with proper scroll handling |
| src/app/[locale]/dashboard/logs/_utils/time-range.ts | Added timezone-aware date/time conversion utilities using date-fns-tz for accurate server timezone handling in logs filtering |
| src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx | Added inline endpoint toggle switch, removed label field from forms, added vendor aggregation tooltip, and hide empty vendor cards |
| src/drizzle/schema.ts | Changed token columns to bigint to prevent overflow, added explicit notNull constraint to providerVendorId (matches existing DB state) |
| drizzle/0057_conscious_quicksilver.sql | Migration to convert token count columns from integer to bigint to prevent overflow for large token values |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as Browser Client
    participant Server as Next.js Server
    participant Action as System Config Action
    participant TimeUtils as Time Range Utils
    participant DB as PostgreSQL DB
    
    Note over Client,DB: Server Timezone Support Flow
    Client->>Server: Load Dashboard Page
    Server->>Action: getServerTimeZone()
    Action->>Action: Read TZ env variable
    Action-->>Server: Return timezone string
    Server-->>Client: Render with serverTimeZone prop
    
    Client->>Client: User selects "Today" filter
    Client->>TimeUtils: getQuickDateRange("today", serverTimeZone)
    TimeUtils->>TimeUtils: toZonedTime(now, timeZone)
    TimeUtils->>TimeUtils: formatInTimeZone(date, timeZone)
    TimeUtils-->>Client: Return {startDate, endDate}
    
    Client->>TimeUtils: dateStringWithClockToTimestamp(date, clock, timezone)
    TimeUtils->>TimeUtils: fromZonedTime(date, timeZone)
    TimeUtils-->>Client: Return timestamp
    
    Client->>DB: Query logs with timestamp range
    DB-->>Client: Return filtered logs
    
    Note over Client,DB: Tag Input in Dialog Flow
    Client->>Client: Open Dialog with TagInput
    Client->>Client: User focuses input
    Client->>Client: Detect [data-slot="dialog-content"]
    Client->>Client: Calculate dropdown position
    alt Inside Dialog
        Client->>Client: Use absolute positioning
        Client->>Client: Listen to dialog scroll events
    else Outside Dialog
        Client->>Client: Use fixed positioning
        Client->>Client: Listen to window scroll events
    end
    Client->>Client: Render dropdown suggestions
    
    Note over Client,DB: Provider Vendor Display Flow
    Client->>DB: Fetch provider endpoints
    DB-->>Client: Return endpoints with vendorId
    
    alt Vendor has providers
        Client->>Client: Show vendor card
        Client->>Client: Render endpoint rows with inline toggle
    else Vendor has no providers
        Client->>Client: Hide vendor card
    end
    
    Client->>Client: User toggles endpoint switch
    Client->>Server: editProviderEndpoint(endpointId, isEnabled)
    Server->>DB: UPDATE provider_endpoints
    DB-->>Server: Success
    Server-->>Client: Invalidate cache & refresh
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->