### PR TITLE
i18n(pricing): add missing multi-provider badge key

### DIFF
--- a/messages/ja/settings/prices.json
+++ b/messages/ja/settings/prices.json
@@ -31,7 +31,8 @@
     "openrouter": "OpenRouter"
   },
   "badges": {
-    "local": "ローカル"
+    "local": "ローカル",
+    "multi": "複数プロバイダー"
   },
   "capabilities": {
     "assistantPrefill": "アシスタント事前入力",

--- a/messages/ru/settings/prices.json
+++ b/messages/ru/settings/prices.json
@@ -31,7 +31,8 @@
     "openrouter": "OpenRouter"
   },
   "badges": {
-    "local": "Локальная"
+    "local": "Локальная",
+    "multi": "Несколько провайдеров"
   },
   "capabilities": {
     "assistantPrefill": "Предзаполнение ассистента",

--- a/messages/zh-TW/settings/prices.json
+++ b/messages/zh-TW/settings/prices.json
@@ -31,7 +31,8 @@
     "openrouter": "OpenRouter"
   },
   "badges": {
-    "local": "本機"
+    "local": "本機",
+    "multi": "多供應商"
   },
   "capabilities": {
     "assistantPrefill": "助手預填充",


### PR DESCRIPTION
## Summary
Adds missing `prices.badges.multi` translation key to Japanese (ja), Russian (ru), and Traditional Chinese (zh-TW) locale files.

## Problem
PR #873 introduced the multi-provider badge for pricing UI, but the translation key `prices.badges.multi` was only added to English, Simplified Chinese (zh-CN), and dashboard translations - not to the three settings price locale files.

This causes the multi-provider badge to render as a missing translation key (e.g., "prices.badges.multi") instead of localized text in Japanese, Russian, and Traditional Chinese interfaces.

**Related PR:**
- #873 - Introduced the multi-provider badge feature with billing logic

## Solution
Add the missing `prices.badges.multi` key to:
- `messages/ja/settings/prices.json` - "複数プロバイダー" (Multiple Providers)
- `messages/ru/settings/prices.json` - "Несколько провайдеров" (Multiple Providers)
- `messages/zh-TW/settings/prices.json` - "多供應商" (Multiple Vendors)

## Changes

### Core Changes
- Added `prices.badges.multi` key to 3 locale files

## Testing
- Run `bunx vitest run tests/unit/i18n/settings-split-guards.test.ts` (if exists)
- Open the Prices settings page in `zh-TW`, `ja`, or `ru` and verify the multi-provider badge renders as localized text

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally (if applicable)

---
*Description enhanced by Claude AI*