### PR TITLE
fix: bound SessionTracker active_sessions zsets by env TTL

### DIFF
--- a/src/lib/rate-limit/service.ts
+++ b/src/lib/rate-limit/service.ts
@@ -91,7 +91,10 @@ import {
   normalizeResetTime,
 } from "./time-utils";
 
-const SESSION_TTL_SECONDS = parseInt(process.env.SESSION_TTL || "300", 10);
+const SESSION_TTL_SECONDS = (() => {
+  const parsed = Number.parseInt(process.env.SESSION_TTL ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 300;
+})();
 const SESSION_TTL_MS = SESSION_TTL_SECONDS * 1000;
 
 interface CostLimit {

--- a/tests/unit/lib/session-tracker-cleanup.test.ts
+++ b/tests/unit/lib/session-tracker-cleanup.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let redisClientRef: any;
+const pipelineCalls: Array<unknown[]> = [];
+
+const makePipeline = () => {
+  const pipeline = {
+    zadd: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["zadd", ...args]);
+      return pipeline;
+    }),
+    expire: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["expire", ...args]);
+      return pipeline;
+    }),
+    setex: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["setex", ...args]);
+      return pipeline;
+    }),
+    zremrangebyscore: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["zremrangebyscore", ...args]);
+      return pipeline;
+    }),
+    zrange: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["zrange", ...args]);
+      return pipeline;
+    }),
+    exists: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["exists", ...args]);
+      return pipeline;
+    }),
+    exec: vi.fn(async () => {
+      pipelineCalls.push(["exec"]);
+      return [];
+    }),
+  };
+  return pipeline;
+};
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/redis", () => ({
+  getRedisClient: () => redisClientRef,
+}));
+
+describe("SessionTracker - TTL and cleanup", () => {
+  const nowMs = 1_700_000_000_000;
+  const ORIGINAL_SESSION_TTL = process.env.SESSION_TTL;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    pipelineCalls.length = 0;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(nowMs));
+
+    redisClientRef = {
+      status: "ready",
+      exists: vi.fn(async () => 1),
+      type: vi.fn(async () => "zset"),
+      del: vi.fn(async () => 1),
+      zremrangebyscore: vi.fn(async () => 0),
+      zrange: vi.fn(async () => []),
+      pipeline: vi.fn(() => makePipeline()),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (ORIGINAL_SESSION_TTL === undefined) {
+      delete process.env.SESSION_TTL;
+    } else {
+      process.env.SESSION_TTL = ORIGINAL_SESSION_TTL;
+    }
+  });
+
+  describe("env-driven TTL", () => {
+    it("should use SESSION_TTL env (seconds) converted to ms for cutoff calculation", async () => {
+      // Set SESSION_TTL to 600 seconds (10 minutes)
+      process.env.SESSION_TTL = "600";
+
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.getGlobalSessionCount();
+
+      // Should call zremrangebyscore with cutoff = now - 600*1000 = now - 600000
+      const expectedCutoff = nowMs - 600 * 1000;
+      expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
+        "global:active_sessions",
+        "-inf",
+        expectedCutoff
+      );
+    });
+
+    it("should default to 300 seconds (5 min) when SESSION_TTL not set", async () => {
+      delete process.env.SESSION_TTL;
+
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.getGlobalSessionCount();
+
+      // Default: 300 seconds = 300000 ms
+      const expectedCutoff = nowMs - 300 * 1000;
+      expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
+        "global:active_sessions",
+        "-inf",
+        expectedCutoff
+      );
+    });
+  });
+
+  describe("refreshSession - provider ZSET EXPIRE", () => {
+    it("should set EXPIRE on provider ZSET with fallback TTL 3600", async () => {
+      process.env.SESSION_TTL = "300";
+
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.refreshSession("sess-123", 1, 42);
+
+      // Check pipeline calls include expire for provider ZSET
+      const providerExpireCall = pipelineCalls.find(
+        (call) => call[0] === "expire" && String(call[1]).includes("provider:42:active_sessions")
+      );
+      expect(providerExpireCall).toBeDefined();
+      expect(providerExpireCall![2]).toBe(3600); // fallback TTL
+    });
+
+    it("should refresh session binding TTLs using env SESSION_TTL (not hardcoded 300)", async () => {
+      process.env.SESSION_TTL = "600"; // 10 minutes
+
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.refreshSession("sess-123", 1, 42);
+
+      // Check expire calls for session bindings use 600 (env value), not 300
+      const providerBindingExpire = pipelineCalls.find(
+        (call) => call[0] === "expire" && String(call[1]) === "session:sess-123:provider"
+      );
+      const keyBindingExpire = pipelineCalls.find(
+        (call) => call[0] === "expire" && String(call[1]) === "session:sess-123:key"
+      );
+      const lastSeenSetex = pipelineCalls.find(
+        (call) => call[0] === "setex" && String(call[1]) === "session:sess-123:last_seen"
+      );
+
+      expect(providerBindingExpire).toBeDefined();
+      expect(providerBindingExpire![2]).toBe(600);
+
+      expect(keyBindingExpire).toBeDefined();
+      expect(keyBindingExpire![2]).toBe(600);
+
+      expect(lastSeenSetex).toBeDefined();
+      expect(lastSeenSetex![2]).toBe(600);
+    });
+  });
+
+  describe("refreshSession - probabilistic cleanup on write path", () => {
+    it("should perform ZREMRANGEBYSCORE cleanup when probability gate hits", async () => {
+      process.env.SESSION_TTL = "300";
+
+      // Mock Math.random to always return 0 (below default 0.01 threshold)
+      vi.spyOn(Math, "random").mockReturnValue(0);
+
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.refreshSession("sess-123", 1, 42);
+
+      // Should have zremrangebyscore call for provider ZSET cleanup
+      const cleanupCall = pipelineCalls.find(
+        (call) =>
+          call[0] === "zremrangebyscore" && String(call[1]).includes("provider:42:active_sessions")
+      );
+      expect(cleanupCall).toBeDefined();
+
+      // Cutoff should be now - SESSION_TTL_MS
+      const expectedCutoff = nowMs - 300 * 1000;
+      expect(cleanupCall![2]).toBe("-inf");
+      expect(cleanupCall![3]).toBe(expectedCutoff);
+    });
+
+    it("should skip cleanup when probability gate does not hit", async () => {
+      process.env.SESSION_TTL = "300";
+
+      // Mock Math.random to return 0.5 (above default 0.01 threshold)
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.refreshSession("sess-123", 1, 42);
+
+      // Should NOT have zremrangebyscore call
+      const cleanupCall = pipelineCalls.find((call) => call[0] === "zremrangebyscore");
+      expect(cleanupCall).toBeUndefined();
+    });
+
+    it("should use env-driven TTL for cleanup cutoff calculation", async () => {
+      process.env.SESSION_TTL = "600"; // 10 minutes
+
+      vi.spyOn(Math, "random").mockReturnValue(0);
+
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.refreshSession("sess-123", 1, 42);
+
+      const cleanupCall = pipelineCalls.find(
+        (call) =>
+          call[0] === "zremrangebyscore" && String(call[1]).includes("provider:42:active_sessions")
+      );
+      expect(cleanupCall).toBeDefined();
+
+      // Cutoff should be now - 600*1000
+      const expectedCutoff = nowMs - 600 * 1000;
+      expect(cleanupCall![3]).toBe(expectedCutoff);
+    });
+  });
+
+  describe("countFromZSet - env-driven TTL", () => {
+    it("should use env SESSION_TTL for cleanup cutoff in batch count", async () => {
+      process.env.SESSION_TTL = "600";
+
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      // getProviderSessionCountBatch uses SESSION_TTL internally
+      await SessionTracker.getProviderSessionCountBatch([1, 2]);
+
+      // Check pipeline zremrangebyscore calls use correct cutoff
+      const cleanupCalls = pipelineCalls.filter((call) => call[0] === "zremrangebyscore");
+      expect(cleanupCalls.length).toBeGreaterThan(0);
+
+      const expectedCutoff = nowMs - 600 * 1000;
+      for (const call of cleanupCalls) {
+        expect(call[3]).toBe(expectedCutoff);
+      }
+    });
+  });
+
+  describe("getActiveSessions - env-driven TTL", () => {
+    it("should use env SESSION_TTL for cleanup cutoff", async () => {
+      process.env.SESSION_TTL = "600";
+
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.getActiveSessions();
+
+      const expectedCutoff = nowMs - 600 * 1000;
+      expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
+        "global:active_sessions",
+        "-inf",
+        expectedCutoff
+      );
+    });
+  });
+
+  describe("Fail-Open behavior", () => {
+    it("refreshSession should not throw when Redis is not ready", async () => {
+      redisClientRef.status = "end";
+
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await expect(SessionTracker.refreshSession("sess-123", 1, 42)).resolves.toBeUndefined();
+    });
+
+    it("refreshSession should not throw when Redis is null", async () => {
+      redisClientRef = null;
+
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await expect(SessionTracker.refreshSession("sess-123", 1, 42)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/lib/session-ttl-validation.test.ts
+++ b/tests/unit/lib/session-ttl-validation.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for SESSION_TTL environment variable validation
+ *
+ * These tests verify that invalid SESSION_TTL values (NaN, 0, negative)
+ * are properly handled with fallback to default 300 seconds.
+ */
+
+let redisClientRef: any;
+const pipelineCalls: Array<unknown[]> = [];
+
+const makePipeline = () => {
+  const pipeline = {
+    zadd: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["zadd", ...args]);
+      return pipeline;
+    }),
+    expire: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["expire", ...args]);
+      return pipeline;
+    }),
+    setex: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["setex", ...args]);
+      return pipeline;
+    }),
+    zremrangebyscore: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["zremrangebyscore", ...args]);
+      return pipeline;
+    }),
+    zrange: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["zrange", ...args]);
+      return pipeline;
+    }),
+    exists: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["exists", ...args]);
+      return pipeline;
+    }),
+    exec: vi.fn(async () => {
+      pipelineCalls.push(["exec"]);
+      return [];
+    }),
+  };
+  return pipeline;
+};
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/redis", () => ({
+  getRedisClient: () => redisClientRef,
+}));
+
+describe("SESSION_TTL environment variable validation", () => {
+  const nowMs = 1_700_000_000_000;
+  const ORIGINAL_SESSION_TTL = process.env.SESSION_TTL;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    pipelineCalls.length = 0;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(nowMs));
+
+    redisClientRef = {
+      status: "ready",
+      exists: vi.fn(async () => 1),
+      type: vi.fn(async () => "zset"),
+      del: vi.fn(async () => 1),
+      zremrangebyscore: vi.fn(async () => 0),
+      zrange: vi.fn(async () => []),
+      pipeline: vi.fn(() => makePipeline()),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (ORIGINAL_SESSION_TTL === undefined) {
+      delete process.env.SESSION_TTL;
+    } else {
+      process.env.SESSION_TTL = ORIGINAL_SESSION_TTL;
+    }
+  });
+
+  describe("SessionTracker TTL parsing", () => {
+    it("should use default 300 when SESSION_TTL is empty string", async () => {
+      process.env.SESSION_TTL = "";
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.getGlobalSessionCount();
+
+      // Default: 300 seconds = 300000 ms
+      const expectedCutoff = nowMs - 300 * 1000;
+      expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
+        "global:active_sessions",
+        "-inf",
+        expectedCutoff
+      );
+    });
+
+    it("should use default 300 when SESSION_TTL is NaN", async () => {
+      process.env.SESSION_TTL = "not-a-number";
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.getGlobalSessionCount();
+
+      const expectedCutoff = nowMs - 300 * 1000;
+      expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
+        "global:active_sessions",
+        "-inf",
+        expectedCutoff
+      );
+    });
+
+    it("should use default 300 when SESSION_TTL is 0", async () => {
+      process.env.SESSION_TTL = "0";
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.getGlobalSessionCount();
+
+      const expectedCutoff = nowMs - 300 * 1000;
+      expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
+        "global:active_sessions",
+        "-inf",
+        expectedCutoff
+      );
+    });
+
+    it("should use default 300 when SESSION_TTL is negative", async () => {
+      process.env.SESSION_TTL = "-100";
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.getGlobalSessionCount();
+
+      const expectedCutoff = nowMs - 300 * 1000;
+      expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
+        "global:active_sessions",
+        "-inf",
+        expectedCutoff
+      );
+    });
+
+    it("should use provided value when SESSION_TTL is valid positive integer", async () => {
+      process.env.SESSION_TTL = "600";
+      const { SessionTracker } = await import("@/lib/session-tracker");
+
+      await SessionTracker.getGlobalSessionCount();
+
+      // Custom: 600 seconds = 600000 ms
+      const expectedCutoff = nowMs - 600 * 1000;
+      expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
+        "global:active_sessions",
+        "-inf",
+        expectedCutoff
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Align SessionTracker ZSET cleanup + session binding TTL refresh with env `SESSION_TTL` (seconds; default 300)
- Ensure `provider:*:active_sessions` gets a fallback `EXPIRE 3600` on the hot write path (`SessionTracker.refreshSession`) to avoid TTL=-1 keys
- Add low-overhead write-path stale member cleanup (1% probabilistic `ZREMRANGEBYSCORE` in `refreshSession`)
- Align provider concurrency Lua cleanup window with env `SESSION_TTL` by passing `ttlMs` into `CHECK_AND_TRACK_SESSION` (backward compatible: defaults to 300000ms when omitted)

## Testing

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`

Closes #714

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

- Plumbs env-derived `SESSION_TTL` into both SessionTracker and the provider concurrency Lua script so cleanup windows and binding TTL refreshes match configuration.
- Updates `CHECK_AND_TRACK_SESSION` to accept optional `ttlMs`, guard invalid TTL, and set provider ZSET expiry based on `max(3600, ttl_seconds)`.
- Adds a low-overhead probabilistic write-path cleanup for provider active session ZSETs.
- Introduces unit tests covering TTL parsing/validation, expiry behavior, and passing `ttlMs` into Lua.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Moderately safe to merge, but verify active_sessions ZSETs cannot be left without TTL on the refresh hot path.
- Core TTL parsing/propagation looks consistent and covered by tests, and the Lua guard prevents catastrophic cleanup on invalid TTL. Main remaining concern is that refreshSession only expires the provider active-sessions ZSET, which can contradict the stated goal of preventing TTL=-1 leaks for other active-sessions keys depending on call paths.
- src/lib/session-tracker.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/rate-limit/service.ts | Passes env-derived SESSION_TTL_MS into CHECK_AND_TRACK_SESSION Lua script as ARGV[4] to align provider concurrency cleanup window with session TTL. |
| src/lib/redis/lua-scripts.ts | CHECK_AND_TRACK_SESSION now accepts optional ttlMs (ARGV[4]), guards invalid TTL, and sets EXPIRE based on max(3600, ttl_seconds) instead of a fixed 1h. |
| src/lib/session-tracker.ts | Uses env SESSION_TTL for binding TTL refresh and adds probabilistic provider ZSET cleanup + provider ZSET EXPIRE; verify other active_sessions ZSETs cannot end up TTL=-1 via refresh path. |
| tests/unit/lib/rate-limit/service-extra.test.ts | Adds unit test asserting RateLimitService.checkAndTrackProviderSession passes ttlMs as ARGV[4] to Redis eval. |
| tests/unit/lib/session-tracker-cleanup.test.ts | New tests for env-driven SESSION_TTL cutoff calculations, provider ZSET expiry behavior, probabilistic write-path cleanup, and fail-open behavior. |
| tests/unit/lib/session-ttl-validation.test.ts | New tests verifying invalid SESSION_TTL values fall back to default 300s and valid values are honored. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  autonumber
  participant App as Request handler
  participant ST as SessionTracker
  participant R as Redis
  participant RLS as RateLimitService
  participant Lua as CHECK_AND_TRACK_SESSION (Lua)

  App->>RLS: checkAndTrackProviderSession(providerId, sessionId, limit)
  RLS->>R: EVAL(script, key, sessionId, limit, nowMs, ttlMs)
  R->>Lua: run script
  Lua->>R: ZREMRANGEBYSCORE(providerZset, -inf, now-ttlMs)
  Lua->>R: ZSCORE / ZCARD
  Lua->>R: ZADD(providerZset, now, sessionId)
  Lua->>R: EXPIRE(providerZset, max(3600, ttlMs/1000))
  Lua-->>RLS: {allowed, count, tracked}
  RLS-->>App: allow/deny

  App->>ST: refreshSession(sessionId, keyId, providerId, userId?)
  ST->>R: PIPELINE zadd global/key/provider/user ZSETs
  ST->>R: PIPELINE expire providerZset
  ST->>R: PIPELINE expire session bindings + setex last_seen
  alt probabilistic cleanup (1%)
    ST->>R: PIPELINE zremrangebyscore(providerZset, -inf, now-ttlMs)
  end
  R-->>ST: pipeline exec results
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->