### PR TITLE
feat(notification): 缓存命中率异常告警

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/drizzle/0076_mighty_lionheart.sql
+++ b/drizzle/0076_mighty_lionheart.sql
@@ -1,0 +1,13 @@
+ALTER TYPE "public"."notification_type" ADD VALUE 'cache_hit_rate_alert';--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_enabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_webhook" varchar(512);--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_window_mode" varchar(10) DEFAULT 'auto';--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_check_interval" integer DEFAULT 5;--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_historical_lookback_days" integer DEFAULT 7;--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_min_eligible_requests" integer DEFAULT 20;--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_min_eligible_tokens" integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_abs_min" numeric(5, 4) DEFAULT '0.05';--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_drop_rel" numeric(5, 4) DEFAULT '0.3';--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_drop_abs" numeric(5, 4) DEFAULT '0.1';--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_cooldown_minutes" integer DEFAULT 30;--> statement-breakpoint
+ALTER TABLE "notification_settings" ADD COLUMN "cache_hit_rate_alert_top_n" integer DEFAULT 10;

--- a/drizzle/meta/0076_snapshot.json
+++ b/drizzle/meta/0076_snapshot.json
@@ -1,0 +1,3903 @@
+{
+  "id": "75cee3f5-1789-413b-a9ed-5aabc52fa0a0",
+  "prevId": "61c4da35-57cf-4629-88de-a1af77c8ae3b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.error_rules": {
+      "name": "error_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regex'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_response": {
+          "name": "override_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_status_code": {
+          "name": "override_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_rules_enabled": {
+          "name": "idx_error_rules_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_pattern": {
+          "name": "unique_pattern",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_category": {
+          "name": "idx_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_match_type": {
+          "name": "idx_match_type",
+          "columns": [
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_login_web_ui": {
+          "name": "can_login_web_ui",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_keys_user_id": {
+          "name": "idx_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_key": {
+          "name": "idx_keys_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_created_at": {
+          "name": "idx_keys_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_deleted_at": {
+          "name": "idx_keys_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_request": {
+      "name": "message_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "provider_chain": {
+          "name": "provider_chain",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "swap_cache_ttl_applied": {
+          "name": "swap_cache_ttl_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "special_settings": {
+          "name": "special_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_cause": {
+          "name": "error_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages_count": {
+          "name": "messages_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_message_request_user_date_cost": {
+          "name": "idx_message_request_user_date_cost",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_created_at_cost_stats": {
+          "name": "idx_message_request_user_created_at_cost_stats",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_query": {
+          "name": "idx_message_request_user_query",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_created_at_active": {
+          "name": "idx_message_request_provider_created_at_active",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_id": {
+          "name": "idx_message_request_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_id_prefix": {
+          "name": "idx_message_request_session_id_prefix",
+          "columns": [
+            {
+              "expression": "\"session_id\" varchar_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_seq": {
+          "name": "idx_message_request_session_seq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_endpoint": {
+          "name": "idx_message_request_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_blocked_by": {
+          "name": "idx_message_request_blocked_by",
+          "columns": [
+            {
+              "expression": "blocked_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_id": {
+          "name": "idx_message_request_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_id": {
+          "name": "idx_message_request_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key": {
+          "name": "idx_message_request_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_created_at_id": {
+          "name": "idx_message_request_key_created_at_id",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_model_active": {
+          "name": "idx_message_request_key_model_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"model\" IS NOT NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_endpoint_active": {
+          "name": "idx_message_request_key_endpoint_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"endpoint\" IS NOT NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_created_at_id_active": {
+          "name": "idx_message_request_created_at_id_active",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_model_active": {
+          "name": "idx_message_request_model_active",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"model\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_status_code_active": {
+          "name": "idx_message_request_status_code_active",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"status_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_created_at": {
+          "name": "idx_message_request_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_deleted_at": {
+          "name": "idx_message_request_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_last_active": {
+          "name": "idx_message_request_key_last_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_cost_active": {
+          "name": "idx_message_request_key_cost_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_user_info": {
+          "name": "idx_message_request_session_user_info",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_prices": {
+      "name": "model_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_data": {
+          "name": "price_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'litellm'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_prices_latest": {
+          "name": "idx_model_prices_latest",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_model_name": {
+          "name": "idx_model_prices_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_created_at": {
+          "name": "idx_model_prices_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_source": {
+          "name": "idx_model_prices_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_legacy_mode": {
+          "name": "use_legacy_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_enabled": {
+          "name": "circuit_breaker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_webhook": {
+          "name": "circuit_breaker_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_enabled": {
+          "name": "daily_leaderboard_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "daily_leaderboard_webhook": {
+          "name": "daily_leaderboard_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_time": {
+          "name": "daily_leaderboard_time",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'09:00'"
+        },
+        "daily_leaderboard_top_n": {
+          "name": "daily_leaderboard_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cost_alert_enabled": {
+          "name": "cost_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cost_alert_webhook": {
+          "name": "cost_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_alert_threshold": {
+          "name": "cost_alert_threshold",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.80'"
+        },
+        "cost_alert_check_interval": {
+          "name": "cost_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "cache_hit_rate_alert_enabled": {
+          "name": "cache_hit_rate_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_hit_rate_alert_webhook": {
+          "name": "cache_hit_rate_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit_rate_alert_window_mode": {
+          "name": "cache_hit_rate_alert_window_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "cache_hit_rate_alert_check_interval": {
+          "name": "cache_hit_rate_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cache_hit_rate_alert_historical_lookback_days": {
+          "name": "cache_hit_rate_alert_historical_lookback_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 7
+        },
+        "cache_hit_rate_alert_min_eligible_requests": {
+          "name": "cache_hit_rate_alert_min_eligible_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 20
+        },
+        "cache_hit_rate_alert_min_eligible_tokens": {
+          "name": "cache_hit_rate_alert_min_eligible_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cache_hit_rate_alert_abs_min": {
+          "name": "cache_hit_rate_alert_abs_min",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "cache_hit_rate_alert_drop_rel": {
+          "name": "cache_hit_rate_alert_drop_rel",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.3'"
+        },
+        "cache_hit_rate_alert_drop_abs": {
+          "name": "cache_hit_rate_alert_drop_abs",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.1'"
+        },
+        "cache_hit_rate_alert_cooldown_minutes": {
+          "name": "cache_hit_rate_alert_cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cache_hit_rate_alert_top_n": {
+          "name": "cache_hit_rate_alert_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_target_bindings": {
+      "name": "notification_target_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule_cron": {
+          "name": "schedule_cron",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_timezone": {
+          "name": "schedule_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_override": {
+          "name": "template_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_notification_target_binding": {
+          "name": "unique_notification_target_binding",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_type": {
+          "name": "idx_notification_bindings_type",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_target": {
+          "name": "idx_notification_bindings_target",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_target_bindings_target_id_webhook_targets_id_fk": {
+          "name": "notification_target_bindings_target_id_webhook_targets_id_fk",
+          "tableFrom": "notification_target_bindings",
+          "tableTo": "webhook_targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoint_probe_logs": {
+      "name": "provider_endpoint_probe_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_endpoint_probe_logs_endpoint_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_endpoint_created_at",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoint_probe_logs_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk": {
+          "name": "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk",
+          "tableFrom": "provider_endpoint_probe_logs",
+          "tableTo": "provider_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoints": {
+      "name": "provider_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_probed_at": {
+          "name": "last_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_ok": {
+          "name": "last_probe_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_status_code": {
+          "name": "last_probe_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_latency_ms": {
+          "name": "last_probe_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_type": {
+          "name": "last_probe_error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_message": {
+          "name": "last_probe_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uniq_provider_endpoints_vendor_type_url": {
+          "name": "uniq_provider_endpoints_vendor_type_url",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_vendor_type": {
+          "name": "idx_provider_endpoints_vendor_type",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_enabled": {
+          "name": "idx_provider_endpoints_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_pick_enabled": {
+          "name": "idx_provider_endpoints_pick_enabled",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_created_at": {
+          "name": "idx_provider_endpoints_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_deleted_at": {
+          "name": "idx_provider_endpoints_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoints_vendor_id_provider_vendors_id_fk": {
+          "name": "provider_endpoints_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "provider_endpoints",
+          "tableTo": "provider_vendors",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_vendors": {
+      "name": "provider_vendors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "website_domain": {
+          "name": "website_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_provider_vendors_website_domain": {
+          "name": "uniq_provider_vendors_website_domain",
+          "columns": [
+            {
+              "expression": "website_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_vendors_created_at": {
+          "name": "idx_provider_vendors_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_vendor_id": {
+          "name": "provider_vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "group_priorities": {
+          "name": "group_priorities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.0'"
+        },
+        "group_tag": {
+          "name": "group_tag",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "preserve_client_ip": {
+          "name": "preserve_client_ip",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_redirects": {
+          "name": "model_redirects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_clients": {
+          "name": "blocked_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "join_claude_pool": {
+          "name": "join_claude_pool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "codex_instructions_strategy": {
+          "name": "codex_instructions_strategy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "mcp_passthrough_type": {
+          "name": "mcp_passthrough_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "mcp_passthrough_url": {
+          "name": "mcp_passthrough_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost_reset_at": {
+          "name": "total_cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_retry_attempts": {
+          "name": "max_retry_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circuit_breaker_failure_threshold": {
+          "name": "circuit_breaker_failure_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "circuit_breaker_open_duration": {
+          "name": "circuit_breaker_open_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1800000
+        },
+        "circuit_breaker_half_open_success_threshold": {
+          "name": "circuit_breaker_half_open_success_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "first_byte_timeout_streaming_ms": {
+          "name": "first_byte_timeout_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "streaming_idle_timeout_ms": {
+          "name": "streaming_idle_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_timeout_non_streaming_ms": {
+          "name": "request_timeout_non_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swap_cache_ttl_billing": {
+          "name": "swap_cache_ttl_billing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "context_1m_preference": {
+          "name": "context_1m_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_effort_preference": {
+          "name": "codex_reasoning_effort_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_summary_preference": {
+          "name": "codex_reasoning_summary_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_text_verbosity_preference": {
+          "name": "codex_text_verbosity_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_parallel_tool_calls_preference": {
+          "name": "codex_parallel_tool_calls_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_max_tokens_preference": {
+          "name": "anthropic_max_tokens_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_thinking_budget_preference": {
+          "name": "anthropic_thinking_budget_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_adaptive_thinking": {
+          "name": "anthropic_adaptive_thinking",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "gemini_google_search_preference": {
+          "name": "gemini_google_search_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tpm": {
+          "name": "tpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpm": {
+          "name": "rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpd": {
+          "name": "rpd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cc": {
+          "name": "cc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_providers_enabled_priority": {
+          "name": "idx_providers_enabled_priority",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_group": {
+          "name": "idx_providers_group",
+          "columns": [
+            {
+              "expression": "group_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_vendor_type_url_active": {
+          "name": "idx_providers_vendor_type_url_active",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_created_at": {
+          "name": "idx_providers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_deleted_at": {
+          "name": "idx_providers_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_vendor_type": {
+          "name": "idx_providers_vendor_type",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_enabled_vendor_type": {
+          "name": "idx_providers_enabled_vendor_type",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL AND \"providers\".\"is_enabled\" = true AND \"providers\".\"provider_vendor_id\" IS NOT NULL AND \"providers\".\"provider_vendor_id\" > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "providers_provider_vendor_id_provider_vendors_id_fk": {
+          "name": "providers_provider_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "provider_vendors",
+          "columnsFrom": [
+            "provider_vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_filters": {
+      "name": "request_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement": {
+          "name": "replacement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "provider_ids": {
+          "name": "provider_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_tags": {
+          "name": "group_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_request_filters_enabled": {
+          "name": "idx_request_filters_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_scope": {
+          "name": "idx_request_filters_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_action": {
+          "name": "idx_request_filters_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_binding": {
+          "name": "idx_request_filters_binding",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sensitive_words": {
+      "name": "sensitive_words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contains'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sensitive_words_enabled": {
+          "name": "idx_sensitive_words_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sensitive_words_created_at": {
+          "name": "idx_sensitive_words_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_title": {
+          "name": "site_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Claude Code Hub'"
+        },
+        "allow_global_usage_view": {
+          "name": "allow_global_usage_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "currency_display": {
+          "name": "currency_display",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "billing_model_source": {
+          "name": "billing_model_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'original'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_auto_cleanup": {
+          "name": "enable_auto_cleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cleanup_retention_days": {
+          "name": "cleanup_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cleanup_schedule": {
+          "name": "cleanup_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 2 * * *'"
+        },
+        "cleanup_batch_size": {
+          "name": "cleanup_batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10000
+        },
+        "enable_client_version_check": {
+          "name": "enable_client_version_check",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verbose_provider_error": {
+          "name": "verbose_provider_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_http2": {
+          "name": "enable_http2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "intercept_anthropic_warmup_requests": {
+          "name": "intercept_anthropic_warmup_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_thinking_signature_rectifier": {
+          "name": "enable_thinking_signature_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_thinking_budget_rectifier": {
+          "name": "enable_thinking_budget_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_billing_header_rectifier": {
+          "name": "enable_billing_header_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_codex_session_id_completion": {
+          "name": "enable_codex_session_id_completion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_claude_metadata_user_id_injection": {
+          "name": "enable_claude_metadata_user_id_injection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_response_fixer": {
+          "name": "enable_response_fixer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "response_fixer_config": {
+          "name": "response_fixer_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"fixTruncatedJson\":true,\"fixSseFormat\":true,\"fixEncoding\":true,\"maxJsonDepth\":200,\"maxFixSize\":1048576}'::jsonb"
+        },
+        "quota_db_refresh_interval_seconds": {
+          "name": "quota_db_refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "quota_lease_percent_5h": {
+          "name": "quota_lease_percent_5h",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_daily": {
+          "name": "quota_lease_percent_daily",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_weekly": {
+          "name": "quota_lease_percent_weekly",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_monthly": {
+          "name": "quota_lease_percent_monthly",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_cap_usd": {
+          "name": "quota_lease_cap_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_ledger": {
+      "name": "usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_provider_id": {
+          "name": "final_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_success": {
+          "name": "is_success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "swap_cache_ttl_applied": {
+          "name": "swap_cache_ttl_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_ledger_request_id": {
+          "name": "idx_usage_ledger_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_user_created_at": {
+          "name": "idx_usage_ledger_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_key_created_at": {
+          "name": "idx_usage_ledger_key_created_at",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_provider_created_at": {
+          "name": "idx_usage_ledger_provider_created_at",
+          "columns": [
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_created_at_minute": {
+          "name": "idx_usage_ledger_created_at_minute",
+          "columns": [
+            {
+              "expression": "date_trunc('minute', \"created_at\" AT TIME ZONE 'UTC')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_created_at_desc_id": {
+          "name": "idx_usage_ledger_created_at_desc_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_session_id": {
+          "name": "idx_usage_ledger_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"session_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_model": {
+          "name": "idx_usage_ledger_model",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"model\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_key_cost": {
+          "name": "idx_usage_ledger_key_cost",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_user_cost_cover": {
+          "name": "idx_usage_ledger_user_cost_cover",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_provider_cost_cover": {
+          "name": "idx_usage_ledger_provider_cost_cover",
+          "columns": [
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "rpm_limit": {
+          "name": "rpm_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_limit_usd": {
+          "name": "daily_limit_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_clients": {
+          "name": "blocked_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_active_role_sort": {
+          "name": "idx_users_active_role_sort",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_enabled_expires_at": {
+          "name": "idx_users_enabled_expires_at",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_tags_gin": {
+          "name": "idx_users_tags_gin",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_deleted_at": {
+          "name": "idx_users_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_targets": {
+      "name": "webhook_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "webhook_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_bot_token": {
+          "name": "telegram_bot_token",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dingtalk_secret": {
+          "name": "dingtalk_secret",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_template": {
+          "name": "custom_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_test_at": {
+          "name": "last_test_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_result": {
+          "name": "last_test_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.daily_reset_mode": {
+      "name": "daily_reset_mode",
+      "schema": "public",
+      "values": [
+        "fixed",
+        "rolling"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "circuit_breaker",
+        "daily_leaderboard",
+        "cost_alert",
+        "cache_hit_rate_alert"
+      ]
+    },
+    "public.webhook_provider_type": {
+      "name": "webhook_provider_type",
+      "schema": "public",
+      "values": [
+        "wechat",
+        "feishu",
+        "dingtalk",
+        "telegram",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -533,6 +533,13 @@
       "when": 1771688588623,
       "tag": "0075_faithful_speed_demon",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1771954926766,
+      "tag": "0076_mighty_lionheart",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/en/settings/notifications.json
+++ b/messages/en/settings/notifications.json
@@ -38,6 +38,22 @@
     "webhookTypeUnknown": "Unknown platform. Please use WeCom or Feishu webhook URL",
     "webhookTypeWeCom": "WeCom"
   },
+  "cacheHitRateAlert": {
+    "absMin": "Absolute Minimum (absMin)",
+    "checkInterval": "Check Interval (minutes)",
+    "cooldownMinutes": "Cooldown (minutes)",
+    "description": "Alert when cache hit rate drops abnormally (provider × model)",
+    "dropAbs": "Absolute Drop (dropAbs)",
+    "dropRel": "Relative Drop (dropRel)",
+    "enable": "Enable Cache Hit Rate Alert",
+    "historicalLookbackDays": "Historical Lookback (days)",
+    "minEligibleRequests": "Min Eligible Requests",
+    "minEligibleTokens": "Min Eligible Tokens",
+    "title": "Cache Hit Rate Alert",
+    "topN": "Top N",
+    "windowMode": "Window",
+    "windowModeAuto": "Auto"
+  },
   "dailyLeaderboard": {
     "description": "Send daily scheduled user consumption Top N leaderboard",
     "enable": "Enable Daily Leaderboard",

--- a/messages/ja/settings/notifications.json
+++ b/messages/ja/settings/notifications.json
@@ -38,6 +38,22 @@
     "webhookTypeUnknown": "不明なプラットフォームです。WeComまたはFeishuのWebhook URLを使用してください",
     "webhookTypeWeCom": "WeCom"
   },
+  "cacheHitRateAlert": {
+    "absMin": "絶対下限（absMin）",
+    "checkInterval": "チェック間隔（分）",
+    "cooldownMinutes": "クールダウン（分）",
+    "description": "キャッシュヒット率（provider × model）が異常に低下した場合に通知します",
+    "dropAbs": "絶対低下幅（dropAbs）",
+    "dropRel": "相対低下幅（dropRel）",
+    "enable": "キャッシュヒット率アラートを有効にする",
+    "historicalLookbackDays": "履歴参照（日）",
+    "minEligibleRequests": "最小 eligible リクエスト数",
+    "minEligibleTokens": "最小 eligible トークン数",
+    "title": "キャッシュヒット率アラート",
+    "topN": "Top N",
+    "windowMode": "ウィンドウ",
+    "windowModeAuto": "自動"
+  },
   "dailyLeaderboard": {
     "description": "毎日定時でユーザー消費トップNランキングを送信",
     "enable": "日次ランキングを有効にする",

--- a/messages/ru/settings/notifications.json
+++ b/messages/ru/settings/notifications.json
@@ -38,6 +38,22 @@
     "webhookTypeUnknown": "Неизвестная платформа. Используйте URL вебхука WeCom или Feishu",
     "webhookTypeWeCom": "WeCom"
   },
+  "cacheHitRateAlert": {
+    "absMin": "Абсолютный минимум (absMin)",
+    "checkInterval": "Интервал проверки (мин)",
+    "cooldownMinutes": "Охлаждение (мин)",
+    "description": "Уведомлять при аномальном падении доли кеш-хитов (provider × model)",
+    "dropAbs": "Абсолютное падение (dropAbs)",
+    "dropRel": "Относительное падение (dropRel)",
+    "enable": "Включить оповещение о кеш-хите",
+    "historicalLookbackDays": "Исторический период (дни)",
+    "minEligibleRequests": "Мин. eligible запросов",
+    "minEligibleTokens": "Мин. eligible токенов",
+    "title": "Оповещение о кеш-хите",
+    "topN": "Top N",
+    "windowMode": "Окно",
+    "windowModeAuto": "Авто"
+  },
   "dailyLeaderboard": {
     "description": "Ежедневная отправка рейтинга топ N пользователей по потреблению",
     "enable": "Включить ежедневный рейтинг",

--- a/messages/zh-CN/settings/notifications.json
+++ b/messages/zh-CN/settings/notifications.json
@@ -130,6 +130,22 @@
     "interval": "检查间隔（分钟）",
     "test": "测试连接"
   },
+  "cacheHitRateAlert": {
+    "title": "缓存命中率异常告警",
+    "description": "当缓存命中率（provider × model）异常下降时发送告警",
+    "enable": "启用缓存命中率告警",
+    "windowMode": "窗口",
+    "windowModeAuto": "自动",
+    "checkInterval": "检查间隔（分钟）",
+    "historicalLookbackDays": "历史回看天数",
+    "cooldownMinutes": "冷却（分钟）",
+    "absMin": "绝对下限（absMin）",
+    "dropAbs": "绝对跌幅阈值（dropAbs）",
+    "dropRel": "相对跌幅阈值（dropRel）",
+    "minEligibleRequests": "最小可命中请求数",
+    "minEligibleTokens": "最小可命中 Tokens",
+    "topN": "Top N"
+  },
   "form": {
     "save": "保存设置",
     "saving": "保存中...",

--- a/messages/zh-TW/settings/notifications.json
+++ b/messages/zh-TW/settings/notifications.json
@@ -38,6 +38,22 @@
     "webhookTypeUnknown": "未知平台，請使用企業微信或飛書的 Webhook URL",
     "webhookTypeWeCom": "企業微信"
   },
+  "cacheHitRateAlert": {
+    "absMin": "絕對下限（absMin）",
+    "checkInterval": "檢查間隔（分鐘）",
+    "cooldownMinutes": "冷卻（分鐘）",
+    "description": "當快取命中率（provider × model）異常下降時發送告警",
+    "dropAbs": "絕對跌幅閾值（dropAbs）",
+    "dropRel": "相對跌幅閾值（dropRel）",
+    "enable": "啟用快取命中率告警",
+    "historicalLookbackDays": "歷史回看天數",
+    "minEligibleRequests": "最小可命中請求數",
+    "minEligibleTokens": "最小可命中 Tokens",
+    "title": "快取命中率異常告警",
+    "topN": "Top N",
+    "windowMode": "視窗",
+    "windowModeAuto": "自動"
+  },
   "dailyLeaderboard": {
     "description": "每天定時發送使用者消費 Top N 排行榜",
     "enable": "啟用每日排行榜",

--- a/messages/zh-TW/settings/notifications.json
+++ b/messages/zh-TW/settings/notifications.json
@@ -48,7 +48,7 @@
     "enable": "啟用快取命中率告警",
     "historicalLookbackDays": "歷史回看天數",
     "minEligibleRequests": "最小可命中請求數",
-    "minEligibleTokens": "最小可命中 Tokens",
+    "minEligibleTokens": "最小可命中 Token 數",
     "title": "快取命中率異常告警",
     "topN": "Top N",
     "windowMode": "視窗",

--- a/src/actions/notification-bindings.ts
+++ b/src/actions/notification-bindings.ts
@@ -13,7 +13,12 @@ import {
 } from "@/repository/notification-bindings";
 import type { ActionResult } from "./types";
 
-const NotificationTypeSchema = z.enum(["circuit_breaker", "daily_leaderboard", "cost_alert"]);
+const NotificationTypeSchema = z.enum([
+  "circuit_breaker",
+  "daily_leaderboard",
+  "cost_alert",
+  "cache_hit_rate_alert",
+]);
 
 const BindingInputSchema: z.ZodType<BindingInput> = z.object({
   targetId: z.number().int().positive(),

--- a/src/actions/webhook-targets.ts
+++ b/src/actions/webhook-targets.ts
@@ -75,7 +75,12 @@ function validateProviderConfig(params: {
 }
 
 const ProviderTypeSchema = z.enum(["wechat", "feishu", "dingtalk", "telegram", "custom"]);
-const NotificationTypeSchema = z.enum(["circuit_breaker", "daily_leaderboard", "cost_alert"]);
+const NotificationTypeSchema = z.enum([
+  "circuit_breaker",
+  "daily_leaderboard",
+  "cost_alert",
+  "cache_hit_rate_alert",
+]);
 
 export type NotificationType = z.infer<typeof NotificationTypeSchema>;
 
@@ -241,6 +246,8 @@ function toJobType(type: NotificationType): NotificationJobType {
       return "daily-leaderboard";
     case "cost_alert":
       return "cost-alert";
+    case "cache_hit_rate_alert":
+      return "cache-hit-rate-alert";
   }
 }
 
@@ -273,6 +280,54 @@ function buildTestData(type: NotificationType): unknown {
         quotaLimit: 100,
         threshold: 0.8,
         period: "本月",
+      };
+    case "cache_hit_rate_alert":
+      return {
+        window: {
+          mode: "5m",
+          startTime: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+          endTime: new Date().toISOString(),
+          durationMinutes: 5,
+        },
+        anomalies: [
+          {
+            providerId: 1,
+            providerName: "测试供应商",
+            providerType: "claude",
+            model: "test-model",
+            baselineSource: "historical",
+            current: {
+              kind: "eligible",
+              requests: 100,
+              denominatorTokens: 10000,
+              hitRateTokens: 0.12,
+            },
+            baseline: {
+              kind: "eligible",
+              requests: 100,
+              denominatorTokens: 10000,
+              hitRateTokens: 0.45,
+            },
+            deltaAbs: -0.33,
+            deltaRel: -0.7333,
+            dropAbs: 0.33,
+            reasonCodes: ["abs_min", "drop_abs_rel"],
+          },
+        ],
+        suppressedCount: 0,
+        settings: {
+          windowMode: "auto",
+          checkIntervalMinutes: 5,
+          historicalLookbackDays: 7,
+          minEligibleRequests: 20,
+          minEligibleTokens: 0,
+          absMin: 0.05,
+          dropRel: 0.3,
+          dropAbs: 0.1,
+          cooldownMinutes: 30,
+          topN: 10,
+        },
+        generatedAt: new Date().toISOString(),
       };
   }
 }

--- a/src/app/[locale]/settings/notifications/_components/notification-type-card.tsx
+++ b/src/app/[locale]/settings/notifications/_components/notification-type-card.tsx
@@ -7,6 +7,7 @@ import { useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
+import { isCacheHitRateAlertSettingsWindowMode } from "@/lib/webhook/types";
 import type {
   ClientActionResult,
   NotificationBindingState,
@@ -292,9 +293,13 @@ export function NotificationTypeCard({
                     id="cacheHitRateAlertWindowMode"
                     value={settings.cacheHitRateAlertWindowMode}
                     disabled={!settings.enabled}
-                    onChange={(e) =>
-                      onUpdateSettings({ cacheHitRateAlertWindowMode: e.target.value })
-                    }
+                    onChange={(e) => {
+                      const nextValue = e.target.value;
+                      if (!isCacheHitRateAlertSettingsWindowMode(nextValue)) {
+                        return;
+                      }
+                      onUpdateSettings({ cacheHitRateAlertWindowMode: nextValue });
+                    }}
                     className={cn(
                       "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
                       "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",

--- a/src/app/[locale]/settings/notifications/_components/notification-type-card.tsx
+++ b/src/app/[locale]/settings/notifications/_components/notification-type-card.tsx
@@ -2,7 +2,7 @@
 
 import { AlertTriangle, Database, DollarSign, Settings2, TrendingUp } from "lucide-react";
 import { useTranslations } from "next-intl";
-import type { ComponentProps } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
@@ -68,6 +68,41 @@ function getTypeConfig(type: NotificationType): TypeConfig {
         IconComponent: Database,
       };
   }
+}
+
+const settingsControlClassName = cn(
+  "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
+  "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
+  "disabled:opacity-50 disabled:cursor-not-allowed"
+);
+
+function LabeledControl({
+  id,
+  label,
+  children,
+}: {
+  id: string;
+  label: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label htmlFor={id} className="text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+type SafeNumberOnChange = NonNullable<ComponentProps<"input">["onChange"]>;
+
+function safeNumberOnChange(onValidNumber: (value: number) => void): SafeNumberOnChange {
+  return (e) => {
+    const nextValue = e.currentTarget.valueAsNumber;
+    if (Number.isNaN(nextValue)) return;
+    onValidNumber(nextValue);
+  };
 }
 
 export function NotificationTypeCard({
@@ -282,29 +317,20 @@ export function NotificationTypeCard({
           {type === "cache_hit_rate_alert" && (
             <div className="space-y-3">
               <div className="grid gap-3 md:grid-cols-2">
-                <div className="space-y-1.5">
-                  <label
-                    htmlFor="cacheHitRateAlertWindowMode"
-                    className="text-xs font-medium text-muted-foreground"
-                  >
-                    {t("notifications.cacheHitRateAlert.windowMode")}
-                  </label>
+                <LabeledControl
+                  id="cacheHitRateAlertWindowMode"
+                  label={t("notifications.cacheHitRateAlert.windowMode")}
+                >
                   <select
                     id="cacheHitRateAlertWindowMode"
                     value={settings.cacheHitRateAlertWindowMode}
                     disabled={!settings.enabled}
                     onChange={(e) => {
                       const nextValue = e.target.value;
-                      if (!isCacheHitRateAlertSettingsWindowMode(nextValue)) {
-                        return;
-                      }
+                      if (!isCacheHitRateAlertSettingsWindowMode(nextValue)) return;
                       onUpdateSettings({ cacheHitRateAlertWindowMode: nextValue });
                     }}
-                    className={cn(
-                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
-                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
-                      "disabled:opacity-50 disabled:cursor-not-allowed"
-                    )}
+                    className={settingsControlClassName}
                   >
                     <option value="auto">
                       {t("notifications.cacheHitRateAlert.windowModeAuto")}
@@ -314,15 +340,12 @@ export function NotificationTypeCard({
                     <option value="1h">1h</option>
                     <option value="1.5h">1.5h</option>
                   </select>
-                </div>
+                </LabeledControl>
 
-                <div className="space-y-1.5">
-                  <label
-                    htmlFor="cacheHitRateAlertCheckInterval"
-                    className="text-xs font-medium text-muted-foreground"
-                  >
-                    {t("notifications.cacheHitRateAlert.checkInterval")}
-                  </label>
+                <LabeledControl
+                  id="cacheHitRateAlertCheckInterval"
+                  label={t("notifications.cacheHitRateAlert.checkInterval")}
+                >
                   <input
                     id="cacheHitRateAlertCheckInterval"
                     type="number"
@@ -330,26 +353,17 @@ export function NotificationTypeCard({
                     max={1440}
                     value={settings.cacheHitRateAlertCheckInterval}
                     disabled={!settings.enabled}
-                    onChange={(e) =>
-                      onUpdateSettings({
-                        cacheHitRateAlertCheckInterval: Number(e.target.value),
-                      })
-                    }
-                    className={cn(
-                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
-                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
-                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    onChange={safeNumberOnChange((nextValue) =>
+                      onUpdateSettings({ cacheHitRateAlertCheckInterval: nextValue })
                     )}
+                    className={settingsControlClassName}
                   />
-                </div>
+                </LabeledControl>
 
-                <div className="space-y-1.5">
-                  <label
-                    htmlFor="cacheHitRateAlertHistoricalLookbackDays"
-                    className="text-xs font-medium text-muted-foreground"
-                  >
-                    {t("notifications.cacheHitRateAlert.historicalLookbackDays")}
-                  </label>
+                <LabeledControl
+                  id="cacheHitRateAlertHistoricalLookbackDays"
+                  label={t("notifications.cacheHitRateAlert.historicalLookbackDays")}
+                >
                   <input
                     id="cacheHitRateAlertHistoricalLookbackDays"
                     type="number"
@@ -357,26 +371,19 @@ export function NotificationTypeCard({
                     max={90}
                     value={settings.cacheHitRateAlertHistoricalLookbackDays}
                     disabled={!settings.enabled}
-                    onChange={(e) =>
+                    onChange={safeNumberOnChange((nextValue) =>
                       onUpdateSettings({
-                        cacheHitRateAlertHistoricalLookbackDays: Number(e.target.value),
+                        cacheHitRateAlertHistoricalLookbackDays: nextValue,
                       })
-                    }
-                    className={cn(
-                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
-                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
-                      "disabled:opacity-50 disabled:cursor-not-allowed"
                     )}
+                    className={settingsControlClassName}
                   />
-                </div>
+                </LabeledControl>
 
-                <div className="space-y-1.5">
-                  <label
-                    htmlFor="cacheHitRateAlertCooldownMinutes"
-                    className="text-xs font-medium text-muted-foreground"
-                  >
-                    {t("notifications.cacheHitRateAlert.cooldownMinutes")}
-                  </label>
+                <LabeledControl
+                  id="cacheHitRateAlertCooldownMinutes"
+                  label={t("notifications.cacheHitRateAlert.cooldownMinutes")}
+                >
                   <input
                     id="cacheHitRateAlertCooldownMinutes"
                     type="number"
@@ -384,28 +391,19 @@ export function NotificationTypeCard({
                     max={1440}
                     value={settings.cacheHitRateAlertCooldownMinutes}
                     disabled={!settings.enabled}
-                    onChange={(e) =>
-                      onUpdateSettings({
-                        cacheHitRateAlertCooldownMinutes: Number(e.target.value),
-                      })
-                    }
-                    className={cn(
-                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
-                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
-                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    onChange={safeNumberOnChange((nextValue) =>
+                      onUpdateSettings({ cacheHitRateAlertCooldownMinutes: nextValue })
                     )}
+                    className={settingsControlClassName}
                   />
-                </div>
+                </LabeledControl>
               </div>
 
               <div className="grid gap-3 md:grid-cols-3">
-                <div className="space-y-1.5">
-                  <label
-                    htmlFor="cacheHitRateAlertAbsMin"
-                    className="text-xs font-medium text-muted-foreground"
-                  >
-                    {t("notifications.cacheHitRateAlert.absMin")}
-                  </label>
+                <LabeledControl
+                  id="cacheHitRateAlertAbsMin"
+                  label={t("notifications.cacheHitRateAlert.absMin")}
+                >
                   <input
                     id="cacheHitRateAlertAbsMin"
                     type="number"
@@ -414,24 +412,18 @@ export function NotificationTypeCard({
                     step={0.01}
                     value={settings.cacheHitRateAlertAbsMin}
                     disabled={!settings.enabled}
-                    onChange={(e) =>
-                      onUpdateSettings({ cacheHitRateAlertAbsMin: Number(e.target.value) })
-                    }
-                    className={cn(
-                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
-                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
-                      "disabled:opacity-50 disabled:cursor-not-allowed"
-                    )}
+                    onChange={safeNumberOnChange((nextValue) => {
+                      if (nextValue < 0 || nextValue > 1) return;
+                      onUpdateSettings({ cacheHitRateAlertAbsMin: nextValue });
+                    })}
+                    className={settingsControlClassName}
                   />
-                </div>
+                </LabeledControl>
 
-                <div className="space-y-1.5">
-                  <label
-                    htmlFor="cacheHitRateAlertDropAbs"
-                    className="text-xs font-medium text-muted-foreground"
-                  >
-                    {t("notifications.cacheHitRateAlert.dropAbs")}
-                  </label>
+                <LabeledControl
+                  id="cacheHitRateAlertDropAbs"
+                  label={t("notifications.cacheHitRateAlert.dropAbs")}
+                >
                   <input
                     id="cacheHitRateAlertDropAbs"
                     type="number"
@@ -440,24 +432,18 @@ export function NotificationTypeCard({
                     step={0.01}
                     value={settings.cacheHitRateAlertDropAbs}
                     disabled={!settings.enabled}
-                    onChange={(e) =>
-                      onUpdateSettings({ cacheHitRateAlertDropAbs: Number(e.target.value) })
-                    }
-                    className={cn(
-                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
-                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
-                      "disabled:opacity-50 disabled:cursor-not-allowed"
-                    )}
+                    onChange={safeNumberOnChange((nextValue) => {
+                      if (nextValue < 0 || nextValue > 1) return;
+                      onUpdateSettings({ cacheHitRateAlertDropAbs: nextValue });
+                    })}
+                    className={settingsControlClassName}
                   />
-                </div>
+                </LabeledControl>
 
-                <div className="space-y-1.5">
-                  <label
-                    htmlFor="cacheHitRateAlertDropRel"
-                    className="text-xs font-medium text-muted-foreground"
-                  >
-                    {t("notifications.cacheHitRateAlert.dropRel")}
-                  </label>
+                <LabeledControl
+                  id="cacheHitRateAlertDropRel"
+                  label={t("notifications.cacheHitRateAlert.dropRel")}
+                >
                   <input
                     id="cacheHitRateAlertDropRel"
                     type="number"
@@ -466,26 +452,20 @@ export function NotificationTypeCard({
                     step={0.01}
                     value={settings.cacheHitRateAlertDropRel}
                     disabled={!settings.enabled}
-                    onChange={(e) =>
-                      onUpdateSettings({ cacheHitRateAlertDropRel: Number(e.target.value) })
-                    }
-                    className={cn(
-                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
-                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
-                      "disabled:opacity-50 disabled:cursor-not-allowed"
-                    )}
+                    onChange={safeNumberOnChange((nextValue) => {
+                      if (nextValue < 0 || nextValue > 1) return;
+                      onUpdateSettings({ cacheHitRateAlertDropRel: nextValue });
+                    })}
+                    className={settingsControlClassName}
                   />
-                </div>
+                </LabeledControl>
               </div>
 
               <div className="grid gap-3 md:grid-cols-3">
-                <div className="space-y-1.5">
-                  <label
-                    htmlFor="cacheHitRateAlertMinEligibleRequests"
-                    className="text-xs font-medium text-muted-foreground"
-                  >
-                    {t("notifications.cacheHitRateAlert.minEligibleRequests")}
-                  </label>
+                <LabeledControl
+                  id="cacheHitRateAlertMinEligibleRequests"
+                  label={t("notifications.cacheHitRateAlert.minEligibleRequests")}
+                >
                   <input
                     id="cacheHitRateAlertMinEligibleRequests"
                     type="number"
@@ -493,52 +473,38 @@ export function NotificationTypeCard({
                     max={100000}
                     value={settings.cacheHitRateAlertMinEligibleRequests}
                     disabled={!settings.enabled}
-                    onChange={(e) =>
+                    onChange={safeNumberOnChange((nextValue) =>
                       onUpdateSettings({
-                        cacheHitRateAlertMinEligibleRequests: Number(e.target.value),
+                        cacheHitRateAlertMinEligibleRequests: nextValue,
                       })
-                    }
-                    className={cn(
-                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
-                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
-                      "disabled:opacity-50 disabled:cursor-not-allowed"
                     )}
+                    className={settingsControlClassName}
                   />
-                </div>
+                </LabeledControl>
 
-                <div className="space-y-1.5">
-                  <label
-                    htmlFor="cacheHitRateAlertMinEligibleTokens"
-                    className="text-xs font-medium text-muted-foreground"
-                  >
-                    {t("notifications.cacheHitRateAlert.minEligibleTokens")}
-                  </label>
+                <LabeledControl
+                  id="cacheHitRateAlertMinEligibleTokens"
+                  label={t("notifications.cacheHitRateAlert.minEligibleTokens")}
+                >
                   <input
                     id="cacheHitRateAlertMinEligibleTokens"
                     type="number"
                     min={0}
                     value={settings.cacheHitRateAlertMinEligibleTokens}
                     disabled={!settings.enabled}
-                    onChange={(e) =>
+                    onChange={safeNumberOnChange((nextValue) =>
                       onUpdateSettings({
-                        cacheHitRateAlertMinEligibleTokens: Number(e.target.value),
+                        cacheHitRateAlertMinEligibleTokens: nextValue,
                       })
-                    }
-                    className={cn(
-                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
-                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
-                      "disabled:opacity-50 disabled:cursor-not-allowed"
                     )}
+                    className={settingsControlClassName}
                   />
-                </div>
+                </LabeledControl>
 
-                <div className="space-y-1.5">
-                  <label
-                    htmlFor="cacheHitRateAlertTopN"
-                    className="text-xs font-medium text-muted-foreground"
-                  >
-                    {t("notifications.cacheHitRateAlert.topN")}
-                  </label>
+                <LabeledControl
+                  id="cacheHitRateAlertTopN"
+                  label={t("notifications.cacheHitRateAlert.topN")}
+                >
                   <input
                     id="cacheHitRateAlertTopN"
                     type="number"
@@ -546,16 +512,12 @@ export function NotificationTypeCard({
                     max={100}
                     value={settings.cacheHitRateAlertTopN}
                     disabled={!settings.enabled}
-                    onChange={(e) =>
-                      onUpdateSettings({ cacheHitRateAlertTopN: Number(e.target.value) })
-                    }
-                    className={cn(
-                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
-                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
-                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    onChange={safeNumberOnChange((nextValue) =>
+                      onUpdateSettings({ cacheHitRateAlertTopN: nextValue })
                     )}
+                    className={settingsControlClassName}
                   />
-                </div>
+                </LabeledControl>
               </div>
             </div>
           )}

--- a/src/app/[locale]/settings/notifications/_components/notification-type-card.tsx
+++ b/src/app/[locale]/settings/notifications/_components/notification-type-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, DollarSign, Settings2, TrendingUp } from "lucide-react";
+import { AlertTriangle, Database, DollarSign, Settings2, TrendingUp } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { ComponentProps } from "react";
 import { useMemo } from "react";
@@ -33,7 +33,7 @@ interface TypeConfig {
   iconColor: string;
   iconBgColor: string;
   borderColor: string;
-  IconComponent: typeof AlertTriangle | typeof TrendingUp | typeof DollarSign;
+  IconComponent: typeof AlertTriangle | typeof TrendingUp | typeof DollarSign | typeof Database;
 }
 
 function getTypeConfig(type: NotificationType): TypeConfig {
@@ -58,6 +58,13 @@ function getTypeConfig(type: NotificationType): TypeConfig {
         iconBgColor: "bg-yellow-500/10",
         borderColor: "border-border/50 hover:border-border",
         IconComponent: DollarSign,
+      };
+    case "cache_hit_rate_alert":
+      return {
+        iconColor: "text-blue-400",
+        iconBgColor: "bg-blue-500/10",
+        borderColor: "border-blue-500/20 hover:border-blue-500/30",
+        IconComponent: Database,
       };
   }
 }
@@ -98,6 +105,14 @@ export function NotificationTypeCard({
           enabled: settings.costAlertEnabled,
           enabledKey: "costAlertEnabled" as const,
           enableLabel: t("notifications.costAlert.enable"),
+        };
+      case "cache_hit_rate_alert":
+        return {
+          title: t("notifications.cacheHitRateAlert.title"),
+          description: t("notifications.cacheHitRateAlert.description"),
+          enabled: settings.cacheHitRateAlertEnabled,
+          enabledKey: "cacheHitRateAlertEnabled" as const,
+          enableLabel: t("notifications.cacheHitRateAlert.enable"),
         };
     }
   }, [settings, t, type]);
@@ -259,6 +274,283 @@ export function NotificationTypeCard({
                     "disabled:opacity-50 disabled:cursor-not-allowed"
                   )}
                 />
+              </div>
+            </div>
+          )}
+
+          {type === "cache_hit_rate_alert" && (
+            <div className="space-y-3">
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="cacheHitRateAlertWindowMode"
+                    className="text-xs font-medium text-muted-foreground"
+                  >
+                    {t("notifications.cacheHitRateAlert.windowMode")}
+                  </label>
+                  <select
+                    id="cacheHitRateAlertWindowMode"
+                    value={settings.cacheHitRateAlertWindowMode}
+                    disabled={!settings.enabled}
+                    onChange={(e) =>
+                      onUpdateSettings({ cacheHitRateAlertWindowMode: e.target.value })
+                    }
+                    className={cn(
+                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
+                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
+                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    )}
+                  >
+                    <option value="auto">
+                      {t("notifications.cacheHitRateAlert.windowModeAuto")}
+                    </option>
+                    <option value="5m">5m</option>
+                    <option value="30m">30m</option>
+                    <option value="1h">1h</option>
+                    <option value="1.5h">1.5h</option>
+                  </select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="cacheHitRateAlertCheckInterval"
+                    className="text-xs font-medium text-muted-foreground"
+                  >
+                    {t("notifications.cacheHitRateAlert.checkInterval")}
+                  </label>
+                  <input
+                    id="cacheHitRateAlertCheckInterval"
+                    type="number"
+                    min={1}
+                    max={1440}
+                    value={settings.cacheHitRateAlertCheckInterval}
+                    disabled={!settings.enabled}
+                    onChange={(e) =>
+                      onUpdateSettings({
+                        cacheHitRateAlertCheckInterval: Number(e.target.value),
+                      })
+                    }
+                    className={cn(
+                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
+                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
+                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    )}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="cacheHitRateAlertHistoricalLookbackDays"
+                    className="text-xs font-medium text-muted-foreground"
+                  >
+                    {t("notifications.cacheHitRateAlert.historicalLookbackDays")}
+                  </label>
+                  <input
+                    id="cacheHitRateAlertHistoricalLookbackDays"
+                    type="number"
+                    min={1}
+                    max={90}
+                    value={settings.cacheHitRateAlertHistoricalLookbackDays}
+                    disabled={!settings.enabled}
+                    onChange={(e) =>
+                      onUpdateSettings({
+                        cacheHitRateAlertHistoricalLookbackDays: Number(e.target.value),
+                      })
+                    }
+                    className={cn(
+                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
+                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
+                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    )}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="cacheHitRateAlertCooldownMinutes"
+                    className="text-xs font-medium text-muted-foreground"
+                  >
+                    {t("notifications.cacheHitRateAlert.cooldownMinutes")}
+                  </label>
+                  <input
+                    id="cacheHitRateAlertCooldownMinutes"
+                    type="number"
+                    min={0}
+                    max={1440}
+                    value={settings.cacheHitRateAlertCooldownMinutes}
+                    disabled={!settings.enabled}
+                    onChange={(e) =>
+                      onUpdateSettings({
+                        cacheHitRateAlertCooldownMinutes: Number(e.target.value),
+                      })
+                    }
+                    className={cn(
+                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
+                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
+                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    )}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-3">
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="cacheHitRateAlertAbsMin"
+                    className="text-xs font-medium text-muted-foreground"
+                  >
+                    {t("notifications.cacheHitRateAlert.absMin")}
+                  </label>
+                  <input
+                    id="cacheHitRateAlertAbsMin"
+                    type="number"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={settings.cacheHitRateAlertAbsMin}
+                    disabled={!settings.enabled}
+                    onChange={(e) =>
+                      onUpdateSettings({ cacheHitRateAlertAbsMin: Number(e.target.value) })
+                    }
+                    className={cn(
+                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
+                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
+                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    )}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="cacheHitRateAlertDropAbs"
+                    className="text-xs font-medium text-muted-foreground"
+                  >
+                    {t("notifications.cacheHitRateAlert.dropAbs")}
+                  </label>
+                  <input
+                    id="cacheHitRateAlertDropAbs"
+                    type="number"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={settings.cacheHitRateAlertDropAbs}
+                    disabled={!settings.enabled}
+                    onChange={(e) =>
+                      onUpdateSettings({ cacheHitRateAlertDropAbs: Number(e.target.value) })
+                    }
+                    className={cn(
+                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
+                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
+                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    )}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="cacheHitRateAlertDropRel"
+                    className="text-xs font-medium text-muted-foreground"
+                  >
+                    {t("notifications.cacheHitRateAlert.dropRel")}
+                  </label>
+                  <input
+                    id="cacheHitRateAlertDropRel"
+                    type="number"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={settings.cacheHitRateAlertDropRel}
+                    disabled={!settings.enabled}
+                    onChange={(e) =>
+                      onUpdateSettings({ cacheHitRateAlertDropRel: Number(e.target.value) })
+                    }
+                    className={cn(
+                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
+                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
+                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    )}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-3">
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="cacheHitRateAlertMinEligibleRequests"
+                    className="text-xs font-medium text-muted-foreground"
+                  >
+                    {t("notifications.cacheHitRateAlert.minEligibleRequests")}
+                  </label>
+                  <input
+                    id="cacheHitRateAlertMinEligibleRequests"
+                    type="number"
+                    min={1}
+                    max={100000}
+                    value={settings.cacheHitRateAlertMinEligibleRequests}
+                    disabled={!settings.enabled}
+                    onChange={(e) =>
+                      onUpdateSettings({
+                        cacheHitRateAlertMinEligibleRequests: Number(e.target.value),
+                      })
+                    }
+                    className={cn(
+                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
+                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
+                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    )}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="cacheHitRateAlertMinEligibleTokens"
+                    className="text-xs font-medium text-muted-foreground"
+                  >
+                    {t("notifications.cacheHitRateAlert.minEligibleTokens")}
+                  </label>
+                  <input
+                    id="cacheHitRateAlertMinEligibleTokens"
+                    type="number"
+                    min={0}
+                    value={settings.cacheHitRateAlertMinEligibleTokens}
+                    disabled={!settings.enabled}
+                    onChange={(e) =>
+                      onUpdateSettings({
+                        cacheHitRateAlertMinEligibleTokens: Number(e.target.value),
+                      })
+                    }
+                    className={cn(
+                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
+                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
+                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    )}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="cacheHitRateAlertTopN"
+                    className="text-xs font-medium text-muted-foreground"
+                  >
+                    {t("notifications.cacheHitRateAlert.topN")}
+                  </label>
+                  <input
+                    id="cacheHitRateAlertTopN"
+                    type="number"
+                    min={1}
+                    max={100}
+                    value={settings.cacheHitRateAlertTopN}
+                    disabled={!settings.enabled}
+                    onChange={(e) =>
+                      onUpdateSettings({ cacheHitRateAlertTopN: Number(e.target.value) })
+                    }
+                    className={cn(
+                      "w-full bg-muted/50 border border-border rounded-lg py-2 px-3 text-sm text-foreground",
+                      "focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all",
+                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                    )}
+                  />
+                </div>
               </div>
             </div>
           )}

--- a/src/app/[locale]/settings/notifications/_components/notifications-skeleton.tsx
+++ b/src/app/[locale]/settings/notifications/_components/notifications-skeleton.tsx
@@ -61,7 +61,7 @@ export function NotificationsSkeleton() {
 
       {/* Notification type cards skeleton */}
       <div className="grid gap-6">
-        {[1, 2, 3].map((i) => (
+        {[1, 2, 3, 4].map((i) => (
           <div
             key={i}
             className="rounded-xl border border-white/5 bg-card/30 p-5 md:p-6 backdrop-blur-sm"

--- a/src/app/[locale]/settings/notifications/_components/template-editor.tsx
+++ b/src/app/[locale]/settings/notifications/_components/template-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Braces, Info } from "lucide-react";
+import { Braces, Info, RotateCcw } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo, useRef } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -8,13 +8,17 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import {
+  DEFAULT_TEMPLATE_BY_NOTIFICATION_TYPE,
+  DEFAULT_TEMPLATES,
+} from "@/lib/webhook/templates/defaults";
 import { getTemplatePlaceholders } from "@/lib/webhook/templates/placeholders";
-import type { NotificationType } from "../_lib/schemas";
+import type { WebhookNotificationType } from "@/lib/webhook/types";
 
 interface TemplateEditorProps {
   value: string;
   onChange: (value: string) => void;
-  notificationType?: NotificationType;
+  notificationType?: WebhookNotificationType;
   className?: string;
 }
 
@@ -26,6 +30,15 @@ export function TemplateEditor({
 }: TemplateEditorProps) {
   const t = useTranslations("settings");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const defaultTemplate = useMemo(() => {
+    if (!notificationType) {
+      return DEFAULT_TEMPLATES.custom_generic;
+    }
+    return (
+      DEFAULT_TEMPLATE_BY_NOTIFICATION_TYPE[notificationType] ?? DEFAULT_TEMPLATES.custom_generic
+    );
+  }, [notificationType]);
 
   const placeholders = useMemo(() => {
     return getTemplatePlaceholders(notificationType);
@@ -65,10 +78,21 @@ export function TemplateEditor({
   return (
     <div className={cn("grid gap-4 md:grid-cols-2", className)}>
       <div className="space-y-2">
-        <Label className="flex items-center gap-2">
-          <Braces className="h-4 w-4" />
-          {t("notifications.templateEditor.title")}
-        </Label>
+        <div className="flex items-center justify-between gap-2">
+          <Label className="flex items-center gap-2">
+            <Braces className="h-4 w-4" />
+            {t("notifications.templateEditor.title")}
+          </Label>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => onChange(JSON.stringify(defaultTemplate, null, 2))}
+          >
+            <RotateCcw className="mr-2 h-4 w-4" />
+            {t("common.reset")}
+          </Button>
+        </div>
         <Textarea
           ref={textareaRef}
           value={value}

--- a/src/app/[locale]/settings/notifications/_components/test-webhook-button.tsx
+++ b/src/app/[locale]/settings/notifications/_components/test-webhook-button.tsx
@@ -14,6 +14,17 @@ import {
 import { cn } from "@/lib/utils";
 import type { NotificationType } from "../_lib/schemas";
 
+const TEST_NOTIFICATION_TYPES = [
+  "circuit_breaker",
+  "daily_leaderboard",
+  "cost_alert",
+  "cache_hit_rate_alert",
+] as const satisfies readonly NotificationType[];
+
+function isNotificationType(value: string): value is NotificationType {
+  return (TEST_NOTIFICATION_TYPES as readonly string[]).includes(value);
+}
+
 interface TestWebhookButtonProps {
   targetId: number;
   disabled?: boolean;
@@ -48,7 +59,10 @@ export function TestWebhookButton({ targetId, disabled, onTest }: TestWebhookBut
     <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
       <Select
         value={type}
-        onValueChange={(v) => setType(v as NotificationType)}
+        onValueChange={(v) => {
+          if (!isNotificationType(v)) return;
+          setType(v);
+        }}
         disabled={disabled || isTesting}
       >
         <SelectTrigger

--- a/src/app/[locale]/settings/notifications/_components/test-webhook-button.tsx
+++ b/src/app/[locale]/settings/notifications/_components/test-webhook-button.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import type { WebhookNotificationType } from "@/lib/webhook/types";
 import type { NotificationType } from "../_lib/schemas";
 
 interface TestWebhookButtonProps {
@@ -22,7 +23,7 @@ interface TestWebhookButtonProps {
 
 export function TestWebhookButton({ targetId, disabled, onTest }: TestWebhookButtonProps) {
   const t = useTranslations("settings");
-  const [type, setType] = useState<NotificationType>("circuit_breaker");
+  const [type, setType] = useState<WebhookNotificationType>("circuit_breaker");
   const [isTesting, setIsTesting] = useState(false);
 
   const options = useMemo(
@@ -30,6 +31,7 @@ export function TestWebhookButton({ targetId, disabled, onTest }: TestWebhookBut
       { value: "circuit_breaker" as const, label: t("notifications.circuitBreaker.title") },
       { value: "daily_leaderboard" as const, label: t("notifications.dailyLeaderboard.title") },
       { value: "cost_alert" as const, label: t("notifications.costAlert.title") },
+      { value: "cache_hit_rate_alert" as const, label: t("notifications.cacheHitRateAlert.title") },
     ],
     [t]
   );
@@ -37,7 +39,7 @@ export function TestWebhookButton({ targetId, disabled, onTest }: TestWebhookBut
   const handleTest = async () => {
     setIsTesting(true);
     try {
-      await onTest(targetId, type);
+      await onTest(targetId, type as unknown as NotificationType);
     } finally {
       setIsTesting(false);
     }
@@ -47,7 +49,7 @@ export function TestWebhookButton({ targetId, disabled, onTest }: TestWebhookBut
     <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
       <Select
         value={type}
-        onValueChange={(v) => setType(v as NotificationType)}
+        onValueChange={(v) => setType(v as WebhookNotificationType)}
         disabled={disabled || isTesting}
       >
         <SelectTrigger

--- a/src/app/[locale]/settings/notifications/_components/test-webhook-button.tsx
+++ b/src/app/[locale]/settings/notifications/_components/test-webhook-button.tsx
@@ -12,7 +12,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import type { WebhookNotificationType } from "@/lib/webhook/types";
 import type { NotificationType } from "../_lib/schemas";
 
 interface TestWebhookButtonProps {
@@ -23,7 +22,7 @@ interface TestWebhookButtonProps {
 
 export function TestWebhookButton({ targetId, disabled, onTest }: TestWebhookButtonProps) {
   const t = useTranslations("settings");
-  const [type, setType] = useState<WebhookNotificationType>("circuit_breaker");
+  const [type, setType] = useState<NotificationType>("circuit_breaker");
   const [isTesting, setIsTesting] = useState(false);
 
   const options = useMemo(
@@ -39,7 +38,7 @@ export function TestWebhookButton({ targetId, disabled, onTest }: TestWebhookBut
   const handleTest = async () => {
     setIsTesting(true);
     try {
-      await onTest(targetId, type as unknown as NotificationType);
+      await onTest(targetId, type);
     } finally {
       setIsTesting(false);
     }
@@ -49,7 +48,7 @@ export function TestWebhookButton({ targetId, disabled, onTest }: TestWebhookBut
     <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
       <Select
         value={type}
-        onValueChange={(v) => setType(v as WebhookNotificationType)}
+        onValueChange={(v) => setType(v as NotificationType)}
         disabled={disabled || isTesting}
       >
         <SelectTrigger

--- a/src/app/[locale]/settings/notifications/_lib/hooks.ts
+++ b/src/app/[locale]/settings/notifications/_lib/hooks.ts
@@ -35,6 +35,18 @@ export interface NotificationSettingsState {
   costAlertWebhook: string;
   costAlertThreshold: number;
   costAlertCheckInterval: number;
+
+  cacheHitRateAlertEnabled: boolean;
+  cacheHitRateAlertWindowMode: string;
+  cacheHitRateAlertCheckInterval: number;
+  cacheHitRateAlertHistoricalLookbackDays: number;
+  cacheHitRateAlertMinEligibleRequests: number;
+  cacheHitRateAlertMinEligibleTokens: number;
+  cacheHitRateAlertAbsMin: number;
+  cacheHitRateAlertDropRel: number;
+  cacheHitRateAlertDropAbs: number;
+  cacheHitRateAlertCooldownMinutes: number;
+  cacheHitRateAlertTopN: number;
 }
 
 export interface WebhookTestResult {
@@ -94,6 +106,7 @@ export const NOTIFICATION_TYPES: NotificationType[] = [
   "circuit_breaker",
   "daily_leaderboard",
   "cost_alert",
+  "cache_hit_rate_alert",
 ];
 
 function toClientSettings(raw: any): NotificationSettingsState {
@@ -109,6 +122,19 @@ function toClientSettings(raw: any): NotificationSettingsState {
     costAlertWebhook: raw?.costAlertWebhook || "",
     costAlertThreshold: parseFloat(raw?.costAlertThreshold || "0.80"),
     costAlertCheckInterval: Number(raw?.costAlertCheckInterval || 60),
+    cacheHitRateAlertEnabled: Boolean(raw?.cacheHitRateAlertEnabled),
+    cacheHitRateAlertWindowMode: raw?.cacheHitRateAlertWindowMode || "auto",
+    cacheHitRateAlertCheckInterval: Number(raw?.cacheHitRateAlertCheckInterval || 5),
+    cacheHitRateAlertHistoricalLookbackDays: Number(
+      raw?.cacheHitRateAlertHistoricalLookbackDays || 7
+    ),
+    cacheHitRateAlertMinEligibleRequests: Number(raw?.cacheHitRateAlertMinEligibleRequests || 20),
+    cacheHitRateAlertMinEligibleTokens: Number(raw?.cacheHitRateAlertMinEligibleTokens || 0),
+    cacheHitRateAlertAbsMin: parseFloat(raw?.cacheHitRateAlertAbsMin || "0.05"),
+    cacheHitRateAlertDropRel: parseFloat(raw?.cacheHitRateAlertDropRel || "0.3"),
+    cacheHitRateAlertDropAbs: parseFloat(raw?.cacheHitRateAlertDropAbs || "0.1"),
+    cacheHitRateAlertCooldownMinutes: Number(raw?.cacheHitRateAlertCooldownMinutes || 30),
+    cacheHitRateAlertTopN: Number(raw?.cacheHitRateAlertTopN || 10),
   };
 }
 
@@ -121,6 +147,7 @@ export function useNotificationsPageData() {
     circuit_breaker: [],
     daily_leaderboard: [],
     cost_alert: [],
+    cache_hit_rate_alert: [],
   }));
 
   const [isLoading, setIsLoading] = useState(true);
@@ -214,6 +241,41 @@ export function useNotificationsPageData() {
       }
       if (patch.costAlertCheckInterval !== undefined) {
         payload.costAlertCheckInterval = patch.costAlertCheckInterval;
+      }
+
+      if (patch.cacheHitRateAlertEnabled !== undefined) {
+        payload.cacheHitRateAlertEnabled = patch.cacheHitRateAlertEnabled;
+      }
+      if (patch.cacheHitRateAlertWindowMode !== undefined) {
+        payload.cacheHitRateAlertWindowMode = patch.cacheHitRateAlertWindowMode;
+      }
+      if (patch.cacheHitRateAlertCheckInterval !== undefined) {
+        payload.cacheHitRateAlertCheckInterval = patch.cacheHitRateAlertCheckInterval;
+      }
+      if (patch.cacheHitRateAlertHistoricalLookbackDays !== undefined) {
+        payload.cacheHitRateAlertHistoricalLookbackDays =
+          patch.cacheHitRateAlertHistoricalLookbackDays;
+      }
+      if (patch.cacheHitRateAlertMinEligibleRequests !== undefined) {
+        payload.cacheHitRateAlertMinEligibleRequests = patch.cacheHitRateAlertMinEligibleRequests;
+      }
+      if (patch.cacheHitRateAlertMinEligibleTokens !== undefined) {
+        payload.cacheHitRateAlertMinEligibleTokens = patch.cacheHitRateAlertMinEligibleTokens;
+      }
+      if (patch.cacheHitRateAlertAbsMin !== undefined) {
+        payload.cacheHitRateAlertAbsMin = patch.cacheHitRateAlertAbsMin.toString();
+      }
+      if (patch.cacheHitRateAlertDropRel !== undefined) {
+        payload.cacheHitRateAlertDropRel = patch.cacheHitRateAlertDropRel.toString();
+      }
+      if (patch.cacheHitRateAlertDropAbs !== undefined) {
+        payload.cacheHitRateAlertDropAbs = patch.cacheHitRateAlertDropAbs.toString();
+      }
+      if (patch.cacheHitRateAlertCooldownMinutes !== undefined) {
+        payload.cacheHitRateAlertCooldownMinutes = patch.cacheHitRateAlertCooldownMinutes;
+      }
+      if (patch.cacheHitRateAlertTopN !== undefined) {
+        payload.cacheHitRateAlertTopN = patch.cacheHitRateAlertTopN;
       }
 
       const result = await updateNotificationSettingsAction(payload);

--- a/src/app/[locale]/settings/notifications/_lib/hooks.ts
+++ b/src/app/[locale]/settings/notifications/_lib/hooks.ts
@@ -116,6 +116,8 @@ export const NOTIFICATION_TYPES: NotificationType[] = [
 const INT32_MAX = 2_147_483_647;
 
 function toFiniteNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
   const n = typeof value === "number" ? value : Number(value);
   return Number.isFinite(n) ? n : null;
 }

--- a/src/app/[locale]/settings/notifications/_lib/hooks.ts
+++ b/src/app/[locale]/settings/notifications/_lib/hooks.ts
@@ -13,6 +13,10 @@ import {
   testWebhookTargetAction,
   updateWebhookTargetAction,
 } from "@/actions/webhook-targets";
+import {
+  type CacheHitRateAlertSettingsWindowMode,
+  isCacheHitRateAlertSettingsWindowMode,
+} from "@/lib/webhook/types";
 import type { NotificationType, WebhookProviderType } from "./schemas";
 
 export interface ClientActionResult<T> {
@@ -37,7 +41,7 @@ export interface NotificationSettingsState {
   costAlertCheckInterval: number;
 
   cacheHitRateAlertEnabled: boolean;
-  cacheHitRateAlertWindowMode: string;
+  cacheHitRateAlertWindowMode: CacheHitRateAlertSettingsWindowMode;
   cacheHitRateAlertCheckInterval: number;
   cacheHitRateAlertHistoricalLookbackDays: number;
   cacheHitRateAlertMinEligibleRequests: number;
@@ -110,6 +114,12 @@ export const NOTIFICATION_TYPES: NotificationType[] = [
 ];
 
 function toClientSettings(raw: any): NotificationSettingsState {
+  const cacheHitRateAlertWindowMode = isCacheHitRateAlertSettingsWindowMode(
+    raw?.cacheHitRateAlertWindowMode
+  )
+    ? raw.cacheHitRateAlertWindowMode
+    : "auto";
+
   return {
     enabled: Boolean(raw?.enabled),
     circuitBreakerEnabled: Boolean(raw?.circuitBreakerEnabled),
@@ -123,7 +133,7 @@ function toClientSettings(raw: any): NotificationSettingsState {
     costAlertThreshold: parseFloat(raw?.costAlertThreshold || "0.80"),
     costAlertCheckInterval: Number(raw?.costAlertCheckInterval || 60),
     cacheHitRateAlertEnabled: Boolean(raw?.cacheHitRateAlertEnabled),
-    cacheHitRateAlertWindowMode: raw?.cacheHitRateAlertWindowMode || "auto",
+    cacheHitRateAlertWindowMode,
     cacheHitRateAlertCheckInterval: Number(raw?.cacheHitRateAlertCheckInterval || 5),
     cacheHitRateAlertHistoricalLookbackDays: Number(
       raw?.cacheHitRateAlertHistoricalLookbackDays || 7

--- a/src/app/[locale]/settings/notifications/_lib/hooks.ts
+++ b/src/app/[locale]/settings/notifications/_lib/hooks.ts
@@ -134,17 +134,17 @@ function toClientSettings(raw: any): NotificationSettingsState {
     costAlertCheckInterval: Number(raw?.costAlertCheckInterval || 60),
     cacheHitRateAlertEnabled: Boolean(raw?.cacheHitRateAlertEnabled),
     cacheHitRateAlertWindowMode,
-    cacheHitRateAlertCheckInterval: Number(raw?.cacheHitRateAlertCheckInterval || 5),
+    cacheHitRateAlertCheckInterval: Number(raw?.cacheHitRateAlertCheckInterval ?? 5),
     cacheHitRateAlertHistoricalLookbackDays: Number(
-      raw?.cacheHitRateAlertHistoricalLookbackDays || 7
+      raw?.cacheHitRateAlertHistoricalLookbackDays ?? 7
     ),
-    cacheHitRateAlertMinEligibleRequests: Number(raw?.cacheHitRateAlertMinEligibleRequests || 20),
-    cacheHitRateAlertMinEligibleTokens: Number(raw?.cacheHitRateAlertMinEligibleTokens || 0),
-    cacheHitRateAlertAbsMin: parseFloat(raw?.cacheHitRateAlertAbsMin || "0.05"),
-    cacheHitRateAlertDropRel: parseFloat(raw?.cacheHitRateAlertDropRel || "0.3"),
-    cacheHitRateAlertDropAbs: parseFloat(raw?.cacheHitRateAlertDropAbs || "0.1"),
-    cacheHitRateAlertCooldownMinutes: Number(raw?.cacheHitRateAlertCooldownMinutes || 30),
-    cacheHitRateAlertTopN: Number(raw?.cacheHitRateAlertTopN || 10),
+    cacheHitRateAlertMinEligibleRequests: Number(raw?.cacheHitRateAlertMinEligibleRequests ?? 20),
+    cacheHitRateAlertMinEligibleTokens: Number(raw?.cacheHitRateAlertMinEligibleTokens ?? 0),
+    cacheHitRateAlertAbsMin: parseFloat(raw?.cacheHitRateAlertAbsMin ?? "0.05"),
+    cacheHitRateAlertDropRel: parseFloat(raw?.cacheHitRateAlertDropRel ?? "0.3"),
+    cacheHitRateAlertDropAbs: parseFloat(raw?.cacheHitRateAlertDropAbs ?? "0.1"),
+    cacheHitRateAlertCooldownMinutes: Number(raw?.cacheHitRateAlertCooldownMinutes ?? 30),
+    cacheHitRateAlertTopN: Number(raw?.cacheHitRateAlertTopN ?? 10),
   };
 }
 

--- a/src/app/[locale]/settings/notifications/_lib/schemas.ts
+++ b/src/app/[locale]/settings/notifications/_lib/schemas.ts
@@ -6,6 +6,7 @@ export const NotificationTypeSchema = z.enum([
   "circuit_breaker",
   "daily_leaderboard",
   "cost_alert",
+  "cache_hit_rate_alert",
 ]);
 export type NotificationType = z.infer<typeof NotificationTypeSchema>;
 

--- a/src/app/api/actions/[...route]/route.ts
+++ b/src/app/api/actions/[...route]/route.ts
@@ -1362,7 +1362,7 @@ const { route: updateNotificationSettingsRoute, handler: updateNotificationSetti
           .optional()
           .describe("缓存命中率异常告警 Webhook URL（旧版模式）"),
         cacheHitRateAlertWindowMode: z
-          .string()
+          .enum(["auto", "5m", "30m", "1h", "1.5h"])
           .optional()
           .describe("检测窗口模式（auto/5m/30m/1h/1.5h）"),
         cacheHitRateAlertCheckInterval: z

--- a/src/app/api/actions/[...route]/route.ts
+++ b/src/app/api/actions/[...route]/route.ts
@@ -1353,6 +1353,66 @@ const { route: updateNotificationSettingsRoute, handler: updateNotificationSetti
           .positive()
           .optional()
           .describe("成本预警检查间隔（分钟）"),
+
+        cacheHitRateAlertEnabled: z.boolean().optional().describe("是否启用缓存命中率异常告警"),
+        cacheHitRateAlertWebhook: z
+          .string()
+          .url()
+          .nullable()
+          .optional()
+          .describe("缓存命中率异常告警 Webhook URL（旧版模式）"),
+        cacheHitRateAlertWindowMode: z
+          .string()
+          .optional()
+          .describe("检测窗口模式（auto/5m/30m/1h/1.5h）"),
+        cacheHitRateAlertCheckInterval: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("缓存命中率告警检查间隔（分钟）"),
+        cacheHitRateAlertHistoricalLookbackDays: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("历史基线回看天数"),
+        cacheHitRateAlertMinEligibleRequests: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("最小 eligible 请求数门槛"),
+        cacheHitRateAlertMinEligibleTokens: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe("最小 eligible tokens 门槛"),
+        cacheHitRateAlertAbsMin: z
+          .string()
+          .optional()
+          .describe("absMin（numeric 字段以 string 表示）"),
+        cacheHitRateAlertDropRel: z
+          .string()
+          .optional()
+          .describe("dropRel（numeric 字段以 string 表示）"),
+        cacheHitRateAlertDropAbs: z
+          .string()
+          .optional()
+          .describe("dropAbs（numeric 字段以 string 表示）"),
+        cacheHitRateAlertCooldownMinutes: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe("冷却时间（分钟）"),
+        cacheHitRateAlertTopN: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("TopN（最多返回/推送条数）"),
       }),
       summary: "更新通知设置",
       description: "更新通知开关与各类型通知配置（生产环境会触发重新调度定时任务）",
@@ -1390,6 +1450,7 @@ const WebhookNotificationTypeSchema = z.enum([
   "circuit_breaker",
   "daily_leaderboard",
   "cost_alert",
+  "cache_hit_rate_alert",
 ]);
 
 const WebhookTargetSchema = z.object({

--- a/src/app/api/actions/[...route]/route.ts
+++ b/src/app/api/actions/[...route]/route.ts
@@ -1308,6 +1308,16 @@ const { route: getNotificationSettingsRoute, handler: getNotificationSettingsHan
   );
 app.openapi(getNotificationSettingsRoute, getNotificationSettingsHandler);
 
+const RatioStringSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .regex(/^\d+(?:\.\d+)?$/)
+  .refine((value) => {
+    const n = Number(value);
+    return Number.isFinite(n) && n >= 0 && n <= 1;
+  });
+
 const { route: updateNotificationSettingsRoute, handler: updateNotificationSettingsHandler } =
   createActionRoute(
     "notifications",
@@ -1334,7 +1344,13 @@ const { route: updateNotificationSettingsRoute, handler: updateNotificationSetti
           .optional()
           .describe("每日排行榜 Webhook URL（旧版模式）"),
         dailyLeaderboardTime: z.string().optional().describe("每日排行榜发送时间（HH:mm）"),
-        dailyLeaderboardTopN: z.number().int().positive().optional().describe("每日排行榜 TopN"),
+        dailyLeaderboardTopN: z
+          .number()
+          .int()
+          .min(1)
+          .max(20)
+          .optional()
+          .describe("每日排行榜 TopN"),
 
         costAlertEnabled: z.boolean().optional().describe("是否启用成本预警"),
         costAlertWebhook: z
@@ -1343,14 +1359,14 @@ const { route: updateNotificationSettingsRoute, handler: updateNotificationSetti
           .nullable()
           .optional()
           .describe("成本预警 Webhook URL（旧版模式）"),
-        costAlertThreshold: z
-          .string()
-          .optional()
-          .describe("成本预警阈值（numeric 字段以 string 表示）"),
+        costAlertThreshold: RatioStringSchema.optional().describe(
+          "成本预警阈值（numeric 字段以 string 表示）"
+        ),
         costAlertCheckInterval: z
           .number()
           .int()
-          .positive()
+          .min(10)
+          .max(1440)
           .optional()
           .describe("成本预警检查间隔（分钟）"),
 
@@ -1368,49 +1384,52 @@ const { route: updateNotificationSettingsRoute, handler: updateNotificationSetti
         cacheHitRateAlertCheckInterval: z
           .number()
           .int()
-          .positive()
+          .min(1)
+          .max(1440)
           .optional()
           .describe("缓存命中率告警检查间隔（分钟）"),
         cacheHitRateAlertHistoricalLookbackDays: z
           .number()
           .int()
-          .positive()
+          .min(1)
+          .max(90)
           .optional()
           .describe("历史基线回看天数"),
         cacheHitRateAlertMinEligibleRequests: z
           .number()
           .int()
-          .positive()
+          .min(1)
+          .max(100000)
           .optional()
           .describe("最小 eligible 请求数门槛"),
         cacheHitRateAlertMinEligibleTokens: z
           .number()
           .int()
           .min(0)
+          .max(2_147_483_647)
           .optional()
           .describe("最小 eligible tokens 门槛"),
-        cacheHitRateAlertAbsMin: z
-          .string()
-          .optional()
-          .describe("absMin（numeric 字段以 string 表示）"),
-        cacheHitRateAlertDropRel: z
-          .string()
-          .optional()
-          .describe("dropRel（numeric 字段以 string 表示）"),
-        cacheHitRateAlertDropAbs: z
-          .string()
-          .optional()
-          .describe("dropAbs（numeric 字段以 string 表示）"),
+        cacheHitRateAlertAbsMin: RatioStringSchema.optional().describe(
+          "absMin（numeric 字段以 string 表示）"
+        ),
+        cacheHitRateAlertDropRel: RatioStringSchema.optional().describe(
+          "dropRel（numeric 字段以 string 表示）"
+        ),
+        cacheHitRateAlertDropAbs: RatioStringSchema.optional().describe(
+          "dropAbs（numeric 字段以 string 表示）"
+        ),
         cacheHitRateAlertCooldownMinutes: z
           .number()
           .int()
           .min(0)
+          .max(1440)
           .optional()
           .describe("冷却时间（分钟）"),
         cacheHitRateAlertTopN: z
           .number()
           .int()
-          .positive()
+          .min(1)
+          .max(100)
           .optional()
           .describe("TopN（最多返回/推送条数）"),
       }),

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -31,6 +31,7 @@ export const notificationTypeEnum = pgEnum('notification_type', [
   'circuit_breaker',
   'daily_leaderboard',
   'cost_alert',
+  'cache_hit_rate_alert',
 ]);
 
 // Users table
@@ -772,6 +773,20 @@ export const notificationSettings = pgTable('notification_settings', {
   costAlertWebhook: varchar('cost_alert_webhook', { length: 512 }),
   costAlertThreshold: numeric('cost_alert_threshold', { precision: 5, scale: 2 }).default('0.80'), // 阈值 0-1 (80% = 0.80)
   costAlertCheckInterval: integer('cost_alert_check_interval').default(60), // 检查间隔（分钟）
+
+  // 缓存命中率异常告警配置（provider × model）
+  cacheHitRateAlertEnabled: boolean('cache_hit_rate_alert_enabled').notNull().default(false),
+  cacheHitRateAlertWebhook: varchar('cache_hit_rate_alert_webhook', { length: 512 }),
+  cacheHitRateAlertWindowMode: varchar('cache_hit_rate_alert_window_mode', { length: 10 }).default('auto'),
+  cacheHitRateAlertCheckInterval: integer('cache_hit_rate_alert_check_interval').default(5), // 检查间隔（分钟）
+  cacheHitRateAlertHistoricalLookbackDays: integer('cache_hit_rate_alert_historical_lookback_days').default(7),
+  cacheHitRateAlertMinEligibleRequests: integer('cache_hit_rate_alert_min_eligible_requests').default(20),
+  cacheHitRateAlertMinEligibleTokens: integer('cache_hit_rate_alert_min_eligible_tokens').default(0),
+  cacheHitRateAlertAbsMin: numeric('cache_hit_rate_alert_abs_min', { precision: 5, scale: 4 }).default('0.05'),
+  cacheHitRateAlertDropRel: numeric('cache_hit_rate_alert_drop_rel', { precision: 5, scale: 4 }).default('0.3'),
+  cacheHitRateAlertDropAbs: numeric('cache_hit_rate_alert_drop_abs', { precision: 5, scale: 4 }).default('0.1'),
+  cacheHitRateAlertCooldownMinutes: integer('cache_hit_rate_alert_cooldown_minutes').default(30),
+  cacheHitRateAlertTopN: integer('cache_hit_rate_alert_top_n').default(10),
 
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),

--- a/src/lib/cache-hit-rate-alert/decision.ts
+++ b/src/lib/cache-hit-rate-alert/decision.ts
@@ -1,0 +1,279 @@
+export interface CacheHitRateAlertMetric {
+  providerId: number;
+  model: string;
+
+  totalRequests: number;
+  denominatorTokens: number;
+  hitRateTokens: number;
+
+  eligibleRequests: number;
+  eligibleDenominatorTokens: number;
+  hitRateTokensEligible: number;
+}
+
+export type CacheHitRateAlertMetricKey = string;
+
+export type CacheHitRateAlertMetricCollection =
+  | ReadonlyArray<CacheHitRateAlertMetric>
+  | ReadonlyMap<CacheHitRateAlertMetricKey, CacheHitRateAlertMetric>;
+
+export interface CacheHitRateAlertDecisionSettings {
+  /** 当前 hitRate 绝对值低于该阈值直接告警 */
+  absMin: number;
+  /** 相对跌幅阈值：dropAbs / baseline >= dropRel */
+  dropRel: number;
+  /** 绝对跌幅阈值：baseline - current >= dropAbs */
+  dropAbs: number;
+  /** eligible 口径不足时可 fallback overall；不足则不参与告警 */
+  minEligibleRequests: number;
+  minEligibleTokens: number;
+  /** 返回的告警条数上限 */
+  topN: number;
+}
+
+export type CacheHitRateAlertBaselineSource = "historical" | "today" | "prev" | null;
+export type CacheHitRateAlertMetricKind = "eligible" | "overall";
+
+export interface CacheHitRateAlertSample {
+  kind: CacheHitRateAlertMetricKind;
+  requests: number;
+  denominatorTokens: number;
+  hitRateTokens: number;
+}
+
+export interface CacheHitRateAlertAnomaly {
+  key: CacheHitRateAlertMetricKey;
+  providerId: number;
+  model: string;
+
+  baselineSource: CacheHitRateAlertBaselineSource;
+  current: CacheHitRateAlertSample;
+  baseline: CacheHitRateAlertSample | null;
+
+  deltaAbs: number | null;
+  deltaRel: number | null;
+  dropAbs: number | null;
+
+  reasonCodes: string[];
+}
+
+export interface CacheHitRateAlertDecisionInput {
+  current: CacheHitRateAlertMetricCollection;
+  prev: CacheHitRateAlertMetricCollection;
+  today: CacheHitRateAlertMetricCollection;
+  historical: CacheHitRateAlertMetricCollection;
+  settings: CacheHitRateAlertDecisionSettings;
+}
+
+function clampRate01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(value, 0), 1);
+}
+
+export function toCacheHitRateAlertMetricKey(providerId: number, model: string): string {
+  return `${providerId}:${model}`;
+}
+
+function isMetricArray(
+  input: CacheHitRateAlertMetricCollection
+): input is ReadonlyArray<CacheHitRateAlertMetric> {
+  return Array.isArray(input);
+}
+
+function toMetricMap(
+  input: CacheHitRateAlertMetricCollection
+): Map<string, CacheHitRateAlertMetric> {
+  if (isMetricArray(input)) {
+    const map = new Map<string, CacheHitRateAlertMetric>();
+    for (const item of input) {
+      if (!item) continue;
+      if (!item.model || item.model.trim() === "") continue;
+      map.set(toCacheHitRateAlertMetricKey(item.providerId, item.model), item);
+    }
+    return map;
+  }
+
+  return new Map([...input]);
+}
+
+function pickSample(
+  metric: CacheHitRateAlertMetric,
+  settings: CacheHitRateAlertDecisionSettings
+): { sample: CacheHitRateAlertSample; reasonCodes: string[] } | null {
+  const eligibleOk =
+    metric.eligibleRequests >= settings.minEligibleRequests &&
+    metric.eligibleDenominatorTokens >= settings.minEligibleTokens;
+  if (eligibleOk) {
+    return {
+      sample: {
+        kind: "eligible",
+        requests: metric.eligibleRequests,
+        denominatorTokens: metric.eligibleDenominatorTokens,
+        hitRateTokens: clampRate01(metric.hitRateTokensEligible),
+      },
+      reasonCodes: ["use_eligible"],
+    };
+  }
+
+  const overallOk =
+    metric.totalRequests >= settings.minEligibleRequests &&
+    metric.denominatorTokens >= settings.minEligibleTokens;
+  if (!overallOk) {
+    return null;
+  }
+
+  return {
+    sample: {
+      kind: "overall",
+      requests: metric.totalRequests,
+      denominatorTokens: metric.denominatorTokens,
+      hitRateTokens: clampRate01(metric.hitRateTokens),
+    },
+    reasonCodes: ["use_overall", "eligible_insufficient"],
+  };
+}
+
+function pickBaseline(
+  kind: CacheHitRateAlertMetricKind,
+  key: string,
+  maps: Array<{
+    source: Exclude<CacheHitRateAlertBaselineSource, null>;
+    map: Map<string, CacheHitRateAlertMetric>;
+  }>,
+  settings: CacheHitRateAlertDecisionSettings
+): {
+  source: CacheHitRateAlertBaselineSource;
+  sample: CacheHitRateAlertSample;
+  reasonCodes: string[];
+} | null {
+  const baselineOk =
+    kind === "eligible"
+      ? (metric: CacheHitRateAlertMetric) =>
+          metric.eligibleRequests >= settings.minEligibleRequests &&
+          metric.eligibleDenominatorTokens >= settings.minEligibleTokens
+      : (metric: CacheHitRateAlertMetric) =>
+          metric.totalRequests >= settings.minEligibleRequests &&
+          metric.denominatorTokens >= settings.minEligibleTokens;
+
+  for (const { source, map } of maps) {
+    const metric = map.get(key);
+    if (!metric) continue;
+    if (!baselineOk(metric)) continue;
+
+    const sample: CacheHitRateAlertSample =
+      kind === "eligible"
+        ? {
+            kind: "eligible",
+            requests: metric.eligibleRequests,
+            denominatorTokens: metric.eligibleDenominatorTokens,
+            hitRateTokens: clampRate01(metric.hitRateTokensEligible),
+          }
+        : {
+            kind: "overall",
+            requests: metric.totalRequests,
+            denominatorTokens: metric.denominatorTokens,
+            hitRateTokens: clampRate01(metric.hitRateTokens),
+          };
+
+    const baselineKindCode = kind === "eligible" ? "baseline_eligible" : "baseline_overall";
+    return {
+      source,
+      sample,
+      reasonCodes: [baselineKindCode, `baseline_${source}`],
+    };
+  }
+  return null;
+}
+
+export function decideCacheHitRateAnomalies(
+  input: CacheHitRateAlertDecisionInput
+): CacheHitRateAlertAnomaly[] {
+  const settings = input.settings;
+  if (settings.topN <= 0) return [];
+
+  const currentMap = toMetricMap(input.current);
+  const prevMap = toMetricMap(input.prev);
+  const todayMap = toMetricMap(input.today);
+  const historicalMap = toMetricMap(input.historical);
+
+  const baselineCandidates: Array<{
+    source: Exclude<CacheHitRateAlertBaselineSource, null>;
+    map: Map<string, CacheHitRateAlertMetric>;
+  }> = [
+    { source: "historical", map: historicalMap },
+    { source: "today", map: todayMap },
+    { source: "prev", map: prevMap },
+  ];
+
+  const anomaliesWithSeverity: Array<{ anomaly: CacheHitRateAlertAnomaly; severity: number }> = [];
+
+  for (const [key, currentMetric] of currentMap) {
+    const currentPicked = pickSample(currentMetric, settings);
+    if (!currentPicked) {
+      continue;
+    }
+
+    const baselinePicked = pickBaseline(
+      currentPicked.sample.kind,
+      key,
+      baselineCandidates,
+      settings
+    );
+    if (!baselinePicked) {
+      continue;
+    }
+    const baselineValue = baselinePicked.sample.hitRateTokens;
+
+    const currentValue = currentPicked.sample.hitRateTokens;
+    const deltaAbs = currentValue - baselineValue;
+    const dropAbs = baselineValue - currentValue;
+    const deltaRel = baselineValue <= 0 ? null : (currentValue - baselineValue) / baselineValue;
+
+    const reasonCodes: string[] = [...currentPicked.reasonCodes];
+
+    reasonCodes.push(...baselinePicked.reasonCodes);
+
+    const triggered: string[] = [];
+
+    if (baselineValue >= settings.absMin && currentValue < settings.absMin) {
+      triggered.push("abs_min");
+    }
+
+    if (baselineValue > 0) {
+      const effDropAbs = baselineValue - currentValue;
+      const effDropRel = effDropAbs / baselineValue;
+      if (effDropAbs >= settings.dropAbs && effDropRel >= settings.dropRel) {
+        triggered.push("drop_abs_rel");
+      }
+    }
+
+    if (triggered.length === 0) {
+      continue;
+    }
+
+    reasonCodes.push(...triggered);
+
+    const severity = Math.max(baselineValue - currentValue, settings.absMin - currentValue, 0);
+
+    anomaliesWithSeverity.push({
+      severity,
+      anomaly: {
+        key,
+        providerId: currentMetric.providerId,
+        model: currentMetric.model,
+        baselineSource: baselinePicked?.source ?? null,
+        current: currentPicked.sample,
+        baseline: baselinePicked?.sample ?? null,
+        deltaAbs,
+        deltaRel,
+        dropAbs,
+        reasonCodes,
+      },
+    });
+  }
+
+  return anomaliesWithSeverity
+    .sort((a, b) => b.severity - a.severity)
+    .slice(0, settings.topN)
+    .map((x) => x.anomaly);
+}

--- a/src/lib/cache-hit-rate-alert/decision.ts
+++ b/src/lib/cache-hit-rate-alert/decision.ts
@@ -93,7 +93,13 @@ function toMetricMap(
     return map;
   }
 
-  return new Map([...input]);
+  const map = new Map<string, CacheHitRateAlertMetric>();
+  for (const [, item] of input) {
+    if (!item) continue;
+    if (!item.model || item.model.trim() === "") continue;
+    map.set(toCacheHitRateAlertMetricKey(item.providerId, item.model), item);
+  }
+  return map;
 }
 
 function pickSample(

--- a/src/lib/cache-hit-rate-alert/decision.ts
+++ b/src/lib/cache-hit-rate-alert/decision.ts
@@ -302,7 +302,20 @@ export function decideCacheHitRateAnomalies(
   }
 
   return anomaliesWithSeverity
-    .sort((a, b) => b.severity - a.severity)
+    .sort((a, b) => {
+      const severityDiff = b.severity - a.severity;
+      if (severityDiff !== 0) return severityDiff;
+
+      const providerDiff = a.anomaly.providerId - b.anomaly.providerId;
+      if (providerDiff !== 0) return providerDiff;
+
+      if (a.anomaly.model < b.anomaly.model) return -1;
+      if (a.anomaly.model > b.anomaly.model) return 1;
+
+      if (a.anomaly.key < b.anomaly.key) return -1;
+      if (a.anomaly.key > b.anomaly.key) return 1;
+      return 0;
+    })
     .slice(0, settings.topN)
     .map((x) => x.anomaly);
 }

--- a/src/lib/cache-hit-rate-alert/decision.ts
+++ b/src/lib/cache-hit-rate-alert/decision.ts
@@ -235,7 +235,7 @@ export function decideCacheHitRateAnomalies(
 
     const triggered: string[] = [];
 
-    if (baselineValue >= settings.absMin && currentValue < settings.absMin) {
+    if (currentValue < settings.absMin) {
       triggered.push("abs_min");
     }
 

--- a/src/lib/cache-hit-rate-alert/decision.ts
+++ b/src/lib/cache-hit-rate-alert/decision.ts
@@ -257,8 +257,8 @@ export function decideCacheHitRateAnomalies(
     const baselineValue = baselinePicked.sample.hitRateTokens;
 
     const deltaAbs = currentValue - baselineValue;
-    const dropAbs = baselineValue - currentValue;
-    const deltaRel = baselineValue <= 0 ? null : (currentValue - baselineValue) / baselineValue;
+    const dropAbs = Math.max(baselineValue - currentValue, 0);
+    const deltaRel = baselineValue <= 0 ? null : deltaAbs / baselineValue;
 
     const reasonCodes: string[] = [...currentPicked.reasonCodes];
 
@@ -282,7 +282,7 @@ export function decideCacheHitRateAnomalies(
 
     reasonCodes.push(...triggered);
 
-    const severity = Math.max(baselineValue - currentValue, settings.absMin - currentValue, 0);
+    const severity = Math.max(dropAbs, settings.absMin - currentValue, 0);
 
     anomaliesWithSeverity.push({
       severity,

--- a/src/lib/cache-hit-rate-alert/decision.ts
+++ b/src/lib/cache-hit-rate-alert/decision.ts
@@ -240,9 +240,7 @@ export function decideCacheHitRateAnomalies(
     }
 
     if (baselineValue > 0) {
-      const effDropAbs = baselineValue - currentValue;
-      const effDropRel = effDropAbs / baselineValue;
-      if (effDropAbs >= settings.dropAbs && effDropRel >= settings.dropRel) {
+      if (dropAbs >= settings.dropAbs && dropAbs / baselineValue >= settings.dropRel) {
         triggered.push("drop_abs_rel");
       }
     }
@@ -261,9 +259,9 @@ export function decideCacheHitRateAnomalies(
         key,
         providerId: currentMetric.providerId,
         model: currentMetric.model,
-        baselineSource: baselinePicked?.source ?? null,
+        baselineSource: baselinePicked.source,
         current: currentPicked.sample,
-        baseline: baselinePicked?.sample ?? null,
+        baseline: baselinePicked.sample,
         deltaAbs,
         deltaRel,
         dropAbs,

--- a/src/lib/constants/notification.constants.ts
+++ b/src/lib/constants/notification.constants.ts
@@ -3,6 +3,7 @@
  */
 export const NOTIFICATION_JOB_TYPES = [
   "circuit-breaker",
+  "cache-hit-rate-alert",
   "cost-alert",
   "daily-leaderboard",
 ] as const;

--- a/src/lib/notification/notification-queue.ts
+++ b/src/lib/notification/notification-queue.ts
@@ -134,6 +134,9 @@ function isCacheHitRateAlertDataPayload(value: unknown): value is CacheHitRateAl
 
   if (!isFiniteNumber(payload.suppressedCount)) return false;
 
+  if (typeof payload.generatedAt !== "string") return false;
+  if (Number.isNaN(Date.parse(payload.generatedAt))) return false;
+
   return true;
 }
 

--- a/src/lib/notification/notification-queue.ts
+++ b/src/lib/notification/notification-queue.ts
@@ -891,6 +891,7 @@ export async function scheduleNotifications() {
         if (bindings.length > 0) {
           // 注意：这里刻意只调度一个共享的 repeat 作业，然后在处理器内 fan-out 到所有 bindings。
           // 这样可以避免对每个 binding 重复计算同一份 payload；代价是 binding 的 scheduleCron/scheduleTimezone 将被忽略。
+          // 另外：interval > 59 分钟会使用 repeat.every（固定间隔，不对齐整点，也不支持 tz），这是 Bull cron 分钟字段的限制。
           // 若未来需要支持 per-binding 的 cron/timezone，需要改为“每个 binding 一个 repeat 作业”或引入更细粒度的调度层。
           await queue.add(
             {

--- a/src/lib/notification/notification-queue.ts
+++ b/src/lib/notification/notification-queue.ts
@@ -24,6 +24,7 @@ import {
   sendWebhookMessage,
   type WebhookNotificationType,
 } from "@/lib/webhook";
+import { isCacheHitRateAlertSettingsWindowMode } from "@/lib/webhook/types";
 
 /**
  * 通知任务数据
@@ -119,7 +120,7 @@ function isCacheHitRateAlertDataPayload(value: unknown): value is CacheHitRateAl
 
   if (!isPlainObject(payload.window)) return false;
   const window = payload.window as Record<string, unknown>;
-  if (typeof window.mode !== "string") return false;
+  if (!isCacheHitRateAlertSettingsWindowMode(window.mode)) return false;
   if (typeof window.startTime !== "string") return false;
   if (typeof window.endTime !== "string") return false;
   if (!isFiniteNumber(window.durationMinutes)) return false;

--- a/src/lib/notification/notification-queue.ts
+++ b/src/lib/notification/notification-queue.ts
@@ -161,7 +161,7 @@ function setupQueueProcessor(queue: Queue.Queue<NotificationJobData>): void {
       // 特殊：targets 模式下，缓存命中率告警使用 fan-out 作业避免重复计算
       if (type === "cache-hit-rate-alert" && !webhookUrl && !targetId) {
         const { getNotificationSettings } = await import("@/repository/notifications");
-        const settings = (await getNotificationSettings()) as any;
+        const settings = await getNotificationSettings();
 
         if (!settings.enabled || !settings.cacheHitRateAlertEnabled) {
           logger.info({
@@ -480,7 +480,7 @@ export async function scheduleNotifications() {
   try {
     // 动态导入以避免循环依赖
     const { getNotificationSettings } = await import("@/repository/notifications");
-    const settings = (await getNotificationSettings()) as any;
+    const settings = await getNotificationSettings();
 
     const queue = getNotificationQueue();
 

--- a/src/lib/notification/tasks/cache-hit-rate-alert.ts
+++ b/src/lib/notification/tasks/cache-hit-rate-alert.ts
@@ -106,7 +106,7 @@ export async function generateCacheHitRateAlertPayload(): Promise<CacheHitRateAl
     return null;
   }
 
-  const intervalMinutes = parseIntNumber(settings.cacheHitRateAlertCheckInterval, 5);
+  const intervalMinutes = Math.max(1, parseIntNumber(settings.cacheHitRateAlertCheckInterval, 5));
   const lookbackDays = parseIntNumber(settings.cacheHitRateAlertHistoricalLookbackDays, 7);
   const cooldownMinutes = parseIntNumber(settings.cacheHitRateAlertCooldownMinutes, 30);
 

--- a/src/lib/notification/tasks/cache-hit-rate-alert.ts
+++ b/src/lib/notification/tasks/cache-hit-rate-alert.ts
@@ -1,0 +1,341 @@
+import { addDays, startOfDay } from "date-fns";
+import { fromZonedTime, toZonedTime } from "date-fns-tz";
+import {
+  type CacheHitRateAlertDecisionSettings,
+  type CacheHitRateAlertMetric,
+  decideCacheHitRateAnomalies,
+} from "@/lib/cache-hit-rate-alert/decision";
+import { logger } from "@/lib/logger";
+import { getRedisClient } from "@/lib/redis/client";
+import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import type {
+  CacheHitRateAlertData,
+  CacheHitRateAlertSettingsSnapshot,
+  CacheHitRateAlertWindow,
+} from "@/lib/webhook";
+import { findProviderModelCacheHitRateMetricsForAlert } from "@/repository/cache-hit-rate-alert";
+import { getNotificationSettings } from "@/repository/notifications";
+import { findAllProviders } from "@/repository/provider";
+
+export interface CacheHitRateAlertTaskResult {
+  payload: CacheHitRateAlertData;
+  dedupKeysToSet: string[];
+  cooldownMinutes: number;
+}
+
+function parseNumber(input: string | null | undefined, fallback: number): number {
+  if (input === null || input === undefined) return fallback;
+  const value = Number(input);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function parseIntNumber(input: number | null | undefined, fallback: number): number {
+  if (input === null || input === undefined) return fallback;
+  const value = Number(input);
+  return Number.isFinite(value) ? Math.trunc(value) : fallback;
+}
+
+function resolveWindowMode(
+  mode: string | null | undefined,
+  intervalMinutes: number
+): {
+  mode: string;
+  durationMinutes: number;
+} {
+  switch (mode) {
+    case "5m":
+      return { mode: "5m", durationMinutes: 5 };
+    case "30m":
+      return { mode: "30m", durationMinutes: 30 };
+    case "1h":
+      return { mode: "1h", durationMinutes: 60 };
+    case "1.5h":
+      return { mode: "1.5h", durationMinutes: 90 };
+    default: {
+      if (intervalMinutes <= 5) return { mode: "5m", durationMinutes: 5 };
+      if (intervalMinutes <= 30) return { mode: "30m", durationMinutes: 30 };
+      if (intervalMinutes <= 60) return { mode: "1h", durationMinutes: 60 };
+      return { mode: "1.5h", durationMinutes: 90 };
+    }
+  }
+}
+
+function buildRedisKeyPart(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function buildCooldownKey(params: {
+  providerId: number;
+  model: string;
+  windowMode: string;
+}): string {
+  return [
+    "cache-hit-rate-alert",
+    "v1",
+    String(params.providerId),
+    buildRedisKeyPart(params.model),
+    params.windowMode,
+  ].join(":");
+}
+
+function toDecisionMetric(
+  row: Awaited<ReturnType<typeof findProviderModelCacheHitRateMetricsForAlert>>[number]
+): CacheHitRateAlertMetric {
+  return {
+    providerId: row.providerId,
+    model: row.model,
+    totalRequests: row.totalRequests,
+    denominatorTokens: row.denominatorTokens,
+    hitRateTokens: row.hitRateTokens,
+    eligibleRequests: row.eligibleRequests,
+    eligibleDenominatorTokens: row.eligibleDenominatorTokens,
+    hitRateTokensEligible: row.hitRateTokensEligible,
+  };
+}
+
+async function getStartOfToday(timezone: string, now: Date): Promise<Date> {
+  const zonedNow = toZonedTime(now, timezone);
+  const zonedStart = startOfDay(zonedNow);
+  return fromZonedTime(zonedStart, timezone);
+}
+
+export async function generateCacheHitRateAlertPayload(): Promise<CacheHitRateAlertTaskResult | null> {
+  const settings = (await getNotificationSettings()) as any;
+
+  if (!settings.enabled || !settings.cacheHitRateAlertEnabled) {
+    logger.info({ action: "cache_hit_rate_alert_disabled" });
+    return null;
+  }
+
+  const intervalMinutes = parseIntNumber(settings.cacheHitRateAlertCheckInterval, 5);
+  const lookbackDays = parseIntNumber(settings.cacheHitRateAlertHistoricalLookbackDays, 7);
+  const cooldownMinutes = parseIntNumber(settings.cacheHitRateAlertCooldownMinutes, 30);
+
+  const decisionSettings: CacheHitRateAlertDecisionSettings = {
+    absMin: parseNumber(settings.cacheHitRateAlertAbsMin, 0.05),
+    dropRel: parseNumber(settings.cacheHitRateAlertDropRel, 0.3),
+    dropAbs: parseNumber(settings.cacheHitRateAlertDropAbs, 0.1),
+    minEligibleRequests: parseIntNumber(settings.cacheHitRateAlertMinEligibleRequests, 20),
+    minEligibleTokens: parseIntNumber(settings.cacheHitRateAlertMinEligibleTokens, 0),
+    topN: parseIntNumber(settings.cacheHitRateAlertTopN, 10),
+  };
+
+  const { mode: resolvedWindowMode, durationMinutes } = resolveWindowMode(
+    settings.cacheHitRateAlertWindowMode,
+    intervalMinutes
+  );
+
+  const now = new Date();
+  const currentEnd = now;
+  const currentStart = new Date(now.getTime() - durationMinutes * 60 * 1000);
+  const prevStart = new Date(now.getTime() - durationMinutes * 2 * 60 * 1000);
+  const prevEnd = currentStart;
+
+  const timezone = await resolveSystemTimezone();
+  const todayStart = await getStartOfToday(timezone, now);
+  const historicalStartZoned = addDays(toZonedTime(todayStart, timezone), -lookbackDays);
+  const historicalStart = fromZonedTime(historicalStartZoned, timezone);
+  const historicalEnd = todayStart;
+
+  const todayEnd = currentStart;
+
+  logger.info({
+    action: "cache_hit_rate_alert_generate_start",
+    windowMode: resolvedWindowMode,
+    durationMinutes,
+    intervalMinutes,
+    lookbackDays,
+    cooldownMinutes,
+    decisionSettings,
+    timezone,
+  });
+
+  const [currentRows, prevRows, todayRows, historicalRows] = await Promise.all([
+    findProviderModelCacheHitRateMetricsForAlert(
+      { start: currentStart, end: currentEnd },
+      undefined,
+      {
+        windowMode: "rolling",
+        statusCodeMode: "2xx",
+      }
+    ),
+    findProviderModelCacheHitRateMetricsForAlert({ start: prevStart, end: prevEnd }, undefined, {
+      windowMode: "rolling",
+      statusCodeMode: "2xx",
+    }),
+    todayStart < todayEnd
+      ? findProviderModelCacheHitRateMetricsForAlert(
+          { start: todayStart, end: todayEnd },
+          undefined,
+          {
+            windowMode: "rolling",
+            statusCodeMode: "2xx",
+          }
+        )
+      : Promise.resolve([]),
+    historicalStart < historicalEnd
+      ? findProviderModelCacheHitRateMetricsForAlert(
+          { start: historicalStart, end: historicalEnd },
+          undefined,
+          { windowMode: "rolling", statusCodeMode: "2xx" }
+        )
+      : Promise.resolve([]),
+  ]);
+
+  const anomalies = decideCacheHitRateAnomalies({
+    current: currentRows.map(toDecisionMetric),
+    prev: prevRows.map(toDecisionMetric),
+    today: todayRows.map(toDecisionMetric),
+    historical: historicalRows.map(toDecisionMetric),
+    settings: decisionSettings,
+  });
+
+  if (anomalies.length === 0) {
+    logger.info({
+      action: "cache_hit_rate_alert_no_anomalies",
+      windowMode: resolvedWindowMode,
+      durationMinutes,
+    });
+    return null;
+  }
+
+  const redis = cooldownMinutes > 0 ? getRedisClient({ allowWhenRateLimitDisabled: true }) : null;
+  const suppressedKeys = new Set<string>();
+
+  if (redis) {
+    for (const anomaly of anomalies) {
+      const key = buildCooldownKey({
+        providerId: anomaly.providerId,
+        model: anomaly.model,
+        windowMode: resolvedWindowMode,
+      });
+      try {
+        const cached = await redis.get(key);
+        if (cached) {
+          suppressedKeys.add(key);
+        }
+      } catch (error) {
+        logger.warn({
+          action: "cache_hit_rate_alert_dedup_read_failed",
+          key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  const suppressedCount = suppressedKeys.size;
+  const remaining = anomalies.filter(
+    (a) =>
+      !suppressedKeys.has(
+        buildCooldownKey({
+          providerId: a.providerId,
+          model: a.model,
+          windowMode: resolvedWindowMode,
+        })
+      )
+  );
+
+  if (remaining.length === 0) {
+    logger.info({
+      action: "cache_hit_rate_alert_all_suppressed",
+      suppressedCount,
+      windowMode: resolvedWindowMode,
+      durationMinutes,
+      cooldownMinutes,
+    });
+    return null;
+  }
+
+  const providers = await findAllProviders();
+  const providerMap = new Map(providers.map((p) => [p.id, p]));
+
+  const window: CacheHitRateAlertWindow = {
+    mode: resolvedWindowMode,
+    startTime: currentStart.toISOString(),
+    endTime: currentEnd.toISOString(),
+    durationMinutes,
+  };
+
+  const settingsSnapshot: CacheHitRateAlertSettingsSnapshot = {
+    windowMode: settings.cacheHitRateAlertWindowMode ?? "auto",
+    checkIntervalMinutes: intervalMinutes,
+    historicalLookbackDays: lookbackDays,
+    minEligibleRequests: decisionSettings.minEligibleRequests,
+    minEligibleTokens: decisionSettings.minEligibleTokens,
+    absMin: decisionSettings.absMin,
+    dropRel: decisionSettings.dropRel,
+    dropAbs: decisionSettings.dropAbs,
+    cooldownMinutes,
+    topN: decisionSettings.topN,
+  };
+
+  const payload: CacheHitRateAlertData = {
+    window,
+    anomalies: remaining.map((a) => {
+      const provider = providerMap.get(a.providerId);
+      return {
+        providerId: a.providerId,
+        providerName: provider?.name,
+        providerType: provider?.providerType,
+        model: a.model,
+        baselineSource: a.baselineSource,
+        current: a.current,
+        baseline: a.baseline,
+        deltaAbs: a.deltaAbs,
+        deltaRel: a.deltaRel,
+        dropAbs: a.dropAbs,
+        reasonCodes: a.reasonCodes,
+      };
+    }),
+    suppressedCount,
+    settings: settingsSnapshot,
+    generatedAt: new Date().toISOString(),
+  };
+
+  const dedupKeysToSet = payload.anomalies.map((a) =>
+    buildCooldownKey({
+      providerId: a.providerId,
+      model: a.model,
+      windowMode: resolvedWindowMode,
+    })
+  );
+
+  logger.info({
+    action: "cache_hit_rate_alert_generated",
+    windowMode: resolvedWindowMode,
+    durationMinutes,
+    anomalies: payload.anomalies.length,
+    suppressedCount,
+  });
+
+  return { payload, dedupKeysToSet, cooldownMinutes };
+}
+
+export async function commitCacheHitRateAlertCooldown(
+  keys: string[],
+  cooldownMinutes: number
+): Promise<void> {
+  if (keys.length === 0) return;
+  if (cooldownMinutes <= 0) return;
+
+  const redis = getRedisClient({ allowWhenRateLimitDisabled: true });
+  if (!redis) return;
+
+  const ttlSeconds = Math.max(1, cooldownMinutes * 60);
+  const pipeline = redis.pipeline();
+  for (const key of keys) {
+    pipeline.set(key, "1", "EX", ttlSeconds);
+  }
+
+  try {
+    await pipeline.exec();
+  } catch (error) {
+    logger.warn({
+      action: "cache_hit_rate_alert_dedup_write_failed",
+      keysCount: keys.length,
+      cooldownMinutes,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/src/lib/notification/tasks/cache-hit-rate-alert.ts
+++ b/src/lib/notification/tasks/cache-hit-rate-alert.ts
@@ -438,7 +438,8 @@ export async function commitCacheHitRateAlertCooldown(
   const redis = getRedisClient({ allowWhenRateLimitDisabled: true });
   if (!redis) return;
 
-  const ttlSeconds = Math.max(1, cooldownMinutes * 60);
+  // Redis EX 需要整数秒；这里做一次截断，避免配置被写成小数导致提交去重失败。
+  const ttlSeconds = Math.max(1, Math.trunc(cooldownMinutes * 60));
   const pipeline = redis.pipeline();
   for (const key of keys) {
     pipeline.set(key, "1", "EX", ttlSeconds);

--- a/src/lib/notification/tasks/cache-hit-rate-alert.ts
+++ b/src/lib/notification/tasks/cache-hit-rate-alert.ts
@@ -109,14 +109,7 @@ export async function applyCacheHitRateAlertCooldownToPayload(params: {
   if (payload.anomalies.length === 0 || cooldownMinutes <= 0) {
     return {
       payload,
-      dedupKeysToSet: payload.anomalies.map((a) =>
-        buildCooldownKey({
-          providerId: a.providerId,
-          model: a.model,
-          windowMode: payload.window.mode,
-          bindingId,
-        })
-      ),
+      dedupKeysToSet: [],
       suppressedCount: 0,
     };
   }
@@ -254,7 +247,8 @@ export async function generateCacheHitRateAlertPayload(
   const historicalStart = fromZonedTime(historicalStartZoned, timezone);
   const historicalEnd = todayStart;
 
-  const todayEnd = currentStart;
+  // today 窗口仅用于“当日累计”基线；currentStart 可能在午夜附近早于 todayStart，因此这里做一次 clamp
+  const todayEnd = currentStart < todayStart ? todayStart : currentStart;
 
   logger.info({
     action: "cache_hit_rate_alert_generate_start",

--- a/src/lib/notification/tasks/cache-hit-rate-alert.ts
+++ b/src/lib/notification/tasks/cache-hit-rate-alert.ts
@@ -100,7 +100,7 @@ async function getStartOfToday(timezone: string, now: Date): Promise<Date> {
 }
 
 export async function generateCacheHitRateAlertPayload(): Promise<CacheHitRateAlertTaskResult | null> {
-  const settings = (await getNotificationSettings()) as any;
+  const settings = await getNotificationSettings();
 
   if (!settings.enabled || !settings.cacheHitRateAlertEnabled) {
     logger.info({ action: "cache_hit_rate_alert_disabled" });

--- a/src/lib/webhook/index.ts
+++ b/src/lib/webhook/index.ts
@@ -6,11 +6,18 @@ export { sendWebhookMessage, WebhookNotifier } from "./notifier";
 export { createRenderer, type Renderer } from "./renderers";
 // Templates
 export {
+  buildCacheHitRateAlertMessage,
   buildCircuitBreakerMessage,
   buildCostAlertMessage,
   buildDailyLeaderboardMessage,
 } from "./templates";
 export type {
+  CacheHitRateAlertAnomaly,
+  CacheHitRateAlertBaselineSource,
+  CacheHitRateAlertData,
+  CacheHitRateAlertSample,
+  CacheHitRateAlertSettingsSnapshot,
+  CacheHitRateAlertWindow,
   CircuitBreakerAlertData,
   CostAlertData,
   DailyLeaderboardData,

--- a/src/lib/webhook/templates/cache-hit-rate-alert.ts
+++ b/src/lib/webhook/templates/cache-hit-rate-alert.ts
@@ -1,0 +1,130 @@
+import type { CacheHitRateAlertAnomaly, CacheHitRateAlertData, StructuredMessage } from "../types";
+import { formatDateTime } from "../utils/date";
+
+function formatPercent(rate: number): string {
+  if (!Number.isFinite(rate)) return "";
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) return "";
+  return Math.round(value).toString();
+}
+
+function formatAnomalyTitle(anomaly: CacheHitRateAlertAnomaly): string {
+  const provider = anomaly.providerName?.trim()
+    ? anomaly.providerName.trim()
+    : `Provider #${anomaly.providerId}`;
+  return `${provider} / ${anomaly.model}`;
+}
+
+function buildAnomalyDetails(anomaly: CacheHitRateAlertAnomaly): string {
+  const lines: string[] = [];
+
+  lines.push(
+    `当前(${anomaly.current.kind}): ${formatPercent(anomaly.current.hitRateTokens)} (req=${formatNumber(
+      anomaly.current.requests
+    )}, tok=${formatNumber(anomaly.current.denominatorTokens)})`
+  );
+
+  if (anomaly.baseline) {
+    const source = anomaly.baselineSource ?? "unknown";
+    lines.push(
+      `基线(${source} ${anomaly.baseline.kind}): ${formatPercent(
+        anomaly.baseline.hitRateTokens
+      )} (req=${formatNumber(anomaly.baseline.requests)}, tok=${formatNumber(
+        anomaly.baseline.denominatorTokens
+      )})`
+    );
+  } else {
+    lines.push("基线: 无");
+  }
+
+  if (anomaly.dropAbs !== null && Number.isFinite(anomaly.dropAbs)) {
+    lines.push(`绝对跌幅: ${formatPercent(anomaly.dropAbs)}`);
+  }
+  if (anomaly.deltaRel !== null && Number.isFinite(anomaly.deltaRel)) {
+    lines.push(`相对变化: ${formatPercent(anomaly.deltaRel)}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function buildCacheHitRateAlertMessage(
+  data: CacheHitRateAlertData,
+  timezone?: string
+): StructuredMessage {
+  const tz = timezone || "UTC";
+  const anomalyCount = data.anomalies.length;
+
+  return {
+    header: {
+      title: "缓存命中率异常告警",
+      icon: "[CACHE]",
+      level: "warning",
+    },
+    sections: [
+      {
+        content: [
+          {
+            type: "quote",
+            value: anomalyCount > 0 ? `检测到缓存命中率异常（${anomalyCount} 条）` : "未检测到异常",
+          },
+        ],
+      },
+      {
+        title: "检测窗口",
+        content: [
+          {
+            type: "fields",
+            items: [
+              {
+                label: "窗口",
+                value: `${data.window.mode} (${data.window.durationMinutes} 分钟)`,
+              },
+              { label: "开始", value: formatDateTime(data.window.startTime, tz) },
+              { label: "结束", value: formatDateTime(data.window.endTime, tz) },
+              { label: "抑制数量", value: String(data.suppressedCount) },
+            ],
+          },
+        ],
+      },
+      {
+        title: "阈值",
+        content: [
+          {
+            type: "fields",
+            items: [
+              { label: "绝对下限(absMin)", value: formatPercent(data.settings.absMin) },
+              { label: "绝对跌幅(dropAbs)", value: formatPercent(data.settings.dropAbs) },
+              { label: "相对跌幅(dropRel)", value: formatPercent(data.settings.dropRel) },
+              {
+                label: "最小样本",
+                value: `req>=${data.settings.minEligibleRequests}, tok>=${data.settings.minEligibleTokens}`,
+              },
+              { label: "冷却", value: `${data.settings.cooldownMinutes} 分钟` },
+            ],
+          },
+        ],
+      },
+      ...(anomalyCount > 0
+        ? [
+            {
+              title: "异常列表",
+              content: [
+                {
+                  type: "list" as const,
+                  style: "bullet" as const,
+                  items: data.anomalies.map((a) => ({
+                    primary: formatAnomalyTitle(a),
+                    secondary: buildAnomalyDetails(a),
+                  })),
+                },
+              ],
+            },
+          ]
+        : []),
+    ],
+    timestamp: new Date(),
+  };
+}

--- a/src/lib/webhook/templates/defaults.ts
+++ b/src/lib/webhook/templates/defaults.ts
@@ -33,6 +33,15 @@ export const DEFAULT_TEMPLATES = {
     quotaLimit: "{{quota_limit}}",
     usagePercent: "{{usage_percent}}",
   },
+
+  cache_hit_rate_alert: {
+    title: "{{title}}",
+    windowMode: "{{window_mode}}",
+    windowStart: "{{window_start}}",
+    windowEnd: "{{window_end}}",
+    anomalyCount: "{{anomaly_count}}",
+    anomalies: "{{anomalies_json}}",
+  },
 } as const;
 
 export const DEFAULT_TEMPLATE_BY_NOTIFICATION_TYPE: Record<
@@ -42,4 +51,5 @@ export const DEFAULT_TEMPLATE_BY_NOTIFICATION_TYPE: Record<
   circuit_breaker: DEFAULT_TEMPLATES.circuit_breaker,
   daily_leaderboard: DEFAULT_TEMPLATES.daily_leaderboard,
   cost_alert: DEFAULT_TEMPLATES.cost_alert,
+  cache_hit_rate_alert: DEFAULT_TEMPLATES.cache_hit_rate_alert,
 };

--- a/src/lib/webhook/templates/index.ts
+++ b/src/lib/webhook/templates/index.ts
@@ -1,3 +1,4 @@
+export { buildCacheHitRateAlertMessage } from "./cache-hit-rate-alert";
 export { buildCircuitBreakerMessage } from "./circuit-breaker";
 export { buildCostAlertMessage } from "./cost-alert";
 export { buildDailyLeaderboardMessage } from "./daily-leaderboard";

--- a/src/lib/webhook/templates/test-messages.ts
+++ b/src/lib/webhook/templates/test-messages.ts
@@ -1,5 +1,6 @@
 import type { NotificationJobType } from "@/lib/constants/notification.constants";
 import type { StructuredMessage } from "../types";
+import { buildCacheHitRateAlertMessage } from "./cache-hit-rate-alert";
 import { buildCircuitBreakerMessage } from "./circuit-breaker";
 import { buildCostAlertMessage } from "./cost-alert";
 import { buildDailyLeaderboardMessage } from "./daily-leaderboard";
@@ -46,5 +47,57 @@ export function buildTestMessage(type: NotificationJobType, timezone?: string): 
         totalRequests: 270,
         totalCost: 22.7,
       });
+
+    case "cache-hit-rate-alert":
+      return buildCacheHitRateAlertMessage(
+        {
+          window: {
+            mode: "5m",
+            startTime: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+            endTime: new Date().toISOString(),
+            durationMinutes: 5,
+          },
+          anomalies: [
+            {
+              providerId: 1,
+              providerName: "测试供应商",
+              providerType: "claude",
+              model: "test-model",
+              baselineSource: "historical",
+              current: {
+                kind: "eligible",
+                requests: 100,
+                denominatorTokens: 10000,
+                hitRateTokens: 0.12,
+              },
+              baseline: {
+                kind: "eligible",
+                requests: 100,
+                denominatorTokens: 10000,
+                hitRateTokens: 0.45,
+              },
+              deltaAbs: -0.33,
+              deltaRel: -0.7333,
+              dropAbs: 0.33,
+              reasonCodes: ["abs_min", "drop_abs_rel"],
+            },
+          ],
+          suppressedCount: 0,
+          settings: {
+            windowMode: "auto",
+            checkIntervalMinutes: 5,
+            historicalLookbackDays: 7,
+            minEligibleRequests: 20,
+            minEligibleTokens: 0,
+            absMin: 0.05,
+            dropRel: 0.3,
+            dropAbs: 0.1,
+            cooldownMinutes: 30,
+            topN: 10,
+          },
+          generatedAt: new Date().toISOString(),
+        },
+        timezone
+      );
   }
 }

--- a/src/lib/webhook/types.ts
+++ b/src/lib/webhook/types.ts
@@ -78,13 +78,71 @@ export interface CostAlertData {
   period: string;
 }
 
+export interface CacheHitRateAlertSample {
+  kind: "eligible" | "overall";
+  requests: number;
+  denominatorTokens: number;
+  hitRateTokens: number;
+}
+
+export type CacheHitRateAlertBaselineSource = "historical" | "today" | "prev" | null;
+
+export interface CacheHitRateAlertAnomaly {
+  providerId: number;
+  providerName?: string;
+  providerType?: string;
+  model: string;
+
+  baselineSource: CacheHitRateAlertBaselineSource;
+  current: CacheHitRateAlertSample;
+  baseline: CacheHitRateAlertSample | null;
+
+  deltaAbs: number | null;
+  deltaRel: number | null;
+  dropAbs: number | null;
+
+  reasonCodes: string[];
+}
+
+export interface CacheHitRateAlertWindow {
+  mode: string;
+  startTime: string;
+  endTime: string;
+  durationMinutes: number;
+}
+
+export interface CacheHitRateAlertSettingsSnapshot {
+  windowMode: string;
+  checkIntervalMinutes: number;
+  historicalLookbackDays: number;
+  minEligibleRequests: number;
+  minEligibleTokens: number;
+  absMin: number;
+  dropRel: number;
+  dropAbs: number;
+  cooldownMinutes: number;
+  topN: number;
+}
+
+export interface CacheHitRateAlertData {
+  window: CacheHitRateAlertWindow;
+  anomalies: CacheHitRateAlertAnomaly[];
+  suppressedCount: number;
+  settings: CacheHitRateAlertSettingsSnapshot;
+  generatedAt: string;
+}
+
 /**
  * Webhook 相关类型
  */
 
 export type ProviderType = "wechat" | "feishu" | "dingtalk" | "telegram" | "custom";
 
-export type WebhookNotificationType = "circuit_breaker" | "daily_leaderboard" | "cost_alert";
+export type WebhookNotificationType =
+  | "circuit_breaker"
+  | "daily_leaderboard"
+  | "cost_alert"
+  | "cache_hit_rate_alert";
 
 export interface WebhookTargetConfig {
   id?: number;

--- a/src/lib/webhook/types.ts
+++ b/src/lib/webhook/types.ts
@@ -87,6 +87,26 @@ export interface CacheHitRateAlertSample {
 
 export type CacheHitRateAlertBaselineSource = "historical" | "today" | "prev" | null;
 
+export const CACHE_HIT_RATE_ALERT_SETTINGS_WINDOW_MODES = [
+  "auto",
+  "5m",
+  "30m",
+  "1h",
+  "1.5h",
+] as const;
+
+export type CacheHitRateAlertSettingsWindowMode =
+  (typeof CACHE_HIT_RATE_ALERT_SETTINGS_WINDOW_MODES)[number];
+
+export function isCacheHitRateAlertSettingsWindowMode(
+  value: unknown
+): value is CacheHitRateAlertSettingsWindowMode {
+  return (
+    typeof value === "string" &&
+    (CACHE_HIT_RATE_ALERT_SETTINGS_WINDOW_MODES as readonly string[]).includes(value)
+  );
+}
+
 export interface CacheHitRateAlertAnomaly {
   providerId: number;
   providerName?: string;
@@ -112,7 +132,7 @@ export interface CacheHitRateAlertWindow {
 }
 
 export interface CacheHitRateAlertSettingsSnapshot {
-  windowMode: string;
+  windowMode: CacheHitRateAlertSettingsWindowMode;
   checkIntervalMinutes: number;
   historicalLookbackDays: number;
   minEligibleRequests: number;

--- a/src/repository/cache-hit-rate-alert.ts
+++ b/src/repository/cache-hit-rate-alert.ts
@@ -1,0 +1,276 @@
+import "server-only";
+
+import { and, desc, eq, gte, isNull, lt, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import { db } from "@/drizzle/db";
+import { messageRequest, providers } from "@/drizzle/schema";
+import { getSystemSettings } from "@/repository/system-config";
+import type { ProviderType } from "@/types/provider";
+import { EXCLUDE_WARMUP_CONDITION } from "./_shared/message-request-conditions";
+
+export interface TimeRange {
+  start: Date;
+  end: Date;
+}
+
+export type CacheHitRateAlertWindowMode = "rolling" | "strict";
+
+export interface CacheHitRateAlertQueryConfig {
+  /**
+   * rolling: 允许 prev request 落在 timeRange 之外（更适合滚动窗口）
+   * strict: 仅当 prev request 也在 timeRange 内时才计 eligible
+   */
+  windowMode?: CacheHitRateAlertWindowMode;
+  /** 2xx: 仅统计 2xx（推荐）；all: 不筛状态码 */
+  statusCodeMode?: "2xx" | "all";
+  /**
+   * 当无法从 row（5m/1h 细分字段或 cacheTtlApplied）推断 TTL 时使用的 fallback。
+   * 优先级：ttlFallbackSecondsByProviderType > ttlFallbackSecondsDefault
+   */
+  ttlFallbackSecondsByProviderType?: Partial<Record<ProviderType, number>>;
+  ttlFallbackSecondsDefault?: number;
+}
+
+export interface ProviderModelCacheHitRateAlertMetric {
+  providerId: number;
+  providerType: ProviderType;
+  model: string;
+
+  totalRequests: number;
+  cacheSignalRequests: number;
+  cacheHitRequests: number;
+
+  sumInputTokens: number;
+  sumCacheCreationTokens: number;
+  sumCacheReadTokens: number;
+  denominatorTokens: number;
+
+  /** 与排行榜一致：cache_read / (input + cache_creation + cache_read) */
+  hitRateTokens: number;
+  engagementRate: number;
+
+  eligibleRequests: number;
+  eligibleDenominatorTokens: number;
+  eligibleCacheReadTokens: number;
+  hitRateTokensEligible: number;
+}
+
+function normalizeTtlFallbackSeconds(config: CacheHitRateAlertQueryConfig): {
+  defaultSeconds: number;
+  byType: Record<ProviderType, number>;
+} {
+  const defaultSeconds = config.ttlFallbackSecondsDefault ?? 3600;
+  const base: Record<ProviderType, number> = {
+    claude: defaultSeconds,
+    "claude-auth": defaultSeconds,
+    codex: 6 * 3600,
+    gemini: defaultSeconds,
+    "gemini-cli": defaultSeconds,
+    "openai-compatible": 6 * 3600,
+  };
+  const overrides = config.ttlFallbackSecondsByProviderType ?? {};
+  return {
+    defaultSeconds,
+    byType: {
+      ...base,
+      ...overrides,
+    },
+  };
+}
+
+function normalizeStatusCodeMode(config: CacheHitRateAlertQueryConfig): "2xx" | "all" {
+  return config.statusCodeMode ?? "2xx";
+}
+
+function normalizeWindowMode(config: CacheHitRateAlertQueryConfig): CacheHitRateAlertWindowMode {
+  return config.windowMode ?? "rolling";
+}
+
+export async function findProviderModelCacheHitRateMetricsForAlert(
+  timeRange: TimeRange,
+  providerType?: ProviderType,
+  config: CacheHitRateAlertQueryConfig = {}
+): Promise<ProviderModelCacheHitRateAlertMetric[]> {
+  if (timeRange.start >= timeRange.end) {
+    return [];
+  }
+
+  const statusCodeMode = normalizeStatusCodeMode(config);
+  const windowMode = normalizeWindowMode(config);
+  const ttlFallback = normalizeTtlFallbackSeconds(config);
+
+  const systemSettings = await getSystemSettings();
+  const billingModelSource = systemSettings.billingModelSource;
+
+  const modelField =
+    billingModelSource === "original"
+      ? sql<string>`COALESCE(${messageRequest.originalModel}, ${messageRequest.model})`
+      : sql<string>`COALESCE(${messageRequest.model}, ${messageRequest.originalModel})`;
+
+  const prev = alias(messageRequest, "prev_message_request");
+  const prevExcludeWarmupCondition = sql`(${prev.blockedBy} IS NULL OR ${prev.blockedBy} <> 'warmup')`;
+
+  const cacheSignalCondition = sql`(
+    COALESCE(${messageRequest.cacheCreationInputTokens}, 0) > 0
+    OR COALESCE(${messageRequest.cacheReadInputTokens}, 0) > 0
+  )`;
+  const cacheHitCondition = sql`(COALESCE(${messageRequest.cacheReadInputTokens}, 0) > 0)`;
+
+  const hasSessionIdCondition = sql`(
+    ${messageRequest.sessionId} IS NOT NULL
+    AND btrim(${messageRequest.sessionId}) <> ''
+  )`;
+
+  const gapToPrevSecondsExpr = sql<
+    number | null
+  >`EXTRACT(EPOCH FROM (${messageRequest.createdAt} - ${prev.createdAt}))::double precision`;
+
+  const ttlFallbackSecondsExpr = sql<number>`CASE
+    WHEN ${providers.providerType} = 'claude' THEN ${ttlFallback.byType.claude}
+    WHEN ${providers.providerType} = 'claude-auth' THEN ${ttlFallback.byType["claude-auth"]}
+    WHEN ${providers.providerType} = 'codex' THEN ${ttlFallback.byType.codex}
+    WHEN ${providers.providerType} = 'gemini' THEN ${ttlFallback.byType.gemini}
+    WHEN ${providers.providerType} = 'gemini-cli' THEN ${ttlFallback.byType["gemini-cli"]}
+    WHEN ${providers.providerType} = 'openai-compatible' THEN ${ttlFallback.byType["openai-compatible"]}
+    ELSE ${ttlFallback.defaultSeconds}
+  END`;
+
+  const ttlSecondsExpr = sql<number>`CASE
+    WHEN COALESCE(${messageRequest.cacheCreation1hInputTokens}, 0) > 0 THEN 3600
+    WHEN COALESCE(${messageRequest.cacheCreation5mInputTokens}, 0) > 0 THEN 300
+    WHEN ${messageRequest.cacheTtlApplied} = '1h' THEN 3600
+    WHEN ${messageRequest.cacheTtlApplied} = '5m' THEN 300
+    WHEN ${messageRequest.cacheTtlApplied} = 'mixed' THEN 3600
+    WHEN ${messageRequest.cacheTtlApplied} ~ '^[0-9]+h$' THEN (substring(${messageRequest.cacheTtlApplied} from '^[0-9]+')::int * 3600)
+    WHEN ${messageRequest.cacheTtlApplied} ~ '^[0-9]+m$' THEN (substring(${messageRequest.cacheTtlApplied} from '^[0-9]+')::int * 60)
+    WHEN ${messageRequest.cacheTtlApplied} ~ '^[0-9]+s$' THEN (substring(${messageRequest.cacheTtlApplied} from '^[0-9]+')::int)
+    ELSE ${ttlFallbackSecondsExpr}
+  END`;
+
+  const eligibleConditionsRaw = [
+    hasSessionIdCondition,
+    sql`${messageRequest.requestSequence} > 1`,
+    sql`${prev.createdAt} IS NOT NULL`,
+    windowMode === "strict"
+      ? sql`(${prev.createdAt} >= ${timeRange.start} AND ${prev.createdAt} < ${timeRange.end})`
+      : undefined,
+    sql`${gapToPrevSecondsExpr} >= 0::double precision`,
+    sql`${gapToPrevSecondsExpr} <= (${ttlSecondsExpr})::double precision`,
+  ] as const;
+
+  const eligibleConditions = eligibleConditionsRaw.filter(
+    (c): c is NonNullable<(typeof eligibleConditionsRaw)[number]> => !!c
+  );
+
+  const eligibleCondition = and(...eligibleConditions);
+
+  const denominatorTokensExpr = sql<number>`(
+    COALESCE(${messageRequest.inputTokens}, 0)::double precision +
+    COALESCE(${messageRequest.cacheCreationInputTokens}, 0)::double precision +
+    COALESCE(${messageRequest.cacheReadInputTokens}, 0)::double precision
+  )`;
+
+  const totalRequestsExpr = sql<number>`count(*)::double precision`;
+  const cacheSignalRequestsExpr = sql<number>`count(*) FILTER (WHERE ${cacheSignalCondition})::double precision`;
+  const cacheHitRequestsExpr = sql<number>`count(*) FILTER (WHERE ${cacheHitCondition})::double precision`;
+
+  const sumInputTokensExpr = sql<number>`COALESCE(sum(COALESCE(${messageRequest.inputTokens}, 0))::double precision, 0::double precision)`;
+  const sumCacheCreationTokensExpr = sql<number>`COALESCE(sum(COALESCE(${messageRequest.cacheCreationInputTokens}, 0))::double precision, 0::double precision)`;
+  const sumCacheReadTokensExpr = sql<number>`COALESCE(sum(COALESCE(${messageRequest.cacheReadInputTokens}, 0))::double precision, 0::double precision)`;
+  const sumDenominatorTokensExpr = sql<number>`COALESCE(sum(${denominatorTokensExpr})::double precision, 0::double precision)`;
+
+  const hitRateTokensExpr = sql<number>`COALESCE(
+    ${sumCacheReadTokensExpr} / NULLIF(${sumDenominatorTokensExpr}, 0::double precision),
+    0::double precision
+  )`;
+
+  const engagementRateExpr = sql<number>`COALESCE(
+    ${cacheSignalRequestsExpr} / NULLIF(${totalRequestsExpr}, 0::double precision),
+    0::double precision
+  )`;
+
+  const eligibleRequestsExpr = sql<number>`count(*) FILTER (WHERE ${eligibleCondition})::double precision`;
+  const eligibleDenominatorTokensExpr = sql<number>`COALESCE(
+    sum(${denominatorTokensExpr}) FILTER (WHERE ${eligibleCondition})::double precision,
+    0::double precision
+  )`;
+  const eligibleCacheReadTokensExpr = sql<number>`COALESCE(
+    sum(COALESCE(${messageRequest.cacheReadInputTokens}, 0)) FILTER (WHERE ${eligibleCondition})::double precision,
+    0::double precision
+  )`;
+  const hitRateTokensEligibleExpr = sql<number>`COALESCE(
+    ${eligibleCacheReadTokensExpr} / NULLIF(${eligibleDenominatorTokensExpr}, 0::double precision),
+    0::double precision
+  )`;
+
+  const whereConditionsRaw = [
+    isNull(messageRequest.deletedAt),
+    EXCLUDE_WARMUP_CONDITION,
+    gte(messageRequest.createdAt, timeRange.start),
+    lt(messageRequest.createdAt, timeRange.end),
+    providerType ? eq(providers.providerType, providerType) : undefined,
+    statusCodeMode === "2xx" ? gte(messageRequest.statusCode, 200) : undefined,
+    statusCodeMode === "2xx" ? lt(messageRequest.statusCode, 300) : undefined,
+    sql`${modelField} IS NOT NULL AND btrim(${modelField}) <> ''`,
+  ] as const;
+
+  const whereConditions = whereConditionsRaw.filter(
+    (c): c is NonNullable<(typeof whereConditionsRaw)[number]> => !!c
+  );
+
+  const rows = await db
+    .select({
+      providerId: messageRequest.providerId,
+      providerType: providers.providerType,
+      model: modelField,
+      totalRequests: totalRequestsExpr,
+      cacheSignalRequests: cacheSignalRequestsExpr,
+      cacheHitRequests: cacheHitRequestsExpr,
+      sumInputTokens: sumInputTokensExpr,
+      sumCacheCreationTokens: sumCacheCreationTokensExpr,
+      sumCacheReadTokens: sumCacheReadTokensExpr,
+      denominatorTokens: sumDenominatorTokensExpr,
+      hitRateTokens: hitRateTokensExpr,
+      engagementRate: engagementRateExpr,
+      eligibleRequests: eligibleRequestsExpr,
+      eligibleDenominatorTokens: eligibleDenominatorTokensExpr,
+      eligibleCacheReadTokens: eligibleCacheReadTokensExpr,
+      hitRateTokensEligible: hitRateTokensEligibleExpr,
+    })
+    .from(messageRequest)
+    .innerJoin(
+      providers,
+      and(eq(messageRequest.providerId, providers.id), isNull(providers.deletedAt))
+    )
+    .leftJoin(
+      prev,
+      and(
+        eq(prev.sessionId, messageRequest.sessionId),
+        eq(prev.requestSequence, sql<number>`(${messageRequest.requestSequence} - 1)`),
+        isNull(prev.deletedAt),
+        prevExcludeWarmupCondition
+      )
+    )
+    .where(and(...whereConditions))
+    .groupBy(messageRequest.providerId, providers.providerType, modelField)
+    .orderBy(desc(totalRequestsExpr));
+
+  return rows.map((row) => ({
+    providerId: row.providerId,
+    providerType: row.providerType,
+    model: row.model,
+    totalRequests: row.totalRequests,
+    cacheSignalRequests: row.cacheSignalRequests,
+    cacheHitRequests: row.cacheHitRequests,
+    sumInputTokens: row.sumInputTokens,
+    sumCacheCreationTokens: row.sumCacheCreationTokens,
+    sumCacheReadTokens: row.sumCacheReadTokens,
+    denominatorTokens: row.denominatorTokens,
+    hitRateTokens: Math.min(Math.max(row.hitRateTokens ?? 0, 0), 1),
+    engagementRate: Math.min(Math.max(row.engagementRate ?? 0, 0), 1),
+    eligibleRequests: row.eligibleRequests,
+    eligibleDenominatorTokens: row.eligibleDenominatorTokens,
+    eligibleCacheReadTokens: row.eligibleCacheReadTokens,
+    hitRateTokensEligible: Math.min(Math.max(row.hitRateTokensEligible ?? 0, 0), 1),
+  }));
+}

--- a/src/repository/cache-hit-rate-alert.ts
+++ b/src/repository/cache-hit-rate-alert.ts
@@ -125,6 +125,11 @@ export async function findProviderModelCacheHitRateMetricsForAlert(
     number | null
   >`EXTRACT(EPOCH FROM (${messageRequest.createdAt} - ${prev.createdAt}))::double precision`;
 
+  // 维护提示：这里的 ttlFallbackSecondsExpr 与 normalizeTtlFallbackSeconds() 内的 base 以及 ProviderType 强耦合。
+  // 如果 ProviderType 新增/调整类型，务必同时更新：
+  // - normalizeTtlFallbackSeconds() 的 base 默认映射
+  // - 本处 ttlFallbackSecondsExpr 的 CASE 分支
+  // 否则 TTL fallback 可能不一致，进而影响 eligible 口径判断。
   const ttlFallbackSecondsExpr = sql<number>`CASE
     WHEN ${providers.providerType} = 'claude' THEN ${ttlFallback.byType.claude}
     WHEN ${providers.providerType} = 'claude-auth' THEN ${ttlFallback.byType["claude-auth"]}

--- a/src/repository/notification-bindings.ts
+++ b/src/repository/notification-bindings.ts
@@ -6,7 +6,11 @@ import { notificationTargetBindings, webhookTargets } from "@/drizzle/schema";
 import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import type { WebhookProviderType, WebhookTarget, WebhookTestResult } from "./webhook-targets";
 
-export type NotificationType = "circuit_breaker" | "daily_leaderboard" | "cost_alert";
+export type NotificationType =
+  | "circuit_breaker"
+  | "daily_leaderboard"
+  | "cost_alert"
+  | "cache_hit_rate_alert";
 
 export interface NotificationBinding {
   id: number;

--- a/src/repository/notifications.ts
+++ b/src/repository/notifications.ts
@@ -29,6 +29,20 @@ export interface NotificationSettings {
   costAlertThreshold: string | null; // numeric 类型作为 string
   costAlertCheckInterval: number | null;
 
+  // 缓存命中率异常告警配置（provider × model）
+  cacheHitRateAlertEnabled: boolean;
+  cacheHitRateAlertWebhook: string | null;
+  cacheHitRateAlertWindowMode: string | null;
+  cacheHitRateAlertCheckInterval: number | null;
+  cacheHitRateAlertHistoricalLookbackDays: number | null;
+  cacheHitRateAlertMinEligibleRequests: number | null;
+  cacheHitRateAlertMinEligibleTokens: number | null;
+  cacheHitRateAlertAbsMin: string | null; // numeric 类型作为 string
+  cacheHitRateAlertDropRel: string | null; // numeric 类型作为 string
+  cacheHitRateAlertDropAbs: string | null; // numeric 类型作为 string
+  cacheHitRateAlertCooldownMinutes: number | null;
+  cacheHitRateAlertTopN: number | null;
+
   createdAt: Date;
   updatedAt: Date;
 }
@@ -52,6 +66,19 @@ export interface UpdateNotificationSettingsInput {
   costAlertWebhook?: string | null;
   costAlertThreshold?: string;
   costAlertCheckInterval?: number;
+
+  cacheHitRateAlertEnabled?: boolean;
+  cacheHitRateAlertWebhook?: string | null;
+  cacheHitRateAlertWindowMode?: string;
+  cacheHitRateAlertCheckInterval?: number;
+  cacheHitRateAlertHistoricalLookbackDays?: number;
+  cacheHitRateAlertMinEligibleRequests?: number;
+  cacheHitRateAlertMinEligibleTokens?: number;
+  cacheHitRateAlertAbsMin?: string;
+  cacheHitRateAlertDropRel?: string;
+  cacheHitRateAlertDropAbs?: string;
+  cacheHitRateAlertCooldownMinutes?: number;
+  cacheHitRateAlertTopN?: number;
 }
 
 /**
@@ -201,6 +228,19 @@ function createFallbackSettings(): NotificationSettings {
     costAlertWebhook: null,
     costAlertThreshold: "0.80",
     costAlertCheckInterval: 60,
+
+    cacheHitRateAlertEnabled: false,
+    cacheHitRateAlertWebhook: null,
+    cacheHitRateAlertWindowMode: "auto",
+    cacheHitRateAlertCheckInterval: 5,
+    cacheHitRateAlertHistoricalLookbackDays: 7,
+    cacheHitRateAlertMinEligibleRequests: 20,
+    cacheHitRateAlertMinEligibleTokens: 0,
+    cacheHitRateAlertAbsMin: "0.05",
+    cacheHitRateAlertDropRel: "0.3",
+    cacheHitRateAlertDropAbs: "0.1",
+    cacheHitRateAlertCooldownMinutes: 30,
+    cacheHitRateAlertTopN: 10,
     createdAt: now,
     updatedAt: now,
   };
@@ -217,6 +257,7 @@ export async function getNotificationSettings(): Promise<NotificationSettings> {
       return {
         ...settings,
         useLegacyMode: settings.useLegacyMode ?? false,
+        cacheHitRateAlertEnabled: settings.cacheHitRateAlertEnabled ?? false,
         createdAt: settings.createdAt ?? new Date(),
         updatedAt: settings.updatedAt ?? new Date(),
       };
@@ -234,6 +275,17 @@ export async function getNotificationSettings(): Promise<NotificationSettings> {
         costAlertEnabled: false,
         costAlertThreshold: "0.80",
         costAlertCheckInterval: 60,
+        cacheHitRateAlertEnabled: false,
+        cacheHitRateAlertWindowMode: "auto",
+        cacheHitRateAlertCheckInterval: 5,
+        cacheHitRateAlertHistoricalLookbackDays: 7,
+        cacheHitRateAlertMinEligibleRequests: 20,
+        cacheHitRateAlertMinEligibleTokens: 0,
+        cacheHitRateAlertAbsMin: "0.05",
+        cacheHitRateAlertDropRel: "0.3",
+        cacheHitRateAlertDropAbs: "0.1",
+        cacheHitRateAlertCooldownMinutes: 30,
+        cacheHitRateAlertTopN: 10,
       })
       .onConflictDoNothing()
       .returning();
@@ -242,6 +294,7 @@ export async function getNotificationSettings(): Promise<NotificationSettings> {
       return {
         ...created,
         useLegacyMode: created.useLegacyMode ?? false,
+        cacheHitRateAlertEnabled: created.cacheHitRateAlertEnabled ?? false,
         createdAt: created.createdAt ?? new Date(),
         updatedAt: created.updatedAt ?? new Date(),
       };
@@ -257,6 +310,7 @@ export async function getNotificationSettings(): Promise<NotificationSettings> {
     return {
       ...fallback,
       useLegacyMode: fallback.useLegacyMode ?? false,
+      cacheHitRateAlertEnabled: fallback.cacheHitRateAlertEnabled ?? false,
       createdAt: fallback.createdAt ?? new Date(),
       updatedAt: fallback.updatedAt ?? new Date(),
     };
@@ -329,6 +383,45 @@ export async function updateNotificationSettings(
     }
     if (payload.costAlertCheckInterval !== undefined) {
       updates.costAlertCheckInterval = payload.costAlertCheckInterval;
+    }
+
+    // 缓存命中率异常告警配置
+    if (payload.cacheHitRateAlertEnabled !== undefined) {
+      updates.cacheHitRateAlertEnabled = payload.cacheHitRateAlertEnabled;
+    }
+    if (payload.cacheHitRateAlertWebhook !== undefined) {
+      updates.cacheHitRateAlertWebhook = payload.cacheHitRateAlertWebhook;
+    }
+    if (payload.cacheHitRateAlertWindowMode !== undefined) {
+      updates.cacheHitRateAlertWindowMode = payload.cacheHitRateAlertWindowMode;
+    }
+    if (payload.cacheHitRateAlertCheckInterval !== undefined) {
+      updates.cacheHitRateAlertCheckInterval = payload.cacheHitRateAlertCheckInterval;
+    }
+    if (payload.cacheHitRateAlertHistoricalLookbackDays !== undefined) {
+      updates.cacheHitRateAlertHistoricalLookbackDays =
+        payload.cacheHitRateAlertHistoricalLookbackDays;
+    }
+    if (payload.cacheHitRateAlertMinEligibleRequests !== undefined) {
+      updates.cacheHitRateAlertMinEligibleRequests = payload.cacheHitRateAlertMinEligibleRequests;
+    }
+    if (payload.cacheHitRateAlertMinEligibleTokens !== undefined) {
+      updates.cacheHitRateAlertMinEligibleTokens = payload.cacheHitRateAlertMinEligibleTokens;
+    }
+    if (payload.cacheHitRateAlertAbsMin !== undefined) {
+      updates.cacheHitRateAlertAbsMin = payload.cacheHitRateAlertAbsMin;
+    }
+    if (payload.cacheHitRateAlertDropRel !== undefined) {
+      updates.cacheHitRateAlertDropRel = payload.cacheHitRateAlertDropRel;
+    }
+    if (payload.cacheHitRateAlertDropAbs !== undefined) {
+      updates.cacheHitRateAlertDropAbs = payload.cacheHitRateAlertDropAbs;
+    }
+    if (payload.cacheHitRateAlertCooldownMinutes !== undefined) {
+      updates.cacheHitRateAlertCooldownMinutes = payload.cacheHitRateAlertCooldownMinutes;
+    }
+    if (payload.cacheHitRateAlertTopN !== undefined) {
+      updates.cacheHitRateAlertTopN = payload.cacheHitRateAlertTopN;
     }
 
     const [updated] = await db

--- a/src/repository/provider.ts
+++ b/src/repository/provider.ts
@@ -901,7 +901,7 @@ export async function updateProviderPrioritiesBatch(
   const result = await db.execute(query);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return Number((result as any).count) || 0;
+  return Number((result as any).rowCount ?? (result as any).count ?? 0) || 0;
 }
 
 export async function deleteProvider(id: number): Promise<boolean> {

--- a/src/repository/provider.ts
+++ b/src/repository/provider.ts
@@ -896,12 +896,11 @@ export async function updateProviderPrioritiesBatch(
       ${priorityCol} = CASE id ${sql.join(cases, sql` `)} ELSE ${priorityCol} END,
       ${updatedAtCol} = NOW()
     WHERE id IN (${idList}) AND deleted_at IS NULL
+    RETURNING id
   `;
 
   const result = await db.execute(query);
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return Number((result as any).rowCount ?? (result as any).count ?? 0) || 0;
+  return Array.from(result).length;
 }
 
 export async function deleteProvider(id: number): Promise<boolean> {

--- a/tests/unit/lib/cache-hit-rate-alert/cooldown-dedup.test.ts
+++ b/tests/unit/lib/cache-hit-rate-alert/cooldown-dedup.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getRedisClient } from "@/lib/redis/client";
+import type { CacheHitRateAlertData, CacheHitRateAlertSample } from "@/lib/webhook";
+import {
+  applyCacheHitRateAlertCooldownToPayload,
+  buildCacheHitRateAlertCooldownKey,
+} from "@/lib/notification/tasks/cache-hit-rate-alert";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/redis/client", () => ({
+  getRedisClient: vi.fn(),
+}));
+
+type RedisMock = {
+  mget: ReturnType<typeof vi.fn>;
+};
+
+function createRedisMock(): RedisMock {
+  return {
+    mget: vi.fn(),
+  };
+}
+
+function sample(hitRateTokens: number): CacheHitRateAlertSample {
+  return {
+    kind: "eligible",
+    requests: 10,
+    denominatorTokens: 1000,
+    hitRateTokens,
+  };
+}
+
+function payload(anomalies: CacheHitRateAlertData["anomalies"]): CacheHitRateAlertData {
+  return {
+    window: {
+      mode: "5m",
+      startTime: "2026-02-25T00:00:00.000Z",
+      endTime: "2026-02-25T00:05:00.000Z",
+      durationMinutes: 5,
+    },
+    anomalies,
+    suppressedCount: 0,
+    settings: {
+      windowMode: "5m",
+      checkIntervalMinutes: 5,
+      historicalLookbackDays: 7,
+      minEligibleRequests: 20,
+      minEligibleTokens: 0,
+      absMin: 0.05,
+      dropRel: 0.3,
+      dropAbs: 0.1,
+      cooldownMinutes: 30,
+      topN: 10,
+    },
+    generatedAt: "2026-02-25T00:05:00.000Z",
+  };
+}
+
+describe("cache-hit-rate-alert cooldown dedup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds binding-scoped keys when bindingId is provided", () => {
+    const globalKey = buildCacheHitRateAlertCooldownKey({
+      providerId: 1,
+      model: "m",
+      windowMode: "5m",
+    });
+    const bindingKey = buildCacheHitRateAlertCooldownKey({
+      providerId: 1,
+      model: "m",
+      windowMode: "5m",
+      bindingId: 42,
+    });
+
+    expect(globalKey.split(":")).toHaveLength(5);
+    expect(bindingKey.split(":").slice(0, 4)).toEqual([
+      "cache-hit-rate-alert",
+      "v1",
+      "binding",
+      "42",
+    ]);
+    expect(bindingKey).not.toEqual(globalKey);
+  });
+
+  it("filters suppressed anomalies per binding", async () => {
+    const redis = createRedisMock();
+    redis.mget.mockResolvedValueOnce(["1", null]);
+    vi.mocked(getRedisClient).mockReturnValue(
+      redis as unknown as NonNullable<ReturnType<typeof getRedisClient>>
+    );
+
+    const input = payload([
+      {
+        providerId: 1,
+        model: "m1",
+        baselineSource: "prev",
+        current: sample(0.5),
+        baseline: sample(0.8),
+        deltaAbs: -0.3,
+        deltaRel: -0.375,
+        dropAbs: 0.3,
+        reasonCodes: ["drop_abs_rel"],
+      },
+      {
+        providerId: 2,
+        model: "m2",
+        baselineSource: "prev",
+        current: sample(0.5),
+        baseline: sample(0.8),
+        deltaAbs: -0.3,
+        deltaRel: -0.375,
+        dropAbs: 0.3,
+        reasonCodes: ["drop_abs_rel"],
+      },
+    ]);
+
+    const result = await applyCacheHitRateAlertCooldownToPayload({ payload: input, bindingId: 7 });
+
+    expect(redis.mget).toHaveBeenCalledTimes(1);
+    const passedKeys = redis.mget.mock.calls[0];
+    expect(passedKeys).toHaveLength(2);
+    expect(passedKeys[0]).toContain(":binding:7:");
+    expect(passedKeys[1]).toContain(":binding:7:");
+
+    expect(result.suppressedCount).toBe(1);
+    expect(result.payload.suppressedCount).toBe(1);
+    expect(result.payload.anomalies).toHaveLength(1);
+    expect(result.payload.anomalies[0].providerId).toBe(2);
+
+    expect(result.dedupKeysToSet).toHaveLength(1);
+    expect(result.dedupKeysToSet[0]).toBe(passedKeys[1]);
+  });
+});

--- a/tests/unit/lib/cache-hit-rate-alert/decision.test.ts
+++ b/tests/unit/lib/cache-hit-rate-alert/decision.test.ts
@@ -381,6 +381,21 @@ describe("decideCacheHitRateAnomalies", () => {
     expect(anomalies[0].reasonCodes).toContain("abs_min");
   });
 
+  it("dropAbs 在 current 高于 baseline 且仅触发 abs_min 时应 clamp 为 0", () => {
+    const anomalies = decideCacheHitRateAnomalies({
+      current: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.04 })],
+      prev: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.01 })],
+      today: [],
+      historical: [],
+      settings: { ...defaultSettings, absMin: 0.05, dropAbs: 0.1, dropRel: 0.3 },
+    });
+
+    expect(anomalies).toHaveLength(1);
+    expect(anomalies[0].reasonCodes).toContain("abs_min");
+    expect(anomalies[0].reasonCodes).not.toContain("drop_abs_rel");
+    expect(anomalies[0].dropAbs).toBe(0);
+  });
+
   it("should set deltaRel to null when baseline hit rate is 0", () => {
     const anomalies = decideCacheHitRateAnomalies({
       current: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0 })],

--- a/tests/unit/lib/cache-hit-rate-alert/decision.test.ts
+++ b/tests/unit/lib/cache-hit-rate-alert/decision.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideCacheHitRateAnomalies,
+  type CacheHitRateAlertMetric,
+  type CacheHitRateAlertDecisionSettings,
+} from "@/lib/cache-hit-rate-alert/decision";
+
+function metric(
+  input: Partial<CacheHitRateAlertMetric> & { providerId: number; model: string }
+): CacheHitRateAlertMetric {
+  return {
+    providerId: input.providerId,
+    model: input.model,
+    totalRequests: input.totalRequests ?? 100,
+    denominatorTokens: input.denominatorTokens ?? 10000,
+    hitRateTokens: input.hitRateTokens ?? 0,
+    eligibleRequests: input.eligibleRequests ?? 100,
+    eligibleDenominatorTokens: input.eligibleDenominatorTokens ?? 10000,
+    hitRateTokensEligible: input.hitRateTokensEligible ?? input.hitRateTokens ?? 0,
+  };
+}
+
+const defaultSettings: CacheHitRateAlertDecisionSettings = {
+  absMin: 0.05,
+  dropRel: 0.3,
+  dropAbs: 0.1,
+  minEligibleRequests: 20,
+  minEligibleTokens: 0,
+  topN: 10,
+};
+
+describe("decideCacheHitRateAnomalies", () => {
+  it("should prefer historical baseline over today/prev", () => {
+    const anomalies = decideCacheHitRateAnomalies({
+      current: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.2 })],
+      prev: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.4 })],
+      today: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.35 })],
+      historical: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.5 })],
+      settings: defaultSettings,
+    });
+
+    expect(anomalies).toHaveLength(1);
+    expect(anomalies[0].baselineSource).toBe("historical");
+  });
+
+  it("should fall back to today baseline when historical kind-sample is insufficient", () => {
+    const anomalies = decideCacheHitRateAnomalies({
+      current: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.2 })],
+      prev: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.4 })],
+      today: [
+        metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.5, eligibleRequests: 50 }),
+      ],
+      historical: [
+        metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.9, eligibleRequests: 1 }),
+      ],
+      settings: defaultSettings,
+    });
+
+    expect(anomalies).toHaveLength(1);
+    expect(anomalies[0].baselineSource).toBe("today");
+  });
+
+  it("should fall back to overall when eligible sample is insufficient", () => {
+    const anomalies = decideCacheHitRateAnomalies({
+      current: [
+        metric({
+          providerId: 1,
+          model: "m",
+          totalRequests: 100,
+          denominatorTokens: 10000,
+          hitRateTokens: 0.1,
+          eligibleRequests: 1,
+          eligibleDenominatorTokens: 100,
+          hitRateTokensEligible: 0,
+        }),
+      ],
+      prev: [
+        metric({
+          providerId: 1,
+          model: "m",
+          totalRequests: 100,
+          denominatorTokens: 10000,
+          hitRateTokens: 0.5,
+          eligibleRequests: 1,
+          eligibleDenominatorTokens: 100,
+          hitRateTokensEligible: 0.5,
+        }),
+      ],
+      today: [],
+      historical: [],
+      settings: defaultSettings,
+    });
+
+    expect(anomalies).toHaveLength(1);
+    expect(anomalies[0].current.kind).toBe("overall");
+    expect(anomalies[0].baseline?.kind).toBe("overall");
+    expect(anomalies[0].reasonCodes).toContain("eligible_insufficient");
+  });
+
+  it("should not compare eligible current against overall baseline", () => {
+    const anomalies = decideCacheHitRateAnomalies({
+      current: [
+        metric({
+          providerId: 1,
+          model: "m",
+          eligibleRequests: 100,
+          eligibleDenominatorTokens: 10000,
+          hitRateTokensEligible: 0.2,
+          totalRequests: 100,
+          denominatorTokens: 10000,
+          hitRateTokens: 0.2,
+        }),
+      ],
+      prev: [
+        metric({
+          providerId: 1,
+          model: "m",
+          // baseline eligible 不足，但 overall 足够
+          eligibleRequests: 1,
+          eligibleDenominatorTokens: 100,
+          hitRateTokensEligible: 0.9,
+          totalRequests: 100,
+          denominatorTokens: 10000,
+          hitRateTokens: 0.9,
+        }),
+      ],
+      today: [],
+      historical: [],
+      settings: defaultSettings,
+    });
+
+    expect(anomalies).toHaveLength(0);
+  });
+
+  it("should trigger drop_abs_rel when thresholds are met", () => {
+    const anomalies = decideCacheHitRateAnomalies({
+      current: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.2 })],
+      prev: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.5 })],
+      today: [],
+      historical: [],
+      settings: { ...defaultSettings, absMin: 0.01 },
+    });
+
+    expect(anomalies).toHaveLength(1);
+    expect(anomalies[0].reasonCodes).toContain("drop_abs_rel");
+    expect(anomalies[0].dropAbs).toBeCloseTo(0.3, 10);
+  });
+
+  it("should trigger abs_min only when baseline is also above absMin", () => {
+    const shouldTrigger = decideCacheHitRateAnomalies({
+      current: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.03 })],
+      prev: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.2 })],
+      today: [],
+      historical: [],
+      settings: { ...defaultSettings, dropAbs: 0.9, dropRel: 0.9 },
+    });
+
+    expect(shouldTrigger).toHaveLength(1);
+    expect(shouldTrigger[0].reasonCodes).toContain("abs_min");
+
+    const shouldNotTrigger = decideCacheHitRateAnomalies({
+      current: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.03 })],
+      prev: [metric({ providerId: 1, model: "m", hitRateTokensEligible: 0.04 })],
+      today: [],
+      historical: [],
+      settings: { ...defaultSettings, dropAbs: 0.9, dropRel: 0.9 },
+    });
+
+    expect(shouldNotTrigger).toHaveLength(0);
+  });
+
+  it("should sort by severity and respect topN", () => {
+    const anomalies = decideCacheHitRateAnomalies({
+      current: [
+        metric({ providerId: 1, model: "a", hitRateTokensEligible: 0.1 }),
+        metric({ providerId: 2, model: "b", hitRateTokensEligible: 0.25 }),
+      ],
+      prev: [
+        metric({ providerId: 1, model: "a", hitRateTokensEligible: 0.6 }),
+        metric({ providerId: 2, model: "b", hitRateTokensEligible: 0.5 }),
+      ],
+      today: [],
+      historical: [],
+      settings: { ...defaultSettings, absMin: 0.01, topN: 1 },
+    });
+
+    expect(anomalies).toHaveLength(1);
+    expect(anomalies[0].providerId).toBe(1);
+    expect(anomalies[0].model).toBe("a");
+  });
+});

--- a/tests/unit/repository/provider.test.ts
+++ b/tests/unit/repository/provider.test.ts
@@ -51,7 +51,7 @@ describe("provider repository - updateProviderPrioritiesBatch", () => {
   test("returns 0 and does not execute SQL when updates is empty", async () => {
     vi.resetModules();
 
-    const executeMock = vi.fn(async () => ({ rowCount: 0 }));
+    const executeMock = vi.fn(async () => []);
 
     vi.doMock("@/drizzle/db", () => ({
       db: {
@@ -69,7 +69,7 @@ describe("provider repository - updateProviderPrioritiesBatch", () => {
   test("generates CASE batch update SQL and returns affected rows", async () => {
     vi.resetModules();
 
-    const executeMock = vi.fn(async () => ({ rowCount: 2 }));
+    const executeMock = vi.fn(async () => [{ id: 1 }, { id: 2 }]);
 
     vi.doMock("@/drizzle/db", () => ({
       db: {
@@ -96,12 +96,13 @@ describe("provider repository - updateProviderPrioritiesBatch", () => {
     expect(sqlText).toContain("WHEN 2 THEN 3");
     expect(sqlText).toContain("updated_at = NOW()");
     expect(sqlText).toContain("WHERE id IN (1, 2) AND deleted_at IS NULL");
+    expect(sqlText).toContain("RETURNING id");
   });
 
   test("deduplicates provider ids (last update wins)", async () => {
     vi.resetModules();
 
-    const executeMock = vi.fn(async () => ({ rowCount: 1 }));
+    const executeMock = vi.fn(async () => [{ id: 1 }]);
 
     vi.doMock("@/drizzle/db", () => ({
       db: {
@@ -123,5 +124,6 @@ describe("provider repository - updateProviderPrioritiesBatch", () => {
 
     expect(sqlText).toContain("WHEN 1 THEN 2");
     expect(sqlText).toContain("WHERE id IN (1) AND deleted_at IS NULL");
+    expect(sqlText).toContain("RETURNING id");
   });
 });

--- a/tests/unit/webhook/templates/templates.test.ts
+++ b/tests/unit/webhook/templates/templates.test.ts
@@ -263,6 +263,60 @@ describe("Message Templates", () => {
       expect(sectionsStr).toContain("异常列表");
     });
 
+    it("should handle anomalies with null baseline", () => {
+      const data: CacheHitRateAlertData = {
+        window: {
+          mode: "5m",
+          startTime: "2026-02-24T00:00:00.000Z",
+          endTime: "2026-02-24T00:05:00.000Z",
+          durationMinutes: 5,
+        },
+        anomalies: [
+          {
+            providerId: 1,
+            providerName: "OpenAI",
+            providerType: "openai-compatible",
+            model: "gpt-4o",
+            baselineSource: null,
+            current: {
+              kind: "eligible",
+              requests: 100,
+              denominatorTokens: 10000,
+              hitRateTokens: 0.1,
+            },
+            baseline: null,
+            deltaAbs: null,
+            deltaRel: null,
+            dropAbs: null,
+            reasonCodes: ["abs_min"],
+          },
+        ],
+        suppressedCount: 0,
+        settings: {
+          windowMode: "auto",
+          checkIntervalMinutes: 5,
+          historicalLookbackDays: 7,
+          minEligibleRequests: 20,
+          minEligibleTokens: 0,
+          absMin: 0.05,
+          dropRel: 0.3,
+          dropAbs: 0.1,
+          cooldownMinutes: 30,
+          topN: 10,
+        },
+        generatedAt: "2026-02-24T00:05:00.000Z",
+      };
+
+      const message = buildCacheHitRateAlertMessage(data, "UTC");
+
+      expect(message.header.level).toBe("warning");
+      expect(message.timestamp).toBeInstanceOf(Date);
+
+      const sectionsStr = JSON.stringify(message.sections);
+      expect(sectionsStr).toContain("gpt-4o");
+      expect(sectionsStr).toContain("基线: 无");
+    });
+
     it("should handle empty anomalies", () => {
       const data: CacheHitRateAlertData = {
         window: {


### PR DESCRIPTION
## Summary

实现 #823：新增通知类型 `cache_hit_rate_alert`，按 **provider×model** 在滑动窗口内统计缓存命中率，并与基线对比；当出现“显著下降”或“低于最低阈值”时，通过 Webhook 推送告警。

## 统计口径（关键约束）

- **仅同一 `sessionId` 内的缓存命中才有意义**：避免跨会话误判。
- **Eligible 口径**：要求存在上一条请求（`requestSequence-1`）、且两条请求的时间间隔 `<= TTL`（TTL 优先来自上游/记录字段，否则按 providerType 回退）。
- 如果 eligible 样本不足，会按配置回退到 overall（与排行榜一致的 token hit rate 口径）用于展示/对比。

## 告警逻辑

- `abs_min`：当前值低于 `absMin` 即触发（即使没有 baseline 也会触发）。
- `drop_abs_rel`：在 baseline 存在时，同时满足 **绝对跌幅**（`dropAbs`）与 **相对跌幅**（`dropRel`）才触发，降低噪声。
- `topN`：按 severity 排序后仅取前 N 条。
- 去重：Redis cooldown（legacy webhook：`providerId+model+windowMode`；targets：`bindingId+providerId+model+windowMode`）。

## 默认配置（DB 默认值）

| Setting | Default |
|---|---|
| windowMode | `auto` |
| checkIntervalMinutes | `5` |
| historicalLookbackDays | `7` |
| minEligibleRequests | `20` |
| minEligibleTokens | `0` |
| absMin | `0.05` |
| dropRel | `0.3` |
| dropAbs | `0.1` |
| cooldownMinutes | `30` |
| topN | `10` |

## DB 变更

- `notification_type` enum 增加 `cache_hit_rate_alert`
- `notification_settings` 新增 **12 列**配置字段（见 `drizzle/0076_mighty_lionheart.sql`）

## 主要代码

- Decision：`src/lib/cache-hit-rate-alert/decision.ts`
- Repo：`src/repository/cache-hit-rate-alert.ts`
- Task：`src/lib/notification/tasks/cache-hit-rate-alert.ts`
- Webhook 模板：`src/lib/webhook/templates/cache-hit-rate-alert.ts`
- UI：`src/app/[locale]/settings/notifications/...`

## 附带修复

- `updateProviderPrioritiesBatch` 使用 `RETURNING` 计数，避免不同驱动 `rowCount/count` 差异。

## Testing

已跑：`bun run build` / `bun run lint` / `bun run lint:fix` / `bun run typecheck` / `bun run test`

## 备注（针对自动化审阅）

- Postgres `numeric(5,4)` 最大值为 `9.9999`（1 位整数 + 4 位小数），因此 `1.0000` 合法；本 PR 以 `0~1` 小数存储比例字段。
- `cacheHitRateAlertCheckInterval > 59` 分钟时已改用 Bull `repeat.every` 调度，避免生成无效 cron。
- API 已对比例类 string 字段（如 `absMin/dropRel/dropAbs`）做格式与范围校验（`0~1`），前端也会 clamp 并格式化写回。

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements cache hit rate anomaly detection for prompt caching by provider×model. The system computes cache hit rates in sliding windows using an "eligible" metric (requests within the same `sessionId` where time gap ≤ TTL), compares against historical/today/previous baselines, and triggers alerts when rates drop below `absMin` or meet both `dropAbs` and `dropRel` thresholds.

**Key implementation details:**
- **DB migration**: Adds `cache_hit_rate_alert` notification type with 12 config columns using `numeric(5,4)` precision for ratio fields
- **Scheduler fix**: Large check intervals (>59 min) now use Bull's `repeat.every` instead of invalid cron expressions
- **Decision logic**: Uses AND operator for `dropAbs` && `dropRel` thresholds (line 274 in decision.ts), meaning both must be exceeded to trigger
- **Query performance**: Self-join on `(session_id, request_sequence-1)` may need indexing verification on production scale
- **Validation**: API includes `RatioStringSchema` with regex and 0-1 range checks; UI clamps and formats to 4 decimals
- **Deduplication**: Redis cooldown keys per provider×model×window, with graceful degradation on Redis failures

**Testing**: Build, lint, typecheck, and unit tests pass. Includes comprehensive test coverage for decision logic and cooldown.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with attention to performance monitoring - the core logic is sound with proper validation and error handling
- Score reflects well-tested implementation with comprehensive validation, but the combined threshold logic (AND vs OR) and self-join query performance should be monitored in production. The cron scheduling fix, numeric precision handling, and graceful Redis failure handling demonstrate good engineering practices.
- Monitor `src/repository/cache-hit-rate-alert.ts` self-join performance on large tables; verify `src/lib/cache-hit-rate-alert/decision.ts:274` AND logic matches intended alert behavior
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| drizzle/0076_mighty_lionheart.sql | Adds `cache_hit_rate_alert` enum value and 12 config columns; `numeric(5,4)` precision allows max 9.9999 which is sufficient for decimal percentages 0.0-0.9999 |
| src/drizzle/schema.ts | Schema matches migration; `numeric(5,4)` columns store ratio values as decimals with defaults 0.05, 0.3, 0.1 |
| src/lib/cache-hit-rate-alert/decision.ts | Decision logic evaluates anomalies; uses AND for `dropAbs` and `dropRel` thresholds (line 274); includes defensive clamping for rate calculations |
| src/repository/cache-hit-rate-alert.ts | Complex aggregation query with self-join on `(session_id, request_sequence-1)`; includes TTL parsing with bounds checking and swap logic for 5m/1h tokens |
| src/lib/notification/tasks/cache-hit-rate-alert.ts | Orchestrates alert generation with window mode resolution, cooldown deduplication via Redis; handles Redis failures gracefully by continuing without dedup |
| src/lib/notification/notification-queue.ts | Scheduler now uses `repeat.every` for intervals >59 minutes (line 794-797); handles both legacy single webhook and targets fan-out modes |
| src/app/api/actions/[...route]/route.ts | API validation includes `RatioStringSchema` with regex and range checks (0-1); applies to all ratio fields (`absMin`, `dropRel`, `dropAbs`) |
| src/app/[locale]/settings/notifications/_lib/hooks.ts | Client hooks normalize ratio inputs to bounded floats (0-1), format to 4 decimals with `.toFixed(4)` before sending to API |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Scheduler: notification-queue.ts] -->|Every N minutes| B[Task: cache-hit-rate-alert.ts]
    B --> C[Query Metrics: cache-hit-rate-alert.ts repo]
    C --> D{Window Mode}
    D -->|Rolling| E[Current + Prev + Today + Historical]
    D -->|Strict| E
    E --> F[Decision Logic: decision.ts]
    F --> G{Check Thresholds}
    G -->|absMin < threshold| H[Trigger Alert]
    G -->|dropAbs AND dropRel| H
    G -->|No trigger| I[Skip]
    H --> J[Redis Cooldown Check]
    J -->|Not in cooldown| K[Fan-out to Targets]
    J -->|In cooldown| L[Suppress]
    K --> M[Webhook Delivery]
    M --> N[Set Redis Cooldown]
```
</details>


<sub>Last reviewed commit: 357a552</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->