### PR TITLE
fix: 修复供应商克隆时因浅拷贝引用共享导致源供应商数据被意外污染的问题

### DIFF
--- a/src/app/[locale]/settings/providers/_components/forms/provider-form/provider-form-context.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/provider-form/provider-form-context.tsx
@@ -22,7 +22,8 @@ export function createInitialState(
   }
 ): ProviderFormState {
   const isEdit = mode === "edit";
-  const sourceProvider = isEdit ? provider : cloneProvider;
+  const raw = isEdit ? provider : cloneProvider;
+  const sourceProvider = raw ? structuredClone(raw) : undefined;
 
   return {
     basic: {
@@ -322,11 +323,13 @@ export function providerFormReducer(
       return { ...state, ui: { ...state.ui, showFailureThresholdConfirm: action.payload } };
 
     // Reset
-    case "RESET_FORM":
+    case "RESET_FORM": {
+      const fresh = structuredClone(defaultInitialState);
       return {
-        ...defaultInitialState,
-        ui: { ...defaultInitialState.ui, activeTab: state.ui.activeTab },
+        ...fresh,
+        ui: { ...fresh.ui, activeTab: state.ui.activeTab },
       };
+    }
 
     // Load provider data
     case "LOAD_PROVIDER":

--- a/tests/unit/dashboard/provider-form-clone-deep-copy.test.ts
+++ b/tests/unit/dashboard/provider-form-clone-deep-copy.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { createInitialState } from "@/app/[locale]/settings/providers/_components/forms/provider-form/provider-form-context";
+import type { ProviderDisplay } from "@/types/provider";
+
+function makeProvider(overrides?: Partial<ProviderDisplay>): ProviderDisplay {
+  return {
+    id: 1,
+    name: "TestProvider",
+    url: "https://api.example.com",
+    maskedKey: "sk-****1234",
+    isEnabled: true,
+    weight: 1,
+    priority: 0,
+    groupPriorities: { groupA: 10, groupB: 20 },
+    costMultiplier: 1.0,
+    groupTag: "groupA,groupB",
+    providerType: "claude",
+    providerVendorId: null,
+    preserveClientIp: false,
+    modelRedirects: { "claude-3": "claude-3.5" },
+    allowedModels: ["claude-3", "claude-3.5"],
+    mcpPassthroughType: "none",
+    mcpPassthroughUrl: null,
+    limit5hUsd: null,
+    limitDailyUsd: null,
+    dailyResetMode: "fixed",
+    dailyResetTime: "00:00",
+    limitWeeklyUsd: null,
+    limitMonthlyUsd: null,
+    limitTotalUsd: null,
+    limitConcurrentSessions: 0,
+    maxRetryAttempts: null,
+    circuitBreakerFailureThreshold: 3,
+    circuitBreakerOpenDuration: 60000,
+    circuitBreakerHalfOpenSuccessThreshold: 2,
+    proxyUrl: null,
+    proxyFallbackToDirect: false,
+    firstByteTimeoutStreamingMs: 30000,
+    streamingIdleTimeoutMs: 60000,
+    requestTimeoutNonStreamingMs: 120000,
+    websiteUrl: null,
+    faviconUrl: null,
+    cacheTtlPreference: null,
+    context1mPreference: null,
+    codexReasoningEffortPreference: null,
+    codexReasoningSummaryPreference: null,
+    codexTextVerbosityPreference: null,
+    codexParallelToolCallsPreference: null,
+    anthropicMaxTokensPreference: null,
+    anthropicThinkingBudgetPreference: null,
+    anthropicAdaptiveThinking: {
+      effort: "high",
+      modelMatchMode: "specific",
+      models: ["claude-opus-4-6"],
+    },
+    geminiGoogleSearchPreference: null,
+    tpm: null,
+    rpm: null,
+    rpd: null,
+    cc: null,
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  } as ProviderDisplay;
+}
+
+describe("createInitialState deep-copy safety", () => {
+  describe("clone mode", () => {
+    it("modelRedirects is a distinct object with equal values", () => {
+      const source = makeProvider();
+      const state = createInitialState("create", undefined, source);
+      expect(state.routing.modelRedirects).toEqual(source.modelRedirects);
+      expect(state.routing.modelRedirects).not.toBe(source.modelRedirects);
+    });
+
+    it("allowedModels is a distinct array with equal values", () => {
+      const source = makeProvider();
+      const state = createInitialState("create", undefined, source);
+      expect(state.routing.allowedModels).toEqual(source.allowedModels);
+      expect(state.routing.allowedModels).not.toBe(source.allowedModels);
+    });
+
+    it("groupPriorities is a distinct object with equal values", () => {
+      const source = makeProvider();
+      const state = createInitialState("create", undefined, source);
+      expect(state.routing.groupPriorities).toEqual(source.groupPriorities);
+      expect(state.routing.groupPriorities).not.toBe(source.groupPriorities);
+    });
+
+    it("anthropicAdaptiveThinking is a distinct object with distinct models array", () => {
+      const source = makeProvider();
+      const state = createInitialState("create", undefined, source);
+      expect(state.routing.anthropicAdaptiveThinking).toEqual(source.anthropicAdaptiveThinking);
+      expect(state.routing.anthropicAdaptiveThinking).not.toBe(source.anthropicAdaptiveThinking);
+      expect(state.routing.anthropicAdaptiveThinking!.models).not.toBe(
+        source.anthropicAdaptiveThinking!.models
+      );
+    });
+
+    it("null anthropicAdaptiveThinking stays null", () => {
+      const source = makeProvider({ anthropicAdaptiveThinking: null });
+      const state = createInitialState("create", undefined, source);
+      expect(state.routing.anthropicAdaptiveThinking).toBeNull();
+    });
+
+    it("null modelRedirects falls back to empty object", () => {
+      const source = makeProvider({ modelRedirects: null });
+      const state = createInitialState("create", undefined, source);
+      expect(state.routing.modelRedirects).toEqual({});
+    });
+
+    it("null allowedModels falls back to empty array", () => {
+      const source = makeProvider({ allowedModels: null });
+      const state = createInitialState("create", undefined, source);
+      expect(state.routing.allowedModels).toEqual([]);
+    });
+
+    it("null groupPriorities falls back to empty object", () => {
+      const source = makeProvider({ groupPriorities: null });
+      const state = createInitialState("create", undefined, source);
+      expect(state.routing.groupPriorities).toEqual({});
+    });
+
+    it("name gets _Copy suffix", () => {
+      const source = makeProvider({ name: "MyProvider" });
+      const state = createInitialState("create", undefined, source);
+      expect(state.basic.name).toBe("MyProvider_Copy");
+    });
+
+    it("key is always empty", () => {
+      const source = makeProvider();
+      const state = createInitialState("create", undefined, source);
+      expect(state.basic.key).toBe("");
+    });
+  });
+
+  describe("edit mode", () => {
+    it("nested objects are isolated from source provider", () => {
+      const source = makeProvider();
+      const state = createInitialState("edit", source);
+      expect(state.routing.modelRedirects).toEqual(source.modelRedirects);
+      expect(state.routing.modelRedirects).not.toBe(source.modelRedirects);
+      expect(state.routing.allowedModels).not.toBe(source.allowedModels);
+      expect(state.routing.groupPriorities).not.toBe(source.groupPriorities);
+      expect(state.routing.anthropicAdaptiveThinking).not.toBe(source.anthropicAdaptiveThinking);
+    });
+  });
+
+  describe("create mode without clone source", () => {
+    it("nested objects use fresh defaults", () => {
+      const state = createInitialState("create");
+      expect(state.routing.modelRedirects).toEqual({});
+      expect(state.routing.allowedModels).toEqual([]);
+      expect(state.routing.groupPriorities).toEqual({});
+      expect(state.routing.anthropicAdaptiveThinking).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fix shallow-copy reference sharing in the provider clone flow that caused mutations in the cloned form to pollute the source provider data held in React Query cache.

Two `structuredClone` calls were added:
1. In `createInitialState` -- deep-copies the source provider before extracting fields into form state.
2. In the `RESET_FORM` reducer -- deep-copies the `defaultInitialState` singleton to prevent shared references after form reset.

## Problem

When cloning a provider, `createInitialState` assigned nested objects (`modelRedirects`, `allowedModels`, `groupPriorities`, `anthropicAdaptiveThinking`) from the source provider directly into the new form state. These objects shared the same memory reference as the React Query cache entry for the source provider. Editing any of these fields in the clone form would mutate the cached source provider, causing the original provider to display incorrect data in the UI.

The same class of bug existed in the `RESET_FORM` reducer, which spread the module-level `defaultInitialState` singleton directly -- meaning a reset form could share mutable references with future form instances.

## Solution

Apply `structuredClone` at the entry point of `createInitialState` to deep-copy the entire source provider object before any field extraction:

```ts
const raw = isEdit ? provider : cloneProvider;
const sourceProvider = raw ? structuredClone(raw) : undefined;
```

And in the `RESET_FORM` reducer, clone the default state before spreading:

```ts
case "RESET_FORM": {
  const fresh = structuredClone(defaultInitialState);
  return {
    ...fresh,
    ui: { ...fresh.ui, activeTab: state.ui.activeTab },
  };
}
```

This severs all nested references in a single operation rather than cloning individual fields.

## Changes

### Core Changes
- `src/app/[locale]/settings/providers/_components/forms/provider-form/provider-form-context.tsx` -- `structuredClone` applied to source provider in `createInitialState` and to `defaultInitialState` in `RESET_FORM` reducer

### Tests
- `tests/unit/dashboard/provider-form-clone-deep-copy.test.ts` (new, 158 lines) -- 13 test cases covering:
  - Clone mode: reference isolation for `modelRedirects`, `allowedModels`, `groupPriorities`, `anthropicAdaptiveThinking`
  - Clone mode: null fallback behavior for each nested field
  - Clone mode: `_Copy` name suffix and empty key
  - Edit mode: nested object isolation from source
  - Create mode (no clone source): correct defaults

## Breaking Changes

None. The function signatures and exported API are unchanged. The only behavioral difference is that form state no longer shares object references with the source provider.

## Testing

### Automated Tests
- [x] 13 unit tests added in `provider-form-clone-deep-copy.test.ts`

### Manual Testing
1. Open the provider list in the dashboard
2. Click "Clone" on a provider that has `modelRedirects`, `allowedModels`, `groupPriorities`, and `anthropicAdaptiveThinking` configured
3. Modify these fields in the clone form
4. Verify the source provider's data in the list remains unchanged

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [ ] Documentation updated (if needed)

---
*Description enhanced by Claude AI*