### PR TITLE
fix: add origin-vs-host fallback for CSRF guard

### DIFF
--- a/src/lib/security/csrf-origin-guard.ts
+++ b/src/lib/security/csrf-origin-guard.ts
@@ -34,7 +34,7 @@ function isDevelopmentRuntime(): boolean {
  */
 function resolveEffectiveHost(
   request: CsrfGuardRequest,
-  trustForwardedHost: boolean,
+  trustForwardedHost: boolean
 ): string | null {
   if (trustForwardedHost) {
     const forwarded = request.headers.get("x-forwarded-host")?.trim().toLowerCase();

--- a/tests/security/csrf-origin-guard.test.ts
+++ b/tests/security/csrf-origin-guard.test.ts
@@ -130,4 +130,110 @@ describe("createCsrfOriginGuard", () => {
     expect(result.allowed).toBe(true);
     expect(result.reason).toBe("csrf_guard_bypassed_in_development");
   });
+
+  describe("origin-vs-host fallback", () => {
+    it("allows request when origin matches host header (no sec-fetch-site)", () => {
+      const guard = createCsrfOriginGuard({
+        allowedOrigins: [],
+        allowSameOrigin: true,
+        enforceInDevelopment: true,
+      });
+
+      const result = guard.check(
+        createRequest({
+          origin: "http://192.168.1.100:13500",
+          host: "192.168.1.100:13500",
+        })
+      );
+
+      expect(result).toEqual({ allowed: true });
+    });
+
+    it("allows request when origin matches x-forwarded-host (reverse proxy)", () => {
+      const guard = createCsrfOriginGuard({
+        allowedOrigins: [],
+        allowSameOrigin: true,
+        enforceInDevelopment: true,
+      });
+
+      const result = guard.check(
+        createRequest({
+          origin: "http://myapp.example.com",
+          host: "localhost:13500",
+          "x-forwarded-host": "myapp.example.com",
+        })
+      );
+
+      expect(result).toEqual({ allowed: true });
+    });
+
+    it("uses first value from comma-separated x-forwarded-host", () => {
+      const guard = createCsrfOriginGuard({
+        allowedOrigins: [],
+        allowSameOrigin: true,
+        enforceInDevelopment: true,
+      });
+
+      const result = guard.check(
+        createRequest({
+          origin: "http://front.example.com",
+          host: "internal:3000",
+          "x-forwarded-host": "front.example.com, proxy.internal",
+        })
+      );
+
+      expect(result).toEqual({ allowed: true });
+    });
+
+    it("rejects request when origin does not match host", () => {
+      const guard = createCsrfOriginGuard({
+        allowedOrigins: [],
+        allowSameOrigin: true,
+        enforceInDevelopment: true,
+      });
+
+      const result = guard.check(
+        createRequest({
+          origin: "http://evil.example.com",
+          host: "myapp.example.com:13500",
+        })
+      );
+
+      expect(result.allowed).toBe(false);
+    });
+
+    it("skips host fallback when allowSameOrigin is false", () => {
+      const guard = createCsrfOriginGuard({
+        allowedOrigins: [],
+        allowSameOrigin: false,
+        enforceInDevelopment: true,
+      });
+
+      const result = guard.check(
+        createRequest({
+          origin: "http://192.168.1.100:13500",
+          host: "192.168.1.100:13500",
+        })
+      );
+
+      expect(result.allowed).toBe(false);
+    });
+
+    it("handles https origin matching host without explicit port", () => {
+      const guard = createCsrfOriginGuard({
+        allowedOrigins: [],
+        allowSameOrigin: true,
+        enforceInDevelopment: true,
+      });
+
+      const result = guard.check(
+        createRequest({
+          origin: "https://example.com",
+          host: "example.com",
+        })
+      );
+
+      expect(result).toEqual({ allowed: true });
+    });
+  });
 });

--- a/tests/security/csrf-origin-guard.test.ts
+++ b/tests/security/csrf-origin-guard.test.ts
@@ -154,6 +154,7 @@ describe("createCsrfOriginGuard", () => {
         allowedOrigins: [],
         allowSameOrigin: true,
         enforceInDevelopment: true,
+        trustForwardedHost: true,
       });
 
       const result = guard.check(
@@ -172,6 +173,7 @@ describe("createCsrfOriginGuard", () => {
         allowedOrigins: [],
         allowSameOrigin: true,
         enforceInDevelopment: true,
+        trustForwardedHost: true,
       });
 
       const result = guard.check(
@@ -183,6 +185,24 @@ describe("createCsrfOriginGuard", () => {
       );
 
       expect(result).toEqual({ allowed: true });
+    });
+
+    it("ignores x-forwarded-host when trustForwardedHost is false (default)", () => {
+      const guard = createCsrfOriginGuard({
+        allowedOrigins: [],
+        allowSameOrigin: true,
+        enforceInDevelopment: true,
+      });
+
+      const result = guard.check(
+        createRequest({
+          origin: "http://myapp.example.com",
+          host: "localhost:13500",
+          "x-forwarded-host": "myapp.example.com",
+        })
+      );
+
+      expect(result.allowed).toBe(false);
     });
 
     it("rejects request when origin does not match host", () => {


### PR DESCRIPTION
## Summary

Closes #846

- CSRF guard relied solely on `sec-fetch-site` header for same-origin detection
- When this header is absent (reverse proxy stripping headers, older browsers), HTTP deployment login requests were rejected with `CSRF_REJECTED`
- Added standard `Origin` vs `Host` comparison as fallback, supporting both `Host` and `X-Forwarded-Host` headers for reverse proxy scenarios

## Changes

- `src/lib/security/csrf-origin-guard.ts`: Added `resolveEffectiveHost()` and `isOriginMatchingHost()` helpers, integrated as fallback after `sec-fetch-site` check
- `tests/security/csrf-origin-guard.test.ts`: Added 6 test cases covering host matching, reverse proxy, comma-separated forwarded host, rejection, and allowSameOrigin=false

## Test plan

- [x] All 131 security tests pass
- [x] Build passes
- [x] Lint + typecheck clean
- [ ] Verify login works on HTTP deployment without `sec-fetch-site` header
- [ ] Verify login still works normally with `sec-fetch-site: same-origin`
- [ ] Verify cross-origin requests are still blocked

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a fallback CSRF protection mechanism to handle environments where the `sec-fetch-site` header is absent (e.g., reverse proxies, older browsers). The implementation introduces standard Origin-vs-Host comparison as a secondary defense layer.

**Key changes:**
- Added `resolveEffectiveHost()` helper to extract effective host from either `Host` or `X-Forwarded-Host` headers
- Added `isOriginMatchingHost()` to compare origin URL against request host
- Introduced `trustForwardedHost` config option (default: false) with clear security documentation about trusted reverse proxy requirements
- Comprehensive test coverage including reverse proxy scenarios, comma-separated forwarded hosts, and edge cases

**Implementation notes:**
- The `trustForwardedHost` feature is well-designed with appropriate defaults and warnings
- Test coverage is thorough with 7 new test cases covering various scenarios
- Code follows existing patterns and is well-documented
- The fallback correctly handles URL parsing errors and normalizes case-sensitivity

**Existing feedback addresses:**
Previous review comments have identified that the fallback currently runs regardless of `sec-fetch-site` header presence, which could allow requests explicitly marked as `cross-site` if origin happens to match host. The suggested approach is to only apply the fallback when the header is truly absent.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor consideration for existing feedback on fallback logic placement
- The implementation is technically sound with good security practices (opt-in for X-Forwarded-Host, proper validation, comprehensive tests). The main consideration is the existing feedback about fallback execution order - while not a critical security flaw, addressing it would improve the defense-in-depth strategy by respecting explicit browser signals
- Pay attention to `src/lib/security/csrf-origin-guard.ts` for the fallback logic placement discussed in existing review comments
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/security/csrf-origin-guard.ts | Added origin-vs-host fallback mechanism with X-Forwarded-Host support; implementation is sound but fallback logic placement needs attention per existing feedback |
| tests/security/csrf-origin-guard.test.ts | Added comprehensive test coverage for origin-host fallback including reverse proxy scenarios; missing test case for sec-fetch-site conflict scenario per existing feedback |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Start([CSRF Guard Check]) --> DevCheck{Development<br/>mode?}
    DevCheck -->|Yes & !enforceInDev| DevBypass[Allow: dev bypass]
    DevCheck -->|No / enforced| FetchSiteCheck{sec-fetch-site<br/>== same-origin?}
    
    FetchSiteCheck -->|Yes & allowSameOrigin| AllowFetch[Allow: same-origin]
    FetchSiteCheck -->|No / missing| GetOrigin[Get Origin header]
    
    GetOrigin --> OriginExists{Origin<br/>present?}
    OriginExists -->|No| CrossSiteCheck{sec-fetch-site<br/>== cross-site?}
    CrossSiteCheck -->|Yes| RejectNoOrigin[Reject: cross-site<br/>missing origin]
    CrossSiteCheck -->|No| AllowNoOrigin[Allow: no origin]
    
    OriginExists -->|Yes| OriginHostFallback{NEW: allowSameOrigin<br/>& origin matches host?}
    OriginHostFallback -->|Get host| ResolveHost{trustForwardedHost?}
    ResolveHost -->|Yes| UseForwarded[Use X-Forwarded-Host<br/>first value if present]
    ResolveHost -->|No| UseHost[Use Host header]
    UseForwarded --> CompareOrigin{Origin host<br/>== resolved host?}
    UseHost --> CompareOrigin
    
    CompareOrigin -->|Yes| AllowOriginHost[Allow: origin matches host]
    CompareOrigin -->|No| CheckAllowlist{Origin in<br/>allowlist?}
    
    OriginHostFallback -->|Skip fallback| CheckAllowlist
    CheckAllowlist -->|Yes| AllowList[Allow: in allowlist]
    CheckAllowlist -->|No| RejectDefault[Reject: not in allowlist]
    
    style OriginHostFallback fill:#e1f5ff
    style ResolveHost fill:#e1f5ff
    style UseForwarded fill:#e1f5ff
    style CompareOrigin fill:#e1f5ff
    style AllowOriginHost fill:#c8e6c9
```
</details>


<sub>Last reviewed commit: aed8d08</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->