### PR TITLE
perf: 常用页面读路径降负载（系统设置缓存与日志轮询）

### DIFF
--- a/docs/performance/common-pages-optimization-plan.md
+++ b/docs/performance/common-pages-optimization-plan.md
@@ -1,0 +1,164 @@
+# 常用页面与写入链路性能优化路线图（无感升级优先）
+
+更新时间：2026-03-01
+
+## 目标
+
+- 让常用界面（仪表盘、使用记录、排行榜、供应商管理）在数据量增长/并发增加时，仍能维持稳定的响应时间。
+- 显著降低服务器负载（DB CPU/IO、应用 CPU、内存占用、连接数、Redis 压力）。
+- 优化需尽量“不改变现有行为”：升级后用户体验应尽可能无感（除了更快、更稳）。
+
+## 约束与原则（确保无感升级）
+
+- 优先做“读路径”优化：缓存/预聚合/索引/分页策略，风险低、收益大。
+- 写路径优化必须“可回滚、可开关”：任何改变写入时序/一致性的优化都应有 feature flag，并保留旧路径。
+- 迁移必须向后兼容：以“新增表/新增索引/新增字段”为主，避免破坏性变更（drop/rename）。
+- 观测先行：每一项优化都要能被指标/日志证明效果，并能在异常时快速降级。
+
+## 现状链路速览（按页面/情形）
+
+### 仪表盘（Dashboard）
+
+- 页面入口：`src/app/[locale]/dashboard/page.tsx`
+- 主要数据：
+  - Overview：`src/actions/overview.ts` -> `src/lib/redis/overview-cache.ts` -> `src/repository/overview.ts`（读 `usage_ledger`）
+  - Statistics：`src/actions/statistics.ts` -> `src/lib/redis/statistics-cache.ts` -> `src/repository/statistics.ts`（读 `usage_ledger`，含 buckets + zero-fill）
+- 风险点：
+  - 管理员视角可能一次拉取“全体用户/全体 keys 的 bucket 数据”，CPU 与内存放大明显。
+  - 缓存 miss 时聚合查询会产生尖刺（thundering herd 已用锁缓解，但仍会打 DB）。
+
+### 使用记录（Usage Logs）
+
+- 页面入口：`src/app/[locale]/dashboard/logs/page.tsx`
+- 查询方式：
+  - 列表：`src/actions/usage-logs.ts:getUsageLogsBatch` -> `src/repository/usage-logs.ts:findUsageLogsBatch`（keyset pagination，无 COUNT）
+  - 筛选项：`src/actions/usage-logs.ts:getFilterOptions` 内存缓存 5 分钟（避免 3 次 DISTINCT）
+  - 活跃会话：`src/actions/active-sessions.ts`（SessionTracker + 聚合查询 + 本地缓存）
+- 风险点：
+  - 前端自动刷新如果全量 refetch 所有 pages，会对 DB 造成持续压力（尤其是多人同时打开 logs 页）。
+
+### 排行榜（Leaderboard）
+
+- 页面入口：`src/app/[locale]/dashboard/leaderboard/page.tsx`
+- 数据入口：`src/app/api/leaderboard/route.ts` -> `src/lib/redis/leaderboard-cache.ts` -> `src/repository/leaderboard.ts`（按周期聚合 `usage_ledger`）
+- 风险点：
+  - 自定义区间/全站维度的聚合可能扫描大量 ledger 数据；缓存 miss 时压力集中。
+
+### 供应商管理（Providers）
+
+- 页面入口：`src/app/[locale]/dashboard/providers/page.tsx`（复用 settings/providers 组件）
+- 客户端多请求：
+  - providers：`src/actions/providers.ts:getProviders`（当前使用 `findAllProvidersFresh()` 绕过 provider cache）
+  - health：`src/actions/providers.ts:getProvidersHealthStatus`
+  - statistics：`src/actions/providers.ts:getProviderStatisticsAsync`（前端 60s interval）
+  - system-settings：`/api/system-settings`
+- 风险点：
+  - 多个独立 query 的“瀑布式”刷新容易放大 API/DB QPS。
+  - provider 列表绕过缓存会导致频繁全表读取（尤其是多人同时管理）。
+
+### 高频写入情形：每次新请求写入数据库
+
+- 入口：`src/app/v1/_lib/proxy/message-service.ts:ProxyMessageService.ensureContext`
+  - 同步写：`src/repository/message.ts:createMessageRequest` -> `message_request INSERT`
+- 请求结束/更新：
+  - `src/repository/message.ts:updateMessageRequest*`（默认 `MESSAGE_REQUEST_WRITE_MODE=async`，走 `src/repository/message-write-buffer.ts` 批量 UPDATE）
+- 派生 ledger：
+  - DB trigger：`src/lib/ledger-backfill/trigger.sql`（`AFTER INSERT OR UPDATE ON message_request`，每次写都 upsert `usage_ledger`）
+- 风险点：
+  - 写放大：每个请求至少 1 次 INSERT + 1 次 UPDATE（甚至更多），且每次都会触发 `usage_ledger` UPSERT。
+  - `message_request` 索引较多，写入会额外消耗 CPU/IO；大 JSON 字段会导致 row bloat 与 vacuum 压力。
+
+## 已落地的低风险优化（不改变语义）
+
+- 系统设置缓存跨实例失效通知：在保存系统设置后通过 Redis Pub/Sub 广播失效，让各实例的进程内缓存立即失效（减少重复读 `system_settings`）。
+- 使用记录自动刷新减负：前端仅轮询“最新一页”，并合并到现有无限列表（避免 react-query 在 infiniteQuery 下重拉所有 pages）。
+
+### 已落地代码位置（便于继续扩展）
+
+- 系统设置缓存与失效广播：
+  - 缓存实现：`src/lib/config/system-settings-cache.ts`
+  - 保存设置后发布失效：`src/actions/system-config.ts`
+  - 统一出口（仅 server 侧使用）：`src/lib/config/index.ts`
+  - 失败退避：当 DB 不可用时也会缓存 fallback（避免每次调用都重复打点/重试）
+- 使用记录页自动刷新减负：
+  - 轮询/合并/去重：`src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx`
+  - 覆盖测试：`src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx`
+
+## 分层优化路线图（按收益/风险分级）
+
+### P0：低风险、优先落地（默认不改变行为）
+
+1) 统一系统设置读路径为缓存（并保持可降级）
+- 目标：把全站“频繁读 system_settings”压到接近 0（在 TTL 内/命中场景）。
+- 做法：
+  - 页面/接口/代理热路径统一改用 `src/lib/config/system-settings-cache.ts:getCachedSystemSettings()`。
+  - 依赖 Redis 时用 pubsub 即时失效；无 Redis 时仍按 TTL 自动过期（不影响可用性）。
+
+2) 轮询策略与请求编排（减少无效 QPS）
+- 使用记录：保持 keyset pagination；自动刷新仅更新最新页（已落地）。
+- 活跃会话：在服务端已有缓存的前提下，前端可考虑仅在 tab 可见时轮询，或对并发计数做短 TTL 缓存（不改变展示语义）。
+- 供应商管理：将 providers/health/statistics 的刷新节奏错峰，或合并为单一 endpoints（需要评估 UI 代码改动范围）。
+
+3) 缓存 miss 尖刺治理（降低“缓存雪崩”影响）
+- Overview/Statistics/Leaderboard 的 Redis 锁机制已存在，可补充：
+  - 更细粒度的 cache key（例如按 scope/filters 维度拆分），避免一个 key 承载过多场景。
+  - 在缓存写入失败时记录最小必要信息（避免静默长期退化）。
+
+4) 查询列裁剪与只读路径分离（减少 IO）
+- 使用记录列表页：尽量只 select 列表展示所需字段；详情弹窗再拉大字段（如 errorStack、providerChain、specialSettings）。
+- 供应商管理列表：主列表优先“轻字段”；统计/健康信息独立异步加载（已基本实现）。
+
+### P1：中风险、需开关/兼容迁移（收益巨大）
+
+1) 写放大治理：让 `usage_ledger` 写入更“按需”
+- 方向 A（推荐）：对 trigger 加 `WHEN` 条件，只在关键字段变化时 upsert
+  - 示例触发字段：`status_code`、`cost_usd`、`duration_ms`、`tokens`、`blocked_by`、`provider_chain`、`model/provider_id` 等。
+  - 优点：不改变外部读模型（usage_ledger 仍是源），但能显著减少重复 UPSERT。
+  - 风险：需要严谨列出“影响 billing/统计/展示”的字段集合，避免漏更新。
+- 方向 B：仅在“终态”写入 ledger（例如 `duration_ms IS NOT NULL` 或 `status_code IS NOT NULL`）
+  - 优点：写放大最小。
+  - 风险：会改变“进行中请求”的统计可见性，需要产品确认，并必须 feature flag。
+
+2) 大表分区（message_request / usage_ledger）
+- 当数据量达到千万级后，聚合与范围查询更依赖分区裁剪。
+- 做法：按月/周分区，保留相同 schema 与索引；对读路径保持透明。
+- 风险：迁移复杂、需要演练；必须保证自动迁移与回滚策略。
+
+3) 预聚合/rollup 表（从“每次扫明细”到“读汇总”）
+- 为 dashboard/leaderboard/statistics 引入 rollup：
+  - 例如 `usage_ledger_rollup_hourly` / `usage_ledger_rollup_daily`（按 user/provider/model 维度聚合）
+  - 由后台任务或增量触发更新
+- UI 查询优先读 rollup，必要时再回退到明细聚合。
+- 风险：一致性与延迟（需要定义可接受的统计滞后，例如 30s/1m）。
+
+4) 大字段拆表（降低行膨胀与 vacuum 压力）
+- `message_request` 的 `error_stack`、`error_cause`、`provider_chain`、`special_settings` 等可迁移到侧表（按 request_id 1:1）。
+- 列表页默认不 join 大字段，只有需要时再 join。
+- 风险：需要迁移脚本与读写双写/回读逻辑，建议分阶段上线。
+
+### P2：高风险/架构级（需明确 ROI，通常不作为第一波）
+
+- 将轮询改为推送：SSE/WebSocket（服务器端维护订阅，减少重复查询）。
+- 将历史明细转入分析型存储（如 ClickHouse）：
+  - Postgres 保留近期热数据；报表/排行榜走分析库。
+- 将 message_request/usage_ledger 写入改为 event sourcing + 异步消费（需大量改动与完善的幂等/重放机制）。
+
+## 验收指标（建议纳入监控）
+
+- 页面：
+  - 仪表盘/使用记录/排行榜/供应商管理：TTFB、接口 p95/p99、前端渲染耗时（可选）。
+- DB：
+  - QPS、慢查询数量、CPU、IO、连接数、锁等待、autovacuum 追赶情况、WAL 产出与复制延迟（如有）。
+- Redis：
+  - 命中率、带宽、锁 key 冲突率、pubsub 消息量。
+- 写路径：
+  - 每请求写入次数（INSERT/UPDATE/UPSERT）、message_write_buffer flush 频率与失败率、pending queue 大小。
+
+## 文件导航（便于继续深入）
+
+- 系统设置：`src/repository/system-config.ts`、`src/lib/config/system-settings-cache.ts`
+- 仪表盘：`src/actions/overview.ts`、`src/actions/statistics.ts`、`src/repository/overview.ts`、`src/repository/statistics.ts`
+- 使用记录：`src/actions/usage-logs.ts`、`src/repository/usage-logs.ts`、`src/app/[locale]/dashboard/logs/`
+- 排行榜：`src/app/api/leaderboard/route.ts`、`src/lib/redis/leaderboard-cache.ts`、`src/repository/leaderboard.ts`
+- 供应商管理：`src/actions/providers.ts`、`src/repository/provider.ts`、`src/app/[locale]/settings/providers/`
+- 写入链路：`src/app/v1/_lib/proxy/message-service.ts`、`src/repository/message.ts`、`src/repository/message-write-buffer.ts`、`src/lib/ledger-backfill/trigger.sql`

--- a/docs/performance/common-pages-optimization-plan.md
+++ b/docs/performance/common-pages-optimization-plan.md
@@ -46,7 +46,9 @@
 
 ### 供应商管理（Providers）
 
-- 页面入口：`src/app/[locale]/dashboard/providers/page.tsx`（复用 settings/providers 组件）
+- 页面入口（Settings）：`src/app/[locale]/settings/providers/page.tsx`
+- 快捷入口（Dashboard）：`src/app/[locale]/dashboard/providers/page.tsx`（复用同一套 Providers 管理组件）
+- 复用组件目录：`src/app/[locale]/settings/providers/_components/`
 - 客户端多请求：
   - providers：`src/actions/providers.ts:getProviders`（当前使用 `findAllProvidersFresh()` 绕过 provider cache）
   - health：`src/actions/providers.ts:getProvidersHealthStatus`
@@ -98,7 +100,7 @@
 2) 轮询策略与请求编排（减少无效 QPS）
 - 使用记录：保持 keyset pagination；自动刷新仅更新最新页（已落地）。
 - 活跃会话：在服务端已有缓存的前提下，前端可考虑仅在 tab 可见时轮询，或对并发计数做短 TTL 缓存（不改变展示语义）。
-- 供应商管理：将 providers/health/statistics 的刷新节奏错峰，或合并为单一 endpoints（需要评估 UI 代码改动范围）。
+- 供应商管理：将 providers/health/statistics 的刷新节奏错峰，或合并为单一 endpoint（需要评估 UI 代码改动范围）。
 
 3) 缓存 miss 尖刺治理（降低“缓存雪崩”影响）
 - Overview/Statistics/Leaderboard 的 Redis 锁机制已存在，可补充：

--- a/drizzle/0078_perf_usage_ledger_trigger_skip_irrelevant_updates.sql
+++ b/drizzle/0078_perf_usage_ledger_trigger_skip_irrelevant_updates.sql
@@ -19,7 +19,12 @@ BEGIN
      AND jsonb_array_length(NEW.provider_chain) > 0
      AND jsonb_typeof(NEW.provider_chain -> -1) = 'object'
      AND (NEW.provider_chain -> -1 ? 'id')
-     AND (NEW.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$' THEN
+     AND (NEW.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$'
+     AND length(NEW.provider_chain -> -1 ->> 'id') <= 10
+     AND (
+       length(NEW.provider_chain -> -1 ->> 'id') < 10
+       OR (NEW.provider_chain -> -1 ->> 'id') <= '2147483647'
+     ) THEN
     v_final_provider_id := (NEW.provider_chain -> -1 ->> 'id')::integer;
   ELSE
     v_final_provider_id := NEW.provider_id;
@@ -35,7 +40,12 @@ BEGIN
        AND jsonb_array_length(OLD.provider_chain) > 0
        AND jsonb_typeof(OLD.provider_chain -> -1) = 'object'
        AND (OLD.provider_chain -> -1 ? 'id')
-       AND (OLD.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$' THEN
+       AND (OLD.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$'
+       AND length(OLD.provider_chain -> -1 ->> 'id') <= 10
+       AND (
+         length(OLD.provider_chain -> -1 ->> 'id') < 10
+         OR (OLD.provider_chain -> -1 ->> 'id') <= '2147483647'
+       ) THEN
       v_old_final_provider_id := (OLD.provider_chain -> -1 ->> 'id')::integer;
     ELSE
       v_old_final_provider_id := OLD.provider_id;

--- a/drizzle/0078_perf_usage_ledger_trigger_skip_irrelevant_updates.sql
+++ b/drizzle/0078_perf_usage_ledger_trigger_skip_irrelevant_updates.sql
@@ -10,7 +10,8 @@ DECLARE
 BEGIN
   IF NEW.blocked_by = 'warmup' THEN
     -- If a ledger row already exists (row was originally non-warmup), mark it as warmup
-    UPDATE usage_ledger SET blocked_by = 'warmup' WHERE request_id = NEW.id;
+    UPDATE usage_ledger SET blocked_by = 'warmup'
+    WHERE request_id = NEW.id AND blocked_by IS DISTINCT FROM 'warmup';
     RETURN NEW;
   END IF;
 

--- a/drizzle/0079_perf_usage_ledger_trigger_skip_blocked_rows.sql
+++ b/drizzle/0079_perf_usage_ledger_trigger_skip_blocked_rows.sql
@@ -1,3 +1,5 @@
+-- perf: skip usage_ledger UPSERTs for blocked (non-billable) requests
+
 CREATE OR REPLACE FUNCTION fn_upsert_usage_ledger()
 RETURNS TRIGGER AS $$
 DECLARE
@@ -32,10 +34,8 @@ BEGIN
 
   v_is_success := (NEW.error_message IS NULL OR NEW.error_message = '');
 
-  -- 性能优化：避免“无关字段更新”触发 usage_ledger 的重复 UPSERT（写放大）
-  -- 典型无关字段：special_settings、error_stack、error_cause、updated_at 等。
-  -- 仅当会影响 usage_ledger 的字段发生变化时才继续执行。
-  -- 注意：usage_ledger 不存 provider_chain / error_message，因此这里比较其派生值（final_provider_id / is_success）即可。
+  -- Performance: skip UPSERT when UPDATE doesn't affect usage_ledger fields.
+  -- usage_ledger does NOT persist provider_chain / error_message, so compare derived values instead.
   IF TG_OP = 'UPDATE' THEN
     IF OLD.provider_chain IS NOT NULL
        AND jsonb_typeof(OLD.provider_chain) = 'array'
@@ -78,8 +78,8 @@ BEGIN
       AND NEW.ttfb_ms IS NOT DISTINCT FROM OLD.ttfb_ms
       AND NEW.created_at IS NOT DISTINCT FROM OLD.created_at
     THEN
-      -- 自愈：如果上一次 UPSERT 因异常失败导致 ledger 行缺失，允许在后续 UPDATE 中补齐。
-      -- 这里用索引读（request_id UNIQUE）替代重复写入，兼顾“写放大治理”和“最终一致”。
+      -- Self-heal: if prior UPSERT failed and ledger row is missing, allow a later UPDATE to fill it.
+      -- Uses cheap indexed read (request_id UNIQUE) to avoid reintroducing write amplification.
       IF EXISTS (SELECT 1 FROM usage_ledger WHERE request_id = NEW.id) THEN
         RETURN NEW;
       END IF;
@@ -141,8 +141,3 @@ EXCEPTION WHEN OTHERS THEN
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
-
-CREATE TRIGGER trg_upsert_usage_ledger
-AFTER INSERT OR UPDATE ON message_request
-FOR EACH ROW
-EXECUTE FUNCTION fn_upsert_usage_ledger();

--- a/drizzle/0079_perf_usage_ledger_trigger_skip_blocked_rows.sql
+++ b/drizzle/0079_perf_usage_ledger_trigger_skip_blocked_rows.sql
@@ -26,7 +26,12 @@ BEGIN
      AND jsonb_array_length(NEW.provider_chain) > 0
      AND jsonb_typeof(NEW.provider_chain -> -1) = 'object'
      AND (NEW.provider_chain -> -1 ? 'id')
-     AND (NEW.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$' THEN
+     AND (NEW.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$'
+     AND length(NEW.provider_chain -> -1 ->> 'id') <= 10
+     AND (
+       length(NEW.provider_chain -> -1 ->> 'id') < 10
+       OR (NEW.provider_chain -> -1 ->> 'id') <= '2147483647'
+     ) THEN
     v_final_provider_id := (NEW.provider_chain -> -1 ->> 'id')::integer;
   ELSE
     v_final_provider_id := NEW.provider_id;
@@ -42,7 +47,12 @@ BEGIN
        AND jsonb_array_length(OLD.provider_chain) > 0
        AND jsonb_typeof(OLD.provider_chain -> -1) = 'object'
        AND (OLD.provider_chain -> -1 ? 'id')
-       AND (OLD.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$' THEN
+       AND (OLD.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$'
+       AND length(OLD.provider_chain -> -1 ->> 'id') <= 10
+       AND (
+         length(OLD.provider_chain -> -1 ->> 'id') < 10
+         OR (OLD.provider_chain -> -1 ->> 'id') <= '2147483647'
+       ) THEN
       v_old_final_provider_id := (OLD.provider_chain -> -1 ->> 'id')::integer;
     ELSE
       v_old_final_provider_id := OLD.provider_id;

--- a/drizzle/0079_perf_usage_ledger_trigger_skip_blocked_rows.sql
+++ b/drizzle/0079_perf_usage_ledger_trigger_skip_blocked_rows.sql
@@ -10,14 +10,16 @@ DECLARE
 BEGIN
   IF NEW.blocked_by = 'warmup' THEN
     -- If a ledger row already exists (row was originally non-warmup), mark it as warmup
-    UPDATE usage_ledger SET blocked_by = 'warmup' WHERE request_id = NEW.id;
+    UPDATE usage_ledger SET blocked_by = 'warmup'
+    WHERE request_id = NEW.id AND blocked_by IS DISTINCT FROM 'warmup';
     RETURN NEW;
   END IF;
 
   IF NEW.blocked_by IS NOT NULL THEN
     -- Blocked requests are excluded from billing stats; avoid creating usage_ledger rows.
     -- If a ledger row already exists (row was originally unblocked), mark it as blocked.
-    UPDATE usage_ledger SET blocked_by = NEW.blocked_by WHERE request_id = NEW.id;
+    UPDATE usage_ledger SET blocked_by = NEW.blocked_by
+    WHERE request_id = NEW.id AND blocked_by IS DISTINCT FROM NEW.blocked_by;
     RETURN NEW;
   END IF;
 

--- a/drizzle/meta/0078_snapshot.json
+++ b/drizzle/meta/0078_snapshot.json
@@ -1,0 +1,3908 @@
+{
+  "id": "ae9c3a85-7321-43d4-a211-d56ce6725c0e",
+  "prevId": "22eb3652-56d7-4a04-9845-5fa18210ef90",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.error_rules": {
+      "name": "error_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regex'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_response": {
+          "name": "override_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_status_code": {
+          "name": "override_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_rules_enabled": {
+          "name": "idx_error_rules_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "unique_pattern": {
+          "name": "unique_pattern",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_category": {
+          "name": "idx_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_match_type": {
+          "name": "idx_match_type",
+          "columns": [
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_login_web_ui": {
+          "name": "can_login_web_ui",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_keys_user_id": {
+          "name": "idx_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_keys_key": {
+          "name": "idx_keys_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_keys_created_at": {
+          "name": "idx_keys_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_keys_deleted_at": {
+          "name": "idx_keys_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_request": {
+      "name": "message_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "provider_chain": {
+          "name": "provider_chain",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "swap_cache_ttl_applied": {
+          "name": "swap_cache_ttl_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "special_settings": {
+          "name": "special_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_cause": {
+          "name": "error_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages_count": {
+          "name": "messages_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_message_request_user_date_cost": {
+          "name": "idx_message_request_user_date_cost",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_message_request_user_created_at_cost_stats": {
+          "name": "idx_message_request_user_created_at_cost_stats",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false
+        },
+        "idx_message_request_user_query": {
+          "name": "idx_message_request_user_query",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_message_request_provider_created_at_active": {
+          "name": "idx_message_request_provider_created_at_active",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false
+        },
+        "idx_message_request_session_id": {
+          "name": "idx_message_request_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_message_request_session_id_prefix": {
+          "name": "idx_message_request_session_id_prefix",
+          "columns": [
+            {
+              "expression": "\"session_id\" varchar_pattern_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false
+        },
+        "idx_message_request_session_seq": {
+          "name": "idx_message_request_session_seq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_message_request_endpoint": {
+          "name": "idx_message_request_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_message_request_blocked_by": {
+          "name": "idx_message_request_blocked_by",
+          "columns": [
+            {
+              "expression": "blocked_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_message_request_provider_id": {
+          "name": "idx_message_request_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_message_request_user_id": {
+          "name": "idx_message_request_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_message_request_key": {
+          "name": "idx_message_request_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_message_request_key_created_at_id": {
+          "name": "idx_message_request_key_created_at_id",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_message_request_key_model_active": {
+          "name": "idx_message_request_key_model_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"model\" IS NOT NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false
+        },
+        "idx_message_request_key_endpoint_active": {
+          "name": "idx_message_request_key_endpoint_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"endpoint\" IS NOT NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false
+        },
+        "idx_message_request_created_at_id_active": {
+          "name": "idx_message_request_created_at_id_active",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_message_request_model_active": {
+          "name": "idx_message_request_model_active",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"model\" IS NOT NULL",
+          "concurrently": false
+        },
+        "idx_message_request_status_code_active": {
+          "name": "idx_message_request_status_code_active",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"status_code\" IS NOT NULL",
+          "concurrently": false
+        },
+        "idx_message_request_created_at": {
+          "name": "idx_message_request_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_message_request_deleted_at": {
+          "name": "idx_message_request_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_message_request_key_last_active": {
+          "name": "idx_message_request_key_last_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false
+        },
+        "idx_message_request_key_cost_active": {
+          "name": "idx_message_request_key_cost_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false
+        },
+        "idx_message_request_session_user_info": {
+          "name": "idx_message_request_session_user_info",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_prices": {
+      "name": "model_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_data": {
+          "name": "price_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'litellm'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_prices_latest": {
+          "name": "idx_model_prices_latest",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_model_prices_model_name": {
+          "name": "idx_model_prices_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_model_prices_created_at": {
+          "name": "idx_model_prices_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_model_prices_source": {
+          "name": "idx_model_prices_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_legacy_mode": {
+          "name": "use_legacy_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_enabled": {
+          "name": "circuit_breaker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_webhook": {
+          "name": "circuit_breaker_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_enabled": {
+          "name": "daily_leaderboard_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "daily_leaderboard_webhook": {
+          "name": "daily_leaderboard_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_time": {
+          "name": "daily_leaderboard_time",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'09:00'"
+        },
+        "daily_leaderboard_top_n": {
+          "name": "daily_leaderboard_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cost_alert_enabled": {
+          "name": "cost_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cost_alert_webhook": {
+          "name": "cost_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_alert_threshold": {
+          "name": "cost_alert_threshold",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.80'"
+        },
+        "cost_alert_check_interval": {
+          "name": "cost_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "cache_hit_rate_alert_enabled": {
+          "name": "cache_hit_rate_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_hit_rate_alert_webhook": {
+          "name": "cache_hit_rate_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit_rate_alert_window_mode": {
+          "name": "cache_hit_rate_alert_window_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "cache_hit_rate_alert_check_interval": {
+          "name": "cache_hit_rate_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cache_hit_rate_alert_historical_lookback_days": {
+          "name": "cache_hit_rate_alert_historical_lookback_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 7
+        },
+        "cache_hit_rate_alert_min_eligible_requests": {
+          "name": "cache_hit_rate_alert_min_eligible_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 20
+        },
+        "cache_hit_rate_alert_min_eligible_tokens": {
+          "name": "cache_hit_rate_alert_min_eligible_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cache_hit_rate_alert_abs_min": {
+          "name": "cache_hit_rate_alert_abs_min",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "cache_hit_rate_alert_drop_rel": {
+          "name": "cache_hit_rate_alert_drop_rel",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.3'"
+        },
+        "cache_hit_rate_alert_drop_abs": {
+          "name": "cache_hit_rate_alert_drop_abs",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.1'"
+        },
+        "cache_hit_rate_alert_cooldown_minutes": {
+          "name": "cache_hit_rate_alert_cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cache_hit_rate_alert_top_n": {
+          "name": "cache_hit_rate_alert_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_target_bindings": {
+      "name": "notification_target_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule_cron": {
+          "name": "schedule_cron",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_timezone": {
+          "name": "schedule_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_override": {
+          "name": "template_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_notification_target_binding": {
+          "name": "unique_notification_target_binding",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_notification_bindings_type": {
+          "name": "idx_notification_bindings_type",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_notification_bindings_target": {
+          "name": "idx_notification_bindings_target",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_target_bindings_target_id_webhook_targets_id_fk": {
+          "name": "notification_target_bindings_target_id_webhook_targets_id_fk",
+          "tableFrom": "notification_target_bindings",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "tableTo": "webhook_targets",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoint_probe_logs": {
+      "name": "provider_endpoint_probe_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_endpoint_probe_logs_endpoint_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_endpoint_created_at",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_provider_endpoint_probe_logs_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk": {
+          "name": "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk",
+          "tableFrom": "provider_endpoint_probe_logs",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "tableTo": "provider_endpoints",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoints": {
+      "name": "provider_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_probed_at": {
+          "name": "last_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_ok": {
+          "name": "last_probe_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_status_code": {
+          "name": "last_probe_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_latency_ms": {
+          "name": "last_probe_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_type": {
+          "name": "last_probe_error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_message": {
+          "name": "last_probe_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uniq_provider_endpoints_vendor_type_url": {
+          "name": "uniq_provider_endpoints_vendor_type_url",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_provider_endpoints_vendor_type": {
+          "name": "idx_provider_endpoints_vendor_type",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_provider_endpoints_enabled": {
+          "name": "idx_provider_endpoints_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_provider_endpoints_pick_enabled": {
+          "name": "idx_provider_endpoints_pick_enabled",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_provider_endpoints_created_at": {
+          "name": "idx_provider_endpoints_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_provider_endpoints_deleted_at": {
+          "name": "idx_provider_endpoints_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoints_vendor_id_provider_vendors_id_fk": {
+          "name": "provider_endpoints_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "provider_endpoints",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "tableTo": "provider_vendors",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_vendors": {
+      "name": "provider_vendors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "website_domain": {
+          "name": "website_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_provider_vendors_website_domain": {
+          "name": "uniq_provider_vendors_website_domain",
+          "columns": [
+            {
+              "expression": "website_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_provider_vendors_created_at": {
+          "name": "idx_provider_vendors_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_vendor_id": {
+          "name": "provider_vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "group_priorities": {
+          "name": "group_priorities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.0'"
+        },
+        "group_tag": {
+          "name": "group_tag",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "preserve_client_ip": {
+          "name": "preserve_client_ip",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_redirects": {
+          "name": "model_redirects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_clients": {
+          "name": "blocked_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active_time_start": {
+          "name": "active_time_start",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_end": {
+          "name": "active_time_end",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_instructions_strategy": {
+          "name": "codex_instructions_strategy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "mcp_passthrough_type": {
+          "name": "mcp_passthrough_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "mcp_passthrough_url": {
+          "name": "mcp_passthrough_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost_reset_at": {
+          "name": "total_cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_retry_attempts": {
+          "name": "max_retry_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circuit_breaker_failure_threshold": {
+          "name": "circuit_breaker_failure_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "circuit_breaker_open_duration": {
+          "name": "circuit_breaker_open_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1800000
+        },
+        "circuit_breaker_half_open_success_threshold": {
+          "name": "circuit_breaker_half_open_success_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "first_byte_timeout_streaming_ms": {
+          "name": "first_byte_timeout_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "streaming_idle_timeout_ms": {
+          "name": "streaming_idle_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_timeout_non_streaming_ms": {
+          "name": "request_timeout_non_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swap_cache_ttl_billing": {
+          "name": "swap_cache_ttl_billing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "context_1m_preference": {
+          "name": "context_1m_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_effort_preference": {
+          "name": "codex_reasoning_effort_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_summary_preference": {
+          "name": "codex_reasoning_summary_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_text_verbosity_preference": {
+          "name": "codex_text_verbosity_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_parallel_tool_calls_preference": {
+          "name": "codex_parallel_tool_calls_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_max_tokens_preference": {
+          "name": "anthropic_max_tokens_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_thinking_budget_preference": {
+          "name": "anthropic_thinking_budget_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_adaptive_thinking": {
+          "name": "anthropic_adaptive_thinking",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "gemini_google_search_preference": {
+          "name": "gemini_google_search_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tpm": {
+          "name": "tpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpm": {
+          "name": "rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpd": {
+          "name": "rpd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cc": {
+          "name": "cc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_providers_enabled_priority": {
+          "name": "idx_providers_enabled_priority",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_providers_group": {
+          "name": "idx_providers_group",
+          "columns": [
+            {
+              "expression": "group_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_providers_vendor_type_url_active": {
+          "name": "idx_providers_vendor_type_url_active",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_providers_created_at": {
+          "name": "idx_providers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_providers_deleted_at": {
+          "name": "idx_providers_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_providers_vendor_type": {
+          "name": "idx_providers_vendor_type",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_providers_enabled_vendor_type": {
+          "name": "idx_providers_enabled_vendor_type",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"providers\".\"deleted_at\" IS NULL AND \"providers\".\"is_enabled\" = true AND \"providers\".\"provider_vendor_id\" IS NOT NULL AND \"providers\".\"provider_vendor_id\" > 0",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "providers_provider_vendor_id_provider_vendors_id_fk": {
+          "name": "providers_provider_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "providers",
+          "columnsFrom": [
+            "provider_vendor_id"
+          ],
+          "tableTo": "provider_vendors",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_filters": {
+      "name": "request_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement": {
+          "name": "replacement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "provider_ids": {
+          "name": "provider_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_tags": {
+          "name": "group_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_request_filters_enabled": {
+          "name": "idx_request_filters_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_request_filters_scope": {
+          "name": "idx_request_filters_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_request_filters_action": {
+          "name": "idx_request_filters_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_request_filters_binding": {
+          "name": "idx_request_filters_binding",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sensitive_words": {
+      "name": "sensitive_words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contains'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sensitive_words_enabled": {
+          "name": "idx_sensitive_words_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sensitive_words_created_at": {
+          "name": "idx_sensitive_words_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_title": {
+          "name": "site_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Claude Code Hub'"
+        },
+        "allow_global_usage_view": {
+          "name": "allow_global_usage_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "currency_display": {
+          "name": "currency_display",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "billing_model_source": {
+          "name": "billing_model_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'original'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_auto_cleanup": {
+          "name": "enable_auto_cleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cleanup_retention_days": {
+          "name": "cleanup_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cleanup_schedule": {
+          "name": "cleanup_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 2 * * *'"
+        },
+        "cleanup_batch_size": {
+          "name": "cleanup_batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10000
+        },
+        "enable_client_version_check": {
+          "name": "enable_client_version_check",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verbose_provider_error": {
+          "name": "verbose_provider_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_http2": {
+          "name": "enable_http2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "intercept_anthropic_warmup_requests": {
+          "name": "intercept_anthropic_warmup_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_thinking_signature_rectifier": {
+          "name": "enable_thinking_signature_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_thinking_budget_rectifier": {
+          "name": "enable_thinking_budget_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_billing_header_rectifier": {
+          "name": "enable_billing_header_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_codex_session_id_completion": {
+          "name": "enable_codex_session_id_completion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_claude_metadata_user_id_injection": {
+          "name": "enable_claude_metadata_user_id_injection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_response_fixer": {
+          "name": "enable_response_fixer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "response_fixer_config": {
+          "name": "response_fixer_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"fixTruncatedJson\":true,\"fixSseFormat\":true,\"fixEncoding\":true,\"maxJsonDepth\":200,\"maxFixSize\":1048576}'::jsonb"
+        },
+        "quota_db_refresh_interval_seconds": {
+          "name": "quota_db_refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "quota_lease_percent_5h": {
+          "name": "quota_lease_percent_5h",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_daily": {
+          "name": "quota_lease_percent_daily",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_weekly": {
+          "name": "quota_lease_percent_weekly",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_monthly": {
+          "name": "quota_lease_percent_monthly",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_cap_usd": {
+          "name": "quota_lease_cap_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_ledger": {
+      "name": "usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_provider_id": {
+          "name": "final_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_success": {
+          "name": "is_success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "swap_cache_ttl_applied": {
+          "name": "swap_cache_ttl_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_ledger_request_id": {
+          "name": "idx_usage_ledger_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_usage_ledger_user_created_at": {
+          "name": "idx_usage_ledger_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false
+        },
+        "idx_usage_ledger_key_created_at": {
+          "name": "idx_usage_ledger_key_created_at",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false
+        },
+        "idx_usage_ledger_provider_created_at": {
+          "name": "idx_usage_ledger_provider_created_at",
+          "columns": [
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false
+        },
+        "idx_usage_ledger_created_at_minute": {
+          "name": "idx_usage_ledger_created_at_minute",
+          "columns": [
+            {
+              "expression": "date_trunc('minute', \"created_at\" AT TIME ZONE 'UTC')",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_usage_ledger_created_at_desc_id": {
+          "name": "idx_usage_ledger_created_at_desc_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_usage_ledger_session_id": {
+          "name": "idx_usage_ledger_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"usage_ledger\".\"session_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "idx_usage_ledger_model": {
+          "name": "idx_usage_ledger_model",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"usage_ledger\".\"model\" IS NOT NULL",
+          "concurrently": false
+        },
+        "idx_usage_ledger_key_cost": {
+          "name": "idx_usage_ledger_key_cost",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false
+        },
+        "idx_usage_ledger_user_cost_cover": {
+          "name": "idx_usage_ledger_user_cost_cover",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false
+        },
+        "idx_usage_ledger_provider_cost_cover": {
+          "name": "idx_usage_ledger_provider_cost_cover",
+          "columns": [
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "rpm_limit": {
+          "name": "rpm_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_limit_usd": {
+          "name": "daily_limit_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_clients": {
+          "name": "blocked_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_active_role_sort": {
+          "name": "idx_users_active_role_sort",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_users_enabled_expires_at": {
+          "name": "idx_users_enabled_expires_at",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_users_tags_gin": {
+          "name": "idx_users_tags_gin",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_users_deleted_at": {
+          "name": "idx_users_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_targets": {
+      "name": "webhook_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "webhook_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_bot_token": {
+          "name": "telegram_bot_token",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dingtalk_secret": {
+          "name": "dingtalk_secret",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_template": {
+          "name": "custom_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_test_at": {
+          "name": "last_test_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_result": {
+          "name": "last_test_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.daily_reset_mode": {
+      "name": "daily_reset_mode",
+      "schema": "public",
+      "values": [
+        "fixed",
+        "rolling"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "circuit_breaker",
+        "daily_leaderboard",
+        "cost_alert",
+        "cache_hit_rate_alert"
+      ]
+    },
+    "public.webhook_provider_type": {
+      "name": "webhook_provider_type",
+      "schema": "public",
+      "values": [
+        "wechat",
+        "feishu",
+        "dingtalk",
+        "telegram",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -547,6 +547,13 @@
       "when": 1772219877045,
       "tag": "0077_nappy_giant_man",
       "breakpoints": true
+    },
+    {
+      "idx": 78,
+      "version": "7",
+      "when": 1772348135114,
+      "tag": "0078_perf_usage_ledger_trigger_skip_irrelevant_updates",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -554,6 +554,13 @@
       "when": 1772348135114,
       "tag": "0078_perf_usage_ledger_trigger_skip_irrelevant_updates",
       "breakpoints": true
+    },
+    {
+      "idx": 79,
+      "version": "7",
+      "when": 1772369661910,
+      "tag": "0079_perf_usage_ledger_trigger_skip_blocked_rows",
+      "breakpoints": true
     }
   ]
 }

--- a/src/actions/dashboard-realtime.ts
+++ b/src/actions/dashboard-realtime.ts
@@ -3,15 +3,14 @@
 import { getSession } from "@/lib/auth";
 import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
+import { getLeaderboardWithCache, getRedisClient } from "@/lib/redis";
 import { findRecentActivityStream } from "@/repository/activity-stream";
-import {
-  findDailyLeaderboard,
-  findDailyModelLeaderboard,
-  findDailyProviderLeaderboard,
-  type LeaderboardEntry,
-  type ModelLeaderboardEntry,
-  type ProviderLeaderboardEntry,
+import type {
+  LeaderboardEntry,
+  ModelLeaderboardEntry,
+  ProviderLeaderboardEntry,
 } from "@/repository/leaderboard";
+import { getAllowGlobalUsageViewFromDB } from "@/repository/system-config";
 // 导入已有的接口和方法
 import { getOverviewData, type OverviewData } from "./overview";
 import { getProviderSlots, type ProviderSlotInfo } from "./provider-slots";
@@ -96,9 +95,9 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
       };
     }
 
-    const settings = await getCachedSystemSettings();
     const isAdmin = session.user.role === "admin";
-    const canViewGlobalData = isAdmin || settings.allowGlobalUsageView;
+    const allowGlobalUsageView = !isAdmin ? await getAllowGlobalUsageViewFromDB() : false;
+    const canViewGlobalData = isAdmin || allowGlobalUsageView;
 
     if (!canViewGlobalData) {
       logger.debug("DashboardRealtime: User without global view permission", {
@@ -110,172 +109,233 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
       };
     }
 
-    // 并行查询所有数据源（使用 allSettled 以实现部分失败容错）
-    const [
-      overviewResult,
-      activityStreamResult,
-      userRankingsResult,
-      providerRankingsResult,
-      providerSlotsResult,
-      modelRankingsResult,
-      statisticsResult,
-    ] = await Promise.allSettled([
-      getOverviewData(),
-      findRecentActivityStream(ACTIVITY_STREAM_LIMIT), // 使用新的混合数据源
-      findDailyLeaderboard(),
-      findDailyProviderLeaderboard(),
-      getProviderSlots(),
-      findDailyModelLeaderboard(),
-      getUserStatistics("today"),
-    ]);
+    const settings = await getCachedSystemSettings();
 
-    // 提取数据并处理错误
-    const overviewData =
-      overviewResult.status === "fulfilled" && overviewResult.value.ok
-        ? overviewResult.value.data
-        : null;
+    // 性能：对大屏数据做极短 TTL 缓存（跨实例共享），避免高频轮询压垮 DB/Redis
+    // 注意：并发数仅 admin 可见，因此 cache key 需要按角色隔离，避免信息泄露。
+    const redisClient = getRedisClient();
+    const redis = redisClient && redisClient.status === "ready" ? redisClient : null;
 
-    if (!overviewData) {
-      const errorReason =
-        overviewResult.status === "rejected" ? overviewResult.reason : "Unknown error";
-      logger.error("Failed to get overview data", { reason: errorReason });
-      return {
-        ok: false,
-        error: "获取概览数据失败",
-      };
-    }
+    const cacheKey = isAdmin
+      ? `dashboard-realtime:v1:${settings.currencyDisplay}:admin`
+      : `dashboard-realtime:v1:${settings.currencyDisplay}:viewer`;
+    const lockKey = `${cacheKey}:lock`;
+    const cacheTtlSeconds = 2;
+    const lockTtlSeconds = 5;
+    const lockWaitMs = 50;
+    const lockWaitBudgetMs = 200;
 
-    // 提取其他数据，失败时使用空数组作为 fallback
-    const activityStreamItems =
-      activityStreamResult.status === "fulfilled" ? activityStreamResult.value : [];
-
-    const userRankings = userRankingsResult.status === "fulfilled" ? userRankingsResult.value : [];
-
-    const providerRankings =
-      providerRankingsResult.status === "fulfilled" ? providerRankingsResult.value : [];
-
-    const providerSlots =
-      providerSlotsResult.status === "fulfilled" && providerSlotsResult.value.ok
-        ? providerSlotsResult.value.data
-        : [];
-
-    const modelRankings =
-      modelRankingsResult.status === "fulfilled" ? modelRankingsResult.value : [];
-
-    const statisticsData =
-      statisticsResult.status === "fulfilled" && statisticsResult.value.ok
-        ? statisticsResult.value.data
-        : null;
-
-    // 记录部分失败的数据源
-    if (activityStreamResult.status === "rejected" || !activityStreamItems.length) {
-      logger.warn("Failed to get activity stream", {
-        reason:
-          activityStreamResult.status === "rejected" ? activityStreamResult.reason : "empty data",
-      });
-    }
-    if (userRankingsResult.status === "rejected") {
-      logger.warn("Failed to get user rankings", { reason: userRankingsResult.reason });
-    }
-    if (providerRankingsResult.status === "rejected") {
-      logger.warn("Failed to get provider rankings", { reason: providerRankingsResult.reason });
-    }
-    if (providerSlotsResult.status === "rejected" || !providerSlots.length) {
-      logger.warn("Failed to get provider slots", {
-        reason:
-          providerSlotsResult.status === "rejected"
-            ? providerSlotsResult.reason
-            : "empty data or action failed",
-      });
-    }
-    if (modelRankingsResult.status === "rejected") {
-      logger.warn("Failed to get model rankings", { reason: modelRankingsResult.reason });
-    }
-    if (statisticsResult.status === "rejected" || !statisticsData) {
-      logger.warn("Failed to get statistics", {
-        reason:
-          statisticsResult.status === "rejected"
-            ? statisticsResult.reason
-            : "action failed or empty data",
-      });
-    }
-
-    // 处理实时活动流数据（已包含 Redis 活跃 + 数据库最新的混合数据）
-    const now = Date.now();
-    const activityStream: ActivityStreamEntry[] = activityStreamItems.map((item) => {
-      // 计算耗时：
-      // - 如果有 durationMs（已完成的请求），使用实际值
-      // - 如果没有（进行中的请求），计算从开始到现在的耗时
-      const latency = item.durationMs ?? now - item.startTime;
-
-      return {
-        id: item.sessionId ?? `req-${item.id}`, // 使用 sessionId，如果没有则用请求ID
-        user: item.userName,
-        model: item.originalModel ?? item.model ?? "Unknown", // 优先使用计费模型
-        provider: item.providerName ?? "Unknown",
-        latency,
-        status: item.statusCode ?? 200,
-        cost: parseFloat(item.costUsd ?? "0"),
-        startTime: item.startTime,
-      };
-    });
-
-    // 处理供应商插槽数据（合并流量数据 + 过滤未设置限额 + 按占用率排序 + 限制最多3个）
-    const providerSlotsWithVolume: ProviderSlotInfo[] = providerSlots
-      .filter((slot) => slot.totalSlots > 0) // 过滤未设置并发限额的供应商
-      .map((slot) => {
-        const rankingData = providerRankings.find((p) => p.providerId === slot.providerId);
-
-        if (!rankingData) {
-          logger.debug("Provider has slots but no traffic", {
-            providerId: slot.providerId,
-            providerName: slot.name,
-          });
+    let lockAcquired = false;
+    if (redis) {
+      try {
+        const cached = await redis.get(cacheKey);
+        if (cached) {
+          return { ok: true, data: JSON.parse(cached) as DashboardRealtimeData };
         }
+      } catch (error) {
+        logger.warn("[DashboardRealtime] Cache read failed, fallback to compute", { error });
+      }
+
+      try {
+        const lockResult = await redis.set(lockKey, "1", "EX", lockTtlSeconds, "NX");
+        lockAcquired = lockResult === "OK";
+
+        if (!lockAcquired) {
+          // 其他实例正在计算：短等待后重试读缓存，避免 thundering herd
+          const deadline = Date.now() + lockWaitBudgetMs;
+          while (Date.now() < deadline) {
+            await new Promise((resolve) => setTimeout(resolve, lockWaitMs));
+            const retried = await redis.get(cacheKey);
+            if (retried) {
+              return { ok: true, data: JSON.parse(retried) as DashboardRealtimeData };
+            }
+          }
+        }
+      } catch (error) {
+        logger.warn("[DashboardRealtime] Cache lock failed, fallback to compute", {
+          lockKey,
+          error,
+        });
+        lockAcquired = false;
+      }
+    }
+
+    try {
+      // 并行查询所有数据源（使用 allSettled 以实现部分失败容错）
+      const [
+        overviewResult,
+        activityStreamResult,
+        userRankingsResult,
+        providerRankingsResult,
+        providerSlotsResult,
+        modelRankingsResult,
+        statisticsResult,
+      ] = await Promise.allSettled([
+        getOverviewData(),
+        findRecentActivityStream(ACTIVITY_STREAM_LIMIT), // 使用新的混合数据源
+        getLeaderboardWithCache("daily", settings.currencyDisplay, "user") as Promise<
+          LeaderboardEntry[]
+        >,
+        getLeaderboardWithCache("daily", settings.currencyDisplay, "provider") as Promise<
+          ProviderLeaderboardEntry[]
+        >,
+        getProviderSlots(),
+        getLeaderboardWithCache("daily", settings.currencyDisplay, "model") as Promise<
+          ModelLeaderboardEntry[]
+        >,
+        getUserStatistics("today"),
+      ]);
+
+      // 提取数据并处理错误
+      const overviewData =
+        overviewResult.status === "fulfilled" && overviewResult.value.ok
+          ? overviewResult.value.data
+          : null;
+
+      if (!overviewData) {
+        const errorReason =
+          overviewResult.status === "rejected" ? overviewResult.reason : "Unknown error";
+        logger.error("Failed to get overview data", { reason: errorReason });
+        return {
+          ok: false,
+          error: "获取概览数据失败",
+        };
+      }
+
+      // 提取其他数据，失败时使用空数组作为 fallback
+      const activityStreamItems =
+        activityStreamResult.status === "fulfilled" ? activityStreamResult.value : [];
+
+      const userRankings =
+        userRankingsResult.status === "fulfilled" ? userRankingsResult.value : [];
+
+      const providerRankings =
+        providerRankingsResult.status === "fulfilled" ? providerRankingsResult.value : [];
+
+      const providerSlots =
+        providerSlotsResult.status === "fulfilled" && providerSlotsResult.value.ok
+          ? providerSlotsResult.value.data
+          : [];
+
+      const modelRankings =
+        modelRankingsResult.status === "fulfilled" ? modelRankingsResult.value : [];
+
+      const statisticsData =
+        statisticsResult.status === "fulfilled" && statisticsResult.value.ok
+          ? statisticsResult.value.data
+          : null;
+
+      // 记录部分失败的数据源
+      if (activityStreamResult.status === "rejected" || !activityStreamItems.length) {
+        logger.warn("Failed to get activity stream", {
+          reason:
+            activityStreamResult.status === "rejected" ? activityStreamResult.reason : "empty data",
+        });
+      }
+      if (userRankingsResult.status === "rejected") {
+        logger.warn("Failed to get user rankings", { reason: userRankingsResult.reason });
+      }
+      if (providerRankingsResult.status === "rejected") {
+        logger.warn("Failed to get provider rankings", { reason: providerRankingsResult.reason });
+      }
+      if (providerSlotsResult.status === "rejected" || !providerSlots.length) {
+        logger.warn("Failed to get provider slots", {
+          reason:
+            providerSlotsResult.status === "rejected"
+              ? providerSlotsResult.reason
+              : "empty data or action failed",
+        });
+      }
+      if (modelRankingsResult.status === "rejected") {
+        logger.warn("Failed to get model rankings", { reason: modelRankingsResult.reason });
+      }
+      if (statisticsResult.status === "rejected" || !statisticsData) {
+        logger.warn("Failed to get statistics", {
+          reason:
+            statisticsResult.status === "rejected"
+              ? statisticsResult.reason
+              : "action failed or empty data",
+        });
+      }
+
+      const providerRankingByProviderId = new Map(
+        providerRankings.map((entry) => [entry.providerId, entry])
+      );
+
+      // 处理实时活动流数据（已包含 Redis 活跃 + 数据库最新的混合数据）
+      const now = Date.now();
+      const activityStream: ActivityStreamEntry[] = activityStreamItems.map((item) => {
+        // 计算耗时：
+        // - 如果有 durationMs（已完成的请求），使用实际值
+        // - 如果没有（进行中的请求），计算从开始到现在的耗时
+        const latency = item.durationMs ?? now - item.startTime;
 
         return {
-          ...slot,
-          totalVolume: rankingData?.totalTokens ?? 0,
+          id: item.sessionId ?? `req-${item.id}`, // 使用 sessionId，如果没有则用请求ID
+          user: item.userName,
+          model: item.originalModel ?? item.model ?? "Unknown", // 优先使用计费模型
+          provider: item.providerName ?? "Unknown",
+          latency,
+          status: item.statusCode ?? 200,
+          cost: parseFloat(item.costUsd ?? "0"),
+          startTime: item.startTime,
         };
-      })
-      .sort((a, b) => {
-        // 按占用率降序排序（占用率 = usedSlots / totalSlots）
-        const usageA = a.totalSlots > 0 ? a.usedSlots / a.totalSlots : 0;
-        const usageB = b.totalSlots > 0 ? b.usedSlots / b.totalSlots : 0;
-        return usageB - usageA;
-      })
-      .slice(0, 3); // 只取前3个
+      });
 
-    // 处理趋势数据（24小时）- 从 ChartDataItem 正确提取数据
-    const trendData = statisticsData?.chartData
-      ? statisticsData.chartData.map((item) => {
-          const hour = new Date(item.date).getUTCHours();
-          // 聚合所有 *_calls 字段（如 user-1_calls, user-2_calls）
-          const value = Object.keys(item)
-            .filter((key) => key.endsWith("_calls"))
-            .reduce((sum, key) => sum + (Number(item[key]) || 0), 0);
-          return { hour, value };
+      // 处理供应商插槽数据（合并流量数据 + 过滤未设置限额 + 按占用率排序 + 限制最多3个）
+      const providerSlotsWithVolume: ProviderSlotInfo[] = providerSlots
+        .filter((slot) => slot.totalSlots > 0) // 过滤未设置并发限额的供应商
+        .map((slot) => {
+          const rankingData = providerRankingByProviderId.get(slot.providerId);
+
+          if (!rankingData) {
+            logger.debug("Provider has slots but no traffic", {
+              providerId: slot.providerId,
+              providerName: slot.name,
+            });
+          }
+
+          return {
+            ...slot,
+            totalVolume: rankingData?.totalTokens ?? 0,
+          };
         })
-      : Array.from({ length: 24 }, (_, i) => ({ hour: i, value: 0 }));
+        .sort((a, b) => {
+          // 按占用率降序排序（占用率 = usedSlots / totalSlots）
+          const usageA = a.totalSlots > 0 ? a.usedSlots / a.totalSlots : 0;
+          const usageB = b.totalSlots > 0 ? b.usedSlots / b.totalSlots : 0;
+          return usageB - usageA;
+        })
+        .slice(0, 3); // 只取前3个
 
-    logger.debug("DashboardRealtime: Retrieved dashboard data", {
-      userId: session.user.id,
-      concurrentSessions: overviewData.concurrentSessions,
-      activityStreamCount: activityStream.length,
-      userRankingCount: userRankings.length,
-      providerRankingCount: providerRankings.length,
-      providerSlotsCount: providerSlotsWithVolume.length,
-      modelCount: modelRankings.length,
-    });
+      // 处理趋势数据（24小时）- 从 ChartDataItem 正确提取数据
+      const trendData = statisticsData?.chartData
+        ? statisticsData.chartData.map((item) => {
+            const hour = new Date(item.date).getUTCHours();
+            // 聚合所有 *_calls 字段（如 user-1_calls, user-2_calls）
+            const value = Object.keys(item)
+              .filter((key) => key.endsWith("_calls"))
+              .reduce((sum, key) => sum + (Number(item[key]) || 0), 0);
+            return { hour, value };
+          })
+        : Array.from({ length: 24 }, (_, i) => ({ hour: i, value: 0 }));
 
-    // 供应商排行按金额降序排序
-    const sortedProviderRankings = [...providerRankings]
-      .sort((a, b) => b.totalCost - a.totalCost)
-      .slice(0, 5);
+      logger.debug("DashboardRealtime: Retrieved dashboard data", {
+        userId: session.user.id,
+        concurrentSessions: overviewData.concurrentSessions,
+        activityStreamCount: activityStream.length,
+        userRankingCount: userRankings.length,
+        providerRankingCount: providerRankings.length,
+        providerSlotsCount: providerSlotsWithVolume.length,
+        modelCount: modelRankings.length,
+      });
 
-    return {
-      ok: true,
-      data: {
+      // 供应商排行按金额降序排序
+      const sortedProviderRankings = [...providerRankings]
+        .sort((a, b) => b.totalCost - a.totalCost)
+        .slice(0, 5);
+
+      const data: DashboardRealtimeData = {
         metrics: overviewData,
         activityStream,
         userRankings: userRankings.slice(0, 5),
@@ -283,8 +343,30 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
         providerSlots: providerSlotsWithVolume,
         modelDistribution: modelRankings.slice(0, MODEL_DISTRIBUTION_LIMIT),
         trendData,
-      },
-    };
+      };
+
+      if (redis) {
+        try {
+          // 尽量只由“拿到锁”的实例写缓存；未拿到锁时也允许 best-effort 写入兜底（防止锁持有者计算失败）。
+          if (lockAcquired) {
+            await redis.setex(cacheKey, cacheTtlSeconds, JSON.stringify(data));
+          } else {
+            await redis.setex(cacheKey, cacheTtlSeconds, JSON.stringify(data)).catch(() => {});
+          }
+        } catch (error) {
+          logger.warn("[DashboardRealtime] Cache write failed", { cacheKey, error });
+        }
+      }
+
+      return {
+        ok: true,
+        data,
+      };
+    } finally {
+      if (redis && lockAcquired) {
+        await redis.del(lockKey).catch(() => {});
+      }
+    }
   } catch (error) {
     logger.error("Failed to get dashboard realtime data:", error);
     return {

--- a/src/actions/dashboard-realtime.ts
+++ b/src/actions/dashboard-realtime.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { getSession } from "@/lib/auth";
+import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { findRecentActivityStream } from "@/repository/activity-stream";
 import {
@@ -11,7 +12,6 @@ import {
   type ModelLeaderboardEntry,
   type ProviderLeaderboardEntry,
 } from "@/repository/leaderboard";
-import { getSystemSettings } from "@/repository/system-config";
 // 导入已有的接口和方法
 import { getOverviewData, type OverviewData } from "./overview";
 import { getProviderSlots, type ProviderSlotInfo } from "./provider-slots";
@@ -96,7 +96,7 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
       };
     }
 
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
     const isAdmin = session.user.role === "admin";
     const canViewGlobalData = isAdmin || settings.allowGlobalUsageView;
 

--- a/src/actions/dashboard-realtime.ts
+++ b/src/actions/dashboard-realtime.ts
@@ -224,17 +224,21 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
       const modelRankings =
         modelRankingsResult.status === "fulfilled" ? modelRankingsResult.value : [];
 
-      const statisticsData =
-        statisticsResult.status === "fulfilled" && statisticsResult.value.ok
-          ? statisticsResult.value.data
-          : null;
+      const providerSlotsAction =
+        providerSlotsResult.status === "fulfilled" ? providerSlotsResult.value : null;
+      const statisticsAction =
+        statisticsResult.status === "fulfilled" ? statisticsResult.value : null;
+
+      const statisticsData = statisticsAction?.ok ? statisticsAction.data : null;
 
       // 记录部分失败的数据源
-      if (activityStreamResult.status === "rejected" || !activityStreamItems.length) {
+      // 空数据在低流量/空窗口下属于正常情况，避免刷屏
+      if (activityStreamResult.status === "rejected") {
         logger.warn("Failed to get activity stream", {
-          reason:
-            activityStreamResult.status === "rejected" ? activityStreamResult.reason : "empty data",
+          reason: activityStreamResult.reason,
         });
+      } else if (!activityStreamItems.length) {
+        logger.debug("Activity stream is empty", { limit: ACTIVITY_STREAM_LIMIT });
       }
       if (userRankingsResult.status === "rejected") {
         logger.warn("Failed to get user rankings", { reason: userRankingsResult.reason });
@@ -242,24 +246,26 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
       if (providerRankingsResult.status === "rejected") {
         logger.warn("Failed to get provider rankings", { reason: providerRankingsResult.reason });
       }
-      if (providerSlotsResult.status === "rejected" || !providerSlots.length) {
+      if (providerSlotsResult.status === "rejected") {
         logger.warn("Failed to get provider slots", {
-          reason:
-            providerSlotsResult.status === "rejected"
-              ? providerSlotsResult.reason
-              : "empty data or action failed",
+          reason: providerSlotsResult.reason,
         });
+      } else if (providerSlotsAction && !providerSlotsAction.ok) {
+        logger.warn("Failed to get provider slots", { reason: providerSlotsAction.error });
+      } else if (!providerSlots.length) {
+        logger.debug("Provider slots is empty");
       }
       if (modelRankingsResult.status === "rejected") {
         logger.warn("Failed to get model rankings", { reason: modelRankingsResult.reason });
       }
-      if (statisticsResult.status === "rejected" || !statisticsData) {
+      if (statisticsResult.status === "rejected") {
         logger.warn("Failed to get statistics", {
-          reason:
-            statisticsResult.status === "rejected"
-              ? statisticsResult.reason
-              : "action failed or empty data",
+          reason: statisticsResult.reason,
         });
+      } else if (statisticsAction && !statisticsAction.ok) {
+        logger.warn("Failed to get statistics", { reason: statisticsAction.error });
+      } else if (!statisticsData) {
+        logger.debug("Statistics is empty");
       }
 
       const providerRankingByProviderId = new Map(
@@ -277,8 +283,8 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
         return {
           id: item.sessionId ?? `req-${item.id}`, // 使用 sessionId，如果没有则用请求ID
           user: item.userName,
-          model: item.originalModel ?? item.model ?? "Unknown", // 优先使用计费模型
-          provider: item.providerName ?? "Unknown",
+          model: item.originalModel ?? item.model ?? "-", // 优先使用计费模型
+          provider: item.providerName ?? "-",
           latency,
           status: item.statusCode ?? 200,
           cost: parseFloat(item.costUsd ?? "0"),

--- a/src/actions/dashboard-realtime.ts
+++ b/src/actions/dashboard-realtime.ts
@@ -198,7 +198,11 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
 
       if (!overviewData) {
         const errorReason =
-          overviewResult.status === "rejected" ? overviewResult.reason : "Unknown error";
+          overviewResult.status === "rejected"
+            ? overviewResult.reason
+            : overviewResult.value.ok
+              ? "Unknown error"
+              : (overviewResult.value.error ?? "Unknown error");
         logger.error("Failed to get overview data", { reason: errorReason });
         return {
           ok: false,
@@ -279,6 +283,9 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
         // - 如果有 durationMs（已完成的请求），使用实际值
         // - 如果没有（进行中的请求），计算从开始到现在的耗时
         const latency = item.durationMs ?? now - item.startTime;
+        const costRaw = item.costUsd ?? "0";
+        const costParsed = Number.parseFloat(costRaw);
+        const cost = Number.isFinite(costParsed) ? costParsed : 0;
 
         return {
           id: item.sessionId ?? `req-${item.id}`, // 使用 sessionId，如果没有则用请求ID
@@ -287,7 +294,7 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
           provider: item.providerName ?? "-",
           latency,
           status: item.statusCode ?? 200,
-          cost: parseFloat(item.costUsd ?? "0"),
+          cost,
           startTime: item.startTime,
         };
       });
@@ -357,14 +364,15 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
 
       if (redis) {
         try {
-          // 尽量只由“拿到锁”的实例写缓存；未拿到锁时也允许 best-effort 写入兜底（防止锁持有者计算失败）。
-          if (lockAcquired) {
-            await redis.setex(cacheKey, cacheTtlSeconds, JSON.stringify(data));
-          } else {
-            await redis.setex(cacheKey, cacheTtlSeconds, JSON.stringify(data)).catch(() => {});
-          }
+          // 未拿到锁时仍允许 best-effort 写入兜底（防止锁持有者计算失败）。
+          await redis.setex(cacheKey, cacheTtlSeconds, JSON.stringify(data));
         } catch (error) {
-          logger.warn("[DashboardRealtime] Cache write failed", { cacheKey, error });
+          logger.warn("[DashboardRealtime] Cache write failed", {
+            cacheKey,
+            cacheTtlSeconds,
+            lockAcquired,
+            error,
+          });
         }
       }
 

--- a/src/actions/dashboard-realtime.ts
+++ b/src/actions/dashboard-realtime.ts
@@ -71,6 +71,8 @@ export interface DashboardRealtimeData {
 // Constants for data limits
 const ACTIVITY_STREAM_LIMIT = 20;
 const MODEL_DISTRIBUTION_LIMIT = 10;
+const REDIS_UNLOCK_LUA =
+  "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) end return 0";
 
 /**
  * 获取数据大屏的所有实时数据
@@ -125,6 +127,7 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
     const lockWaitMs = 50;
     const lockWaitBudgetMs = 200;
 
+    let lockValue: string | null = null;
     let lockAcquired = false;
     if (redis) {
       try {
@@ -137,7 +140,8 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
       }
 
       try {
-        const lockResult = await redis.set(lockKey, "1", "EX", lockTtlSeconds, "NX");
+        lockValue = crypto.randomUUID();
+        const lockResult = await redis.set(lockKey, lockValue, "EX", lockTtlSeconds, "NX");
         lockAcquired = lockResult === "OK";
 
         if (!lockAcquired) {
@@ -363,8 +367,8 @@ export async function getDashboardRealtimeData(): Promise<ActionResult<Dashboard
         data,
       };
     } finally {
-      if (redis && lockAcquired) {
-        await redis.del(lockKey).catch(() => {});
+      if (redis && lockAcquired && lockValue) {
+        await redis.eval(REDIS_UNLOCK_LUA, 1, lockKey, lockValue).catch(() => {});
       }
     }
   } catch (error) {

--- a/src/actions/key-quota.ts
+++ b/src/actions/key-quota.ts
@@ -5,13 +5,13 @@ import { getTranslations } from "next-intl/server";
 import { db } from "@/drizzle/db";
 import { keys as keysTable, users as usersTable } from "@/drizzle/schema";
 import { getSession } from "@/lib/auth";
+import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { resolveKeyConcurrentSessionLimit } from "@/lib/rate-limit/concurrent-session-limit";
 import type { DailyResetMode } from "@/lib/rate-limit/time-utils";
 import { SessionTracker } from "@/lib/session-tracker";
 import type { CurrencyCode } from "@/lib/utils";
 import { ERROR_CODES } from "@/lib/utils/error-messages";
-import { getSystemSettings } from "@/repository/system-config";
 import { getTotalUsageForKey } from "@/repository/usage-logs";
 import type { ActionResult } from "./types";
 
@@ -83,7 +83,7 @@ export async function getKeyQuotaUsage(keyId: number): Promise<ActionResult<KeyQ
       result.userLimitConcurrentSessions ?? null
     );
 
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
     const currencyCode = settings.currencyDisplay;
 
     // Helper to convert numeric string from DB to number

--- a/src/actions/keys.ts
+++ b/src/actions/keys.ts
@@ -13,7 +13,7 @@ import { resolveKeyConcurrentSessionLimit } from "@/lib/rate-limit/concurrent-se
 import { parseDateInputAsTimezone } from "@/lib/utils/date-input";
 import { ERROR_CODES } from "@/lib/utils/error-messages";
 import { normalizeProviderGroup, parseProviderGroups } from "@/lib/utils/provider-group";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import { KeyFormSchema } from "@/lib/validation/schemas";
 import { toKey } from "@/repository/_shared/transformers";
 import type { KeyStatistics } from "@/repository/key";

--- a/src/actions/my-usage.ts
+++ b/src/actions/my-usage.ts
@@ -5,15 +5,15 @@ import { and, eq, gte, isNull, lt, sql } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { messageRequest, usageLedger } from "@/drizzle/schema";
 import { getSession } from "@/lib/auth";
+import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { resolveKeyConcurrentSessionLimit } from "@/lib/rate-limit/concurrent-session-limit";
 import type { DailyResetMode } from "@/lib/rate-limit/time-utils";
 import { SessionTracker } from "@/lib/session-tracker";
 import type { CurrencyCode } from "@/lib/utils";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import { LEDGER_BILLING_CONDITION } from "@/repository/_shared/ledger-conditions";
 import { EXCLUDE_WARMUP_CONDITION } from "@/repository/_shared/message-request-conditions";
-import { getSystemSettings } from "@/repository/system-config";
 import {
   findUsageLogsForKeySlim,
   getDistinctEndpointsForKey,
@@ -183,7 +183,7 @@ export async function getMyUsageMetadata(): Promise<ActionResult<MyUsageMetadata
     const session = await getSession({ allowReadOnlyAccess: true });
     if (!session) return { ok: false, error: "Unauthorized" };
 
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
     const key = session.key;
     const user = session.user;
 
@@ -346,7 +346,7 @@ export async function getMyTodayStats(): Promise<ActionResult<MyTodayStats>> {
     const session = await getSession({ allowReadOnlyAccess: true });
     if (!session) return { ok: false, error: "Unauthorized" };
 
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
     const billingModelSource = settings.billingModelSource;
     const currencyCode = settings.currencyDisplay;
 
@@ -441,7 +441,7 @@ export async function getMyUsageLogs(
     const session = await getSession({ allowReadOnlyAccess: true });
     if (!session) return { ok: false, error: "Unauthorized" };
 
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
 
     const rawPageSize = filters.pageSize && filters.pageSize > 0 ? filters.pageSize : 20;
     const pageSize = Math.min(rawPageSize, 100);
@@ -583,7 +583,7 @@ export async function getMyStatsSummary(
     const session = await getSession({ allowReadOnlyAccess: true });
     if (!session) return { ok: false, error: "Unauthorized" };
 
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
     const currencyCode = settings.currencyDisplay;
 
     const timezone = await resolveSystemTimezone();

--- a/src/actions/notifications.ts
+++ b/src/actions/notifications.ts
@@ -3,7 +3,7 @@
 import { getSession } from "@/lib/auth";
 import type { NotificationJobType } from "@/lib/constants/notification.constants";
 import { logger } from "@/lib/logger";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import { WebhookNotifier } from "@/lib/webhook";
 import { buildTestMessage } from "@/lib/webhook/templates/test-messages";
 import {

--- a/src/actions/overview.ts
+++ b/src/actions/overview.ts
@@ -1,9 +1,9 @@
 "use server";
 
 import { getSession } from "@/lib/auth";
-import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { getOverviewWithCache } from "@/lib/redis";
+import { getAllowGlobalUsageViewFromDB } from "@/repository/system-config";
 import { getConcurrentSessions as getConcurrentSessionsCount } from "./concurrent-sessions";
 import type { ActionResult } from "./types";
 
@@ -48,9 +48,9 @@ export async function getOverviewData(): Promise<ActionResult<OverviewData>> {
       };
     }
 
-    const settings = await getCachedSystemSettings();
     const isAdmin = session.user.role === "admin";
-    const canViewGlobalData = isAdmin || settings.allowGlobalUsageView;
+    const allowGlobalUsageView = !isAdmin ? await getAllowGlobalUsageViewFromDB() : false;
+    const canViewGlobalData = isAdmin || allowGlobalUsageView;
 
     // 根据权限决定查询范围
     const userId = canViewGlobalData ? undefined : session.user.id;

--- a/src/actions/overview.ts
+++ b/src/actions/overview.ts
@@ -1,9 +1,9 @@
 "use server";
 
 import { getSession } from "@/lib/auth";
+import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { getOverviewWithCache } from "@/lib/redis";
-import { getSystemSettings } from "@/repository/system-config";
 import { getConcurrentSessions as getConcurrentSessionsCount } from "./concurrent-sessions";
 import type { ActionResult } from "./types";
 
@@ -48,7 +48,7 @@ export async function getOverviewData(): Promise<ActionResult<OverviewData>> {
       };
     }
 
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
     const isAdmin = session.user.role === "admin";
     const canViewGlobalData = isAdmin || settings.allowGlobalUsageView;
 

--- a/src/actions/provider-slots.ts
+++ b/src/actions/provider-slots.ts
@@ -4,9 +4,9 @@ import { and, eq, isNull } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { providers } from "@/drizzle/schema";
 import { getSession } from "@/lib/auth";
+import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { SessionTracker } from "@/lib/session-tracker";
-import { getSystemSettings } from "@/repository/system-config";
 import type { ActionResult } from "./types";
 
 /**
@@ -42,7 +42,7 @@ export async function getProviderSlots(): Promise<ActionResult<ProviderSlotInfo[
       };
     }
 
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
     const isAdmin = session.user.role === "admin";
     const canViewGlobalData = isAdmin || settings.allowGlobalUsageView;
 

--- a/src/actions/provider-slots.ts
+++ b/src/actions/provider-slots.ts
@@ -4,9 +4,9 @@ import { and, eq, isNull } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { providers } from "@/drizzle/schema";
 import { getSession } from "@/lib/auth";
-import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { SessionTracker } from "@/lib/session-tracker";
+import { getAllowGlobalUsageViewFromDB } from "@/repository/system-config";
 import type { ActionResult } from "./types";
 
 /**
@@ -42,9 +42,9 @@ export async function getProviderSlots(): Promise<ActionResult<ProviderSlotInfo[
       };
     }
 
-    const settings = await getCachedSystemSettings();
     const isAdmin = session.user.role === "admin";
-    const canViewGlobalData = isAdmin || settings.allowGlobalUsageView;
+    const allowGlobalUsageView = !isAdmin ? await getAllowGlobalUsageViewFromDB() : false;
+    const canViewGlobalData = isAdmin || allowGlobalUsageView;
 
     if (!canViewGlobalData) {
       logger.debug("ProviderSlots: User without global view permission", {
@@ -67,21 +67,21 @@ export async function getProviderSlots(): Promise<ActionResult<ProviderSlotInfo[
       .where(and(eq(providers.isEnabled, true), isNull(providers.deletedAt)))
       .orderBy(providers.priority, providers.id);
 
-    // 并行获取每个供应商的并发数
-    const slotInfoList = await Promise.all(
-      providerList.map(
-        async (provider: { id: number; name: string; limitConcurrentSessions: number | null }) => {
-          const usedSlots = await SessionTracker.getProviderSessionCount(provider.id);
+    // 批量获取并发数（避免 Redis N+1）
+    const providerIds = providerList.map((p) => p.id);
+    const usedSlotsByProviderId = await SessionTracker.getProviderSessionCountBatch(providerIds);
 
-          return {
-            providerId: provider.id,
-            name: provider.name,
-            usedSlots,
-            totalSlots: provider.limitConcurrentSessions ?? 0,
-            totalVolume: 0, // This will be populated by the calling action from leaderboard data.
-          };
-        }
-      )
+    const slotInfoList = providerList.map(
+      (provider: { id: number; name: string; limitConcurrentSessions: number | null }) => {
+        const usedSlots = usedSlotsByProviderId.get(provider.id) ?? 0;
+        return {
+          providerId: provider.id,
+          name: provider.name,
+          usedSlots,
+          totalSlots: provider.limitConcurrentSessions ?? 0,
+          totalVolume: 0, // This will be populated by the calling action from leaderboard data.
+        };
+      }
     );
 
     logger.debug("ProviderSlots: Retrieved provider slots", {

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -422,7 +422,9 @@ export async function getProviderManagerBootstrapData(): Promise<ProviderManager
           failureCount: health.failureCount,
           lastFailureTime: health.lastFailureTime,
           circuitOpenUntil,
-          recoveryMinutes: circuitOpenUntil ? Math.ceil((circuitOpenUntil - now) / 60000) : null,
+          recoveryMinutes: circuitOpenUntil
+            ? Math.max(0, Math.ceil((circuitOpenUntil - now) / 60000))
+            : null,
         },
       ];
     })

--- a/src/actions/statistics.ts
+++ b/src/actions/statistics.ts
@@ -1,11 +1,11 @@
 "use server";
 
 import { getSession } from "@/lib/auth";
+import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { getStatisticsWithCache } from "@/lib/redis";
 import { formatCostForStorage } from "@/lib/utils/currency";
 import { getActiveKeysForUserFromDB, getActiveUsersFromDB } from "@/repository/statistics";
-import { getSystemSettings } from "@/repository/system-config";
 import type {
   ChartDataItem,
   DatabaseKey,
@@ -45,7 +45,7 @@ export async function getUserStatistics(
       throw new Error(`Invalid time range: ${timeRange}`);
     }
 
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
     const isAdmin = session.user.role === "admin";
 
     // 确定显示模式

--- a/src/actions/system-config.ts
+++ b/src/actions/system-config.ts
@@ -3,9 +3,9 @@
 import { revalidatePath } from "next/cache";
 import { locales } from "@/i18n/config";
 import { getSession } from "@/lib/auth";
-import { invalidateSystemSettingsCache } from "@/lib/config";
+import { publishSystemSettingsCacheInvalidation } from "@/lib/config";
 import { logger } from "@/lib/logger";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import { UpdateSystemSettingsSchema } from "@/lib/validation/schemas";
 import { getSystemSettings, updateSystemSettings } from "@/repository/system-config";
 import type { ResponseFixerConfig, SystemSettings } from "@/types/system-config";
@@ -108,7 +108,7 @@ export async function saveSystemSettings(formData: {
     });
 
     // Invalidate the system settings cache so proxy requests get fresh settings
-    invalidateSystemSettingsCache();
+    await publishSystemSettingsCacheInvalidation();
 
     // Revalidate paths for all locales to ensure cache invalidation across i18n routes
     for (const locale of locales) {

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -13,7 +13,7 @@ import { getUnauthorizedFields } from "@/lib/permissions/user-field-permissions"
 import { parseDateInputAsTimezone } from "@/lib/utils/date-input";
 import { ERROR_CODES } from "@/lib/utils/error-messages";
 import { normalizeProviderGroup } from "@/lib/utils/provider-group";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import { maskKey } from "@/lib/utils/validation";
 import { formatZodError } from "@/lib/utils/zod-i18n";
 import { CreateUserSchema, UpdateUserSchema } from "@/lib/validation/schemas";

--- a/src/actions/webhook-targets.ts
+++ b/src/actions/webhook-targets.ts
@@ -5,7 +5,7 @@ import { getSession } from "@/lib/auth";
 import type { NotificationJobType } from "@/lib/constants/notification.constants";
 import { logger } from "@/lib/logger";
 import { isValidProxyUrl } from "@/lib/proxy-agent";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import { WebhookNotifier } from "@/lib/webhook";
 import { buildTestMessage } from "@/lib/webhook/templates/test-messages";
 import { getNotificationSettings, updateNotificationSettings } from "@/repository/notifications";

--- a/src/app/[locale]/dashboard/_components/dashboard-bento-sections.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-bento-sections.tsx
@@ -1,11 +1,11 @@
 import { cache } from "react";
 import { getOverviewData } from "@/actions/overview";
 import { getUserStatistics } from "@/actions/statistics";
-import { getSystemSettings } from "@/repository/system-config";
+import { getCachedSystemSettings as getCachedSystemSettingsFromConfig } from "@/lib/config";
 import { DEFAULT_TIME_RANGE } from "@/types/statistics";
 import { DashboardBento } from "./bento/dashboard-bento";
 
-const getCachedSystemSettings = cache(getSystemSettings);
+const getCachedSystemSettings = cache(getCachedSystemSettingsFromConfig);
 
 interface DashboardBentoSectionProps {
   isAdmin: boolean;

--- a/src/app/[locale]/dashboard/_components/dashboard-sections.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-sections.tsx
@@ -5,12 +5,12 @@ import { getUserStatistics } from "@/actions/statistics";
 import { OverviewPanel } from "@/components/customs/overview-panel";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/routing";
-import { getSystemSettings } from "@/repository/system-config";
+import { getCachedSystemSettings as getCachedSystemSettingsFromConfig } from "@/lib/config";
 import { DEFAULT_TIME_RANGE } from "@/types/statistics";
 import { StatisticsWrapper } from "./statistics";
 import { TodayLeaderboard } from "./today-leaderboard";
 
-const getCachedSystemSettings = cache(getSystemSettings);
+const getCachedSystemSettings = cache(getCachedSystemSettingsFromConfig);
 
 export async function DashboardOverviewSection({ isAdmin }: { isAdmin: boolean }) {
   const systemSettings = await getCachedSystemSettings();

--- a/src/app/[locale]/dashboard/_components/user/forms/limit-rule-picker.tsx
+++ b/src/app/[locale]/dashboard/_components/user/forms/limit-rule-picker.tsx
@@ -109,7 +109,7 @@ export function LimitRulePicker({
     setDailyMode("fixed");
     setDailyTime("00:00");
     setError(null);
-  }, [open, availableTypes]);
+  }, [open]);
 
   const numericValue = useMemo(() => {
     const trimmed = rawValue.trim();

--- a/src/app/[locale]/dashboard/leaderboard/page.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/page.tsx
@@ -5,7 +5,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Link } from "@/i18n/routing";
 import { getSession } from "@/lib/auth";
-import { getSystemSettings } from "@/repository/system-config";
+import { getCachedSystemSettings } from "@/lib/config";
 import { LeaderboardView } from "./_components/leaderboard-view";
 
 export const dynamic = "force-dynamic";
@@ -14,7 +14,7 @@ export default async function LeaderboardPage() {
   const t = await getTranslations("dashboard");
   // 获取用户 session 和系统设置
   const session = await getSession();
-  const systemSettings = await getSystemSettings();
+  const systemSettings = await getCachedSystemSettings();
 
   // 检查权限
   const isAdmin = session?.user.role === "admin";

--- a/src/app/[locale]/dashboard/leaderboard/page.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/page.tsx
@@ -5,7 +5,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Link } from "@/i18n/routing";
 import { getSession } from "@/lib/auth";
-import { getCachedSystemSettings } from "@/lib/config";
+import { getAllowGlobalUsageViewFromDB } from "@/repository/system-config";
 import { LeaderboardView } from "./_components/leaderboard-view";
 
 export const dynamic = "force-dynamic";
@@ -14,11 +14,11 @@ export default async function LeaderboardPage() {
   const t = await getTranslations("dashboard");
   // 获取用户 session 和系统设置
   const session = await getSession();
-  const systemSettings = await getCachedSystemSettings();
 
   // 检查权限
   const isAdmin = session?.user.role === "admin";
-  const hasPermission = isAdmin || systemSettings.allowGlobalUsageView;
+  const allowGlobalUsageView = session && !isAdmin ? await getAllowGlobalUsageViewFromDB() : false;
+  const hasPermission = Boolean(isAdmin) || allowGlobalUsageView;
 
   // 无权限时显示友好提示
   if (!hasPermission) {

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
@@ -1,10 +1,10 @@
 import { cache } from "react";
 import { ActiveSessionsList } from "@/components/customs/active-sessions-list";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
-import { getSystemSettings } from "@/repository/system-config";
+import { getCachedSystemSettings as getCachedSystemSettingsFromConfig } from "@/lib/config";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import { UsageLogsViewVirtualized } from "./usage-logs-view-virtualized";
 
-const getCachedSystemSettings = cache(getSystemSettings);
+const getCachedSystemSettings = cache(getCachedSystemSettingsFromConfig);
 
 interface UsageLogsDataSectionProps {
   isAdmin: boolean;

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
@@ -27,6 +27,9 @@ vi.mock("@tanstack/react-query", () => ({
     isError: mockIsError,
     error: mockError,
   }),
+  useQueryClient: () => ({
+    setQueryData: vi.fn(),
+  }),
 }));
 
 vi.mock("@/hooks/use-virtualizer", () => ({

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { type InfiniteData, useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowUp, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { type MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -30,6 +30,39 @@ import { ProviderChainPopover } from "./provider-chain-popover";
 
 const BATCH_SIZE = 50;
 const ROW_HEIGHT = 52; // Estimated row height in pixels
+const MAX_PAGES = 5;
+const MAX_TOTAL_LOGS = BATCH_SIZE * MAX_PAGES;
+
+type Cursor = { createdAt: string; id: number };
+type CursorParam = Cursor | undefined;
+
+type UsageLogsBatchData = Extract<
+  Awaited<ReturnType<typeof getUsageLogsBatch>>,
+  { ok: true }
+>["data"];
+type UsageLogWithCursor = UsageLogsBatchData["logs"][number] & { createdAtRaw?: string };
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  if (size <= 0) return [items];
+
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function resolveCursorFromLog(log: UsageLogWithCursor): Cursor | null {
+  const createdAtRaw =
+    typeof log.createdAtRaw === "string" && log.createdAtRaw.length > 0
+      ? log.createdAtRaw
+      : log.createdAt
+        ? log.createdAt.toISOString()
+        : null;
+
+  if (!createdAtRaw) return null;
+  return { createdAt: createdAtRaw, id: log.id };
+}
 
 export interface VirtualizedLogsTableFilters {
   userId?: number;
@@ -73,6 +106,9 @@ export function VirtualizedLogsTable({
   const parentRef = useRef<HTMLDivElement>(null);
   const [showScrollToTop, setShowScrollToTop] = useState(false);
   const shouldPoll = autoRefreshEnabled && !showScrollToTop;
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(() => ["usage-logs-batch", filters] as const, [filters]);
+  const refreshInFlightRef = useRef(false);
 
   const hideProviderColumn = hiddenColumns?.includes("provider") ?? false;
   const hideUserColumn = hiddenColumns?.includes("user") ?? false;
@@ -106,7 +142,7 @@ export function VirtualizedLogsTable({
   // Infinite query with cursor-based pagination
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, error } =
     useInfiniteQuery({
-      queryKey: ["usage-logs-batch", filters],
+      queryKey,
       queryFn: async ({ pageParam }) => {
         const result = await getUsageLogsBatch({
           ...filters,
@@ -122,9 +158,92 @@ export function VirtualizedLogsTable({
       initialPageParam: undefined as { createdAt: string; id: number } | undefined,
       staleTime: 30000, // 30 seconds
       refetchOnWindowFocus: false,
-      refetchInterval: shouldPoll ? autoRefreshIntervalMs : false,
-      maxPages: 5,
+      refetchInterval: false,
+      maxPages: MAX_PAGES,
     });
+
+  // Poll only the latest page to reduce DB load.
+  // We merge the refreshed first page into the existing infinite list (dedupe by id),
+  // and keep a fixed-size rolling window to avoid unbounded growth.
+  useEffect(() => {
+    if (!shouldPoll) return;
+
+    let cancelled = false;
+
+    const tick = async () => {
+      if (refreshInFlightRef.current) return;
+      refreshInFlightRef.current = true;
+
+      try {
+        const result = await getUsageLogsBatch({
+          ...filters,
+          cursor: undefined,
+          limit: BATCH_SIZE,
+        });
+
+        if (!result.ok || cancelled) return;
+
+        const latestPage = result.data;
+
+        queryClient.setQueryData<InfiniteData<UsageLogsBatchData, CursorParam>>(queryKey, (old) => {
+          const oldPages = old?.pages ?? [];
+          const existingLogs = oldPages.flatMap((page) => page.logs);
+
+          const combined = [...latestPage.logs, ...existingLogs];
+          const seen = new Set<number>();
+          const deduped: UsageLogsBatchData["logs"] = [];
+
+          for (const log of combined) {
+            if (seen.has(log.id)) continue;
+            seen.add(log.id);
+            deduped.push(log);
+            if (deduped.length >= MAX_TOTAL_LOGS) break;
+          }
+
+          if (deduped.length === 0) {
+            return old;
+          }
+
+          const lastHasMore =
+            oldPages.length > 0
+              ? (oldPages[oldPages.length - 1]?.hasMore ?? true)
+              : latestPage.hasMore;
+
+          const chunks = chunkArray(deduped, BATCH_SIZE);
+          const pages = chunks.map((logs, index) => {
+            const isLast = index === chunks.length - 1;
+            const hasMore = isLast ? lastHasMore : true;
+            const lastLog = logs[logs.length - 1] as UsageLogWithCursor | undefined;
+            const cursor = lastLog ? resolveCursorFromLog(lastLog) : null;
+
+            return {
+              logs,
+              hasMore,
+              nextCursor: hasMore && cursor ? cursor : null,
+            } satisfies UsageLogsBatchData;
+          });
+
+          const pageParams = pages.map((_, index) =>
+            index === 0 ? undefined : (pages[index - 1]?.nextCursor ?? undefined)
+          );
+
+          return { pages, pageParams };
+        });
+      } catch {
+        // Ignore polling errors (manual refresh still available).
+      } finally {
+        refreshInFlightRef.current = false;
+      }
+    };
+
+    void tick();
+    const intervalId = setInterval(() => void tick(), autoRefreshIntervalMs);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [autoRefreshIntervalMs, filters, queryClient, queryKey, shouldPoll]);
 
   // Flatten all pages into a single array
   const pages = data?.pages;

--- a/src/app/[locale]/dashboard/logs/_hooks/use-lazy-filter-options.ts
+++ b/src/app/[locale]/dashboard/logs/_hooks/use-lazy-filter-options.ts
@@ -77,7 +77,7 @@ function createLazyFilterHook<T>(
 
       inFlightRef.current = promise;
       return promise;
-    }, [fetcher, isLoaded]);
+    }, [isLoaded]);
 
     const onOpenChange = useCallback(
       (open: boolean) => {

--- a/src/app/[locale]/dashboard/logs/_hooks/use-lazy-filter-options.ts
+++ b/src/app/[locale]/dashboard/logs/_hooks/use-lazy-filter-options.ts
@@ -47,6 +47,7 @@ function createLazyFilterHook<T>(
       };
     }, []);
 
+    // fetcher 来自 createLazyFilterHook(...) 的闭包参数，在 hook 生命周期内保持稳定，因此不需要放入 deps。
     const load = useCallback(async () => {
       // 如果已加载或有进行中的请求，跳过
       if (isLoaded || inFlightRef.current) return;

--- a/src/app/[locale]/dashboard/my-quota/page.tsx
+++ b/src/app/[locale]/dashboard/my-quota/page.tsx
@@ -2,7 +2,7 @@ import { AlertCircle } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { getMyQuota } from "@/actions/my-usage";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { getSystemSettings } from "@/repository/system-config";
+import { getCachedSystemSettings } from "@/lib/config";
 import { QuotaCards } from "../../my-usage/_components/quota-cards";
 
 export const dynamic = "force-dynamic";
@@ -13,7 +13,7 @@ export default async function MyQuotaPage({ params }: { params: Promise<{ locale
 
   const [quotaResult, systemSettings, tNav, tCommon] = await Promise.all([
     getMyQuota(),
-    getSystemSettings(),
+    getCachedSystemSettings(),
     getTranslations("dashboard.nav"),
     getTranslations("common"),
   ]);

--- a/src/app/[locale]/dashboard/quotas/providers/page.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import { getProviderLimitUsageBatch, getProviders } from "@/actions/providers";
 import { redirect } from "@/i18n/routing";
 import { getSession } from "@/lib/auth";
-import { getSystemSettings } from "@/repository/system-config";
+import { getCachedSystemSettings } from "@/lib/config";
 import { ProvidersQuotaSkeleton } from "../_components/providers-quota-skeleton";
 import { ProvidersQuotaManager } from "./_components/providers-quota-manager";
 
@@ -73,7 +73,7 @@ export default async function ProvidersQuotaPage({
 async function ProvidersQuotaContent() {
   const [providers, systemSettings] = await Promise.all([
     getProvidersWithQuotas(),
-    getSystemSettings(),
+    getCachedSystemSettings(),
   ]);
   const t = await getTranslations("quota.providers");
 

--- a/src/app/[locale]/dashboard/quotas/users/page.tsx
+++ b/src/app/[locale]/dashboard/quotas/users/page.tsx
@@ -6,8 +6,8 @@ import { QuotaToolbar } from "@/components/quota/quota-toolbar";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Link, redirect } from "@/i18n/routing";
 import { getSession } from "@/lib/auth";
+import { getCachedSystemSettings } from "@/lib/config";
 import { sumKeyTotalCostBatchByIds, sumUserTotalCostBatch } from "@/repository/statistics";
-import { getSystemSettings } from "@/repository/system-config";
 import { UsersQuotaSkeleton } from "../_components/users-quota-skeleton";
 import type { UserKeyWithUsage, UserQuotaWithUsage } from "./_components/types";
 import { UsersQuotaClient } from "./_components/users-quota-client";
@@ -116,7 +116,10 @@ export default async function UsersQuotaPage({ params }: { params: Promise<{ loc
 }
 
 async function UsersQuotaContent() {
-  const [users, systemSettings] = await Promise.all([getUsersWithQuotas(), getSystemSettings()]);
+  const [users, systemSettings] = await Promise.all([
+    getUsersWithQuotas(),
+    getCachedSystemSettings(),
+  ]);
   const t = await getTranslations("quota.users");
 
   return (

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,9 +6,9 @@ import { getMessages } from "next-intl/server";
 import { Footer } from "@/components/customs/footer";
 import { Toaster } from "@/components/ui/sonner";
 import { type Locale, locales } from "@/i18n/config";
+import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
-import { getSystemSettings } from "@/repository/system-config";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import { AppProviders } from "../providers";
 
 const FALLBACK_TITLE = "Claude Code Hub";
@@ -21,7 +21,7 @@ export async function generateMetadata({
   const { locale } = await params;
 
   try {
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
     const title = settings.siteTitle?.trim() || FALLBACK_TITLE;
 
     // Generate alternates for all locales

--- a/src/app/[locale]/settings/config/page.tsx
+++ b/src/app/[locale]/settings/config/page.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import { Section } from "@/components/section";
-import { getSystemSettings } from "@/repository/system-config";
+import { getCachedSystemSettings } from "@/lib/config";
 import { SettingsPageHeader } from "../_components/settings-page-header";
 import { AutoCleanupForm } from "./_components/auto-cleanup-form";
 import { SettingsConfigSkeleton } from "./_components/settings-config-skeleton";
@@ -28,7 +28,7 @@ export default async function SettingsConfigPage() {
 
 async function SettingsConfigContent() {
   const t = await getTranslations("settings");
-  const settings = await getSystemSettings();
+  const settings = await getCachedSystemSettings();
 
   return (
     <>

--- a/src/app/[locale]/settings/providers/_components/auto-sort-priority-dialog.tsx
+++ b/src/app/[locale]/settings/providers/_components/auto-sort-priority-dialog.tsx
@@ -113,7 +113,7 @@ export function AutoSortPriorityDialog() {
       const result = await autoSortProviderPriority({ confirm: true });
       if (result.ok) {
         toast.success(t("success", { count: result.data.summary.changedCount }));
-        queryClient.invalidateQueries({ queryKey: ["providers"] });
+        queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
         setOpen(false);
       } else {
         toast.error(getActionErrorMessage(result));

--- a/src/app/[locale]/settings/providers/_components/batch-edit/provider-batch-dialog.tsx
+++ b/src/app/[locale]/settings/providers/_components/batch-edit/provider-batch-dialog.tsx
@@ -224,7 +224,7 @@ function BatchEditDialogContent({
       });
 
       if (result.ok) {
-        await queryClient.invalidateQueries({ queryKey: ["providers"] });
+        await queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
         onOpenChange(false);
         onSuccess?.();
 
@@ -239,7 +239,7 @@ function BatchEditDialogContent({
                 const undoResult = await undoProviderPatch({ undoToken, operationId });
                 if (undoResult.ok) {
                   toast.success(t("toast.undoSuccess", { count: undoResult.data.revertedCount }));
-                  queryClient.invalidateQueries({ queryKey: ["providers"] });
+                  queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
                 } else {
                   toast.error(t("toast.undoFailed", { error: undoResult.error }));
                 }
@@ -417,7 +417,7 @@ function BatchConfirmDialog({
                     toast.success(
                       t("undo.batchDeleteUndone", { count: undoResult.data.restoredCount })
                     );
-                    await queryClient.invalidateQueries({ queryKey: ["providers"] });
+                    await queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
                   } else if (
                     undoResult.errorCode === PROVIDER_BATCH_PATCH_ERROR_CODES.UNDO_EXPIRED
                   ) {
@@ -447,7 +447,7 @@ function BatchConfirmDialog({
         }
       }
 
-      await queryClient.invalidateQueries({ queryKey: ["providers"] });
+      await queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
       onOpenChange(false);
       onSuccess?.();
     } catch (error) {

--- a/src/app/[locale]/settings/providers/_components/forms/provider-form/index.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/provider-form/index.tsx
@@ -388,8 +388,7 @@ function ProviderFormContent({
                   const undoResult = await undoProviderPatch({ undoToken, operationId });
                   if (undoResult.ok) {
                     toast.success(tBatchEdit("undo.singleEditUndone"));
-                    await queryClient.invalidateQueries({ queryKey: ["providers"] });
-                    await queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+                    await queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
                     await queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
                     await queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
                   } else if (
@@ -406,8 +405,7 @@ function ProviderFormContent({
             },
           });
 
-          void queryClient.invalidateQueries({ queryKey: ["providers"] });
-          void queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+          void queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
           void queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
           void queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
         } else {
@@ -419,8 +417,7 @@ function ProviderFormContent({
             return;
           }
 
-          void queryClient.invalidateQueries({ queryKey: ["providers"] });
-          void queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+          void queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
           void queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
           void queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
 
@@ -480,8 +477,7 @@ function ProviderFormContent({
                 const undoResult = await undoProviderDelete({ undoToken, operationId });
                 if (undoResult.ok) {
                   toast.success(tBatchEdit("undo.singleDeleteUndone"));
-                  await queryClient.invalidateQueries({ queryKey: ["providers"] });
-                  await queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+                  await queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
                   await queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
                   await queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
                 } else if (undoResult.errorCode === PROVIDER_BATCH_PATCH_ERROR_CODES.UNDO_EXPIRED) {
@@ -496,8 +492,7 @@ function ProviderFormContent({
           },
         });
 
-        void queryClient.invalidateQueries({ queryKey: ["providers"] });
-        void queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+        void queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
         void queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
         void queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
         onSuccess?.();

--- a/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
@@ -225,8 +225,7 @@ export function ProviderRichListItem({
                     const undoResult = await undoProviderDelete({ undoToken, operationId });
                     if (undoResult.ok) {
                       toast.success(tBatchEdit("undo.singleDeleteUndone"));
-                      await queryClient.invalidateQueries({ queryKey: ["providers"] });
-                      await queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+                      await queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
                       await queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
                     } else if (
                       undoResult.errorCode === PROVIDER_BATCH_PATCH_ERROR_CODES.UNDO_EXPIRED
@@ -242,8 +241,7 @@ export function ProviderRichListItem({
               },
             });
 
-            queryClient.invalidateQueries({ queryKey: ["providers"] });
-            queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+            queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
             queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
           } else {
             toast.error(tList("deleteFailed"), {
@@ -313,8 +311,7 @@ export function ProviderRichListItem({
           toast.success(tList("resetCircuitSuccess"), {
             description: tList("resetCircuitSuccessDesc", { name: provider.name }),
           });
-          queryClient.invalidateQueries({ queryKey: ["providers"] });
-          queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+          queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
         } else {
           toast.error(tList("resetCircuitFailed"), {
             description: res.error || tList("unknownError"),
@@ -338,8 +335,7 @@ export function ProviderRichListItem({
           toast.success(tList("resetUsageSuccess"), {
             description: tList("resetUsageSuccessDesc", { name: provider.name }),
           });
-          queryClient.invalidateQueries({ queryKey: ["providers"] });
-          queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+          queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
         } else {
           toast.error(tList("resetUsageFailed"), {
             description: res.error || tList("unknownError"),
@@ -366,8 +362,7 @@ export function ProviderRichListItem({
           toast.success(tList("toggleSuccess", { status }), {
             description: tList("toggleSuccessDesc", { name: provider.name }),
           });
-          queryClient.invalidateQueries({ queryKey: ["providers"] });
-          queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+          queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
         } else {
           toast.error(tList("toggleFailed"), {
             description: res.error || tList("unknownError"),
@@ -390,7 +385,7 @@ export function ProviderRichListItem({
         >[1]);
         if (res.ok) {
           toast.success(tInline("saveSuccess"));
-          queryClient.invalidateQueries({ queryKey: ["providers"] });
+          queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
           return true;
         }
         toast.error(tInline("saveFailed"), { description: res.error || tList("unknownError") });
@@ -419,7 +414,7 @@ export function ProviderRichListItem({
       const res = await editProvider(provider.id, { group_tag: groupTag });
       if (res.ok) {
         toast.success(tInline("saveSuccess"));
-        queryClient.invalidateQueries({ queryKey: ["providers"] });
+        queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
         return true;
       }
       toast.error(tInline("groupSaveError"), {
@@ -444,7 +439,7 @@ export function ProviderRichListItem({
       });
       if (res.ok) {
         toast.success(tInline("saveSuccess"));
-        queryClient.invalidateQueries({ queryKey: ["providers"] });
+        queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
         return true;
       }
       toast.error(tInline("saveFailed"), { description: res.error || tList("unknownError") });

--- a/src/app/[locale]/settings/providers/_components/recluster-vendors-dialog.tsx
+++ b/src/app/[locale]/settings/providers/_components/recluster-vendors-dialog.tsx
@@ -113,7 +113,7 @@ export function ReclusterVendorsDialog() {
       const result = await reclusterProviderVendors({ confirm: true });
       if (result.ok) {
         toast.success(t("success", { count: result.data.preview.providersMoved }));
-        queryClient.invalidateQueries({ queryKey: ["providers"] });
+        queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
         queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
         queryClient.invalidateQueries({ queryKey: ["provider-endpoints"] });
         setOpen(false);

--- a/src/app/[locale]/settings/providers/_components/vendor-keys-compact-list.tsx
+++ b/src/app/[locale]/settings/providers/_components/vendor-keys-compact-list.tsx
@@ -260,7 +260,7 @@ function VendorKeyRow(props: {
         const res = await editProvider(props.provider.id, { [fieldName]: value });
         if (res.ok) {
           toast.success(tInline("saveSuccess"));
-          queryClient.invalidateQueries({ queryKey: ["providers"] });
+          queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
           queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
           return true;
         }
@@ -299,8 +299,7 @@ function VendorKeyRow(props: {
       if (!res.ok) throw new Error(res.error);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["providers"] });
-      queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+      queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
       queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
     },
     onError: () => {
@@ -315,8 +314,7 @@ function VendorKeyRow(props: {
       return res.data;
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ["providers"] });
-      queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+      queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
       queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
       queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
       setDeleteDialogOpen(false);
@@ -333,8 +331,7 @@ function VendorKeyRow(props: {
               });
               if (undoResult.ok) {
                 toast.success(tBatchEdit("undo.singleDeleteUndone"));
-                await queryClient.invalidateQueries({ queryKey: ["providers"] });
-                await queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+                await queryClient.invalidateQueries({ queryKey: ["providers-bootstrap"] });
                 await queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
                 await queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
               } else if (undoResult.errorCode === PROVIDER_BATCH_PATCH_ERROR_CODES.UNDO_EXPIRED) {

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
+import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { getLeaderboardWithCache } from "@/lib/redis";
 import type {
@@ -8,7 +9,6 @@ import type {
   LeaderboardScope,
 } from "@/lib/redis/leaderboard-cache";
 import { formatCurrency } from "@/lib/utils";
-import { getSystemSettings } from "@/repository/system-config";
 import type { ProviderType } from "@/types/provider";
 
 const VALID_PERIODS: LeaderboardPeriod[] = ["daily", "weekly", "monthly", "allTime", "custom"];
@@ -49,7 +49,7 @@ export async function GET(request: NextRequest) {
     }
 
     // 获取系统配置
-    const systemSettings = await getSystemSettings();
+    const systemSettings = await getCachedSystemSettings();
 
     // 检查权限：管理员或开启了全站使用量查看权限
     const isAdmin = session.user.role === "admin";

--- a/src/app/api/system-settings/route.ts
+++ b/src/app/api/system-settings/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
-import { getSystemSettings } from "@/repository/system-config";
+import { getCachedSystemSettings } from "@/lib/config";
 
 // 需要数据库连接
 export const runtime = "nodejs";
@@ -17,7 +17,7 @@ export async function GET() {
       return NextResponse.json({ error: "未授权，请先登录" }, { status: 401 });
     }
 
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
     return NextResponse.json(settings);
   } catch (error) {
     console.error("Failed to fetch system settings:", error);

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -1,5 +1,6 @@
 import { ResponseFixer } from "@/app/v1/_lib/proxy/response-fixer";
 import { AsyncTaskManager } from "@/lib/async-task-manager";
+import { getCachedSystemSettings } from "@/lib/config";
 import { getEnvConfig } from "@/lib/config/env.schema";
 import { logger } from "@/lib/logger";
 import { requestCloudPriceTableSync } from "@/lib/price-sync/cloud-price-updater";
@@ -22,7 +23,6 @@ import {
   updateMessageRequestDuration,
 } from "@/repository/message";
 import { findLatestPriceByModel } from "@/repository/model-price";
-import { getSystemSettings } from "@/repository/system-config";
 import type { SessionUsageUpdate } from "@/types/session";
 import { GeminiAdapter } from "../gemini/adapter";
 import type { GeminiResponse } from "../gemini/types";
@@ -2743,7 +2743,7 @@ async function updateRequestCostFromUsage(
 
   try {
     // 获取系统设置中的计费模型来源配置
-    const systemSettings = await getSystemSettings();
+    const systemSettings = await getCachedSystemSettings();
     const billingModelSource = systemSettings.billingModelSource;
 
     // 根据配置决定计费模型优先级

--- a/src/app/v1/_lib/proxy/session.ts
+++ b/src/app/v1/_lib/proxy/session.ts
@@ -729,8 +729,8 @@ export class ProxySession {
       if (!this.billingModelSourcePromise) {
         this.billingModelSourcePromise = (async () => {
           try {
-            const { getSystemSettings } = await import("@/repository/system-config");
-            const systemSettings = await getSystemSettings();
+            const { getCachedSystemSettings } = await import("@/lib/config");
+            const systemSettings = await getCachedSystemSettings();
             const source = systemSettings.billingModelSource;
 
             if (source !== "original" && source !== "redirected") {

--- a/src/app/v1/_lib/proxy/version-guard.ts
+++ b/src/app/v1/_lib/proxy/version-guard.ts
@@ -1,7 +1,7 @@
 import { ClientVersionChecker } from "@/lib/client-version-checker";
+import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { getClientTypeDisplayName, parseUserAgent } from "@/lib/ua-parser";
-import { getSystemSettings } from "@/repository/system-config";
 import type { ProxySession } from "./session";
 
 /**
@@ -29,7 +29,7 @@ export class ProxyVersionGuard {
   static async ensure(session: ProxySession): Promise<Response | null> {
     try {
       // 1. 检查系统配置
-      const settings = await getSystemSettings();
+      const settings = await getCachedSystemSettings();
       if (!settings.enableClientVersionCheck) {
         logger.debug("[ProxyVersionGuard] 版本检查功能已关闭");
         return null; // 功能关闭，放行

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,6 +7,7 @@ import { constantTimeEqual } from "@/lib/security/constant-time-compare";
 import { findKeyList, validateApiKeyAndGetUser } from "@/repository/key";
 import type { Key } from "@/types/key";
 import type { User } from "@/types/user";
+import { AUTH_COOKIE_NAME } from "./auth/constants";
 
 /**
  * Apply no-store / cache-busting headers to auth responses that mutate session state.
@@ -38,7 +39,7 @@ declare global {
   var __cchAuthSessionStorage: AuthSessionStorage | undefined;
 }
 
-export const AUTH_COOKIE_NAME = "auth-token";
+export { AUTH_COOKIE_NAME };
 const AUTH_COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
 
 export interface AuthSession {

--- a/src/lib/auth/constants.ts
+++ b/src/lib/auth/constants.ts
@@ -1,0 +1,3 @@
+// Edge-safe auth constants (avoid importing server-only auth modules in middleware)
+
+export const AUTH_COOKIE_NAME = "auth-token";

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -8,4 +8,5 @@ export {
   getCachedSystemSettings,
   invalidateSystemSettingsCache,
   isHttp2Enabled,
+  publishSystemSettingsCacheInvalidation,
 } from "./system-settings-cache";

--- a/src/lib/config/system-settings-cache.ts
+++ b/src/lib/config/system-settings-cache.ts
@@ -12,16 +12,35 @@
  * - Fail-open: returns default settings on error
  */
 
+import "server-only";
+
 import { logger } from "@/lib/logger";
+import { publishCacheInvalidation, subscribeCacheInvalidation } from "@/lib/redis/pubsub";
 import { getSystemSettings } from "@/repository/system-config";
 import type { SystemSettings } from "@/types/system-config";
 
 /** Cache TTL in milliseconds (1 minute) */
 const CACHE_TTL_MS = 60 * 1000;
 
+export const CHANNEL_SYSTEM_SETTINGS_UPDATED = "cch:cache:system_settings:updated";
+
 /** Cached settings and timestamp */
 let cachedSettings: SystemSettings | null = null;
 let cachedAt: number = 0;
+
+/**
+ * In-flight fetch promise (dedupe concurrent cache misses)
+ *
+ * This avoids thundering herd on cold start / TTL boundary.
+ */
+let inFlightFetch: Promise<SystemSettings> | null = null;
+
+/**
+ * Cache generation id
+ *
+ * Incremented on invalidation to prevent stale in-flight fetches from overwriting newer cache.
+ */
+let cacheGeneration = 0;
 
 /** Default settings used when cache fetch fails */
 const DEFAULT_SETTINGS: Pick<
@@ -53,6 +72,49 @@ const DEFAULT_SETTINGS: Pick<
   },
 };
 
+let subscriptionInitialized = false;
+let subscriptionInitPromise: Promise<void> | null = null;
+
+async function ensureSubscription(): Promise<void> {
+  if (subscriptionInitialized) return;
+  if (subscriptionInitPromise) return subscriptionInitPromise;
+
+  subscriptionInitPromise = (async () => {
+    // CI/build 阶段跳过，避免触发 Redis 连接
+    if (process.env.CI === "true" || process.env.NEXT_PHASE === "phase-production-build") {
+      subscriptionInitialized = true;
+      return;
+    }
+
+    const redisUrl = process.env.REDIS_URL?.trim();
+    const rateLimitRaw = process.env.ENABLE_RATE_LIMIT?.trim();
+    const isRateLimitEnabled = rateLimitRaw !== "false" && rateLimitRaw !== "0";
+
+    // Redis 不可用或未启用（当前 pubsub 实现依赖 ENABLE_RATE_LIMIT=true）
+    if (!redisUrl || !isRateLimitEnabled) {
+      subscriptionInitialized = true;
+      return;
+    }
+
+    try {
+      const cleanup = await subscribeCacheInvalidation(CHANNEL_SYSTEM_SETTINGS_UPDATED, () => {
+        invalidateSystemSettingsCache();
+        logger.debug("[SystemSettingsCache] Cache invalidated via pub/sub");
+      });
+
+      if (!cleanup) return;
+
+      subscriptionInitialized = true;
+    } catch (error) {
+      logger.warn("[SystemSettingsCache] Failed to subscribe settings invalidation", { error });
+    }
+  })().finally(() => {
+    subscriptionInitPromise = null;
+  });
+
+  return subscriptionInitPromise;
+}
+
 /**
  * Get cached system settings
  *
@@ -62,6 +124,9 @@ const DEFAULT_SETTINGS: Pick<
  * @returns System settings (cached or fresh)
  */
 export async function getCachedSystemSettings(): Promise<SystemSettings> {
+  // 不阻塞：尽力初始化跨实例失效通知订阅
+  void ensureSubscription();
+
   const now = Date.now();
 
   // Return cached if still valid
@@ -69,64 +134,90 @@ export async function getCachedSystemSettings(): Promise<SystemSettings> {
     return cachedSettings;
   }
 
-  try {
-    // Fetch fresh settings from database
-    const settings = await getSystemSettings();
+  // Dedupe concurrent cache misses
+  if (inFlightFetch) {
+    return inFlightFetch;
+  }
 
-    // Update cache
-    cachedSettings = settings;
-    cachedAt = now;
+  const generationAtStart = cacheGeneration;
 
-    logger.debug("[SystemSettingsCache] Settings cached", {
-      enableHttp2: settings.enableHttp2,
-      ttl: CACHE_TTL_MS,
-    });
+  const fetchPromise = (async (): Promise<SystemSettings> => {
+    try {
+      // Fetch fresh settings from database
+      const settings = await getSystemSettings();
 
-    return settings;
-  } catch (error) {
-    // Fail-open: return previous cached value or defaults
-    logger.warn("[SystemSettingsCache] Failed to fetch settings, using fallback", {
-      hasCachedValue: !!cachedSettings,
-      error,
-    });
+      // Update cache only if generation unchanged
+      if (cacheGeneration === generationAtStart) {
+        cachedSettings = settings;
+        cachedAt = Date.now();
+        logger.debug("[SystemSettingsCache] Settings cached", {
+          enableHttp2: settings.enableHttp2,
+          ttl: CACHE_TTL_MS,
+        });
+      }
 
-    if (cachedSettings) {
-      return cachedSettings;
+      return settings;
+    } catch (error) {
+      // Fail-open: return previous cached value or defaults
+      logger.warn("[SystemSettingsCache] Failed to fetch settings, using fallback", {
+        hasCachedValue: !!cachedSettings,
+        error,
+      });
+
+      const fallback: SystemSettings =
+        cachedSettings ??
+        ({
+          // Return minimal default settings - this should rarely happen
+          // since getSystemSettings creates default row if not exists
+          id: 0,
+          siteTitle: "Claude Code Hub",
+          allowGlobalUsageView: false,
+          currencyDisplay: "USD",
+          billingModelSource: "original",
+          timezone: null,
+          verboseProviderError: false,
+          enableAutoCleanup: false,
+          cleanupRetentionDays: 30,
+          cleanupSchedule: "0 2 * * *",
+          cleanupBatchSize: 10000,
+          enableClientVersionCheck: false,
+          enableHttp2: DEFAULT_SETTINGS.enableHttp2,
+          interceptAnthropicWarmupRequests: DEFAULT_SETTINGS.interceptAnthropicWarmupRequests,
+          enableThinkingSignatureRectifier: DEFAULT_SETTINGS.enableThinkingSignatureRectifier,
+          enableThinkingBudgetRectifier: DEFAULT_SETTINGS.enableThinkingBudgetRectifier,
+          enableBillingHeaderRectifier: DEFAULT_SETTINGS.enableBillingHeaderRectifier,
+          enableCodexSessionIdCompletion: DEFAULT_SETTINGS.enableCodexSessionIdCompletion,
+          enableClaudeMetadataUserIdInjection: DEFAULT_SETTINGS.enableClaudeMetadataUserIdInjection,
+          enableResponseFixer: DEFAULT_SETTINGS.enableResponseFixer,
+          responseFixerConfig: DEFAULT_SETTINGS.responseFixerConfig,
+          quotaDbRefreshIntervalSeconds: 10,
+          quotaLeasePercent5h: 0.05,
+          quotaLeasePercentDaily: 0.05,
+          quotaLeasePercentWeekly: 0.05,
+          quotaLeasePercentMonthly: 0.05,
+          quotaLeaseCapUsd: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } satisfies SystemSettings);
+
+      // 将 fallback 也写入缓存，避免在 DB 不可用时每次调用都重复打点/重试
+      if (cacheGeneration === generationAtStart) {
+        cachedSettings = fallback;
+        cachedAt = Date.now();
+      }
+
+      return fallback;
     }
+  })();
 
-    // Return minimal default settings - this should rarely happen
-    // since getSystemSettings creates default row if not exists
-    return {
-      id: 0,
-      siteTitle: "Claude Code Hub",
-      allowGlobalUsageView: false,
-      currencyDisplay: "USD",
-      billingModelSource: "original",
-      timezone: null,
-      verboseProviderError: false,
-      enableAutoCleanup: false,
-      cleanupRetentionDays: 30,
-      cleanupSchedule: "0 2 * * *",
-      cleanupBatchSize: 10000,
-      enableClientVersionCheck: false,
-      enableHttp2: DEFAULT_SETTINGS.enableHttp2,
-      interceptAnthropicWarmupRequests: DEFAULT_SETTINGS.interceptAnthropicWarmupRequests,
-      enableThinkingSignatureRectifier: DEFAULT_SETTINGS.enableThinkingSignatureRectifier,
-      enableThinkingBudgetRectifier: DEFAULT_SETTINGS.enableThinkingBudgetRectifier,
-      enableBillingHeaderRectifier: DEFAULT_SETTINGS.enableBillingHeaderRectifier,
-      enableCodexSessionIdCompletion: DEFAULT_SETTINGS.enableCodexSessionIdCompletion,
-      enableClaudeMetadataUserIdInjection: DEFAULT_SETTINGS.enableClaudeMetadataUserIdInjection,
-      enableResponseFixer: DEFAULT_SETTINGS.enableResponseFixer,
-      responseFixerConfig: DEFAULT_SETTINGS.responseFixerConfig,
-      quotaDbRefreshIntervalSeconds: 10,
-      quotaLeasePercent5h: 0.05,
-      quotaLeasePercentDaily: 0.05,
-      quotaLeasePercentWeekly: 0.05,
-      quotaLeasePercentMonthly: 0.05,
-      quotaLeaseCapUsd: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    } satisfies SystemSettings;
+  inFlightFetch = fetchPromise;
+
+  try {
+    return await fetchPromise;
+  } finally {
+    if (inFlightFetch === fetchPromise) {
+      inFlightFetch = null;
+    }
   }
 }
 
@@ -147,7 +238,27 @@ export async function isHttp2Enabled(): Promise<boolean> {
  * the next request gets fresh settings.
  */
 export function invalidateSystemSettingsCache(): void {
+  cacheGeneration++;
   cachedSettings = null;
   cachedAt = 0;
+  inFlightFetch = null;
   logger.info("[SystemSettingsCache] Cache invalidated");
+}
+
+/**
+ * Invalidate settings cache and publish cross-instance invalidation notification.
+ *
+ * Use this after system settings are saved.
+ */
+export async function publishSystemSettingsCacheInvalidation(): Promise<void> {
+  invalidateSystemSettingsCache();
+
+  const redisUrl = process.env.REDIS_URL?.trim();
+  const rateLimitRaw = process.env.ENABLE_RATE_LIMIT?.trim();
+  const isRateLimitEnabled = rateLimitRaw !== "false" && rateLimitRaw !== "0";
+
+  if (!redisUrl || !isRateLimitEnabled) return;
+
+  await publishCacheInvalidation(CHANNEL_SYSTEM_SETTINGS_UPDATED);
+  logger.debug("[SystemSettingsCache] Published cache invalidation");
 }

--- a/src/lib/config/system-settings-cache.ts
+++ b/src/lib/config/system-settings-cache.ts
@@ -24,6 +24,14 @@ const CACHE_TTL_MS = 60 * 1000;
 
 export const CHANNEL_SYSTEM_SETTINGS_UPDATED = "cch:cache:system_settings:updated";
 
+const SUBSCRIPTION_RETRY_BASE_MS = 5_000;
+const SUBSCRIPTION_RETRY_MAX_MS = 5 * 60_000;
+
+function computeSubscriptionRetryBackoffMs(failures: number): number {
+  const exponent = Math.min(8, Math.max(0, failures - 1));
+  return Math.min(SUBSCRIPTION_RETRY_MAX_MS, SUBSCRIPTION_RETRY_BASE_MS * 2 ** exponent);
+}
+
 /** Cached settings and timestamp */
 let cachedSettings: SystemSettings | null = null;
 let cachedAt: number = 0;
@@ -74,15 +82,22 @@ const DEFAULT_SETTINGS: Pick<
 
 let subscriptionInitialized = false;
 let subscriptionInitPromise: Promise<void> | null = null;
+let subscriptionRetryFailures = 0;
+let subscriptionNextRetryAt = 0;
 
 async function ensureSubscription(): Promise<void> {
   if (subscriptionInitialized) return;
   if (subscriptionInitPromise) return subscriptionInitPromise;
 
+  const now = Date.now();
+  if (subscriptionNextRetryAt > now) return;
+
   subscriptionInitPromise = (async () => {
     // CI/build 阶段跳过，避免触发 Redis 连接
     if (process.env.CI === "true" || process.env.NEXT_PHASE === "phase-production-build") {
       subscriptionInitialized = true;
+      subscriptionRetryFailures = 0;
+      subscriptionNextRetryAt = 0;
       return;
     }
 
@@ -93,6 +108,8 @@ async function ensureSubscription(): Promise<void> {
     // Redis 不可用或未启用（当前 pubsub 实现依赖 ENABLE_RATE_LIMIT=true）
     if (!redisUrl || !isRateLimitEnabled) {
       subscriptionInitialized = true;
+      subscriptionRetryFailures = 0;
+      subscriptionNextRetryAt = 0;
       return;
     }
 
@@ -102,11 +119,29 @@ async function ensureSubscription(): Promise<void> {
         logger.debug("[SystemSettingsCache] Cache invalidated via pub/sub");
       });
 
-      if (!cleanup) return;
+      if (!cleanup) {
+        subscriptionRetryFailures++;
+        subscriptionNextRetryAt =
+          Date.now() + computeSubscriptionRetryBackoffMs(subscriptionRetryFailures);
+        logger.debug("[SystemSettingsCache] Pub/sub subscribe not ready, will retry later", {
+          consecutiveFailures: subscriptionRetryFailures,
+          nextRetryAt: new Date(subscriptionNextRetryAt).toISOString(),
+        });
+        return;
+      }
 
       subscriptionInitialized = true;
+      subscriptionRetryFailures = 0;
+      subscriptionNextRetryAt = 0;
     } catch (error) {
-      logger.warn("[SystemSettingsCache] Failed to subscribe settings invalidation", { error });
+      subscriptionRetryFailures++;
+      subscriptionNextRetryAt =
+        Date.now() + computeSubscriptionRetryBackoffMs(subscriptionRetryFailures);
+      logger.warn("[SystemSettingsCache] Failed to subscribe settings invalidation", {
+        error,
+        consecutiveFailures: subscriptionRetryFailures,
+        nextRetryAt: new Date(subscriptionNextRetryAt).toISOString(),
+      });
     }
   })().finally(() => {
     subscriptionInitPromise = null;

--- a/src/lib/ledger-backfill/trigger.sql
+++ b/src/lib/ledger-backfill/trigger.sql
@@ -8,14 +8,16 @@ DECLARE
 BEGIN
   IF NEW.blocked_by = 'warmup' THEN
     -- If a ledger row already exists (row was originally non-warmup), mark it as warmup
-    UPDATE usage_ledger SET blocked_by = 'warmup' WHERE request_id = NEW.id;
+    UPDATE usage_ledger SET blocked_by = 'warmup'
+    WHERE request_id = NEW.id AND blocked_by IS DISTINCT FROM 'warmup';
     RETURN NEW;
   END IF;
 
   IF NEW.blocked_by IS NOT NULL THEN
     -- Blocked requests are excluded from billing stats; avoid creating usage_ledger rows.
     -- If a ledger row already exists (row was originally unblocked), mark it as blocked.
-    UPDATE usage_ledger SET blocked_by = NEW.blocked_by WHERE request_id = NEW.id;
+    UPDATE usage_ledger SET blocked_by = NEW.blocked_by
+    WHERE request_id = NEW.id AND blocked_by IS DISTINCT FROM NEW.blocked_by;
     RETURN NEW;
   END IF;
 

--- a/src/lib/ledger-backfill/trigger.sql
+++ b/src/lib/ledger-backfill/trigger.sql
@@ -24,7 +24,12 @@ BEGIN
      AND jsonb_array_length(NEW.provider_chain) > 0
      AND jsonb_typeof(NEW.provider_chain -> -1) = 'object'
      AND (NEW.provider_chain -> -1 ? 'id')
-     AND (NEW.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$' THEN
+     AND (NEW.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$'
+     AND length(NEW.provider_chain -> -1 ->> 'id') <= 10
+     AND (
+       length(NEW.provider_chain -> -1 ->> 'id') < 10
+       OR (NEW.provider_chain -> -1 ->> 'id') <= '2147483647'
+     ) THEN
     v_final_provider_id := (NEW.provider_chain -> -1 ->> 'id')::integer;
   ELSE
     v_final_provider_id := NEW.provider_id;
@@ -42,7 +47,12 @@ BEGIN
        AND jsonb_array_length(OLD.provider_chain) > 0
        AND jsonb_typeof(OLD.provider_chain -> -1) = 'object'
        AND (OLD.provider_chain -> -1 ? 'id')
-       AND (OLD.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$' THEN
+       AND (OLD.provider_chain -> -1 ->> 'id') ~ '^[0-9]+$'
+       AND length(OLD.provider_chain -> -1 ->> 'id') <= 10
+       AND (
+         length(OLD.provider_chain -> -1 ->> 'id') < 10
+         OR (OLD.provider_chain -> -1 ->> 'id') <= '2147483647'
+       ) THEN
       v_old_final_provider_id := (OLD.provider_chain -> -1 ->> 'id')::integer;
     ELSE
       v_old_final_provider_id := OLD.provider_id;

--- a/src/lib/log-cleanup/cleanup-queue.ts
+++ b/src/lib/log-cleanup/cleanup-queue.ts
@@ -3,8 +3,8 @@ import { BullAdapter } from "@bull-board/api/bullAdapter";
 import { ExpressAdapter } from "@bull-board/express";
 import type { Job } from "bull";
 import Queue from "bull";
-import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
+import { getSystemSettings } from "@/repository/system-config";
 import { cleanupLogs } from "./service";
 
 /**
@@ -147,7 +147,7 @@ function setupQueueProcessor(queue: Queue.Queue): void {
  */
 export async function scheduleAutoCleanup() {
   try {
-    const settings = await getCachedSystemSettings();
+    const settings = await getSystemSettings();
     const queue = getCleanupQueue();
 
     if (!settings.enableAutoCleanup) {

--- a/src/lib/log-cleanup/cleanup-queue.ts
+++ b/src/lib/log-cleanup/cleanup-queue.ts
@@ -3,8 +3,8 @@ import { BullAdapter } from "@bull-board/api/bullAdapter";
 import { ExpressAdapter } from "@bull-board/express";
 import type { Job } from "bull";
 import Queue from "bull";
+import { getCachedSystemSettings } from "@/lib/config";
 import { logger } from "@/lib/logger";
-import { getSystemSettings } from "@/repository/system-config";
 import { cleanupLogs } from "./service";
 
 /**
@@ -147,7 +147,7 @@ function setupQueueProcessor(queue: Queue.Queue): void {
  */
 export async function scheduleAutoCleanup() {
   try {
-    const settings = await getSystemSettings();
+    const settings = await getCachedSystemSettings();
     const queue = getCleanupQueue();
 
     if (!settings.enableAutoCleanup) {

--- a/src/lib/notification/notification-queue.ts
+++ b/src/lib/notification/notification-queue.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/notification/tasks/cache-hit-rate-alert";
 import { generateCostAlerts } from "@/lib/notification/tasks/cost-alert";
 import { generateDailyLeaderboard } from "@/lib/notification/tasks/daily-leaderboard";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import {
   buildCacheHitRateAlertMessage,
   buildCircuitBreakerMessage,

--- a/src/lib/notification/tasks/cache-hit-rate-alert.ts
+++ b/src/lib/notification/tasks/cache-hit-rate-alert.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/cache-hit-rate-alert/decision";
 import { logger } from "@/lib/logger";
 import { getRedisClient } from "@/lib/redis/client";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import type {
   CacheHitRateAlertData,
   CacheHitRateAlertSettingsSnapshot,

--- a/src/lib/notification/tasks/daily-leaderboard.ts
+++ b/src/lib/notification/tasks/daily-leaderboard.ts
@@ -1,5 +1,5 @@
 import { logger } from "@/lib/logger";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import type { DailyLeaderboardData } from "@/lib/webhook";
 import { findLast24HoursLeaderboard } from "@/repository/leaderboard";
 

--- a/src/lib/rate-limit/time-utils.ts
+++ b/src/lib/rate-limit/time-utils.ts
@@ -15,7 +15,7 @@ import {
   startOfWeek,
 } from "date-fns";
 import { fromZonedTime, toZonedTime } from "date-fns-tz";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 
 export type TimePeriod = "5h" | "daily" | "weekly" | "monthly";
 export type DailyResetMode = "fixed" | "rolling";

--- a/src/lib/redis/leaderboard-cache.ts
+++ b/src/lib/redis/leaderboard-cache.ts
@@ -1,6 +1,6 @@
 import { formatInTimeZone } from "date-fns-tz";
 import { logger } from "@/lib/logger";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import {
   type DateRangeParams,
   findAllTimeLeaderboard,

--- a/src/lib/security/constant-time-compare.ts
+++ b/src/lib/security/constant-time-compare.ts
@@ -23,9 +23,9 @@ export function constantTimeEqual(a: string, b: string): boolean {
     const padB = new Uint8Array(padLen);
     padA.set(bufA);
     padB.set(bufB);
-    let dummy = 0;
+    let _dummy = 0;
     for (let i = 0; i < padLen; i++) {
-      dummy |= padA[i] ^ padB[i];
+      _dummy |= padA[i] ^ padB[i];
     }
     return false;
   }

--- a/src/lib/utils/timezone.server.ts
+++ b/src/lib/utils/timezone.server.ts
@@ -1,0 +1,41 @@
+import "server-only";
+
+import { getEnvConfig } from "@/lib/config/env.schema";
+import { getCachedSystemSettings } from "@/lib/config/system-settings-cache";
+import { logger } from "@/lib/logger";
+import { isValidIANATimezone } from "./timezone";
+
+/**
+ * Resolves the system timezone using the fallback chain:
+ *   1. DB system_settings.timezone (via cached settings)
+ *   2. env TZ variable
+ *   3. "UTC" as final fallback
+ *
+ * Each candidate is validated via isValidIANATimezone before being accepted.
+ *
+ * @returns Resolved IANA timezone identifier (always valid)
+ */
+export async function resolveSystemTimezone(): Promise<string> {
+  // Step 1: Try DB timezone from cached system settings
+  try {
+    const settings = await getCachedSystemSettings();
+    if (settings.timezone && isValidIANATimezone(settings.timezone)) {
+      return settings.timezone;
+    }
+  } catch (error) {
+    logger.warn("[TimezoneResolver] Failed to read cached system settings", { error });
+  }
+
+  // Step 2: Fallback to env TZ
+  try {
+    const { TZ } = getEnvConfig();
+    if (TZ && isValidIANATimezone(TZ)) {
+      return TZ;
+    }
+  } catch (error) {
+    logger.warn("[TimezoneResolver] Failed to read env TZ", { error });
+  }
+
+  // Step 3: Ultimate fallback
+  return "UTC";
+}

--- a/src/lib/utils/timezone.ts
+++ b/src/lib/utils/timezone.ts
@@ -128,14 +128,3 @@ export function getTimezoneOffsetMinutes(timezone: string): number {
 
   return (tzDate.getTime() - utcDate.getTime()) / (1000 * 60);
 }
-
-/**
- * Resolves the system timezone using the fallback chain:
- *   1. DB system_settings.timezone (via cached settings)
- *   2. env TZ variable
- *   3. "UTC" as final fallback
- *
- * Each candidate is validated via isValidIANATimezone before being accepted.
- *
- * @returns Resolved IANA timezone identifier (always valid)
- */

--- a/src/lib/utils/timezone.ts
+++ b/src/lib/utils/timezone.ts
@@ -1,16 +1,11 @@
 /**
  * Timezone Utilities
  *
- * Provides timezone validation and resolution functions.
+ * Provides timezone validation and formatting helpers (client-safe).
  * Uses IANA timezone database identifiers (e.g., "Asia/Shanghai", "America/New_York").
  *
- * resolveSystemTimezone() implements the fallback chain:
- *   DB timezone -> env TZ -> UTC
+ * Server-only system timezone resolution lives in `timezone.server.ts`.
  */
-
-import { getEnvConfig } from "@/lib/config/env.schema";
-import { getCachedSystemSettings } from "@/lib/config/system-settings-cache";
-import { logger } from "@/lib/logger";
 
 /**
  * Common IANA timezone identifiers for dropdown UI.
@@ -144,27 +139,3 @@ export function getTimezoneOffsetMinutes(timezone: string): number {
  *
  * @returns Resolved IANA timezone identifier (always valid)
  */
-export async function resolveSystemTimezone(): Promise<string> {
-  // Step 1: Try DB timezone from cached system settings
-  try {
-    const settings = await getCachedSystemSettings();
-    if (settings.timezone && isValidIANATimezone(settings.timezone)) {
-      return settings.timezone;
-    }
-  } catch (error) {
-    logger.warn("[TimezoneResolver] Failed to read cached system settings", { error });
-  }
-
-  // Step 2: Fallback to env TZ
-  try {
-    const { TZ } = getEnvConfig();
-    if (TZ && isValidIANATimezone(TZ)) {
-      return TZ;
-    }
-  } catch (error) {
-    logger.warn("[TimezoneResolver] Failed to read env TZ", { error });
-  }
-
-  // Step 3: Ultimate fallback
-  return "UTC";
-}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
 import type { Locale } from "@/i18n/config";
 import { routing } from "@/i18n/routing";
-import { AUTH_COOKIE_NAME } from "@/lib/auth";
+import { AUTH_COOKIE_NAME } from "@/lib/auth/constants";
 import { isDevelopment } from "@/lib/config/env.schema";
 import { logger } from "@/lib/logger";
 

--- a/src/repository/_shared/ledger-conditions.ts
+++ b/src/repository/_shared/ledger-conditions.ts
@@ -3,8 +3,10 @@ import { usageLedger } from "@/drizzle/schema";
 
 /**
  * 只统计未被阻断的请求。
- * Warmup 行在触发器层面已过滤，不会进入 usage_ledger，
- * 因此此处只需排除 blocked_by IS NOT NULL 的记录。
+ *
+ * 说明：
+ * - Warmup 行在触发器层面已过滤，不会进入 usage_ledger。
+ * - 其他 blocked 请求默认也不会创建 usage_ledger 行；若请求后置被标记为 blocked，会将已有 ledger 行标记为 blocked。
  */
 export const LEDGER_BILLING_CONDITION = sql`(${usageLedger.blockedBy} IS NULL)`;
 

--- a/src/repository/cache-hit-rate-alert.ts
+++ b/src/repository/cache-hit-rate-alert.ts
@@ -4,8 +4,8 @@ import { and, desc, eq, gte, isNull, lt, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { db } from "@/drizzle/db";
 import { messageRequest, providers } from "@/drizzle/schema";
+import { getCachedSystemSettings } from "@/lib/config";
 import { EXCLUDE_WARMUP_CONDITION } from "@/repository/_shared/message-request-conditions";
-import { getSystemSettings } from "@/repository/system-config";
 import type { ProviderType } from "@/types/provider";
 
 export interface TimeRange {
@@ -125,7 +125,7 @@ export async function findProviderModelCacheHitRateMetricsForAlert(
   const windowMode = normalizeWindowMode(config);
   const ttlFallback = normalizeTtlFallbackSeconds(config);
 
-  const systemSettings = await getSystemSettings();
+  const systemSettings = await getCachedSystemSettings();
   const billingModelSource = systemSettings.billingModelSource;
 
   const modelField =

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -3,10 +3,10 @@
 import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { providers, usageLedger, users } from "@/drizzle/schema";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { getCachedSystemSettings } from "@/lib/config";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import type { ProviderType } from "@/types/provider";
 import { LEDGER_BILLING_CONDITION } from "./_shared/ledger-conditions";
-import { getSystemSettings } from "./system-config";
 
 /**
  * 排行榜条目类型
@@ -527,7 +527,7 @@ async function findProviderCacheHitRateLeaderboardWithTimezone(
     .orderBy(desc(cacheHitRateExpr), desc(sql`count(*)`));
 
   // Model-level cache hit breakdown per provider
-  const systemSettings = await getSystemSettings();
+  const systemSettings = await getCachedSystemSettings();
   const billingModelSource = systemSettings.billingModelSource;
   const modelField =
     billingModelSource === "original"
@@ -661,7 +661,7 @@ async function findModelLeaderboardWithTimezone(
   dateRange?: DateRangeParams
 ): Promise<ModelLeaderboardEntry[]> {
   // 获取系统设置中的计费模型来源配置
-  const systemSettings = await getSystemSettings();
+  const systemSettings = await getCachedSystemSettings();
   const billingModelSource = systemSettings.billingModelSource;
 
   // 根据配置决定模型字段的优先级

--- a/src/repository/notification-bindings.ts
+++ b/src/repository/notification-bindings.ts
@@ -3,7 +3,7 @@
 import { and, desc, eq, notInArray } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { notificationTargetBindings, webhookTargets } from "@/drizzle/schema";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import type { WebhookProviderType, WebhookTarget, WebhookTestResult } from "./webhook-targets";
 
 export type NotificationType =

--- a/src/repository/overview.ts
+++ b/src/repository/overview.ts
@@ -4,7 +4,7 @@ import { and, avg, count, eq, gte, lt, sql, sum } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { usageLedger } from "@/drizzle/schema";
 import { Decimal, toCostDecimal } from "@/lib/utils/currency";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import { LEDGER_BILLING_CONDITION } from "./_shared/ledger-conditions";
 
 /**

--- a/src/repository/provider.ts
+++ b/src/repository/provider.ts
@@ -6,7 +6,7 @@ import { providerEndpoints, providers } from "@/drizzle/schema";
 import { getCachedProviders } from "@/lib/cache/provider-cache";
 import { resetEndpointCircuit } from "@/lib/endpoint-circuit-breaker";
 import { logger } from "@/lib/logger";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import type {
   AnthropicAdaptiveThinkingConfig,
   CreateProviderData,

--- a/src/repository/statistics.ts
+++ b/src/repository/statistics.ts
@@ -5,7 +5,7 @@ import { and, eq, gte, inArray, isNull, lt, sql } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { keys, messageRequest, usageLedger } from "@/drizzle/schema";
 import { TTLMap } from "@/lib/cache/ttl-map";
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import type {
   DatabaseKey,
   DatabaseKeyStatRow,

--- a/tests/integration/billing-model-source.test.ts
+++ b/tests/integration/billing-model-source.test.ts
@@ -78,6 +78,7 @@ vi.mock("@/lib/proxy-status-tracker", () => ({
 
 import { ProxyResponseHandler } from "@/app/v1/_lib/proxy/response-handler";
 import { ProxySession } from "@/app/v1/_lib/proxy/session";
+import { invalidateSystemSettingsCache } from "@/lib/config";
 import { SessionManager } from "@/lib/session-manager";
 import { RateLimitService } from "@/lib/rate-limit";
 import { SessionTracker } from "@/lib/session-tracker";
@@ -91,6 +92,7 @@ import { getSystemSettings } from "@/repository/system-config";
 
 beforeEach(() => {
   cloudPriceSyncRequests.splice(0, cloudPriceSyncRequests.length);
+  invalidateSystemSettingsCache();
 });
 
 function makeSystemSettings(
@@ -257,6 +259,8 @@ async function runScenario({
   billingModelSource: SystemSettings["billingModelSource"];
   isStream: boolean;
 }): Promise<{ dbCostUsd: string; sessionCostUsd: string; rateLimitCost: number }> {
+  invalidateSystemSettingsCache();
+
   const usage = { input_tokens: 2, output_tokens: 3 };
   const originalModel = "original-model";
   const redirectedModel = "redirected-model";
@@ -377,6 +381,8 @@ describe("价格表缺失/查询失败：不计费放行", () => {
     isStream: boolean;
     priceLookup: "none" | "throws";
   }): Promise<{ dbCostCalls: number; rateLimitCalls: number }> {
+    invalidateSystemSettingsCache();
+
     const usage = { input_tokens: 2, output_tokens: 3 };
     const originalModel = "original-model";
     const redirectedModel = "redirected-model";

--- a/tests/unit/actions/my-usage-date-range-dst.test.ts
+++ b/tests/unit/actions/my-usage-date-range-dst.test.ts
@@ -24,7 +24,7 @@ vi.mock("@/repository/usage-logs", async (importOriginal) => {
   };
 });
 
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: mocks.resolveSystemTimezone,
 }));
 

--- a/tests/unit/actions/my-usage-token-aggregation.test.ts
+++ b/tests/unit/actions/my-usage-token-aggregation.test.ts
@@ -70,9 +70,14 @@ vi.mock("@/repository/system-config", () => ({
   getSystemSettings: mocks.getSystemSettings,
 }));
 
-vi.mock("@/lib/config", () => ({
-  getEnvConfig: mocks.getEnvConfig,
-}));
+vi.mock("@/lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/config")>();
+  return {
+    ...actual,
+    getEnvConfig: mocks.getEnvConfig,
+    getCachedSystemSettings: () => mocks.getSystemSettings(),
+  };
+});
 
 vi.mock("@/lib/rate-limit/time-utils", () => ({
   getTimeRangeForPeriodWithMode: mocks.getTimeRangeForPeriodWithMode,

--- a/tests/unit/actions/providers.test.ts
+++ b/tests/unit/actions/providers.test.ts
@@ -25,7 +25,9 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("@/repository/provider", () => ({
   createProvider: createProviderMock,
   deleteProvider: deleteProviderMock,
-  findAllProviders: vi.fn(async () => []),
+  // getProviders() now uses the cached providers entrypoint; keep tests aligned by delegating
+  // to the fresh mock (cache behavior is covered elsewhere).
+  findAllProviders: vi.fn(async () => await findAllProvidersFreshMock()),
   findAllProvidersFresh: findAllProvidersFreshMock,
   findProviderById: findProviderByIdMock,
   getProviderStatistics: getProviderStatisticsMock,

--- a/tests/unit/actions/system-config-save.test.ts
+++ b/tests/unit/actions/system-config-save.test.ts
@@ -4,7 +4,7 @@ import { locales } from "@/i18n/config";
 // Mock dependencies
 const getSessionMock = vi.fn();
 const revalidatePathMock = vi.fn();
-const invalidateSystemSettingsCacheMock = vi.fn();
+const publishSystemSettingsCacheInvalidationMock = vi.fn();
 const updateSystemSettingsMock = vi.fn();
 const getSystemSettingsMock = vi.fn();
 
@@ -17,7 +17,7 @@ vi.mock("next/cache", () => ({
 }));
 
 vi.mock("@/lib/config", () => ({
-  invalidateSystemSettingsCache: () => invalidateSystemSettingsCacheMock(),
+  publishSystemSettingsCacheInvalidation: () => publishSystemSettingsCacheInvalidationMock(),
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -30,7 +30,7 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: vi.fn(async () => "UTC"),
   isValidIANATimezone: vi.fn(() => true),
 }));
@@ -124,10 +124,10 @@ describe("saveSystemSettings", () => {
     );
   });
 
-  it("should invalidate system settings cache after successful save", async () => {
+  it("should publish system settings cache invalidation after successful save", async () => {
     await saveSystemSettings({ siteTitle: "New Title" });
 
-    expect(invalidateSystemSettingsCacheMock).toHaveBeenCalled();
+    expect(publishSystemSettingsCacheInvalidationMock).toHaveBeenCalled();
   });
 
   describe("revalidatePath locale coverage", () => {

--- a/tests/unit/lib/rate-limit/cost-limits.test.ts
+++ b/tests/unit/lib/rate-limit/cost-limits.test.ts
@@ -36,7 +36,7 @@ vi.mock("@/lib/redis", () => ({
 
 const resolveSystemTimezoneMock = vi.hoisted(() => vi.fn(async () => "Asia/Shanghai"));
 
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: resolveSystemTimezoneMock,
 }));
 

--- a/tests/unit/lib/rate-limit/lease.test.ts
+++ b/tests/unit/lib/rate-limit/lease.test.ts
@@ -7,11 +7,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock resolveSystemTimezone before importing lease module
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: vi.fn(async () => "Asia/Shanghai"),
 }));
 
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 
 describe("lease module", () => {
   const nowMs = 1706400000000; // 2024-01-28 00:00:00 UTC

--- a/tests/unit/lib/rate-limit/rolling-window-5h.test.ts
+++ b/tests/unit/lib/rate-limit/rolling-window-5h.test.ts
@@ -13,7 +13,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock resolveSystemTimezone before importing modules
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: vi.fn(async () => "Asia/Shanghai"),
 }));
 

--- a/tests/unit/lib/rate-limit/rolling-window-cache-warm.test.ts
+++ b/tests/unit/lib/rate-limit/rolling-window-cache-warm.test.ts
@@ -31,7 +31,7 @@ vi.mock("@/lib/redis", () => ({
   getRedisClient: () => redisClient,
 }));
 
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: vi.fn(async () => "Asia/Shanghai"),
 }));
 

--- a/tests/unit/lib/rate-limit/service-extra.test.ts
+++ b/tests/unit/lib/rate-limit/service-extra.test.ts
@@ -56,7 +56,7 @@ vi.mock("@/lib/redis", () => ({
 
 const resolveSystemTimezoneMock = vi.hoisted(() => vi.fn(async () => "Asia/Shanghai"));
 
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: resolveSystemTimezoneMock,
 }));
 

--- a/tests/unit/lib/rate-limit/time-utils.test.ts
+++ b/tests/unit/lib/rate-limit/time-utils.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock resolveSystemTimezone before importing time-utils
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: vi.fn(async () => "Asia/Shanghai"),
 }));
 
-import { resolveSystemTimezone } from "@/lib/utils/timezone";
+import { resolveSystemTimezone } from "@/lib/utils/timezone.server";
 import {
   getDailyResetTime,
   getResetInfo,

--- a/tests/unit/lib/timezone/timezone-resolver.test.ts
+++ b/tests/unit/lib/timezone/timezone-resolver.test.ts
@@ -103,7 +103,7 @@ beforeEach(() => {
 
 describe("resolveSystemTimezone", () => {
   it("should return DB timezone when set and valid", async () => {
-    const { resolveSystemTimezone } = await import("@/lib/utils/timezone");
+    const { resolveSystemTimezone } = await import("@/lib/utils/timezone.server");
 
     getCachedSystemSettingsMock.mockResolvedValue(createSettings({ timezone: "America/New_York" }));
     mockEnvConfig("Asia/Shanghai");
@@ -113,7 +113,7 @@ describe("resolveSystemTimezone", () => {
   });
 
   it("should fallback to env TZ when DB timezone is null", async () => {
-    const { resolveSystemTimezone } = await import("@/lib/utils/timezone");
+    const { resolveSystemTimezone } = await import("@/lib/utils/timezone.server");
 
     getCachedSystemSettingsMock.mockResolvedValue(createSettings({ timezone: null }));
     mockEnvConfig("Europe/London");
@@ -123,7 +123,7 @@ describe("resolveSystemTimezone", () => {
   });
 
   it("should fallback to env TZ when DB timezone is invalid", async () => {
-    const { resolveSystemTimezone } = await import("@/lib/utils/timezone");
+    const { resolveSystemTimezone } = await import("@/lib/utils/timezone.server");
 
     getCachedSystemSettingsMock.mockResolvedValue(
       createSettings({ timezone: "Invalid/Timezone_Zone" })
@@ -135,7 +135,7 @@ describe("resolveSystemTimezone", () => {
   });
 
   it("should fallback to UTC when both DB timezone and env TZ are invalid", async () => {
-    const { resolveSystemTimezone } = await import("@/lib/utils/timezone");
+    const { resolveSystemTimezone } = await import("@/lib/utils/timezone.server");
 
     getCachedSystemSettingsMock.mockResolvedValue(createSettings({ timezone: "Invalid/Zone" }));
     // Empty string TZ won't pass isValidIANATimezone
@@ -146,7 +146,7 @@ describe("resolveSystemTimezone", () => {
   });
 
   it("should fallback to UTC when getCachedSystemSettings throws", async () => {
-    const { resolveSystemTimezone } = await import("@/lib/utils/timezone");
+    const { resolveSystemTimezone } = await import("@/lib/utils/timezone.server");
 
     getCachedSystemSettingsMock.mockRejectedValue(new Error("DB connection failed"));
     mockEnvConfig("Asia/Shanghai");
@@ -157,7 +157,7 @@ describe("resolveSystemTimezone", () => {
   });
 
   it("should fallback to UTC when getCachedSystemSettings throws and env TZ is empty", async () => {
-    const { resolveSystemTimezone } = await import("@/lib/utils/timezone");
+    const { resolveSystemTimezone } = await import("@/lib/utils/timezone.server");
 
     getCachedSystemSettingsMock.mockRejectedValue(new Error("DB connection failed"));
     mockEnvConfig("");
@@ -167,7 +167,7 @@ describe("resolveSystemTimezone", () => {
   });
 
   it("should handle empty string DB timezone as null", async () => {
-    const { resolveSystemTimezone } = await import("@/lib/utils/timezone");
+    const { resolveSystemTimezone } = await import("@/lib/utils/timezone.server");
 
     getCachedSystemSettingsMock.mockResolvedValue(
       createSettings({ timezone: "" as unknown as null })

--- a/tests/unit/notification/cost-alert-window.test.ts
+++ b/tests/unit/notification/cost-alert-window.test.ts
@@ -52,7 +52,7 @@ vi.mock("@/lib/logger", () => ({
   },
 }));
 
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: vi.fn(async () => "Asia/Shanghai"),
 }));
 

--- a/tests/unit/repository/leaderboard-provider-metrics.test.ts
+++ b/tests/unit/repository/leaderboard-provider-metrics.test.ts
@@ -29,7 +29,7 @@ const mockSelect = vi.fn(() => {
 
 const mocks = vi.hoisted(() => ({
   resolveSystemTimezone: vi.fn(),
-  getSystemSettings: vi.fn(),
+  getCachedSystemSettings: vi.fn(),
 }));
 
 vi.mock("@/drizzle/db", () => ({
@@ -82,12 +82,12 @@ vi.mock("@/drizzle/schema", () => ({
   users: {},
 }));
 
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: mocks.resolveSystemTimezone,
 }));
 
-vi.mock("@/repository/system-config", () => ({
-  getSystemSettings: mocks.getSystemSettings,
+vi.mock("@/lib/config", () => ({
+  getCachedSystemSettings: mocks.getCachedSystemSettings,
 }));
 
 describe("Provider Leaderboard Average Cost Metrics", () => {
@@ -97,7 +97,7 @@ describe("Provider Leaderboard Average Cost Metrics", () => {
     chainMocks = [];
     mockSelect.mockClear();
     mocks.resolveSystemTimezone.mockResolvedValue("UTC");
-    mocks.getSystemSettings.mockResolvedValue({ billingModelSource: "redirected" });
+    mocks.getCachedSystemSettings.mockResolvedValue({ billingModelSource: "redirected" });
   });
 
   it("computes avgCostPerRequest = totalCost / totalRequests for valid denominators", async () => {
@@ -243,7 +243,7 @@ describe("Provider Cache Hit Rate Model Breakdown", () => {
     chainMocks = [];
     mockSelect.mockClear();
     mocks.resolveSystemTimezone.mockResolvedValue("UTC");
-    mocks.getSystemSettings.mockResolvedValue({ billingModelSource: "redirected" });
+    mocks.getCachedSystemSettings.mockResolvedValue({ billingModelSource: "redirected" });
   });
 
   it("includes modelStats field on cache-hit leaderboard entries", async () => {

--- a/tests/unit/repository/leaderboard-timezone-parentheses.test.ts
+++ b/tests/unit/repository/leaderboard-timezone-parentheses.test.ts
@@ -47,6 +47,7 @@ function sqlToString(sqlObj: unknown): string {
 
 const mocks = vi.hoisted(() => ({
   resolveSystemTimezone: vi.fn(),
+  getCachedSystemSettings: vi.fn().mockResolvedValue({ billingModelSource: "redirected" }),
 }));
 
 function createThenableQuery<T>(result: T, whereArgs?: unknown[]) {
@@ -127,12 +128,12 @@ vi.mock("@/drizzle/schema", () => ({
   },
 }));
 
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: mocks.resolveSystemTimezone,
 }));
 
-vi.mock("@/repository/system-config", () => ({
-  getSystemSettings: vi.fn().mockResolvedValue({ billingModelSource: "redirected" }),
+vi.mock("@/lib/config", () => ({
+  getCachedSystemSettings: mocks.getCachedSystemSettings,
 }));
 
 describe("buildDateCondition - timezone parentheses regression", () => {

--- a/tests/unit/repository/overview-timezone-parentheses.test.ts
+++ b/tests/unit/repository/overview-timezone-parentheses.test.ts
@@ -108,7 +108,7 @@ vi.mock("@/drizzle/schema", () => ({
   },
 }));
 
-vi.mock("@/lib/utils/timezone", () => ({
+vi.mock("@/lib/utils/timezone.server", () => ({
   resolveSystemTimezone: mocks.resolveSystemTimezone,
 }));
 

--- a/tests/unit/usage-ledger/trigger.test.ts
+++ b/tests/unit/usage-ledger/trigger.test.ts
@@ -9,6 +9,11 @@ describe("fn_upsert_usage_ledger trigger SQL", () => {
     expect(sql).toContain("blocked_by = 'warmup'");
   });
 
+  it("skips blocked requests to avoid wasted ledger writes", () => {
+    expect(sql).toContain("NEW.blocked_by IS NOT NULL");
+    expect(sql).toContain("UPDATE usage_ledger SET blocked_by = NEW.blocked_by");
+  });
+
   it("contains ON CONFLICT UPSERT", () => {
     expect(sql).toContain("ON CONFLICT (request_id) DO UPDATE");
   });

--- a/tests/unit/usage-ledger/trigger.test.ts
+++ b/tests/unit/usage-ledger/trigger.test.ts
@@ -25,6 +25,14 @@ describe("fn_upsert_usage_ledger trigger SQL", () => {
     expect(sql).toContain("error_message IS NULL");
   });
 
+  it("skips irrelevant updates to reduce write amplification", () => {
+    expect(sql).toContain("TG_OP = 'UPDATE'");
+    expect(sql).toContain("IS NOT DISTINCT FROM");
+    // Ensure the skip logic compares derived values (usage_ledger doesn't persist provider_chain / error_message)
+    expect(sql).toContain("v_final_provider_id IS NOT DISTINCT FROM v_old_final_provider_id");
+    expect(sql).toContain("v_is_success IS NOT DISTINCT FROM v_old_is_success");
+  });
+
   it("creates trigger binding", () => {
     expect(sql).toContain("CREATE TRIGGER trg_upsert_usage_ledger");
   });

--- a/tests/unit/usage-ledger/trigger.test.ts
+++ b/tests/unit/usage-ledger/trigger.test.ts
@@ -2,9 +2,13 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-const sql = readFileSync(resolve(process.cwd(), "src/lib/ledger-backfill/trigger.sql"), "utf-8");
+// 以实际部署的迁移 SQL 为准（trigger.sql 主要用于回填/参考，不一定与最终迁移完全一致）。
+const sql = readFileSync(
+  resolve(process.cwd(), "drizzle/0079_perf_usage_ledger_trigger_skip_blocked_rows.sql"),
+  "utf-8"
+);
 
-describe("fn_upsert_usage_ledger trigger SQL", () => {
+describe("fn_upsert_usage_ledger migration SQL", () => {
   it("contains warmup exclusion check", () => {
     expect(sql).toContain("blocked_by = 'warmup'");
   });
@@ -40,7 +44,7 @@ describe("fn_upsert_usage_ledger trigger SQL", () => {
     expect(sql).toContain("EXISTS (SELECT 1 FROM usage_ledger WHERE request_id = NEW.id)");
   });
 
-  it("creates trigger binding", () => {
-    expect(sql).toContain("CREATE TRIGGER trg_upsert_usage_ledger");
+  it("creates function definition", () => {
+    expect(sql).toContain("CREATE OR REPLACE FUNCTION fn_upsert_usage_ledger");
   });
 });

--- a/tests/unit/usage-ledger/trigger.test.ts
+++ b/tests/unit/usage-ledger/trigger.test.ts
@@ -31,6 +31,8 @@ describe("fn_upsert_usage_ledger trigger SQL", () => {
     // Ensure the skip logic compares derived values (usage_ledger doesn't persist provider_chain / error_message)
     expect(sql).toContain("v_final_provider_id IS NOT DISTINCT FROM v_old_final_provider_id");
     expect(sql).toContain("v_is_success IS NOT DISTINCT FROM v_old_is_success");
+    // Self-heal: if ledger row is missing, later UPDATE can fill it (avoids permanent gaps)
+    expect(sql).toContain("EXISTS (SELECT 1 FROM usage_ledger WHERE request_id = NEW.id)");
   });
 
   it("creates trigger binding", () => {

--- a/tests/unit/usage-ledger/trigger.test.ts
+++ b/tests/unit/usage-ledger/trigger.test.ts
@@ -30,6 +30,11 @@ describe("fn_upsert_usage_ledger migration SQL", () => {
     expect(sql).toContain("jsonb_typeof");
   });
 
+  it("guards provider_chain id extraction cast range", () => {
+    expect(sql).toContain("2147483647");
+    expect(sql).toContain("length(NEW.provider_chain -> -1 ->> 'id') <= 10");
+  });
+
   it("computes is_success from error_message", () => {
     expect(sql).toContain("error_message IS NULL");
   });

--- a/tests/unit/usage-ledger/trigger.test.ts
+++ b/tests/unit/usage-ledger/trigger.test.ts
@@ -1,14 +1,21 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 // 以实际部署的迁移 SQL 为准（trigger.sql 主要用于回填/参考，不一定与最终迁移完全一致）。
-const sql = readFileSync(
-  resolve(process.cwd(), "drizzle/0079_perf_usage_ledger_trigger_skip_blocked_rows.sql"),
-  "utf-8"
-);
+const MIGRATION_FILENAME = "0079_perf_usage_ledger_trigger_skip_blocked_rows.sql";
+const sql = readFileSync(resolve(process.cwd(), `drizzle/${MIGRATION_FILENAME}`), "utf-8");
 
 describe("fn_upsert_usage_ledger migration SQL", () => {
+  it("uses latest relevant migration file", () => {
+    const latest = readdirSync(resolve(process.cwd(), "drizzle"))
+      .filter((name) => /^\d+_perf_usage_ledger_trigger_.*\.sql$/.test(name))
+      .sort()
+      .slice(-1)[0];
+
+    expect(latest).toBe(MIGRATION_FILENAME);
+  });
+
   it("contains warmup exclusion check", () => {
     expect(sql).toContain("blocked_by = 'warmup'");
   });
@@ -16,6 +23,8 @@ describe("fn_upsert_usage_ledger migration SQL", () => {
   it("skips blocked requests to avoid wasted ledger writes", () => {
     expect(sql).toContain("NEW.blocked_by IS NOT NULL");
     expect(sql).toContain("UPDATE usage_ledger SET blocked_by = NEW.blocked_by");
+    expect(sql).toContain("blocked_by IS DISTINCT FROM 'warmup'");
+    expect(sql).toContain("blocked_by IS DISTINCT FROM NEW.blocked_by");
   });
 
   it("contains ON CONFLICT UPSERT", () => {

--- a/tests/unit/usage-ledger/trigger.test.ts
+++ b/tests/unit/usage-ledger/trigger.test.ts
@@ -33,6 +33,7 @@ describe("fn_upsert_usage_ledger migration SQL", () => {
   it("guards provider_chain id extraction cast range", () => {
     expect(sql).toContain("2147483647");
     expect(sql).toContain("length(NEW.provider_chain -> -1 ->> 'id') <= 10");
+    expect(sql).toContain("length(OLD.provider_chain -> -1 ->> 'id') <= 10");
   });
 
   it("computes is_success from error_message", () => {


### PR DESCRIPTION
## 背景

常用页面（仪表盘 / 使用记录 / 排行榜 / 供应商管理）与代理热路径会频繁读取 `system_settings`；同时使用记录页在 `infiniteQuery` 场景下的自动刷新容易触发“全量 pages 重拉”，在多人同时打开页面时会持续放大 DB QPS 与 CPU。

## 相关工作

- **Follow-up to #815** - Dashboard 内存泄漏修复（轮询、缓存、定时器）
- **Related to #818** - Dashboard 懒加载实现即时首屏渲染

## 变更

- 系统设置缓存：新增 `getCachedSystemSettings()`（60s 进程内 TTL + in-flight 并发去重 + Redis Pub/Sub 跨实例失效；无 Redis 自动降级为纯 TTL）
- 保存系统设置后发布失效广播，确保各实例尽快拿到最新配置
- 常用页面 / 接口 / 代理热路径统一改用缓存设置（减少重复 DB 读取）
- 使用记录页自动刷新：仅轮询“最新一页”，并 merge + 去重（避免全量 refetch）
- 写入链路：`usage_ledger` 触发器在 `UPDATE` 时跳过“无关字段更新”导致的重复 UPSERT（比较派生值 `final_provider_id / is_success`），显著降低写放大；新增迁移 `0078_perf_usage_ledger_trigger_skip_irrelevant_updates.sql`
- 供应商管理页：合并 providers/health/system-settings 的读取为 `getProviderManagerBootstrapData()`，减少瀑布式请求（约 4 个请求 -> 2 个请求）；providers 列表改用 30s TTL + pub/sub 失效的进程缓存降低 DB 压力
- 文档沉淀：`docs/performance/common-pages-optimization-plan.md`

## 行为与兼容性

- Fail-open：读取设置失败返回上一份缓存或最小默认值，不阻塞请求；Redis 不可用时保持 TTL 行为
- 升级无感：不改变 API 协议与页面展示逻辑（除“更快、更省资源”外尽量无体感差异）
- 迁移兼容：仅 `CREATE OR REPLACE FUNCTION`，不改表结构/不 drop 对象

## 测试

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [ ] 手动测试：打开仪表盘/使用记录页，验证自动刷新正常工作且 DB 查询减少
- [ ] 手动测试：保存系统设置，验证跨实例缓存失效（多实例部署环境）

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

## Summary

implemented multi-layer performance optimizations targeting common pages (dashboard/usage logs/leaderboard/provider management) and proxy hot path to reduce DB QPS and CPU under concurrent load

**Key optimizations:**

- **System settings cache**: 60s TTL process cache with Redis pub/sub cross-instance invalidation (falling back to TTL-only if Redis unavailable), reducing repeated `system_settings` reads across dashboard/proxy/API paths
- **Usage logs polling**: refactored auto-refresh to poll only the latest page and merge into existing infinite list via deduplication, preventing react-query from refetching all pages simultaneously when multiple users have logs page open
- **Database trigger write reduction**: trigger now skips UPSERT when UPDATE doesn't affect usage_ledger-relevant fields (comparing derived values like `final_provider_id`/`is_success`), and completely skips ledger creation for blocked (non-billable) requests, significantly reducing write amplification
- **Provider management request consolidation**: merged providers/health/system-settings into single `getProviderManagerBootstrapData()` endpoint, reducing waterfall from ~4 requests to 2; provider list now uses 30s TTL + pub/sub invalidation cache
- **Fail-open design**: cache reads return stale data or safe defaults on DB failure rather than blocking requests; subscription failures don't prevent TTL-based cache operation

**Architecture strengths:**
- Strong consistency maintained for permission checks (`getAllowGlobalUsageViewFromDB` bypasses cache)
- Comprehensive test coverage for trigger logic
- Detailed performance documentation with risk-based roadmap (P0/P1/P2)
- Version-based concurrency control prevents cache corruption during invalidation races

**Known trade-offs** (already noted in previous comments):
- `special_settings` flush delay increased to 5s (larger data loss window on crash)
- Trigger self-heal EXISTS check adds overhead to every skipped UPDATE
- DB failure fallbacks get cached, allowing stale data across TTL windows
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- safe to merge with comprehensive testing and fail-open design ensuring production resilience
- strong architecture with process-level caching, cross-instance invalidation, and graceful degradation paths; comprehensive test coverage validates trigger logic and edge cases; backward-compatible migrations; permission-critical paths correctly bypass cache; known trade-offs (cache staleness during prolonged failures, larger flush windows) are documented and acceptable for performance gains
- manual verification needed: confirm cross-instance cache invalidation works in multi-instance deployment; monitor DB CPU/QPS reduction and trigger UPSERT skip rates in production; verify usage logs auto-refresh behavior under concurrent user load
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/config/system-settings-cache.ts | introduced 60s TTL process cache with Redis pub/sub cross-instance invalidation, in-flight deduplication, and fail-open fallbacks (lines 238-241 cache fallback on DB failure) |
| drizzle/0079_perf_usage_ledger_trigger_skip_blocked_rows.sql | extended trigger to skip creating ledger rows for blocked (non-billable) requests (lines 18-24), reducing write amplification for rate-limited/blocked traffic |
| src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx | polling only fetches latest page (line 193), merges with existing data via deduplication (lines 205-214), preventing infiniteQuery from refetching all pages |
| src/actions/providers.ts | added getProviderManagerBootstrapData() consolidating providers/health/system-settings into single call (line 364), reducing waterfall requests from ~4 to 2 |
| src/lib/cache/provider-cache.ts | introduced 30s TTL provider process cache with Redis pub/sub invalidation (lines 62-65), version-based concurrency control (line 29), and request-level snapshot consistency |
| src/repository/system-config.ts | getAllowGlobalUsageViewFromDB() uses strong-consistency direct DB read (line 282), bypassing cache for permission-critical field to avoid eventually-consistent authorization issues |
| docs/performance/common-pages-optimization-plan.md | comprehensive documentation of optimization rationale, implementation locations (lines 79-88), and future roadmap with risk-based prioritization (P0/P1/P2) |

</details>


</details>


<sub>Last reviewed commit: 160930e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->