### PR TITLE
供应商榜单支持展开模型明细

### DIFF
--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
@@ -41,7 +41,9 @@ interface LeaderboardTableProps<T> {
   period: LeaderboardPeriod;
   columns: ColumnDef<T>[]; // 不包含"排名"列，组件会自动添加
   getRowKey?: (row: T, index: number) => string | number;
+  /** 返回子行数据（非空且长度 > 0 时，父行展示可展开图标） */
   getSubRows?: (row: T, index: number) => T[] | null | undefined;
+  /** 子行的 React key（默认使用 `${parentKey}-${subIndex}` 组合） */
   getSubRowKey?: (
     subRow: T,
     parentRow: T,

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
@@ -28,7 +28,12 @@ import type { LeaderboardPeriod } from "@/repository/leaderboard";
 export interface ColumnDef<T> {
   header: string;
   className?: string;
-  cell: (row: T, index: number) => React.ReactNode;
+  /**
+   * index 语义：
+   * - 父行：按当前排序后的全局行序（从 0 开始）
+   * - 子行：父行内的子行序（从 0 开始）
+   */
+  cell: (row: T, index: number, isSubRow?: boolean) => React.ReactNode;
   sortKey?: string; // 用于排序的字段名
   getValue?: (row: T) => number | string; // 获取排序值的函数
   defaultBold?: boolean; // 默认加粗（无排序时显示加粗）
@@ -285,7 +290,7 @@ export function LeaderboardTable<TParent, TSub = TParent>({
                             key={idx}
                             className={`${col.className || ""} ${shouldBold ? "font-bold" : ""}`}
                           >
-                            {col.cell(row, index)}
+                            {col.cell(row, index, false)}
                           </TableCell>
                         );
                       })}
@@ -310,7 +315,7 @@ export function LeaderboardTable<TParent, TSub = TParent>({
                                   key={idx}
                                   className={`${col.className || ""} ${shouldBold ? "font-bold" : ""}`}
                                 >
-                                  {col.cell(subRow, subIndex)}
+                                  {col.cell(subRow, subIndex, true)}
                                 </TableCell>
                               );
                             })}

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
@@ -272,7 +272,9 @@ export function LeaderboardTable<TParent, TSub = TParent>({
                                 <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
                               )}
                             </button>
-                          ) : null}
+                          ) : (
+                            <div className="h-4 w-4" aria-hidden="true" />
+                          )}
                           {getRankBadge(rank)}
                         </div>
                       </TableCell>

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
@@ -36,31 +36,32 @@ export interface ColumnDef<T> {
 
 type SortDirection = "asc" | "desc" | null;
 
-interface LeaderboardTableProps<T> {
-  data: T[];
+interface LeaderboardTableProps<TParent, TSub = TParent> {
+  data: TParent[];
   period: LeaderboardPeriod;
-  columns: ColumnDef<T>[]; // 不包含"排名"列，组件会自动添加
-  getRowKey?: (row: T, index: number) => string | number;
+  columns: ColumnDef<TParent | TSub>[]; // 不包含"排名"列，组件会自动添加
+  getRowKey?: (row: TParent, index: number) => string | number;
   /** 返回子行数据（非空且长度 > 0 时，父行展示可展开图标） */
-  getSubRows?: (row: T, index: number) => T[] | null | undefined;
+  getSubRows?: (row: TParent, index: number) => TSub[] | null | undefined;
   /** 子行的 React key（默认使用 `${parentKey}-${subIndex}` 组合） */
   getSubRowKey?: (
-    subRow: T,
-    parentRow: T,
+    subRow: TSub,
+    parentRow: TParent,
     parentIndex: number,
     subIndex: number
   ) => string | number;
 }
 
-export function LeaderboardTable<T>({
+export function LeaderboardTable<TParent, TSub = TParent>({
   data,
   period,
   columns,
   getRowKey,
   getSubRows,
   getSubRowKey,
-}: LeaderboardTableProps<T>) {
+}: LeaderboardTableProps<TParent, TSub>) {
   const t = useTranslations("dashboard.leaderboard");
+  type TableRow = TParent | TSub;
 
   // 排序状态
   const [sortKey, setSortKey] = useState<string | null>(null);
@@ -89,7 +90,7 @@ export function LeaderboardTable<T>({
   }, [data, sortKey, sortDirection, getRowKey]);
 
   // 判断列是否需要加粗
-  const getShouldBold = (col: ColumnDef<T>) => {
+  const getShouldBold = (col: ColumnDef<TableRow>) => {
     const isActiveSortColumn = sortKey === col.sortKey && sortDirection !== null;
     const noSorting = sortKey === null;
     return isActiveSortColumn || (col.defaultBold && noSorting);

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
@@ -11,7 +11,7 @@ import {
   Trophy,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -79,6 +79,14 @@ export function LeaderboardTable<T>({
       return next;
     });
   };
+
+  // 当调用方未提供稳定 rowKey 时（回退到 index），排序会导致展开态错位；此时在排序/数据变化时清空展开态，至少避免错位展开。
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 依赖用于在排序/数据变化时触发清空，避免 index key 造成错位展开
+  useEffect(() => {
+    if (!getRowKey) {
+      setExpandedRows(new Set());
+    }
+  }, [data, sortKey, sortDirection, getRowKey]);
 
   // 判断列是否需要加粗
   const getShouldBold = (col: ColumnDef<T>) => {
@@ -244,18 +252,25 @@ export function LeaderboardTable<T>({
 
                 return (
                   <Fragment key={rowKey}>
-                    <TableRow
-                      className={`${isTopThree ? "bg-muted/50" : ""} ${hasExpandable ? "cursor-pointer" : ""}`}
-                      onClick={hasExpandable ? () => toggleRow(rowKey) : undefined}
-                    >
+                    <TableRow className={`${isTopThree ? "bg-muted/50" : ""}`}>
                       <TableCell>
                         <div className="flex items-center gap-1">
                           {hasExpandable ? (
-                            isExpanded ? (
-                              <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0" />
-                            ) : (
-                              <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
-                            )
+                            <button
+                              type="button"
+                              className="inline-flex items-center cursor-pointer rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                              onClick={() => toggleRow(rowKey)}
+                              aria-expanded={isExpanded}
+                              aria-label={
+                                isExpanded ? t("collapseModelStats") : t("expandModelStats")
+                              }
+                            >
+                              {isExpanded ? (
+                                <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0" />
+                              ) : (
+                                <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+                              )}
+                            </button>
                           ) : null}
                           {getRankBadge(rank)}
                         </div>

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
@@ -43,9 +43,9 @@ type ProviderEntry = Omit<ProviderLeaderboardEntry, "modelStats"> &
   ProviderCostFormattedFields & {
     modelStats?: ModelProviderStatClient[];
   };
-type ProviderRow = ProviderEntry | ModelProviderStatClient;
+type ProviderTableRow = ProviderEntry | ModelProviderStatClient;
 type ProviderCacheHitRateEntry = ProviderCacheHitRateLeaderboardEntry;
-type ProviderCacheHitRateRow = ProviderCacheHitRateEntry | ModelCacheHitStat;
+type ProviderCacheHitRateTableRow = ProviderCacheHitRateEntry | ModelCacheHitStat;
 type AnyEntry = UserEntry | ProviderEntry | ProviderCacheHitRateEntry | ModelEntry;
 
 const VALID_PERIODS: LeaderboardPeriod[] = ["daily", "weekly", "monthly", "allTime", "custom"];
@@ -221,7 +221,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     },
   ];
 
-  const providerColumns: ColumnDef<ProviderRow>[] = [
+  const providerColumns: ColumnDef<ProviderTableRow>[] = [
     {
       header: t("columns.provider"),
       cell: (row) => {
@@ -306,7 +306,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     },
   ];
 
-  const providerCacheHitRateColumns: ColumnDef<ProviderCacheHitRateRow>[] = [
+  const providerCacheHitRateColumns: ColumnDef<ProviderCacheHitRateTableRow>[] = [
     {
       header: t("columns.provider"),
       cell: (row) => {
@@ -411,26 +411,26 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
 
     if (scope === "provider") {
       return (
-        <LeaderboardTable<ProviderRow>
-          data={data as ProviderRow[]}
+        <LeaderboardTable<ProviderEntry, ModelProviderStatClient>
+          data={data as ProviderEntry[]}
           period={period}
           columns={providerColumns}
-          getRowKey={(row) => ("providerId" in row ? row.providerId : row.model)}
-          getSubRows={(row) => ("modelStats" in row ? row.modelStats : null)}
-          getSubRowKey={(subRow) => (subRow as ModelProviderStatClient).model}
+          getRowKey={(row) => row.providerId}
+          getSubRows={(row) => row.modelStats}
+          getSubRowKey={(subRow) => subRow.model}
         />
       );
     }
 
     if (scope === "providerCacheHitRate") {
       return (
-        <LeaderboardTable<ProviderCacheHitRateRow>
-          data={data as ProviderCacheHitRateRow[]}
+        <LeaderboardTable<ProviderCacheHitRateEntry, ModelCacheHitStat>
+          data={data as ProviderCacheHitRateEntry[]}
           period={period}
           columns={providerCacheHitRateColumns}
-          getRowKey={(row) => ("providerId" in row ? row.providerId : row.model)}
-          getSubRows={(row) => ("modelStats" in row ? row.modelStats : null)}
-          getSubRowKey={(subRow) => (subRow as ModelCacheHitStat).model}
+          getRowKey={(row) => row.providerId}
+          getSubRows={(row) => row.modelStats}
+          getSubRowKey={(subRow) => subRow.model}
         />
       );
     }

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
@@ -190,6 +190,12 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
   const skeletonGridStyle = { gridTemplateColumns: `repeat(${skeletonColumns}, minmax(0, 1fr))` };
 
   // 列定义（根据 scope 动态切换）
+  const renderSubModelLabel = (model: string) => (
+    <div className="pl-6">
+      <span className="font-mono text-sm">{model}</span>
+    </div>
+  );
+
   const userColumns: ColumnDef<UserEntry>[] = [
     {
       header: t("columns.user"),
@@ -226,11 +232,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
       header: t("columns.provider"),
       cell: (row) => {
         if ("providerName" in row) return row.providerName;
-        return (
-          <div className="pl-6">
-            <span className="font-mono text-sm">{row.model}</span>
-          </div>
-        );
+        return renderSubModelLabel(row.model);
       },
       sortKey: "providerName",
       getValue: (row) => ("providerName" in row ? row.providerName : row.model),
@@ -311,11 +313,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
       header: t("columns.provider"),
       cell: (row) => {
         if ("providerName" in row) return row.providerName;
-        return (
-          <div className="pl-6">
-            <span className="font-mono text-sm">{row.model}</span>
-          </div>
-        );
+        return renderSubModelLabel(row.model);
       },
       sortKey: "providerName",
       getValue: (row) => ("providerName" in row ? row.providerName : row.model),

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
@@ -395,52 +395,51 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     },
   ];
 
+  const renderUserTable = () => (
+    <LeaderboardTable<UserEntry>
+      data={data as UserEntry[]}
+      period={period}
+      columns={userColumns}
+      getRowKey={(row) => row.userId}
+    />
+  );
+
+  const renderProviderTable = () => (
+    <LeaderboardTable<ProviderEntry, ModelProviderStatClient>
+      data={data as ProviderEntry[]}
+      period={period}
+      columns={providerColumns}
+      getRowKey={(row) => row.providerId}
+      getSubRows={(row) => row.modelStats}
+      getSubRowKey={(subRow) => subRow.model}
+    />
+  );
+
+  const renderProviderCacheHitRateTable = () => (
+    <LeaderboardTable<ProviderCacheHitRateEntry, ModelCacheHitStat>
+      data={data as ProviderCacheHitRateEntry[]}
+      period={period}
+      columns={providerCacheHitRateColumns}
+      getRowKey={(row) => row.providerId}
+      getSubRows={(row) => row.modelStats}
+      getSubRowKey={(subRow) => subRow.model}
+    />
+  );
+
+  const renderModelTable = () => (
+    <LeaderboardTable<ModelEntry>
+      data={data as ModelEntry[]}
+      period={period}
+      columns={modelColumns}
+      getRowKey={(row) => row.model}
+    />
+  );
+
   const renderTable = () => {
-    if (scope === "user") {
-      return (
-        <LeaderboardTable<UserEntry>
-          data={data as UserEntry[]}
-          period={period}
-          columns={userColumns}
-          getRowKey={(row) => row.userId}
-        />
-      );
-    }
-
-    if (scope === "provider") {
-      return (
-        <LeaderboardTable<ProviderEntry, ModelProviderStatClient>
-          data={data as ProviderEntry[]}
-          period={period}
-          columns={providerColumns}
-          getRowKey={(row) => row.providerId}
-          getSubRows={(row) => row.modelStats}
-          getSubRowKey={(subRow) => subRow.model}
-        />
-      );
-    }
-
-    if (scope === "providerCacheHitRate") {
-      return (
-        <LeaderboardTable<ProviderCacheHitRateEntry, ModelCacheHitStat>
-          data={data as ProviderCacheHitRateEntry[]}
-          period={period}
-          columns={providerCacheHitRateColumns}
-          getRowKey={(row) => row.providerId}
-          getSubRows={(row) => row.modelStats}
-          getSubRowKey={(subRow) => subRow.model}
-        />
-      );
-    }
-
-    return (
-      <LeaderboardTable<ModelEntry>
-        data={data as ModelEntry[]}
-        period={period}
-        columns={modelColumns}
-        getRowKey={(row) => row.model}
-      />
-    );
+    if (scope === "user") return renderUserTable();
+    if (scope === "provider") return renderProviderTable();
+    if (scope === "providerCacheHitRate") return renderProviderCacheHitRateTable();
+    return renderModelTable();
   };
 
   return (

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
@@ -29,16 +29,23 @@ interface LeaderboardViewProps {
 }
 
 type LeaderboardScope = "user" | "provider" | "providerCacheHitRate" | "model";
-type UserEntry = LeaderboardEntry & { totalCostFormatted?: string };
-type ProviderEntry = ProviderLeaderboardEntry & {
+type TotalCostFormattedFields = { totalCostFormatted?: string };
+type ProviderCostFormattedFields = {
+  // API 额外返回的展示用字段（格式化后的字符串）
   totalCostFormatted?: string;
   avgCostPerRequestFormatted?: string | null;
   avgCostPerMillionTokensFormatted?: string | null;
 };
-type ProviderRow = ProviderEntry | ModelProviderStat;
+type UserEntry = LeaderboardEntry & TotalCostFormattedFields;
+type ModelEntry = ModelLeaderboardEntry & TotalCostFormattedFields;
+type ModelProviderStatClient = ModelProviderStat & ProviderCostFormattedFields;
+type ProviderEntry = Omit<ProviderLeaderboardEntry, "modelStats"> &
+  ProviderCostFormattedFields & {
+    modelStats?: ModelProviderStatClient[];
+  };
+type ProviderRow = ProviderEntry | ModelProviderStatClient;
 type ProviderCacheHitRateEntry = ProviderCacheHitRateLeaderboardEntry;
 type ProviderCacheHitRateRow = ProviderCacheHitRateEntry | ModelCacheHitStat;
-type ModelEntry = ModelLeaderboardEntry & { totalCostFormatted?: string };
 type AnyEntry = UserEntry | ProviderEntry | ProviderCacheHitRateEntry | ModelEntry;
 
 const VALID_PERIODS: LeaderboardPeriod[] = ["daily", "weekly", "monthly", "allTime", "custom"];
@@ -186,33 +193,30 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
   const userColumns: ColumnDef<UserEntry>[] = [
     {
       header: t("columns.user"),
-      cell: (row) => (row as UserEntry).userName,
+      cell: (row) => row.userName,
       sortKey: "userName",
-      getValue: (row) => (row as UserEntry).userName,
+      getValue: (row) => row.userName,
     },
     {
       header: t("columns.requests"),
       className: "text-right",
-      cell: (row) => (row as UserEntry).totalRequests.toLocaleString(),
+      cell: (row) => row.totalRequests.toLocaleString(),
       sortKey: "totalRequests",
-      getValue: (row) => (row as UserEntry).totalRequests,
+      getValue: (row) => row.totalRequests,
     },
     {
       header: t("columns.tokens"),
       className: "text-right",
-      cell: (row) => formatTokenAmount((row as UserEntry).totalTokens),
+      cell: (row) => formatTokenAmount(row.totalTokens),
       sortKey: "totalTokens",
-      getValue: (row) => (row as UserEntry).totalTokens,
+      getValue: (row) => row.totalTokens,
     },
     {
       header: t("columns.consumedAmount"),
       className: "text-right font-mono",
-      cell: (row) => {
-        const r = row as UserEntry & { totalCostFormatted?: string };
-        return r.totalCostFormatted ?? r.totalCost;
-      },
+      cell: (row) => row.totalCostFormatted ?? row.totalCost,
       sortKey: "totalCost",
-      getValue: (row) => (row as UserEntry).totalCost,
+      getValue: (row) => row.totalCost,
       defaultBold: true,
     },
   ];
@@ -241,10 +245,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     {
       header: t("columns.cost"),
       className: "text-right font-mono",
-      cell: (row) => {
-        const r = row as { totalCostFormatted?: string; totalCost: number };
-        return r.totalCostFormatted ?? r.totalCost;
-      },
+      cell: (row) => row.totalCostFormatted ?? row.totalCost,
       sortKey: "totalCost",
       getValue: (row) => row.totalCost,
       defaultBold: true,
@@ -288,9 +289,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
       className: "text-right font-mono",
       cell: (row) => {
         if (row.avgCostPerRequest == null) return "-";
-        const formatted = (row as { avgCostPerRequestFormatted?: string | null })
-          .avgCostPerRequestFormatted;
-        return formatted ?? row.avgCostPerRequest.toFixed(4);
+        return row.avgCostPerRequestFormatted ?? row.avgCostPerRequest.toFixed(4);
       },
       sortKey: "avgCostPerRequest",
       getValue: (row) => row.avgCostPerRequest ?? 0,
@@ -300,9 +299,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
       className: "text-right font-mono",
       cell: (row) => {
         if (row.avgCostPerMillionTokens == null) return "-";
-        const formatted = (row as { avgCostPerMillionTokensFormatted?: string | null })
-          .avgCostPerMillionTokensFormatted;
-        return formatted ?? row.avgCostPerMillionTokens.toFixed(2);
+        return row.avgCostPerMillionTokensFormatted ?? row.avgCostPerMillionTokens.toFixed(2);
       },
       sortKey: "avgCostPerMillionTokens",
       getValue: (row) => row.avgCostPerMillionTokens ?? 0,
@@ -365,41 +362,38 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
   const modelColumns: ColumnDef<ModelEntry>[] = [
     {
       header: t("columns.model"),
-      cell: (row) => <span className="font-mono text-sm">{(row as ModelEntry).model}</span>,
+      cell: (row) => <span className="font-mono text-sm">{row.model}</span>,
       sortKey: "model",
-      getValue: (row) => (row as ModelEntry).model,
+      getValue: (row) => row.model,
     },
     {
       header: t("columns.requests"),
       className: "text-right",
-      cell: (row) => (row as ModelEntry).totalRequests.toLocaleString(),
+      cell: (row) => row.totalRequests.toLocaleString(),
       sortKey: "totalRequests",
-      getValue: (row) => (row as ModelEntry).totalRequests,
+      getValue: (row) => row.totalRequests,
     },
     {
       header: t("columns.tokens"),
       className: "text-right",
-      cell: (row) => formatTokenAmount((row as ModelEntry).totalTokens),
+      cell: (row) => formatTokenAmount(row.totalTokens),
       sortKey: "totalTokens",
-      getValue: (row) => (row as ModelEntry).totalTokens,
+      getValue: (row) => row.totalTokens,
     },
     {
       header: t("columns.cost"),
       className: "text-right font-mono",
-      cell: (row) => {
-        const r = row as ModelEntry & { totalCostFormatted?: string };
-        return r.totalCostFormatted ?? r.totalCost;
-      },
+      cell: (row) => row.totalCostFormatted ?? row.totalCost,
       sortKey: "totalCost",
-      getValue: (row) => (row as ModelEntry).totalCost,
+      getValue: (row) => row.totalCost,
       defaultBold: true,
     },
     {
       header: t("columns.successRate"),
       className: "text-right",
-      cell: (row) => `${(Number((row as ModelEntry).successRate || 0) * 100).toFixed(1)}%`,
+      cell: (row) => `${(Number(row.successRate || 0) * 100).toFixed(1)}%`,
       sortKey: "successRate",
-      getValue: (row) => (row as ModelEntry).successRate,
+      getValue: (row) => row.successRate,
     },
   ];
 
@@ -418,12 +412,12 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     if (scope === "provider") {
       return (
         <LeaderboardTable<ProviderRow>
-          data={data as ProviderEntry[] as ProviderRow[]}
+          data={data as ProviderRow[]}
           period={period}
           columns={providerColumns}
           getRowKey={(row) => ("providerId" in row ? row.providerId : row.model)}
           getSubRows={(row) => ("modelStats" in row ? row.modelStats : null)}
-          getSubRowKey={(row) => ("model" in row ? row.model : row.providerId)}
+          getSubRowKey={(subRow) => (subRow as ModelProviderStatClient).model}
         />
       );
     }
@@ -431,12 +425,12 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     if (scope === "providerCacheHitRate") {
       return (
         <LeaderboardTable<ProviderCacheHitRateRow>
-          data={data as ProviderCacheHitRateEntry[] as ProviderCacheHitRateRow[]}
+          data={data as ProviderCacheHitRateRow[]}
           period={period}
           columns={providerCacheHitRateColumns}
           getRowKey={(row) => ("providerId" in row ? row.providerId : row.model)}
           getSubRows={(row) => ("modelStats" in row ? row.modelStats : null)}
-          getSubRowKey={(row) => ("model" in row ? row.model : row.providerId)}
+          getSubRowKey={(subRow) => (subRow as ModelCacheHitStat).model}
         />
       );
     }

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -231,7 +231,7 @@ export async function GET(request: NextRequest) {
         ...base,
         ...providerFields,
         ...cacheFields,
-        ...(modelStatsFormatted ? { modelStats: modelStatsFormatted } : {}),
+        ...(modelStatsFormatted !== undefined ? { modelStats: modelStatsFormatted } : {}),
       };
     });
 

--- a/src/lib/redis/leaderboard-cache.ts
+++ b/src/lib/redis/leaderboard-cache.ts
@@ -46,6 +46,7 @@ export interface LeaderboardFilters {
   providerType?: ProviderType;
   userTags?: string[];
   userGroups?: string[];
+  includeModelStats?: boolean;
 }
 
 /**
@@ -62,6 +63,8 @@ function buildCacheKey(
 ): string {
   const now = new Date();
   const providerTypeSuffix = filters?.providerType ? `:providerType:${filters.providerType}` : "";
+  const includeModelStatsSuffix =
+    scope === "provider" && filters?.includeModelStats ? ":includeModelStats" : "";
 
   let userFilterSuffix = "";
   if (scope === "user") {
@@ -76,22 +79,22 @@ function buildCacheKey(
 
   if (period === "custom" && dateRange) {
     // leaderboard:{scope}:custom:2025-01-01_2025-01-15:USD
-    return `leaderboard:${scope}:custom:${dateRange.startDate}_${dateRange.endDate}:${currencyDisplay}${providerTypeSuffix}${userFilterSuffix}`;
+    return `leaderboard:${scope}:custom:${dateRange.startDate}_${dateRange.endDate}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
   } else if (period === "daily") {
     // leaderboard:{scope}:daily:2025-01-15:USD
     const dateStr = formatInTimeZone(now, timezone, "yyyy-MM-dd");
-    return `leaderboard:${scope}:daily:${dateStr}:${currencyDisplay}${providerTypeSuffix}${userFilterSuffix}`;
+    return `leaderboard:${scope}:daily:${dateStr}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
   } else if (period === "weekly") {
     // leaderboard:{scope}:weekly:2025-W03:USD (ISO week)
     const weekStr = formatInTimeZone(now, timezone, "yyyy-'W'ww");
-    return `leaderboard:${scope}:weekly:${weekStr}:${currencyDisplay}${providerTypeSuffix}${userFilterSuffix}`;
+    return `leaderboard:${scope}:weekly:${weekStr}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
   } else if (period === "monthly") {
     // leaderboard:{scope}:monthly:2025-01:USD
     const monthStr = formatInTimeZone(now, timezone, "yyyy-MM");
-    return `leaderboard:${scope}:monthly:${monthStr}:${currencyDisplay}${providerTypeSuffix}${userFilterSuffix}`;
+    return `leaderboard:${scope}:monthly:${monthStr}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
   } else {
     // allTime: leaderboard:{scope}:allTime:USD (no date component)
-    return `leaderboard:${scope}:allTime:${currencyDisplay}${providerTypeSuffix}${userFilterSuffix}`;
+    return `leaderboard:${scope}:allTime:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
   }
 }
 
@@ -115,7 +118,11 @@ async function queryDatabase(
       return await findCustomRangeLeaderboard(dateRange, userFilters);
     }
     if (scope === "provider") {
-      return await findCustomRangeProviderLeaderboard(dateRange, filters?.providerType);
+      return await findCustomRangeProviderLeaderboard(
+        dateRange,
+        filters?.providerType,
+        filters?.includeModelStats
+      );
     }
     if (scope === "providerCacheHitRate") {
       return await findCustomRangeProviderCacheHitRateLeaderboard(dateRange, filters?.providerType);
@@ -140,15 +147,30 @@ async function queryDatabase(
   if (scope === "provider") {
     switch (period) {
       case "daily":
-        return await findDailyProviderLeaderboard(filters?.providerType);
+        return await findDailyProviderLeaderboard(
+          filters?.providerType,
+          filters?.includeModelStats
+        );
       case "weekly":
-        return await findWeeklyProviderLeaderboard(filters?.providerType);
+        return await findWeeklyProviderLeaderboard(
+          filters?.providerType,
+          filters?.includeModelStats
+        );
       case "monthly":
-        return await findMonthlyProviderLeaderboard(filters?.providerType);
+        return await findMonthlyProviderLeaderboard(
+          filters?.providerType,
+          filters?.includeModelStats
+        );
       case "allTime":
-        return await findAllTimeProviderLeaderboard(filters?.providerType);
+        return await findAllTimeProviderLeaderboard(
+          filters?.providerType,
+          filters?.includeModelStats
+        );
       default:
-        return await findDailyProviderLeaderboard(filters?.providerType);
+        return await findDailyProviderLeaderboard(
+          filters?.providerType,
+          filters?.includeModelStats
+        );
     }
   }
   if (scope === "providerCacheHitRate") {

--- a/src/lib/redis/leaderboard-cache.ts
+++ b/src/lib/redis/leaderboard-cache.ts
@@ -46,6 +46,7 @@ export interface LeaderboardFilters {
   providerType?: ProviderType;
   userTags?: string[];
   userGroups?: string[];
+  /** 仅 scope=provider 生效：是否包含按模型拆分的数据（ProviderLeaderboardEntry.modelStats） */
   includeModelStats?: boolean;
 }
 

--- a/src/lib/redis/leaderboard-cache.ts
+++ b/src/lib/redis/leaderboard-cache.ts
@@ -321,11 +321,16 @@ export async function getLeaderboardWithCache(
  *
  * @param period - 排行榜周期
  * @param currencyDisplay - 货币显示单位
+ * @param scope - 榜单范围
+ * @param dateRange - 自定义日期范围（仅 period=custom 时使用）
+ * @param filters - 过滤条件（会影响缓存键）
  */
 export async function invalidateLeaderboardCache(
   period: LeaderboardPeriod,
   currencyDisplay: string,
-  scope: LeaderboardScope = "user"
+  scope: LeaderboardScope = "user",
+  dateRange?: DateRangeParams,
+  filters?: LeaderboardFilters
 ): Promise<void> {
   const redis = getRedisClient();
   if (!redis) {
@@ -334,7 +339,7 @@ export async function invalidateLeaderboardCache(
 
   // Resolve timezone once per request
   const timezone = await resolveSystemTimezone();
-  const cacheKey = buildCacheKey(period, currencyDisplay, timezone, scope);
+  const cacheKey = buildCacheKey(period, currencyDisplay, timezone, scope, dateRange, filters);
 
   try {
     await redis.del(cacheKey);

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -301,6 +301,7 @@ export async function findCustomRangeLeaderboard(
 /**
  * 查询今日供应商消耗排行榜（不限制数量）
  * 使用 SQL AT TIME ZONE 进行时区转换，确保"今日"基于系统时区
+ * includeModelStats=true 时会额外返回按模型拆分的统计数据（modelStats）
  */
 export async function findDailyProviderLeaderboard(
   providerType?: ProviderType,
@@ -319,6 +320,7 @@ export async function findDailyProviderLeaderboard(
 /**
  * 查询本月供应商消耗排行榜（不限制数量）
  * 使用 SQL AT TIME ZONE 进行时区转换，确保"本月"基于系统时区
+ * includeModelStats=true 时会额外返回按模型拆分的统计数据（modelStats）
  */
 export async function findMonthlyProviderLeaderboard(
   providerType?: ProviderType,
@@ -336,6 +338,7 @@ export async function findMonthlyProviderLeaderboard(
 
 /**
  * 查询本周供应商消耗排行榜（不限制数量）
+ * includeModelStats=true 时会额外返回按模型拆分的统计数据（modelStats）
  */
 export async function findWeeklyProviderLeaderboard(
   providerType?: ProviderType,
@@ -353,6 +356,7 @@ export async function findWeeklyProviderLeaderboard(
 
 /**
  * 查询全部时间供应商消耗排行榜（不限制数量）
+ * includeModelStats=true 时会额外返回按模型拆分的统计数据（modelStats）
  */
 export async function findAllTimeProviderLeaderboard(
   providerType?: ProviderType,
@@ -430,6 +434,7 @@ export async function findAllTimeProviderCacheHitRateLeaderboard(
 
 /**
  * 通用供应商排行榜查询函数（使用 SQL AT TIME ZONE 确保时区正确）
+ * includeModelStats=true 时会额外返回按模型拆分的统计数据（modelStats）
  */
 async function findProviderLeaderboardWithTimezone(
   period: LeaderboardPeriod,
@@ -444,41 +449,53 @@ async function findProviderLeaderboardWithTimezone(
     providerType ? eq(providers.providerType, providerType) : undefined,
   ];
 
+  const totalRequestsExpr = sql<number>`count(*)::double precision`;
+  const totalCostExpr = sql<string>`COALESCE(sum(${usageLedger.costUsd}), 0)`;
+  const totalTokensExpr = sql<number>`COALESCE(
+    sum(
+      ${usageLedger.inputTokens} +
+      ${usageLedger.outputTokens} +
+      COALESCE(${usageLedger.cacheCreationInputTokens}, 0) +
+      COALESCE(${usageLedger.cacheReadInputTokens}, 0)
+    )::double precision,
+    0::double precision
+  )`;
+  const successRateExpr = sql<number>`COALESCE(
+    count(CASE WHEN ${usageLedger.isSuccess} THEN 1 END)::double precision
+    / NULLIF(count(*)::double precision, 0),
+    0::double precision
+  )`;
+  const avgTtfbMsExpr = sql<number>`COALESCE(avg(${usageLedger.ttfbMs})::double precision, 0::double precision)`;
+  const avgTokensPerSecondExpr = sql<number>`COALESCE(
+    avg(
+      CASE
+        WHEN ${usageLedger.outputTokens} > 0
+          AND ${usageLedger.durationMs} IS NOT NULL
+          AND ${usageLedger.ttfbMs} IS NOT NULL
+          AND ${usageLedger.ttfbMs} < ${usageLedger.durationMs}
+          AND (${usageLedger.durationMs} - ${usageLedger.ttfbMs}) >= 100
+        THEN (${usageLedger.outputTokens}::double precision)
+          / ((${usageLedger.durationMs} - ${usageLedger.ttfbMs}) / 1000.0)
+      END
+    )::double precision,
+    0::double precision
+  )`;
+
+  const computeAvgCosts = (totalCost: number, totalRequests: number, totalTokens: number) => ({
+    avgCostPerRequest: totalRequests > 0 ? totalCost / totalRequests : null,
+    avgCostPerMillionTokens: totalTokens > 0 ? (totalCost * 1_000_000) / totalTokens : null,
+  });
+
   const rankings = await db
     .select({
       providerId: usageLedger.finalProviderId,
       providerName: providers.name,
-      totalRequests: sql<number>`count(*)::double precision`,
-      totalCost: sql<string>`COALESCE(sum(${usageLedger.costUsd}), 0)`,
-      totalTokens: sql<number>`COALESCE(
-        sum(
-          ${usageLedger.inputTokens} +
-          ${usageLedger.outputTokens} +
-          COALESCE(${usageLedger.cacheCreationInputTokens}, 0) +
-          COALESCE(${usageLedger.cacheReadInputTokens}, 0)
-        )::double precision,
-        0::double precision
-      )`,
-      successRate: sql<number>`COALESCE(
-        count(CASE WHEN ${usageLedger.isSuccess} THEN 1 END)::double precision
-        / NULLIF(count(*)::double precision, 0),
-        0::double precision
-      )`,
-      avgTtfbMs: sql<number>`COALESCE(avg(${usageLedger.ttfbMs})::double precision, 0::double precision)`,
-      avgTokensPerSecond: sql<number>`COALESCE(
-        avg(
-          CASE
-            WHEN ${usageLedger.outputTokens} > 0
-              AND ${usageLedger.durationMs} IS NOT NULL
-              AND ${usageLedger.ttfbMs} IS NOT NULL
-              AND ${usageLedger.ttfbMs} < ${usageLedger.durationMs}
-              AND (${usageLedger.durationMs} - ${usageLedger.ttfbMs}) >= 100
-            THEN (${usageLedger.outputTokens}::double precision)
-              / ((${usageLedger.durationMs} - ${usageLedger.ttfbMs}) / 1000.0)
-          END
-        )::double precision,
-        0::double precision
-      )`,
+      totalRequests: totalRequestsExpr,
+      totalCost: totalCostExpr,
+      totalTokens: totalTokensExpr,
+      successRate: successRateExpr,
+      avgTtfbMs: avgTtfbMsExpr,
+      avgTokensPerSecond: avgTokensPerSecondExpr,
     })
     .from(usageLedger)
     .innerJoin(
@@ -495,6 +512,7 @@ async function findProviderLeaderboardWithTimezone(
     const totalCost = parseFloat(entry.totalCost);
     const totalRequests = entry.totalRequests;
     const totalTokens = entry.totalTokens;
+    const avgCosts = computeAvgCosts(totalCost, totalRequests, totalTokens);
     return {
       providerId: entry.providerId,
       providerName: entry.providerName,
@@ -504,8 +522,7 @@ async function findProviderLeaderboardWithTimezone(
       successRate: entry.successRate ?? 0,
       avgTtfbMs: entry.avgTtfbMs ?? 0,
       avgTokensPerSecond: entry.avgTokensPerSecond ?? 0,
-      avgCostPerRequest: totalRequests > 0 ? totalCost / totalRequests : null,
-      avgCostPerMillionTokens: totalTokens > 0 ? (totalCost * 1_000_000) / totalTokens : null,
+      ...avgCosts,
     };
   });
 
@@ -523,37 +540,12 @@ async function findProviderLeaderboardWithTimezone(
     .select({
       providerId: usageLedger.finalProviderId,
       model: modelField,
-      totalRequests: sql<number>`count(*)::double precision`,
-      totalCost: sql<string>`COALESCE(sum(${usageLedger.costUsd}), 0)`,
-      totalTokens: sql<number>`COALESCE(
-        sum(
-          ${usageLedger.inputTokens} +
-          ${usageLedger.outputTokens} +
-          COALESCE(${usageLedger.cacheCreationInputTokens}, 0) +
-          COALESCE(${usageLedger.cacheReadInputTokens}, 0)
-        )::double precision,
-        0::double precision
-      )`,
-      successRate: sql<number>`COALESCE(
-        count(CASE WHEN ${usageLedger.isSuccess} THEN 1 END)::double precision
-        / NULLIF(count(*)::double precision, 0),
-        0::double precision
-      )`,
-      avgTtfbMs: sql<number>`COALESCE(avg(${usageLedger.ttfbMs})::double precision, 0::double precision)`,
-      avgTokensPerSecond: sql<number>`COALESCE(
-        avg(
-          CASE
-            WHEN ${usageLedger.outputTokens} > 0
-              AND ${usageLedger.durationMs} IS NOT NULL
-              AND ${usageLedger.ttfbMs} IS NOT NULL
-              AND ${usageLedger.ttfbMs} < ${usageLedger.durationMs}
-              AND (${usageLedger.durationMs} - ${usageLedger.ttfbMs}) >= 100
-            THEN (${usageLedger.outputTokens}::double precision)
-              / ((${usageLedger.durationMs} - ${usageLedger.ttfbMs}) / 1000.0)
-          END
-        )::double precision,
-        0::double precision
-      )`,
+      totalRequests: totalRequestsExpr,
+      totalCost: totalCostExpr,
+      totalTokens: totalTokensExpr,
+      successRate: successRateExpr,
+      avgTtfbMs: avgTtfbMsExpr,
+      avgTokensPerSecond: avgTokensPerSecondExpr,
     })
     .from(usageLedger)
     .innerJoin(
@@ -568,10 +560,11 @@ async function findProviderLeaderboardWithTimezone(
 
   const modelStatsByProvider = new Map<number, ModelProviderStat[]>();
   for (const row of modelRows) {
-    if (!row.model || row.model.trim() === "") continue;
+    if (!row.model?.trim()) continue;
     const totalCost = parseFloat(row.totalCost);
     const totalRequests = row.totalRequests;
     const totalTokens = row.totalTokens;
+    const avgCosts = computeAvgCosts(totalCost, totalRequests, totalTokens);
     const stats = modelStatsByProvider.get(row.providerId) ?? [];
     stats.push({
       model: row.model,
@@ -581,8 +574,7 @@ async function findProviderLeaderboardWithTimezone(
       successRate: Math.min(Math.max(row.successRate ?? 0, 0), 1),
       avgTtfbMs: row.avgTtfbMs ?? 0,
       avgTokensPerSecond: row.avgTokensPerSecond ?? 0,
-      avgCostPerRequest: totalRequests > 0 ? totalCost / totalRequests : null,
-      avgCostPerMillionTokens: totalTokens > 0 ? (totalCost * 1_000_000) / totalTokens : null,
+      ...avgCosts,
     });
     modelStatsByProvider.set(row.providerId, stats);
   }
@@ -721,6 +713,7 @@ async function findProviderCacheHitRateLeaderboardWithTimezone(
 
 /**
  * 查询自定义日期范围供应商消耗排行榜
+ * includeModelStats=true 时会额外返回按模型拆分的统计数据（modelStats）
  */
 export async function findCustomRangeProviderLeaderboard(
   dateRange: DateRangeParams,

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -43,6 +43,23 @@ export interface ProviderLeaderboardEntry {
   avgTokensPerSecond: number; // tok/s（仅统计流式且可计算的请求）
   avgCostPerRequest: number | null; // totalCost / totalRequests, null when totalRequests === 0
   avgCostPerMillionTokens: number | null; // totalCost * 1_000_000 / totalTokens, null when totalTokens === 0
+  /** 可选：按模型拆分（仅在 includeModelStats=true 时填充） */
+  modelStats?: ModelProviderStat[];
+}
+
+/**
+ * 供应商消耗排行榜 - 模型级统计
+ */
+export interface ModelProviderStat {
+  model: string;
+  totalRequests: number;
+  totalCost: number;
+  totalTokens: number;
+  successRate: number; // 0-1
+  avgTtfbMs: number; // 毫秒
+  avgTokensPerSecond: number; // tok/s
+  avgCostPerRequest: number | null;
+  avgCostPerMillionTokens: number | null;
 }
 
 /**
@@ -286,10 +303,17 @@ export async function findCustomRangeLeaderboard(
  * 使用 SQL AT TIME ZONE 进行时区转换，确保"今日"基于系统时区
  */
 export async function findDailyProviderLeaderboard(
-  providerType?: ProviderType
+  providerType?: ProviderType,
+  includeModelStats?: boolean
 ): Promise<ProviderLeaderboardEntry[]> {
   const timezone = await resolveSystemTimezone();
-  return findProviderLeaderboardWithTimezone("daily", timezone, undefined, providerType);
+  return findProviderLeaderboardWithTimezone(
+    "daily",
+    timezone,
+    undefined,
+    providerType,
+    includeModelStats
+  );
 }
 
 /**
@@ -297,30 +321,51 @@ export async function findDailyProviderLeaderboard(
  * 使用 SQL AT TIME ZONE 进行时区转换，确保"本月"基于系统时区
  */
 export async function findMonthlyProviderLeaderboard(
-  providerType?: ProviderType
+  providerType?: ProviderType,
+  includeModelStats?: boolean
 ): Promise<ProviderLeaderboardEntry[]> {
   const timezone = await resolveSystemTimezone();
-  return findProviderLeaderboardWithTimezone("monthly", timezone, undefined, providerType);
+  return findProviderLeaderboardWithTimezone(
+    "monthly",
+    timezone,
+    undefined,
+    providerType,
+    includeModelStats
+  );
 }
 
 /**
  * 查询本周供应商消耗排行榜（不限制数量）
  */
 export async function findWeeklyProviderLeaderboard(
-  providerType?: ProviderType
+  providerType?: ProviderType,
+  includeModelStats?: boolean
 ): Promise<ProviderLeaderboardEntry[]> {
   const timezone = await resolveSystemTimezone();
-  return findProviderLeaderboardWithTimezone("weekly", timezone, undefined, providerType);
+  return findProviderLeaderboardWithTimezone(
+    "weekly",
+    timezone,
+    undefined,
+    providerType,
+    includeModelStats
+  );
 }
 
 /**
  * 查询全部时间供应商消耗排行榜（不限制数量）
  */
 export async function findAllTimeProviderLeaderboard(
-  providerType?: ProviderType
+  providerType?: ProviderType,
+  includeModelStats?: boolean
 ): Promise<ProviderLeaderboardEntry[]> {
   const timezone = await resolveSystemTimezone();
-  return findProviderLeaderboardWithTimezone("allTime", timezone, undefined, providerType);
+  return findProviderLeaderboardWithTimezone(
+    "allTime",
+    timezone,
+    undefined,
+    providerType,
+    includeModelStats
+  );
 }
 
 /**
@@ -390,7 +435,8 @@ async function findProviderLeaderboardWithTimezone(
   period: LeaderboardPeriod,
   timezone: string,
   dateRange?: DateRangeParams,
-  providerType?: ProviderType
+  providerType?: ProviderType,
+  includeModelStats?: boolean
 ): Promise<ProviderLeaderboardEntry[]> {
   const whereConditions = [
     LEDGER_BILLING_CONDITION,
@@ -445,7 +491,7 @@ async function findProviderLeaderboardWithTimezone(
     .groupBy(usageLedger.finalProviderId, providers.name)
     .orderBy(desc(sql`sum(${usageLedger.costUsd})`));
 
-  return rankings.map((entry) => {
+  const baseEntries: ProviderLeaderboardEntry[] = rankings.map((entry) => {
     const totalCost = parseFloat(entry.totalCost);
     const totalRequests = entry.totalRequests;
     const totalTokens = entry.totalTokens;
@@ -462,6 +508,89 @@ async function findProviderLeaderboardWithTimezone(
       avgCostPerMillionTokens: totalTokens > 0 ? (totalCost * 1_000_000) / totalTokens : null,
     };
   });
+
+  if (!includeModelStats) return baseEntries;
+
+  // Model breakdown per provider
+  const systemSettings = await getSystemSettings();
+  const billingModelSource = systemSettings.billingModelSource;
+  const modelField =
+    billingModelSource === "original"
+      ? sql<string>`COALESCE(${usageLedger.originalModel}, ${usageLedger.model})`
+      : sql<string>`COALESCE(${usageLedger.model}, ${usageLedger.originalModel})`;
+
+  const modelRows = await db
+    .select({
+      providerId: usageLedger.finalProviderId,
+      model: modelField,
+      totalRequests: sql<number>`count(*)::double precision`,
+      totalCost: sql<string>`COALESCE(sum(${usageLedger.costUsd}), 0)`,
+      totalTokens: sql<number>`COALESCE(
+        sum(
+          ${usageLedger.inputTokens} +
+          ${usageLedger.outputTokens} +
+          COALESCE(${usageLedger.cacheCreationInputTokens}, 0) +
+          COALESCE(${usageLedger.cacheReadInputTokens}, 0)
+        )::double precision,
+        0::double precision
+      )`,
+      successRate: sql<number>`COALESCE(
+        count(CASE WHEN ${usageLedger.isSuccess} THEN 1 END)::double precision
+        / NULLIF(count(*)::double precision, 0),
+        0::double precision
+      )`,
+      avgTtfbMs: sql<number>`COALESCE(avg(${usageLedger.ttfbMs})::double precision, 0::double precision)`,
+      avgTokensPerSecond: sql<number>`COALESCE(
+        avg(
+          CASE
+            WHEN ${usageLedger.outputTokens} > 0
+              AND ${usageLedger.durationMs} IS NOT NULL
+              AND ${usageLedger.ttfbMs} IS NOT NULL
+              AND ${usageLedger.ttfbMs} < ${usageLedger.durationMs}
+              AND (${usageLedger.durationMs} - ${usageLedger.ttfbMs}) >= 100
+            THEN (${usageLedger.outputTokens}::double precision)
+              / ((${usageLedger.durationMs} - ${usageLedger.ttfbMs}) / 1000.0)
+          END
+        )::double precision,
+        0::double precision
+      )`,
+    })
+    .from(usageLedger)
+    .innerJoin(
+      providers,
+      and(sql`${usageLedger.finalProviderId} = ${providers.id}`, isNull(providers.deletedAt))
+    )
+    .where(
+      and(...whereConditions.filter((c): c is NonNullable<(typeof whereConditions)[number]> => !!c))
+    )
+    .groupBy(usageLedger.finalProviderId, modelField)
+    .orderBy(desc(sql`sum(${usageLedger.costUsd})`), desc(sql`count(*)`));
+
+  const modelStatsByProvider = new Map<number, ModelProviderStat[]>();
+  for (const row of modelRows) {
+    if (!row.model || row.model.trim() === "") continue;
+    const totalCost = parseFloat(row.totalCost);
+    const totalRequests = row.totalRequests;
+    const totalTokens = row.totalTokens;
+    const stats = modelStatsByProvider.get(row.providerId) ?? [];
+    stats.push({
+      model: row.model,
+      totalRequests,
+      totalCost,
+      totalTokens,
+      successRate: Math.min(Math.max(row.successRate ?? 0, 0), 1),
+      avgTtfbMs: row.avgTtfbMs ?? 0,
+      avgTokensPerSecond: row.avgTokensPerSecond ?? 0,
+      avgCostPerRequest: totalRequests > 0 ? totalCost / totalRequests : null,
+      avgCostPerMillionTokens: totalTokens > 0 ? (totalCost * 1_000_000) / totalTokens : null,
+    });
+    modelStatsByProvider.set(row.providerId, stats);
+  }
+
+  return baseEntries.map((entry) => ({
+    ...entry,
+    modelStats: modelStatsByProvider.get(entry.providerId) ?? [],
+  }));
 }
 
 /**
@@ -595,10 +724,17 @@ async function findProviderCacheHitRateLeaderboardWithTimezone(
  */
 export async function findCustomRangeProviderLeaderboard(
   dateRange: DateRangeParams,
-  providerType?: ProviderType
+  providerType?: ProviderType,
+  includeModelStats?: boolean
 ): Promise<ProviderLeaderboardEntry[]> {
   const timezone = await resolveSystemTimezone();
-  return findProviderLeaderboardWithTimezone("custom", timezone, dateRange, providerType);
+  return findProviderLeaderboardWithTimezone(
+    "custom",
+    timezone,
+    dateRange,
+    providerType,
+    includeModelStats
+  );
 }
 
 /**

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -700,7 +700,7 @@ async function findProviderCacheHitRateLeaderboardWithTimezone(
       totalRequests: row.totalRequests,
       cacheReadTokens: row.cacheReadTokens,
       totalInputTokens: row.totalInputTokens,
-      cacheHitRate: Math.min(Math.max(row.cacheHitRate ?? 0, 0), 1),
+      cacheHitRate: clampRatio01(row.cacheHitRate),
     });
     modelStatsByProvider.set(row.providerId, stats);
   }
@@ -714,7 +714,7 @@ async function findProviderCacheHitRateLeaderboardWithTimezone(
     cacheCreationCost: parseFloat(entry.cacheCreationCost),
     totalInputTokens: entry.totalInputTokens,
     totalTokens: entry.totalInputTokens, // deprecated, for backward compatibility
-    cacheHitRate: Math.min(Math.max(entry.cacheHitRate ?? 0, 0), 1),
+    cacheHitRate: clampRatio01(entry.cacheHitRate),
     modelStats: modelStatsByProvider.get(entry.providerId) ?? [],
   }));
 }

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -45,7 +45,11 @@ export interface ProviderLeaderboardEntry {
   avgTokensPerSecond: number; // tok/s（仅统计流式且可计算的请求）
   avgCostPerRequest: number | null; // totalCost / totalRequests, null when totalRequests === 0
   avgCostPerMillionTokens: number | null; // totalCost * 1_000_000 / totalTokens, null when totalTokens === 0
-  /** 可选：按模型拆分（仅在 includeModelStats=true 时填充） */
+  /**
+   * 可选：按模型拆分
+   * - undefined: 未请求 includeModelStats
+   * - []: 已请求 includeModelStats，但该 provider 下无可用模型统计
+   */
   modelStats?: ModelProviderStat[];
 }
 

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -537,10 +537,11 @@ async function findProviderLeaderboardWithTimezone(
   // Model breakdown per provider
   const systemSettings = await getSystemSettings();
   const billingModelSource = systemSettings.billingModelSource;
-  const modelField =
+  const rawModelField =
     billingModelSource === "original"
       ? sql<string>`COALESCE(${usageLedger.originalModel}, ${usageLedger.model})`
       : sql<string>`COALESCE(${usageLedger.model}, ${usageLedger.originalModel})`;
+  const modelField = sql<string>`NULLIF(TRIM(${rawModelField}), '')`;
 
   const modelRows = await db
     .select({
@@ -566,7 +567,7 @@ async function findProviderLeaderboardWithTimezone(
 
   const modelStatsByProvider = new Map<number, ModelProviderStat[]>();
   for (const row of modelRows) {
-    if (!row.model?.trim()) continue;
+    if (!row.model) continue;
     const totalCost = parseFloat(row.totalCost);
     const totalRequests = row.totalRequests;
     const totalTokens = row.totalTokens;
@@ -656,10 +657,11 @@ async function findProviderCacheHitRateLeaderboardWithTimezone(
   // Model-level cache hit breakdown per provider
   const systemSettings = await getSystemSettings();
   const billingModelSource = systemSettings.billingModelSource;
-  const modelField =
+  const rawModelField =
     billingModelSource === "original"
       ? sql<string>`COALESCE(${usageLedger.originalModel}, ${usageLedger.model})`
       : sql<string>`COALESCE(${usageLedger.model}, ${usageLedger.originalModel})`;
+  const modelField = sql<string>`NULLIF(TRIM(${rawModelField}), '')`;
 
   const modelTotalInput = sql<number>`COALESCE(sum(${totalInputTokensExpr})::double precision, 0::double precision)`;
   const modelCacheRead = sql<number>`COALESCE(sum(COALESCE(${usageLedger.cacheReadInputTokens}, 0))::double precision, 0::double precision)`;
@@ -691,7 +693,7 @@ async function findProviderCacheHitRateLeaderboardWithTimezone(
   // Group model stats by providerId
   const modelStatsByProvider = new Map<number, ModelCacheHitStat[]>();
   for (const row of modelRows) {
-    if (!row.model || row.model.trim() === "") continue;
+    if (!row.model) continue;
     const stats = modelStatsByProvider.get(row.providerId) ?? [];
     stats.push({
       model: row.model,

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -8,6 +8,8 @@ import type { ProviderType } from "@/types/provider";
 import { LEDGER_BILLING_CONDITION } from "./_shared/ledger-conditions";
 import { getSystemSettings } from "./system-config";
 
+const clampRatio01 = (value: number | null | undefined) => Math.min(Math.max(value ?? 0, 0), 1);
+
 /**
  * 排行榜条目类型
  */
@@ -519,7 +521,7 @@ async function findProviderLeaderboardWithTimezone(
       totalRequests,
       totalCost,
       totalTokens,
-      successRate: entry.successRate ?? 0,
+      successRate: clampRatio01(entry.successRate),
       avgTtfbMs: entry.avgTtfbMs ?? 0,
       avgTokensPerSecond: entry.avgTokensPerSecond ?? 0,
       ...avgCosts,
@@ -571,7 +573,7 @@ async function findProviderLeaderboardWithTimezone(
       totalRequests,
       totalCost,
       totalTokens,
-      successRate: Math.min(Math.max(row.successRate ?? 0, 0), 1),
+      successRate: clampRatio01(row.successRate),
       avgTtfbMs: row.avgTtfbMs ?? 0,
       avgTokensPerSecond: row.avgTokensPerSecond ?? 0,
       ...avgCosts,
@@ -833,7 +835,7 @@ async function findModelLeaderboardWithTimezone(
       totalRequests: entry.totalRequests,
       totalCost: parseFloat(entry.totalCost),
       totalTokens: entry.totalTokens,
-      successRate: entry.successRate ?? 0,
+      successRate: clampRatio01(entry.successRate),
     }));
 }
 

--- a/tests/unit/api/leaderboard-route.test.ts
+++ b/tests/unit/api/leaderboard-route.test.ts
@@ -249,5 +249,42 @@ describe("GET /api/leaderboard", () => {
       expect(entry.modelStats[0]).toHaveProperty("avgCostPerRequestFormatted");
       expect(entry.modelStats[0]).toHaveProperty("avgCostPerMillionTokensFormatted");
     });
+
+    it("returns empty modelStats array when includeModelStats is requested but provider has no model data", async () => {
+      mocks.getSession.mockResolvedValue({ user: { id: 1, name: "u", role: "admin" } });
+      mocks.getLeaderboardWithCache.mockResolvedValue([
+        {
+          providerId: 1,
+          providerName: "empty-models-provider",
+          totalRequests: 10,
+          totalCost: 1.0,
+          totalTokens: 1000,
+          successRate: 1,
+          avgTtfbMs: 100,
+          avgTokensPerSecond: 20,
+          avgCostPerRequest: 0.1,
+          avgCostPerMillionTokens: 1000,
+          modelStats: [],
+        },
+      ]);
+
+      const { GET } = await import("@/app/api/leaderboard/route");
+      const url =
+        "http://localhost/api/leaderboard?scope=provider&period=daily&includeModelStats=1";
+      const response = await GET({ nextUrl: new URL(url) } as any);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(mocks.getLeaderboardWithCache).toHaveBeenCalledTimes(1);
+
+      const callArgs = mocks.getLeaderboardWithCache.mock.calls[0];
+      const options = callArgs[4];
+      expect(options.includeModelStats).toBe(true);
+
+      expect(body).toHaveLength(1);
+      expect(body[0]).toHaveProperty("modelStats");
+      expect(Array.isArray(body[0].modelStats)).toBe(true);
+      expect(body[0].modelStats).toHaveLength(0);
+    });
   });
 });

--- a/tests/unit/dashboard/leaderboard-table-expandable-rows.test.tsx
+++ b/tests/unit/dashboard/leaderboard-table-expandable-rows.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type ColumnDef,
+  LeaderboardTable,
+} from "@/app/[locale]/dashboard/leaderboard/_components/leaderboard-table";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+type ChildRow = {
+  model: string;
+  totalRequests: number;
+};
+
+type ParentRow = {
+  providerId: number;
+  providerName: string;
+  totalRequests: number;
+  modelStats: ChildRow[];
+};
+
+type Row = ParentRow | ChildRow;
+
+describe("LeaderboardTable expandable rows", () => {
+  let container: HTMLDivElement | null = null;
+  let root: ReturnType<typeof createRoot> | null = null;
+
+  function renderSimple(node: ReactNode) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root!.render(node));
+    return { container, root };
+  }
+
+  afterEach(() => {
+    if (root) {
+      act(() => root!.unmount());
+      root = null;
+    }
+    if (container) {
+      container.remove();
+      container = null;
+    }
+  });
+
+  it("renders sub rows inline (no nested table) and toggles on click", () => {
+    const data: ParentRow[] = [
+      {
+        providerId: 1,
+        providerName: "Provider A",
+        totalRequests: 10,
+        modelStats: [
+          { model: "model-x", totalRequests: 6 },
+          { model: "model-y", totalRequests: 4 },
+        ],
+      },
+    ];
+
+    const columns: ColumnDef<Row>[] = [
+      {
+        header: "name",
+        cell: (row) => ("providerName" in row ? row.providerName : row.model),
+      },
+      {
+        header: "requests",
+        className: "text-right",
+        cell: (row) => String(row.totalRequests),
+      },
+    ];
+
+    const { container } = renderSimple(
+      <LeaderboardTable<Row>
+        data={data as Row[]}
+        period="daily"
+        columns={columns}
+        getRowKey={(row) => ("providerId" in row ? row.providerId : row.model)}
+        getSubRows={(row) => ("modelStats" in row ? row.modelStats : null)}
+        getSubRowKey={(row) => ("model" in row ? row.model : row.providerId)}
+      />
+    );
+
+    const findCellByText = (text: string) =>
+      Array.from(container.querySelectorAll("td")).find((td) => td.textContent?.trim() === text) ??
+      null;
+
+    expect(findCellByText("Provider A")).toBeTruthy();
+    expect(findCellByText("model-x")).toBeNull();
+
+    const providerCell = findCellByText("Provider A")!;
+    act(() => {
+      providerCell.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const modelCell = findCellByText("model-x");
+    expect(modelCell).toBeTruthy();
+
+    const modelRow = modelCell!.closest("tr");
+    expect(modelRow).toBeTruthy();
+    expect(modelRow!.className).toContain("bg-muted/30");
+  });
+});

--- a/tests/unit/dashboard/leaderboard-table-expandable-rows.test.tsx
+++ b/tests/unit/dashboard/leaderboard-table-expandable-rows.test.tsx
@@ -103,6 +103,7 @@ describe("LeaderboardTable expandable rows", () => {
     act(() => {
       expandButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
+    expect(expandButton!.getAttribute("aria-expanded")).toBe("true");
 
     const modelCell = findCellByText("model-x");
     expect(modelCell).toBeTruthy();
@@ -110,5 +111,11 @@ describe("LeaderboardTable expandable rows", () => {
     const modelRow = modelCell!.closest("tr");
     expect(modelRow).toBeTruthy();
     expect(modelRow!.className).toContain("bg-muted/30");
+
+    act(() => {
+      expandButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(expandButton!.getAttribute("aria-expanded")).toBe("false");
+    expect(findCellByText("model-x")).toBeNull();
   });
 });

--- a/tests/unit/dashboard/leaderboard-table-expandable-rows.test.tsx
+++ b/tests/unit/dashboard/leaderboard-table-expandable-rows.test.tsx
@@ -94,9 +94,14 @@ describe("LeaderboardTable expandable rows", () => {
     expect(findCellByText("Provider A")).toBeTruthy();
     expect(findCellByText("model-x")).toBeNull();
 
-    const providerCell = findCellByText("Provider A")!;
+    const expandButton = container.querySelector(
+      'button[aria-label="expandModelStats"]'
+    ) as HTMLButtonElement | null;
+    expect(expandButton).toBeTruthy();
+    expect(expandButton!.getAttribute("aria-expanded")).toBe("false");
+
     act(() => {
-      providerCell.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      expandButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     const modelCell = findCellByText("model-x");

--- a/tests/unit/dashboard/leaderboard-table-expandable-rows.test.tsx
+++ b/tests/unit/dashboard/leaderboard-table-expandable-rows.test.tsx
@@ -77,13 +77,13 @@ describe("LeaderboardTable expandable rows", () => {
     ];
 
     const { container } = renderSimple(
-      <LeaderboardTable<Row>
-        data={data as Row[]}
+      <LeaderboardTable<ParentRow, ChildRow>
+        data={data}
         period="daily"
         columns={columns}
-        getRowKey={(row) => ("providerId" in row ? row.providerId : row.model)}
-        getSubRows={(row) => ("modelStats" in row ? row.modelStats : null)}
-        getSubRowKey={(row) => ("model" in row ? row.model : row.providerId)}
+        getRowKey={(row) => row.providerId}
+        getSubRows={(row) => row.modelStats}
+        getSubRowKey={(subRow) => subRow.model}
       />
     );
 


### PR DESCRIPTION
## Summary
供应商榜单（Provider Leaderboard）新增模型级明细展开功能。用户现在可以在供应商排行和缓存命中率排行中展开查看每个供应商下的模型拆分数据。

This PR adds model-level breakdown expansion to the Provider Leaderboard. Users can now expand each provider to view per-model statistics in both the provider consumption ranking and cache hit rate ranking.

---

## Changes

### UI Enhancements
- **表内子行展示** (In-table sub-row display): 模型明细改为表内子行展示，复用原表头列，以灰色背景区分，视觉体验更加统一
- **展开交互优化** (Expand interaction): LeaderboardTable 组件重构为支持 `getSubRows` 和 `getSubRowKey` 属性，取代原来的 `renderExpandedContent` 方式

### API Changes
- **新增 `includeModelStats` 参数** (New query parameter): `GET /api/leaderboard?scope=provider` 支持 `includeModelStats=1` 参数，返回供应商下各模型的拆分数据
- **Redis 缓存键更新** (Redis cache key): `includeModelStats` 开关纳入 Redis 缓存键，确保不同参数请求返回正确缓存

### Repository Layer
- **新增 `ModelProviderStat` 类型** (New type): 定义供应商消耗排行的模型级统计结构
- **聚合查询优化** (Aggregation query): 启用 `includeModelStats` 时，通过 SQL 聚合查询 provider+model 级别的指标数据

---

## Testing

### 新增单元测试
- `tests/unit/api/leaderboard-route.test.ts` - 验证 `includeModelStats` 参数传递及响应格式化
- `tests/unit/dashboard/leaderboard-table-expandable-rows.test.tsx` - 验证 LeaderboardTable 子行渲染逻辑
- `tests/unit/repository/leaderboard-provider-metrics.test.ts` - 验证供应商指标计算及 modelStats 聚合

### 手动验证清单
- [ ] 供应商排行页面展开/折叠功能正常
- [ ] 缓存命中率排行展开/折叠功能正常
- [ ] 子行数据（请求数、成本、Token 等）计算正确
- [ ] Redis 缓存键包含 `includeModelStats` 标识
- [ ] 无模型数据的供应商不显示展开按钮

---

## API 文档

### `GET /api/leaderboard?scope=provider`

**新增参数：**

| 参数 | 类型 | 说明 |
|------|------|------|
| `includeModelStats` | `1` \| `true` \| `yes` | 是否返回供应商下各模型的拆分数据 |

**响应示例：**

```json
[
  {
    "providerId": 1,
    "providerName": "test-provider",
    "totalRequests": 10,
    "totalCost": 1.5,
    "totalCostFormatted": "$1.50",
    "totalTokens": 1000,
    "successRate": 1,
    "avgTtfbMs": 100,
    "avgTokensPerSecond": 20,
    "avgCostPerRequest": 0.15,
    "avgCostPerRequestFormatted": "$0.15",
    "avgCostPerMillionTokens": 1500,
    "avgCostPerMillionTokensFormatted": "$1,500.00",
    "modelStats": [
      {
        "model": "model-a",
        "totalRequests": 6,
        "totalCost": 1.0,
        "totalCostFormatted": "$1.00",
        "totalTokens": 600,
        "successRate": 1,
        "avgTtfbMs": 110,
        "avgTokensPerSecond": 25,
        "avgCostPerRequest": 0.1667,
        "avgCostPerRequestFormatted": "$0.17",
        "avgCostPerMillionTokens": 1666.7,
        "avgCostPerMillionTokensFormatted": "$1,666.70"
      }
    ]
  }
]
```

---

## Checklist

- [x] 代码符合项目规范 (Code follows project conventions)
- [x] 自测完成 (Self-review completed)
- [x] 单元测试通过 (Unit tests passing)
- [x] 类型检查通过 (TypeScript typecheck passing)
- [x] Lint 检查通过 (Lint checks passing)
- [x] 构建成功 (Build successful)

---

*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds model-level breakdown expansion to provider leaderboards. Users can expand provider rows to view per-model statistics for consumption and cache hit rate rankings.

## Key Changes

- **Expandable table component**: Refactored `LeaderboardTable` to support sub-row rendering via `getSubRows` and `getSubRowKey` props
- **API parameter**: Added `includeModelStats` query parameter for `GET /api/leaderboard?scope=provider`
- **Repository queries**: Provider leaderboard conditionally executes a second SQL aggregation for model breakdown; cache hit rate leaderboard unconditionally includes model stats
- **Redis cache keys**: Updated to include `includeModelStats` flag for correct cache differentiation
- **Test coverage**: Comprehensive unit tests for API, UI, and repository layers

## Issues Addressed in Previous Threads

Many potential issues were already identified in previous review threads and should be considered before merge. Notable concerns include performance implications of the unconditional cache hit rate model query, lack of configurability for `includeModelStats` in the UI, and missing error handling for model stats query failures.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- This PR is moderately safe to merge with several performance and architecture concerns that should be addressed
- Score reflects solid implementation with comprehensive tests, but previous review threads identified significant performance and design issues that remain unaddressed. The unconditional secondary query for cache hit rate leaderboard and lack of model stats pagination could impact production performance.
- Pay close attention to `src/repository/leaderboard.ts` (unconditional model query performance) and `src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx` (hardcoded includeModelStats with no UI control)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx | Added expandable row support with `getSubRows` and `getSubRowKey` props. Sub-rows render inline with gray background. Added `isSubRow` parameter to cell renderers for semantic clarity. |
| src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx | Integrated expandable rows for provider and cache hit rate tables. Hardcoded `includeModelStats=1` for provider scope with no UI toggle. Column definitions handle both parent and sub-row rendering. |
| src/app/api/leaderboard/route.ts | Added `includeModelStats` parameter parsing for provider scope. Formats nested `modelStats` arrays with currency fields. Type assertions assume repository schema without runtime validation. |
| src/repository/leaderboard.ts | Added model-level breakdown queries for provider and cache hit rate leaderboards. Provider leaderboard conditionally includes model stats. Cache hit rate leaderboard unconditionally runs secondary model query on every request. |

</details>


</details>


<sub>Last reviewed commit: 8bf905a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->