### PR TITLE
fix(proxy): add OpenAI chat completion format support in usage extraction

### DIFF
--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -1193,6 +1193,13 @@ function extractUsageMetrics(value: unknown): UsageMetrics | null {
     result.output_tokens = usage.candidatesTokenCount;
     hasAny = true;
   }
+
+  // OpenAI chat completion format: prompt_tokens → input_tokens
+  // Priority: Claude (input_tokens) > Gemini (promptTokenCount) > OpenAI (prompt_tokens)
+  if (result.input_tokens === undefined && typeof usage.prompt_tokens === "number") {
+    result.input_tokens = usage.prompt_tokens;
+    hasAny = true;
+  }
   // Gemini 缓存支持
   if (typeof usage.cachedContentTokenCount === "number") {
     result.cache_read_input_tokens = usage.cachedContentTokenCount;
@@ -1275,6 +1282,13 @@ function extractUsageMetrics(value: unknown): UsageMetrics | null {
   // 通常存在 output_tokens的时候，thoughtsTokenCount=0
   if (typeof usage.thoughtsTokenCount === "number" && usage.thoughtsTokenCount > 0) {
     result.output_tokens = (result.output_tokens ?? 0) + usage.thoughtsTokenCount;
+    hasAny = true;
+  }
+
+  // OpenAI chat completion format: completion_tokens → output_tokens
+  // Priority: Claude (output_tokens) > Gemini (candidatesTokenCount/thoughtsTokenCount) > OpenAI (completion_tokens)
+  if (result.output_tokens === undefined && typeof usage.completion_tokens === "number") {
+    result.output_tokens = usage.completion_tokens;
     hasAny = true;
   }
 


### PR DESCRIPTION
## Summary
Fixes OpenAI chat completion format token usage extraction bug where `prompt_tokens`/`completion_tokens` were not being extracted, resulting in 0 cost/token display.

**Related Issues:**
- Fixes #705 - OpenAI compatible interface token billing not working
- Closes #700 - Duplicate issue reported by another user

## Problem
When using the `/v1/chat/completions` endpoint with OpenAI-compatible providers, the system failed to extract token usage from responses, causing:
- Usage dashboard showing 0 tokens
- Cost calculation showing $0.00
- Missing billing data despite successful API calls

**Root Cause:**
The `extractUsageMetrics` function (`response-handler.ts:1193-1468`) only handled:
1. **Claude format**: `input_tokens`, `output_tokens`
2. **Gemini format**: `promptTokenCount`, `candidatesTokenCount`

But **OpenAI chat completion format** uses `prompt_tokens`/`completion_tokens`, which were never extracted. This affected both JSON responses and SSE streaming (where usage appears in the final chunk).

## Solution
Enhanced `extractUsageMetrics` to support OpenAI format with **priority-based extraction**:
- Priority: Claude format > Gemini format > OpenAI format
- Added extraction for `prompt_tokens` → `input_tokens` (if `input_tokens` undefined)
- Added extraction for `completion_tokens` → `output_tokens` (if `output_tokens` undefined)

This ensures Claude and Gemini formats take precedence when present, while OpenAI format serves as fallback.

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/response-handler.ts` (+14 lines)
  - Added OpenAI `prompt_tokens` extraction at line 1199-1202
  - Added OpenAI `completion_tokens` extraction at line 1288-1291
  - Preserves existing format priority (Claude > Gemini > OpenAI)

### Testing
- `tests/unit/proxy/extract-usage-metrics.test.ts` (+82 lines)
  - 5 new test cases for OpenAI format:
    1. Basic `prompt_tokens`/`completion_tokens` extraction
    2. Format priority verification (Claude takes precedence)
    3. SSE streaming with usage in final chunk
    4. `completion_tokens_details` handling
    5. Individual field extraction

## Test Results
- ✅ All 43 unit tests pass
- ✅ TypeCheck passes
- ✅ Build succeeds
- ✅ New test coverage: 5 test cases covering OpenAI format edge cases

## Verification
Tested with actual OpenAI-compatible provider response (from Issue #705):
```json
{
  "usage": {
    "completion_tokens": 57,
    "total_tokens": 123,
    "prompt_tokens": 66,
    "completion_tokens_details": {
      "reasoning_tokens": 0
    }
  }
}
```
✅ Now correctly extracts `input_tokens: 66`, `output_tokens: 57`

---
Generated with [Claude Code](https://claude.ai/code)
*Description enhanced by Claude AI PR Agent*
