### PR TITLE
fix: responses/compact endpoint, CB cache invalidation, client restrictions batch edit

### DIFF
--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -1593,6 +1593,12 @@ const GEMINI_ONLY_FIELDS: ReadonlySet<ProviderBatchPatchField> = new Set([
   "gemini_google_search_preference",
 ]);
 
+const CB_PROVIDER_KEYS: ReadonlySet<string> = new Set([
+  "circuitBreakerFailureThreshold",
+  "circuitBreakerOpenDuration",
+  "circuitBreakerHalfOpenSuccessThreshold",
+]);
+
 function isClaudeProviderType(providerType: ProviderType): boolean {
   return providerType === "claude" || providerType === "claude-auth";
 }
@@ -2042,11 +2048,6 @@ export async function undoProviderPatch(
       await publishProviderCacheInvalidation();
     }
 
-    const CB_PROVIDER_KEYS = new Set([
-      "circuitBreakerFailureThreshold",
-      "circuitBreakerOpenDuration",
-      "circuitBreakerHalfOpenSuccessThreshold",
-    ]);
     const hasCbRevert = Object.values(snapshot.preimage).some((fields) =>
       Object.keys(fields).some((k) => CB_PROVIDER_KEYS.has(k))
     );

--- a/src/app/[locale]/settings/providers/_components/batch-edit/build-patch-draft.ts
+++ b/src/app/[locale]/settings/providers/_components/batch-edit/build-patch-draft.ts
@@ -58,6 +58,20 @@ export function buildPatchDraftFromFormState(
       draft.allowed_models = { set: state.routing.allowedModels };
     }
   }
+  if (dirtyFields.has("routing.allowedClients")) {
+    if (state.routing.allowedClients.length === 0) {
+      draft.allowed_clients = { clear: true };
+    } else {
+      draft.allowed_clients = { set: state.routing.allowedClients };
+    }
+  }
+  if (dirtyFields.has("routing.blockedClients")) {
+    if (state.routing.blockedClients.length === 0) {
+      draft.blocked_clients = { clear: true };
+    } else {
+      draft.blocked_clients = { set: state.routing.blockedClients };
+    }
+  }
   if (dirtyFields.has("routing.groupPriorities")) {
     const entries = Object.keys(state.routing.groupPriorities);
     if (entries.length === 0) {

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -77,6 +77,7 @@ const STANDARD_ENDPOINTS = [
   "/v1/messages",
   "/v1/messages/count_tokens",
   "/v1/responses",
+  "/v1/responses/compact",
   "/v1/chat/completions",
   "/v1/models",
 ];

--- a/src/lib/provider-patch-contract.ts
+++ b/src/lib/provider-patch-contract.ts
@@ -268,6 +268,9 @@ function isValidSetValue(field: ProviderBatchPatchField, value: unknown): boolea
       return isStringRecord(value);
     case "allowed_models":
       return Array.isArray(value) && value.every((model) => typeof model === "string");
+    case "allowed_clients":
+    case "blocked_clients":
+      return Array.isArray(value) && value.every((v) => typeof v === "string");
     case "anthropic_adaptive_thinking":
       return isAdaptiveThinkingConfig(value);
     default:

--- a/tests/unit/actions/providers-batch-field-mapping.test.ts
+++ b/tests/unit/actions/providers-batch-field-mapping.test.ts
@@ -253,4 +253,69 @@ describe("batchUpdateProviders - advanced field mapping", () => {
     expect(result.ok).toBe(true);
     expect(updateProvidersBatchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("should map allowed_clients with values correctly", async () => {
+    const { batchUpdateProviders } = await import("@/actions/providers");
+    const result = await batchUpdateProviders({
+      providerIds: [1, 2],
+      updates: { allowed_clients: ["client-a", "client-b"] },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(updateProvidersBatchMock).toHaveBeenCalledWith([1, 2], {
+      allowedClients: ["client-a", "client-b"],
+    });
+  });
+
+  it("should map allowed_clients=null to repository allowedClients=null", async () => {
+    const { batchUpdateProviders } = await import("@/actions/providers");
+    const result = await batchUpdateProviders({
+      providerIds: [3],
+      updates: { allowed_clients: null },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(updateProvidersBatchMock).toHaveBeenCalledWith([3], {
+      allowedClients: null,
+    });
+  });
+
+  it("should pass allowed_clients=[] as empty array", async () => {
+    const { batchUpdateProviders } = await import("@/actions/providers");
+    const result = await batchUpdateProviders({
+      providerIds: [1],
+      updates: { allowed_clients: [] },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(updateProvidersBatchMock).toHaveBeenCalledWith([1], {
+      allowedClients: [],
+    });
+  });
+
+  it("should map blocked_clients with values correctly", async () => {
+    const { batchUpdateProviders } = await import("@/actions/providers");
+    const result = await batchUpdateProviders({
+      providerIds: [1, 2],
+      updates: { blocked_clients: ["bad-client"] },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(updateProvidersBatchMock).toHaveBeenCalledWith([1, 2], {
+      blockedClients: ["bad-client"],
+    });
+  });
+
+  it("should map blocked_clients=null to repository blockedClients=null", async () => {
+    const { batchUpdateProviders } = await import("@/actions/providers");
+    const result = await batchUpdateProviders({
+      providerIds: [5],
+      updates: { blocked_clients: null },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(updateProvidersBatchMock).toHaveBeenCalledWith([5], {
+      blockedClients: null,
+    });
+  });
 });

--- a/tests/unit/actions/providers-patch-contract.test.ts
+++ b/tests/unit/actions/providers-patch-contract.test.ts
@@ -125,6 +125,46 @@ describe("provider patch contract", () => {
     expect(result.error.field).toBe("model_redirects");
   });
 
+  it("accepts allowed_clients with string array", () => {
+    const result = normalizeProviderBatchPatchDraft({
+      allowed_clients: { set: ["client-a", "client-b"] },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects allowed_clients with non-string array", () => {
+    const result = normalizeProviderBatchPatchDraft({
+      allowed_clients: { set: [123] } as never,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.code).toBe(PROVIDER_PATCH_ERROR_CODES.INVALID_PATCH_SHAPE);
+    expect(result.error.field).toBe("allowed_clients");
+  });
+
+  it("accepts blocked_clients with string array", () => {
+    const result = normalizeProviderBatchPatchDraft({
+      blocked_clients: { set: ["bad-client"] },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects blocked_clients with non-string array", () => {
+    const result = normalizeProviderBatchPatchDraft({
+      blocked_clients: { set: { not: "array" } } as never,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.error.code).toBe(PROVIDER_PATCH_ERROR_CODES.INVALID_PATCH_SHAPE);
+    expect(result.error.field).toBe("blocked_clients");
+  });
+
   it("rejects invalid thinking budget string values", () => {
     const result = normalizeProviderBatchPatchDraft({
       anthropic_thinking_budget_preference: {

--- a/tests/unit/proxy/proxy-forwarder-endpoint-audit.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-endpoint-audit.test.ts
@@ -742,4 +742,47 @@ describe("ProxyForwarder - endpoint audit", () => {
     // endpointFilterStats should be undefined when stats call fails
     expect(exhaustedItem!.endpointFilterStats).toBeUndefined();
   });
+
+  test("/v1/responses/compact should use endpoint pool (not MCP path)", async () => {
+    const session = createSession(new URL("https://example.com/v1/responses/compact"));
+    const provider = createProvider({ providerType: "claude", providerVendorId: 123 });
+    session.setProvider(provider);
+
+    mocks.getPreferredProviderEndpoints.mockResolvedValue([
+      makeEndpoint({
+        id: 77,
+        vendorId: 123,
+        providerType: provider.providerType,
+        url: "https://api.example.com/v1/responses/compact",
+      }),
+    ]);
+
+    const doForward = vi.spyOn(
+      ProxyForwarder as unknown as { doForward: (...args: unknown[]) => unknown },
+      "doForward"
+    );
+    doForward.mockResolvedValueOnce(
+      new Response("{}", {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "content-length": "2",
+        },
+      })
+    );
+
+    const response = await ProxyForwarder.send(session);
+    expect(response.status).toBe(200);
+
+    expect(mocks.getPreferredProviderEndpoints).toHaveBeenCalled();
+
+    const chain = session.getProviderChain();
+    expect(chain).toHaveLength(1);
+    expect(chain[0]).toEqual(
+      expect.objectContaining({
+        reason: "request_success",
+        endpointId: 77,
+      })
+    );
+  });
 });

--- a/tests/unit/settings/providers/build-patch-draft.test.ts
+++ b/tests/unit/settings/providers/build-patch-draft.test.ts
@@ -15,6 +15,8 @@ function createBatchState(): ProviderFormState {
       preserveClientIp: false,
       modelRedirects: {},
       allowedModels: [],
+      allowedClients: [],
+      blockedClients: [],
       priority: 0,
       groupPriorities: {},
       weight: 1,
@@ -643,5 +645,45 @@ describe("buildPatchDraftFromFormState", () => {
     const draft = buildPatchDraftFromFormState(state, dirty);
 
     expect(draft.limit_concurrent_sessions).toEqual({ set: 20 });
+  });
+
+  // --- Client restrictions ---
+
+  it("clears allowedClients when dirty and empty array", () => {
+    const state = createBatchState();
+    const dirty = new Set(["routing.allowedClients"]);
+
+    const draft = buildPatchDraftFromFormState(state, dirty);
+
+    expect(draft.allowed_clients).toEqual({ clear: true });
+  });
+
+  it("sets allowedClients when dirty and non-empty", () => {
+    const state = createBatchState();
+    state.routing.allowedClients = ["client-a", "client-b"];
+    const dirty = new Set(["routing.allowedClients"]);
+
+    const draft = buildPatchDraftFromFormState(state, dirty);
+
+    expect(draft.allowed_clients).toEqual({ set: ["client-a", "client-b"] });
+  });
+
+  it("clears blockedClients when dirty and empty array", () => {
+    const state = createBatchState();
+    const dirty = new Set(["routing.blockedClients"]);
+
+    const draft = buildPatchDraftFromFormState(state, dirty);
+
+    expect(draft.blocked_clients).toEqual({ clear: true });
+  });
+
+  it("sets blockedClients when dirty and non-empty", () => {
+    const state = createBatchState();
+    state.routing.blockedClients = ["bad-client"];
+    const dirty = new Set(["routing.blockedClients"]);
+
+    const draft = buildPatchDraftFromFormState(state, dirty);
+
+    expect(draft.blocked_clients).toEqual({ set: ["bad-client"] });
   });
 });


### PR DESCRIPTION
## Summary

Three bug fixes for provider management and proxy routing:

- **Fix 1**: Add `/v1/responses/compact` to `STANDARD_ENDPOINTS` in forwarder, preventing misclassification as MCP request and bypassing endpoint pool selection
- **Fix 2**: Invalidate Redis + in-memory circuit breaker config caches after batch patch apply/undo when CB fields change (matching single-provider `editProvider` behavior)
- **Fix 3**: Add missing `allowedClients`/`blockedClients` handlers in `buildPatchDraftFromFormState` and `isValidSetValue` validation, fixing silent drops in batch edit pipeline

## Problem

1. **Endpoint Routing**: Requests to `/v1/responses/compact` were being treated as MCP requests because the endpoint was not in `STANDARD_ENDPOINTS`. This caused them to bypass proper endpoint pool selection, leading to routing issues.

2. **Circuit Breaker Cache Stale**: When batch editing providers and modifying circuit breaker fields (failure threshold, open duration, half-open success threshold), the in-memory and Redis caches were not being invalidated. This meant new CB configs wouldn't take effect until cache expired (5 minutes).

3. **Client Restrictions Batch Edit**: PR #822 added UI for configuring `allowed_clients`/`blocked_clients`, but the batch edit pipeline was missing handlers for these fields, causing them to be silently dropped during batch operations.

**Related Issues:**
- Related to #797 - Same `/v1/responses/compact` endpoint, this PR addresses endpoint routing while #797 tracks parameter injection and response format issues

**Follow-up to:**
- PR #822 - Added client restriction configuration UI; this PR adds batch edit support
- PR #806 - Introduced batch operations; this PR fixes CB cache invalidation

## Solution

### Fix 1: Standard Endpoints
Added `/v1/responses/compact` to the `STANDARD_ENDPOINTS` array in `forwarder.ts`, ensuring the endpoint goes through proper endpoint pool selection.

### Fix 2: CB Cache Invalidation
Added cache invalidation logic in `applyProviderBatchPatch` and `undoProviderPatch` that:
- Detects if CB fields (`circuit_breaker_failure_threshold`, `circuit_breaker_open_duration`, `circuit_breaker_half_open_success_threshold`) changed
- Calls `deleteProviderCircuitConfig()` to clear Redis cache
- Calls `clearConfigCache()` to clear in-memory cache
- Matches behavior of single-provider `editProvider`

### Fix 3: Client Restrictions Batch Support
- Added `allowed_clients` and `blocked_clients` handlers in `buildPatchDraftFromFormState` for form-to-draft conversion
- Added validation for these fields in `isValidSetValue` function

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/forwarder.ts` - Added `/v1/responses/compact` to STANDARD_ENDPOINTS
- `src/actions/providers.ts` - Added CB cache invalidation in apply/undo batch operations
- `src/app/[locale]/settings/providers/_components/batch-edit/build-patch-draft.ts` - Added client restrictions handlers
- `src/lib/provider-patch-contract.ts` - Added validation for client restriction fields

### Test Coverage
- `tests/unit/proxy/proxy-forwarder-endpoint-audit.test.ts` - Tests for `/v1/responses/compact` routing
- `tests/unit/actions/providers-batch-field-mapping.test.ts` - Tests for client restrictions field mapping
- `tests/unit/actions/providers-patch-contract.test.ts` - Tests for validation of client restrictions
- `tests/unit/settings/providers/build-patch-draft.test.ts` - Tests for form-to-draft conversion

## Test Plan

- [x] `bun run typecheck` -- no type errors
- [x] `bun run lint` -- no new lint violations
- [x] `bun run test` -- all existing + 14 new tests pass (2 pre-existing failures in unrelated files)
- [ ] Manual: batch edit providers, modify client restrictions, verify preview shows changes and apply works
- [ ] Manual: batch set circuit breaker threshold to 0, verify no requests are circuit-broken
- [ ] Manual: send request to `/v1/responses/compact`, verify it uses endpoint pool (check provider chain logs)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes three distinct bugs in provider management and proxy routing:

**Fix 1: Endpoint Routing** - Added `/v1/responses/compact` to `STANDARD_ENDPOINTS`, preventing it from being misclassified as an MCP request and ensuring proper endpoint pool selection.

**Fix 2: Circuit Breaker Cache Invalidation** - Added cache invalidation (Redis + in-memory) in `applyProviderBatchPatch` and `undoProviderPatch` when circuit breaker fields change, matching the behavior of single-provider edits.

**Fix 3: Client Restrictions Batch Support** - Added missing handlers for `allowed_clients`/`blocked_clients` fields in the batch edit pipeline (`buildPatchDraftFromFormState` and `isValidSetValue`), fixing silent drops during batch operations.

All three fixes are well-implemented with comprehensive test coverage (14 new tests). The code follows existing patterns and maintains consistency with related functionality.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge with minimal risk
- All three bug fixes are straightforward, well-tested (14 new tests), and follow existing patterns. The endpoint routing fix is a simple addition to an array. The circuit breaker cache invalidation correctly mirrors the single-provider edit behavior. The client restrictions handlers follow the same pattern as other field handlers. No breaking changes or security concerns identified.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/forwarder.ts | Added `/v1/responses/compact` to STANDARD_ENDPOINTS array to fix endpoint routing |
| src/actions/providers.ts | Added CB_PROVIDER_KEYS constant and cache invalidation logic in batch apply/undo operations when circuit breaker fields change |
| src/app/[locale]/settings/providers/_components/batch-edit/build-patch-draft.ts | Added handlers for `allowed_clients` and `blocked_clients` fields in form-to-draft conversion |
| src/lib/provider-patch-contract.ts | Added validation for `allowed_clients` and `blocked_clients` in isValidSetValue function |

</details>


</details>


<sub>Last reviewed commit: 3aad53a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->