### PR TITLE
fix(proxy): remove deterministic session ID to prevent collision across conversations

### DIFF
--- a/src/app/v1/_lib/proxy/session-guard.ts
+++ b/src/app/v1/_lib/proxy/session-guard.ts
@@ -85,12 +85,11 @@ export class ProxySessionGuard {
         systemSettings.interceptAnthropicWarmupRequests;
 
       // 1. 尝试从客户端提取 session_id（metadata.session_id）
-      const clientSessionId =
-        SessionManager.extractClientSessionId(
-          session.request.message,
-          session.headers,
-          session.userAgent
-        ) || session.generateDeterministicSessionId();
+      const clientSessionId = SessionManager.extractClientSessionId(
+        session.request.message,
+        session.headers,
+        session.userAgent
+      );
 
       // 2. 获取 messages 数组
       const messages = session.getMessages();

--- a/src/app/v1/_lib/proxy/session.ts
+++ b/src/app/v1/_lib/proxy/session.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import type { Context } from "hono";
 import { logger } from "@/lib/logger";
 import { clientRequestsContext1m as clientRequestsContext1mHelper } from "@/lib/special-attributes";
@@ -350,38 +349,6 @@ export class ProxySession {
 
     this.providersSnapshot = await findAllProviders();
     return this.providersSnapshot;
-  }
-
-  /**
-   * 生成基于请求指纹的确定性 Session ID
-   *
-   * 优先级与参考实现一致：
-   * - API Key 前缀（x-api-key / x-goog-api-key 的前10位）
-   * - User-Agent
-   * - 客户端 IP（x-forwarded-for / x-real-ip）
-   *
-   * 当客户端未提供 metadata.session_id 时，可用于稳定绑定会话。
-   */
-  generateDeterministicSessionId(): string | null {
-    const apiKeyHeader = this.headers.get("x-api-key") || this.headers.get("x-goog-api-key");
-    const apiKeyPrefix = apiKeyHeader ? apiKeyHeader.substring(0, 10) : null;
-
-    const userAgent = this.headers.get("user-agent");
-
-    // 取链路上的首个 IP
-    const forwardedFor = this.headers.get("x-forwarded-for");
-    const realIp = this.headers.get("x-real-ip");
-    const ip =
-      forwardedFor?.split(",").map((ip) => ip.trim())[0] || (realIp ? realIp.trim() : null);
-
-    const parts = [userAgent, ip, apiKeyPrefix].filter(Boolean);
-    if (parts.length === 0) {
-      return null;
-    }
-
-    const hash = crypto.createHash("sha256").update(parts.join(":"), "utf8").digest("hex");
-    // 格式对齐为 sess_{8位}_{12位}
-    return `sess_${hash.substring(0, 8)}_${hash.substring(8, 20)}`;
   }
 
   /**

--- a/tests/unit/proxy/metadata-injection.test.ts
+++ b/tests/unit/proxy/metadata-injection.test.ts
@@ -128,18 +128,3 @@ describe("injectClaudeMetadataUserId", () => {
     expect(metadata.user_id).toMatch(/^user_[a-f0-9]{64}_account__session_sess_abc123$/);
   });
 });
-
-describe("ProxySession.generateDeterministicSessionId", () => {
-  it("输出格式应匹配 sess_{8hex}_{12hex}", () => {
-    const session = Object.create(ProxySession.prototype) as ProxySession;
-    (session as Record<string, unknown>).headers = new Headers([
-      ["x-api-key", "sk-test-abcdef123456"],
-      ["user-agent", "Vitest/1.0"],
-      ["x-forwarded-for", "203.0.113.1"],
-    ]);
-
-    const deterministicSessionId = session.generateDeterministicSessionId();
-
-    expect(deterministicSessionId).toMatch(/^sess_[a-f0-9]{8}_[a-f0-9]{12}$/);
-  });
-});

--- a/tests/unit/proxy/session-guard-warmup-intercept.test.ts
+++ b/tests/unit/proxy/session-guard-warmup-intercept.test.ts
@@ -81,9 +81,6 @@ function createMockSession(overrides: Partial<ProxySession> = {}): ProxySession 
     getRequestSequence() {
       return this.requestSequence ?? 1;
     },
-    generateDeterministicSessionId() {
-      return "deterministic_session_id";
-    },
     getMessages() {
       return [];
     },


### PR DESCRIPTION
## Problem

`generateDeterministicSessionId()` hashes `(User-Agent, IP, API Key prefix)` with **no time dimension**, producing identical session IDs for the same user across separate conversations hours apart.

### Impact
- Usage logs merge unrelated conversations into one session
- Dashboard session duration spans hours (actually multiple short chats)
- ZSET tracking entries get "revived", inflating active session counts
- Concurrent session limits bypassed (same ID = same session)

## Root Cause

`session-guard.ts` falls back to `generateDeterministicSessionId()` when `extractClientSessionId()` returns null. Since the hash inputs are static per-user, the same ID is generated every time.

## Fix

Remove `generateDeterministicSessionId()` entirely. The existing fallback in `getOrCreateSessionId()` already handles `clientSessionId = null` correctly:
1. **Content hash** (first 3 messages SHA-256) - provides session continuity for multi-turn conversations
2. **Random `generateSessionId()`** - ensures unique IDs for new conversations

## Changes
- `session-guard.ts`: Remove `|| session.generateDeterministicSessionId()` fallback
- `session.ts`: Delete `generateDeterministicSessionId()` method + unused `crypto` import
- Tests: Remove related test block and mock

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the deterministic session ID generation mechanism that was causing session ID collisions across unrelated conversations. The `generateDeterministicSessionId()` method hashed static per-user attributes (User-Agent, IP, API Key prefix) without any time dimension, producing identical session IDs for the same user across separate conversations.

**Key changes:**
- Removed fallback to `generateDeterministicSessionId()` in `session-guard.ts:88-92`
- Deleted the 38-line `generateDeterministicSessionId()` method from `session.ts:352-384`
- Removed unused `crypto` import from `session.ts:1`
- Cleaned up related test code in both test files

**Impact:** The existing fallback logic in `SessionManager.getOrCreateSessionId()` already handles null client session IDs correctly by using content hash (for multi-turn conversations) or random session ID generation (for new conversations). This fix resolves issues with usage log merging, inflated session durations, ZSET entry revival, and concurrent session limit bypasses.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with no risks
- The change correctly removes a problematic deterministic session ID generation mechanism. The existing fallback logic in `SessionManager.getOrCreateSessionId()` already handles null client session IDs through content hash or random ID generation. All code paths are properly handled, tests are cleaned up, and the fix directly addresses the reported collision issues.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/session-guard.ts | Removed fallback to `generateDeterministicSessionId()`, now passes null directly to `getOrCreateSessionId()` |
| src/app/v1/_lib/proxy/session.ts | Deleted `generateDeterministicSessionId()` method and unused `crypto` import |
| tests/unit/proxy/metadata-injection.test.ts | Removed test block for deleted `generateDeterministicSessionId()` method |
| tests/unit/proxy/session-guard-warmup-intercept.test.ts | Removed mock implementation of deleted `generateDeterministicSessionId()` from test fixtures |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
flowchart TD
    Start[Request arrives at ProxySessionGuard] --> Extract[Extract client session ID<br/>from metadata/headers]
    Extract --> HasClient{Client session ID<br/>exists?}
    
    HasClient -->|Yes| UseClient[Use client-provided<br/>session ID]
    HasClient -->|No| ContentHash[Calculate content hash<br/>from first 3 messages]
    
    ContentHash --> HashExists{Hash calculated<br/>successfully?}
    HashExists -->|Yes| LookupHash[Lookup existing session<br/>in Redis by hash]
    HashExists -->|No| GenNew1[Generate new random<br/>session ID]
    
    LookupHash --> Found{Session found<br/>in Redis?}
    Found -->|Yes| Reuse[Reuse existing<br/>session ID]
    Found -->|No| GenNew2[Generate new random<br/>session ID]
    
    UseClient --> End[Session ID assigned]
    Reuse --> End
    GenNew1 --> End
    GenNew2 --> End
    
    style Start fill:#e1f5ff
    style End fill:#d4edda
    style Extract fill:#fff3cd
    style ContentHash fill:#fff3cd
    style GenNew1 fill:#f8d7da
    style GenNew2 fill:#f8d7da
```
</details>


<sub>Last reviewed commit: 94a409b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->