### PR TITLE
fix: 终止 Session 后仍可复活

### DIFF
--- a/src/actions/active-sessions.ts
+++ b/src/actions/active-sessions.ts
@@ -854,9 +854,9 @@ export async function terminateActiveSession(sessionId: string): Promise<ActionR
 
     // 3. 终止 Session
     const { SessionManager } = await import("@/lib/session-manager");
-    const success = await SessionManager.terminateSession(sessionId);
+    const result = await SessionManager.terminateSession(sessionId);
 
-    if (!success) {
+    if (!result.markerOk) {
       return {
         ok: false,
         error: "终止 Session 失败（Redis 不可用或 Session 已过期）",

--- a/src/lib/session-manager.ts
+++ b/src/lib/session-manager.ts
@@ -2187,14 +2187,14 @@ export class SessionManager {
       const CHUNK_SIZE = 20;
       let successCount = 0;
 
-        for (let i = 0; i < sessionIds.length; i += CHUNK_SIZE) {
-          const chunk = sessionIds.slice(i, i + CHUNK_SIZE);
-          const results = await Promise.all(
-            chunk.map(async (sessionId) => {
-              const result = await SessionManager.terminateSession(sessionId);
-              return result.markerOk ? 1 : 0;
-            })
-          );
+      for (let i = 0; i < sessionIds.length; i += CHUNK_SIZE) {
+        const chunk = sessionIds.slice(i, i + CHUNK_SIZE);
+        const results = await Promise.all(
+          chunk.map(async (sessionId) => {
+            const result = await SessionManager.terminateSession(sessionId);
+            return result.markerOk ? 1 : 0;
+          })
+        );
         successCount += results.reduce<number>((sum, value) => sum + value, 0);
       }
 

--- a/src/lib/session-manager.ts
+++ b/src/lib/session-manager.ts
@@ -152,6 +152,9 @@ export class SessionManager {
     return 24 * 60 * 60; // 1 天
   })();
 
+  private static readonly SCAN_COUNT = 100;
+  private static readonly TERMINATE_SCAN_COUNT = 200;
+
   private static getTerminationMarkerKey(sessionId: string): string {
     return `session:${sessionId}:terminated`;
   }
@@ -1265,7 +1268,7 @@ export class SessionManager {
           "MATCH",
           "session:*:info",
           "COUNT",
-          100
+          SessionManager.SCAN_COUNT
         )) as [string, string[]];
 
         cursor = nextCursor;
@@ -1360,7 +1363,7 @@ export class SessionManager {
           "MATCH",
           "session:*:info",
           "COUNT",
-          100
+          SessionManager.SCAN_COUNT
         )) as [string, string[]];
 
         cursor = nextCursor;
@@ -1451,7 +1454,7 @@ export class SessionManager {
           "MATCH",
           `session:${escapedSessionId}:req:*:messages`,
           "COUNT",
-          100
+          SessionManager.SCAN_COUNT
         )) as [string, string[]];
 
         cursor = nextCursor;
@@ -2178,10 +2181,13 @@ export class SessionManager {
         let deletedInRound = 0;
 
         do {
-          const scanResult = (await redis.scan(cursor, "MATCH", matchPattern, "COUNT", 200)) as [
-            string,
-            string[],
-          ];
+          const scanResult = (await redis.scan(
+            cursor,
+            "MATCH",
+            matchPattern,
+            "COUNT",
+            SessionManager.TERMINATE_SCAN_COUNT
+          )) as [string, string[]];
           const nextCursor = scanResult[0];
           const keys = scanResult[1] ?? [];
           cursor = nextCursor;

--- a/tests/unit/components/form/client-restrictions-editor.test.tsx
+++ b/tests/unit/components/form/client-restrictions-editor.test.tsx
@@ -101,4 +101,3 @@ describe("ClientRestrictionsEditor - custom clients", () => {
     unmount();
   });
 });
-

--- a/tests/unit/lib/session-manager-scan-pattern-escape.test.ts
+++ b/tests/unit/lib/session-manager-scan-pattern-escape.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let redisClientRef: any;
+const getRedisClientMock = vi.fn();
 
 vi.mock("server-only", () => ({}));
 
@@ -26,7 +27,7 @@ vi.mock("@/lib/session-tracker", () => ({
 }));
 
 vi.mock("@/lib/redis", () => ({
-  getRedisClient: () => redisClientRef,
+  getRedisClient: getRedisClientMock,
 }));
 
 describe("SessionManager.hasAnySessionMessages - scan pattern escaping", () => {
@@ -39,6 +40,8 @@ describe("SessionManager.hasAnySessionMessages - scan pattern escaping", () => {
       exists: vi.fn(async () => 0),
       scan: vi.fn(async () => ["0", []]),
     };
+
+    getRedisClientMock.mockReturnValue(redisClientRef);
   });
 
   it("应对 sessionId 中的 glob 特殊字符进行转义（避免误匹配/误删）", async () => {

--- a/tests/unit/lib/session-manager-scan-pattern-escape.test.ts
+++ b/tests/unit/lib/session-manager-scan-pattern-escape.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let redisClientRef: any;
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+vi.mock("@/app/v1/_lib/proxy/errors", () => ({
+  sanitizeHeaders: vi.fn(() => "(empty)"),
+  sanitizeUrl: vi.fn((url: unknown) => String(url)),
+}));
+
+vi.mock("@/lib/session-tracker", () => ({
+  SessionTracker: {
+    getConcurrentCount: vi.fn(async () => 0),
+  },
+}));
+
+vi.mock("@/lib/redis", () => ({
+  getRedisClient: () => redisClientRef,
+}));
+
+describe("SessionManager.hasAnySessionMessages - scan pattern escaping", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+
+    redisClientRef = {
+      status: "ready",
+      exists: vi.fn(async () => 0),
+      scan: vi.fn(async () => ["0", []]),
+    };
+  });
+
+  it("应对 sessionId 中的 glob 特殊字符进行转义（避免误匹配/误删）", async () => {
+    const { SessionManager } = await import("@/lib/session-manager");
+
+    const sessionId = "sess_te*st?[x]";
+    const ok = await SessionManager.hasAnySessionMessages(sessionId);
+
+    expect(ok).toBe(false);
+    expect(redisClientRef.exists).toHaveBeenCalledWith(`session:${sessionId}:messages`);
+    expect(redisClientRef.scan).toHaveBeenCalledWith(
+      "0",
+      "MATCH",
+      "session:sess_te\\*st\\?\\[x\\]:req:*:messages",
+      "COUNT",
+      100
+    );
+  });
+});

--- a/tests/unit/lib/session-manager-terminate-session.test.ts
+++ b/tests/unit/lib/session-manager-terminate-session.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let redisClientRef: any;
 let pipelineRef: any;
+let deletePipelineRef: any;
 
 vi.mock("server-only", () => ({}));
 
@@ -25,21 +26,32 @@ describe("SessionManager.terminateSession", () => {
     vi.resetModules();
 
     pipelineRef = {
-      del: vi.fn(() => pipelineRef),
       zrem: vi.fn(() => pipelineRef),
+      exec: vi.fn(async () => []),
+    };
+
+    deletePipelineRef = {
+      del: vi.fn(() => deletePipelineRef),
       exec: vi.fn(async () => [[null, 1]]),
     };
 
     redisClientRef = {
       status: "ready",
+      set: vi.fn(async () => "OK"),
       get: vi.fn(async () => null),
       hget: vi.fn(async () => null),
-      pipeline: vi.fn(() => pipelineRef),
+      scan: vi.fn(async () => ["0", []]),
+      mget: vi.fn(async () => [null, null]),
+      pipeline: vi
+        .fn()
+        .mockImplementationOnce(() => pipelineRef)
+        .mockImplementationOnce(() => deletePipelineRef),
     };
   });
 
   it("应同时从 global/key/user 的 active_sessions ZSET 中移除 sessionId（若可解析到 userId）", async () => {
     const sessionId = "sess_test";
+    const terminatedKey = `session:${sessionId}:terminated`;
     redisClientRef.get.mockImplementation(async (key: string) => {
       if (key === `session:${sessionId}:provider`) return "42";
       if (key === `session:${sessionId}:key`) return "7";
@@ -49,6 +61,15 @@ describe("SessionManager.terminateSession", () => {
       if (key === `session:${sessionId}:info` && field === "userId") return "123";
       return null;
     });
+    redisClientRef.scan.mockResolvedValueOnce([
+      "0",
+      [
+        terminatedKey,
+        `session:${sessionId}:provider`,
+        `session:${sessionId}:req:1:messages`,
+        `session:${sessionId}:req:1:response`,
+      ],
+    ]);
 
     const { getGlobalActiveSessionsKey, getKeyActiveSessionsKey, getUserActiveSessionsKey } =
       await import("@/lib/redis/active-session-keys");
@@ -57,22 +78,30 @@ describe("SessionManager.terminateSession", () => {
     const ok = await SessionManager.terminateSession(sessionId);
     expect(ok).toBe(true);
 
+    expect(redisClientRef.set).toHaveBeenCalledWith(terminatedKey, expect.any(String), "EX", 86400);
     expect(redisClientRef.hget).toHaveBeenCalledWith(`session:${sessionId}:info`, "userId");
 
     expect(pipelineRef.zrem).toHaveBeenCalledWith(getGlobalActiveSessionsKey(), sessionId);
     expect(pipelineRef.zrem).toHaveBeenCalledWith("provider:42:active_sessions", sessionId);
     expect(pipelineRef.zrem).toHaveBeenCalledWith(getKeyActiveSessionsKey(7), sessionId);
     expect(pipelineRef.zrem).toHaveBeenCalledWith(getUserActiveSessionsKey(123), sessionId);
+
+    expect(deletePipelineRef.del).toHaveBeenCalledWith(`session:${sessionId}:provider`);
+    expect(deletePipelineRef.del).toHaveBeenCalledWith(`session:${sessionId}:req:1:messages`);
+    expect(deletePipelineRef.del).toHaveBeenCalledWith(`session:${sessionId}:req:1:response`);
+    expect(deletePipelineRef.del).not.toHaveBeenCalledWith(terminatedKey);
   });
 
   it("当 userId 不可用时，不应尝试 zrem user active_sessions key", async () => {
     const sessionId = "sess_test";
+    const terminatedKey = `session:${sessionId}:terminated`;
     redisClientRef.get.mockImplementation(async (key: string) => {
       if (key === `session:${sessionId}:provider`) return "42";
       if (key === `session:${sessionId}:key`) return "7";
       return null;
     });
     redisClientRef.hget.mockResolvedValue(null);
+    redisClientRef.scan.mockResolvedValueOnce(["0", [terminatedKey]]);
 
     const { getUserActiveSessionsKey } = await import("@/lib/redis/active-session-keys");
     const { SessionManager } = await import("@/lib/session-manager");

--- a/tests/unit/lib/session-manager-terminate-session.test.ts
+++ b/tests/unit/lib/session-manager-terminate-session.test.ts
@@ -77,8 +77,8 @@ describe("SessionManager.terminateSession", () => {
       await import("@/lib/redis/active-session-keys");
     const { SessionManager } = await import("@/lib/session-manager");
 
-    const ok = await SessionManager.terminateSession(sessionId);
-    expect(ok).toBe(true);
+    const result = await SessionManager.terminateSession(sessionId);
+    expect(result.markerOk).toBe(true);
 
     expect(redisClientRef.set).toHaveBeenCalledWith(terminatedKey, expect.any(String), "EX", 86400);
     expect(redisClientRef.hget).toHaveBeenCalledWith(`session:${sessionId}:info`, "userId");
@@ -119,8 +119,8 @@ describe("SessionManager.terminateSession", () => {
     const { getUserActiveSessionsKey } = await import("@/lib/redis/active-session-keys");
     const { SessionManager } = await import("@/lib/session-manager");
 
-    const ok = await SessionManager.terminateSession(sessionId);
-    expect(ok).toBe(true);
+    const result = await SessionManager.terminateSession(sessionId);
+    expect(result.markerOk).toBe(true);
 
     expect(pipelineRef.zrem).not.toHaveBeenCalledWith(getUserActiveSessionsKey(123), sessionId);
   });

--- a/tests/unit/lib/session-manager-terminate-session.test.ts
+++ b/tests/unit/lib/session-manager-terminate-session.test.ts
@@ -45,8 +45,8 @@ describe("SessionManager.terminateSession", () => {
         .fn()
         // 第一次 pipeline：用于 ZSET 清理（global/key/provider/user）
         .mockImplementationOnce(() => pipelineRef)
-        // 第二次 pipeline：用于批量删除 session:{id}:* key
-        .mockImplementationOnce(() => deletePipelineRef),
+        // 后续 pipeline：用于批量删除 session:{id}:* key（可能多页 SCAN）
+        .mockImplementation(() => deletePipelineRef),
     };
   });
 

--- a/tests/unit/lib/session-manager-terminated-remap.test.ts
+++ b/tests/unit/lib/session-manager-terminated-remap.test.ts
@@ -73,9 +73,12 @@ describe("SessionManager.getOrCreateSessionId - terminated blocking", () => {
 
     const { SessionManager, TerminatedSessionError } = await import("@/lib/session-manager");
 
-    await expect(
-      SessionManager.getOrCreateSessionId(keyId, [], oldSessionId)
-    ).rejects.toBeInstanceOf(TerminatedSessionError);
+    const error = await SessionManager.getOrCreateSessionId(keyId, [], oldSessionId).catch(
+      (e) => e as any
+    );
+    expect(error).toBeInstanceOf(TerminatedSessionError);
+    expect(error.sessionId).toBe(oldSessionId);
+    expect(error.terminatedAt).toBe("1");
   });
 
   it("hash 命中已终止 session 时应创建新 session", async () => {

--- a/tests/unit/lib/session-manager-terminated-remap.test.ts
+++ b/tests/unit/lib/session-manager-terminated-remap.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let redisClientRef: any;
+const pipelineCalls: Array<unknown[]> = [];
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+vi.mock("@/app/v1/_lib/proxy/errors", () => ({
+  sanitizeHeaders: vi.fn(() => "(empty)"),
+  sanitizeUrl: vi.fn((url: unknown) => String(url)),
+}));
+
+vi.mock("@/lib/session-tracker", () => ({
+  SessionTracker: {
+    getConcurrentCount: vi.fn(async () => 0),
+  },
+}));
+
+vi.mock("@/lib/redis", () => ({
+  getRedisClient: () => redisClientRef,
+}));
+
+function makePipeline() {
+  const pipeline = {
+    setex: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["setex", ...args]);
+      return pipeline;
+    }),
+    expire: vi.fn((...args: unknown[]) => {
+      pipelineCalls.push(["expire", ...args]);
+      return pipeline;
+    }),
+    exec: vi.fn(async () => {
+      pipelineCalls.push(["exec"]);
+      return [];
+    }),
+  };
+  return pipeline;
+}
+
+describe("SessionManager.getOrCreateSessionId - terminated remap", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    pipelineCalls.length = 0;
+
+    redisClientRef = {
+      status: "ready",
+      mget: vi.fn(async () => [null, null]),
+      pipeline: vi.fn(() => makePipeline()),
+    };
+  });
+
+  it("未终止时应保持原 sessionId", async () => {
+    const { SessionManager } = await import("@/lib/session-manager");
+
+    const keyId = 1;
+    const oldSessionId = "sess_old";
+    const messages = [{ role: "user", content: "hi" }, { role: "assistant", content: "ok" }, {}];
+
+    const sessionId = await SessionManager.getOrCreateSessionId(keyId, messages, oldSessionId);
+
+    expect(sessionId).toBe(oldSessionId);
+    expect(redisClientRef.mget).toHaveBeenCalledWith(
+      `session:${oldSessionId}:terminated`,
+      `session:${oldSessionId}:terminated_replacement`
+    );
+    expect(
+      pipelineCalls.some(
+        (c) => c[0] === "setex" && c[1] === `session:${oldSessionId}:terminated_replacement`
+      )
+    ).toBe(false);
+  });
+
+  it("已终止且存在 replacement 时应返回 replacement sessionId", async () => {
+    const keyId = 1;
+    const oldSessionId = "sess_old";
+    const replacementSessionId = "sess_new";
+    redisClientRef.mget.mockResolvedValueOnce(["1", replacementSessionId]);
+
+    const { SessionManager } = await import("@/lib/session-manager");
+
+    const sessionId = await SessionManager.getOrCreateSessionId(keyId, [], oldSessionId);
+
+    expect(sessionId).toBe(replacementSessionId);
+    expect(
+      pipelineCalls.some(
+        (c) => c[0] === "setex" && c[1] === `session:${oldSessionId}:terminated_replacement`
+      )
+    ).toBe(false);
+  });
+
+  it("已终止但无 replacement 时应生成并持久化 replacement", async () => {
+    const keyId = 1;
+    const oldSessionId = "sess_old";
+    redisClientRef.mget.mockResolvedValueOnce(["1", null]);
+
+    const { SessionManager } = await import("@/lib/session-manager");
+
+    const sessionId = await SessionManager.getOrCreateSessionId(keyId, [], oldSessionId);
+
+    expect(sessionId).not.toBe(oldSessionId);
+    expect(sessionId).toMatch(/^sess_/);
+
+    expect(
+      pipelineCalls.some(
+        (c) =>
+          c[0] === "setex" &&
+          c[1] === `session:${oldSessionId}:terminated_replacement` &&
+          c[2] === 86400 &&
+          c[3] === sessionId
+      )
+    ).toBe(true);
+    expect(
+      pipelineCalls.some(
+        (c) => c[0] === "expire" && c[1] === `session:${oldSessionId}:terminated` && c[2] === 86400
+      )
+    ).toBe(true);
+  });
+});

--- a/tests/unit/lib/session-manager-terminated-remap.test.ts
+++ b/tests/unit/lib/session-manager-terminated-remap.test.ts
@@ -32,6 +32,7 @@ vi.mock("@/lib/redis", () => ({
 function makePipeline() {
   const pipeline = {
     setex: vi.fn(() => pipeline),
+    expire: vi.fn(() => pipeline),
     exec: vi.fn(async () => []),
   };
   return pipeline;

--- a/tests/unit/repository/provider.test.ts
+++ b/tests/unit/repository/provider.test.ts
@@ -51,7 +51,7 @@ describe("provider repository - updateProviderPrioritiesBatch", () => {
   test("returns 0 and does not execute SQL when updates is empty", async () => {
     vi.resetModules();
 
-    const executeMock = vi.fn(async () => ({ rowCount: 0 }));
+    const executeMock = vi.fn(async () => ({ count: 0 }));
 
     vi.doMock("@/drizzle/db", () => ({
       db: {

--- a/tests/unit/repository/provider.test.ts
+++ b/tests/unit/repository/provider.test.ts
@@ -69,7 +69,7 @@ describe("provider repository - updateProviderPrioritiesBatch", () => {
   test("generates CASE batch update SQL and returns affected rows", async () => {
     vi.resetModules();
 
-    const executeMock = vi.fn(async () => ({ rowCount: 2 }));
+    const executeMock = vi.fn(async () => ({ count: 2 }));
 
     vi.doMock("@/drizzle/db", () => ({
       db: {
@@ -101,7 +101,7 @@ describe("provider repository - updateProviderPrioritiesBatch", () => {
   test("deduplicates provider ids (last update wins)", async () => {
     vi.resetModules();
 
-    const executeMock = vi.fn(async () => ({ rowCount: 1 }));
+    const executeMock = vi.fn(async () => ({ count: 1 }));
 
     vi.doMock("@/drizzle/db", () => ({
       db: {


### PR DESCRIPTION
## Summary

修复“终止 Session 后仍可复活”的行为：
- 终止时写入 `session:{id}:terminated` 标记，并清理 `session:{id}:*`（包含 `req:*` 新格式）
- 客户端后续继续携带同一 `sessionId` 时，直接阻断并返回 410（不会生成新的 sessionId 继续执行）
- Redis `SCAN MATCH` 对 sessionId 做 glob 字面量转义，避免误匹配/误删

## Problem

当前实现存在两个问题：
1. **清理不完整**：遗漏 `req:*` 新格式 key，导致终止后仍可能在详情页看到残留数据
2. **终止可被绕过**：请求端继续使用旧 sessionId 时，可能落入 session 分配的降级逻辑而获得新的 sessionId，终止失去“阻断”意义

## Solution

### 1. Termination marker + complete cleanup
- `SessionManager.terminateSession` 优先写入终止标记（TTL 默认 24h，可用 `SESSION_TERMINATION_TTL_SECONDS` 配置）
- 使用 `SCAN` 删除所有 `session:{id}:*`（保留终止标记），并从 active_sessions ZSET 中移除

### 2. Block terminated session (410)
- `getOrCreateSessionId` 检测到终止标记时抛出 `TerminatedSessionError`
- `ProxySessionGuard` 捕获后转换为 410 并阻断请求（不生成新 sessionId）

## Testing
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes session termination by writing a `session:{id}:terminated` marker that blocks future requests with the same sessionId (returning 410), and implements glob escaping for Redis SCAN to prevent accidental deletion of other sessions.

**Key improvements:**
- Termination marker prevents session resurrection via `TerminatedSessionError` + 410 response
- SCAN pattern escaping (`*?[]` chars) prevents glob injection
- Two-round SCAN cleanup reduces orphaned keys
- Comprehensive test coverage for termination blocking, glob escaping, and error scenarios

**Critical race conditions remain unresolved (flagged 10+ times in previous threads):**
1. In-flight requests that pass line 451 termination check before marker is written (line 2068) will write new keys via `storeSessionInfo`/`storeSessionMessages` in `session-guard.ts:111-176`, which are then deleted by SCAN cleanup causing data loss
2. SCAN lacks snapshot isolation - keys written between iterations escape deletion, allowing partial session resurrection

These race windows are inherent to Redis SCAN without distributed locks or Lua scripts. If accepted as known limitations, document explicitly in function comments.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge with caveats - fixes core termination bypass but race conditions cause potential data loss for concurrent requests
- Score reflects solid implementation of blocking mechanism and glob escaping, but persistent race conditions (flagged 10+ times) can cause data loss for in-flight requests during termination. Test coverage is excellent but doesn't address inherent Redis SCAN limitations.
- Pay close attention to `src/lib/session-manager.ts` - the race conditions between marker write and SCAN cleanup could cause data loss in high-concurrency scenarios
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/session-manager.ts | Adds termination marker with blocking + glob escaping. Race conditions remain: in-flight requests can write keys between marker write and SCAN cleanup, which then get deleted causing data loss. SCAN lacks snapshot isolation. |
| src/app/v1/_lib/proxy/session-guard.ts | Correctly catches `TerminatedSessionError` and blocks with 410. Prevents fallback session generation for terminated sessions. |
| src/actions/active-sessions.ts | Updated to check `result.markerOk` instead of boolean success. Correct integration with new termination API. |
| tests/unit/lib/session-manager-terminate-session.test.ts | Comprehensive coverage: tests marker write, SCAN glob escaping, ZSET cleanup, error handling (markerOk=false, cleanup failures). Tests verify terminatedKey is NOT deleted. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Guard as ProxySessionGuard
    participant SM as SessionManager
    participant Redis
    
    Note over Client,Redis: Normal Request Flow
    Client->>Guard: Request with sessionId
    Guard->>SM: getOrCreateSessionId(sessionId)
    SM->>Redis: GET session:id:terminated
    Redis-->>SM: null (not terminated)
    SM-->>Guard: sessionId (allowed)
    Guard->>SM: storeSessionInfo/Messages
    SM->>Redis: SET session:id:info/messages
    
    Note over Client,Redis: Admin Terminates Session
    activate SM
    SM->>Redis: SET session:id:terminated (marker)
    SM->>Redis: ZREM from active_sessions
    SM->>Redis: SCAN session:id:*
    Redis-->>SM: [keys...]
    SM->>Redis: DEL keys (except :terminated)
    deactivate SM
    
    Note over Client,Redis: Blocked Request (After Termination)
    Client->>Guard: Request with same sessionId
    Guard->>SM: getOrCreateSessionId(sessionId)
    SM->>Redis: GET session:id:terminated
    Redis-->>SM: "timestamp" (terminated!)
    SM-->>Guard: TerminatedSessionError
    Guard-->>Client: 410 Gone
    
    Note over Client,Redis: Race Condition Window
    Client->>Guard: In-flight request (passed line 451)
    Note over SM,Redis: Termination starts
    SM->>Redis: SET session:id:terminated
    Note over Guard: Request continues in session-guard
    Guard->>SM: storeSessionInfo (no marker check)
    SM->>Redis: SET session:id:info
    Note over SM,Redis: SCAN cleanup begins
    SM->>Redis: SCAN & DEL session:id:*
    Redis->>Redis: Deletes newly written keys
    Note over Client,Redis: Data loss for in-flight request
```
</details>


<sub>Last reviewed commit: df6d675</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->