### PR TITLE
修复 My Usage 日期范围筛选多余分隔符

### DIFF
--- a/src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx
@@ -179,8 +179,6 @@ export function LogsDateRangePicker({
         ))}
       </div>
 
-      {/* Separator */}
-      <div className="h-6 w-px bg-border mx-1" />
 
       {/* Navigation and date display */}
       <div className="flex items-center gap-1">

--- a/src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx
@@ -179,7 +179,6 @@ export function LogsDateRangePicker({
         ))}
       </div>
 
-
       {/* Navigation and date display */}
       <div className="flex items-center gap-1">
         <Button


### PR DESCRIPTION
## Summary
Remove the redundant vertical separator between quick period buttons and date navigation in `LogsDateRangePicker` component to fix visual layout issues when the component wraps to multiple lines.

## Problem
In the My Usage page, non-admin users experience a visual layout issue with the date range picker:
- When the date range picker component wraps to two lines due to limited horizontal space, the vertical separator (`<div className="h-6 w-px bg-border mx-1" />`) between the quick period buttons and the date navigation section appears as an orphaned vertical line
- This creates poor visual appearance and confused UI structure

**Related Issues:**
- Related to #766 - Page optimization suggestions (general UI compactness improvements for logs page)

## Solution
Remove the separator element entirely. The spacing between the two sections is maintained by the parent container's `gap-2` class, so the separator is purely decorative and unnecessary.

### Changes Made
- **File:** `src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx`
- **Change:** Removed 3 lines (the separator div and its comment)

## Impact Assessment

| Aspect | Change |
|--------|--------|
| Visual appearance | Cleaner layout when component wraps |
| Functionality | No change |
| Accessibility | No change |
| Breaking changes | None |

## Testing

### Manual Testing Checklist
- [ ] Verify date range picker displays correctly on desktop (single row)
- [ ] Verify date range picker displays correctly on smaller screens (wrapped layout)
- [ ] Verify no visual regression in quick period button spacing
- [ ] Verify no visual regression in date navigation spacing
- [ ] Verify all functionality (period selection, date navigation, calendar popup) works correctly

### Screenshots
*Before:* The separator line appears between quick buttons and navigation, creating an orphaned vertical line when wrapped.

*After:* Clean separation without the orphaned separator line.

## Related Work
- Complements PR #788 which addresses the broader page optimization from #766 by compacting the stats panel and collapsing filters

---
*Description enhanced by Claude AI*