### PR TITLE
fix: address bugbot review issues from codex service tier PR

### DIFF
--- a/messages/ru/dashboard.json
+++ b/messages/ru/dashboard.json
@@ -284,7 +284,7 @@
         "multiplier": "Множитель поставщика",
         "totalCost": "Общая стоимость",
         "fast": "fast",
-        "fastPriority": "Priority service tier (fast mode)",
+        "fastPriority": "Приоритетный уровень обслуживания (режим fast)",
         "context1m": "1M контекст",
         "context1mPricing": "Вход 2x >200k, Выход 1.5x >200k"
       },
@@ -377,7 +377,7 @@
       "multiplier": "Множитель поставщика",
       "totalCost": "Общая стоимость",
       "fast": "fast",
-      "fastPriority": "Priority service tier (fast mode)",
+      "fastPriority": "Приоритетный уровень обслуживания (режим fast)",
       "context1m": "1M Контекст",
       "context1mPricing": "Вход >200k 2x, Выход >200k 1.5x"
     }

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -284,7 +284,7 @@
         "multiplier": "供应商倍率",
         "totalCost": "总费用",
         "fast": "fast",
-        "fastPriority": "Priority service tier（fast 模式）",
+        "fastPriority": "优先服务等级（fast 模式）",
         "context1m": "1M 上下文",
         "context1mPricing": "输入 2x >200k, 输出 1.5x >200k"
       },
@@ -377,7 +377,7 @@
       "multiplier": "供应商倍率",
       "totalCost": "总费用",
       "fast": "fast",
-      "fastPriority": "Priority service tier（fast 模式）",
+      "fastPriority": "优先服务等级（fast 模式）",
       "context1m": "1M 上下文",
       "context1mPricing": "输入 >200k 2倍, 输出 >200k 1.5倍"
     }

--- a/messages/zh-TW/dashboard.json
+++ b/messages/zh-TW/dashboard.json
@@ -284,7 +284,7 @@
         "multiplier": "供應商倍率",
         "totalCost": "總費用",
         "fast": "fast",
-        "fastPriority": "Priority service tier（fast 模式）",
+        "fastPriority": "優先服務層級（fast 模式）",
         "context1m": "1M 上下文",
         "context1mPricing": "輸入 2x >200k, 輸出 1.5x >200k"
       },
@@ -377,7 +377,7 @@
       "multiplier": "供應商倍率",
       "totalCost": "總費用",
       "fast": "fast",
-      "fastPriority": "Priority service tier（fast 模式）",
+      "fastPriority": "優先服務層級（fast 模式）",
       "context1m": "1M 上下文長度",
       "context1mPricing": "輸入 >200k 2倍, 輸出 >200k 1.5倍"
     }

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -2166,6 +2166,7 @@ export interface BatchUpdateProvidersParams {
     allowed_models?: string[] | null;
     allowed_clients?: string[];
     blocked_clients?: string[];
+    codex_service_tier_preference?: CodexServiceTierPreference | null;
     anthropic_thinking_budget_preference?: AnthropicThinkingBudgetPreference | null;
     anthropic_adaptive_thinking?: AnthropicAdaptiveThinkingConfig | null;
   };
@@ -2219,6 +2220,9 @@ export async function batchUpdateProviders(
     }
     if (updates.blocked_clients !== undefined) {
       repositoryUpdates.blockedClients = updates.blocked_clients;
+    }
+    if (updates.codex_service_tier_preference !== undefined) {
+      repositoryUpdates.codexServiceTierPreference = updates.codex_service_tier_preference;
     }
     if (updates.anthropic_thinking_budget_preference !== undefined) {
       repositoryUpdates.anthropicThinkingBudgetPreference =

--- a/src/app/[locale]/settings/providers/_components/forms/provider-form/sections/routing-section.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/provider-form/sections/routing-section.tsx
@@ -670,7 +670,11 @@ export function RoutingSection() {
                         disabled={state.ui.isPending}
                       >
                         <SelectTrigger className="w-full">
-                          <SelectValue placeholder="inherit" />
+                          <SelectValue
+                            placeholder={t(
+                              "sections.routing.codexOverrides.serviceTier.options.inherit"
+                            )}
+                          />
                         </SelectTrigger>
                         <SelectContent>
                           {["inherit", "auto", "default", "flex", "priority"].map((val) => (

--- a/src/lib/provider-patch-contract.ts
+++ b/src/lib/provider-patch-contract.ts
@@ -881,6 +881,9 @@ function applyPatchField<T>(
     case "codex_parallel_tool_calls_preference":
       updates.codex_parallel_tool_calls_preference = "inherit";
       return { ok: true, data: undefined };
+    case "codex_service_tier_preference":
+      updates.codex_service_tier_preference = "inherit";
+      return { ok: true, data: undefined };
     case "anthropic_max_tokens_preference":
       updates.anthropic_max_tokens_preference = "inherit";
       return { ok: true, data: undefined };

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -372,7 +372,7 @@ export interface Provider {
   codexReasoningSummaryPreference: CodexReasoningSummaryPreference | null;
   codexTextVerbosityPreference: CodexTextVerbosityPreference | null;
   codexParallelToolCallsPreference: CodexParallelToolCallsPreference | null;
-  codexServiceTierPreference?: CodexServiceTierPreference | null;
+  codexServiceTierPreference: CodexServiceTierPreference | null;
 
   // Anthropic (Messages API) parameter overrides (only for claude/claude-auth providers)
   anthropicMaxTokensPreference: AnthropicMaxTokensPreference | null;
@@ -459,7 +459,7 @@ export interface ProviderDisplay {
   codexReasoningSummaryPreference: CodexReasoningSummaryPreference | null;
   codexTextVerbosityPreference: CodexTextVerbosityPreference | null;
   codexParallelToolCallsPreference: CodexParallelToolCallsPreference | null;
-  codexServiceTierPreference?: CodexServiceTierPreference | null;
+  codexServiceTierPreference: CodexServiceTierPreference | null;
   anthropicMaxTokensPreference: AnthropicMaxTokensPreference | null;
   anthropicThinkingBudgetPreference: AnthropicThinkingBudgetPreference | null;
   anthropicAdaptiveThinking: AnthropicAdaptiveThinkingConfig | null;


### PR DESCRIPTION
## Summary

Fixes issues reported by bugbot (greptile, CodeRabbit, github-actions) on PR #870.

**Valid issues fixed (6/8):**
- Remove optional modifier from codexServiceTierPreference in Provider and ProviderDisplay interfaces (consistency with sibling codex preference fields)
- Add missing codex_service_tier_preference clear branch in applyPatchField (batch edit clear operation was broken)
- Add codex_service_tier_preference to BatchUpdateProvidersParams and batch update mapping (field was silently dropped)
- Replace hardcoded placeholder inherit with i18n t() call in routing-section SelectValue
- Translate fastPriority strings to proper Russian, Simplified Chinese, and Traditional Chinese

**False positives dismissed (2/8):**
- Russian serviceTier form localization: already properly translated, technical API terms preserved intentionally
- beforeServiceTier equals priority in hit check: intentional design for billing transparency (the changed field already disambiguates client-sent vs provider-overridden)

## Problem

PR #870 introduced the codex service tier provider override feature but had several issues identified by automated code review tools (bugbot):
1. Type inconsistency - codexServiceTierPreference was optional in interfaces while similar fields were required
2. Missing clear operation handler - batch edit clear function did not handle this field
3. Missing batch update params - field was excluded from batch update operations
4. Hardcoded i18n string instead of using translation function
5. Untranslated user-facing strings in Russian and Chinese locales

## Solution

Apply targeted fixes to address each valid bugbot issue while dismissing false positives:
- Make type consistent with sibling fields
- Add missing clear branch in patch contract
- Include field in batch update parameters
- Use i18n function for placeholder text
- Fix translations for fastPriority in ru, zh-CN, zh-TW

## Changes

### Type Fixes
- src/types/provider.ts - Remove optional modifier from codexServiceTierPreference in Provider and ProviderDisplay interfaces

### Batch Operations Fixes
- src/lib/provider-patch-contract.ts - Add codex_service_tier_preference case to applyPatchField clear handler
- src/actions/providers.ts - Add field to BatchUpdateProvidersParams and batch update mapping

### i18n Fixes
- src/app/.../routing-section.tsx - Replace hardcoded placeholder with i18n t() call
- messages/ru/dashboard.json - Fix fastPriority Russian translation
- messages/zh-CN/dashboard.json - Fix fastPriority Simplified Chinese translation
- messages/zh-TW/dashboard.json - Fix fastPriority Traditional Chinese translation

## Breaking Changes

None. This PR only fixes type consistency and adds missing functionality - no API or interface changes that affect consumers.

## Testing

### Automated Tests
- [x] bun run typecheck passes
- [x] bun run build passes
- [x] bun run test passes (3452 tests)
- [x] Lint error pre-exists on dev, not introduced by this PR

### Manual Testing
- Verify batch edit clear operation works for codex_service_tier_preference field
- Verify batch update includes codex_service_tier_preference field
- Verify provider form displays translated placeholder text
- Verify Russian/Chinese translations display correctly

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No lint errors introduced

---
*Description enhanced by Claude AI*
