### PR TITLE
feat(circuit): unify provider-endpoint circuit visibility and notifications

### DIFF
--- a/messages/en/provider-chain.json
+++ b/messages/en/provider-chain.json
@@ -37,7 +37,8 @@
     "systemError": "System Error",
     "concurrentLimit": "Concurrent Limit",
     "http2Fallback": "HTTP/2 Fallback",
-    "clientError": "Client Error"
+    "clientError": "Client Error",
+    "endpointPoolExhausted": "Endpoint Pool Exhausted"
   },
   "reasons": {
     "request_success": "Success",
@@ -48,7 +49,8 @@
     "concurrent_limit_failed": "Concurrent Limit",
     "http2_fallback": "HTTP/2 Fallback",
     "session_reuse": "Session Reuse",
-    "initial_selection": "Initial Selection"
+    "initial_selection": "Initial Selection",
+    "endpoint_pool_exhausted": "Endpoint Pool Exhausted"
   },
   "filterReasons": {
     "rate_limited": "Rate Limited",
@@ -61,7 +63,9 @@
     "context_1m_disabled": "1M Context Disabled",
     "model_not_supported": "Model Not Supported",
     "group_mismatch": "Group Mismatch",
-    "health_check_failed": "Health Check Failed"
+    "health_check_failed": "Health Check Failed",
+    "endpoint_circuit_open": "Endpoint Circuit Open",
+    "endpoint_disabled": "Endpoint Disabled"
   },
   "details": {
     "selectionMethod": "Selection",
@@ -185,6 +189,14 @@
     "ruleMatchType": "Match Type: {matchType}",
     "ruleDescription": "Description: {description}",
     "ruleHasOverride": "Overrides: response={response}, statusCode={statusCode}",
-    "clientErrorNote": "This error is caused by client input and is not retried or counted in the circuit breaker."
+    "clientErrorNote": "This error is caused by client input and is not retried or counted in the circuit breaker.",
+    "endpointPoolExhausted": "Endpoint Pool Exhausted (all endpoints unavailable)",
+    "endpointStats": "Endpoint Filter Stats",
+    "endpointStatsTotal": "Total Endpoints: {count}",
+    "endpointStatsEnabled": "Enabled Endpoints: {count}",
+    "endpointStatsCircuitOpen": "Circuit-Open Endpoints: {count}",
+    "endpointStatsAvailable": "Available Endpoints: {count}",
+    "strictBlockNoEndpoints": "Strict mode: no endpoint candidates available, provider skipped without fallback",
+    "strictBlockSelectorError": "Strict mode: endpoint selector encountered an error, provider skipped without fallback"
   }
 }

--- a/messages/en/settings/providers/filter.json
+++ b/messages/en/settings/providers/filter.json
@@ -1,5 +1,7 @@
 {
   "circuitBroken": "Circuit Broken",
+  "keyCircuitBroken": "Key Circuit",
+  "endpointCircuitBroken": "Endpoint Circuit",
   "groups": {
     "all": "All",
     "default": "default",

--- a/messages/en/settings/providers/filter.json
+++ b/messages/en/settings/providers/filter.json
@@ -1,7 +1,7 @@
 {
   "circuitBroken": "Circuit Broken",
-  "keyCircuitBroken": "Key Circuit",
-  "endpointCircuitBroken": "Endpoint Circuit",
+  "keyCircuitBroken": "Key Circuit Broken",
+  "endpointCircuitBroken": "Endpoint Circuit Broken",
   "groups": {
     "all": "All",
     "default": "default",

--- a/messages/en/settings/providers/list.json
+++ b/messages/en/settings/providers/list.json
@@ -1,6 +1,8 @@
 {
   "cancelButton": "Cancel",
   "circuitBroken": "Circuit Broken",
+  "keyCircuitBroken": "Key Circuit",
+  "endpointCircuitBroken": "Endpoint Circuit",
   "clipboardUnavailable": "Clipboard access is blocked in this environment. Select and copy the key manually.",
   "confirmDeleteMessage": "Are you sure you want to delete provider \"{name}\"? This action cannot be undone.",
   "confirmDeleteTitle": "Confirm Delete Provider?",

--- a/messages/en/settings/providers/strings.json
+++ b/messages/en/settings/providers/strings.json
@@ -112,6 +112,9 @@
     "unhealthy": "Unhealthy",
     "unknown": "Unknown",
     "circuitOpen": "Circuit Open",
-    "circuitHalfOpen": "Circuit Half-Open"
+    "circuitHalfOpen": "Circuit Half-Open",
+    "resetCircuit": "Reset Circuit",
+    "resetCircuitSuccess": "Endpoint circuit breaker reset",
+    "resetCircuitFailed": "Failed to reset endpoint circuit breaker"
   }
 }

--- a/messages/ja/provider-chain.json
+++ b/messages/ja/provider-chain.json
@@ -37,7 +37,8 @@
     "systemError": "システムエラー",
     "concurrentLimit": "同時実行制限",
     "http2Fallback": "HTTP/2 フォールバック",
-    "clientError": "クライアントエラー"
+    "clientError": "クライアントエラー",
+    "endpointPoolExhausted": "エンドポイントプール枯渇"
   },
   "reasons": {
     "request_success": "成功",
@@ -48,7 +49,8 @@
     "concurrent_limit_failed": "同時実行制限",
     "http2_fallback": "HTTP/2 フォールバック",
     "session_reuse": "セッション再利用",
-    "initial_selection": "初期選択"
+    "initial_selection": "初期選択",
+    "endpoint_pool_exhausted": "エンドポイントプール枯渇"
   },
   "filterReasons": {
     "rate_limited": "レート制限",
@@ -61,7 +63,9 @@
     "context_1m_disabled": "1Mコンテキスト無効",
     "model_not_supported": "モデル非対応",
     "group_mismatch": "グループ不一致",
-    "health_check_failed": "ヘルスチェック失敗"
+    "health_check_failed": "ヘルスチェック失敗",
+    "endpoint_circuit_open": "エンドポイントサーキットオープン",
+    "endpoint_disabled": "エンドポイント無効"
   },
   "details": {
     "selectionMethod": "選択方法",
@@ -185,6 +189,14 @@
     "ruleMatchType": "一致タイプ: {matchType}",
     "ruleDescription": "説明: {description}",
     "ruleHasOverride": "上書き: 応答={response} ステータスコード={statusCode}",
-    "clientErrorNote": "このエラーはクライアント入力が原因のため再試行せず、サーキットブレーカーにもカウントされません。"
+    "clientErrorNote": "このエラーはクライアント入力が原因のため再試行せず、サーキットブレーカーにもカウントされません。",
+    "endpointPoolExhausted": "エンドポイントプール枯渇（全エンドポイント利用不可）",
+    "endpointStats": "エンドポイントフィルタ統計",
+    "endpointStatsTotal": "総エンドポイント数: {count}",
+    "endpointStatsEnabled": "有効なエンドポイント: {count}",
+    "endpointStatsCircuitOpen": "サーキットオープンのエンドポイント: {count}",
+    "endpointStatsAvailable": "利用可能なエンドポイント: {count}",
+    "strictBlockNoEndpoints": "厳格モード：利用可能なエンドポイント候補がないため、フォールバックなしでプロバイダーをスキップ",
+    "strictBlockSelectorError": "厳格モード：エンドポイントセレクターでエラーが発生したため、フォールバックなしでプロバイダーをスキップ"
   }
 }

--- a/messages/ja/settings/providers/filter.json
+++ b/messages/ja/settings/providers/filter.json
@@ -1,5 +1,7 @@
 {
   "circuitBroken": "サーキットブレーカー",
+  "keyCircuitBroken": "キー遮断",
+  "endpointCircuitBroken": "エンドポイント遮断",
   "groups": {
     "all": "すべて",
     "default": "default",

--- a/messages/ja/settings/providers/list.json
+++ b/messages/ja/settings/providers/list.json
@@ -1,6 +1,8 @@
 {
   "cancelButton": "キャンセル",
   "circuitBroken": "遮断中",
+  "keyCircuitBroken": "キー遮断",
+  "endpointCircuitBroken": "エンドポイント遮断",
   "clipboardUnavailable": "この環境ではクリップボードを使用できません。手動でコピーしてください。",
   "confirmDeleteMessage": "プロバイダー \"{name}\" を削除してもよろしいですか？この操作は元に戻せません。",
   "confirmDeleteTitle": "プロバイダーの削除を確認しますか?",

--- a/messages/ja/settings/providers/strings.json
+++ b/messages/ja/settings/providers/strings.json
@@ -112,6 +112,9 @@
     "unhealthy": "異常",
     "unknown": "不明",
     "circuitOpen": "サーキットオープン",
-    "circuitHalfOpen": "サーキット半開"
+    "circuitHalfOpen": "サーキット半開",
+    "resetCircuit": "サーキットリセット",
+    "resetCircuitSuccess": "エンドポイントのサーキットブレーカーをリセットしました",
+    "resetCircuitFailed": "エンドポイントのサーキットブレーカーのリセットに失敗しました"
   }
 }

--- a/messages/ru/provider-chain.json
+++ b/messages/ru/provider-chain.json
@@ -37,7 +37,8 @@
     "systemError": "Системная ошибка",
     "concurrentLimit": "Лимит параллельных запросов",
     "http2Fallback": "Откат HTTP/2",
-    "clientError": "Ошибка клиента"
+    "clientError": "Ошибка клиента",
+    "endpointPoolExhausted": "Пул эндпоинтов исчерпан"
   },
   "reasons": {
     "request_success": "Успешно",
@@ -48,7 +49,8 @@
     "concurrent_limit_failed": "Лимит параллельных запросов",
     "http2_fallback": "Откат HTTP/2",
     "session_reuse": "Повторное использование сессии",
-    "initial_selection": "Первоначальный выбор"
+    "initial_selection": "Первоначальный выбор",
+    "endpoint_pool_exhausted": "Пул эндпоинтов исчерпан"
   },
   "filterReasons": {
     "rate_limited": "Ограничение скорости",
@@ -61,7 +63,9 @@
     "context_1m_disabled": "1M контекст отключен",
     "model_not_supported": "Модель не поддерживается",
     "group_mismatch": "Несоответствие группы",
-    "health_check_failed": "Проверка состояния не пройдена"
+    "health_check_failed": "Проверка состояния не пройдена",
+    "endpoint_circuit_open": "Автомат эндпоинта открыт",
+    "endpoint_disabled": "Эндпоинт отключен"
   },
   "details": {
     "selectionMethod": "Метод выбора",
@@ -185,6 +189,14 @@
     "ruleMatchType": "Тип совпадения: {matchType}",
     "ruleDescription": "Описание: {description}",
     "ruleHasOverride": "Переопределения: response={response}, statusCode={statusCode}",
-    "clientErrorNote": "Эта ошибка вызвана вводом клиента, не повторяется и не учитывается в автомате защиты."
+    "clientErrorNote": "Эта ошибка вызвана вводом клиента, не повторяется и не учитывается в автомате защиты.",
+    "endpointPoolExhausted": "Пул эндпоинтов исчерпан (все эндпоинты недоступны)",
+    "endpointStats": "Статистика фильтрации эндпоинтов",
+    "endpointStatsTotal": "Всего эндпоинтов: {count}",
+    "endpointStatsEnabled": "Включено эндпоинтов: {count}",
+    "endpointStatsCircuitOpen": "Эндпоинтов с открытым автоматом: {count}",
+    "endpointStatsAvailable": "Доступных эндпоинтов: {count}",
+    "strictBlockNoEndpoints": "Строгий режим: нет доступных кандидатов эндпоинтов, провайдер пропущен без отката",
+    "strictBlockSelectorError": "Строгий режим: ошибка селектора эндпоинтов, провайдер пропущен без отката"
   }
 }

--- a/messages/ru/provider-chain.json
+++ b/messages/ru/provider-chain.json
@@ -38,7 +38,7 @@
     "concurrentLimit": "Лимит параллельных запросов",
     "http2Fallback": "Откат HTTP/2",
     "clientError": "Ошибка клиента",
-    "endpointPoolExhausted": "Пул эндпоинтов исчерпан"
+    "endpointPoolExhausted": "Пул конечная точкаов исчерпан"
   },
   "reasons": {
     "request_success": "Успешно",
@@ -50,7 +50,7 @@
     "http2_fallback": "Откат HTTP/2",
     "session_reuse": "Повторное использование сессии",
     "initial_selection": "Первоначальный выбор",
-    "endpoint_pool_exhausted": "Пул эндпоинтов исчерпан"
+    "endpoint_pool_exhausted": "Пул конечная точкаов исчерпан"
   },
   "filterReasons": {
     "rate_limited": "Ограничение скорости",
@@ -64,7 +64,7 @@
     "model_not_supported": "Модель не поддерживается",
     "group_mismatch": "Несоответствие группы",
     "health_check_failed": "Проверка состояния не пройдена",
-    "endpoint_circuit_open": "Автомат эндпоинта открыт",
+    "endpoint_circuit_open": "Автомат конечная точкаа открыт",
     "endpoint_disabled": "Эндпоинт отключен"
   },
   "details": {
@@ -190,13 +190,13 @@
     "ruleDescription": "Описание: {description}",
     "ruleHasOverride": "Переопределения: response={response}, statusCode={statusCode}",
     "clientErrorNote": "Эта ошибка вызвана вводом клиента, не повторяется и не учитывается в автомате защиты.",
-    "endpointPoolExhausted": "Пул эндпоинтов исчерпан (все эндпоинты недоступны)",
-    "endpointStats": "Статистика фильтрации эндпоинтов",
-    "endpointStatsTotal": "Всего эндпоинтов: {count}",
-    "endpointStatsEnabled": "Включено эндпоинтов: {count}",
+    "endpointPoolExhausted": "Пул конечная точкаов исчерпан (все конечная точкаы недоступны)",
+    "endpointStats": "Статистика фильтрации конечная точкаов",
+    "endpointStatsTotal": "Всего конечная точкаов: {count}",
+    "endpointStatsEnabled": "Включено конечная точкаов: {count}",
     "endpointStatsCircuitOpen": "Эндпоинтов с открытым автоматом: {count}",
-    "endpointStatsAvailable": "Доступных эндпоинтов: {count}",
-    "strictBlockNoEndpoints": "Строгий режим: нет доступных кандидатов эндпоинтов, провайдер пропущен без отката",
-    "strictBlockSelectorError": "Строгий режим: ошибка селектора эндпоинтов, провайдер пропущен без отката"
+    "endpointStatsAvailable": "Доступных конечная точкаов: {count}",
+    "strictBlockNoEndpoints": "Строгий режим: нет доступных кандидатов конечная точкаов, провайдер пропущен без отката",
+    "strictBlockSelectorError": "Строгий режим: ошибка селектора конечная точкаов, провайдер пропущен без отката"
   }
 }

--- a/messages/ru/settings/providers/filter.json
+++ b/messages/ru/settings/providers/filter.json
@@ -1,5 +1,7 @@
 {
   "circuitBroken": "Сбой соединения",
+  "keyCircuitBroken": "Разрыв ключа",
+  "endpointCircuitBroken": "Разрыв endpoint",
   "groups": {
     "all": "Все",
     "default": "default",

--- a/messages/ru/settings/providers/filter.json
+++ b/messages/ru/settings/providers/filter.json
@@ -1,7 +1,7 @@
 {
   "circuitBroken": "Сбой соединения",
   "keyCircuitBroken": "Разрыв ключа",
-  "endpointCircuitBroken": "Разрыв endpoint",
+  "endpointCircuitBroken": "Разрыв конечной точки",
   "groups": {
     "all": "Все",
     "default": "default",

--- a/messages/ru/settings/providers/list.json
+++ b/messages/ru/settings/providers/list.json
@@ -1,6 +1,8 @@
 {
   "cancelButton": "Отмена",
   "circuitBroken": "Разорвано",
+  "keyCircuitBroken": "Разрыв ключа",
+  "endpointCircuitBroken": "Разрыв endpoint",
   "clipboardUnavailable": "Буфер обмена недоступен в этой среде. Скопируйте ключ вручную.",
   "confirmDeleteMessage": "Вы уверены, что хотите удалить провайдера \"{name}\"? Это действие нельзя отменить.",
   "confirmDeleteTitle": "Подтвердить удаление провайдера?",

--- a/messages/ru/settings/providers/strings.json
+++ b/messages/ru/settings/providers/strings.json
@@ -112,6 +112,9 @@
     "unhealthy": "Недоступен",
     "unknown": "Неизвестно",
     "circuitOpen": "Цепь открыта",
-    "circuitHalfOpen": "Цепь полуоткрыта"
+    "circuitHalfOpen": "Цепь полуоткрыта",
+    "resetCircuit": "Сброс цепи",
+    "resetCircuitSuccess": "Цепь эндпоинта сброшена",
+    "resetCircuitFailed": "Не удалось сбросить цепь эндпоинта"
   }
 }

--- a/messages/zh-CN/provider-chain.json
+++ b/messages/zh-CN/provider-chain.json
@@ -37,7 +37,8 @@
     "systemError": "系统错误",
     "concurrentLimit": "并发限制",
     "http2Fallback": "HTTP/2 回退",
-    "clientError": "客户端错误"
+    "clientError": "客户端错误",
+    "endpointPoolExhausted": "端点池耗尽"
   },
   "reasons": {
     "request_success": "成功",
@@ -48,7 +49,8 @@
     "concurrent_limit_failed": "并发限制",
     "http2_fallback": "HTTP/2 回退",
     "session_reuse": "会话复用",
-    "initial_selection": "首次选择"
+    "initial_selection": "首次选择",
+    "endpoint_pool_exhausted": "端点池耗尽"
   },
   "filterReasons": {
     "rate_limited": "速率限制",
@@ -61,7 +63,9 @@
     "context_1m_disabled": "1M上下文已禁用",
     "model_not_supported": "不支持该模型",
     "group_mismatch": "分组不匹配",
-    "health_check_failed": "健康检查失败"
+    "health_check_failed": "健康检查失败",
+    "endpoint_circuit_open": "端点已熔断",
+    "endpoint_disabled": "端点已禁用"
   },
   "details": {
     "selectionMethod": "选择方式",
@@ -185,6 +189,14 @@
     "ruleMatchType": "匹配类型: {matchType}",
     "ruleDescription": "规则描述: {description}",
     "ruleHasOverride": "覆写配置: 响应体={response}, 状态码={statusCode}",
-    "clientErrorNote": "此错误由用户输入导致，不会重试，不计入熔断器。"
+    "clientErrorNote": "此错误由用户输入导致，不会重试，不计入熔断器。",
+    "endpointPoolExhausted": "端点池耗尽（所有端点不可用）",
+    "endpointStats": "端点过滤统计",
+    "endpointStatsTotal": "总端点数: {count}",
+    "endpointStatsEnabled": "已启用端点: {count}",
+    "endpointStatsCircuitOpen": "已熔断端点: {count}",
+    "endpointStatsAvailable": "可用端点: {count}",
+    "strictBlockNoEndpoints": "严格模式：无可用端点候选，跳过该供应商且不降级",
+    "strictBlockSelectorError": "严格模式：端点选择器发生错误，跳过该供应商且不降级"
   }
 }

--- a/messages/zh-CN/settings/providers/filter.json
+++ b/messages/zh-CN/settings/providers/filter.json
@@ -10,6 +10,8 @@
     "default": "default"
   },
   "circuitBroken": "熔断",
+  "keyCircuitBroken": "Key 熔断",
+  "endpointCircuitBroken": "端点熔断",
   "mobileFilter": "筛选",
   "mobileFilterCount": "筛选 ({count})",
   "resetFilters": "重置筛选"

--- a/messages/zh-CN/settings/providers/list.json
+++ b/messages/zh-CN/settings/providers/list.json
@@ -5,6 +5,8 @@
   "todayUsageLabel": "今日用量",
   "todayUsageCount": "{count} 次",
   "circuitBroken": "熔断中",
+  "keyCircuitBroken": "Key 熔断",
+  "endpointCircuitBroken": "端点熔断",
   "officialWebsite": "官网",
   "viewFullKey": "查看完整 API Key",
   "viewFullKeyDesc": "请妥善保管，不要泄露给他人",

--- a/messages/zh-CN/settings/providers/strings.json
+++ b/messages/zh-CN/settings/providers/strings.json
@@ -112,6 +112,9 @@
     "unhealthy": "故障",
     "unknown": "未知",
     "circuitOpen": "熔断开启",
-    "circuitHalfOpen": "熔断半开"
+    "circuitHalfOpen": "熔断半开",
+    "resetCircuit": "重置熔断",
+    "resetCircuitSuccess": "端点熔断已重置",
+    "resetCircuitFailed": "重置端点熔断失败"
   }
 }

--- a/messages/zh-TW/provider-chain.json
+++ b/messages/zh-TW/provider-chain.json
@@ -37,7 +37,8 @@
     "systemError": "系統錯誤",
     "concurrentLimit": "並發限制",
     "http2Fallback": "HTTP/2 回退",
-    "clientError": "客戶端錯誤"
+    "clientError": "客戶端錯誤",
+    "endpointPoolExhausted": "端點池耗盡"
   },
   "reasons": {
     "request_success": "成功",
@@ -48,7 +49,8 @@
     "concurrent_limit_failed": "並發限制",
     "http2_fallback": "HTTP/2 回退",
     "session_reuse": "會話複用",
-    "initial_selection": "首次選擇"
+    "initial_selection": "首次選擇",
+    "endpoint_pool_exhausted": "端點池耗盡"
   },
   "filterReasons": {
     "rate_limited": "速率限制",
@@ -61,7 +63,9 @@
     "context_1m_disabled": "1M上下文已停用",
     "model_not_supported": "不支援該模型",
     "group_mismatch": "分組不匹配",
-    "health_check_failed": "健康檢查失敗"
+    "health_check_failed": "健康檢查失敗",
+    "endpoint_circuit_open": "端點已熔斷",
+    "endpoint_disabled": "端點已停用"
   },
   "details": {
     "selectionMethod": "選擇方式",
@@ -185,6 +189,14 @@
     "ruleMatchType": "匹配類型: {matchType}",
     "ruleDescription": "規則描述: {description}",
     "ruleHasOverride": "覆寫設定: 回應體={response}, 狀態碼={statusCode}",
-    "clientErrorNote": "此錯誤由使用者輸入導致，不會重試，不計入熔斷器。"
+    "clientErrorNote": "此錯誤由使用者輸入導致，不會重試，不計入熔斷器。",
+    "endpointPoolExhausted": "端點池耗盡（所有端點不可用）",
+    "endpointStats": "端點過濾統計",
+    "endpointStatsTotal": "總端點數: {count}",
+    "endpointStatsEnabled": "已啟用端點: {count}",
+    "endpointStatsCircuitOpen": "已熔斷端點: {count}",
+    "endpointStatsAvailable": "可用端點: {count}",
+    "strictBlockNoEndpoints": "嚴格模式：無可用端點候選，跳過該供應商且不降級",
+    "strictBlockSelectorError": "嚴格模式：端點選擇器發生錯誤，跳過該供應商且不降級"
   }
 }

--- a/messages/zh-TW/settings/providers/filter.json
+++ b/messages/zh-TW/settings/providers/filter.json
@@ -1,5 +1,7 @@
 {
   "circuitBroken": "熔斷",
+  "keyCircuitBroken": "Key 熔斷",
+  "endpointCircuitBroken": "端點熔斷",
   "groups": {
     "all": "所有",
     "default": "default",

--- a/messages/zh-TW/settings/providers/list.json
+++ b/messages/zh-TW/settings/providers/list.json
@@ -1,6 +1,8 @@
 {
   "cancelButton": "關閉",
   "circuitBroken": "熔斷中",
+  "keyCircuitBroken": "Key 熔斷",
+  "endpointCircuitBroken": "端點熔斷",
   "clipboardUnavailable": "目前環境無法使用剪貼簿，請手動選取複製。",
   "confirmDeleteMessage": "確定要刪除供應商 \"{name}\" 嗎？此操作無法撤銷。",
   "confirmDeleteTitle": "確認刪除供應商？",

--- a/messages/zh-TW/settings/providers/strings.json
+++ b/messages/zh-TW/settings/providers/strings.json
@@ -112,6 +112,9 @@
     "unhealthy": "故障",
     "unknown": "未知",
     "circuitOpen": "熔斷開啟",
-    "circuitHalfOpen": "熔斷半開"
+    "circuitHalfOpen": "熔斷半開",
+    "resetCircuit": "重置熔斷",
+    "resetCircuitSuccess": "端點熔斷已重置",
+    "resetCircuitFailed": "重置端點熔斷失敗"
   }
 }

--- a/src/actions/provider-endpoints.ts
+++ b/src/actions/provider-endpoints.ts
@@ -124,7 +124,7 @@ const SetVendorTypeManualOpenSchema = z.object({
 });
 
 const BatchGetEndpointCircuitInfoSchema = z.object({
-  endpointIds: z.array(EndpointIdSchema).min(0).max(500),
+  endpointIds: z.array(EndpointIdSchema).max(500),
 });
 
 async function getAdminSession() {

--- a/src/actions/provider-endpoints.ts
+++ b/src/actions/provider-endpoints.ts
@@ -124,7 +124,7 @@ const SetVendorTypeManualOpenSchema = z.object({
 });
 
 const BatchGetEndpointCircuitInfoSchema = z.object({
-  endpointIds: z.array(EndpointIdSchema).min(0),
+  endpointIds: z.array(EndpointIdSchema).min(0).max(500),
 });
 
 async function getAdminSession() {

--- a/src/app/[locale]/settings/providers/_components/endpoint-status.ts
+++ b/src/app/[locale]/settings/providers/_components/endpoint-status.ts
@@ -157,11 +157,11 @@ export function resolveEndpointDisplayStatus(
     };
   }
 
-  // Priority 2/3: Circuit Closed - check enabled/disabled
+  // Priority 2/3: Circuit Closed - check enabled/disabled (no circuit incident)
   const isExplicitlyDisabled = endpoint.isEnabled === false;
   return {
     status: isExplicitlyDisabled ? "disabled" : "enabled",
-    source: "endpoint",
+    source: "provider",
     priority: isExplicitlyDisabled ? 3 : 2,
   };
 }

--- a/src/app/[locale]/settings/providers/_components/provider-endpoints-table.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-endpoints-table.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Edit2, Loader2, MoreHorizontal, Play, Plus, Trash2 } from "lucide-react";
+import { Edit2, Loader2, MoreHorizontal, Play, Plus, RotateCcw, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
   addProviderEndpoint,
+  batchGetEndpointCircuitInfo,
   editProviderEndpoint,
   getProviderEndpoints,
   getProviderEndpointsByVendor,
   probeProviderEndpoint,
   removeProviderEndpoint,
+  resetEndpointCircuit,
 } from "@/actions/provider-endpoints";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -58,6 +60,7 @@ import {
 import { getErrorMessage } from "@/lib/utils/error-messages";
 import type { ProviderEndpoint, ProviderType } from "@/types/provider";
 import { EndpointLatencySparkline } from "./endpoint-latency-sparkline";
+import type { EndpointCircuitState } from "./endpoint-status";
 import { UrlPreview } from "./forms/url-preview";
 
 // ============================================================================
@@ -127,6 +130,24 @@ export function ProviderEndpointsTable({
     });
   }, [rawEndpoints]);
 
+  // Fetch circuit breaker states for all endpoints in batch
+  const endpointIds = useMemo(() => endpoints.map((ep) => ep.id), [endpoints]);
+  const { data: circuitInfoMap = {} } = useQuery({
+    queryKey: ["endpoint-circuit-info", ...endpointIds],
+    queryFn: async () => {
+      if (endpointIds.length === 0) return {};
+      const res = await batchGetEndpointCircuitInfo({ endpointIds });
+      if (!res.ok || !res.data) return {};
+      const map: Record<number, EndpointCircuitState> = {};
+      for (const item of res.data) {
+        map[item.endpointId] = item.circuitState as EndpointCircuitState;
+      }
+      return map;
+    },
+    enabled: endpointIds.length > 0,
+    staleTime: 15_000,
+  });
+
   if (isLoading) {
     return <div className="text-center py-4 text-sm text-muted-foreground">{t("keyLoading")}</div>;
   }
@@ -160,6 +181,7 @@ export function ProviderEndpointsTable({
               tTypes={tTypes}
               readOnly={readOnly}
               hideTypeColumn={hideTypeColumn}
+              circuitState={circuitInfoMap[endpoint.id] ?? null}
             />
           ))}
         </TableBody>
@@ -177,13 +199,16 @@ function EndpointRow({
   tTypes,
   readOnly,
   hideTypeColumn,
+  circuitState,
 }: {
   endpoint: ProviderEndpoint;
   tTypes: ReturnType<typeof useTranslations>;
   readOnly: boolean;
   hideTypeColumn: boolean;
+  circuitState: EndpointCircuitState | null;
 }) {
   const t = useTranslations("settings.providers");
+  const tStatus = useTranslations("settings.providers.endpointStatus");
   const tCommon = useTranslations("settings.common");
   const queryClient = useQueryClient();
   const [isProbing, setIsProbing] = useState(false);
@@ -255,6 +280,24 @@ function EndpointRow({
     },
   });
 
+  const resetCircuitMutation = useMutation({
+    mutationFn: async () => {
+      const res = await resetEndpointCircuit({ endpointId: endpoint.id });
+      if (!res.ok) throw new Error(res.error);
+      return res;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["endpoint-circuit-info"] });
+      queryClient.invalidateQueries({ queryKey: ["provider-endpoints"] });
+      toast.success(tStatus("resetCircuitSuccess"));
+    },
+    onError: () => {
+      toast.error(tStatus("resetCircuitFailed"));
+    },
+  });
+
+  const isCircuitTripped = circuitState === "open" || circuitState === "half-open";
+
   return (
     <TableRow>
       {!hideTypeColumn && (
@@ -277,8 +320,17 @@ function EndpointRow({
         {endpoint.url}
       </TableCell>
       <TableCell>
-        <div className="flex items-center gap-2">
-          {endpoint.isEnabled ? (
+        <div className="flex items-center gap-2 flex-wrap">
+          {circuitState === "open" ? (
+            <Badge variant="destructive">{tStatus("circuitOpen")}</Badge>
+          ) : circuitState === "half-open" ? (
+            <Badge
+              variant="secondary"
+              className="text-amber-600 bg-amber-500/10 hover:bg-amber-500/20"
+            >
+              {tStatus("circuitHalfOpen")}
+            </Badge>
+          ) : endpoint.isEnabled ? (
             <Badge
               variant="secondary"
               className="text-green-600 bg-green-500/10 hover:bg-green-500/20"
@@ -335,6 +387,15 @@ function EndpointRow({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                {isCircuitTripped && (
+                  <DropdownMenuItem
+                    onClick={() => resetCircuitMutation.mutate()}
+                    disabled={resetCircuitMutation.isPending}
+                  >
+                    <RotateCcw className="mr-2 h-4 w-4" />
+                    {tStatus("resetCircuit")}
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem
                   className="text-destructive focus:text-destructive"
                   onClick={() => {

--- a/src/app/[locale]/settings/providers/_components/provider-endpoints-table.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-endpoints-table.tsx
@@ -133,7 +133,7 @@ export function ProviderEndpointsTable({
   // Fetch circuit breaker states for all endpoints in batch
   const endpointIds = useMemo(() => endpoints.map((ep) => ep.id), [endpoints]);
   const { data: circuitInfoMap = {} } = useQuery({
-    queryKey: ["endpoint-circuit-info", ...endpointIds],
+    queryKey: ["endpoint-circuit-info", endpointIds.toSorted((a, b) => a - b).join(",")],
     queryFn: async () => {
       if (endpointIds.length === 0) return {};
       const res = await batchGetEndpointCircuitInfo({ endpointIds });

--- a/src/app/[locale]/settings/providers/_components/provider-list.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-list.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import type { CurrencyCode } from "@/lib/utils/currency";
 import type { ProviderDisplay, ProviderStatisticsMap } from "@/types/provider";
 import type { User } from "@/types/user";
+import type { EndpointCircuitInfoMap } from "./provider-manager";
 import { ProviderRichListItem } from "./provider-rich-list-item";
 
 interface ProviderListProps {
@@ -19,6 +20,8 @@ interface ProviderListProps {
       recoveryMinutes: number | null;
     }
   >;
+  /** Endpoint-level circuit breaker info, keyed by provider ID */
+  endpointCircuitInfo?: EndpointCircuitInfoMap;
   statistics?: ProviderStatisticsMap;
   statisticsLoading?: boolean;
   currencyCode?: CurrencyCode;
@@ -36,6 +39,7 @@ export function ProviderList({
   providers,
   currentUser,
   healthStatus,
+  endpointCircuitInfo = {},
   statistics = {},
   statisticsLoading = false,
   currencyCode = "USD",
@@ -70,6 +74,7 @@ export function ProviderList({
           provider={provider}
           currentUser={currentUser}
           healthStatus={healthStatus[provider.id]}
+          endpointCircuitInfo={endpointCircuitInfo[provider.id]}
           statistics={statistics[provider.id]}
           statisticsLoading={statisticsLoading}
           currencyCode={currencyCode}

--- a/src/app/[locale]/settings/providers/_components/provider-manager.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-manager.tsx
@@ -109,7 +109,7 @@ export function ProviderManager({
       }
       // Endpoint-level circuit open
       const endpoints = endpointCircuitInfo[providerId];
-      if (endpoints?.some((ep) => ep.circuitState === "open")) {
+      if (Array.isArray(endpoints) && endpoints.some((ep) => ep.circuitState === "open")) {
         return true;
       }
       return false;

--- a/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
@@ -78,6 +78,13 @@ interface ProviderRichListItemProps {
     circuitOpenUntil: number | null;
     recoveryMinutes: number | null;
   };
+  /** Endpoint-level circuit breaker info for this provider */
+  endpointCircuitInfo?: Array<{
+    endpointId: number;
+    circuitState: "closed" | "open" | "half-open";
+    failureCount: number;
+    circuitOpenUntil: number | null;
+  }>;
   statistics?: ProviderStatistics;
   statisticsLoading?: boolean;
   currencyCode?: CurrencyCode;
@@ -98,6 +105,7 @@ export function ProviderRichListItem({
   provider,
   currentUser,
   healthStatus,
+  endpointCircuitInfo = [],
   statistics,
   statisticsLoading = false,
   currencyCode = "USD",
@@ -500,10 +508,21 @@ export function ProviderRichListItem({
           ) : (
             <Badge variant="outline">{PROVIDER_GROUP.DEFAULT}</Badge>
           )}
+          {/* Key-level circuit badge */}
           {healthStatus?.circuitState === "open" && (
             <Badge variant="destructive" className="flex items-center gap-1">
               <AlertTriangle className="h-3 w-3" />
-              {tList("circuitBroken")}
+              {tList("keyCircuitBroken")}
+            </Badge>
+          )}
+          {/* Endpoint-level circuit badge */}
+          {endpointCircuitInfo?.some((ep) => ep.circuitState === "open") && (
+            <Badge
+              variant="outline"
+              className="flex items-center gap-1 bg-orange-100 text-orange-700 border-orange-300 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-700"
+            >
+              <AlertTriangle className="h-3 w-3" />
+              {tList("endpointCircuitBroken")}
             </Badge>
           )}
         </div>
@@ -688,10 +707,21 @@ export function ProviderRichListItem({
                 {PROVIDER_GROUP.DEFAULT}
               </Badge>
             )}
+            {/* Key-level circuit badge */}
             {healthStatus?.circuitState === "open" && (
               <Badge variant="destructive" className="flex items-center gap-1 flex-shrink-0">
                 <AlertTriangle className="h-3 w-3" />
-                {tList("circuitBroken")}
+                {tList("keyCircuitBroken")}
+              </Badge>
+            )}
+            {/* Endpoint-level circuit badge */}
+            {endpointCircuitInfo?.some((ep) => ep.circuitState === "open") && (
+              <Badge
+                variant="outline"
+                className="flex items-center gap-1 flex-shrink-0 bg-orange-100 text-orange-700 border-orange-300 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-400 dark:border-orange-700"
+              >
+                <AlertTriangle className="h-3 w-3" />
+                {tList("endpointCircuitBroken")}
               </Badge>
             )}
           </div>

--- a/src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx
@@ -26,7 +26,7 @@ import { getErrorMessage } from "@/lib/utils/error-messages";
 import type { ProviderDisplay, ProviderVendor } from "@/types/provider";
 import type { User } from "@/types/user";
 import { ProviderEndpointsSection } from "./provider-endpoints-table";
-import type { EndpointCircuitInfoMap } from "./provider-manager";
+
 import { VendorKeysCompactList } from "./vendor-keys-compact-list";
 
 interface ProviderVendorViewProps {
@@ -34,8 +34,6 @@ interface ProviderVendorViewProps {
   currentUser?: User;
   enableMultiProviderTypes: boolean;
   healthStatus: Record<number, any>;
-  /** Endpoint-level circuit breaker info, keyed by provider ID */
-  endpointCircuitInfo?: EndpointCircuitInfoMap;
   statistics: Record<number, any>;
   statisticsLoading: boolean;
   currencyCode: CurrencyCode;

--- a/src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx
@@ -26,6 +26,7 @@ import { getErrorMessage } from "@/lib/utils/error-messages";
 import type { ProviderDisplay, ProviderVendor } from "@/types/provider";
 import type { User } from "@/types/user";
 import { ProviderEndpointsSection } from "./provider-endpoints-table";
+import type { EndpointCircuitInfoMap } from "./provider-manager";
 import { VendorKeysCompactList } from "./vendor-keys-compact-list";
 
 interface ProviderVendorViewProps {
@@ -33,6 +34,8 @@ interface ProviderVendorViewProps {
   currentUser?: User;
   enableMultiProviderTypes: boolean;
   healthStatus: Record<number, any>;
+  /** Endpoint-level circuit breaker info, keyed by provider ID */
+  endpointCircuitInfo?: EndpointCircuitInfoMap;
   statistics: Record<number, any>;
   statisticsLoading: boolean;
   currencyCode: CurrencyCode;

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -523,8 +523,8 @@ export class ProxyForwarder {
           session.addProviderToChain(currentProvider, {
             reason: "endpoint_pool_exhausted",
             strictBlockCause: strictBlockCause as ProviderChainItem["strictBlockCause"],
-            endpointFilterStats: filterStats,
-            decisionContext: exhaustionContext as ProviderChainItem["decisionContext"],
+            ...(filterStats ? { endpointFilterStats: filterStats } : {}),
+            errorMessage: endpointSelectionError?.message,
           });
 
           failedProviderIds.push(currentProvider.id);

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -18,7 +18,10 @@ import { PROVIDER_DEFAULTS, PROVIDER_LIMITS } from "@/lib/constants/provider.con
 import { recordEndpointFailure, recordEndpointSuccess } from "@/lib/endpoint-circuit-breaker";
 import { applyGeminiGoogleSearchOverrideWithAudit } from "@/lib/gemini/provider-overrides";
 import { logger } from "@/lib/logger";
-import { getPreferredProviderEndpoints } from "@/lib/provider-endpoints/endpoint-selector";
+import {
+  getEndpointFilterStats,
+  getPreferredProviderEndpoints,
+} from "@/lib/provider-endpoints/endpoint-selector";
 import { getGlobalAgentPool, getProxyAgentForProvider } from "@/lib/proxy-agent";
 import { SessionManager } from "@/lib/session-manager";
 import { CONTEXT_1M_BETA_HEADER, shouldApplyContext1m } from "@/lib/special-attributes";
@@ -28,6 +31,7 @@ import {
 } from "@/lib/vendor-type-circuit-breaker";
 import { updateMessageRequestDetails } from "@/repository/message";
 import type { CacheTtlPreference, CacheTtlResolved } from "@/types/cache";
+import type { ProviderChainItem } from "@/types/message";
 import type { ClaudeMetadataUserIdInjectionSpecialSetting } from "@/types/special-settings";
 
 import { GeminiAuth } from "../gemini/auth";
@@ -475,6 +479,10 @@ export class ProxyForwarder {
 
       if (endpointCandidates.length === 0) {
         if (shouldEnforceStrictEndpointPool) {
+          const strictBlockCause = endpointSelectionError
+            ? "selector_error"
+            : "no_endpoint_candidates";
+
           logger.warn(
             "ProxyForwarder: Strict endpoint policy blocked legacy provider.url fallback",
             {
@@ -483,12 +491,42 @@ export class ProxyForwarder {
               providerType: currentProvider.providerType,
               requestPath,
               reason: "strict_blocked_legacy_fallback",
-              strictBlockCause: endpointSelectionError
-                ? "selector_error"
-                : "no_endpoint_candidates",
+              strictBlockCause,
               selectorError: endpointSelectionError?.message,
             }
           );
+
+          // Record endpoint pool exhaustion in provider chain for audit trail
+          const exhaustionContext: Record<string, unknown> = { strictBlockCause };
+          if (endpointSelectionError) {
+            exhaustionContext.selectorError = endpointSelectionError.message;
+          }
+
+          // Collect endpoint filter stats for no_endpoint_candidates (selector_error has no data)
+          let filterStats: ProviderChainItem["endpointFilterStats"];
+          if (!endpointSelectionError) {
+            try {
+              const stats = await getEndpointFilterStats({
+                vendorId: providerVendorId,
+                providerType: currentProvider.providerType,
+              });
+              filterStats = stats;
+            } catch (statsError) {
+              logger.warn("[ProxyForwarder] Failed to collect endpoint filter stats", {
+                providerId: currentProvider.id,
+                vendorId: providerVendorId,
+                error: statsError instanceof Error ? statsError.message : String(statsError),
+              });
+            }
+          }
+
+          session.addProviderToChain(currentProvider, {
+            reason: "endpoint_pool_exhausted",
+            strictBlockCause: strictBlockCause as ProviderChainItem["strictBlockCause"],
+            endpointFilterStats: filterStats,
+            decisionContext: exhaustionContext as ProviderChainItem["decisionContext"],
+          });
+
           failedProviderIds.push(currentProvider.id);
           attemptCount = maxAttemptsPerProvider;
         } else {

--- a/src/app/v1/_lib/proxy/session.ts
+++ b/src/app/v1/_lib/proxy/session.ts
@@ -459,7 +459,8 @@ export class ProxySession {
         | "retry_with_official_instructions" // Codex instructions 自动重试（官方）
         | "retry_with_cached_instructions" // Codex instructions 智能重试（缓存）
         | "client_error_non_retryable" // 不可重试的客户端错误（Prompt 超限、内容过滤、PDF 限制、Thinking 格式）
-        | "http2_fallback"; // HTTP/2 协议错误，回退到 HTTP/1.1（不切换供应商、不计入熔断器）
+        | "http2_fallback" // HTTP/2 协议错误，回退到 HTTP/1.1（不切换供应商、不计入熔断器）
+        | "endpoint_pool_exhausted"; // 端点池耗尽（strict endpoint policy 阻止了 fallback）
       selectionMethod?:
         | "session_reuse"
         | "weighted_random"
@@ -476,6 +477,8 @@ export class ProxySession {
       circuitFailureThreshold?: number; // 熔断阈值
       errorDetails?: ProviderChainItem["errorDetails"]; // 结构化错误详情
       decisionContext?: ProviderChainItem["decisionContext"];
+      strictBlockCause?: ProviderChainItem["strictBlockCause"]; // endpoint pool exhaustion cause
+      endpointFilterStats?: ProviderChainItem["endpointFilterStats"]; // endpoint filter statistics
     }
   ): void {
     const item: ProviderChainItem = {
@@ -502,6 +505,8 @@ export class ProxySession {
       circuitFailureThreshold: metadata?.circuitFailureThreshold,
       errorDetails: metadata?.errorDetails, // 结构化错误详情
       decisionContext: metadata?.decisionContext,
+      strictBlockCause: metadata?.strictBlockCause,
+      endpointFilterStats: metadata?.endpointFilterStats,
     };
 
     // 避免重复添加同一个供应商（除非是重试，即有 attemptNumber）

--- a/src/lib/endpoint-circuit-breaker.ts
+++ b/src/lib/endpoint-circuit-breaker.ts
@@ -247,8 +247,11 @@ export async function triggerEndpointCircuitBreakerAlert(
         vendorId = endpoint.vendorId;
         endpointLabel = endpoint.label || "";
       }
-    } catch {
-      // DB lookup failure should not block alert
+    } catch (lookupError) {
+      logger.warn("[EndpointCircuitBreaker] Failed to enrich alert with endpoint info", {
+        endpointId,
+        error: lookupError instanceof Error ? lookupError.message : String(lookupError),
+      });
     }
 
     await sendCircuitBreakerAlert({

--- a/src/lib/endpoint-circuit-breaker.ts
+++ b/src/lib/endpoint-circuit-breaker.ts
@@ -235,21 +235,25 @@ export async function triggerEndpointCircuitBreakerAlert(
   try {
     const { sendCircuitBreakerAlert } = await import("@/lib/notification/notifier");
 
-    // Try to enrich with endpoint URL from database
+    // Try to enrich with endpoint URL and vendor info from database
     let endpointUrl: string | undefined;
+    let vendorId = 0;
+    let endpointLabel = "";
     try {
       const { findProviderEndpointById } = await import("@/repository");
       const endpoint = await findProviderEndpointById(endpointId);
       if (endpoint) {
         endpointUrl = endpoint.url;
+        vendorId = endpoint.vendorId;
+        endpointLabel = endpoint.label || "";
       }
     } catch {
       // DB lookup failure should not block alert
     }
 
     await sendCircuitBreakerAlert({
-      providerId: endpointId, // Use endpointId as providerId for dedup purposes
-      providerName: "",
+      providerId: vendorId,
+      providerName: endpointLabel || `endpoint:${endpointId}`,
       failureCount,
       retryAt,
       lastError,

--- a/src/lib/notification/notifier.ts
+++ b/src/lib/notification/notifier.ts
@@ -25,7 +25,8 @@ export async function sendCircuitBreakerAlert(data: CircuitBreakerAlertData): Pr
     // 防止 5 分钟内重复告警
     const redisClient = getRedisClient();
     const source = data.incidentSource ?? "provider";
-    const dedupSuffix = source === "endpoint" ? `endpoint:${data.endpointId}` : source;
+    const dedupSuffix =
+      source === "endpoint" && data.endpointId != null ? `endpoint:${data.endpointId}` : source;
     if (redisClient) {
       const cacheKey = `circuit-breaker-alert:${data.providerId}:${dedupSuffix}`;
       const cached = await redisClient.get(cacheKey);

--- a/src/lib/notification/notifier.ts
+++ b/src/lib/notification/notifier.ts
@@ -24,14 +24,17 @@ export async function sendCircuitBreakerAlert(data: CircuitBreakerAlertData): Pr
 
     // 防止 5 分钟内重复告警
     const redisClient = getRedisClient();
+    const source = data.incidentSource ?? "provider";
+    const dedupSuffix = source === "endpoint" ? `endpoint:${data.endpointId}` : source;
     if (redisClient) {
-      const cacheKey = `circuit-breaker-alert:${data.providerId}`;
+      const cacheKey = `circuit-breaker-alert:${data.providerId}:${dedupSuffix}`;
       const cached = await redisClient.get(cacheKey);
 
       if (cached) {
         logger.info({
           action: "circuit_breaker_alert_suppressed",
           providerId: data.providerId,
+          incidentSource: source,
           reason: "duplicate_within_5min",
         });
         return;
@@ -112,11 +115,13 @@ export async function sendCircuitBreakerAlert(data: CircuitBreakerAlertData): Pr
     logger.info({
       action: "circuit_breaker_alert_sent",
       providerId: data.providerId,
+      incidentSource: source,
     });
   } catch (error) {
     logger.error({
       action: "send_circuit_breaker_alert_error",
       providerId: data.providerId,
+      incidentSource: data.incidentSource ?? "provider",
       error: error instanceof Error ? error.message : String(error),
     });
   }

--- a/src/lib/utils/provider-chain-formatter.test.ts
+++ b/src/lib/utils/provider-chain-formatter.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, test } from "vitest";
-import { formatProbability, formatProbabilityCompact } from "./provider-chain-formatter";
+import type { ProviderChainItem } from "@/types/message";
+import {
+  formatProbability,
+  formatProbabilityCompact,
+  formatProviderDescription,
+  formatProviderSummary,
+  formatProviderTimeline,
+} from "./provider-chain-formatter";
+
+/**
+ * Simple mock t() function: returns the key followed by interpolated values.
+ * Format: "key" or "key [k1=v1, k2=v2]" when values are provided.
+ * This is enough to verify the formatter calls t() with the right keys and values.
+ */
+function mockT(key: string, values?: Record<string, string | number>): string {
+  if (!values || Object.keys(values).length === 0) {
+    return key;
+  }
+  const pairs = Object.entries(values)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(", ");
+  return `${key} [${pairs}]`;
+}
 
 describe("formatProbability", () => {
   test("formats 0.5 as 50.0%", () => {
@@ -60,5 +82,232 @@ describe("formatProbabilityCompact", () => {
   test("returns null for invalid values", () => {
     expect(formatProbabilityCompact(undefined)).toBeNull();
     expect(formatProbabilityCompact(Number.NaN)).toBeNull();
+  });
+});
+
+// =============================================================================
+// endpoint_pool_exhausted reason tests
+// =============================================================================
+
+describe("endpoint_pool_exhausted", () => {
+  // ---------------------------------------------------------------------------
+  // Shared fixtures
+  // ---------------------------------------------------------------------------
+  const baseExhaustedItem: ProviderChainItem = {
+    id: 1,
+    name: "provider-a",
+    reason: "endpoint_pool_exhausted",
+    timestamp: 1000,
+    endpointFilterStats: {
+      total: 5,
+      enabled: 4,
+      circuitOpen: 3,
+      available: 0,
+    },
+    strictBlockCause: "no_endpoint_candidates",
+  };
+
+  const exhaustedWithSelectorError: ProviderChainItem = {
+    id: 1,
+    name: "provider-a",
+    reason: "endpoint_pool_exhausted",
+    timestamp: 1000,
+    endpointFilterStats: {
+      total: 3,
+      enabled: 2,
+      circuitOpen: 1,
+      available: 0,
+    },
+    strictBlockCause: "selector_error",
+    errorMessage: "endpoint selector threw an unexpected error",
+  };
+
+  const exhaustedNoStats: ProviderChainItem = {
+    id: 1,
+    name: "provider-a",
+    reason: "endpoint_pool_exhausted",
+    timestamp: 1000,
+  };
+
+  // ---------------------------------------------------------------------------
+  // getProviderStatus / isActualRequest (tested implicitly through formatters)
+  // ---------------------------------------------------------------------------
+
+  describe("formatProviderSummary", () => {
+    test("renders exhausted item in chain path with failure mark", () => {
+      const chain: ProviderChainItem[] = [baseExhaustedItem];
+      const result = formatProviderSummary(chain, mockT);
+
+      // Should show a failure status marker for this provider
+      expect(result).toContain("provider-a");
+      expect(result).toContain("✗");
+    });
+
+    test("renders exhausted alongside successful retry in multi-provider chain", () => {
+      const chain: ProviderChainItem[] = [
+        baseExhaustedItem,
+        {
+          id: 2,
+          name: "provider-b",
+          reason: "request_success",
+          statusCode: 200,
+          timestamp: 2000,
+        },
+      ];
+      const result = formatProviderSummary(chain, mockT);
+
+      expect(result).toContain("provider-a");
+      expect(result).toContain("provider-b");
+      // provider-a should be failure, provider-b should be success
+      expect(result).toMatch(/provider-a\(.*\).*provider-b\(.*\)/);
+    });
+  });
+
+  describe("formatProviderDescription", () => {
+    test("shows endpoint pool exhausted label in request chain", () => {
+      const chain: ProviderChainItem[] = [baseExhaustedItem];
+      const result = formatProviderDescription(chain, mockT);
+
+      expect(result).toContain("provider-a");
+      expect(result).toContain("description.endpointPoolExhausted");
+    });
+
+    test("handles exhausted item when it is the only item (no initial_selection)", () => {
+      const chain: ProviderChainItem[] = [baseExhaustedItem];
+      const result = formatProviderDescription(chain, mockT);
+
+      // Should not crash, should produce something reasonable
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("formatProviderTimeline", () => {
+    test("renders endpoint pool exhausted with filter stats", () => {
+      const chain: ProviderChainItem[] = [
+        {
+          id: 1,
+          name: "provider-a",
+          reason: "initial_selection",
+          timestamp: 0,
+          decisionContext: {
+            totalProviders: 3,
+            enabledProviders: 3,
+            targetType: "claude",
+            groupFilterApplied: false,
+            beforeHealthCheck: 3,
+            afterHealthCheck: 3,
+            priorityLevels: [1],
+            selectedPriority: 1,
+            candidatesAtPriority: [],
+          },
+        },
+        baseExhaustedItem,
+      ];
+
+      const { timeline } = formatProviderTimeline(chain, mockT);
+
+      // Should contain the title for endpoint pool exhausted
+      expect(timeline).toContain("timeline.endpointPoolExhausted");
+
+      // Should contain filter stats breakdown with values
+      expect(timeline).toContain("timeline.endpointStatsTotal [count=5]");
+      expect(timeline).toContain("timeline.endpointStatsEnabled [count=4]");
+      expect(timeline).toContain("timeline.endpointStatsCircuitOpen [count=3]");
+      expect(timeline).toContain("timeline.endpointStatsAvailable [count=0]");
+    });
+
+    test("renders strictBlockCause = no_endpoint_candidates", () => {
+      const chain: ProviderChainItem[] = [baseExhaustedItem];
+      const { timeline } = formatProviderTimeline(chain, mockT);
+
+      expect(timeline).toContain("timeline.strictBlockNoEndpoints");
+    });
+
+    test("renders strictBlockCause = selector_error with error message", () => {
+      const chain: ProviderChainItem[] = [exhaustedWithSelectorError];
+      const { timeline } = formatProviderTimeline(chain, mockT);
+
+      expect(timeline).toContain("timeline.strictBlockSelectorError");
+      // The error message is passed through t("timeline.error", { error: ... })
+      expect(timeline).toContain("error=endpoint selector threw an unexpected error");
+    });
+
+    test("degrades gracefully when endpointFilterStats is missing", () => {
+      const chain: ProviderChainItem[] = [exhaustedNoStats];
+      const { timeline } = formatProviderTimeline(chain, mockT);
+
+      // Should still render without crashing
+      expect(timeline).toContain("timeline.endpointPoolExhausted");
+      // Provider name is embedded in the mockT output as a value
+      expect(timeline).toContain("provider=provider-a");
+      // Should NOT contain stats section
+      expect(timeline).not.toContain("timeline.endpointStatsTotal");
+    });
+
+    test("computes totalDuration correctly with exhausted items", () => {
+      const chain: ProviderChainItem[] = [
+        {
+          id: 1,
+          name: "provider-a",
+          reason: "initial_selection",
+          timestamp: 0,
+          decisionContext: {
+            totalProviders: 1,
+            enabledProviders: 1,
+            targetType: "claude",
+            groupFilterApplied: false,
+            beforeHealthCheck: 1,
+            afterHealthCheck: 1,
+            priorityLevels: [1],
+            selectedPriority: 1,
+            candidatesAtPriority: [],
+          },
+        },
+        { ...baseExhaustedItem, timestamp: 500 },
+      ];
+      const { totalDuration } = formatProviderTimeline(chain, mockT);
+      expect(totalDuration).toBe(500);
+    });
+  });
+});
+
+// =============================================================================
+// Unknown reason graceful degradation
+// =============================================================================
+
+describe("unknown reason graceful degradation", () => {
+  const unknownItem: ProviderChainItem = {
+    id: 99,
+    name: "provider-x",
+    // @ts-expect-error -- intentionally testing an unknown reason string
+    reason: "some_future_reason_not_yet_defined",
+    timestamp: 1000,
+  };
+
+  test("formatProviderSummary does not throw for unknown reason", () => {
+    expect(() => formatProviderSummary([unknownItem], mockT)).not.toThrow();
+  });
+
+  test("formatProviderDescription does not throw for unknown reason", () => {
+    expect(() => formatProviderDescription([unknownItem], mockT)).not.toThrow();
+  });
+
+  test("formatProviderTimeline does not throw for unknown reason", () => {
+    expect(() => formatProviderTimeline([unknownItem], mockT)).not.toThrow();
+    const { timeline } = formatProviderTimeline([unknownItem], mockT);
+    // Should include the provider name and the raw reason as fallback
+    expect(timeline).toContain("provider-x");
+    expect(timeline).toContain("some_future_reason_not_yet_defined");
+  });
+
+  test("formatProviderTimeline renders unknown reason with no reason field", () => {
+    const noReasonItem: ProviderChainItem = {
+      id: 99,
+      name: "provider-y",
+      timestamp: 1000,
+    };
+    const { timeline } = formatProviderTimeline([noReasonItem], mockT);
+    expect(timeline).toContain("provider-y");
+    expect(timeline).toContain("timeline.unknown");
   });
 });

--- a/src/lib/utils/provider-chain-formatter.ts
+++ b/src/lib/utils/provider-chain-formatter.ts
@@ -720,7 +720,7 @@ export function formatProviderTimeline(
       timeline += `${t("timeline.provider", { provider: item.name })}\n`;
 
       // 端点过滤统计
-      if (item.endpointFilterStats) {
+      if (item.endpointFilterStats && typeof item.endpointFilterStats.total === "number") {
         const stats = item.endpointFilterStats;
         timeline += `\n${t("timeline.endpointStats")}:\n`;
         timeline += `${t("timeline.endpointStatsTotal", { count: stats.total })}\n`;

--- a/src/lib/webhook/templates/circuit-breaker.ts
+++ b/src/lib/webhook/templates/circuit-breaker.ts
@@ -18,7 +18,7 @@ export function buildCircuitBreakerMessage(
 
   // Add endpoint-specific fields
   if (isEndpoint) {
-    if (data.endpointId) {
+    if (data.endpointId !== undefined) {
       fields.push({ label: "端点ID", value: String(data.endpointId) });
     }
     if (data.endpointUrl) {
@@ -28,7 +28,7 @@ export function buildCircuitBreakerMessage(
 
   const title = isEndpoint ? "端点熔断告警" : "供应商熔断告警";
   const description = isEndpoint
-    ? `供应商 ${data.providerName} 的端点 (ID: ${data.endpointId}) 已触发熔断保护`
+    ? `供应商 ${data.providerName} 的端点 (ID: ${data.endpointId ?? "N/A"}) 已触发熔断保护`
     : `供应商 ${data.providerName} (ID: ${data.providerId}) 已触发熔断保护`;
 
   return {

--- a/src/lib/webhook/templates/circuit-breaker.ts
+++ b/src/lib/webhook/templates/circuit-breaker.ts
@@ -5,6 +5,8 @@ export function buildCircuitBreakerMessage(
   data: CircuitBreakerAlertData,
   timezone?: string
 ): StructuredMessage {
+  const isEndpoint = data.incidentSource === "endpoint";
+
   const fields = [
     { label: "失败次数", value: `${data.failureCount} 次` },
     { label: "预计恢复", value: formatDateTime(data.retryAt, timezone || "UTC") },
@@ -14,9 +16,24 @@ export function buildCircuitBreakerMessage(
     fields.push({ label: "最后错误", value: data.lastError });
   }
 
+  // Add endpoint-specific fields
+  if (isEndpoint) {
+    if (data.endpointId) {
+      fields.push({ label: "端点ID", value: String(data.endpointId) });
+    }
+    if (data.endpointUrl) {
+      fields.push({ label: "端点地址", value: data.endpointUrl });
+    }
+  }
+
+  const title = isEndpoint ? "端点熔断告警" : "供应商熔断告警";
+  const description = isEndpoint
+    ? `供应商 ${data.providerName} 的端点 (ID: ${data.endpointId}) 已触发熔断保护`
+    : `供应商 ${data.providerName} (ID: ${data.providerId}) 已触发熔断保护`;
+
   return {
     header: {
-      title: "供应商熔断告警",
+      title,
       icon: "🔌",
       level: "error",
     },
@@ -25,7 +42,7 @@ export function buildCircuitBreakerMessage(
         content: [
           {
             type: "quote",
-            value: `供应商 ${data.providerName} (ID: ${data.providerId}) 已触发熔断保护`,
+            value: description,
           },
         ],
       },

--- a/src/lib/webhook/templates/placeholders.ts
+++ b/src/lib/webhook/templates/placeholders.ts
@@ -38,6 +38,13 @@ export const TEMPLATE_PLACEHOLDERS = {
     { key: "{{failure_count}}", label: "失败次数", description: "连续失败计数" },
     { key: "{{retry_at}}", label: "恢复时间", description: "预计恢复时间" },
     { key: "{{last_error}}", label: "错误信息", description: "最后一次错误详情" },
+    {
+      key: "{{incident_source}}",
+      label: "熔断来源",
+      description: "provider(Key 熔断) 或 endpoint(Endpoint 熔断)",
+    },
+    { key: "{{endpoint_id}}", label: "端点ID", description: "触发熔断的端点 ID" },
+    { key: "{{endpoint_url}}", label: "端点地址", description: "触发熔断的端点 URL" },
   ],
   daily_leaderboard: [
     { key: "{{date}}", label: "统计日期", description: "YYYY-MM-DD 格式" },
@@ -91,6 +98,9 @@ export function buildTemplateVariables(params: {
     values["{{failure_count}}"] = cb?.failureCount !== undefined ? String(cb.failureCount) : "";
     values["{{retry_at}}"] = cb?.retryAt ?? "";
     values["{{last_error}}"] = cb?.lastError ?? "";
+    values["{{incident_source}}"] = cb?.incidentSource ?? "provider";
+    values["{{endpoint_id}}"] = cb?.endpointId !== undefined ? String(cb.endpointId) : "";
+    values["{{endpoint_url}}"] = cb?.endpointUrl ?? "";
   }
 
   if (notificationType === "daily_leaderboard") {

--- a/src/lib/webhook/types.ts
+++ b/src/lib/webhook/types.ts
@@ -45,6 +45,12 @@ export interface CircuitBreakerAlertData {
   failureCount: number;
   retryAt: string;
   lastError?: string;
+  /** Incident source: 'provider' for key circuit, 'endpoint' for endpoint circuit */
+  incidentSource?: "provider" | "endpoint";
+  /** Endpoint ID when incidentSource is 'endpoint' */
+  endpointId?: number;
+  /** Endpoint URL when incidentSource is 'endpoint' */
+  endpointUrl?: string;
 }
 
 export interface DailyLeaderboardEntry {

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -32,7 +32,8 @@ export interface ProviderChainItem {
     | "retry_with_official_instructions" // Codex instructions 自动重试（官方）
     | "retry_with_cached_instructions" // Codex instructions 智能重试（缓存）
     | "client_error_non_retryable" // 不可重试的客户端错误（Prompt 超限、内容过滤、PDF 限制、Thinking 格式）
-    | "http2_fallback"; // HTTP/2 协议错误，回退到 HTTP/1.1（不切换供应商、不计入熔断器）
+    | "http2_fallback" // HTTP/2 协议错误，回退到 HTTP/1.1（不切换供应商、不计入熔断器）
+    | "endpoint_pool_exhausted"; // 端点池耗尽（所有端点熔断或不可用，严格模式阻止降级）
 
   // === 选择方法（细化） ===
   selectionMethod?:
@@ -53,6 +54,15 @@ export interface ProviderChainItem {
   // 修复：新增熔断计数信息（用于显示距离熔断还有多少次）
   circuitFailureCount?: number; // 失败计数（包含本次失败）
   circuitFailureThreshold?: number; // 熔断阈值
+
+  // 端点池耗尽详情（endpoint_pool_exhausted 专用）
+  strictBlockCause?: "selector_error" | "no_endpoint_candidates"; // 严格模式阻止降级的原因
+  endpointFilterStats?: {
+    total: number; // 总端点数
+    enabled: number; // 启用的端点数
+    circuitOpen: number; // 熔断的端点数
+    available: number; // 可用的端点数（通过熔断检查后）
+  };
 
   // 时间戳和尝试信息
   timestamp?: number;

--- a/tests/unit/lib/endpoint-circuit-breaker.test.ts
+++ b/tests/unit/lib/endpoint-circuit-breaker.test.ts
@@ -121,4 +121,80 @@ describe("endpoint-circuit-breaker", () => {
     ]?.[1] as SavedEndpointCircuitState;
     expect(lastState.failureCount).toBe(0);
   });
+
+  test("triggerEndpointCircuitBreakerAlert should call sendCircuitBreakerAlert", async () => {
+    vi.resetModules();
+
+    const sendAlertMock = vi.fn(async () => {});
+    vi.doMock("@/lib/notification/notifier", () => ({
+      sendCircuitBreakerAlert: sendAlertMock,
+    }));
+    vi.doMock("@/repository", () => ({
+      findProviderEndpointById: vi.fn(async () => null),
+    }));
+
+    const { triggerEndpointCircuitBreakerAlert } = await import("@/lib/endpoint-circuit-breaker");
+
+    await triggerEndpointCircuitBreakerAlert(
+      5,
+      3,
+      "2026-01-01T00:05:00.000Z",
+      "connection refused"
+    );
+
+    expect(sendAlertMock).toHaveBeenCalledTimes(1);
+    expect(sendAlertMock).toHaveBeenCalledWith({
+      providerId: 5,
+      providerName: "",
+      failureCount: 3,
+      retryAt: "2026-01-01T00:05:00.000Z",
+      lastError: "connection refused",
+      incidentSource: "endpoint",
+      endpointId: 5,
+      endpointUrl: undefined,
+    });
+  });
+
+  test("triggerEndpointCircuitBreakerAlert should include endpointUrl when available", async () => {
+    const sendAlertMock = vi.fn(async () => {});
+    vi.doMock("@/lib/notification/notifier", () => ({
+      sendCircuitBreakerAlert: sendAlertMock,
+    }));
+    vi.doMock("@/repository", () => ({
+      findProviderEndpointById: vi.fn(async () => ({
+        id: 10,
+        url: "https://custom.example.com/v1/chat/completions",
+        vendorId: 1,
+        providerType: "openai",
+        label: "Custom Endpoint",
+        sortOrder: 0,
+        isEnabled: true,
+        lastProbedAt: null,
+        lastProbeOk: null,
+        lastProbeStatusCode: null,
+        lastProbeLatencyMs: null,
+        lastProbeErrorType: null,
+        lastProbeErrorMessage: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      })),
+    }));
+
+    const { triggerEndpointCircuitBreakerAlert } = await import("@/lib/endpoint-circuit-breaker");
+
+    await triggerEndpointCircuitBreakerAlert(10, 3, "2026-01-01T00:05:00.000Z", "timeout");
+
+    expect(sendAlertMock).toHaveBeenCalledTimes(1);
+    expect(sendAlertMock).toHaveBeenCalledWith({
+      providerId: 10,
+      providerName: "",
+      failureCount: 3,
+      retryAt: "2026-01-01T00:05:00.000Z",
+      lastError: "timeout",
+      incidentSource: "endpoint",
+      endpointId: 10,
+      endpointUrl: "https://custom.example.com/v1/chat/completions",
+    });
+  });
 });

--- a/tests/unit/lib/endpoint-circuit-breaker.test.ts
+++ b/tests/unit/lib/endpoint-circuit-breaker.test.ts
@@ -144,8 +144,8 @@ describe("endpoint-circuit-breaker", () => {
 
     expect(sendAlertMock).toHaveBeenCalledTimes(1);
     expect(sendAlertMock).toHaveBeenCalledWith({
-      providerId: 5,
-      providerName: "",
+      providerId: 0,
+      providerName: "endpoint:5",
       failureCount: 3,
       retryAt: "2026-01-01T00:05:00.000Z",
       lastError: "connection refused",
@@ -156,6 +156,8 @@ describe("endpoint-circuit-breaker", () => {
   });
 
   test("triggerEndpointCircuitBreakerAlert should include endpointUrl when available", async () => {
+    vi.resetModules();
+
     const sendAlertMock = vi.fn(async () => {});
     vi.doMock("@/lib/notification/notifier", () => ({
       sendCircuitBreakerAlert: sendAlertMock,
@@ -187,8 +189,8 @@ describe("endpoint-circuit-breaker", () => {
 
     expect(sendAlertMock).toHaveBeenCalledTimes(1);
     expect(sendAlertMock).toHaveBeenCalledWith({
-      providerId: 10,
-      providerName: "",
+      providerId: 1,
+      providerName: "Custom Endpoint",
       failureCount: 3,
       retryAt: "2026-01-01T00:05:00.000Z",
       lastError: "timeout",

--- a/tests/unit/lib/endpoint-circuit-breaker.test.ts
+++ b/tests/unit/lib/endpoint-circuit-breaker.test.ts
@@ -126,6 +126,7 @@ describe("endpoint-circuit-breaker", () => {
     vi.resetModules();
 
     const sendAlertMock = vi.fn(async () => {});
+    vi.doMock("@/lib/logger", () => ({ logger: createLoggerMock() }));
     vi.doMock("@/lib/notification/notifier", () => ({
       sendCircuitBreakerAlert: sendAlertMock,
     }));

--- a/tests/unit/proxy/proxy-forwarder-endpoint-audit.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-endpoint-audit.test.ts
@@ -532,7 +532,7 @@ describe("ProxyForwarder - endpoint audit", () => {
       "doForward"
     );
 
-    await ProxyForwarder.send(session).catch(() => {});
+    await expect(ProxyForwarder.send(session)).rejects.toThrow();
 
     expect(doForward).not.toHaveBeenCalled();
 
@@ -580,7 +580,7 @@ describe("ProxyForwarder - endpoint audit", () => {
       "doForward"
     );
 
-    await ProxyForwarder.send(session).catch(() => {});
+    await expect(ProxyForwarder.send(session)).rejects.toThrow();
 
     expect(doForward).not.toHaveBeenCalled();
 
@@ -618,7 +618,7 @@ describe("ProxyForwarder - endpoint audit", () => {
     session1.setProvider(provider1);
     mocks.getPreferredProviderEndpoints.mockRejectedValueOnce(new Error("timeout"));
 
-    await ProxyForwarder.send(session1).catch(() => {});
+    await expect(ProxyForwarder.send(session1)).rejects.toThrow();
 
     const chain1 = session1.getProviderChain();
     const item1 = chain1.find((i) => i.reason === "endpoint_pool_exhausted");
@@ -644,7 +644,7 @@ describe("ProxyForwarder - endpoint audit", () => {
       available: 0,
     });
 
-    await ProxyForwarder.send(session2).catch(() => {});
+    await expect(ProxyForwarder.send(session2)).rejects.toThrow();
 
     const chain2 = session2.getProviderChain();
     const item2 = chain2.find((i) => i.reason === "endpoint_pool_exhausted");
@@ -678,7 +678,7 @@ describe("ProxyForwarder - endpoint audit", () => {
       "doForward"
     );
 
-    await ProxyForwarder.send(session).catch(() => {});
+    await expect(ProxyForwarder.send(session)).rejects.toThrow();
 
     expect(doForward).not.toHaveBeenCalled();
 

--- a/tests/unit/proxy/proxy-forwarder-endpoint-audit.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-endpoint-audit.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const mocks = vi.hoisted(() => {
   return {
     getPreferredProviderEndpoints: vi.fn(),
+    getEndpointFilterStats: vi.fn(async () => null),
     recordEndpointSuccess: vi.fn(async () => {}),
     recordEndpointFailure: vi.fn(async () => {}),
     recordSuccess: vi.fn(),
@@ -31,6 +32,7 @@ vi.mock("@/lib/logger", () => ({
 
 vi.mock("@/lib/provider-endpoints/endpoint-selector", () => ({
   getPreferredProviderEndpoints: mocks.getPreferredProviderEndpoints,
+  getEndpointFilterStats: mocks.getEndpointFilterStats,
 }));
 
 vi.mock("@/lib/endpoint-circuit-breaker", () => ({
@@ -504,5 +506,205 @@ describe("ProxyForwarder - endpoint audit", () => {
 
     const warnMessages = vi.mocked(logger.warn).mock.calls.map(([message]) => message);
     expect(warnMessages).not.toContain("[ProxyForwarder] Failed to load provider endpoints");
+  });
+
+  test("endpoint pool exhausted (no_endpoint_candidates) should record endpoint_pool_exhausted in provider chain", async () => {
+    const requestPath = "/v1/messages";
+    const session = createSession(new URL(`https://example.com${requestPath}`));
+    const provider = createProvider({
+      providerType: "claude",
+      providerVendorId: 123,
+      url: "https://provider.example.com/v1/messages",
+    });
+    session.setProvider(provider);
+
+    // Return empty array => no_endpoint_candidates
+    mocks.getPreferredProviderEndpoints.mockResolvedValueOnce([]);
+    mocks.getEndpointFilterStats.mockResolvedValueOnce({
+      total: 3,
+      enabled: 2,
+      circuitOpen: 2,
+      available: 0,
+    });
+
+    const doForward = vi.spyOn(
+      ProxyForwarder as unknown as { doForward: (...args: unknown[]) => unknown },
+      "doForward"
+    );
+
+    await ProxyForwarder.send(session).catch(() => {});
+
+    expect(doForward).not.toHaveBeenCalled();
+
+    const chain = session.getProviderChain();
+    const exhaustedItem = chain.find((item) => item.reason === "endpoint_pool_exhausted");
+    expect(exhaustedItem).toBeDefined();
+    expect(exhaustedItem).toEqual(
+      expect.objectContaining({
+        id: provider.id,
+        name: provider.name,
+        vendorId: 123,
+        providerType: "claude",
+        reason: "endpoint_pool_exhausted",
+        strictBlockCause: "no_endpoint_candidates",
+      })
+    );
+
+    // endpointFilterStats should be present at top level
+    expect(exhaustedItem!.endpointFilterStats).toEqual({
+      total: 3,
+      enabled: 2,
+      circuitOpen: 2,
+      available: 0,
+    });
+
+    // decisionContext should contain strictBlockCause
+    expect(exhaustedItem!.decisionContext).toBeDefined();
+    expect(exhaustedItem!.decisionContext).toEqual(
+      expect.objectContaining({
+        strictBlockCause: "no_endpoint_candidates",
+      })
+    );
+    // Should NOT contain selectorError for no_endpoint_candidates
+    expect(exhaustedItem!.decisionContext).not.toHaveProperty("selectorError");
+  });
+
+  test("endpoint pool exhausted (selector_error) should record endpoint_pool_exhausted with selectorError in decisionContext", async () => {
+    const requestPath = "/v1/responses";
+    const session = createSession(new URL(`https://example.com${requestPath}`));
+    const provider = createProvider({
+      providerType: "codex",
+      providerVendorId: 456,
+      url: "https://provider.example.com/v1/responses",
+    });
+    session.setProvider(provider);
+
+    // Throw error => selector_error cause
+    mocks.getPreferredProviderEndpoints.mockRejectedValueOnce(new Error("Redis connection lost"));
+
+    const doForward = vi.spyOn(
+      ProxyForwarder as unknown as { doForward: (...args: unknown[]) => unknown },
+      "doForward"
+    );
+
+    await ProxyForwarder.send(session).catch(() => {});
+
+    expect(doForward).not.toHaveBeenCalled();
+
+    const chain = session.getProviderChain();
+    const exhaustedItem = chain.find((item) => item.reason === "endpoint_pool_exhausted");
+    expect(exhaustedItem).toBeDefined();
+    expect(exhaustedItem).toEqual(
+      expect.objectContaining({
+        id: provider.id,
+        name: provider.name,
+        vendorId: 456,
+        providerType: "codex",
+        reason: "endpoint_pool_exhausted",
+        strictBlockCause: "selector_error",
+      })
+    );
+
+    // selector_error should NOT call getEndpointFilterStats (exception path, no data available)
+    // endpointFilterStats should be undefined for selector_error
+    expect(exhaustedItem!.endpointFilterStats).toBeUndefined();
+
+    // decisionContext should contain strictBlockCause and selectorError
+    expect(exhaustedItem!.decisionContext).toBeDefined();
+    expect(exhaustedItem!.decisionContext).toEqual(
+      expect.objectContaining({
+        strictBlockCause: "selector_error",
+        selectorError: "Redis connection lost",
+      })
+    );
+  });
+
+  test("selector_error and no_endpoint_candidates are correctly distinguished in provider chain", async () => {
+    // Test 1: selector_error (exception thrown)
+    const session1 = createSession(new URL("https://example.com/v1/chat/completions"));
+    const provider1 = createProvider({
+      id: 10,
+      name: "p-selector-err",
+      providerType: "openai-compatible",
+      providerVendorId: 789,
+    });
+    session1.setProvider(provider1);
+    mocks.getPreferredProviderEndpoints.mockRejectedValueOnce(new Error("timeout"));
+
+    await ProxyForwarder.send(session1).catch(() => {});
+
+    const chain1 = session1.getProviderChain();
+    const item1 = chain1.find((i) => i.reason === "endpoint_pool_exhausted");
+    expect(item1).toBeDefined();
+    expect(item1!.strictBlockCause).toBe("selector_error");
+    expect(item1!.endpointFilterStats).toBeUndefined();
+    expect(item1!.decisionContext).toEqual(
+      expect.objectContaining({ strictBlockCause: "selector_error" })
+    );
+
+    // Test 2: no_endpoint_candidates (empty array returned)
+    const session2 = createSession(new URL("https://example.com/v1/chat/completions"));
+    const provider2 = createProvider({
+      id: 20,
+      name: "p-empty-pool",
+      providerType: "openai-compatible",
+      providerVendorId: 789,
+    });
+    session2.setProvider(provider2);
+    mocks.getPreferredProviderEndpoints.mockResolvedValueOnce([]);
+    mocks.getEndpointFilterStats.mockResolvedValueOnce({
+      total: 5,
+      enabled: 3,
+      circuitOpen: 3,
+      available: 0,
+    });
+
+    await ProxyForwarder.send(session2).catch(() => {});
+
+    const chain2 = session2.getProviderChain();
+    const item2 = chain2.find((i) => i.reason === "endpoint_pool_exhausted");
+    expect(item2).toBeDefined();
+    expect(item2!.strictBlockCause).toBe("no_endpoint_candidates");
+    expect(item2!.endpointFilterStats).toEqual({
+      total: 5,
+      enabled: 3,
+      circuitOpen: 3,
+      available: 0,
+    });
+    expect(item2!.decisionContext).toEqual(
+      expect.objectContaining({ strictBlockCause: "no_endpoint_candidates" })
+    );
+    expect(item2!.decisionContext).not.toHaveProperty("selectorError");
+  });
+
+  test("endpointFilterStats should gracefully handle getEndpointFilterStats failure", async () => {
+    const requestPath = "/v1/messages";
+    const session = createSession(new URL(`https://example.com${requestPath}`));
+    const provider = createProvider({
+      providerType: "claude",
+      providerVendorId: 123,
+      url: "https://provider.example.com/v1/messages",
+    });
+    session.setProvider(provider);
+
+    mocks.getPreferredProviderEndpoints.mockResolvedValueOnce([]);
+    // Stats call fails - should not break the flow
+    mocks.getEndpointFilterStats.mockRejectedValueOnce(new Error("DB unavailable"));
+
+    const doForward = vi.spyOn(
+      ProxyForwarder as unknown as { doForward: (...args: unknown[]) => unknown },
+      "doForward"
+    );
+
+    await ProxyForwarder.send(session).catch(() => {});
+
+    expect(doForward).not.toHaveBeenCalled();
+
+    const chain = session.getProviderChain();
+    const exhaustedItem = chain.find((item) => item.reason === "endpoint_pool_exhausted");
+    expect(exhaustedItem).toBeDefined();
+    expect(exhaustedItem!.strictBlockCause).toBe("no_endpoint_candidates");
+    // endpointFilterStats should be undefined when stats call fails
+    expect(exhaustedItem!.endpointFilterStats).toBeUndefined();
   });
 });

--- a/tests/unit/proxy/proxy-forwarder-endpoint-audit.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-endpoint-audit.test.ts
@@ -558,15 +558,8 @@ describe("ProxyForwarder - endpoint audit", () => {
       available: 0,
     });
 
-    // decisionContext should contain strictBlockCause
-    expect(exhaustedItem!.decisionContext).toBeDefined();
-    expect(exhaustedItem!.decisionContext).toEqual(
-      expect.objectContaining({
-        strictBlockCause: "no_endpoint_candidates",
-      })
-    );
-    // Should NOT contain selectorError for no_endpoint_candidates
-    expect(exhaustedItem!.decisionContext).not.toHaveProperty("selectorError");
+    // errorMessage should be undefined for no_endpoint_candidates (no exception)
+    expect(exhaustedItem!.errorMessage).toBeUndefined();
   });
 
   test("endpoint pool exhausted (selector_error) should record endpoint_pool_exhausted with selectorError in decisionContext", async () => {
@@ -609,14 +602,8 @@ describe("ProxyForwarder - endpoint audit", () => {
     // endpointFilterStats should be undefined for selector_error
     expect(exhaustedItem!.endpointFilterStats).toBeUndefined();
 
-    // decisionContext should contain strictBlockCause and selectorError
-    expect(exhaustedItem!.decisionContext).toBeDefined();
-    expect(exhaustedItem!.decisionContext).toEqual(
-      expect.objectContaining({
-        strictBlockCause: "selector_error",
-        selectorError: "Redis connection lost",
-      })
-    );
+    // errorMessage should contain the selector error message
+    expect(exhaustedItem!.errorMessage).toBe("Redis connection lost");
   });
 
   test("selector_error and no_endpoint_candidates are correctly distinguished in provider chain", async () => {
@@ -638,9 +625,7 @@ describe("ProxyForwarder - endpoint audit", () => {
     expect(item1).toBeDefined();
     expect(item1!.strictBlockCause).toBe("selector_error");
     expect(item1!.endpointFilterStats).toBeUndefined();
-    expect(item1!.decisionContext).toEqual(
-      expect.objectContaining({ strictBlockCause: "selector_error" })
-    );
+    expect(item1!.errorMessage).toBe("timeout");
 
     // Test 2: no_endpoint_candidates (empty array returned)
     const session2 = createSession(new URL("https://example.com/v1/chat/completions"));
@@ -671,10 +656,7 @@ describe("ProxyForwarder - endpoint audit", () => {
       circuitOpen: 3,
       available: 0,
     });
-    expect(item2!.decisionContext).toEqual(
-      expect.objectContaining({ strictBlockCause: "no_endpoint_candidates" })
-    );
-    expect(item2!.decisionContext).not.toHaveProperty("selectorError");
+    expect(item2!.errorMessage).toBeUndefined();
   });
 
   test("endpointFilterStats should gracefully handle getEndpointFilterStats failure", async () => {

--- a/tests/unit/settings/providers/endpoint-status.test.ts
+++ b/tests/unit/settings/providers/endpoint-status.test.ts
@@ -171,7 +171,7 @@ describe("resolveEndpointDisplayStatus", () => {
 
       expect(result).toEqual({
         status: "enabled",
-        source: "endpoint",
+        source: "provider",
         priority: 2,
       });
     });
@@ -182,7 +182,7 @@ describe("resolveEndpointDisplayStatus", () => {
 
       expect(result).toEqual({
         status: "disabled",
-        source: "endpoint",
+        source: "provider",
         priority: 3,
       });
     });
@@ -193,7 +193,7 @@ describe("resolveEndpointDisplayStatus", () => {
 
       expect(result).toEqual({
         status: "enabled",
-        source: "endpoint",
+        source: "provider",
         priority: 2,
       });
     });
@@ -204,7 +204,7 @@ describe("resolveEndpointDisplayStatus", () => {
 
       expect(result).toEqual({
         status: "enabled",
-        source: "endpoint",
+        source: "provider",
         priority: 2,
       });
     });
@@ -235,7 +235,7 @@ describe("resolveEndpointDisplayStatus", () => {
 
       expect(result).toEqual({
         status: "enabled",
-        source: "endpoint",
+        source: "provider",
         priority: 2,
       });
     });
@@ -246,7 +246,7 @@ describe("resolveEndpointDisplayStatus", () => {
 
       expect(result).toEqual({
         status: "enabled",
-        source: "endpoint",
+        source: "provider",
         priority: 2,
       });
     });
@@ -259,7 +259,7 @@ describe("resolveEndpointDisplayStatus", () => {
 
       expect(result).toEqual({
         status: "enabled",
-        source: "endpoint",
+        source: "provider",
         priority: 2,
       });
     });

--- a/tests/unit/settings/providers/endpoint-status.test.ts
+++ b/tests/unit/settings/providers/endpoint-status.test.ts
@@ -198,7 +198,7 @@ describe("resolveEndpointDisplayStatus", () => {
       });
     });
 
-    it("should return disabled when circuit is closed and isEnabled is null", () => {
+    it("should return enabled when circuit is closed and isEnabled is null", () => {
       const endpoint = createEndpoint(true, null as unknown as undefined);
       const result = resolveEndpointDisplayStatus(endpoint, "closed");
 

--- a/tests/unit/settings/providers/endpoint-status.test.ts
+++ b/tests/unit/settings/providers/endpoint-status.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   type EndpointCircuitState,
   getEndpointStatusModel,
+  type IncidentSource,
+  resolveEndpointDisplayStatus,
 } from "@/app/[locale]/settings/providers/_components/endpoint-status";
 import { AlertTriangle, Ban, CheckCircle2, HelpCircle, XCircle } from "lucide-react";
 
@@ -95,6 +97,181 @@ describe("getEndpointStatusModel", () => {
         color: "text-slate-400",
         bgColor: "bg-slate-400/10",
         borderColor: "border-slate-400/30",
+      });
+    });
+  });
+});
+
+describe("IncidentSource", () => {
+  it("should have correct type values", () => {
+    const source: IncidentSource = "provider";
+    expect(source).toBe("provider");
+
+    const endpointSource: IncidentSource = "endpoint";
+    expect(endpointSource).toBe("endpoint");
+  });
+});
+
+describe("resolveEndpointDisplayStatus", () => {
+  const createEndpoint = (lastProbeOk: boolean | null, isEnabled?: boolean) =>
+    ({ lastProbeOk, isEnabled }) as { lastProbeOk: boolean | null; isEnabled?: boolean };
+
+  describe("Priority: circuit-open", () => {
+    it("should return circuit-open with endpoint source when circuit is open", () => {
+      const endpoint = createEndpoint(true);
+      const result = resolveEndpointDisplayStatus(endpoint, "open");
+
+      expect(result).toEqual({
+        status: "circuit-open",
+        source: "endpoint",
+        priority: 0,
+      });
+    });
+
+    it("should return circuit-open even when probe is failed", () => {
+      const endpoint = createEndpoint(false);
+      const result = resolveEndpointDisplayStatus(endpoint, "open");
+
+      expect(result).toEqual({
+        status: "circuit-open",
+        source: "endpoint",
+        priority: 0,
+      });
+    });
+  });
+
+  describe("Priority: circuit-half-open", () => {
+    it("should return circuit-half-open with endpoint source when circuit is half-open", () => {
+      const endpoint = createEndpoint(false);
+      const result = resolveEndpointDisplayStatus(endpoint, "half-open");
+
+      expect(result).toEqual({
+        status: "circuit-half-open",
+        source: "endpoint",
+        priority: 1,
+      });
+    });
+
+    it("should return circuit-half-open even when probe is ok", () => {
+      const endpoint = createEndpoint(true);
+      const result = resolveEndpointDisplayStatus(endpoint, "half-open");
+
+      expect(result).toEqual({
+        status: "circuit-half-open",
+        source: "endpoint",
+        priority: 1,
+      });
+    });
+  });
+
+  describe("Priority: enabled/disabled (circuit-closed)", () => {
+    it("should return enabled when circuit is closed and endpoint is enabled", () => {
+      const endpoint = createEndpoint(true, true);
+      const result = resolveEndpointDisplayStatus(endpoint, "closed");
+
+      expect(result).toEqual({
+        status: "enabled",
+        source: "endpoint",
+        priority: 2,
+      });
+    });
+
+    it("should return disabled when circuit is closed and endpoint is disabled", () => {
+      const endpoint = createEndpoint(true, false);
+      const result = resolveEndpointDisplayStatus(endpoint, "closed");
+
+      expect(result).toEqual({
+        status: "disabled",
+        source: "endpoint",
+        priority: 3,
+      });
+    });
+
+    it("should return enabled when circuit is closed and isEnabled is undefined", () => {
+      const endpoint = createEndpoint(true, undefined);
+      const result = resolveEndpointDisplayStatus(endpoint, "closed");
+
+      expect(result).toEqual({
+        status: "enabled",
+        source: "endpoint",
+        priority: 2,
+      });
+    });
+
+    it("should return disabled when circuit is closed and isEnabled is null", () => {
+      const endpoint = createEndpoint(true, null as unknown as undefined);
+      const result = resolveEndpointDisplayStatus(endpoint, "closed");
+
+      expect(result).toEqual({
+        status: "enabled",
+        source: "endpoint",
+        priority: 2,
+      });
+    });
+  });
+
+  describe("Priority ordering", () => {
+    it("should have circuit-open (0) > circuit-half-open (1) > enabled (2) > disabled (3)", () => {
+      const endpoint = createEndpoint(true, true);
+
+      const openResult = resolveEndpointDisplayStatus(endpoint, "open");
+      const halfOpenResult = resolveEndpointDisplayStatus(endpoint, "half-open");
+      const enabledResult = resolveEndpointDisplayStatus(endpoint, "closed");
+
+      const disabledEndpoint = createEndpoint(true, false);
+      const disabledResult = resolveEndpointDisplayStatus(disabledEndpoint, "closed");
+
+      expect(openResult.priority).toBe(0);
+      expect(halfOpenResult.priority).toBe(1);
+      expect(enabledResult.priority).toBe(2);
+      expect(disabledResult.priority).toBe(3);
+    });
+  });
+
+  describe("Null/undefined circuit state", () => {
+    it("should return enabled when circuit is null and endpoint is enabled", () => {
+      const endpoint = createEndpoint(true, true);
+      const result = resolveEndpointDisplayStatus(endpoint, null);
+
+      expect(result).toEqual({
+        status: "enabled",
+        source: "endpoint",
+        priority: 2,
+      });
+    });
+
+    it("should return enabled when circuit is undefined", () => {
+      const endpoint = createEndpoint(true, true);
+      const result = resolveEndpointDisplayStatus(endpoint, undefined);
+
+      expect(result).toEqual({
+        status: "enabled",
+        source: "endpoint",
+        priority: 2,
+      });
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle endpoint without isEnabled property", () => {
+      const endpoint = { lastProbeOk: true } as { lastProbeOk: boolean | null };
+      const result = resolveEndpointDisplayStatus(endpoint, "closed");
+
+      expect(result).toEqual({
+        status: "enabled",
+        source: "endpoint",
+        priority: 2,
+      });
+    });
+
+    it("should return circuit-open when probe is null and circuit is open", () => {
+      const endpoint = createEndpoint(null);
+      const result = resolveEndpointDisplayStatus(endpoint, "open");
+
+      expect(result).toEqual({
+        status: "circuit-open",
+        source: "endpoint",
+        priority: 0,
       });
     });
   });

--- a/tests/unit/settings/providers/provider-manager.test.tsx
+++ b/tests/unit/settings/providers/provider-manager.test.tsx
@@ -1,0 +1,441 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { NextIntlClientProvider } from "next-intl";
+import { type ReactNode, act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { ProviderDisplay } from "@/types/provider";
+import enMessages from "../../../../messages/en";
+
+// ---------------------------------------------------------------------------
+// Mocks -- keep them minimal, only stub what provider-manager.tsx touches
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/hooks/use-debounce", () => ({
+  useDebounce: (value: string, _delay: number) => value,
+}));
+
+// Batch-edit subcomponents (heavy, irrelevant to this test scope)
+vi.mock("@/app/[locale]/settings/providers/_components/batch-edit", () => ({
+  ProviderBatchActions: () => null,
+  ProviderBatchDialog: () => null,
+  ProviderBatchToolbar: () => null,
+}));
+
+// ProviderList -- render a simple list so we can inspect filtered output
+vi.mock("@/app/[locale]/settings/providers/_components/provider-list", () => ({
+  ProviderList: ({ providers }: { providers: ProviderDisplay[] }) => (
+    <ul data-testid="provider-list">
+      {providers.map((p) => (
+        <li key={p.id} data-testid={`provider-${p.id}`}>
+          {p.name}
+        </li>
+      ))}
+    </ul>
+  ),
+}));
+
+// ProviderVendorView -- not under test
+vi.mock("@/app/[locale]/settings/providers/_components/provider-vendor-view", () => ({
+  ProviderVendorView: () => null,
+}));
+
+// ProviderTypeFilter
+vi.mock("@/app/[locale]/settings/providers/_components/provider-type-filter", () => ({
+  ProviderTypeFilter: () => null,
+}));
+
+// ProviderSortDropdown
+vi.mock("@/app/[locale]/settings/providers/_components/provider-sort-dropdown", () => ({
+  ProviderSortDropdown: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProvider(overrides: Partial<ProviderDisplay> = {}): ProviderDisplay {
+  return {
+    id: 1,
+    name: "Provider A",
+    url: "https://api.example.com",
+    maskedKey: "sk-***",
+    isEnabled: true,
+    weight: 1,
+    priority: 1,
+    costMultiplier: 1,
+    groupTag: null,
+    groupPriorities: null,
+    providerType: "claude",
+    providerVendorId: null,
+    preserveClientIp: false,
+    modelRedirects: null,
+    allowedModels: null,
+    mcpPassthroughType: "none",
+    mcpPassthroughUrl: null,
+    limit5hUsd: null,
+    limitDailyUsd: null,
+    dailyResetMode: "fixed",
+    dailyResetTime: "00:00",
+    limitWeeklyUsd: null,
+    limitMonthlyUsd: null,
+    limitTotalUsd: null,
+    limitConcurrentSessions: 1,
+    maxRetryAttempts: null,
+    circuitBreakerFailureThreshold: 1,
+    circuitBreakerOpenDuration: 60,
+    circuitBreakerHalfOpenSuccessThreshold: 1,
+    proxyUrl: null,
+    proxyFallbackToDirect: false,
+    firstByteTimeoutStreamingMs: 0,
+    streamingIdleTimeoutMs: 0,
+    requestTimeoutNonStreamingMs: 0,
+    websiteUrl: null,
+    faviconUrl: null,
+    cacheTtlPreference: null,
+    context1mPreference: null,
+    codexReasoningEffortPreference: null,
+    codexReasoningSummaryPreference: null,
+    codexTextVerbosityPreference: null,
+    codexParallelToolCallsPreference: null,
+    anthropicMaxTokensPreference: null,
+    anthropicThinkingBudgetPreference: null,
+    geminiGoogleSearchPreference: null,
+    tpm: null,
+    rpm: null,
+    rpd: null,
+    cc: null,
+    createdAt: "2026-01-01",
+    updatedAt: "2026-01-01",
+    ...overrides,
+  };
+}
+
+function renderWithProviders(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <NextIntlClientProvider locale="en" messages={enMessages} timeZone="UTC">
+        {node}
+      </NextIntlClientProvider>
+    );
+  });
+
+  return {
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+    container,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Lazy-import after mocks are established
+let ProviderManager: typeof import("@/app/[locale]/settings/providers/_components/provider-manager").ProviderManager;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+  // Dynamic import to ensure mocks take effect
+  const mod = await import("@/app/[locale]/settings/providers/_components/provider-manager");
+  ProviderManager = mod.ProviderManager;
+});
+
+describe("ProviderManager circuitBrokenCount with endpoint circuits", () => {
+  const providers = [
+    makeProvider({ id: 1, name: "Provider A" }),
+    makeProvider({ id: 2, name: "Provider B" }),
+    makeProvider({ id: 3, name: "Provider C" }),
+  ];
+
+  test("counts only key-level circuit breaker when no endpointCircuitInfo", () => {
+    const healthStatus = {
+      1: {
+        circuitState: "open" as const,
+        failureCount: 5,
+        lastFailureTime: Date.now(),
+        circuitOpenUntil: Date.now() + 60000,
+        recoveryMinutes: 1,
+      },
+    };
+
+    const { unmount, container } = renderWithProviders(
+      <ProviderManager
+        providers={providers}
+        healthStatus={healthStatus}
+        enableMultiProviderTypes={true}
+      />
+    );
+
+    // The circuit broken count should show 1 (only Provider A has key-level open)
+    const text = container.textContent || "";
+    expect(text).toContain("(1)");
+
+    unmount();
+  });
+
+  test("counts providers with endpoint-level circuit open in addition to key-level", () => {
+    // Provider 1: key-level circuit open
+    // Provider 2: healthy key, but has an endpoint circuit open
+    // Provider 3: all healthy
+    const healthStatus = {
+      1: {
+        circuitState: "open" as const,
+        failureCount: 5,
+        lastFailureTime: Date.now(),
+        circuitOpenUntil: Date.now() + 60000,
+        recoveryMinutes: 1,
+      },
+    };
+
+    const endpointCircuitInfo: Record<
+      number,
+      Array<{
+        endpointId: number;
+        circuitState: "closed" | "open" | "half-open";
+        failureCount: number;
+        circuitOpenUntil: number | null;
+      }>
+    > = {
+      2: [
+        {
+          endpointId: 10,
+          circuitState: "open",
+          failureCount: 3,
+          circuitOpenUntil: Date.now() + 60000,
+        },
+        {
+          endpointId: 11,
+          circuitState: "closed",
+          failureCount: 0,
+          circuitOpenUntil: null,
+        },
+      ],
+    };
+
+    const { unmount, container } = renderWithProviders(
+      <ProviderManager
+        providers={providers}
+        healthStatus={healthStatus}
+        endpointCircuitInfo={endpointCircuitInfo}
+        enableMultiProviderTypes={true}
+      />
+    );
+
+    // Count should be 2: Provider A (key open) + Provider B (endpoint open)
+    const text = container.textContent || "";
+    expect(text).toContain("(2)");
+
+    unmount();
+  });
+
+  test("does not double-count provider with both key and endpoint circuits open", () => {
+    const healthStatus = {
+      1: {
+        circuitState: "open" as const,
+        failureCount: 5,
+        lastFailureTime: Date.now(),
+        circuitOpenUntil: Date.now() + 60000,
+        recoveryMinutes: 1,
+      },
+    };
+
+    const endpointCircuitInfo: Record<
+      number,
+      Array<{
+        endpointId: number;
+        circuitState: "closed" | "open" | "half-open";
+        failureCount: number;
+        circuitOpenUntil: number | null;
+      }>
+    > = {
+      1: [
+        {
+          endpointId: 10,
+          circuitState: "open",
+          failureCount: 3,
+          circuitOpenUntil: Date.now() + 60000,
+        },
+      ],
+    };
+
+    const { unmount, container } = renderWithProviders(
+      <ProviderManager
+        providers={providers}
+        healthStatus={healthStatus}
+        endpointCircuitInfo={endpointCircuitInfo}
+        enableMultiProviderTypes={true}
+      />
+    );
+
+    // Should still be 1 -- provider 1 has both, but count is deduplicated
+    const text = container.textContent || "";
+    expect(text).toContain("(1)");
+
+    unmount();
+  });
+
+  test("circuit broken filter includes providers with endpoint circuits open", () => {
+    // Use a state-based approach:
+    // We'll set circuitBrokenFilter active programmatically by clicking the toggle.
+    // Provider 2 only has an endpoint circuit open (no key circuit).
+
+    const healthStatus = {};
+    const endpointCircuitInfo: Record<
+      number,
+      Array<{
+        endpointId: number;
+        circuitState: "closed" | "open" | "half-open";
+        failureCount: number;
+        circuitOpenUntil: number | null;
+      }>
+    > = {
+      2: [
+        {
+          endpointId: 10,
+          circuitState: "open",
+          failureCount: 3,
+          circuitOpenUntil: Date.now() + 60000,
+        },
+      ],
+    };
+
+    const { unmount, container } = renderWithProviders(
+      <ProviderManager
+        providers={providers}
+        healthStatus={healthStatus}
+        endpointCircuitInfo={endpointCircuitInfo}
+        enableMultiProviderTypes={true}
+      />
+    );
+
+    // Circuit broken count should be 1 (Provider B has endpoint open)
+    const text = container.textContent || "";
+    expect(text).toContain("(1)");
+
+    // Find and click the circuit broken toggle
+    const toggle = container.querySelector("#circuit-broken-filter");
+    if (toggle) {
+      act(() => {
+        toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      // After activating the filter, only Provider B should be shown
+      const listItems = container.querySelectorAll("[data-testid^='provider-']");
+      const providerNames = Array.from(listItems).map((el) => el.textContent);
+      expect(providerNames).toContain("Provider B");
+      expect(providerNames).not.toContain("Provider A");
+      expect(providerNames).not.toContain("Provider C");
+    }
+
+    unmount();
+  });
+
+  test("shows zero circuit broken count when no circuits are open", () => {
+    const healthStatus = {};
+
+    const { unmount, container } = renderWithProviders(
+      <ProviderManager
+        providers={providers}
+        healthStatus={healthStatus}
+        enableMultiProviderTypes={true}
+      />
+    );
+
+    // When count is 0, the circuit broken section should NOT be rendered
+    const toggleDesktop = container.querySelector("#circuit-broken-filter");
+    expect(toggleDesktop).toBeNull();
+
+    unmount();
+  });
+
+  test("endpointCircuitInfo defaults to empty when not provided", () => {
+    const healthStatus = {};
+
+    const { unmount, container } = renderWithProviders(
+      <ProviderManager
+        providers={providers}
+        healthStatus={healthStatus}
+        enableMultiProviderTypes={true}
+      />
+    );
+
+    // No circuit broken UI should appear
+    const toggleDesktop = container.querySelector("#circuit-broken-filter");
+    expect(toggleDesktop).toBeNull();
+
+    unmount();
+  });
+});
+
+describe("ProviderManager layered circuit labels", () => {
+  const providers = [
+    makeProvider({ id: 1, name: "Provider Key Broken" }),
+    makeProvider({ id: 2, name: "Provider Endpoint Broken" }),
+    makeProvider({ id: 3, name: "Provider Both Broken" }),
+  ];
+
+  test("passes endpointCircuitInfo to ProviderList for rendering", () => {
+    const healthStatus = {
+      1: {
+        circuitState: "open" as const,
+        failureCount: 5,
+        lastFailureTime: Date.now(),
+        circuitOpenUntil: Date.now() + 60000,
+        recoveryMinutes: 1,
+      },
+      3: {
+        circuitState: "open" as const,
+        failureCount: 3,
+        lastFailureTime: Date.now(),
+        circuitOpenUntil: Date.now() + 30000,
+        recoveryMinutes: 0.5,
+      },
+    };
+
+    const endpointCircuitInfo = {
+      2: [
+        {
+          endpointId: 20,
+          circuitState: "open" as const,
+          failureCount: 2,
+          circuitOpenUntil: Date.now() + 60000,
+        },
+      ],
+      3: [
+        {
+          endpointId: 30,
+          circuitState: "open" as const,
+          failureCount: 4,
+          circuitOpenUntil: Date.now() + 60000,
+        },
+      ],
+    };
+
+    const { unmount, container } = renderWithProviders(
+      <ProviderManager
+        providers={providers}
+        healthStatus={healthStatus}
+        endpointCircuitInfo={endpointCircuitInfo}
+        enableMultiProviderTypes={true}
+      />
+    );
+
+    // The circuit broken count should be 3 (all three providers have some form of circuit open)
+    const text = container.textContent || "";
+    expect(text).toContain("(3)");
+
+    unmount();
+  });
+});

--- a/tests/unit/settings/providers/provider-manager.test.tsx
+++ b/tests/unit/settings/providers/provider-manager.test.tsx
@@ -386,7 +386,7 @@ describe("ProviderManager layered circuit labels", () => {
     makeProvider({ id: 3, name: "Provider Both Broken" }),
   ];
 
-  test("passes endpointCircuitInfo to ProviderList for rendering", () => {
+  test("counts all providers with any circuit open for layered labels", () => {
     const healthStatus = {
       1: {
         circuitState: "open" as const,

--- a/tests/unit/settings/providers/provider-manager.test.tsx
+++ b/tests/unit/settings/providers/provider-manager.test.tsx
@@ -326,18 +326,18 @@ describe("ProviderManager circuitBrokenCount with endpoint circuits", () => {
 
     // Find and click the circuit broken toggle
     const toggle = container.querySelector("#circuit-broken-filter");
-    if (toggle) {
-      act(() => {
-        toggle.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      });
+    expect(toggle).not.toBeNull();
 
-      // After activating the filter, only Provider B should be shown
-      const listItems = container.querySelectorAll("[data-testid^='provider-']");
-      const providerNames = Array.from(listItems).map((el) => el.textContent);
-      expect(providerNames).toContain("Provider B");
-      expect(providerNames).not.toContain("Provider A");
-      expect(providerNames).not.toContain("Provider C");
-    }
+    act(() => {
+      toggle!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // After activating the filter, only Provider B should be shown
+    const listItems = container.querySelectorAll("[data-testid^='provider-']");
+    const providerNames = Array.from(listItems).map((el) => el.textContent);
+    expect(providerNames).toContain("Provider B");
+    expect(providerNames).not.toContain("Provider A");
+    expect(providerNames).not.toContain("Provider C");
 
     unmount();
   });

--- a/tests/unit/webhook/notifier-circuit-breaker.test.ts
+++ b/tests/unit/webhook/notifier-circuit-breaker.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CircuitBreakerAlertData } from "@/lib/webhook/types";
+
+describe("sendCircuitBreakerAlert", () => {
+  const mockRedisGet = vi.fn();
+  const mockRedisSet = vi.fn();
+  const mockAddNotificationJob = vi.fn(async () => {});
+  const mockAddNotificationJobForTarget = vi.fn(async () => {});
+
+  beforeEach(() => {
+    vi.resetModules();
+
+    vi.doMock("@/lib/redis/client", () => ({
+      getRedisClient: vi.fn(() => ({
+        get: mockRedisGet,
+        set: mockRedisSet,
+      })),
+    }));
+
+    vi.doMock("@/repository/notifications", () => ({
+      getNotificationSettings: vi.fn(async () => ({
+        enabled: true,
+        circuitBreakerEnabled: true,
+        useLegacyMode: true,
+        circuitBreakerWebhook: "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx",
+      })),
+    }));
+
+    vi.doMock("@/lib/notification/notification-queue", () => ({
+      addNotificationJob: mockAddNotificationJob,
+      addNotificationJobForTarget: mockAddNotificationJobForTarget,
+    }));
+
+    vi.doMock("@/lib/logger", () => ({
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trace: vi.fn(),
+        fatal: vi.fn(),
+      },
+    }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("dedup key with incidentSource", () => {
+    it("should use provider dedup key when incidentSource is provider", async () => {
+      mockRedisGet.mockResolvedValue(null); // No cached alert
+
+      const { sendCircuitBreakerAlert } = await import("@/lib/notification/notifier");
+
+      const data: CircuitBreakerAlertData = {
+        providerName: "OpenAI",
+        providerId: 1,
+        failureCount: 5,
+        retryAt: "2025-01-02T12:30:00Z",
+        incidentSource: "provider",
+      };
+
+      await sendCircuitBreakerAlert(data);
+
+      // Should use dedup key with provider source
+      expect(mockRedisSet).toHaveBeenCalledWith("circuit-breaker-alert:1:provider", "1", "EX", 300);
+    });
+
+    it("should use endpoint dedup key when incidentSource is endpoint", async () => {
+      mockRedisGet.mockResolvedValue(null);
+
+      const { sendCircuitBreakerAlert } = await import("@/lib/notification/notifier");
+
+      const data: CircuitBreakerAlertData = {
+        providerName: "OpenAI",
+        providerId: 1,
+        failureCount: 3,
+        retryAt: "2025-01-02T13:00:00Z",
+        incidentSource: "endpoint",
+        endpointId: 42,
+        endpointUrl: "https://api.openai.com/v1",
+      };
+
+      await sendCircuitBreakerAlert(data);
+
+      // Should use dedup key with endpoint source including endpointId
+      expect(mockRedisSet).toHaveBeenCalledWith(
+        "circuit-breaker-alert:1:endpoint:42",
+        "1",
+        "EX",
+        300
+      );
+    });
+
+    it("should dedup independently for same provider with different sources", async () => {
+      // Provider alert is cached
+      mockRedisGet.mockResolvedValueOnce("1");
+      // Endpoint alert is NOT cached
+      mockRedisGet.mockResolvedValueOnce(null);
+
+      const { sendCircuitBreakerAlert } = await import("@/lib/notification/notifier");
+
+      const providerData: CircuitBreakerAlertData = {
+        providerName: "OpenAI",
+        providerId: 1,
+        failureCount: 5,
+        retryAt: "2025-01-02T12:30:00Z",
+        incidentSource: "provider",
+      };
+
+      const endpointData: CircuitBreakerAlertData = {
+        providerName: "OpenAI",
+        providerId: 1,
+        failureCount: 3,
+        retryAt: "2025-01-02T13:00:00Z",
+        incidentSource: "endpoint",
+        endpointId: 42,
+        endpointUrl: "https://api.openai.com/v1",
+      };
+
+      await sendCircuitBreakerAlert(providerData);
+      await sendCircuitBreakerAlert(endpointData);
+
+      // Provider alert should be suppressed (cached)
+      expect(mockRedisSet).toHaveBeenCalledTimes(1);
+      // That one call should be for endpoint source
+      expect(mockRedisSet).toHaveBeenCalledWith(
+        "circuit-breaker-alert:1:endpoint:42",
+        "1",
+        "EX",
+        300
+      );
+    });
+
+    it("should default to provider source when incidentSource is undefined", async () => {
+      mockRedisGet.mockResolvedValue(null);
+
+      const { sendCircuitBreakerAlert } = await import("@/lib/notification/notifier");
+
+      const data: CircuitBreakerAlertData = {
+        providerName: "Anthropic",
+        providerId: 2,
+        failureCount: 3,
+        retryAt: "2025-01-02T13:00:00Z",
+        // incidentSource is undefined - should default to provider
+      };
+
+      await sendCircuitBreakerAlert(data);
+
+      // Should use dedup key with default provider source
+      expect(mockRedisSet).toHaveBeenCalledWith("circuit-breaker-alert:2:provider", "1", "EX", 300);
+    });
+
+    it("should suppress endpoint alert when same endpointId was recently alerted", async () => {
+      // First call: not cached
+      mockRedisGet.mockResolvedValueOnce(null);
+      // Second call: cached
+      mockRedisGet.mockResolvedValueOnce("1");
+
+      const { sendCircuitBreakerAlert } = await import("@/lib/notification/notifier");
+
+      const data: CircuitBreakerAlertData = {
+        providerName: "OpenAI",
+        providerId: 1,
+        failureCount: 3,
+        retryAt: "2025-01-02T13:00:00Z",
+        incidentSource: "endpoint",
+        endpointId: 42,
+      };
+
+      await sendCircuitBreakerAlert(data);
+      await sendCircuitBreakerAlert(data);
+
+      // Only first call should have set cache
+      expect(mockRedisSet).toHaveBeenCalledTimes(1);
+      // Should have checked cache twice
+      expect(mockRedisGet).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Unify provider/endpoint circuit breaker visibility and notification semantics across the settings UI, proxy decision chain, and webhook alerts.

## Problem

The system has three layers of circuit breakers (provider / endpoint / vendor-type), but the UI and decision chain only had full visibility into provider (key) level circuits. Endpoint-level circuit breakers had blind spots:

1. **Endpoint table**: Only showed `isEnabled` from DB, not runtime circuit state -- users saw "enabled" for actually-unavailable endpoints
2. **Provider filter/count**: Circuit broken filter and counter only covered key-level circuits, missing providers whose endpoints were all circuit-broken
3. **Decision chain/timeline**: `endpoint-selector` silently filtered circuit-broken endpoints without recording to `ProviderChainItem`, making it impossible to diagnose why requests hung

**Related Issues:**
- Fixes #754 - Addresses all three endpoint circuit visibility gaps described in the issue
- Related to #728 - Adds endpoint-level circuit badges and reset actions in provider management UI

## Solution

### Unified Status Semantics (Foundation)
- Add `IncidentSource` enum (`provider` | `endpoint`) and `resolveEndpointDisplayStatus()` with priority: circuit-open > circuit-half-open > enabled/disabled
- Add `batchGetEndpointCircuitInfo()` server action for bulk endpoint circuit state queries

### Settings UI (Feature Surfaces)
- Display circuit-open/half-open badges in the endpoints table with a reset button in the row action menu
- Extend provider filter and counter to include endpoint-level circuit breakers (deduplicated with key-level)
- Show layered badges in provider list items distinguishing "Key Circuit" vs "Endpoint Circuit"

### Proxy Explainability (Decision Chain)
- Add `endpoint_pool_exhausted` reason to `ProviderChainItem` with `strictBlockCause` and `endpointFilterStats` metadata
- Record endpoint filtering statistics (total/enabled/circuitOpen/available) when no candidates are available
- Render the new reason in the provider chain timeline with full stats breakdown

### Notifications
- Extend `CircuitBreakerAlertData` with `incidentSource`, `endpointId`, `endpointUrl`
- Dedup keys now distinguish provider vs endpoint events (`circuit-breaker-alert:{id}:endpoint:{endpointId}`)
- Endpoint circuit OPEN triggers notifications via the same toggle as provider circuits
- Add `{{incident_source}}`, `{{endpoint_id}}`, `{{endpoint_url}}` template placeholders for custom webhook templates

## Changes

### Core Changes
- `src/lib/endpoint-circuit-breaker.ts` - Trigger endpoint circuit alerts on OPEN, add `triggerEndpointCircuitBreakerAlert()`
- `src/lib/provider-endpoints/endpoint-selector.ts` - Add `getEndpointFilterStats()` for audit trail
- `src/app/v1/_lib/proxy/forwarder.ts` - Record `endpoint_pool_exhausted` in provider chain with filter stats
- `src/app/v1/_lib/proxy/session.ts` - Accept `strictBlockCause` and `endpointFilterStats` in chain metadata
- `src/types/message.ts` - Extend `ProviderChainItem` with `endpoint_pool_exhausted` reason and stats fields
- `src/lib/webhook/types.ts` - Extend `CircuitBreakerAlertData` with incident source fields
- `src/lib/notification/notifier.ts` - Source-aware dedup keys and logging
- `src/lib/webhook/templates/circuit-breaker.ts` - Endpoint-specific alert title/description/fields
- `src/lib/webhook/templates/placeholders.ts` - New template variables for endpoint circuit events

### UI Changes
- `src/app/[locale]/settings/providers/_components/endpoint-status.ts` - Add `IncidentSource`, `EndpointDisplayStatus`, `resolveEndpointDisplayStatus()`
- `src/app/[locale]/settings/providers/_components/provider-endpoints-table.tsx` - Batch-fetch circuit states, show badges, add reset action
- `src/app/[locale]/settings/providers/_components/provider-manager.tsx` - Unified `hasAnyCircuitOpen()` for filter and counter
- `src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx` - Layered "Key Circuit" / "Endpoint Circuit" badges
- `src/app/[locale]/settings/providers/_components/provider-list.tsx` - Pass `endpointCircuitInfo` prop
- `src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx` - Accept `endpointCircuitInfo` prop
- `src/actions/provider-endpoints.ts` - Add `batchGetEndpointCircuitInfo()` action
- `src/lib/utils/provider-chain-formatter.ts` - Render `endpoint_pool_exhausted` in summary, description, and timeline

### i18n
- 12+ new keys across all 5 languages (zh-CN, zh-TW, en, ja, ru) for endpoint circuit states, filter stats, strict block causes, and reset actions

## Testing

### Automated Tests
- [x] Unit tests added for `batchGetEndpointCircuitInfo` action (`tests/unit/actions/provider-endpoints.test.ts`)
- [x] Unit tests added for `triggerEndpointCircuitBreakerAlert` (`tests/unit/lib/endpoint-circuit-breaker.test.ts`)
- [x] Unit tests added for `getEndpointFilterStats` (`tests/unit/lib/provider-endpoints/endpoint-selector.test.ts`)
- [x] Unit tests added for proxy forwarder endpoint audit trail (`tests/unit/proxy/proxy-forwarder-endpoint-audit.test.ts`)
- [x] Unit tests added for `resolveEndpointDisplayStatus` (`tests/unit/settings/providers/endpoint-status.test.ts`)
- [x] Unit tests added for provider manager circuit filter/counter (`tests/unit/settings/providers/provider-manager.test.tsx`)
- [x] Unit tests added for provider vendor view circuit UI (`tests/unit/settings/providers/provider-vendor-view-circuit-ui.test.tsx`)
- [x] Unit tests added for notifier circuit breaker dedup (`tests/unit/webhook/notifier-circuit-breaker.test.ts`)
- [x] Unit tests added for template placeholders (`tests/unit/webhook/templates/placeholders.test.ts`)
- [x] Unit tests added for circuit breaker webhook templates (`tests/unit/webhook/templates/templates.test.ts`)
- [x] Unit tests added for provider chain formatter (`src/lib/utils/provider-chain-formatter.test.ts`)

### Manual Testing
1. Open Settings > Providers, verify endpoint table shows circuit-open/half-open badges when endpoints are circuit-broken
2. Use the "Reset Circuit" action from the endpoint row menu and verify the badge clears
3. Toggle the "Circuit Broken" filter and verify it catches providers with endpoint-level circuits (not just key-level)
4. Trigger an endpoint circuit break and verify webhook notification includes endpoint-specific fields
5. Check the decision chain timeline for a request that hit endpoint pool exhaustion -- verify stats breakdown is shown

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally (2129 tests passing)
- [x] i18n strings added for all 5 languages
- [x] No breaking changes to existing APIs

---
*Description enhanced by Claude AI*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR unifies circuit-breaker visibility and semantics across the settings UI, proxy decision chain, and webhook notifications by adding an endpoint incident source, bulk endpoint circuit-state lookups, and a new `endpoint_pool_exhausted` provider-chain reason with filter statistics.

Key integrations:
- Settings Providers UI now fetches endpoint circuit state in batch, displays circuit-open/half-open badges, offers a per-endpoint reset action, and updates provider-level circuit filters/counters to include endpoint-level circuits.
- Proxy forwarder records strict endpoint pool exhaustion into the provider chain (including strictBlockCause and optional endpoint filter stats) to improve explainability.
- Notifications/templates are extended to distinguish provider vs endpoint circuit incidents, with new placeholders and endpoint metadata fields.

Blocking issues to address before merge:
- The “batch” endpoint circuit lookup still does per-endpoint health reads (`Promise.all`), which can become a large burst (up to 500 calls) and undermine UI performance.
- The reset-circuit mutation invalidates a base query key that may not match the composed circuit-info query key, potentially leaving stale circuit badges after a reset depending on React Query’s partial matching behavior.
- The new server action returns Chinese-only error strings, which can surface inconsistent UX in non-zh locales; it should follow the repo’s standard error/i18n strategy.
- Endpoint filter stats collection performs per-endpoint circuit checks, which can add load/latency during strict-block incident paths; a batched circuit-state read (or reuse of computed state) is preferable.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- This PR is close to mergeable but has a few correctness/performance integration issues to fix first.
- Main logic changes are coherent and covered by tests, but the new endpoint circuit “batch” path is still N+1 and the UI reset invalidation may not refresh the active query cache, both of which can cause real user-visible problems (latency/stale badges).
- src/actions/provider-endpoints.ts, src/app/[locale]/settings/providers/_components/provider-endpoints-table.tsx, src/lib/provider-endpoints/endpoint-selector.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/actions/provider-endpoints.ts | Adds batchGetEndpointCircuitInfo server action for endpoint circuit state; still does per-endpoint health lookups and returns hardcoded Chinese errors on permission/exception paths. |
| src/lib/endpoint-circuit-breaker.ts | Triggers async notifications when an endpoint circuit opens and enriches alert with endpoint metadata; adds safer logging on enrichment failure. |
| src/lib/provider-endpoints/endpoint-selector.ts | Adds getEndpointFilterStats to compute enabled/circuit-open/available counts; uses per-endpoint circuit checks which may be expensive under load. |
| src/app/v1/_lib/proxy/forwarder.ts | Records endpoint_pool_exhausted in provider chain with strictBlockCause and optional filter stats; guards attachment of endpointFilterStats when collection fails. |
| src/lib/utils/provider-chain-formatter.ts | Formats new endpoint_pool_exhausted reason in summary/description/timeline; renders stats only when numeric totals are present. |
| src/lib/notification/notifier.ts | Updates circuit-breaker dedup keys to include incidentSource/endpointId and logs incidentSource; avoids endpointId=undefined collision by falling back to source-only suffix. |
| src/lib/webhook/templates/circuit-breaker.ts | Adds endpoint-vs-provider messaging and includes endpointId/endpointUrl fields when incidentSource is endpoint; uses undefined checks for endpointId. |
| src/lib/webhook/templates/placeholders.ts | Adds incident_source/endpoint_id/endpoint_url placeholders and populates them in buildTemplateVariables. |
| src/app/[locale]/settings/providers/_components/provider-endpoints-table.tsx | Batch fetches endpoint circuit states via React Query and displays circuit badges/reset action; invalidation uses a base key that may not match composed query keys depending on React Query config. |
| src/app/[locale]/settings/providers/_components/endpoint-status.ts | Introduces IncidentSource/EndpointDisplayStatus and resolveEndpointDisplayStatus with correct source for non-circuit states. |
| src/app/[locale]/settings/providers/_components/provider-manager.tsx | Extends circuit-broken filter/count to include endpoint-level circuit info; uses Array.isArray guard to avoid runtime crashes on malformed endpointCircuitInfo. |
| src/types/message.ts | Extends ProviderChainItem with endpoint_pool_exhausted reason and endpointFilterStats/strictBlockCause fields used by forwarder + formatter. |
| src/app/v1/_lib/proxy/session.ts | Extends provider chain metadata typing to include endpoint_pool_exhausted-related fields so forwarder can record strict block causes and stats. |
| src/lib/webhook/types.ts | Extends CircuitBreakerAlertData with incidentSource and optional endpoint fields to support endpoint circuit notifications. |
| src/lib/utils/provider-chain-formatter.test.ts | Adds unit tests for endpoint_pool_exhausted formatting with and without stats/selector errors. |
| messages/en/provider-chain.json | Adds i18n strings for endpoint_pool_exhausted reason and endpoint filter stats/timeline details. |
| messages/en/settings/providers/filter.json | Adds i18n keys for circuit-broken filter semantics covering endpoint-level circuits. |
| messages/en/settings/providers/list.json | Adds i18n keys for layered key/endpoint circuit badges in provider list items. |
| messages/en/settings/providers/strings.json | Adds i18n keys for endpoint status labels and reset-circuit actions. |
| messages/ja/provider-chain.json | Adds Japanese i18n strings for endpoint_pool_exhausted and endpoint stats. |
| messages/ja/settings/providers/filter.json | Adds Japanese i18n keys for provider filters including endpoint-level circuit conditions. |
| messages/ja/settings/providers/list.json | Adds Japanese i18n keys for provider list circuit badges and counts. |
| messages/ja/settings/providers/strings.json | Adds Japanese i18n keys for endpoint circuit status and reset actions. |
| messages/ru/provider-chain.json | Adds Russian i18n strings for endpoint_pool_exhausted and endpoint stats. |
| messages/ru/settings/providers/filter.json | Adds Russian i18n keys for provider filters including endpoint-level circuit breakers. |
| messages/ru/settings/providers/list.json | Adds Russian i18n keys for provider list layered circuit badges. |
| messages/ru/settings/providers/strings.json | Adds Russian i18n keys for endpoint status and reset-circuit actions. |
| messages/zh-CN/provider-chain.json | Adds zh-CN i18n strings for endpoint_pool_exhausted and endpoint stats. |
| messages/zh-CN/settings/providers/filter.json | Adds zh-CN i18n keys for circuit-broken filter that includes endpoint circuits. |
| messages/zh-CN/settings/providers/list.json | Adds zh-CN i18n keys for provider list endpoint/key circuit badges. |
| messages/zh-CN/settings/providers/strings.json | Adds zh-CN i18n keys for endpoint circuit-open/half-open and reset-circuit actions. |
| messages/zh-TW/provider-chain.json | Adds zh-TW i18n strings for endpoint_pool_exhausted and endpoint stats. |
| messages/zh-TW/settings/providers/filter.json | Adds zh-TW i18n keys for circuit-broken filter including endpoint circuits. |
| messages/zh-TW/settings/providers/list.json | Adds zh-TW i18n keys for provider list circuit badges. |
| messages/zh-TW/settings/providers/strings.json | Adds zh-TW i18n keys for endpoint circuit status and reset actions. |
| src/app/[locale]/settings/providers/_components/provider-list.tsx | Wires endpointCircuitInfo through provider list rendering so child components can display endpoint-level circuit badges. |
| src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx | Displays layered key-circuit vs endpoint-circuit badges for providers when endpointCircuitInfo indicates open endpoints. |
| src/app/[locale]/settings/providers/_components/provider-vendor-view.tsx | Accepts endpointCircuitInfo prop and passes through to endpoints table / provider list UI for endpoint-level circuit visibility. |
| tests/unit/actions/provider-endpoints.test.ts | Adds unit tests covering batchGetEndpointCircuitInfo behavior and edge cases. |
| tests/unit/lib/endpoint-circuit-breaker.test.ts | Updates endpoint circuit breaker tests to assert alert triggering/logging behavior more explicitly. |
| tests/unit/lib/provider-endpoints/endpoint-selector.test.ts | Adds tests for getEndpointFilterStats counting enabled/circuit-open endpoints. |
| tests/unit/proxy/proxy-forwarder-endpoint-audit.test.ts | Adds tests ensuring endpoint_pool_exhausted chain items include strictBlockCause and omit stats when collection fails. |
| tests/unit/settings/providers/endpoint-status.test.ts | Adds tests for resolveEndpointDisplayStatus priority ordering and correct source assignment. |
| tests/unit/settings/providers/provider-manager.test.tsx | Updates provider-manager tests to cover circuit-broken count/filter behavior with endpointCircuitInfo. |
| tests/unit/settings/providers/provider-vendor-view-circuit-ui.test.tsx | Adds tests verifying vendor view renders endpoint circuit badges and reset behavior integration. |
| tests/unit/webhook/notifier-circuit-breaker.test.ts | Adds tests for notifier dedup behavior across provider vs endpoint incidents. |
| tests/unit/webhook/templates/placeholders.test.ts | Adds tests for new circuit-breaker template placeholders for incident source and endpoint fields. |
| tests/unit/webhook/templates/templates.test.ts | Updates webhook template tests to cover endpoint circuit breaker message rendering. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Settings UI
  participant Actions as provider-endpoints actions
  participant Redis as Endpoint circuit store
  participant Proxy as ProxyForwarder
  participant Session as Proxy Session (ProviderChain)
  participant Webhook as Notifier/Webhook

  UI->>Actions: batchGetEndpointCircuitInfo({endpointIds[]})
  Actions->>Redis: getEndpointHealthInfo(endpointId) (per id)
  Redis-->>Actions: {circuitState,failureCount,circuitOpenUntil}
  Actions-->>UI: map endpointId -> circuitState
  UI->>Actions: resetEndpointCircuit({endpointId})
  Actions->>Redis: deleteEndpointCircuitState(endpointId)
  Actions-->>UI: ok

  Proxy->>Proxy: getPreferredProviderEndpoints(...)
  alt strict policy + no candidates
    Proxy->>Proxy: getEndpointFilterStats(vendorId, providerType)
    Proxy->>Session: addProviderToChain(reason=endpoint_pool_exhausted, strictBlockCause, endpointFilterStats?)
    Session-->>Proxy: chain updated
  end

  Proxy->>Redis: recordEndpointFailure(endpointId)
  alt circuit opens
    Proxy->>Webhook: triggerEndpointCircuitBreakerAlert(endpointId,...)
    Webhook->>Webhook: sendCircuitBreakerAlert(incidentSource=endpoint, endpointId, endpointUrl?)
  end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->