### PR TITLE
fix(proxy): persist Fake 200 error detail to DB/Redis and display in dashboard

### DIFF
--- a/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx
@@ -69,9 +69,11 @@ export function SummaryTab({
     specialSettings && specialSettings.length > 0 ? JSON.stringify(specialSettings, null, 2) : null;
   const isFake200PostStreamFailure =
     typeof errorMessage === "string" && errorMessage.startsWith("FAKE_200_");
+  const fake200Code =
+    isFake200PostStreamFailure && errorMessage ? errorMessage.split(": ")[0] : errorMessage;
   const fake200Reason =
-    isFake200PostStreamFailure && typeof errorMessage === "string"
-      ? t(getFake200ReasonKey(errorMessage, "fake200Reasons"))
+    isFake200PostStreamFailure && fake200Code
+      ? t(getFake200ReasonKey(fake200Code, "fake200Reasons"))
       : null;
 
   return (

--- a/src/app/[locale]/dashboard/logs/_components/provider-chain-popover.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/provider-chain-popover.tsx
@@ -131,9 +131,11 @@ export function ProviderChainPopover({
   const hasFake200PostStreamFailure = chain.some(
     (item) => typeof item.errorMessage === "string" && item.errorMessage.startsWith("FAKE_200_")
   );
-  const fake200CodeForDisplay = chain.find(
-    (item) => typeof item.errorMessage === "string" && item.errorMessage.startsWith("FAKE_200_")
-  )?.errorMessage;
+  const fake200CodeForDisplay = chain
+    .find(
+      (item) => typeof item.errorMessage === "string" && item.errorMessage.startsWith("FAKE_200_")
+    )
+    ?.errorMessage?.split(": ")[0];
 
   // Calculate actual request count (excluding intermediate states)
   const requestCount = chain.filter(isActualRequest).length;
@@ -545,7 +547,7 @@ export function ProviderChainPopover({
                             {t("logs.details.fake200DetectedReason", {
                               reason: t(
                                 getFake200ReasonKey(
-                                  item.errorMessage,
+                                  item.errorMessage.split(": ")[0],
                                   "logs.details.fake200Reasons"
                                 )
                               ),

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -330,7 +330,7 @@ async function finalizeDeferredStreamingFinalizationIfNeeded(
       attemptNumber: meta.attemptNumber,
       statusCode: effectiveStatusCode,
       statusCodeInferred,
-      errorMessage: detected.detail ?? detected.code,
+      errorMessage: detected.detail ? `${detected.code}: ${detected.detail}` : detected.code,
     });
 
     return { effectiveStatusCode, errorMessage, providerIdForPersistence };

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -185,7 +185,7 @@ async function finalizeDeferredStreamingFinalizationIfNeeded(
     } else {
       effectiveStatusCode = 502;
     }
-    errorMessage = detected.code;
+    errorMessage = detected.detail ? `${detected.code}: ${detected.detail}` : detected.code;
   } else if (!streamEndedNormally) {
     effectiveStatusCode = clientAborted ? 499 : 502;
     errorMessage = clientAborted ? "CLIENT_ABORTED" : (abortReason ?? "STREAM_ABORTED");
@@ -330,7 +330,7 @@ async function finalizeDeferredStreamingFinalizationIfNeeded(
       attemptNumber: meta.attemptNumber,
       statusCode: effectiveStatusCode,
       statusCodeInferred,
-      errorMessage: detected.code,
+      errorMessage: detected.detail ?? detected.code,
     });
 
     return { effectiveStatusCode, errorMessage, providerIdForPersistence };


### PR DESCRIPTION
## Summary

When upstream returns HTTP 200 but the JSON body contains `error.message` (Fake 200 detection code `FAKE_200_JSON_ERROR_MESSAGE_NON_EMPTY`), the actual error text from `detected.detail` was only logged via `logger.warn` and then discarded. Only `detected.code` was persisted.

This caused two UX issues:
1. **LogicTraceTab**: `providerChain[].errorMessage` showed the raw code `"FAKE_200_JSON_ERROR_MESSAGE_NON_EMPTY"` instead of the actual upstream error (e.g. "Invalid API key")
2. **SummaryTab**: `errorMessage` in DB was just the code, losing the actual cause

**Related Issues & PRs:**
- Fixes #749 - Original issue about upstream returning 200 + error body being misrecorded as success
- Follow-up to #790 - Extends fake 200 error logging improvements with proper detail persistence
- Follow-up to #765 - Core fake 200 detection and status inference improvements
- Follow-up to #735 - Initial SSE streaming fake-200 detection

## Changes

### `response-handler.ts`
- **DB/Redis persistence** (line 188): `errorMessage` now stores `"CODE: detail"` format (e.g. `"FAKE_200_JSON_ERROR_MESSAGE_NON_EMPTY: Invalid API key"`) so the actual error is persisted
- **Provider chain** (line 333): `addProviderToChain` now uses `detected.detail ?? detected.code`, so LogicTraceTab shows the actual error text

### `SummaryTab.tsx`
- Extract the code prefix from the new `"CODE: detail"` format before passing to `getFake200ReasonKey()` for correct i18n lookup
- `isFake200PostStreamFailure` check still works since the new format still starts with `"FAKE_200_"`

## Data Flow After Fix

```
Stream ends -> allContent collected
  -> detectUpstreamErrorFromSseOrJsonText(allContent)
  -> detected = { code: "FAKE_200_...", detail: "Invalid API key" }
  -> errorMessage = "FAKE_200_...: Invalid API key"        [DB + Redis]
  -> addProviderToChain({ errorMessage: "Invalid API key" }) [LogicTraceTab]
```

## Breaking Changes

None. This is a UX improvement that changes the internal format of `errorMessage` persistence but maintains backward compatibility:
- Old format: `"FAKE_200_JSON_ERROR_MESSAGE_NON_EMPTY"`
- New format: `"FAKE_200_JSON_ERROR_MESSAGE_NON_EMPTY: Invalid API key"`
- The `startsWith("FAKE_200_")` check in `SummaryTab.tsx` continues to work correctly

## Testing

### Automated Tests
- [x] `bun run typecheck` - passed
- [x] `bun run lint` - passed (no new warnings)
- [x] `bun run test` - 348 files, 3234 tests passed

### Manual Testing
- [ ] Send request through provider returning `{"error":{"message":"some error"}}` with HTTP 200, verify SummaryTab and LogicTraceTab display correctly

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No breaking changes

---
*Description enhanced with related issue/PR links*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Enhanced fake 200 error handling by persisting the actual upstream error detail (e.g., "Invalid API key") alongside the detection code in a `"CODE: detail"` format, improving visibility in both the dashboard summary and provider chain logs.

- Updated `response-handler.ts` to persist errors as `"FAKE_200_JSON_ERROR_MESSAGE_NON_EMPTY: Invalid API key"` instead of just `"FAKE_200_JSON_ERROR_MESSAGE_NON_EMPTY"`
- Modified `SummaryTab.tsx` to extract the code prefix for i18n lookup while displaying the full detail
- Updated `provider-chain-popover.tsx` to handle the new format in fake 200 detection and display logic

**Issues Found:**
- Line 550 in `provider-chain-popover.tsx` lacks optional chaining and may cause runtime errors if `item.errorMessage` is undefined or doesn't contain ": "
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- This PR improves UX but contains a logic bug that could cause runtime errors
- The implementation correctly updates the error format across the codebase, but line 550 in provider-chain-popover.tsx has inconsistent null-safety handling compared to line 138, which could cause crashes when processing provider chain items
- Pay close attention to `src/app/[locale]/dashboard/logs/_components/provider-chain-popover.tsx` - fix the optional chaining issue on line 550
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/response-handler.ts | Updated fake 200 error persistence to include detail text in "CODE: detail" format for both DB/Redis (line 188) and provider chain (line 333) |
| src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx | Extracts code prefix from new "CODE: detail" format before i18n lookup, maintains backward compatibility with old format |
| src/app/[locale]/dashboard/logs/_components/provider-chain-popover.tsx | Extracts code prefix from "CODE: detail" format in two locations (line 138, 550) but has potential runtime error on line 550 |

</details>


</details>


<sub>Last reviewed commit: 13563c9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->