### PR TITLE
feat(probe): implement dynamic endpoint probe intervals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,9 +122,16 @@ PROBE_INTERVAL_MS=30000
 PROBE_TIMEOUT_MS=5000
 
 # Provider Endpoint Probing (always enabled)
-# 功能说明：每 10 秒探测所有启用端点的速度与连通性，并刷新端点选择排序。
-# 注意：没有 ENABLE 开关，默认启用；可通过下列参数调优。
-ENDPOINT_PROBE_INTERVAL_MS=10000
+# Probes all enabled endpoints based on dynamic intervals and refreshes endpoint selection ranking.
+# Note: No ENABLE switch, enabled by default; tune via parameters below.
+#
+# Dynamic Interval Rules (in priority order):
+# 1. Timeout Override (10s): If endpoint's lastProbeErrorType === "timeout" and not recovered (lastProbeOk !== true)
+# 2. Single-Vendor (10min): If vendor has only 1 enabled endpoint
+# 3. Base Interval (default): All other endpoints
+#
+# ENDPOINT_PROBE_INTERVAL_MS controls the base interval. Single-vendor and timeout intervals are fixed.
+ENDPOINT_PROBE_INTERVAL_MS=60000
 ENDPOINT_PROBE_TIMEOUT_MS=5000
 ENDPOINT_PROBE_CONCURRENCY=10
 ENDPOINT_PROBE_CYCLE_JITTER_MS=1000

--- a/messages/en/settings/providers/strings.json
+++ b/messages/en/settings/providers/strings.json
@@ -82,6 +82,8 @@
   "probeOk": "OK",
   "probeError": "Error",
   "addEndpointDesc": "Add a new {providerType} endpoint for this vendor.",
+  "addEndpointDescGeneric": "Add a new API endpoint for this vendor.",
+  "columnType": "Type",
   "endpointUrlLabel": "URL",
   "endpointUrlPlaceholder": "https://api.example.com/v1",
   "endpointLabelOptional": "Label (optional)",

--- a/messages/ja/settings/providers/strings.json
+++ b/messages/ja/settings/providers/strings.json
@@ -82,6 +82,8 @@
   "probeOk": "OK",
   "probeError": "エラー",
   "addEndpointDesc": "このベンダーに {providerType} エンドポイントを追加します。",
+  "addEndpointDescGeneric": "このベンダーに新しい API エンドポイントを追加します。",
+  "columnType": "種類",
   "endpointUrlLabel": "URL",
   "endpointUrlPlaceholder": "https://api.example.com/v1",
   "endpointLabelOptional": "ラベル (任意)",

--- a/messages/ru/settings/providers/strings.json
+++ b/messages/ru/settings/providers/strings.json
@@ -82,6 +82,8 @@
   "probeOk": "OK",
   "probeError": "Ошибка",
   "addEndpointDesc": "Добавьте новый эндпоинт {providerType} для этого вендора.",
+  "addEndpointDescGeneric": "Добавьте новый API эндпоинт для этого вендора.",
+  "columnType": "Тип",
   "endpointUrlLabel": "URL",
   "endpointUrlPlaceholder": "https://api.example.com/v1",
   "endpointLabelOptional": "Метка (необязательно)",

--- a/messages/zh-CN/settings/providers/strings.json
+++ b/messages/zh-CN/settings/providers/strings.json
@@ -82,6 +82,8 @@
   "probeOk": "正常",
   "probeError": "异常",
   "addEndpointDesc": "为该服务商添加一个新的 {providerType} 端点。",
+  "addEndpointDescGeneric": "为该服务商添加一个新的 API 端点。",
+  "columnType": "类型",
   "endpointUrlLabel": "URL",
   "endpointUrlPlaceholder": "https://api.example.com/v1",
   "endpointLabelOptional": "标签（可选）",

--- a/messages/zh-TW/settings/providers/strings.json
+++ b/messages/zh-TW/settings/providers/strings.json
@@ -82,6 +82,8 @@
   "probeOk": "正常",
   "probeError": "異常",
   "addEndpointDesc": "為此供應商新增一個 {providerType} 端點。",
+  "addEndpointDescGeneric": "為此供應商新增一個新的 API 端點。",
+  "columnType": "類型",
   "endpointUrlLabel": "URL",
   "endpointUrlPlaceholder": "https://api.example.com/v1",
   "endpointLabelOptional": "標籤（選填）",

--- a/src/actions/provider-endpoints.ts
+++ b/src/actions/provider-endpoints.ts
@@ -21,6 +21,7 @@ import {
   deleteProviderVendor,
   findProviderEndpointById,
   findProviderEndpointProbeLogs,
+  findProviderEndpointsByVendor,
   findProviderEndpointsByVendorAndType,
   findProviderVendorById,
   findProviderVendors,
@@ -181,6 +182,30 @@ export async function getProviderEndpoints(input: {
     );
   } catch (error) {
     logger.error("getProviderEndpoints:error", error);
+    return [];
+  }
+}
+
+export async function getProviderEndpointsByVendor(input: {
+  vendorId: number;
+}): Promise<ProviderEndpoint[]> {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return [];
+    }
+
+    const parsed = z.object({ vendorId: VendorIdSchema }).safeParse(input);
+    if (!parsed.success) {
+      logger.debug("getProviderEndpointsByVendor:invalid_input", {
+        error: parsed.error,
+      });
+      return [];
+    }
+
+    return await findProviderEndpointsByVendor(parsed.data.vendorId);
+  } catch (error) {
+    logger.error("getProviderEndpointsByVendor:error", error);
     return [];
   }
 }

--- a/src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx
@@ -540,7 +540,9 @@ function AddEndpointButton({ vendorId }: { vendorId: number }) {
   const [providerType, setProviderType] = useState<ProviderType>("claude");
 
   // Get provider types for the selector (exclude claude-auth and gemini-cli which are internal)
-  const selectableTypes: ProviderType[] = ["claude", "codex", "gemini", "openai-compatible"];
+  const selectableTypes: ProviderType[] = getAllProviderTypes().filter(
+    (type) => !["claude-auth", "gemini-cli"].includes(type)
+  );
 
   useEffect(() => {
     if (!open) {

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -44,7 +44,7 @@ export {
   getDistinctProviderGroups,
   updateProvider,
 } from "./provider";
-
+export type { ProviderEndpointProbeTarget } from "./provider-endpoints";
 export {
   createProviderEndpoint,
   deleteProviderEndpointProbeLogsBeforeDateBatch,
@@ -52,6 +52,7 @@ export {
   findEnabledProviderEndpointsForProbing,
   findProviderEndpointById,
   findProviderEndpointProbeLogs,
+  findProviderEndpointsByVendor,
   findProviderEndpointsByVendorAndType,
   findProviderVendorById,
   findProviderVendors,

--- a/tests/unit/settings/providers/provider-vendor-view-circuit-ui.test.tsx
+++ b/tests/unit/settings/providers/provider-vendor-view-circuit-ui.test.tsx
@@ -29,7 +29,7 @@ const providerEndpointsActionMocks = vi.hoisted(() => ({
   addProviderEndpoint: vi.fn(async () => ({ ok: true, data: { endpoint: {} } })),
   editProviderEndpoint: vi.fn(async () => ({ ok: true, data: { endpoint: {} } })),
   getProviderEndpointProbeLogs: vi.fn(async () => ({ ok: true, data: { logs: [] } })),
-  getProviderEndpoints: vi.fn(async () => [
+  getProviderEndpointsByVendor: vi.fn(async () => [
     {
       id: 1,
       vendorId: 1,
@@ -56,21 +56,9 @@ const providerEndpointsActionMocks = vi.hoisted(() => ({
       updatedAt: "2026-01-01",
     },
   ]),
-  getVendorTypeCircuitInfo: vi.fn(async () => ({
-    ok: true,
-    data: {
-      vendorId: 1,
-      providerType: "claude",
-      circuitState: "open",
-      circuitOpenUntil: null,
-      lastFailureTime: null,
-      manualOpen: false,
-    },
-  })),
   probeProviderEndpoint: vi.fn(async () => ({ ok: true, data: { result: { ok: true } } })),
   removeProviderEndpoint: vi.fn(async () => ({ ok: true })),
   removeProviderVendor: vi.fn(async () => ({ ok: true })),
-  resetVendorTypeCircuit: vi.fn(async () => ({ ok: true })),
 }));
 vi.mock("@/actions/provider-endpoints", () => providerEndpointsActionMocks);
 
@@ -196,7 +184,7 @@ async function flushTicks(times = 3) {
   }
 }
 
-describe("ProviderVendorView: VendorTypeCircuitControl 仅在熔断时展示关闭按钮", () => {
+describe("ProviderVendorView: Endpoints table renders with type icons", () => {
   beforeEach(() => {
     queryClient = new QueryClient({
       defaultOptions: {
@@ -205,22 +193,12 @@ describe("ProviderVendorView: VendorTypeCircuitControl 仅在熔断时展示关�
       },
     });
     vi.clearAllMocks();
-    document.body.innerHTML = "";
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
   });
 
-  test("circuitState=open 时显示 Close Circuit，且不显示 Manually Open Circuit", async () => {
-    providerEndpointsActionMocks.getVendorTypeCircuitInfo.mockResolvedValueOnce({
-      ok: true,
-      data: {
-        vendorId: 1,
-        providerType: "claude",
-        circuitState: "open",
-        circuitOpenUntil: null,
-        lastFailureTime: null,
-        manualOpen: false,
-      },
-    });
-
+  test("renders endpoint URL and latency header", async () => {
     const { unmount } = renderWithProviders(
       <ProviderVendorView
         providers={[makeProviderDisplay()]}
@@ -235,31 +213,17 @@ describe("ProviderVendorView: VendorTypeCircuitControl 仅在熔断时展示关�
 
     await flushTicks(6);
 
-    expect(document.body.textContent || "").toContain("Close Circuit");
-    expect(document.body.textContent || "").not.toContain("Manually Open Circuit");
-    // Check that provider type tabs are rendered
-    expect(document.body.textContent || "").toContain("Gemini");
-    expect(document.body.textContent || "").toContain("Claude");
+    // Check that endpoint URL is rendered
+    expect(document.body.textContent || "").toContain("https://api.example.com/v1");
 
+    // Check that latency header is present
     const latencyHeader = document.querySelector('th[class*="w-[220px]"]');
     expect(latencyHeader?.textContent || "").toContain("Latency");
 
     unmount();
   });
 
-  test("circuitState=closed 时不显示 Close Circuit，也不显示 Manually Open Circuit", async () => {
-    providerEndpointsActionMocks.getVendorTypeCircuitInfo.mockResolvedValueOnce({
-      ok: true,
-      data: {
-        vendorId: 1,
-        providerType: "claude",
-        circuitState: "closed",
-        circuitOpenUntil: null,
-        lastFailureTime: null,
-        manualOpen: false,
-      },
-    });
-
+  test("renders type column header", async () => {
     const { unmount } = renderWithProviders(
       <ProviderVendorView
         providers={[makeProviderDisplay()]}
@@ -274,14 +238,8 @@ describe("ProviderVendorView: VendorTypeCircuitControl 仅在熔断时展示关�
 
     await flushTicks(6);
 
-    expect(document.body.textContent || "").not.toContain("Close Circuit");
-    expect(document.body.textContent || "").not.toContain("Manually Open Circuit");
-    // Check that provider type tabs are rendered
-    expect(document.body.textContent || "").toContain("Gemini");
-    expect(document.body.textContent || "").toContain("Claude");
-
-    const latencyHeader = document.querySelector('th[class*="w-[220px]"]');
-    expect(latencyHeader?.textContent || "").toContain("Latency");
+    // Check that type column header is present
+    expect(document.body.textContent || "").toContain("Type");
 
     unmount();
   });
@@ -296,7 +254,9 @@ describe("ProviderVendorView vendor list", () => {
       },
     });
     vi.clearAllMocks();
-    document.body.innerHTML = "";
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
   });
 
   test("vendors with zero providers are hidden", async () => {
@@ -341,7 +301,9 @@ describe("ProviderVendorView endpoints table", () => {
       },
     });
     vi.clearAllMocks();
-    document.body.innerHTML = "";
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild);
+    }
   });
 
   test("renders endpoints and toggles enabled status", async () => {


### PR DESCRIPTION
## Summary

Implement dynamic per-endpoint probe intervals with three-tier priority system to optimize probe frequency based on endpoint context:
- **Base interval**: 60s (configurable via `ENDPOINT_PROBE_INTERVAL_MS`)
- **Single-endpoint vendor**: 10min (reduces unnecessary probing when no failover is possible)
- **Timeout override**: 10s (faster recovery for endpoints experiencing timeout errors)

Additionally, simplify the provider vendor UI by removing type tabs and showing all endpoints in a unified table with type icons.

## Problem

**Related Issues:**
- Fixes #660 - Users requested configurable probe frequency to reduce unnecessary health checks when not using multi-endpoint failover

**Related PRs:**
- Follow-up to #608 - Builds on the vendor-endpoint architecture
- Follow-up to #636 - Complements the probe logging improvements

The original probe scheduler used a fixed 10s interval for all endpoints regardless of context. This caused:
1. **Excessive probing for single-endpoint vendors** - No benefit from frequent probes when there is no failover target
2. **Slow recovery for timeout errors** - Endpoints with timeout issues needed faster re-probing to detect recovery
3. **Unnecessary resource usage** - Probing endpoints that do not need frequent checks

## Solution

Implement a dynamic interval calculation system with priority-based rules:

| Priority | Condition | Interval | Rationale |
|----------|-----------|----------|-----------|
| 1 (Highest) | `lastProbeErrorType === "timeout"` AND `lastProbeOk \!== true` | 10s | Fast recovery detection for timeout errors |
| 2 | Vendor has only 1 enabled endpoint | 10min | No failover benefit, reduce unnecessary probes |
| 3 (Default) | All other endpoints | 60s (configurable) | Standard monitoring interval |

The scheduler now uses a tick-based approach where it runs at the shortest interval (10s) but only probes endpoints that are "due" based on their effective interval.

## Changes

### Core Changes
- `src/lib/provider-endpoints/probe-scheduler.ts`: Dynamic interval calculation with `getEffectiveIntervalMs()` and `filterDueEndpoints()` functions
- `src/repository/provider-endpoints.ts`: Extended `ProviderEndpointProbeTarget` type to include `vendorId` and `lastProbeErrorType`; added `findProviderEndpointsByVendor()` function

### UI Changes
- `src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx`:
  - Remove type tabs from VendorEndpointsSection, show all endpoints in unified table
  - Add type icon column with tooltip for each endpoint
  - Sort endpoints by type order then sortOrder
  - Add type selector in AddEndpointButton dialog
  - Remove VendorTypeCircuitControl component (circuit breaker UI removed)

### Supporting Changes
- `src/actions/provider-endpoints.ts`: Add `getProviderEndpointsByVendor()` action
- `src/repository/index.ts`: Export new type and function
- `.env.example`: Update default interval to 60s with documentation for dynamic rules
- i18n: Add `addEndpointDescGeneric` and `columnType` keys for all 5 languages

## Breaking Changes

| Change | Impact | Migration |
|--------|--------|-----------|
| Default `ENDPOINT_PROBE_INTERVAL_MS` changed from 10s to 60s | Existing deployments will probe less frequently | No action needed; set `ENDPOINT_PROBE_INTERVAL_MS=10000` to restore old behavior |
| `getEndpointProbeSchedulerStatus()` return type changed | Code using this function needs update | Update to use new interval fields (`baseIntervalMs`, `singleVendorIntervalMs`, `timeoutOverrideIntervalMs`, `tickIntervalMs`) |

## Testing

### Automated Tests
- [x] 8 probe scheduler tests pass (6 new tests for dynamic interval rules)
- [x] UI tests updated for new endpoint table structure
- [x] TypeScript type check passes
- [x] Production build succeeds

### Test Coverage for Dynamic Intervals
- Default 60s interval for multi-endpoint vendors
- 10min interval for single-endpoint vendors
- 10s timeout override takes priority over single-vendor interval
- Recovered endpoints (lastProbeOk=true) revert to normal interval
- Never-probed endpoints (lastProbedAt=null) are always due

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] i18n strings added for all 5 languages

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements a well-designed dynamic probe interval system that intelligently adjusts endpoint health check frequency based on context. The implementation uses a three-tier priority system: timeout errors trigger 10s fast recovery checks, single-endpoint vendors get 10min reduced frequency (no failover benefit), and multi-endpoint vendors use the configurable base interval (default 60s). 

Key improvements:
- Reduces unnecessary resource usage for single-endpoint vendors (10min vs 60s)
- Enables faster recovery detection for timeout errors (10s override)
- Maintains responsive monitoring for multi-endpoint failover scenarios (60s)
- Uses tick-based scheduling at 10s to support the fastest interval while only probing due endpoints
- Comprehensive test coverage with 6 new test cases validating all priority rules

The UI changes simplify the provider vendor interface by removing type tabs and presenting all endpoints in a unified table with type icons, making it easier to view and manage endpoints across different provider types. The change is backwards-compatible with clear migration guidance in the PR description.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no significant issues found
- The implementation is well-architected with clear separation of concerns, comprehensive test coverage validates all dynamic interval rules, proper error handling and boundary conditions are covered, and the UI changes are straightforward refactoring with no logic errors
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/provider-endpoints/probe-scheduler.ts | Implements dynamic probe intervals with three-tier priority system (timeout override 10s, single-vendor 10min, base 60s); logic is sound and well-tested |
| src/repository/provider-endpoints.ts | Extended ProviderEndpointProbeTarget type to include vendorId and lastProbeErrorType; added findProviderEndpointsByVendor function |
| src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx | Removed type tabs, unified endpoint table with type icons, added type selector to AddEndpointButton; proper sorting by type order then sortOrder |
| tests/unit/lib/provider-endpoints/probe-scheduler.test.ts | Added comprehensive test coverage for all dynamic interval rules with 6 new test cases covering priority logic |
| .env.example | Updated default interval to 60s with clear documentation explaining dynamic interval rules and priorities |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Scheduler as Probe Scheduler
    participant DB as Database
    participant Lock as Leader Lock
    participant Probe as Probe Function
    
    Note over Scheduler: Timer triggers every TICK_INTERVAL_MS (10s)
    
    Scheduler->>Lock: Acquire/renew leader lock
    alt Not leader
        Lock-->>Scheduler: Lock failed
        Note over Scheduler: Exit early (another instance is leader)
    end
    
    Scheduler->>DB: findEnabledProviderEndpointsForProbing()
    DB-->>Scheduler: Return all enabled endpoints with vendorId, lastProbeErrorType
    
    Note over Scheduler: countEndpointsByVendor()
    Note over Scheduler: Calculate vendor endpoint counts
    
    loop For each endpoint
        alt Never probed (lastProbedAt === null)
            Note over Scheduler: Always due for probing
        else Has timeout error (lastProbeErrorType === "timeout" && lastProbeOk !== true)
            Note over Scheduler: Use 10s timeout override interval
        else Single-endpoint vendor (count === 1)
            Note over Scheduler: Use 10min single-vendor interval
        else Multi-endpoint vendor
            Note over Scheduler: Use 60s base interval
        end
        
        Note over Scheduler: Check if (now >= lastProbedAt + effectiveInterval)
    end
    
    Note over Scheduler: Filter to due endpoints only
    
    alt No due endpoints
        Scheduler-->>Scheduler: Exit early
    end
    
    Note over Scheduler: Shuffle due endpoints
    
    par Concurrent probing (up to CONCURRENCY workers)
        Scheduler->>Probe: probeProviderEndpointAndRecordByEndpoint()
        Probe->>DB: Update endpoint probe results
        DB-->>Probe: Success
        Probe-->>Scheduler: Complete
    and Worker 2
        Scheduler->>Probe: probeProviderEndpointAndRecordByEndpoint()
        Probe->>DB: Update endpoint probe results
    and Worker N
        Scheduler->>Probe: probeProviderEndpointAndRecordByEndpoint()
        Probe->>DB: Update endpoint probe results
    end
    
    Note over Scheduler: Wait 10s until next tick
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->