### PR TITLE
refactor(logs): :recycle: remove hardcoded max-width from provider column and optimize flex ratios

### DIFF
--- a/src/app/[locale]/dashboard/logs/_components/provider-chain-popover.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/provider-chain-popover.tsx
@@ -24,8 +24,6 @@ import { getFake200ReasonKey } from "./fake200-reason";
 interface ProviderChainPopoverProps {
   chain: ProviderChainItem[];
   finalProvider: string;
-  /** Whether a cost badge is displayed, affects name max width */
-  hasCostBadge?: boolean;
   /** Callback when a chain item is clicked in the popover */
   onChainItemClick?: (chainIndex: number) => void;
 }
@@ -121,13 +119,12 @@ function getItemStatus(item: ProviderChainItem): {
 export function ProviderChainPopover({
   chain,
   finalProvider,
-  hasCostBadge = false,
   onChainItemClick,
 }: ProviderChainPopoverProps) {
   const t = useTranslations("dashboard");
   const tChain = useTranslations("provider-chain");
 
-  // “假 200”识别发生在 SSE 流式结束后：此时响应内容可能已透传给客户端，但内部会按失败统计/熔断。
+  // "假 200"识别发生在 SSE 流式结束后：此时响应内容可能已透传给客户端，但内部会按失败统计/熔断。
   const hasFake200PostStreamFailure = chain.some(
     (item) => typeof item.errorMessage === "string" && item.errorMessage.startsWith("FAKE_200_")
   );
@@ -142,9 +139,6 @@ export function ProviderChainPopover({
 
   // Fallback for empty string
   const displayName = finalProvider || "-";
-
-  // Determine max width based on whether cost badge is present
-  const maxWidthClass = hasCostBadge ? "max-w-[140px]" : "max-w-[180px]";
 
   // Check if this is a session reuse
   const isSessionReuse =
@@ -164,7 +158,7 @@ export function ProviderChainPopover({
     const singleRequestItem = chain.find(isActualRequest);
 
     return (
-      <div className={`${maxWidthClass} min-w-0 w-full`}>
+      <div className="min-w-0 w-full">
         <TooltipProvider>
           <Tooltip delayDuration={300}>
             <TooltipTrigger asChild>

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
@@ -198,7 +198,6 @@ export function UsageLogsTable({
                                   log.providerName ||
                                   tChain("circuit.unknown")
                                 }
-                                hasCostBadge={hasCostBadge}
                                 onChainItemClick={(chainIndex) => {
                                   setDialogState({
                                     logId: log.id,

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -212,12 +212,12 @@ export function VirtualizedLogsTable({
           {/* Fixed header */}
           <div className="bg-muted/40 border-b sticky top-0 z-10">
             <div className="flex items-center h-9 text-xs font-medium text-muted-foreground uppercase tracking-wider">
-              <div className="flex-[0.6] min-w-[56px] pl-3 truncate" title={t("logs.columns.time")}>
+              <div className="flex-[0.4] min-w-[56px] pl-3 truncate" title={t("logs.columns.time")}>
                 {t("logs.columns.time")}
               </div>
               {hideUserColumn ? null : (
                 <div
-                  className="flex-[0.8] min-w-[50px] px-1.5 truncate"
+                  className="flex-[1] min-w-[50px] px-1.5 truncate"
                   title={t("logs.columns.user")}
                 >
                   {t("logs.columns.user")}
@@ -225,7 +225,7 @@ export function VirtualizedLogsTable({
               )}
               {hideKeyColumn ? null : (
                 <div
-                  className="flex-[0.6] min-w-[50px] px-1.5 truncate"
+                  className="flex-[0.8] min-w-[50px] px-1.5 truncate"
                   title={t("logs.columns.key")}
                 >
                   {t("logs.columns.key")}
@@ -233,7 +233,7 @@ export function VirtualizedLogsTable({
               )}
               {hideSessionIdColumn ? null : (
                 <div
-                  className="flex-[0.8] min-w-[80px] px-1.5 truncate"
+                  className="flex-[1] min-w-[80px] px-1.5 truncate"
                   title={t("logs.columns.sessionId")}
                 >
                   {t("logs.columns.sessionId")}
@@ -241,21 +241,21 @@ export function VirtualizedLogsTable({
               )}
               {hideProviderColumn ? null : (
                 <div
-                  className="flex-[1.5] min-w-[100px] px-1.5 truncate"
+                  className="flex-[2] min-w-[100px] px-1.5 truncate"
                   title={t("logs.columns.provider")}
                 >
                   {t("logs.columns.provider")}
                 </div>
               )}
               <div
-                className="flex-[1] min-w-[80px] px-1.5 truncate"
+                className="flex-[1.5] min-w-[80px] px-1.5 truncate"
                 title={t("logs.columns.model")}
               >
                 {t("logs.columns.model")}
               </div>
               {hideTokensColumn ? null : (
                 <div
-                  className="flex-[0.7] min-w-[70px] text-right px-1.5 truncate"
+                  className="flex-[0.5] min-w-[70px] text-right px-1.5 truncate"
                   title={t("logs.columns.tokens")}
                 >
                   {t("logs.columns.tokens")}
@@ -263,7 +263,7 @@ export function VirtualizedLogsTable({
               )}
               {hideCacheColumn ? null : (
                 <div
-                  className="flex-[0.8] min-w-[70px] text-right px-1.5 truncate"
+                  className="flex-[0.5] min-w-[70px] text-right px-1.5 truncate"
                   title={t("logs.columns.cache")}
                 >
                   {t("logs.columns.cache")}
@@ -271,7 +271,7 @@ export function VirtualizedLogsTable({
               )}
               {hideCostColumn ? null : (
                 <div
-                  className="flex-[0.7] min-w-[60px] text-right px-1.5 truncate"
+                  className="flex-[0.4] min-w-[60px] text-right px-1.5 truncate"
                   title={t("logs.columns.cost")}
                 >
                   {t("logs.columns.cost")}
@@ -279,14 +279,14 @@ export function VirtualizedLogsTable({
               )}
               {hidePerformanceColumn ? null : (
                 <div
-                  className="flex-[0.8] min-w-[80px] text-right px-1.5 truncate"
+                  className="flex-[0.6] min-w-[80px] text-right px-1.5 truncate"
                   title={t("logs.columns.performance")}
                 >
                   {t("logs.columns.performance")}
                 </div>
               )}
               <div
-                className="flex-[0.7] min-w-[70px] pr-3 truncate"
+                className="flex-[0.4] min-w-[70px] pr-3 truncate"
                 title={t("logs.columns.status")}
               >
                 {t("logs.columns.status")}
@@ -349,14 +349,14 @@ export function VirtualizedLogsTable({
                     )}
                   >
                     {/* Time */}
-                    <div className="flex-[0.6] min-w-[56px] font-mono text-xs truncate pl-3">
+                    <div className="flex-[0.4] min-w-[56px] font-mono text-xs truncate pl-3">
                       <RelativeTime date={log.createdAt} fallback="-" format="short" />
                     </div>
 
                     {/* User */}
                     {hideUserColumn ? null : (
                       <div
-                        className="flex-[0.8] min-w-[50px] text-sm truncate px-1.5"
+                        className="flex-[1] min-w-[50px] text-sm truncate px-1.5"
                         title={log.userName}
                       >
                         {log.userName}
@@ -366,7 +366,7 @@ export function VirtualizedLogsTable({
                     {/* Key */}
                     {hideKeyColumn ? null : (
                       <div
-                        className="flex-[0.6] min-w-[50px] font-mono text-xs truncate px-1.5"
+                        className="flex-[0.8] min-w-[50px] font-mono text-xs truncate px-1.5"
                         title={log.keyName}
                       >
                         {log.keyName}
@@ -375,7 +375,7 @@ export function VirtualizedLogsTable({
 
                     {/* Session ID */}
                     {hideSessionIdColumn ? null : (
-                      <div className="flex-[0.8] min-w-[80px] px-1.5">
+                      <div className="flex-[1] min-w-[80px] px-1.5">
                         {log.sessionId ? (
                           <TooltipProvider>
                             <Tooltip delayDuration={300}>
@@ -404,7 +404,7 @@ export function VirtualizedLogsTable({
 
                     {/* Provider */}
                     {hideProviderColumn ? null : (
-                      <div className="flex-[1.5] min-w-[100px] px-1.5">
+                      <div className="flex-[2] min-w-[100px] px-1.5">
                         {log.blockedBy ? (
                           <span className="inline-flex items-center gap-1 rounded-md bg-orange-100 dark:bg-orange-950 px-2 py-1 text-xs font-medium text-orange-700 dark:text-orange-300">
                             <span className="h-1.5 w-1.5 rounded-full bg-orange-600 dark:bg-orange-400" />
@@ -468,7 +468,6 @@ export function VirtualizedLogsTable({
                                           log.providerName ||
                                           tChain("circuit.unknown")
                                         }
-                                        hasCostBadge={hasCostBadge}
                                         onChainItemClick={(chainIndex) => {
                                           setDialogState({
                                             logId: log.id,
@@ -502,7 +501,7 @@ export function VirtualizedLogsTable({
                     )}
 
                     {/* Model */}
-                    <div className="flex-[1] min-w-[80px] font-mono text-xs px-1.5">
+                    <div className="flex-[1.5] min-w-[80px] font-mono text-xs px-1.5">
                       <TooltipProvider>
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -526,7 +525,7 @@ export function VirtualizedLogsTable({
 
                     {/* Tokens */}
                     {hideTokensColumn ? null : (
-                      <div className="flex-[0.7] min-w-[70px] text-right font-mono text-xs px-1.5">
+                      <div className="flex-[0.5] min-w-[70px] text-right font-mono text-xs px-1.5">
                         <TooltipProvider>
                           <Tooltip delayDuration={250}>
                             <TooltipTrigger asChild>
@@ -554,7 +553,7 @@ export function VirtualizedLogsTable({
 
                     {/* Cache */}
                     {hideCacheColumn ? null : (
-                      <div className="flex-[0.8] min-w-[70px] text-right font-mono text-xs px-1.5">
+                      <div className="flex-[0.5] min-w-[70px] text-right font-mono text-xs px-1.5">
                         <TooltipProvider>
                           <Tooltip delayDuration={250}>
                             <TooltipTrigger asChild>
@@ -622,7 +621,7 @@ export function VirtualizedLogsTable({
 
                     {/* Cost */}
                     {hideCostColumn ? null : (
-                      <div className="flex-[0.7] min-w-[60px] text-right font-mono text-xs px-1.5">
+                      <div className="flex-[0.4] min-w-[60px] text-right font-mono text-xs px-1.5">
                         {isNonBilling ? (
                           "-"
                         ) : log.costUsd != null ? (
@@ -669,7 +668,7 @@ export function VirtualizedLogsTable({
 
                     {/* Performance */}
                     {hidePerformanceColumn ? null : (
-                      <div className="flex-[0.8] min-w-[80px] text-right font-mono text-xs px-1.5">
+                      <div className="flex-[0.6] min-w-[80px] text-right font-mono text-xs px-1.5">
                         {(() => {
                           const rate = calculateOutputRate(
                             log.outputTokens,
@@ -728,7 +727,7 @@ export function VirtualizedLogsTable({
                     )}
 
                     {/* Status */}
-                    <div className="flex-[0.7] min-w-[70px] pr-3">
+                    <div className="flex-[0.4] min-w-[70px] pr-3">
                       <ErrorDetailsDialog
                         statusCode={log.statusCode}
                         errorMessage={log.errorMessage}


### PR DESCRIPTION
## Summary

- Remove hardcoded \`max-w-[140px]\`/\`max-w-[180px]\` constraints from \`ProviderChainPopover\`, allowing the provider column to fill available space dynamically
- Optimize flex ratios in \`VirtualizedLogsTable\`: tighten numeric columns (Time, Tokens, Cache, Cost, Performance, Status) and widen text columns (Provider, Model, User, Key, SessionId)
- Clean up now-unused \`hasCostBadge\` prop from \`ProviderChainPopover\` interface and both callers

## Problem

The provider column in the usage logs table displayed truncated text (e.g. \"Antigravity Ultra...\") even when many columns were hidden and there was plenty of horizontal space available. This was caused by:

1. **Primary**: \`ProviderChainPopover\` hardcoded \`max-w-[140px]\` / \`max-w-[180px]\` on the provider name text, regardless of available container space
2. **Secondary**: Flex ratios didn't distinguish between predictable-width numeric columns and variable-width text columns, so space wasn't distributed efficiently

## Related Issues

- Related to #788 - Both PRs improve logs page UX (this PR optimizes column widths, #788 compacts stats panel and collapses filters)
- Related to #766 - Part of the broader logs page optimization effort to improve usability and screen real estate usage

## Changes

### \`provider-chain-popover.tsx\` (+2, -8)
- Removed \`hasCostBadge\` from \`ProviderChainPopoverProps\` interface
- Removed \`maxWidthClass\` variable calculation
- Changed provider name container from \`className={maxWidthClass + \" min-w-0 w-full\"}\` to \`className=\"min-w-0 w-full\"\`

### \`virtualized-logs-table.tsx\` (+22, -23)
- Adjusted 22 flex ratio values (11 header + 11 body, kept in perfect symmetry):
  - **Numeric columns tightened**: Time 0.6->0.4, Tokens 0.7->0.5, Cache 0.8->0.5, Cost 0.7->0.4, Performance 0.8->0.6, Status 0.7->0.4
  - **Text columns widened**: Provider 1.5->2, Model 1->1.5, User 0.8->1, Key 0.6->0.8, SessionId 0.8->1
- Removed \`hasCostBadge\` prop from \`ProviderChainPopover\` usage

### \`usage-logs-table.tsx\` (+0, -1)
- Removed \`hasCostBadge\` prop from \`ProviderChainPopover\` usage

## Testing

### Automated Tests
- [x] Unit tests pass - 2299/2299 PASS (52/52 logs-related tests pass)
- [x] Type check - PASS
- [x] Lint check - PASS
- [x] Build - PASS

### Verification Steps
- Grep confirms zero remaining references to \`max-w-[140px]\`, \`max-w-[180px]\`, or \`maxWidthClass\` in popover file
- Header/body flex ratio symmetry verified

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No breaking changes (internal component prop removal)

---
*Description enhanced with related issue links*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removed hardcoded width constraints (`max-w-[140px]`/`max-w-[180px]`) from the provider column and optimized flex ratios across all columns in the logs table. Numeric columns (Time, Tokens, Cache, Cost, Performance, Status) were tightened to use less space, while text columns (Provider, Model, User, Key, SessionId) were widened to utilize available space more effectively. The unused `hasCostBadge` prop was cleaned up from the `ProviderChainPopover` interface and all call sites.

**Key improvements:**
- Provider column now fills available space dynamically instead of being truncated
- Better space distribution between numeric and text-based columns
- Cleaner component interface with prop removal
- All changes maintain header/body flex ratio symmetry
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- The changes are purely UI layout optimizations with no logic changes. The removal of the unused prop is clean and complete across all files. Flex ratio adjustments are symmetric between headers and body rows, preventing layout mismatches. All tests pass and the changes are well-documented.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/logs/_components/provider-chain-popover.tsx | Removed unused `hasCostBadge` prop and hardcoded max-width constraints, allowing dynamic width |
| src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx | Removed `hasCostBadge` prop from ProviderChainPopover call |
| src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx | Optimized flex ratios for better column width distribution and removed `hasCostBadge` prop |

</details>


</details>


<sub>Last reviewed commit: fe819d7</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->