### PR TITLE
fix(logs): split compact logs layout changes from PR 788

### DIFF
--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
@@ -19,6 +19,7 @@ export async function UsageLogsActiveSessionsSection() {
       currencyCode={systemSettings.currencyDisplay}
       maxHeight="200px"
       showTokensCost={false}
+      compactEmpty
     />
   );
 }

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-stats-panel.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-stats-panel.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 import { getUsageLogsStats } from "@/actions/usage-logs";
 import { Skeleton } from "@/components/ui/skeleton";
-import { cn, formatTokenAmount } from "@/lib/utils";
+import { formatTokenAmount } from "@/lib/utils";
 import type { CurrencyCode } from "@/lib/utils/currency";
 import { formatCurrency } from "@/lib/utils/currency";
 import type { UsageLogSummary } from "@/repository/usage-logs";
@@ -27,21 +27,14 @@ interface UsageLogsStatsPanelProps {
   currencyCode?: CurrencyCode;
 }
 
-/**
- * Stats panel component with glass morphism UI
- * Always expanded (not collapsible), loads data asynchronously
- * Re-fetches when filters change
- */
 export function UsageLogsStatsPanel({ filters, currencyCode = "USD" }: UsageLogsStatsPanelProps) {
   const t = useTranslations("dashboard");
   const [stats, setStats] = useState<UsageLogSummary | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Create stable filter key for dependency comparison
   const filtersKey = JSON.stringify(filters);
 
-  // Load stats data
   const loadStats = useCallback(async () => {
     setIsLoading(true);
     setError(null);
@@ -61,79 +54,30 @@ export function UsageLogsStatsPanel({ filters, currencyCode = "USD" }: UsageLogs
     }
   }, [filters, t]);
 
-  // Load data on mount and when filters change
   // biome-ignore lint/correctness/useExhaustiveDependencies: filtersKey is used to detect filter changes
   useEffect(() => {
     loadStats();
   }, [filtersKey, loadStats]);
 
   return (
-    <div
-      className={cn(
-        // Glass morphism base
-        "relative overflow-hidden rounded-xl border bg-card/30 backdrop-blur-sm",
-        "transition-all duration-200",
-        "border-border/50 hover:border-border"
-      )}
-    >
-      {/* Glassmorphism gradient overlay */}
-      <div className="absolute inset-0 bg-gradient-to-br from-white/[0.02] to-transparent pointer-events-none" />
-
-      <div className="relative z-10">
-        {/* Header */}
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-border/30">
-          <span
-            className={cn(
-              "flex items-center justify-center w-8 h-8 rounded-lg shrink-0",
-              "bg-muted text-muted-foreground"
-            )}
-          >
-            <BarChart3 className="h-4 w-4" />
-          </span>
-          <div className="space-y-0.5">
-            <h3 className="text-sm font-semibold text-foreground leading-none">
-              {t("logs.stats.title")}
-            </h3>
-            <p className="text-xs text-muted-foreground leading-relaxed hidden sm:block">
-              {t("logs.stats.description")}
-            </p>
-          </div>
-        </div>
-
-        {/* Content */}
-        <div className="px-4 py-4">
-          {isLoading ? (
-            <StatsSkeletons />
-          ) : error ? (
-            <div className="text-center py-4 text-destructive">{error}</div>
-          ) : stats ? (
-            <StatsContent stats={stats} currencyCode={currencyCode} />
-          ) : null}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/**
- * Stats data skeletons
- */
-function StatsSkeletons() {
-  return (
-    <div className="grid gap-4 md:grid-cols-4">
-      {[1, 2, 3, 4].map((i) => (
-        <div key={i} className="space-y-2 p-4 border border-border/50 rounded-lg bg-card/20">
+    <div className="flex items-center gap-3 px-4 py-2.5 rounded-lg border border-border/50 bg-card/30 text-sm flex-wrap">
+      <BarChart3 className="h-4 w-4 text-muted-foreground shrink-0" />
+      {isLoading ? (
+        <div className="flex items-center gap-4 flex-wrap">
           <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-4 w-28" />
         </div>
-      ))}
+      ) : error ? (
+        <span className="text-destructive">{error}</span>
+      ) : stats ? (
+        <StatsContent stats={stats} currencyCode={currencyCode} />
+      ) : null}
     </div>
   );
 }
 
-/**
- * Stats data content
- */
 function StatsContent({
   stats,
   currencyCode,
@@ -144,58 +88,48 @@ function StatsContent({
   const t = useTranslations("dashboard");
 
   return (
-    <div className="grid gap-4 md:grid-cols-4">
-      {/* Total Requests */}
-      <div className="p-4 border border-border/50 rounded-lg bg-card/20">
-        <div className="text-sm text-muted-foreground mb-1">{t("logs.stats.totalRequests")}</div>
-        <div className="text-2xl font-mono font-semibold">
-          {stats.totalRequests.toLocaleString()}
-        </div>
-      </div>
+    <div className="flex items-center gap-x-4 gap-y-1 flex-wrap">
+      <StatItem
+        label={t("logs.stats.totalRequests")}
+        value={stats.totalRequests.toLocaleString()}
+      />
 
-      {/* Total Amount */}
-      <div className="p-4 border border-border/50 rounded-lg bg-card/20">
-        <div className="text-sm text-muted-foreground mb-1">{t("logs.stats.totalAmount")}</div>
-        <div className="text-2xl font-mono font-semibold">
-          {formatCurrency(stats.totalCost, currencyCode)}
-        </div>
-      </div>
+      <Separator />
 
-      {/* Total Tokens */}
-      <div className="p-4 border border-border/50 rounded-lg bg-card/20">
-        <div className="text-sm text-muted-foreground mb-1">{t("logs.stats.totalTokens")}</div>
-        <div className="text-2xl font-mono font-semibold">
-          {formatTokenAmount(stats.totalTokens)}
-        </div>
-        <div className="mt-2 text-xs text-muted-foreground space-y-1">
-          <div className="flex justify-between">
-            <span>{t("logs.stats.input")}:</span>
-            <span className="font-mono">{formatTokenAmount(stats.totalInputTokens)}</span>
-          </div>
-          <div className="flex justify-between">
-            <span>{t("logs.stats.output")}:</span>
-            <span className="font-mono">{formatTokenAmount(stats.totalOutputTokens)}</span>
-          </div>
-        </div>
-      </div>
+      <StatItem
+        label={t("logs.stats.totalAmount")}
+        value={formatCurrency(stats.totalCost, currencyCode)}
+      />
 
-      {/* Cache Tokens */}
-      <div className="p-4 border border-border/50 rounded-lg bg-card/20">
-        <div className="text-sm text-muted-foreground mb-1">{t("logs.stats.cacheTokens")}</div>
-        <div className="text-2xl font-mono font-semibold">
-          {formatTokenAmount(stats.totalCacheCreationTokens + stats.totalCacheReadTokens)}
-        </div>
-        <div className="mt-2 text-xs text-muted-foreground space-y-1">
-          <div className="flex justify-between">
-            <span>{t("logs.stats.write")}:</span>
-            <span className="font-mono">{formatTokenAmount(stats.totalCacheCreationTokens)}</span>
-          </div>
-          <div className="flex justify-between">
-            <span>{t("logs.stats.read")}:</span>
-            <span className="font-mono">{formatTokenAmount(stats.totalCacheReadTokens)}</span>
-          </div>
-        </div>
-      </div>
+      <Separator />
+
+      <StatItem
+        label={t("logs.stats.totalTokens")}
+        value={formatTokenAmount(stats.totalTokens)}
+        detail={`${t("logs.stats.input")} ${formatTokenAmount(stats.totalInputTokens)} / ${t("logs.stats.output")} ${formatTokenAmount(stats.totalOutputTokens)}`}
+      />
+
+      <Separator />
+
+      <StatItem
+        label={t("logs.stats.cacheTokens")}
+        value={formatTokenAmount(stats.totalCacheCreationTokens + stats.totalCacheReadTokens)}
+        detail={`${t("logs.stats.write")} ${formatTokenAmount(stats.totalCacheCreationTokens)} / ${t("logs.stats.read")} ${formatTokenAmount(stats.totalCacheReadTokens)}`}
+      />
     </div>
   );
+}
+
+function StatItem({ label, value, detail }: { label: string; value: string; detail?: string }) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono font-medium">{value}</span>
+      {detail ? <span className="text-xs text-muted-foreground/70">({detail})</span> : null}
+    </span>
+  );
+}
+
+function Separator() {
+  return <span className="text-border hidden sm:inline">|</span>;
 }

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Expand, Filter, ListOrdered, Minimize2, Pause, Play, RefreshCw } from "lucide-react";
+import {
+  ChevronDown,
+  Expand,
+  Filter,
+  ListOrdered,
+  Minimize2,
+  Pause,
+  Play,
+  RefreshCw,
+} from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -10,8 +19,10 @@ import { getKeys } from "@/actions/keys";
 import type { OverviewData } from "@/actions/overview";
 import { getOverviewData } from "@/actions/overview";
 import { getProviders } from "@/actions/providers";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Switch } from "@/components/ui/switch";
 import { useFullscreen } from "@/hooks/use-fullscreen";
 import { getHiddenColumns, type LogsTableColumn } from "@/lib/column-visibility";
@@ -81,6 +92,7 @@ function UsageLogsViewContent({
   const [hideProviderColumn, setHideProviderColumn] = useState(false);
   const wasInFullscreenRef = useRef(false);
   const [hiddenColumns, setHiddenColumns] = useState<LogsTableColumn[]>([]);
+  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
 
   // Load initial hidden columns from localStorage
   useEffect(() => {
@@ -250,21 +262,47 @@ function UsageLogsViewContent({
     };
   }, []);
 
-  const statsFilters = {
-    userId: filters.userId,
-    keyId: filters.keyId,
-    providerId: filters.providerId,
-    sessionId: filters.sessionId,
-    startTime: filters.startTime,
-    endTime: filters.endTime,
-    statusCode: filters.statusCode,
-    excludeStatusCode200: filters.excludeStatusCode200,
-    model: filters.model,
-    endpoint: filters.endpoint,
-    minRetryCount: filters.minRetryCount,
-  };
+  const statsFilters = useMemo(
+    () => ({
+      userId: filters.userId,
+      keyId: filters.keyId,
+      providerId: filters.providerId,
+      sessionId: filters.sessionId,
+      startTime: filters.startTime,
+      endTime: filters.endTime,
+      statusCode: filters.statusCode,
+      excludeStatusCode200: filters.excludeStatusCode200,
+      model: filters.model,
+      endpoint: filters.endpoint,
+      minRetryCount: filters.minRetryCount,
+    }),
+    [filters]
+  );
 
   const hasStatsFilters = Object.values(statsFilters).some((v) => v !== undefined && v !== false);
+
+  const activeFilterCount = useMemo(() => {
+    let count = 0;
+    if (filters.userId !== undefined) count++;
+    if (filters.keyId !== undefined) count++;
+    if (filters.providerId !== undefined) count++;
+    if (filters.sessionId) count++;
+    if (filters.startTime && filters.endTime) count++;
+    if (filters.statusCode !== undefined || filters.excludeStatusCode200) count++;
+    if (filters.model) count++;
+    if (filters.endpoint) count++;
+    if (filters.minRetryCount !== undefined && filters.minRetryCount > 0) count++;
+    return count;
+  }, [filters]);
+
+  // Auto-expand filter panel when URL-based filters are present on initial load
+  const filterAutoExpandRef = useRef(true);
+  useEffect(() => {
+    if (filterAutoExpandRef.current && activeFilterCount > 0) {
+      setIsFiltersOpen(true);
+    }
+    filterAutoExpandRef.current = false;
+  }, [activeFilterCount]);
 
   return (
     <>
@@ -274,35 +312,41 @@ function UsageLogsViewContent({
           <UsageLogsStatsPanel filters={statsFilters} currencyCode={resolvedCurrencyCode} />
         )}
 
-        {/* Filter Criteria */}
-        <Card className="border-border/50">
-          <CardHeader className="pb-3">
-            <div className="flex items-center gap-2">
-              <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-muted/50">
-                <Filter className="h-4 w-4 text-muted-foreground" />
-              </div>
-              <div>
-                <CardTitle className="text-base">{t("title.filterCriteria")}</CardTitle>
-                <CardDescription className="text-xs">
-                  {t("title.filterCriteriaDescription")}
-                </CardDescription>
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent className="pt-0">
-            <UsageLogsFilters
-              isAdmin={isAdmin}
-              providers={resolvedProviders}
-              initialKeys={resolvedKeys}
-              filters={filters}
-              onChange={handleFilterChange}
-              onReset={() => router.push("/dashboard/logs")}
-              isProvidersLoading={isProvidersLoading}
-              isKeysLoading={isKeysLoading}
-              serverTimeZone={serverTimeZone}
-            />
-          </CardContent>
-        </Card>
+        {/* Filter Criteria - Collapsible */}
+        <Collapsible open={isFiltersOpen} onOpenChange={setIsFiltersOpen}>
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full items-center gap-3 px-4 py-2.5 rounded-lg border border-border/50 bg-card/30 text-sm cursor-pointer select-none hover:border-border transition-colors"
+            >
+              <Filter className="h-4 w-4 text-muted-foreground shrink-0" />
+              <span className="text-muted-foreground">{t("title.filterCriteria")}</span>
+              {!isFiltersOpen && activeFilterCount > 0 ? (
+                <Badge variant="secondary">{activeFilterCount}</Badge>
+              ) : null}
+              <ChevronDown
+                className={`ml-auto h-4 w-4 text-muted-foreground transition-transform duration-200 ${isFiltersOpen ? "rotate-180" : ""}`}
+              />
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <Card className="border-border/50 mt-2">
+              <CardContent className="pt-4">
+                <UsageLogsFilters
+                  isAdmin={isAdmin}
+                  providers={resolvedProviders}
+                  initialKeys={resolvedKeys}
+                  filters={filters}
+                  onChange={handleFilterChange}
+                  onReset={() => router.push("/dashboard/logs")}
+                  isProvidersLoading={isProvidersLoading}
+                  isKeysLoading={isKeysLoading}
+                  serverTimeZone={serverTimeZone}
+                />
+              </CardContent>
+            </Card>
+          </CollapsibleContent>
+        </Collapsible>
 
         {/* Usage Records Table */}
         <Card className="border-border/50">

--- a/src/components/customs/active-sessions-list.tsx
+++ b/src/components/customs/active-sessions-list.tsx
@@ -30,6 +30,8 @@ interface ActiveSessionsListProps {
   maxHeight?: string;
   /** 是否显示 Token/成本（默认显示） */
   showTokensCost?: boolean;
+  /** 空状态时压缩为单行 */
+  compactEmpty?: boolean;
   /** 自定义类名 */
   className?: string;
 }
@@ -45,6 +47,7 @@ export function ActiveSessionsList({
   maxItems,
   showHeader = true,
   maxHeight = "200px",
+  compactEmpty = false,
   showTokensCost = true,
   className = "",
 }: ActiveSessionsListProps) {
@@ -62,6 +65,18 @@ export function ActiveSessionsList({
   const displaySessions = maxItems ? data.slice(0, maxItems) : data;
   // 实际的活跃 session 总数（用于计数显示）
   const totalCount = data.length;
+
+  if (compactEmpty && !isLoading && totalCount === 0) {
+    return (
+      <div
+        className={`flex items-center gap-3 px-4 py-2.5 rounded-lg border border-border/50 bg-card/30 text-sm ${className}`}
+      >
+        <Activity className="h-4 w-4 text-muted-foreground shrink-0" />
+        <span className="text-muted-foreground">{tc("activeSessions.title")}</span>
+        <span className="text-xs text-muted-foreground">{tc("activeSessions.empty")}</span>
+      </div>
+    );
+  }
 
   return (
     <div className={`border rounded-lg bg-card ${className}`}>


### PR DESCRIPTION
## Summary
Split from PR #788 to isolate the logs page UI changes into a standalone, independently reviewable PR.

## Problem
Issue #766 requested optimizing the logs page to reduce above-fold space, specifically:
- Collapsing the filter criteria panel by default
- Making the stats panel more compact
- Compressing empty states

## Related Issues
- Closes #766 - Original issue requesting logs page optimization

## Changes

### Core Changes
This PR extracts only the logs dashboard layout changes from PR #788:
- usage-logs-sections.tsx - Added compactEmpty prop to ActiveSessionsList
- usage-logs-stats-panel.tsx - Redesigned from 4-card grid to compact inline bar
- usage-logs-view-virtualized.tsx - Collapsible filter panel with active filter count badge
- active-sessions-list.tsx - Added compactEmpty prop for compact empty state

### Excluded from this PR
- Chart typing or build fixes
- Pricing i18n fixes  
- Pricing semantics changes
- Lease budget / rate-limit behavior changes

## Why Split This Way
- The logs page UI changes are independently reviewable user-facing work
- Keeping the branch limited to the 4 logs-related files preserves a clean review boundary
- Unrelated regressions can be reviewed and merged separately instead of being mixed into one PR

## How to Verify
- Run git diff --name-only upstream/dev...split/pr788-logs-ui and confirm only the 4 intended files differ
- Run bun run typecheck
- Open the logs dashboard and verify the compact layout / filter presentation changes visually

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the logs dashboard UI into a more compact layout by collapsing the filter panel into a togglable trigger row (with an active-filter count badge), replacing the glassmorphism 4-column stats card with an inline stats bar, and showing a compact single-row empty state for the active sessions list.

**Key changes:**
- `usage-logs-view-virtualized.tsx`: Filter criteria section is now a `Collapsible` with a chevron trigger; active filter count badge appears when collapsed; `statsFilters` wrapped in `useMemo`; auto-expand logic via a `filterAutoExpandRef` fires only on initial mount if URL filters are present.
- `usage-logs-stats-panel.tsx`: Entire glassmorphism card replaced with a slim inline `flex` row using `StatItem` sub-components and a local pipe `Separator`. `cn` import correctly removed.
- `active-sessions-list.tsx`: New `compactEmpty` boolean prop renders a compact single-line empty state instead of the full card; all hooks are still called unconditionally (valid).
- `usage-logs-sections.tsx`: Passes `compactEmpty` to the `ActiveSessionsList` used on the logs page.

**Issues found:**
- A brief layout shift occurs in `ActiveSessionsList` when `compactEmpty=true` because the compact path is gated on `!isLoading`, so the component renders at full card height during the initial fetch before collapsing.
- `activeFilterCount` only increments for a date range when **both** `startTime` and `endTime` are set, but `hasStatsFilters` checks each independently — a partial date range will show the stats panel without incrementing the filter badge.
- The local `Separator` component in `usage-logs-stats-panel.tsx` shadows shadcn's `Separator` in name only; no runtime impact but may confuse future maintainers.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge — changes are purely UI/layout with no data-layer or business-logic impact; issues found are cosmetic or minor.
- All four files contain well-scoped UI refactors. The logic issues are low-severity: the layout shift is a brief visual flicker on initial load, and the filter-count inconsistency only matters in a partial date-range edge case. No data mutations, no auth changes, and no new async paths are introduced.
- `src/components/customs/active-sessions-list.tsx` (layout shift with `compactEmpty`) and `src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx` (date range counting in `activeFilterCount`).
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx | Replaces the always-visible filter card with a collapsible trigger row, adds an active-filter count badge, wraps `statsFilters` in `useMemo`, and auto-expands the panel on initial load when URL-based filters are detected. Minor inconsistency found between `activeFilterCount` and `hasStatsFilters` for partial date ranges. |
| src/app/[locale]/dashboard/logs/_components/usage-logs-stats-panel.tsx | Replaces the glassmorphism 4-column card grid with a compact inline stats bar. Code is cleaner; `cn` import correctly removed; local `Separator` component has a naming collision risk with shadcn's `Separator` (cosmetic only). |
| src/components/customs/active-sessions-list.tsx | Adds `compactEmpty` prop for a compact single-row empty state. Logic is placed after all hooks (valid). A layout shift occurs during initial load because the compact path is gated on `!isLoading`, causing the component to briefly render at full card height before collapsing. |
| src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx | One-line change that passes the new `compactEmpty` prop to `ActiveSessionsList`. Straightforward and correct. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Logs Page Mount] --> B{URL has filters?}
    B -- Yes --> C[filterAutoExpandRef fires\nsetIsFiltersOpen true]
    B -- No --> D[isFiltersOpen = false\nFilter panel collapsed]
    C --> E[Filter panel expanded]

    D --> F{User clicks trigger row}
    F --> G[isFiltersOpen toggles]
    G --> H{activeFilterCount > 0\nand panel collapsed?}
    H -- Yes --> I[Show active filter Badge]
    H -- No --> J[No badge]

    E --> K{hasStatsFilters?}
    D --> K
    K -- Yes --> L[UsageLogsStatsPanel\nInline stats bar]
    K -- No --> M[Stats panel hidden]

    N[ActiveSessionsList compactEmpty=true] --> O{isLoading?}
    O -- true --> P[Full card layout\nLoading spinner]
    O -- false --> Q{totalCount === 0?}
    Q -- Yes --> R[Compact single-row\nempty state]
    Q -- No --> S[Full card with sessions]
```
</details>

<sub>Last reviewed commit: eed4b90</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->