### PR TITLE
修复多 Key 并发下 User 并发 Session 上限可能被击穿

### DIFF
--- a/scripts/clear-session-bindings.ts
+++ b/scripts/clear-session-bindings.ts
@@ -33,6 +33,7 @@ import Redis, { type RedisOptions } from "ioredis";
 import postgres from "postgres";
 
 import * as schema from "../src/drizzle/schema";
+import { getGlobalActiveSessionsKey, getKeyActiveSessionsKey } from "../src/lib/redis/active-session-keys";
 
 // ============================================================================
 // 常量配置
@@ -585,14 +586,14 @@ async function clearSessionBindings(
       pipeline.del(...keysToDelete);
       commandTypes.push("del");
 
-      pipeline.zrem("global:active_sessions", sessionId);
+      pipeline.zrem(getGlobalActiveSessionsKey(), sessionId);
       commandTypes.push("zrem");
 
       pipeline.zrem(`provider:${binding.providerId}:active_sessions`, sessionId);
       commandTypes.push("zrem");
 
       if (binding.keyId != null) {
-        pipeline.zrem(`key:${binding.keyId}:active_sessions`, sessionId);
+        pipeline.zrem(getKeyActiveSessionsKey(binding.keyId), sessionId);
         commandTypes.push("zrem");
       } else {
         missingKeyRefs += 1;

--- a/scripts/clear-session-bindings.ts
+++ b/scripts/clear-session-bindings.ts
@@ -32,8 +32,8 @@ import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import Redis, { type RedisOptions } from "ioredis";
 import postgres from "postgres";
 
-import * as schema from "../src/drizzle/schema";
-import { getGlobalActiveSessionsKey, getKeyActiveSessionsKey } from "../src/lib/redis/active-session-keys";
+import * as schema from "@/drizzle/schema";
+import { getGlobalActiveSessionsKey, getKeyActiveSessionsKey } from "@/lib/redis/active-session-keys";
 
 // ============================================================================
 // 常量配置

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -83,6 +83,9 @@ export interface BatchUpdateUsersParams {
   };
 }
 
+/**
+ * 批量更新用户时的结构化错误（携带 errorCode 便于前端区分提示）。
+ */
 class BatchUpdateError extends Error {
   readonly errorCode: string;
 

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -1560,7 +1560,9 @@ export async function resetUserAllStatistics(userId: number): Promise<ActionResu
     // 2. Clear Redis cache
     const { getRedisClient } = await import("@/lib/redis");
     const { scanPattern } = await import("@/lib/redis/scan-helper");
-    const { getKeyActiveSessionsKey } = await import("@/lib/redis/active-session-keys");
+    const { getKeyActiveSessionsKey, getUserActiveSessionsKey } = await import(
+      "@/lib/redis/active-session-keys"
+    );
     const redis = getRedisClient();
 
     if (redis && redis.status === "ready") {
@@ -1590,6 +1592,7 @@ export async function resetUserAllStatistics(userId: number): Promise<ActionResu
         for (const keyId of keyIds) {
           pipeline.del(getKeyActiveSessionsKey(keyId));
         }
+        pipeline.del(getUserActiveSessionsKey(userId));
 
         // Cost keys
         for (const key of allCostKeys) {
@@ -1612,7 +1615,7 @@ export async function resetUserAllStatistics(userId: number): Promise<ActionResu
           userId,
           keyCount: keyIds.length,
           costKeysDeleted: allCostKeys.length,
-          activeSessionsDeleted: keyIds.length,
+          activeSessionsDeleted: keyIds.length + 1,
           durationMs: duration,
         });
       } catch (error) {

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -1560,6 +1560,7 @@ export async function resetUserAllStatistics(userId: number): Promise<ActionResu
     // 2. Clear Redis cache
     const { getRedisClient } = await import("@/lib/redis");
     const { scanPattern } = await import("@/lib/redis/scan-helper");
+    const { getKeyActiveSessionsKey } = await import("@/lib/redis/active-session-keys");
     const redis = getRedisClient();
 
     if (redis && redis.status === "ready") {
@@ -1587,7 +1588,7 @@ export async function resetUserAllStatistics(userId: number): Promise<ActionResu
 
         // Active sessions
         for (const keyId of keyIds) {
-          pipeline.del(`key:${keyId}:active_sessions`);
+          pipeline.del(getKeyActiveSessionsKey(keyId));
         }
 
         // Cost keys

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -38,6 +38,9 @@ import {
 import type { User, UserDisplay } from "@/types/user";
 import type { ActionResult } from "./types";
 
+/**
+ * 批量获取用户列表的查询参数（用于用户管理列表页）。
+ */
 export interface GetUsersBatchParams {
   cursor?: number;
   limit?: number;
@@ -58,18 +61,27 @@ export interface GetUsersBatchParams {
   sortOrder?: "asc" | "desc";
 }
 
+/**
+ * 批量获取用户列表的返回结果。
+ */
 export interface GetUsersBatchResult {
   users: UserDisplay[];
   nextCursor: number | null;
   hasMore: boolean;
 }
 
+/**
+ * 批量更新的结果统计（便于前端展示成功/失败数量）。
+ */
 export interface BatchUpdateResult {
   requestedCount: number;
   updatedCount: number;
   updatedIds: number[];
 }
 
+/**
+ * 批量更新用户的请求参数。
+ */
 export interface BatchUpdateUsersParams {
   userIds: number[];
   updates: {

--- a/src/app/v1/_lib/proxy/rate-limit-guard.ts
+++ b/src/app/v1/_lib/proxy/rate-limit-guard.ts
@@ -136,6 +136,9 @@ export class ProxyRateLimitGuard {
     // 理论上 session guard 一定会分配 sessionId；这里兜底生成，避免降级回非原子路径
     const ensuredSessionId = session.sessionId ?? SessionManager.generateSessionId();
     if (!session.sessionId) {
+      logger.warn(
+        `[RateLimit] SessionId missing in rate-limit-guard, using fallback: key=${key.id}, user=${user.id} (potential atomicity gap)`
+      );
       session.setSessionId(ensuredSessionId);
     }
 

--- a/src/app/v1/_lib/proxy/rate-limit-guard.ts
+++ b/src/app/v1/_lib/proxy/rate-limit-guard.ts
@@ -134,7 +134,7 @@ export class ProxyRateLimitGuard {
 
     // 注意：并发 Session 限制必须“原子性检查 + 追踪”，否则会被并发击穿（尤其是多 Key 同时使用时）
     // 理论上 session guard 一定会分配 sessionId；这里兜底生成，避免降级回非原子路径
-    const ensuredSessionId = session.sessionId ?? SessionManager.generateSessionId();
+    const ensuredSessionId = session.sessionId || SessionManager.generateSessionId();
     if (!session.sessionId) {
       logger.warn(
         `[RateLimit] SessionId missing in rate-limit-guard, using fallback: key=${key.id}, user=${user.id} (potential atomicity gap)`
@@ -182,7 +182,7 @@ export class ProxyRateLimitGuard {
       );
     }
 
-    // 5. User RPM（频率闸门，挡住高频噪声）- null/0 表示无限制
+    // 4. User RPM（频率闸门，挡住高频噪声）- null/0 表示无限制
     if (user.rpm != null && user.rpm > 0) {
       const rpmCheck = await RateLimitService.checkRpmLimit(user.id, "user", user.rpm);
       if (!rpmCheck.allowed) {

--- a/src/app/v1/_lib/proxy/rate-limit-guard.ts
+++ b/src/app/v1/_lib/proxy/rate-limit-guard.ts
@@ -36,9 +36,9 @@ export class ProxyRateLimitGuard {
    *
    * 检查顺序（基于 Codex 专业分析）：
    * 1-2. 永久硬限制：Key 总限额 → User 总限额
-   * 3-5. 资源/频率保护：Key 并发 → User 并发 → User RPM
-   * 6-9. 短期周期限额：Key 5h → User 5h → Key 每日 → User 每日
-   * 10-13. 中长期周期限额：Key 周 → User 周 → Key 月 → User 月
+   * 3-4. 资源/频率保护：Key/User 并发 → User RPM
+   * 5-8. 短期周期限额：Key 5h → User 5h → Key 每日 → User 每日
+   * 9-12. 中长期周期限额：Key 周 → User 周 → Key 月 → User 月
    *
    * 设计原则：
    * - 硬上限优先于周期上限
@@ -152,11 +152,20 @@ export class ProxyRateLimitGuard {
 
     if (!concurrentCheck.allowed) {
       const rejectedBy = concurrentCheck.rejectedBy ?? "key";
-      logger.warn(
-        `[RateLimit] ${rejectedBy === "user" ? "User" : "Key"} session limit exceeded: key=${key.id}, user=${user.id}, ${concurrentCheck.reason}`
-      );
+      const fallbackCurrentUsage =
+        rejectedBy === "user" ? concurrentCheck.userCount : concurrentCheck.keyCount;
+      const fallbackLimitValue =
+        rejectedBy === "user" ? normalizedUserConcurrentLimit : effectiveKeyConcurrentLimit;
+      const currentUsage = Number(concurrentCheck.reasonParams?.current);
+      const limitValue = Number(concurrentCheck.reasonParams?.limit);
+      const resolvedCurrentUsage = Number.isFinite(currentUsage)
+        ? currentUsage
+        : fallbackCurrentUsage;
+      const resolvedLimitValue = Number.isFinite(limitValue) ? limitValue : fallbackLimitValue;
 
-      const { currentUsage, limitValue } = parseLimitInfo(concurrentCheck.reason!);
+      logger.warn(
+        `[RateLimit] ${rejectedBy === "user" ? "User" : "Key"} session limit exceeded: key=${key.id}, user=${user.id}, current=${resolvedCurrentUsage}, limit=${resolvedLimitValue}`
+      );
 
       const resetTime = new Date().toISOString();
 
@@ -164,10 +173,10 @@ export class ProxyRateLimitGuard {
       const locale = await getLocale();
       const message = await getErrorMessageServer(
         locale,
-        ERROR_CODES.RATE_LIMIT_CONCURRENT_SESSIONS_EXCEEDED,
+        concurrentCheck.reasonCode ?? ERROR_CODES.RATE_LIMIT_CONCURRENT_SESSIONS_EXCEEDED,
         {
-          current: String(currentUsage),
-          limit: String(limitValue),
+          current: String(resolvedCurrentUsage),
+          limit: String(resolvedLimitValue),
         }
       );
 
@@ -175,8 +184,8 @@ export class ProxyRateLimitGuard {
         "rate_limit_error",
         message,
         "concurrent_sessions",
-        currentUsage,
-        limitValue,
+        resolvedCurrentUsage,
+        resolvedLimitValue,
         resetTime,
         null
       );

--- a/src/app/v1/_lib/proxy/rate-limit-guard.ts
+++ b/src/app/v1/_lib/proxy/rate-limit-guard.ts
@@ -30,6 +30,11 @@ function parseLimitInfo(reason: string): { currentUsage: number; limitValue: num
   return { currentUsage: 0, limitValue: 0 };
 }
 
+/**
+ * 限流守卫：集中执行 Key/User 各维度限额校验（含并发 Session / RPM 等资源保护）。
+ *
+ * 调用时机：`ProxySessionGuard` 分配 sessionId 之后、转发到上游之前。
+ */
 export class ProxyRateLimitGuard {
   /**
    * 检查限流（Key 层 + User 层）

--- a/src/lib/rate-limit/concurrent-session-limit.ts
+++ b/src/lib/rate-limit/concurrent-session-limit.ts
@@ -12,6 +12,13 @@ export function normalizeConcurrentSessionLimit(value: number | null | undefined
   return Math.floor(value);
 }
 
+/**
+ * 同时解析 Key/User 的并发 Session 上限（供 proxy guards 统一复用）。
+ *
+ * - `effectiveKeyLimit`：Key 的有效上限（Key>0 优先，否则回退到 User>0；都未设置则为 0）
+ * - `normalizedUserLimit`：User 上限的归一化结果（<=0 视为 0）
+ * - `enabled`：任一维度上限 >0 即为 true
+ */
 export function resolveKeyUserConcurrentSessionLimits(
   keyLimit: number | null | undefined,
   userLimit: number | null | undefined

--- a/src/lib/rate-limit/concurrent-session-limit.ts
+++ b/src/lib/rate-limit/concurrent-session-limit.ts
@@ -4,12 +4,23 @@
  * - 非数字 / 非有限值 / <= 0 视为 0（无限制）
  * - > 0 时向下取整
  */
-function normalizePositiveLimit(value: unknown): number {
+export function normalizeConcurrentSessionLimit(value: number | null | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return 0;
   }
 
   return Math.floor(value);
+}
+
+export function resolveKeyUserConcurrentSessionLimits(
+  keyLimit: number | null | undefined,
+  userLimit: number | null | undefined
+): { effectiveKeyLimit: number; normalizedUserLimit: number; enabled: boolean } {
+  const normalizedUserLimit = normalizeConcurrentSessionLimit(userLimit);
+  const effectiveKeyLimit = resolveKeyConcurrentSessionLimit(keyLimit, userLimit);
+  const enabled = effectiveKeyLimit > 0 || normalizedUserLimit > 0;
+
+  return { effectiveKeyLimit, normalizedUserLimit, enabled };
 }
 
 /**
@@ -24,10 +35,10 @@ export function resolveKeyConcurrentSessionLimit(
   keyLimit: number | null | undefined,
   userLimit: number | null | undefined
 ): number {
-  const normalizedKeyLimit = normalizePositiveLimit(keyLimit);
+  const normalizedKeyLimit = normalizeConcurrentSessionLimit(keyLimit);
   if (normalizedKeyLimit > 0) {
     return normalizedKeyLimit;
   }
 
-  return normalizePositiveLimit(userLimit);
+  return normalizeConcurrentSessionLimit(userLimit);
 }

--- a/src/lib/rate-limit/service.ts
+++ b/src/lib/rate-limit/service.ts
@@ -68,6 +68,7 @@
 import { logger } from "@/lib/logger";
 import { getRedisClient } from "@/lib/redis";
 import {
+  CHECK_AND_TRACK_KEY_USER_SESSION,
   CHECK_AND_TRACK_SESSION,
   GET_COST_5H_ROLLING_WINDOW,
   GET_COST_DAILY_ROLLING_WINDOW,
@@ -541,6 +542,92 @@ export class RateLimitService {
     } catch (error) {
       logger.error("[RateLimit] Session check failed:", error);
       return { allowed: true }; // Fail Open
+    }
+  }
+
+  /**
+   * 原子性检查并追踪 Key/User 并发 Session（解决竞态条件）
+   *
+   * 与 checkSessionLimit 的区别：
+   * - checkSessionLimit：只读检查（可能被并发击穿），且无法区分“新 session”与“已存在 session”
+   * - 本方法：使用 Lua 脚本原子性完成“检查 + 追踪”，并允许已存在的 session 在达到上限时继续请求
+   *
+   * 注意：
+   * - keyLimit/userLimit 均 <=0 时表示无限制，直接放行且不追踪（由 SessionTracker.refreshSession 等路径负责观测）
+   * - Redis 不可用时 Fail Open
+   */
+  static async checkAndTrackKeyUserSession(
+    keyId: number,
+    userId: number,
+    sessionId: string,
+    keyLimit: number,
+    userLimit: number
+  ): Promise<{
+    allowed: boolean;
+    keyCount: number;
+    userCount: number;
+    trackedKey: boolean;
+    trackedUser: boolean;
+    rejectedBy?: "key" | "user";
+    reason?: string;
+  }> {
+    if (keyLimit <= 0 && userLimit <= 0) {
+      return { allowed: true, keyCount: 0, userCount: 0, trackedKey: false, trackedUser: false };
+    }
+
+    if (!RateLimitService.redis || RateLimitService.redis.status !== "ready") {
+      logger.warn("[RateLimit] Redis not ready, Fail Open");
+      return { allowed: true, keyCount: 0, userCount: 0, trackedKey: false, trackedUser: false };
+    }
+
+    try {
+      const globalKey = "global:active_sessions";
+      const keyKey = `key:${keyId}:active_sessions`;
+      const userKey = `user:${userId}:active_sessions`;
+      const now = Date.now();
+
+      const result = (await RateLimitService.redis.eval(
+        CHECK_AND_TRACK_KEY_USER_SESSION,
+        3, // KEYS count
+        globalKey, // KEYS[1]
+        keyKey, // KEYS[2]
+        userKey, // KEYS[3]
+        sessionId, // ARGV[1]
+        keyLimit.toString(), // ARGV[2]
+        userLimit.toString(), // ARGV[3]
+        now.toString(), // ARGV[4]
+        SESSION_TTL_MS.toString() // ARGV[5]
+      )) as [number, number, number, number, number, number];
+
+      const [allowed, rejectedBy, keyCount, keyTracked, userCount, userTracked] = result;
+
+      if (allowed === 0) {
+        const rejectTarget: "key" | "user" = rejectedBy === 1 ? "key" : "user";
+        const limit = rejectTarget === "key" ? keyLimit : userLimit;
+        const count = rejectTarget === "key" ? keyCount : userCount;
+        const typeLabel = rejectTarget === "key" ? "Key" : "User";
+
+        return {
+          allowed: false,
+          keyCount,
+          userCount,
+          trackedKey: false,
+          trackedUser: false,
+          rejectedBy: rejectTarget,
+          reason: `${typeLabel}并发 Session 上限已达到（${count}/${limit}）`,
+        };
+      }
+
+      return {
+        allowed: true,
+        keyCount,
+        userCount,
+        trackedKey: keyTracked === 1,
+        trackedUser: userTracked === 1,
+      };
+    } catch (error) {
+      logger.error("[RateLimit] Key/User session check+track failed:", error);
+      return { allowed: true, keyCount: 0, userCount: 0, trackedKey: false, trackedUser: false };
     }
   }
 

--- a/src/lib/rate-limit/service.ts
+++ b/src/lib/rate-limit/service.ts
@@ -68,6 +68,11 @@
 import { logger } from "@/lib/logger";
 import { getRedisClient } from "@/lib/redis";
 import {
+  getGlobalActiveSessionsKey,
+  getKeyActiveSessionsKey,
+  getUserActiveSessionsKey,
+} from "@/lib/redis/active-session-keys";
+import {
   CHECK_AND_TRACK_KEY_USER_SESSION,
   CHECK_AND_TRACK_SESSION,
   GET_COST_5H_ROLLING_WINDOW,
@@ -581,9 +586,9 @@ export class RateLimitService {
     }
 
     try {
-      const globalKey = "global:active_sessions";
-      const keyKey = `key:${keyId}:active_sessions`;
-      const userKey = `user:${userId}:active_sessions`;
+      const globalKey = getGlobalActiveSessionsKey();
+      const keyKey = getKeyActiveSessionsKey(keyId);
+      const userKey = getUserActiveSessionsKey(userId);
       const now = Date.now();
 
       const result = (await RateLimitService.redis.eval(

--- a/src/lib/rate-limit/service.ts
+++ b/src/lib/rate-limit/service.ts
@@ -112,6 +112,12 @@ interface CostLimit {
   resetMode?: DailyResetMode; // 日限额重置模式（仅 daily 使用）
 }
 
+/**
+ * 限流/配额服务：统一封装 Redis + DB 的限额检查与消费追踪。
+ *
+ * 设计约束：
+ * - Redis 不可用时默认 Fail Open，避免误伤正常请求（仍会在日志中记录）。
+ */
 export class RateLimitService {
   // 使用 getter 实现懒加载，避免模块加载时立即连接 Redis（构建阶段触发）
   private static get redis() {

--- a/src/lib/redis/active-session-keys.ts
+++ b/src/lib/redis/active-session-keys.ts
@@ -7,14 +7,23 @@
  */
 const ACTIVE_SESSIONS_HASH_TAG = "{active_sessions}";
 
+/**
+ * 全局活跃 Session ZSET（仅用于观测 / Sessions 页面）。
+ */
 export function getGlobalActiveSessionsKey(): string {
   return `${ACTIVE_SESSIONS_HASH_TAG}:global:active_sessions`;
 }
 
+/**
+ * Key 维度活跃 Session ZSET（用于 Key 并发上限判断）。
+ */
 export function getKeyActiveSessionsKey(keyId: number): string {
   return `${ACTIVE_SESSIONS_HASH_TAG}:key:${keyId}:active_sessions`;
 }
 
+/**
+ * User 维度活跃 Session ZSET（用于跨多 Key 的 User 并发上限判断）。
+ */
 export function getUserActiveSessionsKey(userId: number): string {
   return `${ACTIVE_SESSIONS_HASH_TAG}:user:${userId}:active_sessions`;
 }

--- a/src/lib/redis/active-session-keys.ts
+++ b/src/lib/redis/active-session-keys.ts
@@ -1,0 +1,20 @@
+/**
+ * Active sessions 相关 Redis key 生成器。
+ *
+ * 说明：
+ * - 为兼容 Redis Cluster 下的 Lua 脚本多 key 操作，需要相关 key 共享相同 hash tag，避免 CROSSSLOT。
+ * - 目前仅对 global/key/user 三类 active_sessions key 统一加 hash tag；provider 维度不需要。
+ */
+const ACTIVE_SESSIONS_HASH_TAG = "{active_sessions}";
+
+export function getGlobalActiveSessionsKey(): string {
+  return `${ACTIVE_SESSIONS_HASH_TAG}:global:active_sessions`;
+}
+
+export function getKeyActiveSessionsKey(keyId: number): string {
+  return `${ACTIVE_SESSIONS_HASH_TAG}:key:${keyId}:active_sessions`;
+}
+
+export function getUserActiveSessionsKey(userId: number): string {
+  return `${ACTIVE_SESSIONS_HASH_TAG}:user:${userId}:active_sessions`;
+}

--- a/src/lib/redis/lua-scripts.ts
+++ b/src/lib/redis/lua-scripts.ts
@@ -135,10 +135,8 @@ if key_limit > 0 and not is_tracked_key and current_key_count >= key_limit then
 end
 
 -- 5. Check User limit (exclude already tracked session)
--- Self-heal: 如果 session 已在同一个 key 的集合中，则可视为该 user 的“已存在会话”，避免因为 user 集合缺失
--- 单条 member 而误拦截（该脚本后续会通过 ZADD 补齐 user 集合）。
--- 说明：跨 key 复用同一 sessionId 的场景依赖 is_tracked_user；is_tracked_key 仅覆盖“同一个 key”的自愈。
-if user_limit > 0 and not (is_tracked_user or is_tracked_key) and current_user_count >= user_limit then
+-- 说明：User 上限以 user ZSET 为准；key ZSET 不参与 user 维度的“已追踪”判定，避免绕过 user 并发限制。
+if user_limit > 0 and not is_tracked_user and current_user_count >= user_limit then
   return {0, 2, current_key_count, 0, current_user_count, 0}
 end
 

--- a/src/lib/redis/lua-scripts.ts
+++ b/src/lib/redis/lua-scripts.ts
@@ -81,9 +81,12 @@ end
  *   SessionTracker.trackSession，因此此脚本也负责更新 global，保证 Sessions 页面可见性。
  * - key/user 使用 ZSET 分别追踪活跃 sessionId（score=timestamp）
  *
- * KEYS[1]: global:active_sessions
- * KEYS[2]: key:${keyId}:active_sessions
- * KEYS[3]: user:${userId}:active_sessions
+ * Redis Cluster 注意：
+ * - 该脚本同时操作多个 key，因此 KEYS[1..3] 必须共享相同 hash tag（例如 {active_sessions}），否则会触发 CROSSSLOT。
+ *
+ * KEYS[1]: {active_sessions}:global:active_sessions
+ * KEYS[2]: {active_sessions}:key:${keyId}:active_sessions
+ * KEYS[3]: {active_sessions}:user:${userId}:active_sessions
  * ARGV[1]: sessionId
  * ARGV[2]: keyLimit
  * ARGV[3]: userLimit
@@ -112,11 +115,11 @@ if ttl <= 0 then
   ttl = 300000
 end
 
- -- 1. Cleanup expired sessions (TTL window ago)
- local cutoff = now - ttl
- redis.call('ZREMRANGEBYSCORE', global_key, '-inf', cutoff)
- redis.call('ZREMRANGEBYSCORE', key_key, '-inf', cutoff)
- redis.call('ZREMRANGEBYSCORE', user_key, '-inf', cutoff)
+-- 1. Cleanup expired sessions (TTL window ago)
+local cutoff = now - ttl
+redis.call('ZREMRANGEBYSCORE', global_key, '-inf', cutoff)
+redis.call('ZREMRANGEBYSCORE', key_key, '-inf', cutoff)
+redis.call('ZREMRANGEBYSCORE', user_key, '-inf', cutoff)
 
 -- 2. Check if session is already tracked
 local is_tracked_key = redis.call('ZSCORE', key_key, session_id)
@@ -131,9 +134,10 @@ if key_limit > 0 and not is_tracked_key and current_key_count >= key_limit then
   return {0, 1, current_key_count, 0, current_user_count, 0}
 end
 
- -- 5. Check User limit (exclude already tracked session)
- -- Self-heal: 如果 session 已在同一个 key 的集合中，则可视为该 user 的“已存在会话”，避免因为 user 集合缺失
- -- 单条 member 而误拦截（该脚本后续会通过 ZADD 补齐 user 集合）。
+-- 5. Check User limit (exclude already tracked session)
+-- Self-heal: 如果 session 已在同一个 key 的集合中，则可视为该 user 的“已存在会话”，避免因为 user 集合缺失
+-- 单条 member 而误拦截（该脚本后续会通过 ZADD 补齐 user 集合）。
+-- 说明：跨 key 复用同一 sessionId 的场景依赖 is_tracked_user；is_tracked_key 仅覆盖“同一个 key”的自愈。
 if user_limit > 0 and not (is_tracked_user or is_tracked_key) and current_user_count >= user_limit then
   return {0, 2, current_key_count, 0, current_user_count, 0}
 end

--- a/src/lib/session-manager.ts
+++ b/src/lib/session-manager.ts
@@ -26,6 +26,9 @@ import {
 } from "./redis/active-session-keys";
 import { SessionTracker } from "./session-tracker";
 
+/**
+ * 将已脱敏的 header 文本解析为可序列化对象（用于写入 Session 元信息）。
+ */
 function headersToSanitizedObject(headers: Headers): Record<string, string> {
   const sanitizedText = sanitizeHeaders(headers);
   if (!sanitizedText || sanitizedText === "(empty)") {
@@ -51,6 +54,12 @@ function headersToSanitizedObject(headers: Headers): Record<string, string> {
   return obj;
 }
 
+/**
+ * 解析存储在 Redis 中的 header JSON 字符串。
+ *
+ * - 成功返回 `{ [name]: value }`
+ * - 解析失败/结构不合法则返回 null
+ */
 function parseHeaderRecord(value: string): Record<string, string> | null {
   try {
     const parsed: unknown = JSON.parse(value);

--- a/tests/unit/lib/endpoint-circuit-breaker.test.ts
+++ b/tests/unit/lib/endpoint-circuit-breaker.test.ts
@@ -170,6 +170,10 @@ describe("endpoint-circuit-breaker", () => {
     await flushPromises();
     sendAlertMock.mockClear();
 
+    // Prime module cache for dynamic import() consumers
+    await import("@/lib/config/env.schema");
+    await import("@/lib/notification/notifier");
+
     const { triggerEndpointCircuitBreakerAlert } = await import("@/lib/endpoint-circuit-breaker");
 
     await triggerEndpointCircuitBreakerAlert(
@@ -226,6 +230,10 @@ describe("endpoint-circuit-breaker", () => {
     // recordEndpointFailure 会 non-blocking 触发告警；先让 event-loop 跑完再清空计数，避免串台导致误判
     await flushPromises();
     sendAlertMock.mockClear();
+
+    // Prime module cache for dynamic import() consumers
+    await import("@/lib/config/env.schema");
+    await import("@/lib/notification/notifier");
 
     const { triggerEndpointCircuitBreakerAlert } = await import("@/lib/endpoint-circuit-breaker");
 

--- a/tests/unit/lib/rate-limit/service-extra.test.ts
+++ b/tests/unit/lib/rate-limit/service-extra.test.ts
@@ -190,6 +190,85 @@ describe("RateLimitService - other quota paths", () => {
     expect(ttlMsArg).toBe("300000");
   });
 
+  it("checkAndTrackKeyUserSession：keyLimit/userLimit 均 <=0 时应放行且不追踪", async () => {
+    const { RateLimitService } = await import("@/lib/rate-limit");
+
+    const result = await RateLimitService.checkAndTrackKeyUserSession(2, 1, "sess", 0, 0);
+    expect(result).toEqual({
+      allowed: true,
+      keyCount: 0,
+      userCount: 0,
+      trackedKey: false,
+      trackedUser: false,
+    });
+    expect(redisClientRef.eval).not.toHaveBeenCalled();
+  });
+
+  it("checkAndTrackKeyUserSession：Redis 非 ready 时应 Fail Open", async () => {
+    const { RateLimitService } = await import("@/lib/rate-limit");
+
+    redisClientRef.status = "end";
+    const result = await RateLimitService.checkAndTrackKeyUserSession(2, 1, "sess", 2, 2);
+    expect(result).toEqual({
+      allowed: true,
+      keyCount: 0,
+      userCount: 0,
+      trackedKey: false,
+      trackedUser: false,
+    });
+  });
+
+  it("checkAndTrackKeyUserSession：Key 超限时应返回 not allowed", async () => {
+    const { RateLimitService } = await import("@/lib/rate-limit");
+
+    redisClientRef.eval.mockResolvedValueOnce([0, 1, 2, 0, 1, 0]);
+    const result = await RateLimitService.checkAndTrackKeyUserSession(2, 1, "sess", 2, 10);
+    expect(result.allowed).toBe(false);
+    expect(result.rejectedBy).toBe("key");
+    expect(result.reason).toContain("Key并发 Session 上限已达到（2/2）");
+  });
+
+  it("checkAndTrackKeyUserSession：User 超限时应返回 not allowed", async () => {
+    const { RateLimitService } = await import("@/lib/rate-limit");
+
+    redisClientRef.eval.mockResolvedValueOnce([0, 2, 1, 0, 2, 0]);
+    const result = await RateLimitService.checkAndTrackKeyUserSession(2, 1, "sess", 10, 2);
+    expect(result.allowed).toBe(false);
+    expect(result.rejectedBy).toBe("user");
+    expect(result.reason).toContain("User并发 Session 上限已达到（2/2）");
+  });
+
+  it("checkAndTrackKeyUserSession：未超限时应返回 allowed 且可标记 tracked", async () => {
+    const { RateLimitService } = await import("@/lib/rate-limit");
+
+    redisClientRef.eval.mockResolvedValueOnce([1, 0, 2, 1, 2, 1]);
+    const result = await RateLimitService.checkAndTrackKeyUserSession(2, 1, "sess", 2, 2);
+    expect(result).toEqual({
+      allowed: true,
+      keyCount: 2,
+      userCount: 2,
+      trackedKey: true,
+      trackedUser: true,
+    });
+  });
+
+  it("checkAndTrackKeyUserSession: should pass SESSION_TTL_MS as ARGV[5] to Lua script", async () => {
+    const { RateLimitService } = await import("@/lib/rate-limit");
+
+    redisClientRef.eval.mockResolvedValueOnce([1, 0, 1, 1, 1, 1]);
+    await RateLimitService.checkAndTrackKeyUserSession(2, 1, "sess", 2, 2);
+
+    expect(redisClientRef.eval).toHaveBeenCalledTimes(1);
+
+    const evalCall = redisClientRef.eval.mock.calls[0];
+    // evalCall: [script, numkeys, globalKey, keyKey, userKey, sessionId, keyLimit, userLimit, now, ttlMs]
+    // Indices:   0        1        2          3      4       5         6        7         8    9
+    expect(evalCall.length).toBe(10);
+
+    const ttlMsArg = evalCall[9];
+    expect(ttlMsArg).toBe("300000");
+  });
+
   it("trackUserDailyCost：fixed 模式应使用 STRING + TTL", async () => {
     const { RateLimitService } = await import("@/lib/rate-limit");
 

--- a/tests/unit/lib/rate-limit/service-extra.test.ts
+++ b/tests/unit/lib/rate-limit/service-extra.test.ts
@@ -225,7 +225,8 @@ describe("RateLimitService - other quota paths", () => {
     const result = await RateLimitService.checkAndTrackKeyUserSession(2, 1, "sess", 2, 10);
     expect(result.allowed).toBe(false);
     expect(result.rejectedBy).toBe("key");
-    expect(result.reason).toContain("Key并发 Session 上限已达到（2/2）");
+    expect(result.reasonCode).toBe("RATE_LIMIT_CONCURRENT_SESSIONS_EXCEEDED");
+    expect(result.reasonParams).toEqual({ current: 2, limit: 2, target: "key" });
   });
 
   it("checkAndTrackKeyUserSession：User 超限时应返回 not allowed", async () => {
@@ -235,7 +236,8 @@ describe("RateLimitService - other quota paths", () => {
     const result = await RateLimitService.checkAndTrackKeyUserSession(2, 1, "sess", 10, 2);
     expect(result.allowed).toBe(false);
     expect(result.rejectedBy).toBe("user");
-    expect(result.reason).toContain("User并发 Session 上限已达到（2/2）");
+    expect(result.reasonCode).toBe("RATE_LIMIT_CONCURRENT_SESSIONS_EXCEEDED");
+    expect(result.reasonParams).toEqual({ current: 2, limit: 2, target: "user" });
   });
 
   it("checkAndTrackKeyUserSession：未超限时应返回 allowed 且可标记 tracked", async () => {

--- a/tests/unit/lib/session-manager-terminate-session.test.ts
+++ b/tests/unit/lib/session-manager-terminate-session.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let redisClientRef: any;
+let pipelineRef: any;
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/redis", () => ({
+  getRedisClient: () => redisClientRef,
+}));
+
+describe("SessionManager.terminateSession", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+
+    pipelineRef = {
+      del: vi.fn(() => pipelineRef),
+      zrem: vi.fn(() => pipelineRef),
+      exec: vi.fn(async () => [[null, 1]]),
+    };
+
+    redisClientRef = {
+      status: "ready",
+      get: vi.fn(async () => null),
+      hget: vi.fn(async () => null),
+      pipeline: vi.fn(() => pipelineRef),
+    };
+  });
+
+  it("应同时从 global/key/user 的 active_sessions ZSET 中移除 sessionId（若可解析到 userId）", async () => {
+    const sessionId = "sess_test";
+    redisClientRef.get.mockImplementation(async (key: string) => {
+      if (key === `session:${sessionId}:provider`) return "42";
+      if (key === `session:${sessionId}:key`) return "7";
+      return null;
+    });
+    redisClientRef.hget.mockImplementation(async (key: string, field: string) => {
+      if (key === `session:${sessionId}:info` && field === "userId") return "123";
+      return null;
+    });
+
+    const { getGlobalActiveSessionsKey, getKeyActiveSessionsKey, getUserActiveSessionsKey } =
+      await import("@/lib/redis/active-session-keys");
+    const { SessionManager } = await import("@/lib/session-manager");
+
+    const ok = await SessionManager.terminateSession(sessionId);
+    expect(ok).toBe(true);
+
+    expect(redisClientRef.hget).toHaveBeenCalledWith(`session:${sessionId}:info`, "userId");
+
+    expect(pipelineRef.zrem).toHaveBeenCalledWith(getGlobalActiveSessionsKey(), sessionId);
+    expect(pipelineRef.zrem).toHaveBeenCalledWith("provider:42:active_sessions", sessionId);
+    expect(pipelineRef.zrem).toHaveBeenCalledWith(getKeyActiveSessionsKey(7), sessionId);
+    expect(pipelineRef.zrem).toHaveBeenCalledWith(getUserActiveSessionsKey(123), sessionId);
+  });
+
+  it("当 userId 不可用时，不应尝试 zrem user active_sessions key", async () => {
+    const sessionId = "sess_test";
+    redisClientRef.get.mockImplementation(async (key: string) => {
+      if (key === `session:${sessionId}:provider`) return "42";
+      if (key === `session:${sessionId}:key`) return "7";
+      return null;
+    });
+    redisClientRef.hget.mockResolvedValue(null);
+
+    const { getUserActiveSessionsKey } = await import("@/lib/redis/active-session-keys");
+    const { SessionManager } = await import("@/lib/session-manager");
+
+    const ok = await SessionManager.terminateSession(sessionId);
+    expect(ok).toBe(true);
+
+    expect(pipelineRef.zrem).not.toHaveBeenCalledWith(getUserActiveSessionsKey(123), sessionId);
+  });
+});

--- a/tests/unit/lib/session-tracker-cleanup.test.ts
+++ b/tests/unit/lib/session-tracker-cleanup.test.ts
@@ -4,6 +4,9 @@ import { getGlobalActiveSessionsKey } from "@/lib/redis/active-session-keys";
 let redisClientRef: any;
 const pipelineCalls: Array<unknown[]> = [];
 
+/**
+ * 构造一个可记录调用的 Redis pipeline mock（用于断言 cleanup/expire 等行为）。
+ */
 const makePipeline = () => {
   const pipeline = {
     zadd: vi.fn((...args: unknown[]) => {

--- a/tests/unit/lib/session-tracker-cleanup.test.ts
+++ b/tests/unit/lib/session-tracker-cleanup.test.ts
@@ -94,7 +94,7 @@ describe("SessionTracker - TTL and cleanup", () => {
       // Should call zremrangebyscore with cutoff = now - 600*1000 = now - 600000
       const expectedCutoff = nowMs - 600 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "global:active_sessions",
+        "{active_sessions}:global:active_sessions",
         "-inf",
         expectedCutoff
       );
@@ -110,7 +110,7 @@ describe("SessionTracker - TTL and cleanup", () => {
       // Default: 300 seconds = 300000 ms
       const expectedCutoff = nowMs - 300 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "global:active_sessions",
+        "{active_sessions}:global:active_sessions",
         "-inf",
         expectedCutoff
       );
@@ -267,7 +267,7 @@ describe("SessionTracker - TTL and cleanup", () => {
 
       const expectedCutoff = nowMs - 600 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "global:active_sessions",
+        "{active_sessions}:global:active_sessions",
         "-inf",
         expectedCutoff
       );

--- a/tests/unit/lib/session-tracker-cleanup.test.ts
+++ b/tests/unit/lib/session-tracker-cleanup.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getGlobalActiveSessionsKey } from "@/lib/redis/active-session-keys";
 
 let redisClientRef: any;
 const pipelineCalls: Array<unknown[]> = [];
@@ -53,6 +54,7 @@ vi.mock("@/lib/redis", () => ({
 
 describe("SessionTracker - TTL and cleanup", () => {
   const nowMs = 1_700_000_000_000;
+  const globalKey = getGlobalActiveSessionsKey();
   const ORIGINAL_SESSION_TTL = process.env.SESSION_TTL;
 
   beforeEach(() => {
@@ -94,7 +96,7 @@ describe("SessionTracker - TTL and cleanup", () => {
       // Should call zremrangebyscore with cutoff = now - 600*1000 = now - 600000
       const expectedCutoff = nowMs - 600 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "{active_sessions}:global:active_sessions",
+        globalKey,
         "-inf",
         expectedCutoff
       );
@@ -110,7 +112,7 @@ describe("SessionTracker - TTL and cleanup", () => {
       // Default: 300 seconds = 300000 ms
       const expectedCutoff = nowMs - 300 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "{active_sessions}:global:active_sessions",
+        globalKey,
         "-inf",
         expectedCutoff
       );
@@ -267,7 +269,7 @@ describe("SessionTracker - TTL and cleanup", () => {
 
       const expectedCutoff = nowMs - 600 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "{active_sessions}:global:active_sessions",
+        globalKey,
         "-inf",
         expectedCutoff
       );

--- a/tests/unit/lib/session-ttl-validation.test.ts
+++ b/tests/unit/lib/session-ttl-validation.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getGlobalActiveSessionsKey } from "@/lib/redis/active-session-keys";
 
 /**
  * Tests for SESSION_TTL environment variable validation
@@ -99,7 +100,7 @@ describe("SESSION_TTL environment variable validation", () => {
       // Default: 300 seconds = 300000 ms
       const expectedCutoff = nowMs - 300 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "{active_sessions}:global:active_sessions",
+        getGlobalActiveSessionsKey(),
         "-inf",
         expectedCutoff
       );
@@ -113,7 +114,7 @@ describe("SESSION_TTL environment variable validation", () => {
 
       const expectedCutoff = nowMs - 300 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "{active_sessions}:global:active_sessions",
+        getGlobalActiveSessionsKey(),
         "-inf",
         expectedCutoff
       );
@@ -127,7 +128,7 @@ describe("SESSION_TTL environment variable validation", () => {
 
       const expectedCutoff = nowMs - 300 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "{active_sessions}:global:active_sessions",
+        getGlobalActiveSessionsKey(),
         "-inf",
         expectedCutoff
       );
@@ -141,7 +142,7 @@ describe("SESSION_TTL environment variable validation", () => {
 
       const expectedCutoff = nowMs - 300 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "{active_sessions}:global:active_sessions",
+        getGlobalActiveSessionsKey(),
         "-inf",
         expectedCutoff
       );
@@ -156,7 +157,7 @@ describe("SESSION_TTL environment variable validation", () => {
       // Custom: 600 seconds = 600000 ms
       const expectedCutoff = nowMs - 600 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "{active_sessions}:global:active_sessions",
+        getGlobalActiveSessionsKey(),
         "-inf",
         expectedCutoff
       );

--- a/tests/unit/lib/session-ttl-validation.test.ts
+++ b/tests/unit/lib/session-ttl-validation.test.ts
@@ -99,7 +99,7 @@ describe("SESSION_TTL environment variable validation", () => {
       // Default: 300 seconds = 300000 ms
       const expectedCutoff = nowMs - 300 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "global:active_sessions",
+        "{active_sessions}:global:active_sessions",
         "-inf",
         expectedCutoff
       );
@@ -113,7 +113,7 @@ describe("SESSION_TTL environment variable validation", () => {
 
       const expectedCutoff = nowMs - 300 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "global:active_sessions",
+        "{active_sessions}:global:active_sessions",
         "-inf",
         expectedCutoff
       );
@@ -127,7 +127,7 @@ describe("SESSION_TTL environment variable validation", () => {
 
       const expectedCutoff = nowMs - 300 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "global:active_sessions",
+        "{active_sessions}:global:active_sessions",
         "-inf",
         expectedCutoff
       );
@@ -141,7 +141,7 @@ describe("SESSION_TTL environment variable validation", () => {
 
       const expectedCutoff = nowMs - 300 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "global:active_sessions",
+        "{active_sessions}:global:active_sessions",
         "-inf",
         expectedCutoff
       );
@@ -156,7 +156,7 @@ describe("SESSION_TTL environment variable validation", () => {
       // Custom: 600 seconds = 600000 ms
       const expectedCutoff = nowMs - 600 * 1000;
       expect(redisClientRef.zremrangebyscore).toHaveBeenCalledWith(
-        "global:active_sessions",
+        "{active_sessions}:global:active_sessions",
         "-inf",
         expectedCutoff
       );

--- a/tests/unit/proxy/rate-limit-guard.test.ts
+++ b/tests/unit/proxy/rate-limit-guard.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const rateLimitServiceMock = {
   checkTotalCostLimit: vi.fn(),
   checkSessionLimit: vi.fn(),
+  checkAndTrackKeyUserSession: vi.fn(),
   checkRpmLimit: vi.fn(),
   checkCostLimitsWithLease: vi.fn(),
   checkUserDailyCost: vi.fn(),
@@ -68,6 +69,7 @@ describe("ProxyRateLimitGuard - key daily limit enforcement", () => {
     }>;
   }) => {
     return {
+      sessionId: "sess_test",
       authState: {
         user: {
           id: 1,
@@ -104,6 +106,13 @@ describe("ProxyRateLimitGuard - key daily limit enforcement", () => {
 
     rateLimitServiceMock.checkTotalCostLimit.mockResolvedValue({ allowed: true });
     rateLimitServiceMock.checkSessionLimit.mockResolvedValue({ allowed: true });
+    rateLimitServiceMock.checkAndTrackKeyUserSession.mockResolvedValue({
+      allowed: true,
+      keyCount: 0,
+      userCount: 0,
+      trackedKey: false,
+      trackedUser: false,
+    });
     rateLimitServiceMock.checkRpmLimit.mockResolvedValue({ allowed: true });
     rateLimitServiceMock.checkUserDailyCost.mockResolvedValue({ allowed: true });
     rateLimitServiceMock.checkCostLimitsWithLease.mockResolvedValue({ allowed: true });
@@ -247,9 +256,14 @@ describe("ProxyRateLimitGuard - key daily limit enforcement", () => {
   it("Key 并发 Session 超限应拦截（concurrent_sessions）", async () => {
     const { ProxyRateLimitGuard } = await import("@/app/v1/_lib/proxy/rate-limit-guard");
 
-    rateLimitServiceMock.checkSessionLimit.mockResolvedValueOnce({
+    rateLimitServiceMock.checkAndTrackKeyUserSession.mockResolvedValueOnce({
       allowed: false,
+      rejectedBy: "key",
       reason: "Key并发 Session 上限已达到（2/1）",
+      keyCount: 2,
+      userCount: 0,
+      trackedKey: false,
+      trackedUser: false,
     });
 
     const session = createSession({
@@ -267,9 +281,15 @@ describe("ProxyRateLimitGuard - key daily limit enforcement", () => {
   it("User 并发 Session 超限应拦截（concurrent_sessions）", async () => {
     const { ProxyRateLimitGuard } = await import("@/app/v1/_lib/proxy/rate-limit-guard");
 
-    rateLimitServiceMock.checkSessionLimit
-      .mockResolvedValueOnce({ allowed: true }) // key session
-      .mockResolvedValueOnce({ allowed: false, reason: "User并发 Session 上限已达到（2/1）" });
+    rateLimitServiceMock.checkAndTrackKeyUserSession.mockResolvedValueOnce({
+      allowed: false,
+      rejectedBy: "user",
+      reason: "User并发 Session 上限已达到（2/1）",
+      keyCount: 0,
+      userCount: 2,
+      trackedKey: false,
+      trackedUser: false,
+    });
 
     const session = createSession({
       user: { limitConcurrentSessions: 1 },
@@ -294,8 +314,13 @@ describe("ProxyRateLimitGuard - key daily limit enforcement", () => {
 
     await expect(ProxyRateLimitGuard.ensure(session)).resolves.toBeUndefined();
 
-    expect(rateLimitServiceMock.checkSessionLimit).toHaveBeenNthCalledWith(1, 2, "key", 15);
-    expect(rateLimitServiceMock.checkSessionLimit).toHaveBeenNthCalledWith(2, 1, "user", 15);
+    expect(rateLimitServiceMock.checkAndTrackKeyUserSession).toHaveBeenCalledWith(
+      2,
+      1,
+      "sess_test",
+      15,
+      15
+    );
   });
 
   it("User RPM 超限应拦截（rpm）", async () => {

--- a/tests/unit/proxy/rate-limit-guard.test.ts
+++ b/tests/unit/proxy/rate-limit-guard.test.ts
@@ -4,7 +4,6 @@ const generateSessionIdMock = vi.hoisted(() => vi.fn(() => "sess_generated"));
 
 const rateLimitServiceMock = {
   checkTotalCostLimit: vi.fn(),
-  checkSessionLimit: vi.fn(),
   checkAndTrackKeyUserSession: vi.fn(),
   checkRpmLimit: vi.fn(),
   checkCostLimitsWithLease: vi.fn(),
@@ -120,7 +119,6 @@ describe("ProxyRateLimitGuard - key daily limit enforcement", () => {
     generateSessionIdMock.mockReturnValue("sess_generated");
 
     rateLimitServiceMock.checkTotalCostLimit.mockResolvedValue({ allowed: true });
-    rateLimitServiceMock.checkSessionLimit.mockResolvedValue({ allowed: true });
     rateLimitServiceMock.checkAndTrackKeyUserSession.mockResolvedValue({
       allowed: true,
       keyCount: 0,

--- a/tests/unit/proxy/rate-limit-guard.test.ts
+++ b/tests/unit/proxy/rate-limit-guard.test.ts
@@ -272,7 +272,8 @@ describe("ProxyRateLimitGuard - key daily limit enforcement", () => {
     rateLimitServiceMock.checkAndTrackKeyUserSession.mockResolvedValueOnce({
       allowed: false,
       rejectedBy: "key",
-      reason: "Key并发 Session 上限已达到（2/1）",
+      reasonCode: "RATE_LIMIT_CONCURRENT_SESSIONS_EXCEEDED",
+      reasonParams: { current: 2, limit: 1, target: "key" },
       keyCount: 2,
       userCount: 0,
       trackedKey: false,
@@ -297,7 +298,8 @@ describe("ProxyRateLimitGuard - key daily limit enforcement", () => {
     rateLimitServiceMock.checkAndTrackKeyUserSession.mockResolvedValueOnce({
       allowed: false,
       rejectedBy: "user",
-      reason: "User并发 Session 上限已达到（2/1）",
+      reasonCode: "RATE_LIMIT_CONCURRENT_SESSIONS_EXCEEDED",
+      reasonParams: { current: 2, limit: 1, target: "user" },
       keyCount: 0,
       userCount: 2,
       trackedKey: false,


### PR DESCRIPTION
## 背景 / 问题

#772 合入后，Key 的 `limitConcurrentSessions` 默认会继承 User 的并发上限，解决了配置/展示不一致的问题。

但并发 Session 仍是“先检查（只读计数）→ 后追踪（异步 ZADD）”的两段式流程：在多 Key + 高并发创建新 Session 时，会出现竞态窗口，导致 **User 级并发上限被短时间击穿**。

关联：
- #769（Concurrent User limit）
- #772（Key 并发上限继承 User）

## 根因

- `checkSessionLimit()` 仅做读计数，不负责原子追踪。
- Session 追踪在 `ProxySessionGuard` 中 fire-and-forget，多个并发请求可能同时通过检查后再各自追踪。
- 因为“检查/追踪”不是一个 Redis 原子操作，所以无法在高并发下保证严格上限。

## 解决方案

- 新增 Redis Lua 脚本 `CHECK_AND_TRACK_KEY_USER_SESSION`：对 `global/key/user` 的 active_sessions 做 **原子性** 的「清理过期 → 检查上限 → 追踪 sessionId」。
  - 仅阻止“新 session”进入；已存在 session 在达到上限时仍允许继续请求。
  - `{active_sessions}:global:active_sessions` 仅用于 Sessions 页面观测，不参与限额判断；同时在脚本中加入过期清理，避免长时间流量下膨胀。
  - 为兼容 Redis Cluster，global/key/user 相关 key 统一使用 `{active_sessions}` hash tag，避免 CROSSSLOT。
- 新增 `RateLimitService.checkAndTrackKeyUserSession()` 封装脚本调用与结果解析（Redis 不可用时 Fail Open）。
  - 超限时返回 `reasonCode/reasonParams`（不硬编码文案，交给上层 i18n）。
- `ProxySessionGuard`：当启用 Key/User 并发上限时，跳过 `SessionTracker.trackSession()` 的预追踪，避免“先追踪再检查”导致击穿。
- `ProxyRateLimitGuard`：并发检查统一改为调用 `checkAndTrackKeyUserSession()`；若 `sessionId` 异常缺失则兜底生成，避免回退到非原子路径。
- `resetUserAllStatistics`：同步清理 user 级 active_sessions，避免残留影响并发判断。

## RPM 复核

本 PR 未改动 RPM（`checkRpmLimit` / `checkUserRPM`）逻辑；RPM 以 `user:${userId}:rpm_window` 维度统计，天然覆盖多 Key 同时使用的场景。

## 测试

本地运行：
- `npm run build`
- `npm run lint`
- `npm run lint:fix`
- `npm run typecheck`
- `npm run test`


## 为什么这个 PR 仍然必要（影响与复现）

即使 #772 让 Key 的 `limitConcurrentSessions` 在(解析/展示)层面默认继承 User 上限，旧实现的并发 Session 限制依然存在竞态窗口：并发校验与追踪是两段式流程（读计数 → 异步追踪），在高并发创建新 Session 时无法保证严格上限。

复现思路（旧实现）：
1. 将 User 的 `limitConcurrentSessions` 设为 15；
2. 创建两个 Key（KeyA/KeyB），其 `limitConcurrentSessions` 保持 0（按 #772 逻辑继承 User=15）；
3. 在 KeyA/KeyB 下同时并发发起 N（>15）个"新 session"的请求（例如每个请求携带不同的 `metadata.session_id`，或客户端不传 session_id 导致服务端生成不同 session）；
4. 多个请求可能在追踪写入 Redis ZSET 之前同时通过 `checkSessionLimit()` 的只读计数检查，从而放行超过 15 个新 session，随后才陆续异步追踪，导致 user 级 active_sessions 计数瞬时 > 15。

影响：
- 账号级并发保护可被短时间击穿，造成上游连接/资源被超量占用；
- 在多 Key 场景下会被误解为"每个 Key 各 15"，实际是 User 上限没有被严格执行；
- 由于竞态具有偶发性（更偏高并发/多 Key/高频新建 session），问题更难排查与复现。

因此需要将「清理过期 → 检查上限 → 追踪」合并为单个 Redis 原子操作，才能保证严格上限。

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition in concurrent session limit enforcement that could allow user-level limits to be bypassed when multiple keys are used simultaneously under high concurrency.

## Root Cause
The old implementation used a two-phase check-then-track approach: `checkSessionLimit()` performed a read-only count check, followed by asynchronous `SessionTracker.trackSession()`. Multiple concurrent requests could pass the check before any tracking occurred, causing the user concurrent limit to be exceeded temporarily.

## Solution
Introduced atomic Redis Lua script `CHECK_AND_TRACK_KEY_USER_SESSION` that combines cleanup, checking, and tracking in a single atomic operation:

- Cleans expired sessions from global/key/user ZSETs
- Checks if session already exists (allows existing sessions to continue even at limit)
- Validates key and user concurrent limits (rejects only new sessions when at limit)
- Tracks session atomically across all three ZSETs with proper TTL
- Uses `{active_sessions}` hash tag for Redis Cluster compatibility

## Key Changes
- **Lua Script** (lua-scripts.ts:102-171): New 101-line atomic script handling all three dimensions
- **Service Integration** (service.ts:571-645): `checkAndTrackKeyUserSession()` method with fail-open behavior
- **Guard Logic** (rate-limit-guard.ts:147-153): Calls atomic method with fallback sessionId generation
- **Session Guard** (session-guard.ts:143-146): Skips pre-tracking when concurrent limits enabled using `resolveKeyUserConcurrentSessionLimits().enabled`
- **Cleanup Fix** (users.ts:1608-1609): `resetUserAllStatistics` now clears user-level active_sessions ZSET

## Test Coverage
Added comprehensive tests for limit resolution logic, Redis interactions, and guard integration covering edge cases like null/undefined/NaN/Infinity values.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor observability trade-offs that are well-documented and intentional
- The atomic Lua script correctly solves the race condition with proper Redis Cluster support. The implementation follows fail-open principles, includes comprehensive tests, and has clear documentation. Previous review threads raised valid observability concerns (early exit when both limits are 0 prevents global tracking), but these are intentional design trade-offs clearly documented in the code comments.
- No files require special attention - all core logic files have adequate test coverage and clear documentation
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/redis/lua-scripts.ts | adds atomic check-and-track Lua script for key/user concurrent sessions with proper cleanup, tracking, and Redis Cluster hash tag support |
| src/lib/rate-limit/service.ts | implements checkAndTrackKeyUserSession method that atomically checks and tracks sessions, with proper fail-open behavior when Redis is unavailable |
| src/app/v1/_lib/proxy/rate-limit-guard.ts | integrates atomic session check with fallback sessionId generation, ensuring concurrent limits are enforced atomically before other rate limits |
| src/app/v1/_lib/proxy/session-guard.ts | conditionally skips SessionTracker.trackSession when concurrent limits are enabled, delegating tracking to atomic Lua script path |
| src/lib/redis/active-session-keys.ts | adds Redis Cluster-compatible key generators with shared hash tag for global/key/user active sessions |
| src/lib/rate-limit/concurrent-session-limit.ts | adds resolveKeyUserConcurrentSessionLimits helper that returns effective key limit, normalized user limit, and enabled flag |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant SessionGuard
    participant RateLimitGuard
    participant RateLimitService
    participant Redis
    participant LuaScript

    Client->>SessionGuard: Request with metadata
    SessionGuard->>SessionGuard: Extract/generate sessionId
    Note over SessionGuard: Check if concurrent limits enabled
    alt Concurrent limits disabled
        SessionGuard->>Redis: SessionTracker.trackSession (async)
    else Concurrent limits enabled
        SessionGuard->>SessionGuard: Skip tracking (defer to atomic path)
    end
    SessionGuard->>RateLimitGuard: Pass session with sessionId

    RateLimitGuard->>RateLimitGuard: Resolve key/user limits
    Note over RateLimitGuard: Fallback generate sessionId if missing
    RateLimitGuard->>RateLimitService: checkAndTrackKeyUserSession(keyId, userId, sessionId, keyLimit, userLimit)
    
    RateLimitService->>Redis: EVAL CHECK_AND_TRACK_KEY_USER_SESSION
    Redis->>LuaScript: Execute atomic script
    
    Note over LuaScript: Step 1: Clean expired sessions from all 3 ZSETs
    LuaScript->>LuaScript: ZREMRANGEBYSCORE (global, key, user)
    
    Note over LuaScript: Step 2: Check if session already tracked
    LuaScript->>LuaScript: ZSCORE key_key, ZSCORE user_key
    
    Note over LuaScript: Step 3: Get current counts
    LuaScript->>LuaScript: ZCARD key_key, ZCARD user_key
    
    Note over LuaScript: Step 4-5: Check limits (skip if already tracked)
    alt Key limit exceeded AND not tracked
        LuaScript-->>Redis: {0, 1, keyCount, 0, userCount, 0}
        Redis-->>RateLimitService: Rejected by key
        RateLimitService-->>RateLimitGuard: allowed=false, rejectedBy=key
        RateLimitGuard-->>Client: 429 Key concurrent limit exceeded
    else User limit exceeded AND not tracked
        LuaScript-->>Redis: {0, 2, keyCount, 0, userCount, 0}
        Redis-->>RateLimitService: Rejected by user
        RateLimitService-->>RateLimitGuard: allowed=false, rejectedBy=user
        RateLimitGuard-->>Client: 429 User concurrent limit exceeded
    else Allowed
        Note over LuaScript: Step 6-7: Track session in all 3 ZSETs + set TTL
        LuaScript->>LuaScript: ZADD global/key/user + EXPIRE
        LuaScript-->>Redis: {1, 0, newKeyCount, tracked, newUserCount, tracked}
        Redis-->>RateLimitService: Allowed with counts
        RateLimitService-->>RateLimitGuard: allowed=true
        RateLimitGuard->>RateLimitGuard: Continue with other rate limit checks
        RateLimitGuard-->>Client: Proceed to upstream
    end
```
</details>


<sub>Last reviewed commit: 16e89d8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->