### PR TITLE
refactor(proxy): introduce EndpointPolicy to replace hardcoded count_tokens checks

### DIFF
--- a/src/app/v1/_lib/proxy/endpoint-paths.ts
+++ b/src/app/v1/_lib/proxy/endpoint-paths.ts
@@ -1,0 +1,64 @@
+const V1_PREFIX = "/v1";
+
+export const V1_ENDPOINT_PATHS = {
+  MESSAGES: "/v1/messages",
+  MESSAGES_COUNT_TOKENS: "/v1/messages/count_tokens",
+  RESPONSES: "/v1/responses",
+  RESPONSES_COMPACT: "/v1/responses/compact",
+  CHAT_COMPLETIONS: "/v1/chat/completions",
+  MODELS: "/v1/models",
+} as const;
+
+export const STANDARD_ENDPOINT_PATHS = [
+  V1_ENDPOINT_PATHS.MESSAGES,
+  V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS,
+  V1_ENDPOINT_PATHS.RESPONSES,
+  V1_ENDPOINT_PATHS.RESPONSES_COMPACT,
+  V1_ENDPOINT_PATHS.CHAT_COMPLETIONS,
+  V1_ENDPOINT_PATHS.MODELS,
+] as const;
+
+export const STRICT_STANDARD_ENDPOINT_PATHS = [
+  V1_ENDPOINT_PATHS.MESSAGES,
+  V1_ENDPOINT_PATHS.RESPONSES,
+  V1_ENDPOINT_PATHS.RESPONSES_COMPACT,
+  V1_ENDPOINT_PATHS.CHAT_COMPLETIONS,
+] as const;
+
+const standardEndpointPathSet = new Set<string>(STANDARD_ENDPOINT_PATHS);
+const strictStandardEndpointPathSet = new Set<string>(STRICT_STANDARD_ENDPOINT_PATHS);
+
+export function normalizeEndpointPath(pathname: string): string {
+  const pathWithoutQuery = pathname.split("?")[0];
+  const trimmedPath =
+    pathWithoutQuery.length > 1 && pathWithoutQuery.endsWith("/")
+      ? pathWithoutQuery.slice(0, -1)
+      : pathWithoutQuery;
+
+  return trimmedPath.toLowerCase();
+}
+
+export function isStandardEndpointPath(pathname: string): boolean {
+  return standardEndpointPathSet.has(normalizeEndpointPath(pathname));
+}
+
+export function isStrictStandardEndpointPath(pathname: string): boolean {
+  return strictStandardEndpointPathSet.has(normalizeEndpointPath(pathname));
+}
+
+export function isCountTokensEndpointPath(pathname: string): boolean {
+  return normalizeEndpointPath(pathname) === V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS;
+}
+
+export function isResponseCompactEndpointPath(pathname: string): boolean {
+  return normalizeEndpointPath(pathname) === V1_ENDPOINT_PATHS.RESPONSES_COMPACT;
+}
+
+export function toV1RoutePath(pathname: string): string {
+  if (!pathname.startsWith(V1_PREFIX)) {
+    return pathname;
+  }
+
+  const routePath = pathname.slice(V1_PREFIX.length);
+  return routePath.length > 0 ? routePath : "/";
+}

--- a/src/app/v1/_lib/proxy/endpoint-policy.ts
+++ b/src/app/v1/_lib/proxy/endpoint-policy.ts
@@ -1,0 +1,68 @@
+import { normalizeEndpointPath, V1_ENDPOINT_PATHS } from "./endpoint-paths";
+
+export type EndpointGuardPreset = "chat" | "raw_passthrough";
+
+export type EndpointPoolStrictness = "inherit" | "strict";
+
+export interface EndpointPolicy {
+  readonly kind: "default" | "raw_passthrough";
+  readonly guardPreset: EndpointGuardPreset;
+  readonly allowRetry: boolean;
+  readonly allowProviderSwitch: boolean;
+  readonly allowCircuitBreakerAccounting: boolean;
+  readonly trackConcurrentRequests: boolean;
+  readonly bypassRequestFilters: boolean;
+  readonly bypassForwarderPreprocessing: boolean;
+  readonly bypassSpecialSettings: boolean;
+  readonly bypassResponseRectifier: boolean;
+  readonly endpointPoolStrictness: EndpointPoolStrictness;
+}
+
+const DEFAULT_ENDPOINT_POLICY: EndpointPolicy = Object.freeze({
+  kind: "default",
+  guardPreset: "chat",
+  allowRetry: true,
+  allowProviderSwitch: true,
+  allowCircuitBreakerAccounting: true,
+  trackConcurrentRequests: true,
+  bypassRequestFilters: false,
+  bypassForwarderPreprocessing: false,
+  bypassSpecialSettings: false,
+  bypassResponseRectifier: false,
+  endpointPoolStrictness: "inherit",
+});
+
+const RAW_PASSTHROUGH_ENDPOINT_POLICY: EndpointPolicy = Object.freeze({
+  kind: "raw_passthrough",
+  guardPreset: "raw_passthrough",
+  allowRetry: false,
+  allowProviderSwitch: false,
+  allowCircuitBreakerAccounting: false,
+  trackConcurrentRequests: false,
+  bypassRequestFilters: true,
+  bypassForwarderPreprocessing: true,
+  bypassSpecialSettings: true,
+  bypassResponseRectifier: true,
+  endpointPoolStrictness: "strict",
+});
+
+const rawPassthroughEndpointPathSet = new Set<string>([
+  V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS,
+  V1_ENDPOINT_PATHS.RESPONSES_COMPACT,
+]);
+
+export function isRawPassthroughEndpointPath(pathname: string): boolean {
+  return rawPassthroughEndpointPathSet.has(normalizeEndpointPath(pathname));
+}
+
+export function isRawPassthroughEndpointPolicy(policy: EndpointPolicy): boolean {
+  return policy.kind === "raw_passthrough";
+}
+
+export function resolveEndpointPolicy(pathname: string): EndpointPolicy {
+  if (isRawPassthroughEndpointPath(pathname)) {
+    return RAW_PASSTHROUGH_ENDPOINT_POLICY;
+  }
+
+  return DEFAULT_ENDPOINT_POLICY;
+}

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -1621,18 +1621,19 @@ export class ProxyForwarder {
               break;
             }
 
-            // 🆕 count_tokens 请求特殊处理：不计入熔断，不触发供应商切换
-            if (session.isCountTokensRequest()) {
+            // Raw passthrough endpoints: no circuit breaker, no provider switch, no retry
+            if (!session.getEndpointPolicy().allowRetry) {
               logger.debug(
-                "ProxyForwarder: count_tokens request error, skipping circuit breaker and provider switch",
+                "ProxyForwarder: raw passthrough endpoint error, skipping circuit breaker and provider switch",
                 {
                   providerId: currentProvider.id,
                   providerName: currentProvider.name,
                   statusCode,
                   error: proxyError.message,
+                  policyKind: session.getEndpointPolicy().kind,
                 }
               );
-              // 直接抛出错误，不重试，不切换供应商
+              // Throw immediately: no retry, no provider switch
               throw lastError;
             }
 
@@ -1780,12 +1781,14 @@ export class ProxyForwarder {
       session.setContext1mApplied(context1mApplied);
     }
 
-    // 应用模型重定向（如果配置了）
-    const wasRedirected = ModelRedirector.apply(session, provider);
-    if (wasRedirected) {
-      logger.debug("ProxyForwarder: Model redirected", {
-        providerId: provider.id,
-      });
+    // Apply model redirect (if configured) - skip for raw passthrough endpoints
+    if (!session.getEndpointPolicy().bypassForwarderPreprocessing) {
+      const wasRedirected = ModelRedirector.apply(session, provider);
+      if (wasRedirected) {
+        logger.debug("ProxyForwarder: Model redirected", {
+          providerId: provider.id,
+        });
+      }
     }
 
     let processedHeaders: Headers;
@@ -1898,138 +1901,140 @@ export class ProxyForwarder {
       });
     } else {
       // --- STANDARD HANDLING ---
-      if (
-        resolvedCacheTtl &&
-        (provider.providerType === "claude" || provider.providerType === "claude-auth")
-      ) {
-        const applied = applyCacheTtlOverrideToMessage(session.request.message, resolvedCacheTtl);
-        if (applied) {
-          logger.info("ProxyForwarder: Applied cache TTL override to request", {
-            providerId: provider.id,
-            providerName: provider.name,
-            cacheTtl: resolvedCacheTtl,
-          });
-        }
-      }
-
-      // Codex 供应商级参数覆写（默认 inherit=遵循客户端）
-      if (provider.providerType === "codex") {
-        const { request: overridden, audit } = applyCodexProviderOverridesWithAudit(
-          provider,
-          session.request.message as Record<string, unknown>
-        );
-        session.request.message = overridden;
-
-        if (audit) {
-          session.addSpecialSetting(audit);
-          const specialSettings = session.getSpecialSettings();
-
-          if (session.sessionId) {
-            // 这里用 await：避免后续响应侧写入（ResponseFixer 等）先完成后，被本次旧快照覆写
-            await SessionManager.storeSessionSpecialSettings(
-              session.sessionId,
-              specialSettings,
-              session.requestSequence
-            ).catch((err) => {
-              logger.error("[ProxyForwarder] Failed to store special settings", {
-                error: err,
-                sessionId: session.sessionId,
-              });
-            });
-          }
-
-          if (session.messageContext?.id) {
-            // 同上：确保 special_settings 的"旧值"不会在并发下覆盖"新值"
-            await updateMessageRequestDetails(session.messageContext.id, {
-              specialSettings,
-            }).catch((err) => {
-              logger.error("[ProxyForwarder] Failed to persist special settings", {
-                error: err,
-                messageRequestId: session.messageContext?.id,
-              });
+      if (!session.getEndpointPolicy().bypassForwarderPreprocessing) {
+        if (
+          resolvedCacheTtl &&
+          (provider.providerType === "claude" || provider.providerType === "claude-auth")
+        ) {
+          const applied = applyCacheTtlOverrideToMessage(session.request.message, resolvedCacheTtl);
+          if (applied) {
+            logger.info("ProxyForwarder: Applied cache TTL override to request", {
+              providerId: provider.id,
+              providerName: provider.name,
+              cacheTtl: resolvedCacheTtl,
             });
           }
         }
-      }
 
-      // Anthropic 供应商级参数覆写（默认 inherit=遵循客户端）
-      // 说明：允许管理员在供应商层面强制覆写 max_tokens 和 thinking.budget_tokens
-      if (provider.providerType === "claude" || provider.providerType === "claude-auth") {
-        // Billing header rectifier: proactively strip x-anthropic-billing-header from system prompt
-        {
-          const settings = await getCachedSystemSettings();
-          const billingRectifierEnabled = settings.enableBillingHeaderRectifier ?? true;
-          if (billingRectifierEnabled) {
-            const billingResult = rectifyBillingHeader(
-              session.request.message as Record<string, unknown>
-            );
-            if (billingResult.applied) {
-              session.addSpecialSetting({
-                type: "billing_header_rectifier",
-                scope: "request",
-                hit: true,
-                removedCount: billingResult.removedCount,
-                extractedValues: billingResult.extractedValues,
+        // Codex 供应商级参数覆写（默认 inherit=遵循客户端）
+        if (provider.providerType === "codex") {
+          const { request: overridden, audit } = applyCodexProviderOverridesWithAudit(
+            provider,
+            session.request.message as Record<string, unknown>
+          );
+          session.request.message = overridden;
+
+          if (audit) {
+            session.addSpecialSetting(audit);
+            const specialSettings = session.getSpecialSettings();
+
+            if (session.sessionId) {
+              // 这里用 await：避免后续响应侧写入（ResponseFixer 等）先完成后，被本次旧快照覆写
+              await SessionManager.storeSessionSpecialSettings(
+                session.sessionId,
+                specialSettings,
+                session.requestSequence
+              ).catch((err) => {
+                logger.error("[ProxyForwarder] Failed to store special settings", {
+                  error: err,
+                  sessionId: session.sessionId,
+                });
               });
-              logger.info("ProxyForwarder: Billing header rectifier applied", {
-                providerId: provider.id,
-                providerName: provider.name,
-                removedCount: billingResult.removedCount,
+            }
+
+            if (session.messageContext?.id) {
+              // 同上：确保 special_settings 的"旧值"不会在并发下覆盖"新值"
+              await updateMessageRequestDetails(session.messageContext.id, {
+                specialSettings,
+              }).catch((err) => {
+                logger.error("[ProxyForwarder] Failed to persist special settings", {
+                  error: err,
+                  messageRequestId: session.messageContext?.id,
+                });
               });
-              await persistSpecialSettings(session);
             }
           }
         }
 
-        const { request: anthropicOverridden, audit: anthropicAudit } =
-          applyAnthropicProviderOverridesWithAudit(
-            provider,
-            session.request.message as Record<string, unknown>
-          );
-        session.request.message = anthropicOverridden;
-
-        if (anthropicAudit) {
-          session.addSpecialSetting(anthropicAudit);
-          const specialSettings = session.getSpecialSettings();
-
-          if (session.sessionId) {
-            await SessionManager.storeSessionSpecialSettings(
-              session.sessionId,
-              specialSettings,
-              session.requestSequence
-            ).catch((err) => {
-              logger.error("[ProxyForwarder] Failed to store Anthropic special settings", {
-                error: err,
-                sessionId: session.sessionId,
-              });
-            });
+        // Anthropic 供应商级参数覆写（默认 inherit=遵循客户端）
+        // 说明：允许管理员在供应商层面强制覆写 max_tokens 和 thinking.budget_tokens
+        if (provider.providerType === "claude" || provider.providerType === "claude-auth") {
+          // Billing header rectifier: proactively strip x-anthropic-billing-header from system prompt
+          {
+            const settings = await getCachedSystemSettings();
+            const billingRectifierEnabled = settings.enableBillingHeaderRectifier ?? true;
+            if (billingRectifierEnabled) {
+              const billingResult = rectifyBillingHeader(
+                session.request.message as Record<string, unknown>
+              );
+              if (billingResult.applied) {
+                session.addSpecialSetting({
+                  type: "billing_header_rectifier",
+                  scope: "request",
+                  hit: true,
+                  removedCount: billingResult.removedCount,
+                  extractedValues: billingResult.extractedValues,
+                });
+                logger.info("ProxyForwarder: Billing header rectifier applied", {
+                  providerId: provider.id,
+                  providerName: provider.name,
+                  removedCount: billingResult.removedCount,
+                });
+                await persistSpecialSettings(session);
+              }
+            }
           }
 
-          if (session.messageContext?.id) {
-            await updateMessageRequestDetails(session.messageContext.id, {
-              specialSettings,
-            }).catch((err) => {
-              logger.error("[ProxyForwarder] Failed to persist Anthropic special settings", {
-                error: err,
-                messageRequestId: session.messageContext?.id,
+          const { request: anthropicOverridden, audit: anthropicAudit } =
+            applyAnthropicProviderOverridesWithAudit(
+              provider,
+              session.request.message as Record<string, unknown>
+            );
+          session.request.message = anthropicOverridden;
+
+          if (anthropicAudit) {
+            session.addSpecialSetting(anthropicAudit);
+            const specialSettings = session.getSpecialSettings();
+
+            if (session.sessionId) {
+              await SessionManager.storeSessionSpecialSettings(
+                session.sessionId,
+                specialSettings,
+                session.requestSequence
+              ).catch((err) => {
+                logger.error("[ProxyForwarder] Failed to store Anthropic special settings", {
+                  error: err,
+                  sessionId: session.sessionId,
+                });
               });
+            }
+
+            if (session.messageContext?.id) {
+              await updateMessageRequestDetails(session.messageContext.id, {
+                specialSettings,
+              }).catch((err) => {
+                logger.error("[ProxyForwarder] Failed to persist Anthropic special settings", {
+                  error: err,
+                  messageRequestId: session.messageContext?.id,
+                });
+              });
+            }
+          }
+        }
+
+        if (
+          resolvedCacheTtl &&
+          (provider.providerType === "claude" || provider.providerType === "claude-auth")
+        ) {
+          const applied = applyCacheTtlOverrideToMessage(session.request.message, resolvedCacheTtl);
+          if (applied) {
+            logger.debug("ProxyForwarder: Applied cache TTL override to request", {
+              providerId: provider.id,
+              ttl: resolvedCacheTtl,
             });
           }
         }
-      }
-
-      if (
-        resolvedCacheTtl &&
-        (provider.providerType === "claude" || provider.providerType === "claude-auth")
-      ) {
-        const applied = applyCacheTtlOverrideToMessage(session.request.message, resolvedCacheTtl);
-        if (applied) {
-          logger.debug("ProxyForwarder: Applied cache TTL override to request", {
-            providerId: provider.id,
-            ttl: resolvedCacheTtl,
-          });
-        }
-      }
+      } // end bypassForwarderPreprocessing gate
 
       processedHeaders = ProxyForwarder.buildHeaders(session, provider);
 

--- a/src/app/v1/_lib/proxy/provider-request-filter.ts
+++ b/src/app/v1/_lib/proxy/provider-request-filter.ts
@@ -9,6 +9,10 @@ import type { ProxySession } from "./session";
  */
 export class ProxyProviderRequestFilter {
   static async ensure(session: ProxySession): Promise<void> {
+    if (session.getEndpointPolicy().bypassRequestFilters) {
+      return;
+    }
+
     if (!session.provider) {
       logger.warn(
         "[ProxyProviderRequestFilter] No provider selected, skipping provider-specific filters"

--- a/src/app/v1/_lib/proxy/request-filter.ts
+++ b/src/app/v1/_lib/proxy/request-filter.ts
@@ -12,6 +12,10 @@ import type { ProxySession } from "./session";
  */
 export class ProxyRequestFilter {
   static async ensure(session: ProxySession): Promise<void> {
+    if (session.getEndpointPolicy().bypassRequestFilters) {
+      return;
+    }
+
     try {
       await requestFilterEngine.applyGlobal(session);
     } catch (error) {

--- a/tests/unit/proxy/endpoint-path-normalization.test.ts
+++ b/tests/unit/proxy/endpoint-path-normalization.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import { isRawPassthroughEndpointPath } from "@/app/v1/_lib/proxy/endpoint-policy";
+import {
+  isCountTokensEndpointPath,
+  isResponseCompactEndpointPath,
+} from "@/app/v1/_lib/proxy/endpoint-paths";
+import { ProxySession } from "@/app/v1/_lib/proxy/session";
+
+const countTokensVariants = [
+  "/v1/messages/count_tokens",
+  "/v1/messages/count_tokens/",
+  "/V1/MESSAGES/COUNT_TOKENS",
+];
+
+const compactVariants = [
+  "/v1/responses/compact",
+  "/v1/responses/compact/",
+  "/V1/RESPONSES/COMPACT",
+];
+
+function isCountTokensRequestWithEndpoint(pathname: string | null): boolean {
+  const sessionLike = {
+    getEndpoint: () => pathname,
+  } as Pick<ProxySession, "getEndpoint">;
+
+  return ProxySession.prototype.isCountTokensRequest.call(sessionLike as ProxySession);
+}
+
+describe("endpoint path normalization", () => {
+  test.each(countTokensVariants)("count_tokens stays classified for variant %s", (pathname) => {
+    expect(isCountTokensEndpointPath(pathname)).toBe(true);
+    expect(isRawPassthroughEndpointPath(pathname)).toBe(true);
+    expect(isCountTokensRequestWithEndpoint(pathname)).toBe(true);
+  });
+
+  test.each(compactVariants)("responses/compact stays classified for variant %s", (pathname) => {
+    expect(isResponseCompactEndpointPath(pathname)).toBe(true);
+    expect(isRawPassthroughEndpointPath(pathname)).toBe(true);
+  });
+
+  test.each([
+    "/v1/messages",
+    "/v1/responses",
+    "/v1/messages/count",
+    "/v1/responses/mini",
+  ])("non-target path is not misclassified for %s", (pathname) => {
+    expect(isCountTokensEndpointPath(pathname)).toBe(false);
+    expect(isResponseCompactEndpointPath(pathname)).toBe(false);
+    expect(isRawPassthroughEndpointPath(pathname)).toBe(false);
+    expect(isCountTokensRequestWithEndpoint(pathname)).toBe(false);
+  });
+
+  test("session count_tokens detection handles null endpoint", () => {
+    expect(isCountTokensRequestWithEndpoint(null)).toBe(false);
+  });
+});

--- a/tests/unit/proxy/endpoint-policy-parity.test.ts
+++ b/tests/unit/proxy/endpoint-policy-parity.test.ts
@@ -1,0 +1,341 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  type EndpointPolicy,
+  isRawPassthroughEndpointPath,
+  isRawPassthroughEndpointPolicy,
+  resolveEndpointPolicy,
+} from "@/app/v1/_lib/proxy/endpoint-policy";
+import { V1_ENDPOINT_PATHS } from "@/app/v1/_lib/proxy/endpoint-paths";
+
+// ---------------------------------------------------------------------------
+// Shared constants
+// ---------------------------------------------------------------------------
+
+const RAW_PASSTHROUGH_ENDPOINTS = [
+  V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS,
+  V1_ENDPOINT_PATHS.RESPONSES_COMPACT,
+] as const;
+
+const DEFAULT_ENDPOINTS = [
+  V1_ENDPOINT_PATHS.MESSAGES,
+  V1_ENDPOINT_PATHS.RESPONSES,
+  V1_ENDPOINT_PATHS.CHAT_COMPLETIONS,
+] as const;
+
+// ---------------------------------------------------------------------------
+// T11: Endpoint parity -- count_tokens and responses/compact produce
+//      identical EndpointPolicy objects and exhibit identical behaviour
+//      under provider errors.
+// ---------------------------------------------------------------------------
+
+describe("T11: raw passthrough endpoint parity", () => {
+  test("count_tokens and responses/compact resolve to the exact same EndpointPolicy object", () => {
+    const countTokensPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS);
+    const compactPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.RESPONSES_COMPACT);
+
+    // Reference equality: same frozen singleton
+    expect(countTokensPolicy).toBe(compactPolicy);
+
+    // Both recognized as raw_passthrough
+    expect(isRawPassthroughEndpointPolicy(countTokensPolicy)).toBe(true);
+    expect(isRawPassthroughEndpointPolicy(compactPolicy)).toBe(true);
+  });
+
+  test("both raw passthrough endpoints have identical strict policy fields", () => {
+    const countTokensPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS);
+    const compactPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.RESPONSES_COMPACT);
+
+    const expectedPolicy: EndpointPolicy = {
+      kind: "raw_passthrough",
+      guardPreset: "raw_passthrough",
+      allowRetry: false,
+      allowProviderSwitch: false,
+      allowCircuitBreakerAccounting: false,
+      trackConcurrentRequests: false,
+      bypassRequestFilters: true,
+      bypassForwarderPreprocessing: true,
+      bypassSpecialSettings: true,
+      bypassResponseRectifier: true,
+      endpointPoolStrictness: "strict",
+    };
+
+    expect(countTokensPolicy).toEqual(expectedPolicy);
+    expect(compactPolicy).toEqual(expectedPolicy);
+  });
+
+  test("under provider error, both endpoints result in no retry, no provider switch, no circuit breaker accounting", () => {
+    for (const pathname of RAW_PASSTHROUGH_ENDPOINTS) {
+      const policy = resolveEndpointPolicy(pathname);
+
+      expect(policy.allowRetry).toBe(false);
+      expect(policy.allowProviderSwitch).toBe(false);
+      expect(policy.allowCircuitBreakerAccounting).toBe(false);
+    }
+  });
+
+  test("isRawPassthroughEndpointPath returns true for both raw passthrough canonical paths", () => {
+    for (const pathname of RAW_PASSTHROUGH_ENDPOINTS) {
+      expect(isRawPassthroughEndpointPath(pathname)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T12: Bypass completeness -- spy-based zero-call assertions to verify that
+//      request filter guards early-return without invoking the engine.
+// ---------------------------------------------------------------------------
+
+const applyGlobalMock = vi.fn(async () => {});
+const applyForProviderMock = vi.fn(async () => {});
+
+vi.mock("@/lib/request-filter-engine", () => ({
+  requestFilterEngine: {
+    applyGlobal: applyGlobalMock,
+    applyForProvider: applyForProviderMock,
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+describe("T12: bypass completeness (spy-based zero-call assertions)", () => {
+  beforeEach(() => {
+    applyGlobalMock.mockClear();
+    applyForProviderMock.mockClear();
+  });
+
+  test("ProxyRequestFilter.ensure early-returns without calling applyGlobal for raw passthrough", async () => {
+    const { ProxyRequestFilter } = await import("@/app/v1/_lib/proxy/request-filter");
+
+    for (const pathname of RAW_PASSTHROUGH_ENDPOINTS) {
+      applyGlobalMock.mockClear();
+
+      const session = {
+        getEndpointPolicy: () => resolveEndpointPolicy(pathname),
+      } as any;
+
+      await ProxyRequestFilter.ensure(session);
+      expect(applyGlobalMock).not.toHaveBeenCalled();
+    }
+  });
+
+  test("ProxyProviderRequestFilter.ensure early-returns without calling applyForProvider for raw passthrough", async () => {
+    const { ProxyProviderRequestFilter } = await import(
+      "@/app/v1/_lib/proxy/provider-request-filter"
+    );
+
+    for (const pathname of RAW_PASSTHROUGH_ENDPOINTS) {
+      applyForProviderMock.mockClear();
+
+      const session = {
+        getEndpointPolicy: () => resolveEndpointPolicy(pathname),
+        provider: { id: 1 },
+      } as any;
+
+      await ProxyProviderRequestFilter.ensure(session);
+      expect(applyForProviderMock).not.toHaveBeenCalled();
+    }
+  });
+
+  test("ProxyRequestFilter.ensure calls applyGlobal for default policy endpoints", async () => {
+    const { ProxyRequestFilter } = await import("@/app/v1/_lib/proxy/request-filter");
+
+    for (const pathname of DEFAULT_ENDPOINTS) {
+      applyGlobalMock.mockClear();
+
+      const session = {
+        getEndpointPolicy: () => resolveEndpointPolicy(pathname),
+      } as any;
+
+      await ProxyRequestFilter.ensure(session);
+      expect(applyGlobalMock).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  test("ProxyProviderRequestFilter.ensure calls applyForProvider for default policy endpoints", async () => {
+    const { ProxyProviderRequestFilter } = await import(
+      "@/app/v1/_lib/proxy/provider-request-filter"
+    );
+
+    for (const pathname of DEFAULT_ENDPOINTS) {
+      applyForProviderMock.mockClear();
+
+      const session = {
+        getEndpointPolicy: () => resolveEndpointPolicy(pathname),
+        provider: { id: 1 },
+      } as any;
+
+      await ProxyProviderRequestFilter.ensure(session);
+      expect(applyForProviderMock).toHaveBeenCalledTimes(1);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T13: Non-target regression -- default endpoints retain full default policy.
+// ---------------------------------------------------------------------------
+
+describe("T13: non-target regression (default policy preserved)", () => {
+  const expectedDefaultPolicy: EndpointPolicy = {
+    kind: "default",
+    guardPreset: "chat",
+    allowRetry: true,
+    allowProviderSwitch: true,
+    allowCircuitBreakerAccounting: true,
+    trackConcurrentRequests: true,
+    bypassRequestFilters: false,
+    bypassForwarderPreprocessing: false,
+    bypassSpecialSettings: false,
+    bypassResponseRectifier: false,
+    endpointPoolStrictness: "inherit",
+  };
+
+  test("/v1/messages retains full default policy", () => {
+    const policy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.MESSAGES);
+    expect(policy).toEqual(expectedDefaultPolicy);
+    expect(isRawPassthroughEndpointPolicy(policy)).toBe(false);
+  });
+
+  test("/v1/responses retains full default policy", () => {
+    const policy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.RESPONSES);
+    expect(policy).toEqual(expectedDefaultPolicy);
+    expect(isRawPassthroughEndpointPolicy(policy)).toBe(false);
+  });
+
+  test("/v1/chat/completions retains full default policy", () => {
+    const policy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.CHAT_COMPLETIONS);
+    expect(policy).toEqual(expectedDefaultPolicy);
+    expect(isRawPassthroughEndpointPolicy(policy)).toBe(false);
+  });
+
+  test("all default endpoints resolve to the same singleton object", () => {
+    const policies = DEFAULT_ENDPOINTS.map((p) => resolveEndpointPolicy(p));
+    // All should be the same reference
+    for (let i = 1; i < policies.length; i++) {
+      expect(policies[i]).toBe(policies[0]);
+    }
+  });
+
+  test("default policy has all bypass flags set to false", () => {
+    for (const pathname of DEFAULT_ENDPOINTS) {
+      const policy = resolveEndpointPolicy(pathname);
+      expect(policy.bypassRequestFilters).toBe(false);
+      expect(policy.bypassForwarderPreprocessing).toBe(false);
+      expect(policy.bypassSpecialSettings).toBe(false);
+      expect(policy.bypassResponseRectifier).toBe(false);
+    }
+  });
+
+  test("default policy has all allow flags set to true", () => {
+    for (const pathname of DEFAULT_ENDPOINTS) {
+      const policy = resolveEndpointPolicy(pathname);
+      expect(policy.allowRetry).toBe(true);
+      expect(policy.allowProviderSwitch).toBe(true);
+      expect(policy.allowCircuitBreakerAccounting).toBe(true);
+      expect(policy.trackConcurrentRequests).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T14: Path edge-case tests -- normalization handles trailing slashes, case
+//      variants, query strings, and non-matching paths correctly.
+// ---------------------------------------------------------------------------
+
+describe("T14: path edge-case normalization", () => {
+  test("trailing slash: /v1/messages/count_tokens/ -> raw_passthrough", () => {
+    expect(isRawPassthroughEndpointPath("/v1/messages/count_tokens/")).toBe(true);
+    const policy = resolveEndpointPolicy("/v1/messages/count_tokens/");
+    expect(policy.kind).toBe("raw_passthrough");
+  });
+
+  test("trailing slash: /v1/responses/compact/ -> raw_passthrough", () => {
+    expect(isRawPassthroughEndpointPath("/v1/responses/compact/")).toBe(true);
+    const policy = resolveEndpointPolicy("/v1/responses/compact/");
+    expect(policy.kind).toBe("raw_passthrough");
+  });
+
+  test("uppercase: /V1/MESSAGES/COUNT_TOKENS -> raw_passthrough", () => {
+    expect(isRawPassthroughEndpointPath("/V1/MESSAGES/COUNT_TOKENS")).toBe(true);
+    const policy = resolveEndpointPolicy("/V1/MESSAGES/COUNT_TOKENS");
+    expect(policy.kind).toBe("raw_passthrough");
+  });
+
+  test("uppercase: /V1/RESPONSES/COMPACT -> raw_passthrough", () => {
+    expect(isRawPassthroughEndpointPath("/V1/RESPONSES/COMPACT")).toBe(true);
+    const policy = resolveEndpointPolicy("/V1/RESPONSES/COMPACT");
+    expect(policy.kind).toBe("raw_passthrough");
+  });
+
+  test("query string: /v1/messages/count_tokens?foo=bar -> raw_passthrough", () => {
+    expect(isRawPassthroughEndpointPath("/v1/messages/count_tokens?foo=bar")).toBe(true);
+    const policy = resolveEndpointPolicy("/v1/messages/count_tokens?foo=bar");
+    expect(policy.kind).toBe("raw_passthrough");
+  });
+
+  test("query string: /v1/responses/compact?foo=bar -> raw_passthrough", () => {
+    expect(isRawPassthroughEndpointPath("/v1/responses/compact?foo=bar")).toBe(true);
+    const policy = resolveEndpointPolicy("/v1/responses/compact?foo=bar");
+    expect(policy.kind).toBe("raw_passthrough");
+  });
+
+  test("combined edge case: uppercase + trailing slash + query string", () => {
+    expect(isRawPassthroughEndpointPath("/V1/MESSAGES/COUNT_TOKENS/?x=1")).toBe(true);
+    expect(isRawPassthroughEndpointPath("/V1/RESPONSES/COMPACT/?x=1")).toBe(true);
+
+    const policy1 = resolveEndpointPolicy("/V1/MESSAGES/COUNT_TOKENS/?x=1");
+    const policy2 = resolveEndpointPolicy("/V1/RESPONSES/COMPACT/?x=1");
+    expect(policy1.kind).toBe("raw_passthrough");
+    expect(policy2.kind).toBe("raw_passthrough");
+  });
+
+  test("/v1/messages/ (with trailing slash) -> default, NOT raw_passthrough", () => {
+    expect(isRawPassthroughEndpointPath("/v1/messages/")).toBe(false);
+    const policy = resolveEndpointPolicy("/v1/messages/");
+    expect(policy.kind).toBe("default");
+  });
+
+  test("/v1/messages (no trailing slash) -> default", () => {
+    expect(isRawPassthroughEndpointPath("/v1/messages")).toBe(false);
+    const policy = resolveEndpointPolicy("/v1/messages");
+    expect(policy.kind).toBe("default");
+  });
+
+  test("/v1/responses (no sub-path) -> default", () => {
+    expect(isRawPassthroughEndpointPath("/v1/responses")).toBe(false);
+    const policy = resolveEndpointPolicy("/v1/responses");
+    expect(policy.kind).toBe("default");
+  });
+
+  test("/v1/chat/completions -> default", () => {
+    expect(isRawPassthroughEndpointPath("/v1/chat/completions")).toBe(false);
+    const policy = resolveEndpointPolicy("/v1/chat/completions");
+    expect(policy.kind).toBe("default");
+  });
+
+  test.each([
+    "/v1/messages/count",
+    "/v1/messages/count_token",
+    "/v1/responses/mini",
+    "/v1/responses/compacted",
+    "/v2/messages/count_tokens",
+    "/v1/messages/count_tokens/extra",
+  ])("non-matching path %s -> default", (pathname) => {
+    expect(isRawPassthroughEndpointPath(pathname)).toBe(false);
+    const policy = resolveEndpointPolicy(pathname);
+    expect(policy.kind).toBe("default");
+  });
+
+  test("empty and root paths -> default", () => {
+    expect(resolveEndpointPolicy("/").kind).toBe("default");
+    expect(resolveEndpointPolicy("").kind).toBe("default");
+  });
+});

--- a/tests/unit/proxy/endpoint-policy.test.ts
+++ b/tests/unit/proxy/endpoint-policy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+import {
+  isRawPassthroughEndpointPath,
+  isRawPassthroughEndpointPolicy,
+  resolveEndpointPolicy,
+} from "@/app/v1/_lib/proxy/endpoint-policy";
+import { V1_ENDPOINT_PATHS } from "@/app/v1/_lib/proxy/endpoint-paths";
+
+describe("endpoint-policy", () => {
+  test("raw passthrough endpoints resolve to identical strict policy", () => {
+    const countTokensPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS);
+    const compactPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.RESPONSES_COMPACT);
+
+    expect(countTokensPolicy).toBe(compactPolicy);
+    expect(isRawPassthroughEndpointPolicy(countTokensPolicy)).toBe(true);
+    expect(countTokensPolicy).toEqual({
+      kind: "raw_passthrough",
+      guardPreset: "raw_passthrough",
+      allowRetry: false,
+      allowProviderSwitch: false,
+      allowCircuitBreakerAccounting: false,
+      trackConcurrentRequests: false,
+      bypassRequestFilters: true,
+      bypassForwarderPreprocessing: true,
+      bypassSpecialSettings: true,
+      bypassResponseRectifier: true,
+      endpointPoolStrictness: "strict",
+    });
+  });
+
+  test.each([
+    "/v1/messages/count_tokens/",
+    "/V1/MESSAGES/COUNT_TOKENS",
+    "/v1/responses/compact/",
+    "/V1/RESPONSES/COMPACT",
+  ])("raw passthrough endpoints path helper matches variant %s", (pathname) => {
+    expect(isRawPassthroughEndpointPath(pathname)).toBe(true);
+    expect(isRawPassthroughEndpointPolicy(resolveEndpointPolicy(pathname))).toBe(true);
+  });
+
+  test("default policy stays on non-target endpoints", () => {
+    const messagesPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.MESSAGES);
+    const responsesPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.RESPONSES);
+
+    expect(messagesPolicy).toBe(responsesPolicy);
+    expect(isRawPassthroughEndpointPolicy(messagesPolicy)).toBe(false);
+    expect(messagesPolicy).toEqual({
+      kind: "default",
+      guardPreset: "chat",
+      allowRetry: true,
+      allowProviderSwitch: true,
+      allowCircuitBreakerAccounting: true,
+      trackConcurrentRequests: true,
+      bypassRequestFilters: false,
+      bypassForwarderPreprocessing: false,
+      bypassSpecialSettings: false,
+      bypassResponseRectifier: false,
+      endpointPoolStrictness: "inherit",
+    });
+  });
+});

--- a/tests/unit/proxy/proxy-forwarder-fake-200-html.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-fake-200-html.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
 
 const mocks = vi.hoisted(() => {
   return {
@@ -185,6 +186,7 @@ function createSession(): ProxySession {
     specialSettings: [],
     cachedPriceData: undefined,
     cachedBillingModelSource: undefined,
+    endpointPolicy: resolveEndpointPolicy("/v1/messages"),
     isHeaderModified: () => false,
   });
 

--- a/tests/unit/proxy/proxy-forwarder-large-chunked-response.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-large-chunked-response.test.ts
@@ -2,6 +2,7 @@ import { createServer } from "node:http";
 import type { Socket } from "node:net";
 import { describe, expect, test, vi } from "vitest";
 import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
+import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
 import { ProxySession } from "@/app/v1/_lib/proxy/session";
 import type { Provider } from "@/types/provider";
 
@@ -128,6 +129,7 @@ function createSession(params?: { clientAbortSignal?: AbortSignal | null }): Pro
     specialSettings: [],
     cachedPriceData: undefined,
     cachedBillingModelSource: undefined,
+    endpointPolicy: resolveEndpointPolicy("/v1/chat/completions"),
     isHeaderModified: () => false,
   });
 

--- a/tests/unit/proxy/proxy-forwarder-nonok-body-hang.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-nonok-body-hang.test.ts
@@ -2,6 +2,7 @@ import { createServer } from "node:http";
 import type { Socket } from "node:net";
 import { describe, expect, test, vi } from "vitest";
 import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
+import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
 import { ProxyError } from "@/app/v1/_lib/proxy/errors";
 import { ProxySession } from "@/app/v1/_lib/proxy/session";
 import type { Provider } from "@/types/provider";
@@ -128,6 +129,7 @@ function createSession(params?: { clientAbortSignal?: AbortSignal | null }): Pro
     specialSettings: [],
     cachedPriceData: undefined,
     cachedBillingModelSource: undefined,
+    endpointPolicy: resolveEndpointPolicy("/v1/chat/completions"),
     isHeaderModified: () => false,
   });
 

--- a/tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts
+++ b/tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
 import type { ModelPriceData } from "@/types/model-price";
 
 // Track async tasks for draining
@@ -173,6 +174,7 @@ function createSession(opts?: { sessionId?: string | null }): ProxySession {
     specialSettings: [],
     cachedPriceData: undefined,
     cachedBillingModelSource: undefined,
+    endpointPolicy: resolveEndpointPolicy("/v1/messages"),
     isHeaderModified: () => false,
     getContext1mApplied: () => false,
     getOriginalModel: () => "test-model",

--- a/tests/unit/proxy/response-handler-gemini-stream-passthrough-timeouts.test.ts
+++ b/tests/unit/proxy/response-handler-gemini-stream-passthrough-timeouts.test.ts
@@ -2,6 +2,7 @@ import { createServer } from "node:http";
 import type { Socket } from "node:net";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
+import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
 import { ProxyResponseHandler } from "@/app/v1/_lib/proxy/response-handler";
 import { ProxySession } from "@/app/v1/_lib/proxy/session";
 import type { Provider } from "@/types/provider";
@@ -191,6 +192,7 @@ function createSession(params: {
     specialSettings: [],
     cachedPriceData: undefined,
     cachedBillingModelSource: undefined,
+    endpointPolicy: resolveEndpointPolicy("/v1/chat/completions"),
     isHeaderModified: () => false,
   });
 

--- a/tests/unit/proxy/response-handler-lease-decrement.test.ts
+++ b/tests/unit/proxy/response-handler-lease-decrement.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
 import type { ModelPriceData } from "@/types/model-price";
 
 // Track async tasks for draining
@@ -157,6 +158,7 @@ function createSession(opts: {
     specialSettings: [],
     cachedPriceData: undefined,
     cachedBillingModelSource: undefined,
+    endpointPolicy: resolveEndpointPolicy("/v1/messages"),
     isHeaderModified: () => false,
     getContext1mApplied: () => false,
     getOriginalModel: () => originalModel,


### PR DESCRIPTION
## Summary

Introduce `EndpointPolicy` system to replace scattered `isCountTokensRequest()` conditionals across the proxy pipeline. This generalizes the \"raw passthrough\" behavior to cover both `count_tokens` and `responses/compact` endpoints via a unified policy object resolved once at `ProxySession` construction.

## Related Issues

- Partially addresses #797 - Fixes the `prompt_cache_key` injection bug for `/v1/responses/compact` endpoint by bypassing forwarder preprocessing for raw passthrough endpoints.

## Problem

1. **Scattered conditional logic**: The codebase had hardcoded `isCountTokensRequest()` checks spread across proxy-handler, forwarder, response-handler, and filters - making it difficult to maintain consistent special-case handling.

2. **Codex CLI compact endpoint issues** (Issue #797):
   - Invalid `prompt_cache_key` parameter was being injected into `/v1/responses/compact` requests
   - Circuit breaker and retry logic were incorrectly applied to this internal diagnostic endpoint

3. **Extensibility**: Adding new special-case endpoints required modifying multiple files with repetitive conditional checks.

## Solution

Create a declarative `EndpointPolicy` system:

1. **Centralized path constants** (`endpoint-paths.ts`): Case-insensitive, trailing-slash tolerant, query-string safe path normalization

2. **Immutable policy objects** (`endpoint-policy.ts`): Two frozen policies:
   - `DEFAULT_ENDPOINT_POLICY`: Full pipeline for normal chat requests
   - `RAW_PASSTHROUGH_ENDPOINT_POLICY`: Minimal processing for `count_tokens` and `responses/compact`

3. **Policy-driven behavior**: All components now read from `session.getEndpointPolicy()` instead of hardcoded checks:
   - `trackConcurrentRequests`: Skip for passthrough endpoints
   - `bypassForwarderPreprocessing`: Skip model redirects, cache TTL overrides, provider-specific injections (fixes #797 bug 1)
   - `bypassRequestFilters`: Skip global/provider request filters
   - `bypassResponseRectifier`: Skip response fixer processing
   - `allowRetry`/`allowCircuitBreakerAccounting`: Skip for passthrough endpoints

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/endpoint-paths.ts` - Centralized endpoint path constants + normalization utilities
- `src/app/v1/_lib/proxy/endpoint-policy.ts` - `EndpointPolicy` interface with `resolveEndpointPolicy()` resolver
- `src/app/v1/_lib/proxy/session.ts` - Hold immutable `EndpointPolicy`, expose via `getEndpointPolicy()`
- `src/app/v1/_lib/proxy/guard-pipeline.ts` - New `fromSession()` / `fromEndpointPolicy()` builders; rename `COUNT_TOKENS_PIPELINE` -> `RAW_PASSTHROUGH_PIPELINE`
- `src/app/v1/_lib/proxy/forwarder.ts` - Gate retry/circuit-breaker/preprocessing on policy flags (`allowRetry`, `bypassForwarderPreprocessing`)
- `src/app/v1/_lib/proxy/response-handler.ts` - Gate circuit-breaker accounting and response rectifier on policy flags
- `src/app/v1/_lib/proxy/request-filter.ts` / `provider-request-filter.ts` - Early return when `bypassRequestFilters` is set
- `src/app/v1/_lib/proxy-handler.ts` - Use `trackConcurrentRequests` from policy instead of `isCountTokensRequest()`

### Tests (12 files)
- **New tests (3):**
  - `tests/unit/proxy/endpoint-path-normalization.test.ts` - Path normalization edge cases
  - `tests/unit/proxy/endpoint-policy.test.ts` - Policy resolution correctness
  - `tests/unit/proxy/endpoint-policy-parity.test.ts` - T11-T14: parity, bypass completeness, non-target regression, edge cases
- **Updated tests (9):**
  - All existing proxy tests updated to supply `endpointPolicy` in session stubs

## Breaking Changes

None. This is an internal refactoring that maintains backward compatibility.

## Test Plan

- [x] `bun run test` - 497 tests pass (45 files)
- [x] `bun run typecheck` - clean
- [x] `bun run lint` - clean
- [ ] Verify count_tokens requests still bypass session/rate-limit/message-context guards
- [ ] Verify responses/compact requests get the same raw passthrough treatment (fixes #797 part 1)
- [ ] Verify normal chat endpoints (/v1/messages, /v1/chat/completions) retain full pipeline behavior

## Implementation Notes

- The policy is resolved once at `ProxySession` construction and frozen - no runtime overhead
- `RAW_PASSTHROUGH_PIPELINE` guard steps: `[auth, client, model, version, probe, provider]` - minimal validation only
- `fromRequestType()` is deprecated but retained for backward compatibility; new code should use `fromSession()` or `fromEndpointPolicy()`

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces scattered `isCountTokensRequest()` conditionals with a centralized `EndpointPolicy` system resolved once at `ProxySession` construction. The `count_tokens` and `responses/compact` endpoints now share a unified `raw_passthrough` policy that bypasses forwarder preprocessing (fixing the `prompt_cache_key` injection bug for `/v1/responses/compact`), request filters, response rectifier, circuit breaker accounting, retry logic, and concurrent request tracking. Normal chat endpoints retain the full pipeline via the frozen `default` policy.

- **New files**: `endpoint-paths.ts` (path constants + normalization), `endpoint-policy.ts` (`EndpointPolicy` interface + resolver)
- **Core changes**: `session.ts` holds immutable policy; `proxy-handler.ts`, `forwarder.ts`, `response-handler.ts`, `request-filter.ts`, `provider-request-filter.ts`, and `guard-pipeline.ts` all switch from hardcoded checks to policy-driven behavior
- **Guard pipeline**: `COUNT_TOKENS_PIPELINE` renamed to `RAW_PASSTHROUGH_PIPELINE` with fewer steps (removes `requestFilter`/`providerRequestFilter`); backward-compat alias retained
- **Tests**: 3 new test files with thorough parity, bypass, regression, and edge-case coverage; 9 existing test files updated with `endpointPolicy` in session stubs
- **Minor observations**: Several `EndpointPolicy` fields (`bypassSpecialSettings`, `allowProviderSwitch`, `endpointPoolStrictness`) and `endpoint-paths.ts` exports are defined but not consumed yet — these appear to be forward-looking placeholders
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is a well-structured internal refactoring with comprehensive test coverage and no behavioral regressions for standard endpoints.
- The refactoring cleanly centralizes previously scattered conditionals into a frozen, immutable policy resolved once at construction time. All six circuit-breaker sites, the response rectifier, forwarder preprocessing, and request filters are consistently gated. The follow-up commit fixes a duplicate cache TTL call introduced during the restructuring. Tests cover parity, bypass completeness, regression, and edge cases. Minor deduction for unused policy fields and dead exports that add surface area without consumption.
- `src/app/v1/_lib/proxy/endpoint-policy.ts` and `src/app/v1/_lib/proxy/endpoint-paths.ts` have unused exported symbols that could be cleaned up.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/endpoint-paths.ts | New file: Centralized endpoint path constants and normalization utilities. Several exported functions and constants (toV1RoutePath, STANDARD_ENDPOINT_PATHS, STRICT_STANDARD_ENDPOINT_PATHS, isStandardEndpointPath, isStrictStandardEndpointPath) are unused anywhere in the codebase. |
| src/app/v1/_lib/proxy/endpoint-policy.ts | New file: EndpointPolicy interface with two frozen singleton policies and resolver. Fields bypassSpecialSettings, allowProviderSwitch, and endpointPoolStrictness are defined but not consumed anywhere in production code. |
| src/app/v1/_lib/proxy/session.ts | Adds private readonly endpointPolicy field resolved at construction time. Defensive resolveSessionEndpointPolicy wrapper handles malformed URLs gracefully. isCountTokensRequest() updated to use normalized path matching. |
| src/app/v1/_lib/proxy/guard-pipeline.ts | Adds fromSession/fromEndpointPolicy builders; renames COUNT_TOKENS_PIPELINE to RAW_PASSTHROUGH_PIPELINE (with backward-compat alias). Removes requestFilter and providerRequestFilter steps from passthrough pipeline. |
| src/app/v1/_lib/proxy/forwarder.ts | Gates retry/circuit-breaker/preprocessing on policy flags. Cache TTL duplication fixed in follow-up commit. Reorder within bypass gate is correct (cache TTL now applied after provider overrides). |
| src/app/v1/_lib/proxy/response-handler.ts | All circuit breaker recordFailure calls and ResponseFixer invocation gated behind policy flags. Six circuit-breaker sites updated consistently. |
| src/app/v1/_lib/proxy-handler.ts | Switches from isCountTokensRequest() + RequestType enum to policy-driven pipeline selection and concurrent request tracking. Clean simplification. |
| src/app/v1/_lib/proxy/request-filter.ts | Adds early-return guard for bypassRequestFilters policy. Defense-in-depth alongside pipeline step removal. |
| src/app/v1/_lib/proxy/provider-request-filter.ts | Adds early-return guard for bypassRequestFilters policy. Defense-in-depth alongside pipeline step removal. |
| tests/unit/proxy/endpoint-policy-parity.test.ts | New test: Comprehensive parity tests (T11-T14) covering policy equality, bypass completeness via spies, non-target regression, and path edge cases. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
flowchart TD
    A[Incoming Request] --> B[ProxySession.fromContext]
    B --> C[resolveSessionEndpointPolicy<br/>pathname → EndpointPolicy]
    C --> D{policy.guardPreset}
    D -->|chat| E[CHAT_PIPELINE<br/>auth → sensitive → client → model<br/>→ version → probe → session → warmup<br/>→ requestFilter → rateLimit → provider<br/>→ providerRequestFilter → messageContext]
    D -->|raw_passthrough| F[RAW_PASSTHROUGH_PIPELINE<br/>auth → client → model<br/>→ version → probe → provider]
    E --> G[trackConcurrentRequests ✓]
    F --> H[trackConcurrentRequests ✗]
    G --> I[ProxyForwarder.send]
    H --> I
    I --> J{bypassForwarderPreprocessing?}
    J -->|No| K[Model redirect + Provider overrides<br/>+ Cache TTL + Billing rectifier]
    J -->|Yes| L[Skip all preprocessing]
    K --> M[Upstream Request]
    L --> M
    M --> N[ProxyResponseHandler.dispatch]
    N --> O{bypassResponseRectifier?}
    O -->|No| P[ResponseFixer.process]
    O -->|Yes| Q[Skip ResponseFixer]
    P --> R{allowCircuitBreakerAccounting?}
    Q --> R
    R -->|Yes| S[Record success/failure in circuit breaker]
    R -->|No| T[Skip circuit breaker accounting]
    S --> U[Return Response]
    T --> U
```
</details>


<sub>Last reviewed commit: 40b030d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->