### PR TITLE
feat(leaderboard): provider avg-cost metrics and cache-hit model drilldown

### DIFF
--- a/messages/en/dashboard.json
+++ b/messages/en/dashboard.json
@@ -410,8 +410,12 @@
       "successRate": "Success Rate",
       "avgResponseTime": "Avg Response Time",
       "avgTtfbMs": "Avg TTFB",
-      "avgTokensPerSecond": "Avg tok/s"
+      "avgTokensPerSecond": "Avg tok/s",
+      "avgCostPerRequest": "Avg Cost/Req",
+      "avgCostPerMillionTokens": "Avg Cost/1M Tokens"
     },
+    "expandModelStats": "Expand model details",
+    "collapseModelStats": "Collapse model details",
     "states": {
       "loading": "Loading...",
       "noData": "No data available",

--- a/messages/ja/dashboard.json
+++ b/messages/ja/dashboard.json
@@ -410,8 +410,12 @@
       "successRate": "成功率(%)",
       "avgResponseTime": "平均応答時間",
       "avgTtfbMs": "平均TTFB",
-      "avgTokensPerSecond": "平均トークン/秒"
+      "avgTokensPerSecond": "平均トークン/秒",
+      "avgCostPerRequest": "平均リクエスト単価",
+      "avgCostPerMillionTokens": "100万トークンあたりコスト"
     },
+    "expandModelStats": "モデル詳細を展開",
+    "collapseModelStats": "モデル詳細を折りたたむ",
     "states": {
       "loading": "読み込み中...",
       "noData": "データなし",

--- a/messages/ru/dashboard.json
+++ b/messages/ru/dashboard.json
@@ -410,8 +410,12 @@
       "successRate": "Процент успеха",
       "avgResponseTime": "Среднее время ответа",
       "avgTtfbMs": "Средний TTFB",
-      "avgTokensPerSecond": "Средн. ток/с"
+      "avgTokensPerSecond": "Средн. ток/с",
+      "avgCostPerRequest": "Ср. стоимость/запрос",
+      "avgCostPerMillionTokens": "Ср. стоимость/1М токенов"
     },
+    "expandModelStats": "Развернуть модели",
+    "collapseModelStats": "Свернуть модели",
     "states": {
       "loading": "Загрузка...",
       "noData": "Нет данных",

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -410,8 +410,12 @@
     "successRate": "成功率",
     "avgResponseTime": "平均响应时间",
     "avgTtfbMs": "平均 TTFB",
-    "avgTokensPerSecond": "平均输出速率"
+    "avgTokensPerSecond": "平均输出速率",
+    "avgCostPerRequest": "平均单次请求成本",
+    "avgCostPerMillionTokens": "平均百万 Token 成本"
   },
+    "expandModelStats": "展开模型详情",
+    "collapseModelStats": "收起模型详情",
     "states": {
       "loading": "加载中...",
       "noData": "暂无数据",

--- a/messages/zh-TW/dashboard.json
+++ b/messages/zh-TW/dashboard.json
@@ -410,8 +410,12 @@
       "successRate": "成功率（%）",
       "avgResponseTime": "平均回覆時間",
       "avgTtfbMs": "平均 TTFB（ms）",
-      "avgTokensPerSecond": "平均輸出速率"
+      "avgTokensPerSecond": "平均輸出速率",
+      "avgCostPerRequest": "平均每次請求成本",
+      "avgCostPerMillionTokens": "平均每百萬 Token 成本"
     },
+    "expandModelStats": "展開模型詳情",
+    "collapseModelStats": "收起模型詳情",
     "states": {
       "loading": "載入中...",
       "noData": "暫無資料",

--- a/tests/unit/repository/leaderboard-provider-metrics.test.ts
+++ b/tests/unit/repository/leaderboard-provider-metrics.test.ts
@@ -1,0 +1,473 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * GREEN tests for provider leaderboard average cost metrics and cache-hit model breakdown.
+ *
+ * These tests verify the semantic contracts:
+ * - avgCostPerRequest = totalCost / totalRequests (null when totalRequests === 0)
+ * - avgCostPerMillionTokens = totalCost * 1_000_000 / totalTokens (null when totalTokens === 0)
+ * - ProviderCacheHitRateLeaderboardEntry.modelStats: nested model-level breakdown
+ */
+
+const createChainMock = (resolvedData: unknown[]) => ({
+  from: vi.fn().mockReturnThis(),
+  innerJoin: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  groupBy: vi.fn().mockReturnThis(),
+  orderBy: vi.fn().mockResolvedValue(resolvedData),
+});
+
+// Track select calls to return different chains for different queries
+let selectCallIndex = 0;
+let chainMocks: ReturnType<typeof createChainMock>[] = [];
+
+const mockSelect = vi.fn(() => {
+  const chain = chainMocks[selectCallIndex] ?? createChainMock([]);
+  selectCallIndex++;
+  return chain;
+});
+
+const mocks = vi.hoisted(() => ({
+  resolveSystemTimezone: vi.fn(),
+  getSystemSettings: vi.fn(),
+}));
+
+vi.mock("@/drizzle/db", () => ({
+  db: {
+    select: (...args: unknown[]) => mockSelect(...args),
+  },
+}));
+
+vi.mock("@/drizzle/schema", () => ({
+  messageRequest: {
+    deletedAt: "deletedAt",
+    providerId: "providerId",
+    userId: "userId",
+    costUsd: "costUsd",
+    inputTokens: "inputTokens",
+    outputTokens: "outputTokens",
+    cacheCreationInputTokens: "cacheCreationInputTokens",
+    cacheReadInputTokens: "cacheReadInputTokens",
+    errorMessage: "errorMessage",
+    blockedBy: "blockedBy",
+    createdAt: "createdAt",
+    ttfbMs: "ttfbMs",
+    durationMs: "durationMs",
+    model: "model",
+    originalModel: "originalModel",
+  },
+  providers: {
+    id: "id",
+    name: "name",
+    deletedAt: "deletedAt",
+    providerType: "providerType",
+  },
+  users: {},
+}));
+
+vi.mock("@/lib/utils/timezone", () => ({
+  resolveSystemTimezone: mocks.resolveSystemTimezone,
+}));
+
+vi.mock("@/repository/system-config", () => ({
+  getSystemSettings: mocks.getSystemSettings,
+}));
+
+describe("Provider Leaderboard Average Cost Metrics", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    selectCallIndex = 0;
+    chainMocks = [];
+    mockSelect.mockClear();
+    mocks.resolveSystemTimezone.mockResolvedValue("UTC");
+    mocks.getSystemSettings.mockResolvedValue({ billingModelSource: "redirected" });
+  });
+
+  it("computes avgCostPerRequest = totalCost / totalRequests for valid denominators", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "test-provider",
+          totalRequests: 100,
+          totalCost: "5.0",
+          totalTokens: 500000,
+          successRate: 0.95,
+          avgTtfbMs: 200,
+          avgTokensPerSecond: 50,
+        },
+      ]),
+    ];
+
+    const { findDailyProviderLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderLeaderboard();
+
+    expect(result).toHaveLength(1);
+    const entry = result[0];
+    expect(entry).toHaveProperty("avgCostPerRequest");
+    expect(entry.avgCostPerRequest).toBeCloseTo(5.0 / 100);
+
+    type HasAvgCostPerRequest = { avgCostPerRequest: number | null };
+    const _typeCheck: HasAvgCostPerRequest = {} as Awaited<
+      ReturnType<typeof findDailyProviderLeaderboard>
+    >[number];
+    expect(_typeCheck).toBeDefined();
+  });
+
+  it("computes avgCostPerMillionTokens = totalCost * 1_000_000 / totalTokens for valid denominators", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "test-provider",
+          totalRequests: 100,
+          totalCost: "5.0",
+          totalTokens: 500000,
+          successRate: 0.95,
+          avgTtfbMs: 200,
+          avgTokensPerSecond: 50,
+        },
+      ]),
+    ];
+
+    const { findDailyProviderLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderLeaderboard();
+
+    expect(result).toHaveLength(1);
+    const entry = result[0];
+    expect(entry).toHaveProperty("avgCostPerMillionTokens");
+    expect(entry.avgCostPerMillionTokens).toBeCloseTo((5.0 * 1_000_000) / 500000);
+  });
+
+  it("returns null for avgCostPerRequest when totalRequests is 0", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "zero-provider",
+          totalRequests: 0,
+          totalCost: "0",
+          totalTokens: 0,
+          successRate: 0,
+          avgTtfbMs: 0,
+          avgTokensPerSecond: 0,
+        },
+      ]),
+    ];
+
+    const { findDailyProviderLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderLeaderboard();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].avgCostPerRequest).toBeNull();
+  });
+
+  it("returns null for avgCostPerMillionTokens when totalTokens is 0", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "zero-provider",
+          totalRequests: 5,
+          totalCost: "1.0",
+          totalTokens: 0,
+          successRate: 0,
+          avgTtfbMs: 0,
+          avgTokensPerSecond: 0,
+        },
+      ]),
+    ];
+
+    const { findDailyProviderLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderLeaderboard();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].avgCostPerMillionTokens).toBeNull();
+  });
+
+  it("preserves provider sort order by totalCost descending", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "expensive",
+          totalRequests: 100,
+          totalCost: "10.0",
+          totalTokens: 500000,
+          successRate: 0.95,
+          avgTtfbMs: 200,
+          avgTokensPerSecond: 50,
+        },
+        {
+          providerId: 2,
+          providerName: "cheap",
+          totalRequests: 50,
+          totalCost: "2.0",
+          totalTokens: 100000,
+          successRate: 0.9,
+          avgTtfbMs: 300,
+          avgTokensPerSecond: 40,
+        },
+      ]),
+    ];
+
+    const { findDailyProviderLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderLeaderboard();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].totalCost).toBeGreaterThanOrEqual(result[1].totalCost);
+  });
+});
+
+describe("Provider Cache Hit Rate Model Breakdown", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    selectCallIndex = 0;
+    chainMocks = [];
+    mockSelect.mockClear();
+    mocks.resolveSystemTimezone.mockResolvedValue("UTC");
+    mocks.getSystemSettings.mockResolvedValue({ billingModelSource: "redirected" });
+  });
+
+  it("includes modelStats field on cache-hit leaderboard entries", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "cache-provider",
+          totalRequests: 50,
+          totalCost: "2.5",
+          cacheReadTokens: 10000,
+          cacheCreationCost: "1.0",
+          totalInputTokens: 20000,
+          cacheHitRate: 0.5,
+        },
+      ]),
+      createChainMock([
+        {
+          providerId: 1,
+          model: "claude-3-opus",
+          totalRequests: 30,
+          cacheReadTokens: 8000,
+          totalInputTokens: 15000,
+          cacheHitRate: 0.53,
+        },
+        {
+          providerId: 1,
+          model: "claude-3-sonnet",
+          totalRequests: 20,
+          cacheReadTokens: 2000,
+          totalInputTokens: 5000,
+          cacheHitRate: 0.4,
+        },
+      ]),
+    ];
+
+    const { findDailyProviderCacheHitRateLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderCacheHitRateLeaderboard();
+
+    expect(result).toHaveLength(1);
+    const entry = result[0];
+    expect(entry).toHaveProperty("modelStats");
+    expect(Array.isArray(entry.modelStats)).toBe(true);
+    expect(entry.modelStats).toHaveLength(2);
+    expect(entry.modelStats[0].model).toBe("claude-3-opus");
+  });
+
+  it("provider cache hit ranking sort stability preserved after adding modelStats", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "high-cache",
+          totalRequests: 50,
+          totalCost: "2.5",
+          cacheReadTokens: 15000,
+          cacheCreationCost: "1.0",
+          totalInputTokens: 20000,
+          cacheHitRate: 0.75,
+        },
+        {
+          providerId: 2,
+          providerName: "low-cache",
+          totalRequests: 30,
+          totalCost: "1.0",
+          cacheReadTokens: 2000,
+          cacheCreationCost: "0.5",
+          totalInputTokens: 10000,
+          cacheHitRate: 0.2,
+        },
+      ]),
+      createChainMock([]),
+    ];
+
+    const { findDailyProviderCacheHitRateLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderCacheHitRateLeaderboard();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].cacheHitRate).toBeGreaterThanOrEqual(result[1].cacheHitRate);
+  });
+
+  it("model breakdown excludes empty model names and has deterministic order", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "provider-a",
+          totalRequests: 50,
+          totalCost: "2.5",
+          cacheReadTokens: 10000,
+          cacheCreationCost: "1.0",
+          totalInputTokens: 20000,
+          cacheHitRate: 0.5,
+        },
+      ]),
+      createChainMock([
+        {
+          providerId: 1,
+          model: "claude-3-opus",
+          totalRequests: 30,
+          cacheReadTokens: 8000,
+          totalInputTokens: 15000,
+          cacheHitRate: 0.53,
+        },
+        {
+          providerId: 1,
+          model: "",
+          totalRequests: 5,
+          cacheReadTokens: 100,
+          totalInputTokens: 500,
+          cacheHitRate: 0.2,
+        },
+        {
+          providerId: 1,
+          model: "claude-3-sonnet",
+          totalRequests: 15,
+          cacheReadTokens: 1900,
+          totalInputTokens: 4500,
+          cacheHitRate: 0.42,
+        },
+      ]),
+    ];
+
+    const { findDailyProviderCacheHitRateLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderCacheHitRateLeaderboard();
+
+    expect(result).toHaveLength(1);
+    const entry = result[0];
+    // Empty model names must be excluded (only 2 valid models)
+    expect(entry.modelStats).toHaveLength(2);
+    for (const ms of entry.modelStats) {
+      expect(ms.model).toBeTruthy();
+      expect(ms.model.trim()).not.toBe("");
+    }
+    // Deterministic order: cacheHitRate desc (0.53 > 0.42)
+    expect(entry.modelStats[0].cacheHitRate).toBeGreaterThanOrEqual(
+      entry.modelStats[entry.modelStats.length - 1].cacheHitRate
+    );
+  });
+
+  it("preserves all existing provider-level fields unchanged", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "full-provider",
+          totalRequests: 50,
+          totalCost: "2.5",
+          cacheReadTokens: 10000,
+          cacheCreationCost: "1.0",
+          totalInputTokens: 20000,
+          cacheHitRate: 0.5,
+        },
+      ]),
+      createChainMock([]),
+    ];
+
+    const { findDailyProviderCacheHitRateLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderCacheHitRateLeaderboard();
+
+    expect(result).toHaveLength(1);
+    const entry = result[0];
+    expect(entry).toHaveProperty("providerId", 1);
+    expect(entry).toHaveProperty("providerName", "full-provider");
+    expect(entry).toHaveProperty("totalRequests", 50);
+    expect(entry).toHaveProperty("cacheReadTokens", 10000);
+    expect(entry).toHaveProperty("totalCost", 2.5);
+    expect(entry).toHaveProperty("cacheCreationCost", 1.0);
+    expect(entry).toHaveProperty("totalInputTokens", 20000);
+    expect(entry).toHaveProperty("cacheHitRate", 0.5);
+    expect(entry).toHaveProperty("modelStats");
+  });
+
+  it("groups model stats correctly across multiple providers", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "provider-alpha",
+          totalRequests: 50,
+          totalCost: "2.5",
+          cacheReadTokens: 10000,
+          cacheCreationCost: "1.0",
+          totalInputTokens: 20000,
+          cacheHitRate: 0.5,
+        },
+        {
+          providerId: 2,
+          providerName: "provider-beta",
+          totalRequests: 30,
+          totalCost: "1.0",
+          cacheReadTokens: 5000,
+          cacheCreationCost: "0.5",
+          totalInputTokens: 10000,
+          cacheHitRate: 0.5,
+        },
+      ]),
+      createChainMock([
+        {
+          providerId: 1,
+          model: "model-a",
+          totalRequests: 30,
+          cacheReadTokens: 6000,
+          totalInputTokens: 12000,
+          cacheHitRate: 0.5,
+        },
+        {
+          providerId: 1,
+          model: "model-b",
+          totalRequests: 20,
+          cacheReadTokens: 4000,
+          totalInputTokens: 8000,
+          cacheHitRate: 0.5,
+        },
+        {
+          providerId: 2,
+          model: "model-c",
+          totalRequests: 30,
+          cacheReadTokens: 5000,
+          totalInputTokens: 10000,
+          cacheHitRate: 0.5,
+        },
+      ]),
+    ];
+
+    const { findDailyProviderCacheHitRateLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderCacheHitRateLeaderboard();
+
+    expect(result).toHaveLength(2);
+
+    // Provider 1 should have 2 model stats
+    const p1 = result.find((r) => r.providerId === 1);
+    expect(p1).toBeDefined();
+    expect(p1!.modelStats).toHaveLength(2);
+    const p1Models = p1!.modelStats.map((m) => m.model).sort();
+    expect(p1Models).toEqual(["model-a", "model-b"]);
+
+    // Provider 2 should have 1 model stat
+    const p2 = result.find((r) => r.providerId === 2);
+    expect(p2).toBeDefined();
+    expect(p2!.modelStats).toHaveLength(1);
+    expect(p2!.modelStats[0].model).toBe("model-c");
+  });
+});


### PR DESCRIPTION
## Summary

Add two average cost metrics to the provider leaderboard and a per-model expandable drilldown to the cache-hit rate ranking, with full i18n and test coverage.

## Problem

The provider leaderboard showed total cost but lacked normalized cost-efficiency metrics (cost per request, cost per million tokens), making it hard to compare providers of different scale. The cache-hit rate ranking showed only provider-level aggregates with no way to see which models contributed to the hit rate.

**Related PRs:**
- Follow-up to #398 - extends the provider cache hit rate ranking with model-level drilldown
- Related to #427 - continues the pattern of adding per-provider performance metrics (TTFB, output rate) to the leaderboard
- Related to #448 - builds on the leaderboard table infrastructure (sorting, filtering) with generic expandable row support
- Related to #497 - applies the same null-safe division pattern used to fix output rate calculation

## Solution

- **Repository layer**: Compute `avgCostPerRequest` (`totalCost / totalRequests`) and `avgCostPerMillionTokens` (`totalCost * 1_000_000 / totalTokens`) with null-safe division (returns `null` when denominator is 0). Add a second grouped query for cache-hit rankings keyed by `billingModelSource` to produce per-model `ModelCacheHitStat` entries.
- **API layer**: Format new cost fields via immutable spread pattern, preserving all existing fields.
- **UI layer**: Make `LeaderboardTable` support generic expandable rows with chevron toggle. Add 2 new provider columns and a cache-hit model drilldown sub-table.

## Changes

### Core Changes
- `src/repository/leaderboard.ts` - `avgCostPerRequest`, `avgCostPerMillionTokens` fields on `ProviderLeaderboardEntry`; new `ModelCacheHitStat` interface and model sub-query on `ProviderCacheHitRateLeaderboardEntry`
- `src/app/api/leaderboard/route.ts` - Format new cost fields with currency display; refactored to immutable spread pattern
- `src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx` - Generic expandable row support (`renderExpandedContent` prop, chevron toggle, `Fragment` keying)
- `src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx` - 2 new provider columns (avg cost/req, avg cost/1M tokens); cache-hit model drilldown with color-coded hit rates

### Supporting Changes
- `messages/{en,ja,ru,zh-CN,zh-TW}/dashboard.json` - 4 new i18n keys per locale (`avgCostPerRequest`, `avgCostPerMillionTokens`, `expandModelStats`, `collapseModelStats`)

## Breaking Changes

None. All changes are additive - new fields are appended to existing interfaces and API responses. Existing fields and behavior are unchanged.

## Testing

### Automated Tests
- [x] Unit tests added: `tests/unit/repository/leaderboard-provider-metrics.test.ts` (10 tests covering avg-cost computation, null-safe division, model breakdown grouping, empty model exclusion, field preservation)
- [x] Unit tests added: `tests/unit/api/leaderboard-route.test.ts` (3 new tests covering provider formatted fields, null cost handling, modelStats passthrough)

### Manual Testing
1. Navigate to Dashboard > Leaderboard > Provider tab
2. Verify "Avg Cost/Req" and "Avg Cost/1M Tokens" columns appear with formatted currency values
3. Switch to Cache Hit Rate tab, click a provider row with the chevron icon
4. Verify model-level breakdown table expands with per-model cache hit rates (color-coded: green >= 85%, yellow >= 60%, orange < 60%)

## Changed Files

| Layer | Files | What |
|-------|-------|------|
| Repository | `src/repository/leaderboard.ts` | `avgCostPerRequest`, `avgCostPerMillionTokens`, `ModelCacheHitStat`, model sub-query |
| API | `src/app/api/leaderboard/route.ts` | Formatted fields via immutable spread |
| UI | `leaderboard-table.tsx` | Generic expandable row support |
| UI | `leaderboard-view.tsx` | 2 new provider columns + cache-hit model drilldown |
| i18n | `messages/*/dashboard.json` | 4 new keys x 5 locales |
| Tests | `leaderboard-provider-metrics.test.ts` | 10 tests (avg-cost + cache-hit model) |
| Tests | `leaderboard-route.test.ts` | 3 new tests (API formatting) |

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally (2063 tests GREEN)
- [x] TypeScript typecheck clean (tsgo)
- [x] Biome lint clean (971 files)
- [x] i18n: all 5 locales updated

---
*Description enhanced by Claude AI*