### PR TITLE
fix(billing): 修复 Gemini 图片生成模型的 IMAGE modality token 计费问题

### DIFF
--- a/src/types/model-price.ts
+++ b/src/types/model-price.ts
@@ -20,6 +20,12 @@ export interface ModelPriceData {
 
   // 图片生成价格
   output_cost_per_image?: number;
+  // 图片 token 价格（按 token 计费，用于 Gemini 等模型的图片输出）
+  output_cost_per_image_token?: number;
+  // 图片输入价格（按张计费）
+  input_cost_per_image?: number;
+  // 图片输入 token 价格（按 token 计费）
+  input_cost_per_image_token?: number;
 
   // 搜索上下文价格
   search_context_cost_per_query?: {

--- a/tests/unit/lib/cost-calculation-image-tokens.test.ts
+++ b/tests/unit/lib/cost-calculation-image-tokens.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "vitest";
+import { calculateRequestCost } from "@/lib/utils/cost-calculation";
+
+describe("calculateRequestCost: image token pricing (Gemini image generation)", () => {
+  test("output_image_tokens 应使用 output_cost_per_image_token 计费", () => {
+    const cost = calculateRequestCost(
+      { output_image_tokens: 2000 },
+      {
+        output_cost_per_token: 0.000012,
+        output_cost_per_image_token: 0.00012,
+      }
+    );
+
+    // 2000 * 0.00012 = 0.24
+    expect(cost.toString()).toBe("0.24");
+  });
+
+  test("output_image_tokens 未配置 image 价格时应回退到 output_cost_per_token", () => {
+    const cost = calculateRequestCost(
+      { output_image_tokens: 2000 },
+      {
+        output_cost_per_token: 0.000012,
+      }
+    );
+
+    // 2000 * 0.000012 = 0.024
+    expect(cost.toString()).toBe("0.024");
+  });
+
+  test("input_image_tokens 应使用 input_cost_per_image_token 计费", () => {
+    const cost = calculateRequestCost(
+      { input_image_tokens: 560 },
+      {
+        input_cost_per_token: 0.000002,
+        input_cost_per_image_token: 0.00000196,
+      }
+    );
+
+    // 560 * 0.00000196 = 0.0010976
+    expect(cost.toNumber()).toBeCloseTo(0.0010976, 6);
+  });
+
+  test("input_image_tokens 未配置 image 价格时应回退到 input_cost_per_token", () => {
+    const cost = calculateRequestCost(
+      { input_image_tokens: 560 },
+      {
+        input_cost_per_token: 0.000002,
+      }
+    );
+
+    // 560 * 0.000002 = 0.00112
+    expect(cost.toString()).toBe("0.00112");
+  });
+
+  test("混合响应：text + image tokens 应分别计费", () => {
+    const cost = calculateRequestCost(
+      {
+        input_tokens: 326,
+        output_tokens: 340,
+        output_image_tokens: 2000,
+      },
+      {
+        input_cost_per_token: 0.000002,
+        output_cost_per_token: 0.000012,
+        output_cost_per_image_token: 0.00012,
+      }
+    );
+
+    // input: 326 * 0.000002 = 0.000652
+    // output text: 340 * 0.000012 = 0.00408
+    // output image: 2000 * 0.00012 = 0.24
+    // total: 0.000652 + 0.00408 + 0.24 = 0.244732
+    expect(cost.toNumber()).toBeCloseTo(0.244732, 6);
+  });
+
+  test("完整 Gemini image 响应计费示例", () => {
+    const cost = calculateRequestCost(
+      {
+        input_tokens: 326,
+        output_tokens: 340,
+        output_image_tokens: 2000,
+      },
+      {
+        input_cost_per_token: 0.000002,
+        output_cost_per_token: 0.000012,
+        output_cost_per_image_token: 0.00012,
+      }
+    );
+
+    // Google 官方价格验证
+    // input: 326 * $0.000002 = $0.000652
+    // output text: 340 * $0.000012 = $0.00408
+    // output image: 2000 * $0.00012 = $0.24 (4K image = 2000 tokens)
+    // total: $0.244732
+    expect(cost.toNumber()).toBeCloseTo(0.244732, 6);
+  });
+
+  test("倍率应同时作用于 image token 费用", () => {
+    const cost = calculateRequestCost(
+      { output_image_tokens: 2000 },
+      {
+        output_cost_per_image_token: 0.00012,
+      },
+      2
+    );
+
+    // 2000 * 0.00012 * 2 = 0.48
+    expect(cost.toString()).toBe("0.48");
+  });
+
+  test("output_image_tokens 为 0 时不应产生费用", () => {
+    const cost = calculateRequestCost(
+      { output_image_tokens: 0 },
+      {
+        output_cost_per_image_token: 0.00012,
+      }
+    );
+
+    expect(cost.toString()).toBe("0");
+  });
+
+  test("output_image_tokens 为 undefined 时不应产生费用", () => {
+    const cost = calculateRequestCost(
+      { output_tokens: 1000 },
+      {
+        output_cost_per_token: 0.000012,
+        output_cost_per_image_token: 0.00012,
+      }
+    );
+
+    // 只计算 output_tokens: 1000 * 0.000012 = 0.012
+    expect(cost.toString()).toBe("0.012");
+  });
+
+  test("同时有 input_image_tokens 和 output_image_tokens", () => {
+    const cost = calculateRequestCost(
+      {
+        input_image_tokens: 560,
+        output_image_tokens: 2000,
+      },
+      {
+        input_cost_per_image_token: 0.00000196,
+        output_cost_per_image_token: 0.00012,
+      }
+    );
+
+    // input: 560 * 0.00000196 = 0.0010976
+    // output: 2000 * 0.00012 = 0.24
+    // total: 0.2410976
+    expect(cost.toNumber()).toBeCloseTo(0.2410976, 6);
+  });
+});


### PR DESCRIPTION
## Summary

Fix billing calculation for Gemini image generation models (e.g., `gemini-3-pro-image-preview`). IMAGE modality tokens cost $0.00012/token, which is 10x more expensive than TEXT tokens at $0.000012/token. The previous implementation did not parse modality-specific token details, resulting in approximately 7.6x undercharging.

## Problem

The system was treating all output tokens uniformly without distinguishing between IMAGE and TEXT modalities in Gemini's `candidatesTokensDetails` and `promptTokensDetails` response fields.

**Related Issues:**
- Fixes #663 - Image generation models billing calculation is incorrect

## Solution

1. **Extended type definitions** (`src/types/model-price.ts`)
   - Added `output_cost_per_image_token` and `input_cost_per_image_token` fields

2. **Updated usage extraction** (`src/app/v1/_lib/proxy/response-handler.ts`)
   - Parse `candidatesTokensDetails` to extract `output_image_tokens` and `output_tokens` (TEXT)
   - Parse `promptTokensDetails` to extract `input_image_tokens` and `input_tokens` (TEXT)
   - Case-insensitive modality matching via `toUpperCase()`
   - Calculate unaccounted tokens from `candidatesTokenCount` difference as TEXT

3. **Updated cost calculation** (`src/lib/utils/cost-calculation.ts`)
   - `output_image_tokens` uses `output_cost_per_image_token` when available
   - Falls back to `output_cost_per_token` for backward compatibility

## Changes

### Core Changes
| File | Changes |
|------|---------|
| `src/types/model-price.ts` | Added 4 new image token price fields |
| `src/app/v1/_lib/proxy/response-handler.ts` | Added modality parsing logic (+68 lines) |
| `src/lib/utils/cost-calculation.ts` | Added image token cost calculation (+18 lines) |

### Test Coverage
| File | Tests |
|------|-------|
| `tests/unit/lib/cost-calculation-image-tokens.test.ts` | 10 new tests |
| `tests/unit/proxy/extract-usage-metrics.test.ts` | 12 new Gemini image tests |

## Billing Example

| Item | Tokens | Unit Price | Cost |
|------|--------|------------|------|
| Input TEXT | 326 | $0.000002 | $0.000652 |
| Output TEXT | 340+337 | $0.000012 | $0.008124 |
| Output IMAGE | 2000 | $0.00012 | $0.240000 |
| **Total** | - | - | **$0.248776** |

**Before fix:** $0.244696 (undercharged by $0.00408)

## Testing

### Automated Tests
- [x] Unit tests added for image token cost calculation (10 tests)
- [x] Unit tests added for usage metrics extraction (12 tests)
- [x] All tests pass locally

### Manual Testing
1. Configure a provider with `gemini-3-pro-image-preview` model
2. Set `output_cost_per_image_token: 0.00012` in model pricing
3. Send an image generation request
4. Verify that IMAGE modality tokens are billed at the higher rate

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally (`bun run test`)
- [x] Backward compatible (falls back to standard token pricing if image pricing not configured)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a critical billing issue for Gemini image generation models by properly extracting and billing IMAGE modality tokens at 10x the rate of TEXT tokens ($0.00012 vs $0.000012).

**Key Changes:**
- Extended type system with `output_cost_per_image_token` and `input_cost_per_image_token` fields
- Enhanced usage extraction to parse `candidatesTokensDetails` and `promptTokensDetails` from Gemini responses
- Implemented case-insensitive modality matching and proper handling of unaccounted tokens
- Updated cost calculation with graceful fallback to regular token pricing for backward compatibility
- Added comprehensive test coverage (22 new tests across billing and extraction)

**Potential Issue:**
- When `promptTokensDetails` is present along with `cachedContentTokenCount`, the cache deduction logic may not work correctly. The code at line 1354 overwrites `input_tokens` with raw `textTokens` from details without deducting cached tokens that were previously subtracted at line 1281. This scenario lacks test coverage.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge with one logical issue that needs verification
- The implementation correctly extracts modality tokens and calculates costs for the primary use case. However, there's a potential cache + image token interaction bug that could cause incorrect billing when both features are used together. The issue is uncommon but should be addressed.
- src/app/v1/_lib/proxy/response-handler.ts requires attention for the cache + image token interaction at lines 1278-1357
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/types/model-price.ts | Added optional fields for image token pricing with clear comments |
| src/lib/utils/cost-calculation.ts | Properly calculates image token costs with fallback to regular token pricing |
| src/app/v1/_lib/proxy/response-handler.ts | Extracts modality-specific tokens but may have cache interaction issue |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant ResponseHandler
    participant UsageExtractor
    participant CostCalculator
    participant PriceData

    Client->>ResponseHandler: Gemini API Response
    ResponseHandler->>UsageExtractor: extractUsageMetrics(response)
    
    UsageExtractor->>UsageExtractor: Parse usageMetadata
    
    alt Has candidatesTokensDetails
        UsageExtractor->>UsageExtractor: Iterate through candidatesTokensDetails
        UsageExtractor->>UsageExtractor: Filter IMAGE modality (case-insensitive)
        UsageExtractor->>UsageExtractor: Sum output_image_tokens
        UsageExtractor->>UsageExtractor: Calculate unaccounted TEXT tokens
        Note over UsageExtractor: output_tokens = textTokens + (candidatesTotal - detailsSum)
    end
    
    alt Has promptTokensDetails
        UsageExtractor->>UsageExtractor: Iterate through promptTokensDetails
        UsageExtractor->>UsageExtractor: Filter IMAGE modality (case-insensitive)
        UsageExtractor->>UsageExtractor: Sum input_image_tokens
        UsageExtractor->>UsageExtractor: Extract input_tokens (TEXT only)
    end
    
    UsageExtractor->>UsageExtractor: Add thoughtsTokenCount to output_tokens
    UsageExtractor-->>ResponseHandler: Return UsageMetrics
    
    ResponseHandler->>CostCalculator: calculateRequestCost(metrics, priceData)
    
    CostCalculator->>PriceData: Get output_cost_per_image_token
    alt Has output_cost_per_image_token
        CostCalculator->>CostCalculator: Calculate image token cost at $0.00012/token
    else Fallback
        CostCalculator->>PriceData: Use output_cost_per_token
        CostCalculator->>CostCalculator: Calculate at TEXT token rate
    end
    
    CostCalculator->>PriceData: Get input_cost_per_image_token
    alt Has input_cost_per_image_token
        CostCalculator->>CostCalculator: Calculate input image cost
    else Fallback
        CostCalculator->>PriceData: Use input_cost_per_token
    end
    
    CostCalculator->>CostCalculator: Sum all segments + apply multiplier
    CostCalculator-->>ResponseHandler: Return total cost
    ResponseHandler-->>Client: Billing Record
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->