### PR TITLE
fix(my-usage): UX improvements for quota and statistics cards

### DIFF
--- a/messages/en/myUsage.json
+++ b/messages/en/myUsage.json
@@ -92,6 +92,9 @@
     "keyStats": "Key",
     "userStats": "User",
     "noData": "No data for selected period",
+    "breakdownPrevPage": "Previous page",
+    "breakdownNextPage": "Next page",
+    "breakdownPageIndicator": "{current} / {total}",
     "unknownModel": "Unknown",
     "modal": {
       "requests": "Requests",

--- a/messages/ja/myUsage.json
+++ b/messages/ja/myUsage.json
@@ -92,6 +92,9 @@
     "keyStats": "キー",
     "userStats": "ユーザー",
     "noData": "選択期間のデータがありません",
+    "breakdownPrevPage": "前のページ",
+    "breakdownNextPage": "次のページ",
+    "breakdownPageIndicator": "{current} / {total}",
     "unknownModel": "不明",
     "modal": {
       "requests": "リクエスト",

--- a/messages/ru/myUsage.json
+++ b/messages/ru/myUsage.json
@@ -92,6 +92,9 @@
     "keyStats": "Ключ",
     "userStats": "Пользователь",
     "noData": "Нет данных за выбранный период",
+    "breakdownPrevPage": "Предыдущая страница",
+    "breakdownNextPage": "Следующая страница",
+    "breakdownPageIndicator": "{current} / {total}",
     "unknownModel": "Неизвестно",
     "modal": {
       "requests": "Запросов",

--- a/messages/zh-CN/myUsage.json
+++ b/messages/zh-CN/myUsage.json
@@ -92,6 +92,9 @@
     "keyStats": "密钥",
     "userStats": "用户",
     "noData": "所选时段无数据",
+    "breakdownPrevPage": "上一页",
+    "breakdownNextPage": "下一页",
+    "breakdownPageIndicator": "{current} / {total}",
     "unknownModel": "未知",
     "modal": {
       "requests": "请求",

--- a/messages/zh-TW/myUsage.json
+++ b/messages/zh-TW/myUsage.json
@@ -92,6 +92,9 @@
     "keyStats": "金鑰",
     "userStats": "使用者",
     "noData": "所選時段無資料",
+    "breakdownPrevPage": "上一頁",
+    "breakdownNextPage": "下一頁",
+    "breakdownPageIndicator": "{current} / {total}",
     "unknownModel": "不明",
     "modal": {
       "requests": "請求",

--- a/src/app/[locale]/my-usage/_components/collapsible-quota-card.tsx
+++ b/src/app/[locale]/my-usage/_components/collapsible-quota-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, ChevronDown, Infinity, PieChart } from "lucide-react";
+import { AlertTriangle, ChevronDown, Infinity as InfinityIcon, PieChart } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import type { MyUsageQuota } from "@/actions/my-usage";
@@ -94,7 +94,7 @@ export function CollapsibleQuotaCard({
                 <div className="flex items-center gap-1.5">
                   <span className="text-muted-foreground">{t("daily")}:</span>
                   {dailyPct === null ? (
-                    <Infinity className="h-4 w-4 text-muted-foreground" />
+                    <InfinityIcon className="h-4 w-4 text-muted-foreground" />
                   ) : (
                     <>
                       <span className={cn("font-semibold", getPercentColor(dailyPct))}>
@@ -108,7 +108,7 @@ export function CollapsibleQuotaCard({
                 <div className="flex items-center gap-1.5">
                   <span className="text-muted-foreground">{t("monthly")}:</span>
                   {monthlyPct === null ? (
-                    <Infinity className="h-4 w-4 text-muted-foreground" />
+                    <InfinityIcon className="h-4 w-4 text-muted-foreground" />
                   ) : (
                     <>
                       <span className={cn("font-semibold", getPercentColor(monthlyPct))}>
@@ -122,7 +122,7 @@ export function CollapsibleQuotaCard({
                 <div className="flex items-center gap-1.5">
                   <span className="text-muted-foreground">{t("total")}:</span>
                   {totalPct === null ? (
-                    <Infinity className="h-4 w-4 text-muted-foreground" />
+                    <InfinityIcon className="h-4 w-4 text-muted-foreground" />
                   ) : (
                     <>
                       <span className={cn("font-semibold", getPercentColor(totalPct))}>

--- a/src/app/[locale]/my-usage/_components/provider-group-info.tsx
+++ b/src/app/[locale]/my-usage/_components/provider-group-info.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { cn } from "@/lib/utils";
 
 function abbreviateModel(name: string): string {
-  const parts = name.split("-");
+  const parts = name.split("-").filter(Boolean);
 
   if (parts.length === 1) {
     return parts[0].length <= 4 ? parts[0].toUpperCase() : parts[0].slice(0, 2).toUpperCase();
@@ -51,7 +51,7 @@ function abbreviateModel(name: string): string {
 }
 
 function abbreviateClient(name: string): string {
-  const parts = name.split(/[-\s]+/);
+  const parts = name.split(/[-\s]+/).filter(Boolean);
   if (parts.length === 1) {
     return name.slice(0, 2).toUpperCase();
   }
@@ -133,11 +133,9 @@ export function ProviderGroupInfo({
               userAllowedModels.map((name) => (
                 <Tooltip key={name}>
                   <TooltipTrigger asChild>
-                    <span>
-                      <Badge variant="outline" className="cursor-default font-mono text-xs">
-                        {abbreviateModel(name)}
-                      </Badge>
-                    </span>
+                    <Badge variant="outline" className="cursor-default font-mono text-xs">
+                      {abbreviateModel(name)}
+                    </Badge>
                   </TooltipTrigger>
                   <TooltipContent>{name}</TooltipContent>
                 </Tooltip>
@@ -156,11 +154,9 @@ export function ProviderGroupInfo({
               userAllowedClients.map((name) => (
                 <Tooltip key={name}>
                   <TooltipTrigger asChild>
-                    <span>
-                      <Badge variant="outline" className="cursor-default font-mono text-xs">
-                        {abbreviateClient(name)}
-                      </Badge>
-                    </span>
+                    <Badge variant="outline" className="cursor-default font-mono text-xs">
+                      {abbreviateClient(name)}
+                    </Badge>
                   </TooltipTrigger>
                   <TooltipContent>{name}</TooltipContent>
                 </Tooltip>

--- a/src/app/[locale]/my-usage/_components/quota-cards.tsx
+++ b/src/app/[locale]/my-usage/_components/quota-cards.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Infinity } from "lucide-react";
+import { Infinity as InfinityIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
 import type { MyUsageQuota } from "@/actions/my-usage";
@@ -180,7 +180,9 @@ function QuotaRow({
 
   return (
     <div className="flex items-center gap-2">
-      <span className="w-8 shrink-0 text-[11px] text-muted-foreground">{label}</span>
+      <span className="w-auto shrink-0 whitespace-nowrap text-[11px] text-muted-foreground">
+        {label}
+      </span>
       {!unlimited ? (
         <Progress value={percent ?? 0} className={progressClass} aria-label={ariaLabel} />
       ) : (
@@ -195,7 +197,7 @@ function QuotaRow({
         {formatValue(current)}
         <span className="text-muted-foreground">
           {" / "}
-          {unlimited ? <Infinity className="inline h-3.5 w-3.5" /> : limitDisplay}
+          {unlimited ? <InfinityIcon className="inline h-3.5 w-3.5" /> : limitDisplay}
         </span>
       </span>
     </div>

--- a/src/app/[locale]/my-usage/_components/statistics-summary-card.tsx
+++ b/src/app/[locale]/my-usage/_components/statistics-summary-card.tsx
@@ -118,11 +118,11 @@ export function StatisticsSummaryCard({
 
   const [breakdownPage, setBreakdownPage] = useState(1);
 
-  // Reset breakdown page when stats change (date range switch, refresh)
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset on stats identity change
+  // Reset breakdown page when date range changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deps used as reset trigger on date range change
   useEffect(() => {
     setBreakdownPage(1);
-  }, [stats]);
+  }, [dateRange.startDate, dateRange.endDate]);
 
   const isLoading = loading || refreshing;
   const currencyCode = stats?.currencyCode ?? "USD";
@@ -244,11 +244,11 @@ export function StatisticsSummaryCard({
             <div className="space-y-3">
               <p className="text-sm font-medium text-muted-foreground">{t("modelBreakdown")}</p>
               <div className="grid gap-4 md:grid-cols-2">
-                {keyPageItems.length > 0 && (
-                  <div className="space-y-2">
-                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                      {t("keyStats")}
-                    </p>
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    {t("keyStats")}
+                  </p>
+                  {keyPageItems.length > 0 ? (
                     <ModelBreakdownColumn
                       pageItems={keyPageItems}
                       currencyCode={currencyCode}
@@ -256,14 +256,16 @@ export function StatisticsSummaryCard({
                       keyPrefix="key"
                       pageOffset={sliceStart}
                     />
-                  </div>
-                )}
+                  ) : (
+                    <p className="text-sm text-muted-foreground">{t("noData")}</p>
+                  )}
+                </div>
 
-                {userPageItems.length > 0 && (
-                  <div className="space-y-2">
-                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                      {t("userStats")}
-                    </p>
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    {t("userStats")}
+                  </p>
+                  {userPageItems.length > 0 ? (
                     <ModelBreakdownColumn
                       pageItems={userPageItems}
                       currencyCode={currencyCode}
@@ -271,8 +273,10 @@ export function StatisticsSummaryCard({
                       keyPrefix="user"
                       pageOffset={sliceStart}
                     />
-                  </div>
-                )}
+                  ) : (
+                    <p className="text-sm text-muted-foreground">{t("noData")}</p>
+                  )}
+                </div>
               </div>
 
               {breakdownTotalPages > 1 && (
@@ -281,18 +285,23 @@ export function StatisticsSummaryCard({
                     size="icon"
                     variant="ghost"
                     className="h-7 w-7"
+                    aria-label={t("breakdownPrevPage")}
                     disabled={breakdownPage <= 1}
                     onClick={() => setBreakdownPage((p) => p - 1)}
                   >
                     <ChevronLeft className="h-4 w-4" />
                   </Button>
                   <span className="text-xs text-muted-foreground">
-                    {breakdownPage} / {breakdownTotalPages}
+                    {t("breakdownPageIndicator", {
+                      current: breakdownPage,
+                      total: breakdownTotalPages,
+                    })}
                   </span>
                   <Button
                     size="icon"
                     variant="ghost"
                     className="h-7 w-7"
+                    aria-label={t("breakdownNextPage")}
                     disabled={breakdownPage >= breakdownTotalPages}
                     onClick={() => setBreakdownPage((p) => p + 1)}
                   >


### PR DESCRIPTION
## Summary
- Replace "Unlimited" text with infinity icon in quota cards for a cleaner look
- Use currency symbol instead of currency code in quota display
- Use Badge component for provider group values for visual consistency
- Add pagination to model breakdown in statistics summary card (5 items per page)
- Suppress biome exhaustive-deps lint for intentional stats-change page reset

**Related Issues:**
- Related to #717 - Extends currency symbol formatting to my-usage quota cards for consistency

## Test plan
- [ ] Verify infinity icon renders in quota cards when limit is unlimited
- [ ] Verify currency symbol (e.g. $) is shown instead of code (e.g. USD) in quota rows
- [ ] Verify provider group values display as Badge components
- [ ] Verify model breakdown pagination works (next/prev, page indicator, reset on data change)
- [ ] `bun run typecheck` passes
- [ ] `bun run build` succeeds

---
*Description enhanced by Claude AI*

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR delivers several UX improvements to the my-usage page's quota and statistics cards:

- **Quota cards redesign**: Replaces the previous `Card`-based grid layout with a more compact row-based design using inline progress bars, an infinity icon (`InfinityIcon`) for unlimited quotas, and `formatCurrency()` for proper currency symbol display (e.g., `$` instead of `USD`).
- **Provider group badges**: Switches from plain text to `Badge` components with tooltip-enabled abbreviated model/client names, improving visual density and consistency.
- **Model breakdown pagination**: Adds client-side pagination (5 items per page) to the statistics summary card's model breakdown section, with page reset on date range changes.
- **i18n**: Adds pagination translation keys (`breakdownPrevPage`, `breakdownNextPage`, `breakdownPageIndicator`) across all 5 locale files.
- **Collapsible card**: Minor cleanup aliasing the `Infinity` import to `InfinityIcon` to avoid shadowing the global.

The changes align with the existing codebase patterns (using the shared `formatCurrency` utility, `Badge`/`Tooltip` components) and extend the currency symbol formatting from #717 to the quota cards.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge — it's a UI-only refactor with no backend or data logic changes.
- All changes are confined to client-side presentation components and i18n files. The pagination logic is straightforward, the currency formatting uses the existing shared utility, and the abbreviation helpers are well-guarded against edge cases. One minor style nit on constant ordering. No security, data integrity, or functional risks.
- No files require special attention. `statistics-summary-card.tsx` and `provider-group-info.tsx` have the most substantial changes but both are well-structured.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/my-usage/_components/statistics-summary-card.tsx | Adds model breakdown pagination (5 per page) with page reset on date range change. Clean extraction into `ModelBreakdownColumn` component. `MODEL_BREAKDOWN_PAGE_SIZE` is defined after usage but is safe at runtime. |
| src/app/[locale]/my-usage/_components/quota-cards.tsx | Major refactor: replaces Card-based layout with compact row layout using inline progress bars, infinity icon for unlimited quotas, and `formatCurrency` for currency symbols. Cleaner and more compact design. |
| src/app/[locale]/my-usage/_components/provider-group-info.tsx | Adds Badge-based display for provider groups and access restrictions with abbreviated model/client names in tooltips. New `abbreviateModel` and `abbreviateClient` helper functions added. |
| src/app/[locale]/my-usage/_components/collapsible-quota-card.tsx | Trivial rename: `Infinity` import aliased to `InfinityIcon` to avoid shadowing the global `Infinity`. No logic changes. |
| messages/en/myUsage.json | Adds three new i18n keys for pagination controls in model breakdown section. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
flowchart TD
    A[StatisticsSummaryCard] -->|date range change| B[Reset breakdownPage to 1]
    A -->|loadStats| C[Fetch MyStatsSummary]
    C --> D{stats available?}
    D -->|yes| E[Compute maxBreakdownLen]
    E --> F[Slice keyModelBreakdown & userModelBreakdown]
    F --> G[ModelBreakdownColumn key]
    F --> H[ModelBreakdownColumn user]
    G --> I[ModelBreakdownRow x N]
    H --> J[ModelBreakdownRow x N]
    D -->|no| K[Show noData]

    L[QuotaCards] --> M[QuotaBlock per quota item]
    M --> N[QuotaRow keyLevel]
    M --> O[QuotaRow userLevel]
    N --> P{unlimited?}
    P -->|yes| Q[InfinityIcon + muted bar]
    P -->|no| R[Progress bar + formatted value]
    O --> P

    S[ProviderGroupInfo] --> T[Badge for groups]
    S --> U{hasModels?}
    U -->|yes| V[Tooltip + Badge with abbreviateModel]
    U -->|no| W[noRestrictions text]
```
</details>


<sub>Last reviewed commit: 3007012</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->