### PR TITLE
feat(ledger): usage_ledger decoupling

### DIFF
--- a/drizzle/0073_magical_manta.sql
+++ b/drizzle/0073_magical_manta.sql
@@ -47,6 +47,8 @@ DECLARE
   v_is_success boolean;
 BEGIN
   IF NEW.blocked_by = 'warmup' THEN
+    -- If a ledger row already exists (row was originally non-warmup), mark it as warmup
+    UPDATE usage_ledger SET blocked_by = 'warmup' WHERE request_id = NEW.id;
     RETURN NEW;
   END IF;
 

--- a/src/lib/ledger-backfill/service.ts
+++ b/src/lib/ledger-backfill/service.ts
@@ -33,12 +33,12 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
     }
 
     try {
-    let totalProcessed = 0;
-    let totalInserted = 0;
-    let lastId = 0;
+      let totalProcessed = 0;
+      let totalInserted = 0;
+      let lastId = 0;
 
-    while (true) {
-      const batchResult = await tx.execute(sql`
+      while (true) {
+        const batchResult = await tx.execute(sql`
         WITH batch AS (
           SELECT
             mr.id,
@@ -135,32 +135,32 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
           COALESCE((SELECT MAX(id) FROM batch), 0)::integer AS max_id
       `);
 
-      const batchRow = (
-        batchResult as unknown as Array<{
-          processed?: number | string;
-          inserted?: number | string;
-          max_id?: number | string;
-        }>
-      )[0];
+        const batchRow = (
+          batchResult as unknown as Array<{
+            processed?: number | string;
+            inserted?: number | string;
+            max_id?: number | string;
+          }>
+        )[0];
 
-      const processed = Number(batchRow?.processed ?? 0);
-      const inserted = Number(batchRow?.inserted ?? 0);
-      const maxId = Number(batchRow?.max_id ?? 0);
+        const processed = Number(batchRow?.processed ?? 0);
+        const inserted = Number(batchRow?.inserted ?? 0);
+        const maxId = Number(batchRow?.max_id ?? 0);
 
-      if (processed === 0) {
-        break;
+        if (processed === 0) {
+          break;
+        }
+
+        totalProcessed += processed;
+        totalInserted += inserted;
+        lastId = maxId;
+
+        logger.info("Backfill progress", {
+          processed: totalProcessed,
+          inserted: totalInserted,
+          elapsed: Date.now() - startTime,
+        });
       }
-
-      totalProcessed += processed;
-      totalInserted += inserted;
-      lastId = maxId;
-
-      logger.info("Backfill progress", {
-        processed: totalProcessed,
-        inserted: totalInserted,
-        elapsed: Date.now() - startTime,
-      });
-    }
 
       const durationMs = Date.now() - startTime;
       return {

--- a/src/lib/ledger-backfill/trigger.sql
+++ b/src/lib/ledger-backfill/trigger.sql
@@ -5,6 +5,8 @@ DECLARE
   v_is_success boolean;
 BEGIN
   IF NEW.blocked_by = 'warmup' THEN
+    -- If a ledger row already exists (row was originally non-warmup), mark it as warmup
+    UPDATE usage_ledger SET blocked_by = 'warmup' WHERE request_id = NEW.id;
     RETURN NEW;
   END IF;
 

--- a/src/lib/ledger-fallback.ts
+++ b/src/lib/ledger-fallback.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { sql } from "drizzle-orm";
 import { db } from "@/drizzle/db";
+import { logger } from "@/lib/logger";
 
 let cachedResult: boolean | null = null;
 let cacheExpiry = 0;
@@ -18,9 +19,10 @@ export async function isLedgerOnlyMode(): Promise<boolean> {
     cachedResult = !hasData;
     cacheExpiry = now + 60_000;
     return cachedResult;
-  } catch {
-    cachedResult = true;
+  } catch (err) {
+    logger.warn("[ledger-fallback] Failed to check message_request existence", { error: err });
+    cachedResult = cachedResult ?? false;
     cacheExpiry = now + 60_000;
-    return true;
+    return cachedResult;
   }
 }

--- a/src/repository/usage-logs.ts
+++ b/src/repository/usage-logs.ts
@@ -975,7 +975,7 @@ export async function findUsageLogsStats(
   }
 
   if (providerId !== undefined) {
-    conditions.push(eq(usageLedger.providerId, providerId));
+    conditions.push(eq(usageLedger.finalProviderId, providerId));
   }
 
   const trimmedSessionId = filters.sessionId?.trim();
@@ -1029,8 +1029,10 @@ export async function findUsageLogsStats(
       ? baseQuery.innerJoin(keysTable, eq(usageLedger.key, keysTable.key))
       : baseQuery;
 
+  // In ledger-only mode, message_request is empty — skip the innerJoin to avoid zeroing all results
+  const ledgerOnly = await isLedgerOnlyMode();
   const query =
-    filters.minRetryCount !== undefined
+    filters.minRetryCount !== undefined && !ledgerOnly
       ? queryByKey.innerJoin(messageRequest, eq(usageLedger.requestId, messageRequest.id))
       : queryByKey;
 

--- a/tests/unit/repository/leaderboard-timezone-parentheses.test.ts
+++ b/tests/unit/repository/leaderboard-timezone-parentheses.test.ts
@@ -76,6 +76,24 @@ vi.mock("@/drizzle/db", () => {
 });
 
 vi.mock("@/drizzle/schema", () => ({
+  usageLedger: {
+    userId: "userId",
+    providerId: "providerId",
+    finalProviderId: "finalProviderId",
+    costUsd: "costUsd",
+    inputTokens: "inputTokens",
+    outputTokens: "outputTokens",
+    cacheCreationInputTokens: "cacheCreationInputTokens",
+    cacheReadInputTokens: "cacheReadInputTokens",
+    blockedBy: "blockedBy",
+    createdAt: "createdAt",
+    ttfbMs: "ttfbMs",
+    durationMs: "durationMs",
+    statusCode: "statusCode",
+    isSuccess: "isSuccess",
+    model: "model",
+    originalModel: "originalModel",
+  },
   messageRequest: {
     deletedAt: "deletedAt",
     providerId: "providerId",

--- a/tests/unit/repository/usage-logs-sessionid-filter.test.ts
+++ b/tests/unit/repository/usage-logs-sessionid-filter.test.ts
@@ -64,15 +64,21 @@ describe("Usage logs sessionId filter", () => {
         execute: vi.fn(async () => ({ count: 0 })),
       },
     }));
+    vi.doMock("@/lib/ledger-fallback", () => ({
+      isLedgerOnlyMode: vi.fn(async () => true),
+    }));
 
     const { findUsageLogsBatch } = await import("@/repository/usage-logs");
     await findUsageLogsBatch({});
     await findUsageLogsBatch({ sessionId: "   " });
 
-    expect(whereArgs).toHaveLength(2);
-    const baseWhereSql = sqlToString(whereArgs[0]).toLowerCase();
-    const blankWhereSql = sqlToString(whereArgs[1]).toLowerCase();
-    expect(blankWhereSql).toBe(baseWhereSql);
+    expect(whereArgs).toHaveLength(4);
+    const basePrimaryWhereSql = sqlToString(whereArgs[0]).toLowerCase();
+    const baseLedgerWhereSql = sqlToString(whereArgs[1]).toLowerCase();
+    const blankPrimaryWhereSql = sqlToString(whereArgs[2]).toLowerCase();
+    const blankLedgerWhereSql = sqlToString(whereArgs[3]).toLowerCase();
+    expect(blankPrimaryWhereSql).toBe(basePrimaryWhereSql);
+    expect(blankLedgerWhereSql).toBe(baseLedgerWhereSql);
   });
 
   test("findUsageLogsBatch: sessionId 应 trim 后精确匹配", async () => {
@@ -87,14 +93,20 @@ describe("Usage logs sessionId filter", () => {
         execute: vi.fn(async () => ({ count: 0 })),
       },
     }));
+    vi.doMock("@/lib/ledger-fallback", () => ({
+      isLedgerOnlyMode: vi.fn(async () => true),
+    }));
 
     const { findUsageLogsBatch } = await import("@/repository/usage-logs");
     await findUsageLogsBatch({ sessionId: "  abc  " });
 
-    expect(whereArgs.length).toBeGreaterThan(0);
-    const whereSql = sqlToString(whereArgs[0]).toLowerCase();
-    expect(whereSql).toContain("abc");
-    expect(whereSql).not.toContain("  abc  ");
+    expect(whereArgs).toHaveLength(2);
+    const primaryWhereSql = sqlToString(whereArgs[0]).toLowerCase();
+    const ledgerWhereSql = sqlToString(whereArgs[1]).toLowerCase();
+    expect(primaryWhereSql).toContain("abc");
+    expect(primaryWhereSql).not.toContain("  abc  ");
+    expect(ledgerWhereSql).toContain("abc");
+    expect(ledgerWhereSql).not.toContain("  abc  ");
   });
 
   test("findUsageLogsWithDetails: sessionId 为空/空白不应追加条件", async () => {

--- a/tests/unit/usage-ledger/cleanup-immunity.test.ts
+++ b/tests/unit/usage-ledger/cleanup-immunity.test.ts
@@ -7,7 +7,7 @@ const usersTs = readFileSync(resolve(process.cwd(), "src/actions/users.ts"), "ut
 
 describe("usage_ledger cleanup immunity", () => {
   it("log cleanup service never imports or queries usageLedger", () => {
-    expect(serviceTs).not.toContain("import.*usageLedger");
+    expect(serviceTs).not.toMatch(/import\b.*\busageLedger\b/);
     expect(serviceTs).not.toMatch(/from.*schema.*usageLedger/);
     expect(serviceTs).not.toContain("db.delete(usageLedger)");
     expect(serviceTs).not.toContain('from("usage_ledger")');


### PR DESCRIPTION
## Summary

Introduces `usage_ledger` as a durable, billing-safe read layer decoupled from `message_request` log churn.

## Related Issues
- Related to #800 - Leaderboard SQL AT TIME ZONE operator precedence issue (this PR migrates leaderboard read paths to use `usage_ledger`)

## Changes

### Core Infrastructure
- `usage_ledger` table with all billing-critical columns (no FK constraints, no deletedAt)
- PostgreSQL trigger `fn_upsert_usage_ledger` — fires on every non-warmup INSERT/UPDATE to `message_request`, UPSERT pattern, warmup rows excluded at trigger level, `is_success` and `final_provider_id` pre-computed
- Shared `LEDGER_BILLING_CONDITION` (`blockedBy IS NULL`)
- Idempotent backfill service (10k-row batches, advisory lock, ON CONFLICT DO NOTHING)
- Drizzle migration `0073_magical_manta.sql` + startup backfill hook (fire-and-forget)

### Read Path Migration
All quota/stats/leaderboard/overview functions now read from `usage_ledger`:
- `statistics.ts` — all 14 cost-sum and quota functions
- `leaderboard.ts` — all 4 leaderboard functions (uses `finalProviderId`, `isSuccess`)
- `overview.ts` — both overview metric functions
- `message.ts` — session aggregation functions
- `usage-logs.ts` — summary function
- `key.ts` + `provider.ts` — statistics queries
- `my-usage.ts` — today stats

### Features
- Ledger-only fallback mode (`isLedgerOnlyMode()`) — auto-detected, 60s cache
- Export enhancement: `full | excludeLogs | ledgerOnly` modes with i18n (5 languages)
- `resetUserAllStatistics()` now clears both `messageRequest` and `usageLedger`
- Log cleanup immunity — `usage_ledger` is intentionally immune to log cleanup

### Tests
- Unit test infrastructure for trigger verification
- Integration tests (`tests/integration/usage-ledger.test.ts`)
- Data consistency verification suite + script
- Fixed 5 unit tests to match new ledger-based implementations

## Verification
- `bun run typecheck` — clean
- `bun run test` — 3145 pass / 0 fail
- `bun run lint` — clean
- `bun run build` — clean

## Breaking Changes
None — all function signatures unchanged, interfaces unchanged, rate-limit algorithms untouched.

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses Bugbot review feedback for the `usage_ledger` decoupling feature. The changes focus on three main improvements:

**Key Fixes:**
- **Warmup row handling**: Added logic in the database trigger to mark existing ledger rows as warmup when a `message_request` row is updated to warmup status (lines 50-51 in migration). This prevents data inconsistency where a non-warmup row could exist in the ledger while the source is marked as warmup.
- **Advisory lock safety**: Switched from session-scoped `pg_advisory_lock` to transaction-scoped `pg_try_advisory_xact_lock` in the backfill service. This eliminates the risk of lock leaks in connection-pooled environments and removes the need for manual unlock logic.
- **Provider filtering bug**: Fixed `findUsageLogsStats` to correctly filter by `finalProviderId` instead of `providerId` when querying the ledger table, ensuring consistency with other ledger-based queries.
- **Ledger-only mode optimization**: Added logic to skip joining empty `message_request` table when `minRetryCount` filtering is applied in ledger-only mode, preventing query results from being zeroed out.

**Test Improvements:**
- Enhanced test stability by addressing timing issues in circuit breaker tests
- Added documentation comments for timezone parentheses regression tests
- Improved mock structures in usage logs tests

All changes are backwards compatible with no breaking changes to APIs or function signatures.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- All changes address specific Bugbot review feedback with well-tested solutions. The warmup handling fix prevents data inconsistency, the advisory lock improvement eliminates connection pool issues, and the provider filtering bug fix ensures correct query results. All tests pass (3145/3145), and the changes are incremental improvements to an existing feature with no breaking changes.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| drizzle/0073_magical_manta.sql | Added warmup row handling in trigger to mark existing ledger rows as warmup when message_request is updated to warmup status |
| src/lib/ledger-backfill/service.ts | Improved advisory lock to use transaction-scoped pg_try_advisory_xact_lock, eliminating need for manual unlock and making it connection-pool safe |
| src/lib/ledger-backfill/trigger.sql | Synchronized trigger function with migration file, adding warmup row handling logic |
| src/repository/usage-logs.ts | Fixed two bugs: uses finalProviderId for provider filtering in stats, and prevents joining empty message_request table in ledger-only mode |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Message Request Write] --> B{Trigger Fires}
    B -->|blocked_by = warmup| C[Update Existing Ledger Row<br/>Set blocked_by = warmup]
    B -->|Not warmup| D[Extract final_provider_id<br/>from provider_chain]
    D --> E[Compute is_success<br/>from error_message]
    E --> F[UPSERT usage_ledger<br/>ON CONFLICT request_id<br/>DO UPDATE]
    
    G[Backfill Service] -->|On Startup| H{Try Advisory Lock<br/>pg_try_advisory_xact_lock}
    H -->|Lock Acquired| I[Process 10k Batches<br/>FROM message_request<br/>WHERE id > lastId<br/>AND blocked_by != warmup]
    I --> J[INSERT INTO usage_ledger<br/>ON CONFLICT DO NOTHING]
    J -->|More Rows| I
    J -->|Complete| K[Return Summary<br/>Transaction Commits<br/>Lock Auto-Released]
    H -->|Lock Failed| L[Return Zero Summary<br/>Another Instance Running]
    
    M[Read Queries] --> N{Check Table State}
    N -->|message_request Empty| O[isLedgerOnlyMode = true<br/>Read from usage_ledger ONLY]
    N -->|message_request Has Data| P[isLedgerOnlyMode = false<br/>Read from message_request<br/>Fallback to usage_ledger if empty]
    
    Q[Statistics/Leaderboard] --> R[Query usage_ledger<br/>WHERE blocked_by IS NULL]
    S[Usage Logs] --> T{Primary Query Empty?}
    T -->|Yes & Ledger-Only Mode| U[Fallback Query<br/>FROM usage_ledger]
    T -->|No| V[Return Primary Results<br/>FROM message_request]
```
</details>


<sub>Last reviewed commit: 912b1bb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->