### PR TITLE
fix(proxy): prevent stuck requesting on upstream non-ok body hang

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -2830,7 +2830,7 @@ export class ProxyForwarder {
       // 将 Gunzip 流转换为 Web 流（容错版本）
       bodyStream = ProxyForwarder.nodeStreamToWebStreamSafe(gunzip, providerId, providerName);
 
-      // 移�� content-encoding 和 content-length（避免下游再解压或使用错误长度）
+      // 移除 content-encoding 和 content-length（避免下游再解压或使用错误长度）
       responseHeaders.delete("content-encoding");
       responseHeaders.delete("content-length");
     } else {

--- a/src/repository/provider-endpoints.ts
+++ b/src/repository/provider-endpoints.ts
@@ -370,11 +370,15 @@ export async function deleteProviderEndpointProbeLogsBeforeDateBatch(input: {
   batchSize?: number;
 }): Promise<number> {
   const batchSize = input.batchSize ?? 10_000;
+  // ⚠️ 兼容性：某些运行时/驱动组合会把 Date 参数序列化成
+  // "Mon Feb ... GMT+0800 (China Standard Time)" 这类字符串，Postgres 无法解析（time zone not recognized）。
+  // 统一转为 ISO-8601，并显式 cast 为 timestamptz，避免清理任务异常导致日志堆积。
+  const beforeDateIso = input.beforeDate.toISOString();
 
   const result = await db.execute(sql`
     WITH ids_to_delete AS (
       SELECT id FROM provider_endpoint_probe_logs
-      WHERE created_at < ${input.beforeDate}
+      WHERE created_at < ${beforeDateIso}::timestamptz
       ORDER BY created_at ASC
       LIMIT ${batchSize}
       FOR UPDATE SKIP LOCKED

--- a/src/repository/provider-endpoints.ts
+++ b/src/repository/provider-endpoints.ts
@@ -378,7 +378,7 @@ export async function deleteProviderEndpointProbeLogsBeforeDateBatch(input: {
   const result = await db.execute(sql`
     WITH ids_to_delete AS (
       SELECT id FROM provider_endpoint_probe_logs
-      WHERE created_at < ${beforeDateIso}::timestamptz
+      WHERE created_at < CAST(${beforeDateIso} AS timestamptz)
       ORDER BY created_at ASC
       LIMIT ${batchSize}
       FOR UPDATE SKIP LOCKED

--- a/src/repository/provider-endpoints.ts
+++ b/src/repository/provider-endpoints.ts
@@ -370,7 +370,7 @@ export async function deleteProviderEndpointProbeLogsBeforeDateBatch(input: {
   batchSize?: number;
 }): Promise<number> {
   const batchSize = input.batchSize ?? 10_000;
-  // ⚠️ 兼容性：某些运行时/驱动组合会把 Date 参数序列化成
+  // Note: 兼容性：某些运行时/驱动组合会把 Date 参数序列化成
   // "Mon Feb ... GMT+0800 (China Standard Time)" 这类字符串，Postgres 无法解析（time zone not recognized）。
   // 统一转为 ISO-8601，并显式 cast 为 timestamptz，避免清理任务异常导致日志堆积。
   const beforeDateIso = input.beforeDate.toISOString();

--- a/tests/unit/proxy/proxy-forwarder-nonok-body-hang.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-nonok-body-hang.test.ts
@@ -1,0 +1,209 @@
+import { createServer, type Server } from "node:http";
+import { describe, expect, test, vi } from "vitest";
+import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
+import { ProxyError } from "@/app/v1/_lib/proxy/errors";
+import { ProxySession } from "@/app/v1/_lib/proxy/session";
+import type { Provider } from "@/types/provider";
+
+const mocks = vi.hoisted(() => {
+  return {
+    isHttp2Enabled: vi.fn(async () => false),
+  };
+});
+
+vi.mock("@/lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/config")>();
+  return {
+    ...actual,
+    isHttp2Enabled: mocks.isHttp2Enabled,
+  };
+});
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    trace: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+function createProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    id: 1,
+    name: "p1",
+    url: "http://127.0.0.1:1",
+    key: "k",
+    providerVendorId: null,
+    isEnabled: true,
+    weight: 1,
+    priority: 0,
+    groupPriorities: null,
+    costMultiplier: 1,
+    groupTag: null,
+    providerType: "openai-compatible",
+    preserveClientIp: false,
+    modelRedirects: null,
+    allowedModels: null,
+    mcpPassthroughType: "none",
+    mcpPassthroughUrl: null,
+    limit5hUsd: null,
+    limitDailyUsd: null,
+    dailyResetMode: "fixed",
+    dailyResetTime: "00:00",
+    limitWeeklyUsd: null,
+    limitMonthlyUsd: null,
+    limitTotalUsd: null,
+    totalCostResetAt: null,
+    limitConcurrentSessions: 0,
+    maxRetryAttempts: null,
+    circuitBreakerFailureThreshold: 5,
+    circuitBreakerOpenDuration: 1_800_000,
+    circuitBreakerHalfOpenSuccessThreshold: 2,
+    proxyUrl: null,
+    proxyFallbackToDirect: false,
+    firstByteTimeoutStreamingMs: 30_000,
+    streamingIdleTimeoutMs: 10_000,
+    requestTimeoutNonStreamingMs: 1_000,
+    websiteUrl: null,
+    faviconUrl: null,
+    cacheTtlPreference: null,
+    context1mPreference: null,
+    codexReasoningEffortPreference: null,
+    codexReasoningSummaryPreference: null,
+    codexTextVerbosityPreference: null,
+    codexParallelToolCallsPreference: null,
+    tpm: 0,
+    rpm: 0,
+    rpd: 0,
+    cc: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function createSession(params?: { clientAbortSignal?: AbortSignal | null }): ProxySession {
+  const headers = new Headers();
+  const session = Object.create(ProxySession.prototype);
+
+  Object.assign(session, {
+    startTime: Date.now(),
+    method: "POST",
+    requestUrl: new URL("https://example.com/v1/chat/completions"),
+    headers,
+    originalHeaders: new Headers(headers),
+    headerLog: JSON.stringify(Object.fromEntries(headers.entries())),
+    request: {
+      model: "gpt-5.2",
+      log: "(test)",
+      message: {
+        model: "gpt-5.2",
+        messages: [{ role: "user", content: "hi" }],
+      },
+    },
+    userAgent: null,
+    context: null,
+    clientAbortSignal: params?.clientAbortSignal ?? null,
+    userName: "test-user",
+    authState: { success: true, user: null, key: null, apiKey: null },
+    provider: null,
+    messageContext: null,
+    sessionId: null,
+    requestSequence: 1,
+    originalFormat: "claude",
+    providerType: null,
+    originalModelName: null,
+    originalUrlPathname: null,
+    providerChain: [],
+    cacheTtlResolved: null,
+    context1mApplied: false,
+    specialSettings: [],
+    cachedPriceData: undefined,
+    cachedBillingModelSource: undefined,
+    isHeaderModified: () => false,
+  });
+
+  return session as ProxySession;
+}
+
+async function startServer(): Promise<{ server: Server; baseUrl: string }> {
+  const server = createServer((req, res) => {
+    // 模拟上游异常：返回 403，但永远不结束 body（导致 response.text() 无限等待）
+    res.writeHead(403, { "content-type": "application/json" });
+    res.write(JSON.stringify({ error: { message: "forbidden" } }));
+
+    // 当客户端中断时，主动销毁连接，避免测试进程残留挂起连接
+    req.on("aborted", () => {
+      try {
+        res.destroy();
+      } catch {
+        // ignore
+      }
+    });
+  });
+
+  const baseUrl = await new Promise<string>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        reject(new Error("Failed to get server address"));
+        return;
+      }
+      resolve(`http://127.0.0.1:${addr.port}`);
+    });
+  });
+
+  return { server, baseUrl };
+}
+
+describe("ProxyForwarder - non-ok response body hang", () => {
+  test("HTTP 4xx/5xx 在 body 不结束时也应被超时中断，避免请求悬挂", async () => {
+    const { server, baseUrl } = await startServer();
+    const clientAbortController = new AbortController();
+
+    try {
+      const provider = createProvider({
+        url: baseUrl,
+        requestTimeoutNonStreamingMs: 200,
+      });
+
+      const session = createSession({ clientAbortSignal: clientAbortController.signal });
+      session.setProvider(provider);
+
+      const doForward = (
+        ProxyForwarder as unknown as { doForward: (...args: unknown[]) => unknown }
+      ).doForward;
+
+      const forwardPromise = doForward(session, provider, baseUrl) as Promise<Response>;
+
+      const result = await Promise.race([
+        forwardPromise.then(
+          () => ({ type: "resolved" as const }),
+          (error) => ({ type: "rejected" as const, error })
+        ),
+        new Promise<{ type: "timeout" }>((resolve) =>
+          setTimeout(() => resolve({ type: "timeout" as const }), 2_000)
+        ),
+      ]);
+
+      if (result.type === "timeout") {
+        // 兜底：避免回归时测试套件整体挂死
+        clientAbortController.abort(new Error("test_timeout"));
+        throw new Error("doForward 超时未返回：可能存在非 ok 响应体读取悬挂问题");
+      }
+
+      expect(result.type).toBe("rejected");
+      expect(result.type === "rejected" ? result.error : null).toBeInstanceOf(ProxyError);
+
+      const err = (result as { type: "rejected"; error: unknown }).error as ProxyError;
+      expect(err.statusCode).toBe(403);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/tests/unit/proxy/proxy-forwarder-nonok-body-hang.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-nonok-body-hang.test.ts
@@ -75,6 +75,9 @@ function createProvider(overrides: Partial<Provider> = {}): Provider {
     codexReasoningSummaryPreference: null,
     codexTextVerbosityPreference: null,
     codexParallelToolCallsPreference: null,
+    anthropicMaxTokensPreference: null,
+    anthropicThinkingBudgetPreference: null,
+    geminiGoogleSearchPreference: null,
     tpm: 0,
     rpm: 0,
     rpd: 0,
@@ -175,6 +178,7 @@ describe("ProxyForwarder - non-ok response body hang", () => {
       const session = createSession({ clientAbortSignal: clientAbortController.signal });
       session.setProvider(provider);
 
+      // 直接测试 doForward 以隔离单次转发行为，避免 send() 的重试/供应商切换逻辑干扰。
       const doForward = (
         ProxyForwarder as unknown as { doForward: (...args: unknown[]) => unknown }
       ).doForward;
@@ -222,6 +226,7 @@ describe("ProxyForwarder - non-ok response body hang", () => {
       const session = createSession({ clientAbortSignal: clientAbortController.signal });
       session.setProvider(provider);
 
+      // 直接测试 doForward 以隔离单次转发行为，避免 send() 的重试/供应商切换逻辑干扰。
       const doForward = (
         ProxyForwarder as unknown as { doForward: (...args: unknown[]) => unknown }
       ).doForward;


### PR DESCRIPTION
## 概要

修复一个会导致代理请求长期卡在 requesting 的问题：当上游返回 4xx/5xx，但响应 body 永远不结束时，服务端在读取错误体阶段会无限等待，从而让整条请求链路（含客户端）一直悬挂（重启进程后暂时恢复）。

同时修复探针日志清理任务在部分运行时/驱动组合下的 `timestamptz` 解析失败问题，避免清理失败导致日志持续堆积。

## 问题与根因

在 `ProxyForwarder.doForward()` 中：

- 当上游返回非 2xx 时，错误处理会读取 `response.text()` 来构造 `ProxyError`；
- 若上游在返回 403/5xx 后保持连接不关闭、body 也不结束，则 `response.text()` 会无限等待；
- 若在读取错误体之前提前清除 response timeout，则 abort 信号不会触发，导致该请求永远不结束，前端表现为一直“请求中”，并可能逐步耗尽连接/资源。

另外，在代理失败降级到直连（`proxyFallbackToDirect`）或 HTTP/2 -> HTTP/1.1 回退时，`catch` 分支会清除 response timeout。若随后直连/回退请求拿到非 2xx 且 body 仍不结束，会再次进入同样的“无 timeout 读取错误体”路径，从而复现 hang。

探针日志清理方面，直接把 `Date` 作为 SQL 参数传入时，部分运行时/驱动会把它序列化成类似 `"Mon Feb ... GMT+0800 (China Standard Time)"` 的非 ISO 字符串，Postgres 无法解析为 `timestamptz`，导致清理任务报错并无法继续清理。

## 解决方案

1) 非 2xx 错误体读取路径保持超时监控

- 在读取错误体前不清除 response timeout；
- 用 `try/finally` 包裹 `ProxyError.fromUpstreamResponse()`，在 `finally` 中统一清理超时定时器；
- 当上游错误响应 body 卡住时，仍会被现有的 response timeout abort，中断 `response.text()`，避免整条链路永久悬挂。

2) 代理降级/协议回退后恢复 response timeout

- 在 fallback 请求成功后重新启动 response timeout，确保后续的非 2xx 错误体读取仍受超时保护，避免“proxy 失败 -> 直连拿到 403 -> 读取错误体挂起”。

3) 探针日志清理 `timestamptz` 兼容性修复

- 将 `beforeDate` 统一转为 `toISOString()`；
- 在 SQL 中显式 `::timestamptz` cast，避免 Postgres 解析歧义/失败。

## 变更点

- `src/app/v1/_lib/proxy/forwarder.ts`
  - 非 2xx 响应处理：确保 response timeout 覆盖错误体读取（避免 `response.text()` 悬挂）
  - 代理失败降级到直连：恢复 response timeout（避免 fallback 后再次 hang）
  - （小）修复一处注释文本乱码（仅注释，无行为变化）
- `src/repository/provider-endpoints.ts`
  - 探针日志清理：`beforeDate` 改用 ISO-8601 字符串 + `::timestamptz`
- `tests/unit/proxy/proxy-forwarder-nonok-body-hang.test.ts`
  - 新增回归测试：模拟上游返回 403 且永不结束 body，验证在超时窗口内抛出 `ProxyError`，不会挂死
  - 覆盖 `proxyFallbackToDirect` 降级场景

## 测试

- `npm run test`
- `npm run typecheck`
- `npm run build`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

该 PR 修复代理转发在上游返回非 2xx 且响应 body 永不结束时，服务端在读取错误体阶段可能永久等待的问题：通过保证 response timeout 覆盖 `ProxyError.fromUpstreamResponse()` 的错误体读取，并在 fallback（proxy->direct / h2->h1）后恢复 timeout，避免请求链路长期卡在 requesting。

另外，探针日志清理任务改为用 ISO-8601 字符串传参并显式 `timestamptz` cast，解决部分运行时/驱动把 `Date` 序列化为非 ISO 字符串导致 Postgres 解析失败、清理任务中断的问题。
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is reasonably safe to merge once the remaining timeout-timer overlap risk is confirmed/removed.
- Core fix (keeping response timeout active during non-OK body reads and restoring it after fallback) addresses the described hang, and the SQL cleanup change is now robust via CAST. The only concrete merge-blocker risk is potential overlapping/stale response-timeout timers when restarting after fallback, which could abort later attempts unexpectedly.
- src/app/v1/_lib/proxy/forwarder.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/forwarder.ts | Keeps response timeout active while reading non-OK bodies and restarts timeout after direct fallback; fixes one garbled comment. Main remaining concern is ensuring timeout timers can’t overlap across attempts when restarting after fallback. |
| src/repository/provider-endpoints.ts | Changes probe-log cleanup to bind an ISO timestamp string and explicitly cast to timestamptz via CAST(... AS timestamptz), improving compatibility with drivers that stringify Date non-ISO. |
| tests/unit/proxy/proxy-forwarder-nonok-body-hang.test.ts | Adds regression tests for hanging non-OK response bodies and for proxyFallbackToDirect; includes socket tracking and forced teardown to reduce suite hangs. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Forwarder as ProxyForwarder.doForward()
  participant Upstream
  participant Timeout as responseTimeout

  Client->>Forwarder: request (with responseController)
  Forwarder->>Timeout: start response timeout
  Forwarder->>Upstream: fetch/forward request
  Upstream-->>Forwarder: response (status 4xx/5xx)
  alt response.ok
    Forwarder-->>Client: stream response
  else !response.ok
    Forwarder->>Forwarder: ProxyError.fromUpstreamResponse()
    Note over Forwarder,Upstream: error body may never end
    Timeout-->>Forwarder: timer fires
    Forwarder->>Forwarder: responseController.abort()
    Forwarder-->>Client: throw ProxyError (timeout-protected)
    Forwarder->>Timeout: clear timeout
  end

  opt proxyFallbackToDirect / h2->h1 fallback
    Forwarder->>Timeout: restart response timeout
    Forwarder->>Upstream: retry request
  end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->