### PR TITLE
修复：熔断器禁用后仍拦截供应商

### DIFF
--- a/src/lib/circuit-breaker.ts
+++ b/src/lib/circuit-breaker.ts
@@ -27,6 +27,7 @@ import {
   loadCircuitState,
   saveCircuitState,
 } from "@/lib/redis/circuit-breaker-state";
+import { publishCacheInvalidation, subscribeCacheInvalidation } from "@/lib/redis/pubsub";
 
 // 修复：导出 ProviderHealth 类型，供其他模块使用
 export interface ProviderHealth {
@@ -47,13 +48,161 @@ const healthMap = new Map<number, ProviderHealth>();
 const CONFIG_CACHE_TTL = 5 * 60 * 1000;
 
 // 非 closed 状态下，为了及时响应管理员禁用配置，最小间隔强制刷新一次配置（避免每次调用都打 Redis）
-const NON_CLOSED_CONFIG_FORCE_RELOAD_INTERVAL_MS = 2_000;
+const NON_CLOSED_CONFIG_FORCE_RELOAD_INTERVAL_MS = 60_000;
+
+export const CHANNEL_CIRCUIT_BREAKER_CONFIG_UPDATED = "cch:cache:circuit_breaker_config:updated";
 
 // getAllHealthStatusAsync 中批量强制刷新配置时的并发批大小（避免瞬时放大 Redis/配置存储压力）
 const CONFIG_FORCE_RELOAD_BATCH_SIZE = 20;
 
 // 标记已从 Redis 加载过状态的供应商（避免重复加载）
 const loadedFromRedis = new Set<number>();
+
+// 配置加载去抖：同一 provider 同时只允许一个配置加载任务
+const configLoadInFlight = new Map<number, Promise<CircuitBreakerConfig>>();
+
+// 配置缓存版本号：用于避免“失效事件”被 in-flight 旧结果覆盖
+const configCacheVersion = new Map<number, number>();
+
+let configInvalidationSubscriptionInitialized = false;
+let configInvalidationSubscriptionPromise: Promise<void> | null = null;
+
+function bumpConfigCacheVersion(providerId: number): number {
+  const next = (configCacheVersion.get(providerId) ?? 0) + 1;
+  configCacheVersion.set(providerId, next);
+  return next;
+}
+
+function getConfigCacheVersion(providerId: number): number {
+  return configCacheVersion.get(providerId) ?? 0;
+}
+
+function parseConfigInvalidationProviderIds(message: string): number[] | null {
+  // 兼容：纯数字字符串（做上限保护，避免误把时间戳当作 providerId 导致内存膨胀）
+  const trimmed = message.trim();
+  const asNumber = Number.parseInt(trimmed, 10);
+  if (
+    Number.isFinite(asNumber) &&
+    `${asNumber}` === trimmed &&
+    asNumber > 0 &&
+    asNumber <= 1_000_000_000
+  ) {
+    return [asNumber];
+  }
+
+  try {
+    const parsed = JSON.parse(message) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+
+    const obj = parsed as {
+      providerId?: unknown;
+      providerIds?: unknown;
+    };
+
+    if (
+      typeof obj.providerId === "number" &&
+      Number.isFinite(obj.providerId) &&
+      Number.isInteger(obj.providerId) &&
+      obj.providerId > 0 &&
+      obj.providerId <= 1_000_000_000
+    ) {
+      return [obj.providerId];
+    }
+
+    if (Array.isArray(obj.providerIds)) {
+      const ids = obj.providerIds
+        .map((v) => (typeof v === "number" ? v : Number.NaN))
+        .filter((v) => Number.isFinite(v) && Number.isInteger(v) && v > 0 && v <= 1_000_000_000);
+      return ids.length > 0 ? ids : null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureConfigInvalidationSubscription(): Promise<void> {
+  if (configInvalidationSubscriptionInitialized) return;
+  if (configInvalidationSubscriptionPromise) return configInvalidationSubscriptionPromise;
+
+  configInvalidationSubscriptionPromise = (async () => {
+    // CI/build 阶段跳过，避免订阅超时拖慢检查
+    if (process.env.CI === "true" || process.env.NEXT_PHASE === "phase-production-build") {
+      configInvalidationSubscriptionInitialized = true;
+      return;
+    }
+
+    // Edge runtime 跳过（不支持 ioredis）
+    if (typeof process !== "undefined" && process.env.NEXT_RUNTIME === "edge") {
+      configInvalidationSubscriptionInitialized = true;
+      return;
+    }
+
+    const cleanup = await subscribeCacheInvalidation(
+      CHANNEL_CIRCUIT_BREAKER_CONFIG_UPDATED,
+      (message) => {
+        const ids = parseConfigInvalidationProviderIds(message);
+        if (!ids) return;
+
+        for (const providerId of ids) {
+          clearConfigCache(providerId);
+        }
+
+        logger.debug("[CircuitBreaker] Config cache invalidated via pub/sub", {
+          count: ids.length,
+        });
+      }
+    );
+
+    if (!cleanup) return;
+    configInvalidationSubscriptionInitialized = true;
+  })().finally(() => {
+    configInvalidationSubscriptionPromise = null;
+  });
+
+  return configInvalidationSubscriptionPromise;
+}
+
+async function loadProviderConfigDeduped(providerId: number): Promise<CircuitBreakerConfig> {
+  const existing = configLoadInFlight.get(providerId);
+  if (existing) return existing;
+
+  const promise = loadProviderCircuitConfig(providerId);
+  configLoadInFlight.set(providerId, promise);
+
+  promise.then(
+    () => {
+      if (configLoadInFlight.get(providerId) === promise) {
+        configLoadInFlight.delete(providerId);
+      }
+    },
+    () => {
+      if (configLoadInFlight.get(providerId) === promise) {
+        configLoadInFlight.delete(providerId);
+      }
+    }
+  );
+
+  return promise;
+}
+
+export async function publishCircuitBreakerConfigInvalidation(
+  providerIds: number | number[]
+): Promise<void> {
+  const ids = Array.isArray(providerIds) ? providerIds : [providerIds];
+  if (ids.length === 0) return;
+
+  for (const providerId of ids) {
+    clearConfigCache(providerId);
+  }
+
+  await publishCacheInvalidation(
+    CHANNEL_CIRCUIT_BREAKER_CONFIG_UPDATED,
+    JSON.stringify({ providerIds: ids })
+  );
+  logger.debug("[CircuitBreaker] Published config cache invalidation", { count: ids.length });
+}
 
 function isCircuitBreakerDisabled(config: CircuitBreakerConfig): boolean {
   return !Number.isFinite(config.failureThreshold) || config.failureThreshold <= 0;
@@ -222,6 +371,9 @@ async function getProviderConfigForHealth(
   health: ProviderHealth,
   options?: { forceReload?: boolean }
 ): Promise<CircuitBreakerConfig> {
+  // 异步初始化订阅（不阻塞主流程）
+  void ensureConfigInvalidationSubscription();
+
   const forceReload = options?.forceReload ?? false;
   // 检查内存缓存是否有效
   const now = Date.now();
@@ -234,24 +386,47 @@ async function getProviderConfigForHealth(
     return health.config;
   }
 
-  // 从 Redis/数据库加载配置
-  try {
-    const config = await loadProviderCircuitConfig(providerId);
-    health.config = config;
-    health.configLoadedAt = now;
-    return config;
-  } catch (error) {
-    logger.warn(
-      `[CircuitBreaker] Failed to load config for provider ${providerId}, using default`,
-      {
-        error: error instanceof Error ? error.message : String(error),
+  // 从 Redis/数据库加载配置（in-flight 合并 + 版本号防止失效竞态）
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const startedAt = Date.now();
+    const versionAtStart = getConfigCacheVersion(providerId);
+
+    try {
+      const config = await loadProviderConfigDeduped(providerId);
+
+      if (getConfigCacheVersion(providerId) !== versionAtStart) {
+        // 失效事件在加载期间发生，重试一次（避免把旧结果写回缓存）
+        if (attempt < 1) continue;
+        return config;
       }
-    );
-    // 缓存默认配置，避免配置读取失败时在高频路径反复打 Redis/数据库
-    health.config = DEFAULT_CIRCUIT_BREAKER_CONFIG;
-    health.configLoadedAt = now;
-    return health.config;
+
+      health.config = config;
+      health.configLoadedAt = startedAt;
+      return config;
+    } catch (error) {
+      // 如果加载期间发生失效事件，允许重试一次再降级
+      if (getConfigCacheVersion(providerId) !== versionAtStart && attempt < 1) {
+        continue;
+      }
+
+      logger.warn(
+        `[CircuitBreaker] Failed to load config for provider ${providerId}, using default`,
+        {
+          error: error instanceof Error ? error.message : String(error),
+        }
+      );
+
+      // 缓存默认配置，避免配置读取失败时在高频路径反复打 Redis/数据库
+      health.config = DEFAULT_CIRCUIT_BREAKER_CONFIG;
+      health.configLoadedAt = startedAt;
+      return health.config;
+    }
   }
+
+  // 理论上不应到达这里，兜底返回默认配置
+  health.config = DEFAULT_CIRCUIT_BREAKER_CONFIG;
+  health.configLoadedAt = Date.now();
+  return health.config;
 }
 
 /**
@@ -709,6 +884,36 @@ export function resetCircuit(providerId: number): void {
 }
 
 /**
+ * 强制将熔断器状态关闭并写回 Redis（跨实例立即生效）
+ * 典型使用场景：管理员禁用熔断器配置后，应立即解除 OPEN/HALF-OPEN 拦截。
+ */
+export async function forceCloseCircuitState(
+  providerId: number,
+  options?: { reason?: string }
+): Promise<void> {
+  const health = healthMap.get(providerId);
+  const previousState = health?.circuitState ?? null;
+
+  if (health) {
+    resetHealthToClosed(health);
+  }
+
+  await saveCircuitState(providerId, {
+    failureCount: 0,
+    lastFailureTime: null,
+    circuitState: "closed",
+    circuitOpenUntil: null,
+    halfOpenSuccessCount: 0,
+  });
+
+  logger.info(`[CircuitBreaker] Provider ${providerId} circuit forced closed`, {
+    providerId,
+    previousState,
+    reason: options?.reason,
+  });
+}
+
+/**
  * 将熔断器从 OPEN 状态转换到 HALF_OPEN 状态（用于智能探测）
  * 比直接 resetCircuit 更安全，允许通过 HALF_OPEN 阶段验证恢复
  */
@@ -753,12 +958,15 @@ export function tripToHalfOpen(providerId: number): boolean {
  * 清除供应商的配置缓存（供应商更新后调用）
  */
 export function clearConfigCache(providerId: number): void {
+  bumpConfigCacheVersion(providerId);
+  configLoadInFlight.delete(providerId);
+
   const health = healthMap.get(providerId);
   if (health) {
     health.config = null;
     health.configLoadedAt = null;
-    logger.debug(`[CircuitBreaker] Cleared config cache for provider ${providerId}`);
   }
+  logger.debug(`[CircuitBreaker] Cleared config cache for provider ${providerId}`);
 }
 
 /**
@@ -769,6 +977,8 @@ export async function clearProviderState(providerId: number): Promise<void> {
   // 清除内存状态
   healthMap.delete(providerId);
   loadedFromRedis.delete(providerId);
+  configLoadInFlight.delete(providerId);
+  configCacheVersion.delete(providerId);
 
   // 清除 Redis 状态
   const { deleteCircuitState } = await import("@/lib/redis/circuit-breaker-state");

--- a/src/lib/redis/__tests__/pubsub.test.ts
+++ b/src/lib/redis/__tests__/pubsub.test.ts
@@ -80,8 +80,10 @@ describe("Redis Pub/Sub cache invalidation", () => {
     expect(base.duplicate).toHaveBeenCalledTimes(1);
     expect(subscriber.subscribe).toHaveBeenCalledWith("test-channel");
 
-    subscriber.emit("message", "test-channel", Date.now().toString());
+    const message = Date.now().toString();
+    subscriber.emit("message", "test-channel", message);
     expect(onInvalidate).toHaveBeenCalledTimes(1);
+    expect(onInvalidate).toHaveBeenCalledWith(message);
 
     cleanup!();
     subscriber.emit("message", "test-channel", Date.now().toString());

--- a/src/lib/redis/__tests__/pubsub.test.ts
+++ b/src/lib/redis/__tests__/pubsub.test.ts
@@ -160,6 +160,49 @@ describe("Redis Pub/Sub cache invalidation", () => {
     expect(onInvalidate).not.toHaveBeenCalled();
   });
 
+  test("subscribeCacheInvalidation: should backoff reconnect attempts after connection error", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    try {
+      const base = new MockRedis();
+      const subscriber1 = new MockRedis();
+      const subscriber2 = new MockRedis();
+      base.duplicate.mockReturnValueOnce(subscriber1).mockReturnValueOnce(subscriber2);
+      subscriber2.subscribe.mockResolvedValue(1);
+
+      const { getRedisClient } = await import("@/lib/redis/client");
+      (getRedisClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(base);
+
+      const { subscribeCacheInvalidation } = await import("@/lib/redis/pubsub");
+
+      const cleanup1Promise = subscribeCacheInvalidation("test-channel", vi.fn());
+      subscriber1.emit("error", new Error("Connection refused"));
+
+      const cleanup1 = await cleanup1Promise;
+      expect(cleanup1).toBeNull();
+      expect(base.duplicate).toHaveBeenCalledTimes(1);
+
+      const cleanup2Promise = subscribeCacheInvalidation("test-channel", vi.fn());
+      expect(base.duplicate).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(base.duplicate).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(base.duplicate).toHaveBeenCalledTimes(2);
+
+      subscriber2.status = "ready";
+      subscriber2.emit("ready");
+
+      const cleanup2 = await cleanup2Promise;
+      expect(cleanup2).not.toBeNull();
+      cleanup2!();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("subscribeCacheInvalidation: should rollback callback when subscribe fails and allow retry", async () => {
     const base = new MockRedis();
     const subscriber = new MockRedis();

--- a/src/lib/redis/pubsub.ts
+++ b/src/lib/redis/pubsub.ts
@@ -19,6 +19,21 @@ const subscribedChannels = new Set<string>();
 
 let resubscribeInFlight: Promise<void> | null = null;
 
+const SUBSCRIBER_CONNECT_TIMEOUT_MS = 10000;
+const SUBSCRIBER_CONNECT_BACKOFF_BASE_MS = 1000;
+const SUBSCRIBER_CONNECT_BACKOFF_MAX_MS = 60000;
+
+let subscriberConnectFailures = 0;
+let subscriberNextConnectAt = 0;
+
+function computeSubscriberConnectBackoffMs(consecutiveFailures: number): number {
+  if (!Number.isFinite(consecutiveFailures) || consecutiveFailures <= 0) return 0;
+
+  const exponent = Math.min(consecutiveFailures - 1, 10);
+  const backoffMs = SUBSCRIBER_CONNECT_BACKOFF_BASE_MS * 2 ** exponent;
+  return Math.min(SUBSCRIBER_CONNECT_BACKOFF_MAX_MS, backoffMs);
+}
+
 async function resubscribeAll(sub: Redis): Promise<void> {
   if (resubscribeInFlight) return resubscribeInFlight;
 
@@ -62,13 +77,25 @@ async function resubscribeAll(sub: Redis): Promise<void> {
 function ensureSubscriber(baseClient: Redis): Promise<Redis> {
   if (subscriberReady) return subscriberReady;
 
+  const now = Date.now();
+  const startDelayMs = Math.max(0, subscriberNextConnectAt - now);
+
   subscriberReady = new Promise<Redis>((resolve, reject) => {
-    const sub = baseClient.duplicate();
+    let sub: Redis | null = null;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let startDelayTimeoutId: ReturnType<typeof setTimeout> | null = null;
+    let settled = false;
 
     function cleanup(): void {
-      sub.off("ready", onReady);
-      sub.off("error", onError);
+      if (startDelayTimeoutId) {
+        clearTimeout(startDelayTimeoutId);
+        startDelayTimeoutId = null;
+      }
+
+      if (sub) {
+        sub.off("ready", onReady);
+        sub.off("error", onError);
+      }
 
       if (timeoutId) {
         clearTimeout(timeoutId);
@@ -77,10 +104,24 @@ function ensureSubscriber(baseClient: Redis): Promise<Redis> {
     }
 
     function fail(error: Error): void {
+      if (settled) return;
+      settled = true;
+
       cleanup();
       subscriberReady = null;
+
+      subscriberConnectFailures++;
+      const backoffMs = computeSubscriberConnectBackoffMs(subscriberConnectFailures);
+      subscriberNextConnectAt = Date.now() + backoffMs;
+
+      logger.warn("[RedisPubSub] Subscriber connection failed", {
+        error,
+        consecutiveFailures: subscriberConnectFailures,
+        nextRetryAt: new Date(subscriberNextConnectAt).toISOString(),
+        backoffMs,
+      });
       try {
-        sub.disconnect();
+        sub?.disconnect();
       } catch {
         // ignore
       }
@@ -88,18 +129,32 @@ function ensureSubscriber(baseClient: Redis): Promise<Redis> {
     }
 
     function onReady(): void {
+      if (settled) return;
+      settled = true;
+
       cleanup();
-      subscriberClient = sub;
+      if (!sub) {
+        subscriberReady = null;
+        reject(new Error("Redis subscriber connection ready without client"));
+        return;
+      }
+
+      const readySub = sub;
+
+      subscriberClient = readySub;
       subscribedChannels.clear();
 
-      sub.on("error", (error) =>
+      subscriberConnectFailures = 0;
+      subscriberNextConnectAt = 0;
+
+      readySub.on("error", (error) =>
         logger.warn("[RedisPubSub] Subscriber connection error", { error })
       );
-      sub.on("close", () => subscribedChannels.clear());
-      sub.on("end", () => subscribedChannels.clear());
-      sub.on("ready", () => void resubscribeAll(sub));
+      readySub.on("close", () => subscribedChannels.clear());
+      readySub.on("end", () => subscribedChannels.clear());
+      readySub.on("ready", () => void resubscribeAll(readySub));
 
-      sub.on("message", (channel: string, message: string) => {
+      readySub.on("message", (channel: string, message: string) => {
         const callbacks = subscriptions.get(channel);
         if (!callbacks || callbacks.size === 0) return;
         for (const cb of callbacks) {
@@ -112,23 +167,33 @@ function ensureSubscriber(baseClient: Redis): Promise<Redis> {
       });
 
       logger.info("[RedisPubSub] Subscriber connection ready");
-      resolve(sub);
+      resolve(readySub);
     }
 
     function onError(error: Error): void {
-      logger.warn("[RedisPubSub] Subscriber connection error", { error });
       fail(error);
     }
 
-    sub.once("ready", onReady);
-    sub.once("error", onError);
+    function startConnection(): void {
+      if (settled) return;
 
-    // Timeout 10 seconds
-    timeoutId = setTimeout(() => {
-      if (sub.status !== "ready") {
-        fail(new Error("Redis subscriber connection timeout"));
-      }
-    }, 10000);
+      sub = baseClient.duplicate();
+      sub.once("ready", onReady);
+      sub.once("error", onError);
+
+      // Timeout 10 seconds
+      timeoutId = setTimeout(() => {
+        if (sub?.status !== "ready") {
+          fail(new Error("Redis subscriber connection timeout"));
+        }
+      }, SUBSCRIBER_CONNECT_TIMEOUT_MS);
+    }
+
+    if (startDelayMs > 0) {
+      startDelayTimeoutId = setTimeout(startConnection, startDelayMs);
+    } else {
+      startConnection();
+    }
   });
 
   return subscriberReady;
@@ -159,43 +224,45 @@ export async function subscribeCacheInvalidation(
   const baseClient = getRedisClient();
   if (!baseClient) return null;
 
+  let sub: Redis;
   try {
-    const sub = await ensureSubscriber(baseClient);
-
-    const callbacks = subscriptions.get(channel) ?? new Set<CacheInvalidationCallback>();
-    callbacks.add(callback);
-    subscriptions.set(channel, callbacks);
-
-    if (!subscribedChannels.has(channel)) {
-      try {
-        await sub.subscribe(channel);
-        subscribedChannels.add(channel);
-        logger.info("[RedisPubSub] Subscribed to channel", { channel });
-      } catch (error) {
-        callbacks.delete(callback);
-        if (callbacks.size === 0) {
-          subscriptions.delete(channel);
-        }
-        throw error;
-      }
-    }
-
-    return () => {
-      const cbs = subscriptions.get(channel);
-      if (!cbs) return;
-
-      cbs.delete(callback);
-
-      if (cbs.size === 0) {
-        subscriptions.delete(channel);
-        subscribedChannels.delete(channel);
-        if (subscriberClient) {
-          void subscriberClient.unsubscribe(channel);
-        }
-      }
-    };
-  } catch (error) {
-    logger.warn("[RedisPubSub] Failed to subscribe cache invalidation", { channel, error });
+    sub = await ensureSubscriber(baseClient);
+  } catch {
+    // ensureSubscriber 内部已记录连接失败与 backoff 信息，避免这里按 channel 重复刷屏
     return null;
   }
+
+  const callbacks = subscriptions.get(channel) ?? new Set<CacheInvalidationCallback>();
+  callbacks.add(callback);
+  subscriptions.set(channel, callbacks);
+
+  if (!subscribedChannels.has(channel)) {
+    try {
+      await sub.subscribe(channel);
+      subscribedChannels.add(channel);
+      logger.info("[RedisPubSub] Subscribed to channel", { channel });
+    } catch (error) {
+      callbacks.delete(callback);
+      if (callbacks.size === 0) {
+        subscriptions.delete(channel);
+      }
+      logger.warn("[RedisPubSub] Failed to subscribe channel", { channel, error });
+      return null;
+    }
+  }
+
+  return () => {
+    const cbs = subscriptions.get(channel);
+    if (!cbs) return;
+
+    cbs.delete(callback);
+
+    if (cbs.size === 0) {
+      subscriptions.delete(channel);
+      subscribedChannels.delete(channel);
+      if (subscriberClient) {
+        void subscriberClient.unsubscribe(channel);
+      }
+    }
+  };
 }

--- a/tests/unit/lib/circuit-breaker.test.ts
+++ b/tests/unit/lib/circuit-breaker.test.ts
@@ -248,10 +248,6 @@ describe("circuit-breaker", () => {
     // recordFailure 在达到阈值后会触发异步告警（dynamic import + non-blocking）。
     // 切回真实计时器推进事件循环，避免任务悬挂导致后续用例 mock 串台。
     vi.useRealTimers();
-    const startedAt = Date.now();
-    while (sendAlertMock.mock.calls.length === 0 && Date.now() - startedAt < 1000) {
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    }
-    expect(sendAlertMock).toHaveBeenCalledTimes(1);
+    await expect.poll(() => sendAlertMock.mock.calls.length, { timeout: 1000 }).toBe(1);
   });
 });

--- a/tests/unit/lib/circuit-breaker.test.ts
+++ b/tests/unit/lib/circuit-breaker.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+type SavedCircuitState = {
+  failureCount: number;
+  lastFailureTime: number | null;
+  circuitState: "closed" | "open" | "half-open";
+  circuitOpenUntil: number | null;
+  halfOpenSuccessCount: number;
+};
+
+function createLoggerMock() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    trace: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("circuit-breaker", () => {
+  test("failureThreshold=0 时应视为禁用：即便 Redis 为 OPEN 也不应阻止请求，并自动复位为 CLOSED", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    vi.resetModules();
+
+    let redisState: SavedCircuitState | null = {
+      failureCount: 10,
+      lastFailureTime: Date.now() - 1000,
+      circuitState: "open",
+      circuitOpenUntil: Date.now() + 300000,
+      halfOpenSuccessCount: 0,
+    };
+
+    const loadStateMock = vi.fn(async () => redisState);
+    const saveStateMock = vi.fn(async (_providerId: number, state: SavedCircuitState) => {
+      redisState = state;
+    });
+
+    vi.doMock("@/lib/logger", () => ({ logger: createLoggerMock() }));
+    vi.doMock("@/lib/redis/circuit-breaker-state", () => ({
+      loadCircuitState: loadStateMock,
+      loadAllCircuitStates: vi.fn(async () => new Map()),
+      saveCircuitState: saveStateMock,
+    }));
+    vi.doMock("@/lib/redis/circuit-breaker-config", () => ({
+      DEFAULT_CIRCUIT_BREAKER_CONFIG: {
+        failureThreshold: 5,
+        openDuration: 1800000,
+        halfOpenSuccessThreshold: 2,
+      },
+      loadProviderCircuitConfig: vi.fn(async () => ({
+        failureThreshold: 0,
+        openDuration: 1800000,
+        halfOpenSuccessThreshold: 2,
+      })),
+    }));
+
+    const { getCircuitState, isCircuitOpen } = await import("@/lib/circuit-breaker");
+
+    expect(await isCircuitOpen(1)).toBe(false);
+    expect(getCircuitState(1)).toBe("closed");
+
+    const lastState = saveStateMock.mock.calls[saveStateMock.mock.calls.length - 1]?.[1] as
+      | SavedCircuitState
+      | undefined;
+    expect(lastState?.circuitState).toBe("closed");
+    expect(lastState?.failureCount).toBe(0);
+    expect(lastState?.lastFailureTime).toBeNull();
+    expect(lastState?.circuitOpenUntil).toBeNull();
+    expect(lastState?.halfOpenSuccessCount).toBe(0);
+  });
+
+  test("getAllHealthStatusAsync: failureThreshold=0 时应强制返回 CLOSED 并写回 Redis", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    vi.resetModules();
+
+    const openState: SavedCircuitState = {
+      failureCount: 10,
+      lastFailureTime: Date.now() - 1000,
+      circuitState: "open",
+      circuitOpenUntil: Date.now() + 300000,
+      halfOpenSuccessCount: 0,
+    };
+
+    let savedState: SavedCircuitState | null = null;
+    const saveStateMock = vi.fn(async (_providerId: number, state: SavedCircuitState) => {
+      savedState = state;
+    });
+
+    vi.doMock("@/lib/logger", () => ({ logger: createLoggerMock() }));
+    vi.doMock("@/lib/redis/circuit-breaker-state", () => ({
+      loadCircuitState: vi.fn(async () => null),
+      loadAllCircuitStates: vi.fn(async () => new Map([[1, openState]])),
+      saveCircuitState: saveStateMock,
+    }));
+    vi.doMock("@/lib/redis/circuit-breaker-config", () => ({
+      DEFAULT_CIRCUIT_BREAKER_CONFIG: {
+        failureThreshold: 5,
+        openDuration: 1800000,
+        halfOpenSuccessThreshold: 2,
+      },
+      loadProviderCircuitConfig: vi.fn(async () => ({
+        failureThreshold: 0,
+        openDuration: 1800000,
+        halfOpenSuccessThreshold: 2,
+      })),
+    }));
+
+    const { getAllHealthStatusAsync } = await import("@/lib/circuit-breaker");
+
+    const status = await getAllHealthStatusAsync([1], { forceRefresh: true });
+    expect(status[1]?.circuitState).toBe("closed");
+
+    expect(savedState?.circuitState).toBe("closed");
+    expect(savedState?.failureCount).toBe(0);
+    expect(savedState?.lastFailureTime).toBeNull();
+    expect(savedState?.circuitOpenUntil).toBeNull();
+    expect(savedState?.halfOpenSuccessCount).toBe(0);
+  });
+
+  test("recordFailure: 已处于 OPEN 时不应重置 circuitOpenUntil（避免延长熔断时间）", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    vi.resetModules();
+
+    let redisState: SavedCircuitState | null = null;
+    const loadStateMock = vi.fn(async () => redisState);
+    const saveStateMock = vi.fn(async (_providerId: number, state: SavedCircuitState) => {
+      redisState = state;
+    });
+
+    const sendAlertMock = vi.fn(async () => {});
+
+    vi.doMock("@/lib/logger", () => ({ logger: createLoggerMock() }));
+    vi.doMock("@/lib/notification/notifier", () => ({
+      sendCircuitBreakerAlert: sendAlertMock,
+    }));
+    vi.doMock("@/drizzle/schema", () => ({
+      providers: { id: "id", name: "name" },
+    }));
+    vi.doMock("drizzle-orm", () => ({ eq: vi.fn(() => ({})) }));
+    vi.doMock("@/drizzle/db", () => ({
+      db: {
+        select: vi.fn(() => ({
+          from: vi.fn(() => ({
+            where: vi.fn(() => ({
+              limit: vi.fn(async () => [{ name: "Test Provider" }]),
+            })),
+          })),
+        })),
+      },
+    }));
+    vi.doMock("@/lib/redis/circuit-breaker-state", () => ({
+      loadCircuitState: loadStateMock,
+      loadAllCircuitStates: vi.fn(async () => new Map()),
+      saveCircuitState: saveStateMock,
+    }));
+    vi.doMock("@/lib/redis/circuit-breaker-config", () => ({
+      DEFAULT_CIRCUIT_BREAKER_CONFIG: {
+        failureThreshold: 5,
+        openDuration: 1800000,
+        halfOpenSuccessThreshold: 2,
+      },
+      loadProviderCircuitConfig: vi.fn(async () => ({
+        failureThreshold: 2,
+        openDuration: 300000,
+        halfOpenSuccessThreshold: 2,
+      })),
+    }));
+
+    const { recordFailure } = await import("@/lib/circuit-breaker");
+
+    await recordFailure(1, new Error("boom"));
+    await recordFailure(1, new Error("boom"));
+
+    expect(redisState?.circuitState).toBe("open");
+    const openUntil = redisState?.circuitOpenUntil;
+    expect(openUntil).toBe(Date.now() + 300000);
+
+    vi.advanceTimersByTime(1000);
+
+    await recordFailure(1, new Error("boom"));
+    expect(redisState?.circuitOpenUntil).toBe(openUntil);
+
+    // recordFailure 在达到阈值后会触发异步告警（dynamic import + non-blocking）。
+    // 切回真实计时器推进事件循环，避免任务悬挂导致后续用例 mock 串台。
+    vi.useRealTimers();
+    const startedAt = Date.now();
+    while (sendAlertMock.mock.calls.length === 0 && Date.now() - startedAt < 1000) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+    expect(sendAlertMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 问题 / Problem

当将供应商熔断器配置设置为禁用（failureThreshold=0）后，如果 Redis/内存仍残留 OPEN 状态，`isCircuitOpen()` 仍会返回 true，导致供应商持续被过滤/拒绝。

When the circuit breaker is configured as disabled (failureThreshold=0), if Redis/memory still has a stale OPEN state, `isCircuitOpen()` still returns true, causing providers to remain blocked.

## 解决 / Solution

- 统一将 `failureThreshold<=0` 视为"熔断器禁用"。在 `isCircuitOpen()` / `recordFailure()` / `recordSuccess()` 以及 `getAllHealthStatusAsync()` 发现非 closed 状态时，强制复位为 closed 并写回 Redis，保证禁用语义优先于历史状态。
- 将非 closed 状态下的配置强刷间隔从 2s 调整为 60s，并通过 Redis Pub/Sub 推送配置失效（按 providerId 定向），使管理员配置变更跨实例即时生效；60s 强刷作为安全网。
- 管理员禁用熔断器（`failureThreshold<=0`）时，主动将熔断状态强制闭合并写回 Redis，确保跨实例立即解除 OPEN/HALF-OPEN 拦截。
- `recordFailure()` 在已 OPEN 时不再重置 `circuitOpenUntil`，避免并发失败导致熔断窗口被不断延长。

- Treat `failureThreshold<=0` consistently as "circuit breaker disabled". In `isCircuitOpen()` / `recordFailure()` / `recordSuccess()` and `getAllHealthStatusAsync()`, when a non-closed state is detected, force reset to closed and write back to Redis, ensuring disabled semantics take priority over historical state.
- Reduce the non-closed-state config force-reload interval from 2s to 60s, and add Redis Pub/Sub cache invalidation (per provider) so admin config changes propagate immediately; 60s force-reload remains a safety net.
- When disabling the circuit breaker config (`failureThreshold<=0`), proactively force-close the circuit state and persist CLOSED to Redis to unblock immediately across instances.
- Add in-flight config load dedupe + versioning to avoid concurrent reload storms and invalidation races overwriting cache.
- `recordFailure()` no longer resets `circuitOpenUntil` when already OPEN, preventing concurrent failures from extending the circuit open window.

## 相关 Issues / Related Issues

- Follow-up to #498 - The previous PR allowed failureThreshold=0 to disable the circuit breaker, but did not handle the case where stale OPEN state exists in Redis/memory

## 变更 / Changes

### Core Changes
- `src/lib/redis/pubsub.ts`:
  - Subscription callbacks now receive the published message payload
  - `publishCacheInvalidation()` supports custom payloads (used for per-provider cache invalidation)
- `src/lib/circuit-breaker.ts`:
  - Added `handleDisabledCircuitBreaker()` (+ helpers) to unify “CB disabled” semantics (`failureThreshold<=0`) and force-reset stale runtime state to CLOSED (with Redis persistence)
  - Added per-provider config cache invalidation via Redis Pub/Sub (`cch:cache:circuit_breaker_config:updated`) + `publishCircuitBreakerConfigInvalidation()`
  - `isCircuitOpen()`: for non-closed states, force-reload config at most every 60 seconds (Pub/Sub makes admin changes near-instant; 60s acts as a safety net)
  - `recordFailure()`: do not extend `circuitOpenUntil` when already OPEN (avoid “熔断续命”)
  - `getProviderConfigForHealth()`: cache default config on load failures; in-flight dedupe + version guard to avoid concurrent loads and invalidation races
  - `getAllHealthStatusAsync()`: batch-load states; clear stale memory states when Redis has no state; force-reload configs for non-closed providers with bounded concurrency
  - Added `forceCloseCircuitState()` to proactively persist CLOSED state when admins disable the circuit breaker
- `src/actions/providers.ts`:
  - On circuit breaker config changes (single edit/batch apply/undo), publish per-provider config invalidation so all instances clear their in-memory config cache
  - When `failureThreshold<=0`, proactively force-close circuit state (CLOSED) and persist to Redis for immediate unblocking across instances

### Test Coverage
- `tests/unit/lib/circuit-breaker.test.ts`:
  - Disabled CB with stale OPEN state should not block and should persist CLOSED back to Redis
  - getAllHealthStatusAsync should force CLOSED + persist when disabled, and clear stale memory when Redis state is missing
  - recordFailure should not extend openUntil when already OPEN, and should send alert only once when opening
  - Config load failure should cache default config to avoid repeated load attempts
  - Config load should be de-duped in-flight under concurrency
  - Pub/Sub invalidation should clear config cache and trigger reload; invalidation during in-flight load should retry and avoid caching stale config
- `src/lib/redis/__tests__/pubsub.test.ts`:
  - subscribe callback receives message payload

## 测试 / Testing

- Local verification: `bun run lint`, `bun run lint:fix`, `bun run typecheck`, `bun run build`, `bun run test`

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a critical bug where circuit breakers remained OPEN even after admins disabled them (`failureThreshold=0`). The solution adds Redis Pub/Sub for near-instant config propagation across instances, with a 60s force-reload safety net for non-closed circuits. When disabled, stale OPEN/HALF-OPEN states are automatically reset to CLOSED and persisted to Redis.

**Key improvements:**
- `handleDisabledCircuitBreaker()` unifies disabled semantics: `failureThreshold<=0` always forces CLOSED state with Redis persistence
- Per-provider config invalidation via Pub/Sub (`cch:cache:circuit_breaker_config:updated`) enables near-instant propagation
- Config load in-flight deduplication + versioning prevents race conditions where invalidation events overwrite fresh configs  
- `recordFailure()` no longer extends `circuitOpenUntil` when already OPEN, preventing concurrent failures from indefinitely prolonging the circuit open window
- Proactive `forceCloseCircuitState()` when admins set `threshold<=0`, ensuring immediate unblocking across all instances
- Redis Pub/Sub subscriber now has exponential backoff (1s to 60s) for connection failures

**Architecture:**
- Config cache TTL remains 5 minutes for normal operation
- Non-closed circuits force-reload config every 60s (down from 2s) since Pub/Sub provides near-instant updates
- `getAllHealthStatusAsync` batch-loads configs for non-closed providers with concurrency limit (20)

The implementation is comprehensive and well-tested, with proper handling of Redis failures, concurrent config loads, and invalidation races.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge with thorough implementation and comprehensive test coverage
- Score reflects solid implementation of critical bug fix with proper cross-instance synchronization. The 60s force-reload interval for non-closed circuits (when Pub/Sub unavailable) is intentional design. All edge cases (config load failures, invalidation races, concurrent loads) are properly handled with retries, versioning, and defensive programming. Comprehensive test suite validates disabled CB behavior, Redis sync, and race conditions.
- No files require special attention
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/redis/pubsub.ts | Enhanced Redis Pub/Sub with exponential backoff for reconnection failures, message payload support for callbacks, and improved connection lifecycle management. All changes are backward-compatible and properly tested. |
| src/lib/circuit-breaker.ts | Major enhancement adding disabled circuit breaker detection with Redis Pub/Sub config invalidation, in-flight deduplication, and proactive state reset. Correctly prevents extending `circuitOpenUntil` when already OPEN. Config force-reload interval changed from 2s to 60s with Pub/Sub providing near-instant propagation. |
| src/actions/providers.ts | Integrated proactive circuit state closure when admins disable circuit breaker (`failureThreshold<=0`). Properly publishes config invalidation across all instances. Handles single edit, batch apply, and undo scenarios with appropriate batching. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Admin
    participant InstanceA as Instance A
    participant Redis
    participant InstanceB as Instance B
    participant Provider

    Admin->>InstanceA: Set failureThreshold=0 (disable CB)
    InstanceA->>Redis: Save config (threshold=0)
    InstanceA->>InstanceA: Clear local config cache
    InstanceA->>Redis: Publish invalidation (providerId)
    InstanceA->>Redis: Force close circuit state (CLOSED)
    
    Redis-->>InstanceB: Pub/Sub: config invalidated
    InstanceB->>InstanceB: Clear local config cache
    InstanceB->>InstanceB: Bump cache version
    
    Provider->>InstanceB: Request (circuit is OPEN in memory)
    InstanceB->>InstanceB: isCircuitOpen() checks state
    InstanceB->>Redis: Force reload config (version-aware)
    Redis-->>InstanceB: Config (threshold=0)
    InstanceB->>InstanceB: handleDisabledCircuitBreaker()
    InstanceB->>InstanceB: Reset health to CLOSED
    InstanceB->>Redis: Persist CLOSED state
    InstanceB->>Provider: Allow request (circuit now CLOSED)
    
    Note over InstanceA,InstanceB: Pub/Sub provides near-instant propagation<br/>60s force-reload acts as safety net
```
</details>


<sub>Last reviewed commit: 1d45ec5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->