### PR TITLE
修复 Key 并发限制继承用户并发上限

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/actions/keys.ts
+++ b/src/actions/keys.ts
@@ -5,7 +5,7 @@ import { and, count, eq, inArray, isNull } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { getTranslations } from "next-intl/server";
 import { db } from "@/drizzle/db";
-import { keys as keysTable } from "@/drizzle/schema";
+import { keys as keysTable, users as usersTable } from "@/drizzle/schema";
 import { getSession } from "@/lib/auth";
 import { PROVIDER_GROUP } from "@/lib/constants/provider.constants";
 import { logger } from "@/lib/logger";
@@ -15,6 +15,7 @@ import { ERROR_CODES } from "@/lib/utils/error-messages";
 import { normalizeProviderGroup, parseProviderGroups } from "@/lib/utils/provider-group";
 import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import { KeyFormSchema } from "@/lib/validation/schemas";
+import { toKey } from "@/repository/_shared/transformers";
 import type { KeyStatistics } from "@/repository/key";
 import {
   countActiveKeysByUser,
@@ -697,10 +698,21 @@ export async function getKeyLimitUsage(keyId: number): Promise<
       return { ok: false, error: "未登录" };
     }
 
-    const key = await findKeyById(keyId);
-    if (!key) {
+    const [result] = await db
+      .select({
+        key: keysTable,
+        userLimitConcurrentSessions: usersTable.limitConcurrentSessions,
+      })
+      .from(keysTable)
+      .leftJoin(usersTable, and(eq(keysTable.userId, usersTable.id), isNull(usersTable.deletedAt)))
+      .where(and(eq(keysTable.id, keyId), isNull(keysTable.deletedAt)))
+      .limit(1);
+
+    if (!result) {
       return { ok: false, error: "密钥不存在" };
     }
+
+    const key = toKey(result.key);
 
     // 权限检查
     if (session.user.role !== "admin" && session.user.id !== key.userId) {
@@ -716,11 +728,9 @@ export async function getKeyLimitUsage(keyId: number): Promise<
       getTimeRangeForPeriodWithMode,
     } = await import("@/lib/rate-limit/time-utils");
     const { sumKeyTotalCost, sumKeyCostInTimeRange } = await import("@/repository/statistics");
-    const { findUserById } = await import("@/repository/user");
-    const user = await findUserById(key.userId);
     const effectiveConcurrentLimit = resolveKeyConcurrentSessionLimit(
       key.limitConcurrentSessions,
-      user?.limitConcurrentSessions
+      result.userLimitConcurrentSessions ?? null
     );
 
     // Calculate time ranges using Key's dailyResetTime/dailyResetMode configuration

--- a/src/actions/my-usage.ts
+++ b/src/actions/my-usage.ts
@@ -92,7 +92,7 @@ export interface MyUsageQuota {
   keyLimitWeeklyUsd: number | null;
   keyLimitMonthlyUsd: number | null;
   keyLimitTotalUsd: number | null;
-  keyLimitConcurrentSessions: number | null;
+  keyLimitConcurrentSessions: number;
   keyCurrent5hUsd: number;
   keyCurrentDailyUsd: number;
   keyCurrentWeeklyUsd: number;

--- a/src/app/api/actions/[...route]/route.ts
+++ b/src/app/api/actions/[...route]/route.ts
@@ -891,7 +891,7 @@ const { route: getMyQuotaRoute, handler: getMyQuotaHandler } = createActionRoute
       keyLimitWeeklyUsd: z.number().nullable(),
       keyLimitMonthlyUsd: z.number().nullable(),
       keyLimitTotalUsd: z.number().nullable(),
-      keyLimitConcurrentSessions: z.number().nullable(),
+      keyLimitConcurrentSessions: z.number(),
       keyCurrent5hUsd: z.number(),
       keyCurrentDailyUsd: z.number(),
       keyCurrentWeeklyUsd: z.number(),

--- a/src/lib/rate-limit/concurrent-session-limit.ts
+++ b/src/lib/rate-limit/concurrent-session-limit.ts
@@ -1,0 +1,27 @@
+function normalizePositiveLimit(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+
+  return Math.floor(value);
+}
+
+/**
+ * 解析 Key 的“有效并发 Session 上限”。
+ *
+ * 规则：
+ * - Key 自身设置（>0）优先生效
+ * - Key 未设置/为 0 时，回退到 User 并发上限（>0）
+ * - 都未设置/为 0 时，返回 0（表示无限制）
+ */
+export function resolveKeyConcurrentSessionLimit(
+  keyLimit: number | null | undefined,
+  userLimit: number | null | undefined
+): number {
+  const normalizedKeyLimit = normalizePositiveLimit(keyLimit);
+  if (normalizedKeyLimit > 0) {
+    return normalizedKeyLimit;
+  }
+
+  return normalizePositiveLimit(userLimit);
+}

--- a/src/lib/rate-limit/concurrent-session-limit.ts
+++ b/src/lib/rate-limit/concurrent-session-limit.ts
@@ -1,3 +1,9 @@
+/**
+ * 将输入归一化为正整数限额。
+ *
+ * - 非数字 / 非有限值 / <= 0 视为 0（无限制）
+ * - > 0 时向下取整
+ */
 function normalizePositiveLimit(value: unknown): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return 0;

--- a/tests/unit/actions/key-quota-concurrent-inherit.test.ts
+++ b/tests/unit/actions/key-quota-concurrent-inherit.test.ts
@@ -47,7 +47,8 @@ vi.mock("@/repository/statistics", () => ({
 
 const limitMock = vi.fn();
 const whereMock = vi.fn(() => ({ limit: limitMock }));
-const fromMock = vi.fn(() => ({ where: whereMock }));
+const leftJoinMock = vi.fn(() => ({ where: whereMock }));
+const fromMock = vi.fn(() => ({ leftJoin: leftJoinMock }));
 const selectMock = vi.fn(() => ({ from: fromMock }));
 
 vi.mock("@/drizzle/db", () => ({
@@ -70,9 +71,9 @@ describe("getKeyQuotaUsage - concurrent limit inheritance", () => {
   });
 
   it("Key 并发为 0 时应回退到 User 并发上限", async () => {
-    limitMock
-      .mockResolvedValueOnce([
-        {
+    limitMock.mockResolvedValueOnce([
+      {
+        key: {
           id: 1,
           userId: 10,
           key: "sk-test",
@@ -87,8 +88,9 @@ describe("getKeyQuotaUsage - concurrent limit inheritance", () => {
           dailyResetMode: "fixed",
           limitConcurrentSessions: 0,
         },
-      ])
-      .mockResolvedValueOnce([{ limitConcurrentSessions: 15, deletedAt: null }]);
+        userLimitConcurrentSessions: 15,
+      },
+    ]);
 
     const { getKeyQuotaUsage } = await import("@/actions/key-quota");
     const result = await getKeyQuotaUsage(1);

--- a/tests/unit/actions/key-quota-concurrent-inherit.test.ts
+++ b/tests/unit/actions/key-quota-concurrent-inherit.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+}));
+
+const getTranslationsMock = vi.fn(async () => (key: string) => key);
+vi.mock("next-intl/server", () => ({
+  getTranslations: getTranslationsMock,
+}));
+
+const getSystemSettingsMock = vi.fn(async () => ({ currencyDisplay: "USD" }));
+vi.mock("@/repository/system-config", () => ({
+  getSystemSettings: getSystemSettingsMock,
+}));
+
+const getTotalUsageForKeyMock = vi.fn(async () => 0);
+vi.mock("@/repository/usage-logs", () => ({
+  getTotalUsageForKey: getTotalUsageForKeyMock,
+}));
+
+const getKeySessionCountMock = vi.fn(async () => 2);
+vi.mock("@/lib/session-tracker", () => ({
+  SessionTracker: {
+    getKeySessionCount: getKeySessionCountMock,
+  },
+}));
+
+const getTimeRangeForPeriodWithModeMock = vi.fn(async () => ({
+  startTime: new Date("2026-02-11T00:00:00.000Z"),
+  endTime: new Date("2026-02-12T00:00:00.000Z"),
+}));
+const getTimeRangeForPeriodMock = vi.fn(async () => ({
+  startTime: new Date("2026-02-11T00:00:00.000Z"),
+  endTime: new Date("2026-02-12T00:00:00.000Z"),
+}));
+vi.mock("@/lib/rate-limit/time-utils", () => ({
+  getTimeRangeForPeriodWithMode: getTimeRangeForPeriodWithModeMock,
+  getTimeRangeForPeriod: getTimeRangeForPeriodMock,
+}));
+
+const sumKeyCostInTimeRangeMock = vi.fn(async () => 0);
+vi.mock("@/repository/statistics", () => ({
+  sumKeyCostInTimeRange: sumKeyCostInTimeRangeMock,
+}));
+
+const limitMock = vi.fn();
+const whereMock = vi.fn(() => ({ limit: limitMock }));
+const fromMock = vi.fn(() => ({ where: whereMock }));
+const selectMock = vi.fn(() => ({ from: fromMock }));
+
+vi.mock("@/drizzle/db", () => ({
+  db: {
+    select: selectMock,
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("getKeyQuotaUsage - concurrent limit inheritance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
+  });
+
+  it("Key 并发为 0 时应回退到 User 并发上限", async () => {
+    limitMock
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          userId: 10,
+          key: "sk-test",
+          name: "k",
+          deletedAt: null,
+          limit5hUsd: null,
+          limitDailyUsd: null,
+          limitWeeklyUsd: null,
+          limitMonthlyUsd: null,
+          limitTotalUsd: null,
+          dailyResetTime: "00:00",
+          dailyResetMode: "fixed",
+          limitConcurrentSessions: 0,
+        },
+      ])
+      .mockResolvedValueOnce([{ limitConcurrentSessions: 15, deletedAt: null }]);
+
+    const { getKeyQuotaUsage } = await import("@/actions/key-quota");
+    const result = await getKeyQuotaUsage(1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const item = result.data.items.find((i) => i.type === "limitSessions");
+      expect(item).toMatchObject({ current: 2, limit: 15 });
+    }
+  });
+});

--- a/tests/unit/actions/my-usage-concurrent-inherit.test.ts
+++ b/tests/unit/actions/my-usage-concurrent-inherit.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+}));
+
+const getKeySessionCountMock = vi.fn(async () => 2);
+vi.mock("@/lib/session-tracker", () => ({
+  SessionTracker: {
+    getKeySessionCount: getKeySessionCountMock,
+  },
+}));
+
+const getTimeRangeForPeriodWithModeMock = vi.fn(async () => ({
+  startTime: new Date("2026-02-11T00:00:00.000Z"),
+  endTime: new Date("2026-02-12T00:00:00.000Z"),
+}));
+const getTimeRangeForPeriodMock = vi.fn(async () => ({
+  startTime: new Date("2026-02-11T00:00:00.000Z"),
+  endTime: new Date("2026-02-12T00:00:00.000Z"),
+}));
+vi.mock("@/lib/rate-limit/time-utils", () => ({
+  getTimeRangeForPeriodWithMode: getTimeRangeForPeriodWithModeMock,
+  getTimeRangeForPeriod: getTimeRangeForPeriodMock,
+}));
+
+const statisticsMock = {
+  sumUserCostInTimeRange: vi.fn(async () => 0),
+  sumUserTotalCost: vi.fn(async () => 0),
+  sumKeyCostInTimeRange: vi.fn(async () => 0),
+  sumKeyTotalCostById: vi.fn(async () => 0),
+};
+vi.mock("@/repository/statistics", () => statisticsMock);
+
+const whereMock = vi.fn(async () => [{ id: 1 }]);
+const fromMock = vi.fn(() => ({ where: whereMock }));
+const selectMock = vi.fn(() => ({ from: fromMock }));
+vi.mock("@/drizzle/db", () => ({
+  db: {
+    select: selectMock,
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("getMyQuota - concurrent limit inheritance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getSessionMock.mockResolvedValue({
+      key: {
+        id: 1,
+        key: "sk-test",
+        name: "k",
+        dailyResetTime: "00:00",
+        dailyResetMode: "fixed",
+        limit5hUsd: null,
+        limitDailyUsd: null,
+        limitWeeklyUsd: null,
+        limitMonthlyUsd: null,
+        limitTotalUsd: null,
+        limitConcurrentSessions: 0,
+        providerGroup: null,
+        isEnabled: true,
+        expiresAt: null,
+      },
+      user: {
+        id: 10,
+        name: "u",
+        dailyResetTime: "00:00",
+        dailyResetMode: "fixed",
+        limit5hUsd: null,
+        dailyQuota: null,
+        limitWeeklyUsd: null,
+        limitMonthlyUsd: null,
+        limitTotalUsd: null,
+        limitConcurrentSessions: 15,
+        rpm: null,
+        providerGroup: null,
+        isEnabled: true,
+        expiresAt: null,
+        allowedModels: [],
+        allowedClients: [],
+      },
+    });
+  });
+
+  it("Key 并发为 0 时应回退到 User 并发上限", async () => {
+    const { getMyQuota } = await import("@/actions/my-usage");
+    const result = await getMyQuota();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.keyLimitConcurrentSessions).toBe(15);
+    }
+  });
+});

--- a/tests/unit/lib/rate-limit/concurrent-session-limit.test.ts
+++ b/tests/unit/lib/rate-limit/concurrent-session-limit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { resolveKeyConcurrentSessionLimit } from "@/lib/rate-limit/concurrent-session-limit";
+
+describe("resolveKeyConcurrentSessionLimit", () => {
+  const cases: Array<{
+    title: string;
+    keyLimit: number | null | undefined;
+    userLimit: number | null | undefined;
+    expected: number;
+  }> = [
+    { title: "Key > 0 时应优先使用 Key", keyLimit: 10, userLimit: 15, expected: 10 },
+    { title: "Key 为 0 时应回退到 User", keyLimit: 0, userLimit: 15, expected: 15 },
+    { title: "Key 为 null 时应回退到 User", keyLimit: null, userLimit: 15, expected: 15 },
+    { title: "Key 为 undefined 时应回退到 User", keyLimit: undefined, userLimit: 15, expected: 15 },
+    {
+      title: "Key 为 NaN 时应回退到 User",
+      keyLimit: Number.NaN,
+      userLimit: 15,
+      expected: 15,
+    },
+    {
+      title: "Key 为 Infinity 时应回退到 User",
+      keyLimit: Number.POSITIVE_INFINITY,
+      userLimit: 15,
+      expected: 15,
+    },
+    { title: "Key < 0 时应回退到 User", keyLimit: -1, userLimit: 15, expected: 15 },
+    { title: "Key 为小数时应向下取整", keyLimit: 5.9, userLimit: 15, expected: 5 },
+    { title: "Key 小数 < 1 时应回退到 User", keyLimit: 0.9, userLimit: 15, expected: 15 },
+    { title: "User 为小数时应向下取整", keyLimit: 0, userLimit: 7.8, expected: 7 },
+    {
+      title: "Key 与 User 均未设置/无效时应返回 0（无限制）",
+      keyLimit: undefined,
+      userLimit: null,
+      expected: 0,
+    },
+    {
+      title: "Key 为 0 且 User 为 Infinity 时应返回 0（无限制）",
+      keyLimit: 0,
+      userLimit: Number.POSITIVE_INFINITY,
+      expected: 0,
+    },
+  ];
+
+  for (const testCase of cases) {
+    it(testCase.title, () => {
+      expect(resolveKeyConcurrentSessionLimit(testCase.keyLimit, testCase.userLimit)).toBe(
+        testCase.expected
+      );
+    });
+  }
+});

--- a/tests/unit/proxy/rate-limit-guard.test.ts
+++ b/tests/unit/proxy/rate-limit-guard.test.ts
@@ -284,6 +284,20 @@ describe("ProxyRateLimitGuard - key daily limit enforcement", () => {
     });
   });
 
+  it("当 Key 并发未设置（0）且 User 并发已设置时，Key 并发检查应继承 User 并发上限", async () => {
+    const { ProxyRateLimitGuard } = await import("@/app/v1/_lib/proxy/rate-limit-guard");
+
+    const session = createSession({
+      user: { limitConcurrentSessions: 15 },
+      key: { limitConcurrentSessions: 0 },
+    });
+
+    await expect(ProxyRateLimitGuard.ensure(session)).resolves.toBeUndefined();
+
+    expect(rateLimitServiceMock.checkSessionLimit).toHaveBeenNthCalledWith(1, 2, "key", 15);
+    expect(rateLimitServiceMock.checkSessionLimit).toHaveBeenNthCalledWith(2, 1, "user", 15);
+  });
+
   it("User RPM 超限应拦截（rpm）", async () => {
     const { ProxyRateLimitGuard } = await import("@/app/v1/_lib/proxy/rate-limit-guard");
 

--- a/tests/unit/vacuum-filter/vacuum-filter-has.bench.test.ts
+++ b/tests/unit/vacuum-filter/vacuum-filter-has.bench.test.ts
@@ -31,7 +31,7 @@ function makeAsciiKey(rng: () => number, len: number): string {
 
 function freshSameContent(s: string): string {
   // 让 V8 很难复用同一个 string 实例（模拟“请求头解析后每次都是新字符串对象”）
-  return (" " + s).slice(1);
+  return ` ${s}`.slice(1);
 }
 
 function median(values: number[]): number {


### PR DESCRIPTION
﻿## 结论

修复 #769：当 Key 的 `limitConcurrentSessions` 未设置/为 0（默认值）时，Key 将**默认继承**所属 User 的并发上限（若 User 配置了 >0）。避免“User 已设置并发，但 Key 仍显示/按无限制处理”的不一致。

## 根因

- `keys.limitConcurrentSessions` 默认值为 `0`（语义：无限制）。
- 原逻辑在 Key 层并发检查与多处配额展示中只读取 Key 自身值；当 Key 为 `0` 时不会回退到 User 的并发上限。

## 方案

- 新增 `resolveKeyConcurrentSessionLimit(keyLimit, userLimit)`：
  - Key > 0 优先生效
  - Key <= 0 时回退 User > 0
  - 都无效时返回 0（无限制）
  - 对 NaN/Infinity/负数/小数做归一化（<=0 视为无限制，>0 向下取整）
- Proxy guard：Key 并发检查使用“有效并发上限”。
- Dashboard：Key 配额/Key limit usage/my-usage 返回与展示均使用“有效并发上限”。
- 性能：`key-quota` 与 `getKeyLimitUsage` 通过 `LEFT JOIN` 一次取回 User 并发上限，减少 DB 往返。

## 语义说明

- User 级并发检查仍保留，用于跨 Key 的总并发保护。
- 本 PR 的“继承”含义为：Key 未设置时，Key 的默认并发上限取 User 值，从而保证 UI 与 Key 层检查一致；并不改变 User 级检查的语义。

## RPM 复核

- RPM 限制逻辑未改动：仍由 `ProxyRateLimitGuard` 的 `user.rpm > 0` 分支触发 `RateLimitService.checkUserRPM`（滑动窗口）。

## 测试

- 本地：`bun run lint` / `bun run typecheck` / `bun run build` / `bun run test` 均通过
- 单测覆盖：resolver 分支覆盖 + key-quota / my-usage / guard 继承场景

