### PR TITLE
Fix: 移除 placeholderData 配置以修复用户搜索时分页无法正常工作的问题

### DIFF
--- a/src/app/[locale]/dashboard/users/users-page-client.tsx
+++ b/src/app/[locale]/dashboard/users/users-page-client.tsx
@@ -161,7 +161,6 @@ function UsersPageContent({ currentUser }: UsersPageClientProps) {
     },
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     initialPageParam: undefined as string | undefined,
-    placeholderData: (previousData) => previousData,
   });
 
   // Independent tag query - breaks circular dependency


### PR DESCRIPTION
## Summary
Removes the `placeholderData` configuration from `useInfiniteQuery` to fix the user search pagination issue in the admin panel.

## Problem
When searching for users that are not in the currently loaded pages, the search incorrectly shows no results.

**Fixes #835**

### Bug Root Cause
The `useInfiniteQuery` configuration used `placeholderData: (previousData) => previousData`, which caused:

1. When users load multiple pages of data (e.g., pages 1, 2, 3 with 150 users), this old data is cached as placeholder
2. When performing a new search, even with a different search term (queryKey changes), React Query still shows the old placeholder data first
3. If the searched user is not in the cached old data, the UI incorrectly shows "no results"
4. Even if the backend correctly returns search results, users cannot see them because they are hidden by incorrect placeholder data

## Solution
Remove the `placeholderData` configuration, allowing React Query to properly show loading state and fetch fresh results during search, instead of displaying potentially stale cached data.

## Changes

### Core Changes
- **src/app/[locale]/dashboard/users/users-page-client.tsx**: Remove `placeholderData: (previousData) => previousData` from `useInfiniteQuery` configuration

## Impact Analysis

### User Experience
- Users now see correct loading state during search instead of old data
- Search results now display correctly, unaffected by previously loaded pagination data

### Performance Considerations
- Removing `placeholderData` means search shows loading state instead of instantly showing old data
- This is the correct trade-off: accuracy over perceived performance

## Testing

### Manual Testing Steps
1. Navigate to the admin panel users management page
2. Scroll to load multiple pages of user data
3. Enter a username in the search box that is not in the currently loaded pages
4. Verify search results display correctly instead of showing "no results"

### Expected Behavior
- Loading state displays during search
- Search results correctly show matching users
- Does not incorrectly show "no results" due to cached pagination data

## Checklist
- [x] Bug fix - removed configuration causing search issues
- [x] Code follows project conventions
- [x] Fix verified locally

---
*Description enhanced by Claude AI*