### PR TITLE
perf(vacuum-filter): 优化 has 热路径（降低 API Key 负向短路成本）

### DIFF
--- a/src/lib/vacuum-filter/vacuum-filter.ts
+++ b/src/lib/vacuum-filter/vacuum-filter.ts
@@ -507,11 +507,13 @@ export class VacuumFilter {
     // - 其它：回退到 `%`
     const bucketMask = this.bucketMask;
     const fastReduceMul = this.fastReduceMul;
+    // fastReduceMul != null 时：value = hvIndex * numBuckets / 2^32 < numBuckets <= 2^21，
+    // 因此 `>>> 0` 与 Math.floor 等价且不会发生 2^32 wrap。
     const index =
       bucketMask !== 0
         ? (hvIndex & bucketMask) >>> 0
-        : fastReduceMul
-          ? (hvIndex * fastReduceMul) >>> 0 // >>>0 用于截断（等价 floor；值域 < 2^32）
+        : fastReduceMul !== null
+          ? (hvIndex * fastReduceMul) >>> 0
           : hvIndex % this.numBuckets;
 
     let tag = (hvTag & this.tagMask) >>> 0;

--- a/src/lib/vacuum-filter/vacuum-filter.ts
+++ b/src/lib/vacuum-filter/vacuum-filter.ts
@@ -511,7 +511,7 @@ export class VacuumFilter {
       bucketMask !== 0
         ? (hvIndex & bucketMask) >>> 0
         : fastReduceMul
-          ? ((hvIndex * fastReduceMul) | 0) >>> 0 // |0 用于截断（等价 floor；值域 < 2^31）
+          ? ((hvIndex * fastReduceMul) >>> 0) // >>>0 用于截断（等价 floor；值域 < 2^32）
           : hvIndex % this.numBuckets;
 
     let tag = (hvTag & this.tagMask) >>> 0;

--- a/src/lib/vacuum-filter/vacuum-filter.ts
+++ b/src/lib/vacuum-filter/vacuum-filter.ts
@@ -12,7 +12,10 @@ const IS_LITTLE_ENDIAN = (() => {
   return new Uint32Array(buf)[0] === 0x11223344;
 })();
 
-function computeFastReduceParams(numBuckets: number): { bucketMask: number; fastReduceMul: number | null } {
+function computeFastReduceParams(numBuckets: number): {
+  bucketMask: number;
+  fastReduceMul: number | null;
+} {
   // 1) numBuckets 为 2 的幂：位与最快
   // 2) 否则使用 multiply-high 等价式：floor(hvIndex * numBuckets / 2^32)
   //    该实现依赖 IEEE754 精度：当 numBuckets <= 2^21 时，32-bit hvIndex 与 numBuckets 的乘积 < 2^53，

--- a/src/lib/vacuum-filter/vacuum-filter.ts
+++ b/src/lib/vacuum-filter/vacuum-filter.ts
@@ -511,7 +511,7 @@ export class VacuumFilter {
       bucketMask !== 0
         ? (hvIndex & bucketMask) >>> 0
         : fastReduceMul
-          ? ((hvIndex * fastReduceMul) >>> 0) // >>>0 用于截断（等价 floor；值域 < 2^32）
+          ? (hvIndex * fastReduceMul) >>> 0 // >>>0 用于截断（等价 floor；值域 < 2^32）
           : hvIndex % this.numBuckets;
 
     let tag = (hvTag & this.tagMask) >>> 0;

--- a/src/lib/vacuum-filter/vacuum-filter.ts
+++ b/src/lib/vacuum-filter/vacuum-filter.ts
@@ -3,6 +3,14 @@ import { randomBytes } from "@/lib/vacuum-filter/random";
 const textEncoder = new TextEncoder();
 const BUCKET_SIZE = 4 as const;
 const DEFAULT_SCRATCH_BYTES = 256;
+const INV_2_32 = 1 / 4294967296;
+const FAST_REDUCE_MAX_BUCKETS = 1 << 21; // 2^21：保证 hv(32-bit) * buckets 在 IEEE754 中仍可精确表示整数
+const IS_LITTLE_ENDIAN = (() => {
+  const buf = new ArrayBuffer(4);
+  const view = new DataView(buf);
+  view.setUint32(0, 0x11223344, true);
+  return new Uint32Array(buf)[0] === 0x11223344;
+})();
 
 /**
  * Vacuum Filter（真空过滤器）
@@ -174,16 +182,24 @@ function readU32LE(bytes: Uint8Array, offset: number): number {
   );
 }
 
-// MurmurHash3 x86 32-bit x2（共享同一份 bytes 扫描；用于生成 index/tag）
-function murmur3X86_32x2(
+function fmix32(h: number): number {
+  let x = h >>> 0;
+  x ^= x >>> 16;
+  x = Math.imul(x, 0x85ebca6b) >>> 0;
+  x ^= x >>> 13;
+  x = Math.imul(x, 0xc2b2ae35) >>> 0;
+  x ^= x >>> 16;
+  return x >>> 0;
+}
+
+// MurmurHash3 x86 32-bit（用于生成 index；tag 由二次混合派生）
+function murmur3X86_32(
   bytes: Uint8Array,
   len: number,
-  seedA: number,
-  seedB: number,
-  out: Uint32Array
-): void {
-  let hA = seedA >>> 0;
-  let hB = seedB >>> 0;
+  seed: number,
+  words?: Uint32Array
+): number {
+  let h = seed >>> 0;
   const c1 = 0xcc9e2d51;
   const c2 = 0x1b873593;
 
@@ -191,22 +207,32 @@ function murmur3X86_32x2(
   const nblocks = (length / 4) | 0;
   const blockLen = nblocks * 4;
 
-  for (let base = 0; base < blockLen; base += 4) {
-    let k =
-      (bytes[base] | (bytes[base + 1] << 8) | (bytes[base + 2] << 16) | (bytes[base + 3] << 24)) >>>
-      0;
+  if (words && IS_LITTLE_ENDIAN && bytes.byteOffset === 0) {
+    for (let i = 0; i < nblocks; i++) {
+      let k = words[i] >>> 0;
 
-    k = Math.imul(k, c1) >>> 0;
-    k = ((k << 15) | (k >>> 17)) >>> 0;
-    k = Math.imul(k, c2) >>> 0;
+      k = Math.imul(k, c1) >>> 0;
+      k = ((k << 15) | (k >>> 17)) >>> 0;
+      k = Math.imul(k, c2) >>> 0;
 
-    hA ^= k;
-    hA = ((hA << 13) | (hA >>> 19)) >>> 0;
-    hA = (Math.imul(hA, 5) + 0xe6546b64) >>> 0;
+      h ^= k;
+      h = ((h << 13) | (h >>> 19)) >>> 0;
+      h = (Math.imul(h, 5) + 0xe6546b64) >>> 0;
+    }
+  } else {
+    for (let base = 0; base < blockLen; base += 4) {
+      let k =
+        (bytes[base] | (bytes[base + 1] << 8) | (bytes[base + 2] << 16) | (bytes[base + 3] << 24)) >>>
+        0;
 
-    hB ^= k;
-    hB = ((hB << 13) | (hB >>> 19)) >>> 0;
-    hB = (Math.imul(hB, 5) + 0xe6546b64) >>> 0;
+      k = Math.imul(k, c1) >>> 0;
+      k = ((k << 15) | (k >>> 17)) >>> 0;
+      k = Math.imul(k, c2) >>> 0;
+
+      h ^= k;
+      h = ((h << 13) | (h >>> 19)) >>> 0;
+      h = (Math.imul(h, 5) + 0xe6546b64) >>> 0;
+    }
   }
 
   // tail
@@ -224,28 +250,11 @@ function murmur3X86_32x2(
     k1 = Math.imul(k1, c1) >>> 0;
     k1 = ((k1 << 15) | (k1 >>> 17)) >>> 0;
     k1 = Math.imul(k1, c2) >>> 0;
-    hA ^= k1;
-    hB ^= k1;
+    h ^= k1;
   }
 
-  // fmix (A)
-  hA ^= length;
-  hA ^= hA >>> 16;
-  hA = Math.imul(hA, 0x85ebca6b) >>> 0;
-  hA ^= hA >>> 13;
-  hA = Math.imul(hA, 0xc2b2ae35) >>> 0;
-  hA ^= hA >>> 16;
-
-  // fmix (B)
-  hB ^= length;
-  hB ^= hB >>> 16;
-  hB = Math.imul(hB, 0x85ebca6b) >>> 0;
-  hB ^= hB >>> 13;
-  hB = Math.imul(hB, 0xc2b2ae35) >>> 0;
-  hB ^= hB >>> 16;
-
-  out[0] = hA >>> 0;
-  out[1] = hB >>> 0;
+  h ^= length;
+  return fmix32(h);
 }
 
 export class VacuumFilter {
@@ -261,12 +270,14 @@ export class VacuumFilter {
   private readonly lenMasks: [number, number, number, number];
 
   private readonly numBuckets: number;
+  private readonly bucketMask: number;
+  private readonly fastReduceMul: number | null;
   private readonly table: Uint32Array;
   private numItems = 0;
 
   // 热路径优化：避免 TextEncoder.encode 分配；每次 has/add/delete 复用同一块 scratch
   private scratch: Uint8Array = new Uint8Array(DEFAULT_SCRATCH_BYTES);
-  private readonly hashOut: Uint32Array = new Uint32Array(2);
+  private scratch32: Uint32Array = new Uint32Array(this.scratch.buffer);
   private tmpIndex = 0;
   private tmpTag = 0;
 
@@ -320,6 +331,11 @@ export class VacuumFilter {
       const mask = bigSeg - 1;
       this.lenMasks = [mask, mask, mask, mask];
       this.numBuckets = bucketCount;
+      this.bucketMask = (this.numBuckets & (this.numBuckets - 1)) === 0 ? this.numBuckets - 1 : 0;
+      this.fastReduceMul =
+        this.bucketMask === 0 && this.numBuckets <= FAST_REDUCE_MAX_BUCKETS
+          ? this.numBuckets * INV_2_32
+          : null;
       this.table = new Uint32Array(this.numBuckets * BUCKET_SIZE);
       return;
     }
@@ -341,6 +357,11 @@ export class VacuumFilter {
     const segLens = [l0 + 1, l1 + 1, l2 + 1, l3 + 1];
     const maxSegLen = Math.max(...segLens);
     this.numBuckets = roundUpToMultiple(bucketCount, upperPower2(maxSegLen));
+    this.bucketMask = (this.numBuckets & (this.numBuckets - 1)) === 0 ? this.numBuckets - 1 : 0;
+    this.fastReduceMul =
+      this.bucketMask === 0 && this.numBuckets <= FAST_REDUCE_MAX_BUCKETS
+        ? this.numBuckets * INV_2_32
+        : null;
     this.table = new Uint32Array(this.numBuckets * BUCKET_SIZE);
   }
 
@@ -432,32 +453,46 @@ export class VacuumFilter {
 
   private indexTag(key: string): void {
     // 使用 seeded MurmurHash3（32-bit）生成确定性哈希，降低可控输入退化风险
-    // 关键优化：ASCII 快路径（API Key/ID 通常为 ASCII），避免 TextEncoder.encode 分配
+    // 关键优化：尽量走 TextEncoder.encodeInto（无分配，且编码在原生层完成）
     const strLen = key.length;
     if (this.scratch.length < strLen) {
       this.scratch = new Uint8Array(Math.max(this.scratch.length * 2, strLen));
+      this.scratch32 = new Uint32Array(this.scratch.buffer);
     }
 
-    let asciiLen = 0;
-    for (; asciiLen < strLen; asciiLen++) {
-      const c = key.charCodeAt(asciiLen);
-      if (c > 0x7f) break;
-      this.scratch[asciiLen] = c;
+    // encodeInto 可能因 out buffer 不足而截断：read < strLen 时扩容重试
+    let encoded = textEncoder.encodeInto(key, this.scratch);
+    if (encoded.read < strLen) {
+      // UTF-8 最坏 4 bytes/char；用 4x 作为上界（仅影响少见的非 ASCII key）
+      this.scratch = new Uint8Array(Math.max(this.scratch.length * 2, strLen * 4));
+      this.scratch32 = new Uint32Array(this.scratch.buffer);
+      encoded = textEncoder.encodeInto(key, this.scratch);
     }
 
-    if (asciiLen === strLen) {
-      murmur3X86_32x2(this.scratch, strLen, this.hashSeedA, this.hashSeedB, this.hashOut);
-    } else {
-      // 非 ASCII：交给 TextEncoder（少见路径）
-      const keyBytes = textEncoder.encode(key);
-      murmur3X86_32x2(keyBytes, keyBytes.length, this.hashSeedA, this.hashSeedB, this.hashOut);
-    }
+    // 极端情况下 encodeInto 仍可能因缓冲不足而截断：回退到 encode（保证正确性）
+    const bytes = encoded.read < strLen ? textEncoder.encode(key) : this.scratch;
+    const byteLen = encoded.read < strLen ? bytes.length : encoded.written;
+    const hvIndex = murmur3X86_32(
+      bytes,
+      byteLen,
+      this.hashSeedA,
+      bytes === this.scratch ? this.scratch32 : undefined
+    );
+    // tag 从 index hash 二次混合派生（避免再扫一遍 bytes）
+    const hvTag = fmix32((hvIndex ^ this.hashSeedB) >>> 0);
 
-    const hvIndex = this.hashOut[0] >>> 0;
-    const hvTag = this.hashOut[1] >>> 0;
-
-    // 参考实现使用 `hash % numBuckets`。这里保持简单、快速（即便 numBuckets 非 2 的幂也可用）。
-    const index = hvIndex % this.numBuckets;
+    // 参考实现使用 `hash % numBuckets`；这里做一个“尽量快”的等价映射：
+    // - numBuckets 为 2 的幂：位与（最快）
+    // - numBuckets 较小：使用 multiply-high 等价式（避免 `%`）
+    // - 其它：回退到 `%`
+    const bucketMask = this.bucketMask;
+    const fastReduceMul = this.fastReduceMul;
+    const index =
+      bucketMask !== 0
+        ? (hvIndex & bucketMask) >>> 0
+        : fastReduceMul
+          ? ((hvIndex * fastReduceMul) | 0) >>> 0
+          : hvIndex % this.numBuckets;
 
     let tag = (hvTag & this.tagMask) >>> 0;
     if (tag === 0) tag = 1;

--- a/src/lib/vacuum-filter/vacuum-filter.ts
+++ b/src/lib/vacuum-filter/vacuum-filter.ts
@@ -193,12 +193,7 @@ function fmix32(h: number): number {
 }
 
 // MurmurHash3 x86 32-bit（用于生成 index；tag 由二次混合派生）
-function murmur3X86_32(
-  bytes: Uint8Array,
-  len: number,
-  seed: number,
-  words?: Uint32Array
-): number {
+function murmur3X86_32(bytes: Uint8Array, len: number, seed: number, words?: Uint32Array): number {
   let h = seed >>> 0;
   const c1 = 0xcc9e2d51;
   const c2 = 0x1b873593;
@@ -222,7 +217,10 @@ function murmur3X86_32(
   } else {
     for (let base = 0; base < blockLen; base += 4) {
       let k =
-        (bytes[base] | (bytes[base + 1] << 8) | (bytes[base + 2] << 16) | (bytes[base + 3] << 24)) >>>
+        (bytes[base] |
+          (bytes[base + 1] << 8) |
+          (bytes[base + 2] << 16) |
+          (bytes[base + 3] << 24)) >>>
         0;
 
       k = Math.imul(k, c1) >>> 0;

--- a/tests/unit/lib/endpoint-circuit-breaker.test.ts
+++ b/tests/unit/lib/endpoint-circuit-breaker.test.ts
@@ -19,6 +19,12 @@ function createLoggerMock() {
   };
 }
 
+async function flushPromises(rounds = 2): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 afterEach(() => {
   vi.useRealTimers();
 });
@@ -134,6 +140,10 @@ describe("endpoint-circuit-breaker", () => {
       findProviderEndpointById: vi.fn(async () => null),
     }));
 
+    // recordEndpointFailure 会 non-blocking 触发告警；先让 event-loop 跑完再清空计数，避免串台导致误判
+    await flushPromises();
+    sendAlertMock.mockClear();
+
     const { triggerEndpointCircuitBreakerAlert } = await import("@/lib/endpoint-circuit-breaker");
 
     await triggerEndpointCircuitBreakerAlert(
@@ -183,6 +193,10 @@ describe("endpoint-circuit-breaker", () => {
         deletedAt: null,
       })),
     }));
+
+    // recordEndpointFailure 会 non-blocking 触发告警；先让 event-loop 跑完再清空计数，避免串台导致误判
+    await flushPromises();
+    sendAlertMock.mockClear();
 
     const { triggerEndpointCircuitBreakerAlert } = await import("@/lib/endpoint-circuit-breaker");
 

--- a/tests/unit/vacuum-filter/vacuum-filter-has.bench.test.ts
+++ b/tests/unit/vacuum-filter/vacuum-filter-has.bench.test.ts
@@ -1,0 +1,221 @@
+import { VacuumFilter } from "@/lib/vacuum-filter/vacuum-filter";
+import os from "node:os";
+import { describe, expect, test } from "vitest";
+
+// 说明：
+// - 这是一个“可复现的本机 microbench”，用于量化 VacuumFilter.has 的优化收益。
+// - 默认跳过（避免 CI/本地 `npm test` 触发超时）；需要显式开启：
+//   - *nix:  RUN_VACUUM_FILTER_BENCH=1 node --expose-gc node_modules/vitest/vitest.mjs run tests/unit/vacuum-filter/vacuum-filter-has.bench.test.ts
+//   - pwsh:  $env:RUN_VACUUM_FILTER_BENCH='1'; node --expose-gc node_modules/vitest/vitest.mjs run tests/unit/vacuum-filter/vacuum-filter-has.bench.test.ts
+
+const shouldRunBench = process.env.RUN_VACUUM_FILTER_BENCH === "1";
+const benchTest = shouldRunBench ? test : test.skip;
+
+function xorshift32(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s ^= (s << 13) >>> 0;
+    s ^= s >>> 17;
+    s ^= (s << 5) >>> 0;
+    return s >>> 0;
+  };
+}
+
+const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-";
+
+function makeAsciiKey(rng: () => number, len: number): string {
+  let out = "";
+  for (let i = 0; i < len; i++) out += ALPHABET[rng() % ALPHABET.length];
+  return out;
+}
+
+function freshSameContent(s: string): string {
+  // 让 V8 很难复用同一个 string 实例（模拟“请求头解析后每次都是新字符串对象”）
+  return (" " + s).slice(1);
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return Number.NaN;
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mid = (sorted.length / 2) | 0;
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function nsPerOp(elapsedNs: bigint, ops: number): number {
+  return Number(elapsedNs) / ops;
+}
+
+function opsPerSecFromNsPerOp(ns: number): number {
+  return 1e9 / ns;
+}
+
+function gcIfAvailable(): void {
+  const g = (globalThis as unknown as { gc?: () => void }).gc;
+  if (typeof g === "function") g();
+}
+
+type Scenario = {
+  name: string;
+  kind: "hit" | "miss";
+  strings: "reuse" | "single_use";
+  makeLookups: () => string[];
+  expectedHitsSet: number;
+  expectedHitsVf: number | null; // miss 场景 VF 允许 false positive
+};
+
+function formatMops(opsPerSec: number): string {
+  return `${(opsPerSec / 1e6).toFixed(2)} Mops/s`;
+}
+
+describe("VacuumFilter.has bench (local only)", () => {
+  benchTest(
+    "quantify Set.has vs VacuumFilter.has",
+    () => {
+      const N = 50_000;
+      const KEY_LEN = 48;
+      const LOOKUPS = 200_000;
+      const WARMUP_ROUNDS = 2;
+      const MEASURE_ROUNDS = 7;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[bench-env] node=${process.version} v8=${process.versions.v8} platform=${process.platform} arch=${process.arch}`
+      );
+      // eslint-disable-next-line no-console
+      console.log(`[bench-env] cpu=${os.cpus()[0]?.model ?? "unknown"}`);
+      // eslint-disable-next-line no-console
+      console.log(
+        `[bench-params] N=${N} keyLen=${KEY_LEN} lookups=${LOOKUPS} warmup=${WARMUP_ROUNDS} rounds=${MEASURE_ROUNDS}`
+      );
+
+      const rng = xorshift32(0x12345678);
+      const keys: string[] = Array.from({ length: N }, () => makeAsciiKey(rng, KEY_LEN));
+
+      const set = new Set(keys);
+      const vf = new VacuumFilter({ maxItems: N, fingerprintBits: 32, seed: "bench-seed" });
+      for (const k of keys) {
+        expect(vf.add(k)).toBe(true);
+      }
+
+      const lookupIdx: number[] = Array.from({ length: LOOKUPS }, () => rng() % N);
+
+      const reusedHits: string[] = lookupIdx.map((i) => keys[i]);
+      const reusedMisses: string[] = lookupIdx.map((i) => `!${keys[i].slice(1)}`); // '!' 不在 ALPHABET，保证 miss
+
+      // Sanity: misses must be misses for Set
+      for (let i = 0; i < 1000; i++) {
+        expect(set.has(reusedMisses[i])).toBe(false);
+      }
+
+      const scenarios: Scenario[] = [
+        {
+          name: "hit/reuse",
+          kind: "hit",
+          strings: "reuse",
+          makeLookups: () => reusedHits,
+          expectedHitsSet: LOOKUPS,
+          expectedHitsVf: LOOKUPS,
+        },
+        {
+          name: "miss/reuse",
+          kind: "miss",
+          strings: "reuse",
+          makeLookups: () => reusedMisses,
+          expectedHitsSet: 0,
+          expectedHitsVf: null,
+        },
+        {
+          name: "hit/single_use",
+          kind: "hit",
+          strings: "single_use",
+          makeLookups: () => lookupIdx.map((i) => freshSameContent(keys[i])),
+          expectedHitsSet: LOOKUPS,
+          expectedHitsVf: LOOKUPS,
+        },
+        {
+          name: "miss/single_use",
+          kind: "miss",
+          strings: "single_use",
+          makeLookups: () => lookupIdx.map((i) => freshSameContent(`!${keys[i].slice(1)}`)),
+          expectedHitsSet: 0,
+          expectedHitsVf: null,
+        },
+      ];
+
+      function runSet(lookups: string[]): number {
+        let hits = 0;
+        for (let i = 0; i < lookups.length; i++) hits += set.has(lookups[i]) ? 1 : 0;
+        return hits;
+      }
+
+      function runVf(lookups: string[]): number {
+        let hits = 0;
+        for (let i = 0; i < lookups.length; i++) hits += vf.has(lookups[i]) ? 1 : 0;
+        return hits;
+      }
+
+      for (const scenario of scenarios) {
+        const setNsSamples: number[] = [];
+        const vfNsSamples: number[] = [];
+
+        // Warmup（同时也让 Set 可能缓存 string hash；这正是需要量化的差异）
+        for (let round = 0; round < WARMUP_ROUNDS; round++) {
+          const lookups = scenario.makeLookups();
+          runSet(lookups);
+          runVf(lookups);
+        }
+
+        for (let round = 0; round < MEASURE_ROUNDS; round++) {
+          const lookups = scenario.makeLookups();
+
+          // 交替测量顺序，减少“先测导致的 cache/JIT 影响”
+          const measureSetFirst = round % 2 === 0;
+          if (measureSetFirst) {
+            gcIfAvailable();
+            const t0 = process.hrtime.bigint();
+            const hitsSet = runSet(lookups);
+            const t1 = process.hrtime.bigint();
+            setNsSamples.push(nsPerOp(t1 - t0, LOOKUPS));
+            expect(hitsSet).toBe(scenario.expectedHitsSet);
+
+            gcIfAvailable();
+            const t2 = process.hrtime.bigint();
+            const hitsVf = runVf(lookups);
+            const t3 = process.hrtime.bigint();
+            vfNsSamples.push(nsPerOp(t3 - t2, LOOKUPS));
+            if (typeof scenario.expectedHitsVf === "number") expect(hitsVf).toBe(scenario.expectedHitsVf);
+          } else {
+            gcIfAvailable();
+            const t0 = process.hrtime.bigint();
+            const hitsVf = runVf(lookups);
+            const t1 = process.hrtime.bigint();
+            vfNsSamples.push(nsPerOp(t1 - t0, LOOKUPS));
+            if (typeof scenario.expectedHitsVf === "number") expect(hitsVf).toBe(scenario.expectedHitsVf);
+
+            gcIfAvailable();
+            const t2 = process.hrtime.bigint();
+            const hitsSet = runSet(lookups);
+            const t3 = process.hrtime.bigint();
+            setNsSamples.push(nsPerOp(t3 - t2, LOOKUPS));
+            expect(hitsSet).toBe(scenario.expectedHitsSet);
+          }
+        }
+
+        const setMedianNs = median(setNsSamples);
+        const vfMedianNs = median(vfNsSamples);
+        const setMedianOps = opsPerSecFromNsPerOp(setMedianNs);
+        const vfMedianOps = opsPerSecFromNsPerOp(vfMedianNs);
+        const ratio = vfMedianNs / setMedianNs;
+
+        // eslint-disable-next-line no-console
+        console.log(
+          `[bench] ${scenario.name} Set=${formatMops(setMedianOps)} (${setMedianNs.toFixed(1)} ns/op) | ` +
+            `VF=${formatMops(vfMedianOps)} (${vfMedianNs.toFixed(1)} ns/op) | ` +
+            `VF/Set=${ratio.toFixed(2)}x`
+        );
+      }
+    },
+    60_000
+  );
+});
+

--- a/tests/unit/vacuum-filter/vacuum-filter-has.bench.test.ts
+++ b/tests/unit/vacuum-filter/vacuum-filter-has.bench.test.ts
@@ -183,14 +183,16 @@ describe("VacuumFilter.has bench (local only)", () => {
             const hitsVf = runVf(lookups);
             const t3 = process.hrtime.bigint();
             vfNsSamples.push(nsPerOp(t3 - t2, LOOKUPS));
-            if (typeof scenario.expectedHitsVf === "number") expect(hitsVf).toBe(scenario.expectedHitsVf);
+            if (typeof scenario.expectedHitsVf === "number")
+              expect(hitsVf).toBe(scenario.expectedHitsVf);
           } else {
             gcIfAvailable();
             const t0 = process.hrtime.bigint();
             const hitsVf = runVf(lookups);
             const t1 = process.hrtime.bigint();
             vfNsSamples.push(nsPerOp(t1 - t0, LOOKUPS));
-            if (typeof scenario.expectedHitsVf === "number") expect(hitsVf).toBe(scenario.expectedHitsVf);
+            if (typeof scenario.expectedHitsVf === "number")
+              expect(hitsVf).toBe(scenario.expectedHitsVf);
 
             gcIfAvailable();
             const t2 = process.hrtime.bigint();
@@ -218,4 +220,3 @@ describe("VacuumFilter.has bench (local only)", () => {
     60_000
   );
 });
-

--- a/tests/unit/vacuum-filter/vacuum-filter.test.ts
+++ b/tests/unit/vacuum-filter/vacuum-filter.test.ts
@@ -141,8 +141,10 @@ describe("VacuumFilter", () => {
     expect(bucketMask).toBe(0);
     expect(fastReduceMul).not.toBeNull();
 
-    // @ts-expect-error: 单测需要覆盖私有方法的核心不变量
-    const indexTag = (key: string) => vf.indexTag(key) as void;
+    const indexTag = (key: string): void => {
+      // @ts-expect-error: 单测需要覆盖私有方法的核心不变量
+      vf.indexTag(key);
+    };
 
     for (let i = 0; i < 10_000; i++) {
       indexTag(`key_${i}`);

--- a/tests/unit/vacuum-filter/vacuum-filter.test.ts
+++ b/tests/unit/vacuum-filter/vacuum-filter.test.ts
@@ -107,6 +107,22 @@ describe("VacuumFilter", () => {
     }
   });
 
+  test("超长 key 也应可用（避免 scratch32 对齐导致 RangeError）", () => {
+    const vf = new VacuumFilter({
+      maxItems: 1000,
+      fingerprintBits: 32,
+      maxKickSteps: 500,
+      seed: "unit-test-long-key",
+    });
+
+    // 触发 scratch 扩容：> DEFAULT_SCRATCH_BYTES*2 且不是 4 的倍数
+    const longKey = "a".repeat(1001);
+    expect(vf.add(longKey)).toBe(true);
+    expect(vf.has(longKey)).toBe(true);
+    expect(vf.delete(longKey)).toBe(true);
+    expect(vf.has(longKey)).toBe(false);
+  });
+
   test("alternate index 应为可逆映射（alt(alt(i,tag),tag)=i）且不越界", () => {
     const vf = new VacuumFilter({
       maxItems: 50_000,


### PR DESCRIPTION
## 背景
在 #734 合入后，本地 microbench 发现 `VacuumFilter.has` 在“重复查询同一批 string 实例”的场景下会明显慢于 `Set.has`（有时看起来可达 ~10x）。

主要原因：
- `Set.has` 是 V8 原生实现；并且 V8 会把 string hash 缓存在 string 实例上（当基准反复复用同一批 string 对象时优势极大）。
- 旧 `VacuumFilter.has` 每次查询都会走纯 JS 热路径：JS 层手写 ASCII 拷贝（string -> bytes）+ MurmurHash3 再扫一遍 bytes（双遍历）+ 同时计算两份 hash（index/tag）+ `% numBuckets`。

因此 microbench 下差距会被放大；而在真实请求里（从请求头解析得到的 key 通常是“新 string 实例”），`Set.has` 的缓存优势会明显减弱。

## 改进
- **编码优化**：优先 `TextEncoder.encodeInto` 写入复用 scratch（无分配；编码在原生层完成）。
- **哈希优化**：由“双 hash（index/tag）”改为“单次 MurmurHash3”；tag 由二次混合派生（避免再扫一遍 bytes）。
- **index 映射优化**：
  - `numBuckets` 为 2 的幂：位与（最快）；
  - 否则在 `numBuckets <= 2^21` 时使用 fast reduction：`floor(hvIndex * numBuckets / 2^32)`（在 IEEE754 精度约束下可精确计算）；
  - 其它情况回退到 `% numBuckets`。
- **block 读取优化**：little-endian 下用 `Uint32Array` 视图读取 4-byte blocks；其它端回退 byte 读取，保持可移植性。
- **正确性修复**：修复 scratch 扩容时 `scratch32` 4-byte 对齐导致的 `RangeError`，并新增单测覆盖。

## 量化基准（本机 microbench）
命令：
（默认跳过；需要显式开启环境变量 `RUN_VACUUM_FILTER_BENCH=1`）

*nix:
`RUN_VACUUM_FILTER_BENCH=1 node --expose-gc node_modules/vitest/vitest.mjs run tests/unit/vacuum-filter/vacuum-filter-has.bench.test.ts`

PowerShell:
`$env:RUN_VACUUM_FILTER_BENCH='1'; node --expose-gc node_modules/vitest/vitest.mjs run tests/unit/vacuum-filter/vacuum-filter-has.bench.test.ts`

参数（测试内部固定）：
- N=50_000, keyLen=48, lookups=200_000
- warmup=2, measure=7（取 median）
- reuse：复用同一批 string 实例（`Set.has` 受益于 string hash 缓存，偏向 Set）
- single_use：每次 lookup 都是新的 string 实例（更贴近请求头解析场景）

环境：
- node=v20.20.0, v8=11.3.244.8-node.33, win32 x64

结果（median；ns/op 越低越好）：

| scenario | dev Set (ns/op) | dev VF (ns/op) | dev VF/Set | PR Set (ns/op) | PR VF (ns/op) | PR VF/Set | VF 加速（dev->PR） |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| hit/reuse | 45.8 | 272.1 | 5.94x | 62.8 | 187.8 | 2.99x | 1.45x |
| miss/reuse | 75.0 | 229.0 | 3.06x | 76.3 | 137.3 | 1.80x | 1.67x |
| hit/single_use | 352.6 | 233.0 | 0.66x | 365.5 | 151.4 | 0.41x | 1.54x |
| miss/single_use | 282.8 | 218.8 | 0.77x | 293.6 | 127.9 | 0.44x | 1.71x |

解读要点：
- **reuse 场景（偏向 Set）**：`VF/Set` 从 ~5.9x 降到 ~3.0x（hit）；从 ~3.1x 降到 ~1.8x（miss）。
- **single_use 场景（更贴近请求头解析）**：本机上 `VacuumFilter.has` 明显快于 `Set.has`（`VF/Set < 1`），并且优化后进一步拉开差距。

## 备注
- tag 由 `hvIndex` 二次混合派生，(index, tag) 不再是两份独立 hash；但在当前默认的 **32-bit fingerprint** 场景下碰撞概率仍极低。

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR optimizes the hot path of `VacuumFilter.has` to reduce overhead for API key lookups, addressing performance gaps identified in microbenchmarks.

**Key improvements:**
- Replaced dual-hash approach (index/tag) with single MurmurHash3 + derived tag via secondary mixing
- Optimized encoding path: prioritized `TextEncoder.encodeInto` with reusable scratch buffer (zero allocation)
- Added fast bucket index reduction for non-power-of-2 bucket counts using multiply-high technique `floor(hvIndex * numBuckets / 2^32)` when `numBuckets <= 2^21` (maintains IEEE754 precision)
- Leveraged little-endian `Uint32Array` view for 4-byte block reads in MurmurHash3 (falls back to byte-level reads for portability)
- Fixed scratch buffer expansion to maintain 4-byte alignment, preventing `RangeError` when creating `Uint32Array` view

**Correctness verification:**
- Previous PR comments raised concerns about fast-reduce implementation being incorrect. After thorough mathematical analysis, the current implementation is **correct**: when `numBuckets <= 2^21` and `hvIndex < 2^32`, the product stays within IEEE754 double precision (< 2^53), ensuring `(hvIndex * fastReduceMul) >>> 0` is equivalent to `Math.floor(hvIndex * numBuckets / 2^32)` and always produces results in range `[0, numBuckets)`
- Comprehensive test coverage added: 10,000-iteration index boundary validation test, scratch buffer alignment edge case test
- Benchmark suite quantifies improvements across realistic scenarios (1.45x-1.71x speedup per PR description)

**Test quality fix:**
- Fixed flaky endpoint circuit breaker tests by flushing async promises before clearing alert mocks
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge - well-tested performance optimization with correct fast-reduce implementation
- All previous concerns about fast-reduce implementation have been addressed with mathematically correct logic. The code includes comprehensive test coverage for edge cases (scratch buffer alignment, index boundary validation), and the optimization is backed by IEEE754 precision analysis. The benchmark suite provides empirical validation of correctness and performance improvements.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/vacuum-filter/vacuum-filter.ts | Optimized `VacuumFilter.has` hot path with encoding/hashing improvements, correct fast-reduce implementation, and scratch buffer alignment fix |
| tests/unit/vacuum-filter/vacuum-filter.test.ts | Added comprehensive tests for scratch buffer alignment edge case and fast-reduce index boundary validation |
| tests/unit/vacuum-filter/vacuum-filter-has.bench.test.ts | Added thorough benchmark suite to quantify `VacuumFilter.has` performance improvements (opt-in via env variable) |
| tests/unit/lib/endpoint-circuit-breaker.test.ts | Fixed test flakiness by flushing async alert promises before clearing mocks |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->