### PR TITLE
fix: /v1/models 返回 modelRedirects key，修复模型调度误判 (#786)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/app/v1/_lib/proxy/provider-selector.ts
+++ b/src/app/v1/_lib/proxy/provider-selector.ts
@@ -94,25 +94,6 @@ function checkProviderGroupMatch(providerGroupTag: string | null, userGroups: st
 }
 
 /**
- * 检查供应商是否支持指定模型（用于调度器匹配）
- *
- * 核心逻辑：
- * 1. Claude 模型请求 (claude-*)：
- *    - Anthropic 提供商：根据 allowedModels 白名单判断
- *    - 非 Anthropic 提供商：不支持 claude-* 模型调度
- *
- * 2. 非 Claude 模型请求 (gpt-*, gemini-*, 或其他任意模型)：
- *    - Anthropic 提供商：不支持（仅支持 Claude 模型）
- *    - 非 Anthropic 提供商（codex, gemini-cli, openai-compatible）：
- *      a. 如果未设置 allowedModels（null 或空数组）：接受任意模型
- *      b. 如果设置了 allowedModels：检查模型是否在声明列表中，或有模型重定向配置
- *      注意：allowedModels 是声明性列表（用户可填写任意字符串），用于调度器匹配，不是真实模型校验
- *
- * @param provider - 供应商信息
- * @param requestedModel - 用户请求的模型名称
- * @returns 是否支持该模型（用于调度器筛选）
- */
-/**
  * 根据原始请求格式限制可选供应商类型
  *
  * 核心逻辑：确保客户端请求格式与供应商类型兼容，避免格式错配

--- a/src/app/v1/_lib/proxy/provider-selector.ts
+++ b/src/app/v1/_lib/proxy/provider-selector.ts
@@ -9,6 +9,7 @@ import { getSystemSettings } from "@/repository/system-config";
 import type { ProviderChainItem } from "@/types/message";
 import type { Provider } from "@/types/provider";
 import type { ClientFormat } from "./format-mapper";
+import { providerSupportsModel } from "./provider-supports-model";
 import { ProxyResponses } from "./responses";
 import type { ProxySession } from "./session";
 
@@ -111,58 +112,6 @@ function checkProviderGroupMatch(providerGroupTag: string | null, userGroups: st
  * @param requestedModel - 用户请求的模型名称
  * @returns 是否支持该模型（用于调度器筛选）
  */
-function providerSupportsModel(provider: Provider, requestedModel: string): boolean {
-  const isClaudeModel = requestedModel.startsWith("claude-");
-  const isClaudeProvider =
-    provider.providerType === "claude" || provider.providerType === "claude-auth";
-
-  // Case 1: Claude 模型请求
-  if (isClaudeModel) {
-    // 1a. Anthropic 提供商
-    if (isClaudeProvider) {
-      // 未设置 allowedModels 或为空数组：允许所有 claude 模型
-      if (!provider.allowedModels || provider.allowedModels.length === 0) {
-        return true;
-      }
-      // 检查白名单
-      return provider.allowedModels.includes(requestedModel);
-    }
-
-    // 1b. 非 Anthropic 提供商不支持 Claude 模型调度
-    return false;
-  }
-
-  // Case 2: 非 Claude 模型请求（gpt-*, gemini-*, 或其他任意模型）
-  // 2a. 优先检查显式声明（支持跨类型代理）
-  // 原因：允许 Claude 类型供应商通过 allowedModels/modelRedirects 声明支持非 Claude 模型
-  // 场景：Claude 供应商配置模型重定向，将 gemini-* 请求转发到真实的 Gemini 上游
-  const explicitlyDeclared = !!(
-    provider.allowedModels?.includes(requestedModel) || provider.modelRedirects?.[requestedModel]
-  );
-
-  if (explicitlyDeclared) {
-    return true; // 显式声明优先级最高，允许跨类型代理
-  }
-
-  // 2b. Anthropic 提供商不支持非声明的非 Claude 模型
-  // 保护机制：防止将非 Claude 模型误路由到 Anthropic API
-  if (isClaudeProvider) {
-    return false;
-  }
-
-  // 2c. 非 Anthropic 提供商（codex, gemini, gemini-cli, openai-compatible）
-  // allowedModels 是声明列表，用于调度器匹配提供商
-  // 用户可以手动填写任意模型名称（不限于真实模型），用于声明该提供商"支持"哪些模型
-
-  // 未设置 allowedModels 或为空数组：接受任意模型（由上游提供商判断）
-  if (!provider.allowedModels || provider.allowedModels.length === 0) {
-    return true;
-  }
-
-  // 不在声明列表中且无重定向配置（前面已检查过 explicitlyDeclared）
-  return false;
-}
-
 /**
  * 根据原始请求格式限制可选供应商类型
  *

--- a/src/app/v1/_lib/proxy/provider-supports-model.ts
+++ b/src/app/v1/_lib/proxy/provider-supports-model.ts
@@ -1,0 +1,60 @@
+import type { Provider } from "@/types/provider";
+
+/**
+ * 检查供应商是否支持指定模型（用于调度器匹配）
+ *
+ * 说明：
+ * - 这里的“支持”指的是：该 provider 能否接受客户端请求的 model 作为入口，并在必要时通过 modelRedirects
+ *   重写为上游实际模型。
+ * - 对于配置了 modelRedirects 的场景，映射前（key）模型名应被视为可请求模型。
+ */
+export function providerSupportsModel(provider: Provider, requestedModel: string): boolean {
+  const isClaudeModel = requestedModel.startsWith("claude-");
+  const isClaudeProvider =
+    provider.providerType === "claude" || provider.providerType === "claude-auth";
+
+  // Case 1: Claude 模型请求
+  if (isClaudeModel) {
+    // 1a. Anthropic 提供商
+    if (isClaudeProvider) {
+      // 未设置 allowedModels 或为空数组：允许所有 claude 模型
+      if (!provider.allowedModels || provider.allowedModels.length === 0) {
+        return true;
+      }
+
+      // Fix #786：当存在 modelRedirects 映射时，映射前模型名（key）也应视为可请求模型
+      return (
+        provider.allowedModels.includes(requestedModel) ||
+        !!provider.modelRedirects?.[requestedModel]
+      );
+    }
+
+    // 1b. 非 Anthropic 提供商不支持 Claude 模型调度
+    return false;
+  }
+
+  // Case 2: 非 Claude 模型请求（gpt-*, gemini-*, 或其他任意模型）
+  // 2a. 优先检查显式声明（支持跨类型别名）
+  const explicitlyDeclared = !!(
+    provider.allowedModels?.includes(requestedModel) || provider.modelRedirects?.[requestedModel]
+  );
+
+  if (explicitlyDeclared) {
+    return true; // 显式声明优先级最高，允许跨类型别名
+  }
+
+  // 2b. Anthropic 提供商不支持非声明的非 Claude 模型
+  // 保护机制：防止将非 Claude 模型误路由到 Anthropic API
+  if (isClaudeProvider) {
+    return false;
+  }
+
+  // 2c. 非 Anthropic 提供商（codex, gemini, gemini-cli, openai-compatible）
+  // 未设置 allowedModels 或为空数组：接受任意模型（由上游提供商判断）
+  if (!provider.allowedModels || provider.allowedModels.length === 0) {
+    return true;
+  }
+
+  // 不在声明列表中且无重定向配置（前面已检查 explicitlyDeclared）
+  return false;
+}

--- a/tests/unit/models/available-models-include-redirect-keys.test.ts
+++ b/tests/unit/models/available-models-include-redirect-keys.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test, vi } from "vitest";
+import type { Provider } from "@/types/provider";
+
+vi.mock("@/repository/key", () => {
+  return {
+    validateApiKeyAndGetUser: vi.fn(async () => ({
+      user: { id: 1, providerGroup: null, isEnabled: true, expiresAt: null },
+      key: { providerGroup: null, name: "test-key" },
+    })),
+  };
+});
+
+vi.mock("@/lib/proxy-agent", () => {
+  return {
+    createProxyAgentForProvider: vi.fn(() => null),
+  };
+});
+
+describe("handleAvailableModels - include modelRedirects keys", () => {
+  test("anthropic response includes redirect source model (key)", async () => {
+    const { ProxyProviderResolver } = await import("@/app/v1/_lib/proxy/provider-selector");
+    const { handleAvailableModels } = await import("@/app/v1/_lib/models/available-models");
+
+    const claudeProvider = {
+      id: 1,
+      name: "claude",
+      providerType: "claude",
+      url: "https://api.anthropic.com",
+      key: "upstream-api-key",
+      preserveClientIp: false,
+      allowedModels: ["claude-opus-4-6-think"],
+      modelRedirects: { "claude-opus-4-6": "claude-opus-4-6-think" },
+    } as unknown as Provider;
+
+    vi.spyOn(ProxyProviderResolver, "selectProviderByType").mockImplementation(
+      async (_authState, providerType) => {
+        if (providerType === "claude") {
+          return { provider: claudeProvider, context: {} as any };
+        }
+        return { provider: null, context: {} as any };
+      }
+    );
+
+    const c = {
+      req: {
+        path: "/v1/models",
+        header: (name: string) => {
+          const key = name.toLowerCase();
+          if (key === "x-api-key") return "user-api-key";
+          if (key === "anthropic-version") return "2023-06-01";
+          return undefined;
+        },
+        query: () => undefined,
+      },
+      json: (body: unknown, status?: number) => {
+        return new Response(JSON.stringify(body), {
+          status: status ?? 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    } as any;
+
+    const res = await handleAvailableModels(c);
+    const body = (await res.json()) as any;
+    const ids = (body?.data ?? []).map((m: any) => m.id);
+
+    expect(ids).toContain("claude-opus-4-6");
+    expect(ids).toContain("claude-opus-4-6-think");
+  });
+
+  test("openai response does not include claude-* redirect keys on non-claude providers", async () => {
+    const { ProxyProviderResolver } = await import("@/app/v1/_lib/proxy/provider-selector");
+    const { handleAvailableModels } = await import("@/app/v1/_lib/models/available-models");
+
+    const openaiProvider = {
+      id: 2,
+      name: "openai-compatible",
+      providerType: "openai-compatible",
+      url: "https://api.example.com",
+      key: "upstream-api-key",
+      preserveClientIp: false,
+      allowedModels: ["gpt-4o"],
+      modelRedirects: { "claude-test": "gpt-4o" },
+    } as unknown as Provider;
+
+    vi.spyOn(ProxyProviderResolver, "selectProviderByType").mockImplementation(
+      async (_authState, providerType) => {
+        if (providerType === "openai-compatible") {
+          return { provider: openaiProvider, context: {} as any };
+        }
+        return { provider: null, context: {} as any };
+      }
+    );
+
+    const c = {
+      req: {
+        path: "/v1/models",
+        header: (name: string) => {
+          const key = name.toLowerCase();
+          if (key === "x-api-key") return "user-api-key";
+          return undefined;
+        },
+        query: () => undefined,
+      },
+      json: (body: unknown, status?: number) => {
+        return new Response(JSON.stringify(body), {
+          status: status ?? 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    } as any;
+
+    const res = await handleAvailableModels(c);
+    const body = (await res.json()) as any;
+    const ids = (body?.data ?? []).map((m: any) => m.id);
+
+    expect(ids).toContain("gpt-4o");
+    expect(ids).not.toContain("claude-test");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes model scheduling misjudgment when provider uses `modelRedirects` with `allowedModels` whitelist, and exposes `modelRedirects` keys in `/v1/models` endpoint.

**Fixes #786**

## Problem

When a Claude provider is configured with:
- `allowedModels: ["claude-opus-4-6-think"]` (only redirect target)
- `modelRedirects: { "claude-opus-4-6": "claude-opus-4-6-think" }` (redirect mapping)

The provider selection logic incorrectly filters out this provider when users request `claude-opus-4-6`, because:
1. The scheduling filter checks if `claude-opus-4-6` is in `allowedModels` - it's not
2. It doesn't consider that `modelRedirects` makes this model requestable as an "entry alias"

Additionally, `/v1/models` endpoint doesn't expose the redirect source model names (keys), causing clients/frontend to incorrectly judge entry models as unavailable.

## Solution

1. **Extract unified model support check**: Create `src/app/v1/_lib/proxy/provider-supports-model.ts` to centralize the logic
2. **Fix scheduling logic**: For Claude providers, if `modelRedirects[requestedModel]` exists, treat it as supported even if not in `allowedModels`
3. **Fix `/v1/models`**: Merge `modelRedirects` keys into provider model list (deduplicated, using same filtering rules to avoid exposing `claude-*` on non-Claude providers)

## Changes

### Core Changes
- **`src/app/v1/_lib/proxy/provider-supports-model.ts`** (+60 lines): New module with unified `providerSupportsModel()` function
- **`src/app/v1/_lib/proxy/provider-selector.ts`** (-52/+1 lines): Extract model support logic to new module
- **`src/app/v1/_lib/models/available-models.ts`** (+47/-18 lines): Include `modelRedirects` keys in model list

### Supporting Changes
- **`biome.json`**: Update schema to 2.3.15 (match current CLI version)

### Tests
- **`tests/unit/proxy/provider-selector-model-redirect.test.ts`** (+70 lines): Test redirect key as supported with whitelist
- **`tests/unit/models/available-models-include-redirect-keys.test.ts`** (+120 lines): Test `/v1/models` includes redirect keys

## Testing

- [x] `bun run build` - Production build
- [x] `bun run lint` / `bun run lint:fix` - Biome check
- [x] `bun run typecheck` - TypeScript check
- [x] `bun run test` - Vitest tests

## Related

- **Related to #633** - Previous fix for provider exhaustion after model redirect (different issue in same feature area)

---

## Background (中文)

issue #786：当 Claude provider 配置了 `modelRedirects`（例如把客户端请求的 `claude-opus-4-6` 重定向到上游实际可用的 `claude-opus-4-6-think`），但该 provider 的 `allowedModels` 只包含重定向后的模型时，调度筛选会误判为"不支持模型"，从而把该 provider 过滤掉。

另外，`/v1/models` 目前不会暴露 `modelRedirects` 的 key（映射前模型名）。这会导致依赖模型列表的客户端/前端误判入口模型不可用。

## 变更 (中文)

- 抽离并统一模型支持判断：新增 `src/app/v1/_lib/proxy/provider-supports-model.ts`
- Fix #786：Claude 模型请求时，若存在 `modelRedirects[requestedModel]`，即使 `requestedModel` 不在 `allowedModels` 中也视为支持（入口别名语义）
- `/v1/models`：在 provider 模型列表中合并 `modelRedirects` 的 key（去重，并复用同一规则过滤，避免在非 Claude provider 暴露 `claude-*` key）
- 更新 `biome.json` 的 `$schema` 到 2.3.15（与当前 CLI 版本匹配）

## 测试 (中文)

- `bun run build`
- `bun run lint` / `bun run lint:fix`
- `bun run typecheck`
- `bun run test`

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes model scheduling misjudgment when providers use `modelRedirects` with `allowedModels` whitelist, and exposes redirect keys in `/v1/models` endpoint.

**Key Changes:**
- Extracted unified model support logic into `provider-supports-model.ts` module for better code reuse
- Fixed scheduling filter to treat `modelRedirects` keys as supported entry models, even when only redirect targets are in `allowedModels`
- Enhanced `/v1/models` to include redirect source model names (keys), filtered by same `providerSupportsModel` logic to maintain consistency
- Added comprehensive test coverage for both provider selection and model listing scenarios

**Impact:**
Resolves issue #786 where Claude providers configured with `modelRedirects: { "claude-opus-4-6": "claude-opus-4-6-think" }` and `allowedModels: ["claude-opus-4-6-think"]` were incorrectly filtered out when users requested `claude-opus-4-6`. Both the scheduling logic and model listing endpoint now correctly recognize redirect keys as valid entry points.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge with high confidence - clean refactoring with comprehensive test coverage
- The implementation is well-structured with proper separation of concerns, consistent logic across provider selection and model listing, and thorough test coverage for the fix. The refactoring extracts duplicate code into a reusable module while maintaining backward compatibility.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/provider-supports-model.ts | New module extracting unified model support logic with proper handling of modelRedirects |
| src/app/v1/_lib/proxy/provider-selector.ts | Refactored to import providerSupportsModel from dedicated module, removing duplicate logic |
| src/app/v1/_lib/models/available-models.ts | Enhanced to include modelRedirects keys in response, properly filtered by providerSupportsModel |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
flowchart TD
    A[Client requests claude-opus-4-6] --> B[Provider Selection]
    B --> C[providerSupportsModel check]
    C --> D{Check explicitlyDeclared}
    D -->|modelRedirects key exists| E[Provider matches]
    D -->|allowedModels includes requested| E
    D -->|Not explicitly declared| F{Check implicit rules}
    F -->|Claude model on Claude provider| G{allowedModels set?}
    G -->|No or empty| E
    G -->|Yes but not in list| H[Provider filtered out]
    
    I[v1 models endpoint] --> J[fetchModelsFromProvider]
    J --> K[Get base models from allowedModels or upstream]
    K --> L{Has modelRedirects?}
    L -->|Yes| M[Add redirect keys to model list]
    M --> N{providerSupportsModel for each key}
    N -->|Supported| O[Include redirect key in response]
    N -->|Not supported| P[Skip redirect key]
    L -->|No| Q[Return base models]
    O --> Q
    P --> Q
```
</details>


<sub>Last reviewed commit: d1d4bc4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->