### PR TITLE
fix: support Responses input string shortcut

### DIFF
--- a/tests/unit/proxy/chat-completions-handler-guard-pipeline.test.ts
+++ b/tests/unit/proxy/chat-completions-handler-guard-pipeline.test.ts
@@ -415,6 +415,45 @@ describe("handleChatCompletions：必须走 GuardPipeline", () => {
     ]);
   });
 
+  test("Response(input) 支持 input 为 string（OpenAI shortcut）", async () => {
+    h.session = createSession({
+      model: "gpt-4.1-mini",
+      input: "hi",
+      stream: false,
+    });
+
+    const { handleChatCompletions } = await import("@/app/v1/_lib/codex/chat-completions-handler");
+    const res = await handleChatCompletions({} as any);
+
+    expect(res.status).toBe(200);
+    expect(h.session.originalFormat).toBe("response");
+    expect((h.session.request.message as any).input).toEqual([
+      {
+        role: "user",
+        content: [{ type: "input_text", text: "hi" }],
+      },
+    ]);
+    expect(h.callOrder).toEqual([
+      "auth",
+      "sensitive",
+      "client",
+      "model",
+      "version",
+      "probe",
+      "session",
+      "warmup",
+      "requestFilter",
+      "rateLimit",
+      "provider",
+      "providerRequestFilter",
+      "messageContext",
+      "concurrencyInc",
+      "forward",
+      "dispatch",
+      "concurrencyDec",
+    ]);
+  });
+
   test("当 sessionId 未分配时，不应进行并发计数（覆盖分支）", async () => {
     h.assignSessionId = false;
     h.session = createSession({


### PR DESCRIPTION
## Summary
Fix `/v1/responses` OpenAI-compatible parsing to accept `input` as a string shortcut and normalize it to standard `input[]` before the guard pipeline.

## Problem
Some OpenAI-compatible clients send requests with a string shortcut format:
```json
{"model": "...", "input": "hi"}
```

Previously, this was rejected and treated as missing required fields, while other gateways accept this format.

## Solution
Added `normalizeResponseInput()` function that:
1. Converts string input to standard array format:
   ```json
   "input": "hello" → [{ "role": "user", "content": [{ "type": "input_text", "text": "hello" }] }]
   ```
2. Wraps single object input into an array for compatibility
3. Handles empty strings by converting to empty array

## Changes

### Core Changes
- `src/app/v1/_lib/codex/chat-completions-handler.ts` (+35/-1)
  - Added `normalizeResponseInput()` function for input format normalization
  - Updated format detection to recognize string and object inputs as valid Response API format
  - Call normalization before downstream guards/filters

### Tests
- `tests/unit/proxy/chat-completions-handler-guard-pipeline.test.ts` (+39/-0)
  - Added test case for string input shortcut support

## Testing

### Automated Tests
- [x] Unit tests added

### Manual Testing
```bash
bun run typecheck
bun run test -- tests/unit/proxy/chat-completions-handler-guard-pipeline.test.ts
```

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No behavior change for existing `input: [...]` requests

---
*Description enhanced by Claude AI*