### PR TITLE
fix: restore admin token auth in opaque session mode

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -291,6 +291,13 @@ export async function validateAuthToken(
     return validateKey(token, options);
   }
 
+  // Opaque mode: allow raw ADMIN_TOKEN for backward-compatible programmatic API access.
+  // Safe because admin token is a server-side env secret, not a user-issued DB key.
+  const adminToken = config.auth.adminToken;
+  if (adminToken && constantTimeEqual(token, adminToken)) {
+    return validateKey(token, options);
+  }
+
   return null;
 }
 

--- a/tests/unit/auth/admin-token-opaque-fallback.test.ts
+++ b/tests/unit/auth/admin-token-opaque-fallback.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted mocks
+const mockCookies = vi.hoisted(() => vi.fn());
+const mockHeaders = vi.hoisted(() => vi.fn());
+const mockGetEnvConfig = vi.hoisted(() => vi.fn());
+const mockValidateApiKeyAndGetUser = vi.hoisted(() => vi.fn());
+const mockFindKeyList = vi.hoisted(() => vi.fn());
+const mockReadSession = vi.hoisted(() => vi.fn());
+const mockCookieStore = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  delete: vi.fn(),
+}));
+const mockHeadersStore = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+const mockConfig = vi.hoisted(() => ({
+  auth: { adminToken: "test-admin-secret-token-12345" },
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: mockCookies,
+  headers: mockHeaders,
+}));
+
+vi.mock("@/lib/config/env.schema", () => ({
+  getEnvConfig: mockGetEnvConfig,
+}));
+
+vi.mock("@/repository/key", () => ({
+  validateApiKeyAndGetUser: mockValidateApiKeyAndGetUser,
+  findKeyList: mockFindKeyList,
+}));
+
+vi.mock("@/lib/auth-session-store/redis-session-store", () => ({
+  RedisSessionStore: class {
+    read = mockReadSession;
+    create = vi.fn();
+    revoke = vi.fn();
+    rotate = vi.fn();
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/lib/config/config", () => ({
+  config: mockConfig,
+}));
+
+function setSessionMode(mode: "legacy" | "dual" | "opaque") {
+  mockGetEnvConfig.mockReturnValue({
+    SESSION_TOKEN_MODE: mode,
+    ENABLE_SECURE_COOKIES: false,
+  });
+}
+
+function setAuthCookie(token?: string) {
+  mockCookieStore.get.mockReturnValue(token ? { value: token } : undefined);
+}
+
+function setBearerHeader(token?: string) {
+  mockHeadersStore.get.mockReturnValue(token ? `Bearer ${token}` : null);
+}
+
+describe("admin token opaque-mode fallback", () => {
+  const ADMIN_TOKEN = "test-admin-secret-token-12345";
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockCookies.mockResolvedValue(mockCookieStore);
+    mockHeaders.mockResolvedValue(mockHeadersStore);
+    mockHeadersStore.get.mockReturnValue(null);
+    mockCookieStore.get.mockReturnValue(undefined);
+
+    setSessionMode("opaque");
+    mockReadSession.mockResolvedValue(null);
+    mockFindKeyList.mockResolvedValue([]);
+    mockValidateApiKeyAndGetUser.mockResolvedValue(null);
+    mockConfig.auth.adminToken = ADMIN_TOKEN;
+  });
+
+  it("opaque mode + raw admin token via cookie -> auth succeeds", async () => {
+    setAuthCookie(ADMIN_TOKEN);
+
+    const { getSession } = await import("@/lib/auth");
+    const session = await getSession();
+
+    expect(session).not.toBeNull();
+    expect(session!.user.id).toBe(-1);
+    expect(session!.user.role).toBe("admin");
+    expect(session!.key.name).toBe("ADMIN_TOKEN");
+  });
+
+  it("opaque mode + raw non-admin API key via cookie -> auth fails", async () => {
+    setAuthCookie("sk-regular-user-key");
+    // Even if this key is valid in DB, opaque mode must reject raw keys
+    mockValidateApiKeyAndGetUser.mockResolvedValue({
+      user: { id: 1, name: "user", role: "user", isEnabled: true },
+      key: {
+        id: 1,
+        userId: 1,
+        name: "key-1",
+        key: "sk-regular-user-key",
+        isEnabled: true,
+        canLoginWebUi: true,
+      },
+    });
+
+    const { getSession } = await import("@/lib/auth");
+    const session = await getSession();
+
+    expect(session).toBeNull();
+    // Must NOT fall back to validateApiKeyAndGetUser for non-admin keys
+    expect(mockValidateApiKeyAndGetUser).not.toHaveBeenCalled();
+  });
+
+  it("opaque mode + admin token via Bearer header -> auth succeeds", async () => {
+    // No cookie set; use Authorization header instead
+    setBearerHeader(ADMIN_TOKEN);
+
+    const { getSession } = await import("@/lib/auth");
+    const session = await getSession();
+
+    expect(session).not.toBeNull();
+    expect(session!.user.id).toBe(-1);
+    expect(session!.user.role).toBe("admin");
+    expect(session!.key.name).toBe("ADMIN_TOKEN");
+  });
+
+  it("opaque mode + valid opaque session -> auth succeeds (original logic unchanged)", async () => {
+    const crypto = await import("node:crypto");
+    const keyString = "sk-opaque-source-key";
+    const fingerprint = `sha256:${crypto.createHash("sha256").update(keyString, "utf8").digest("hex")}`;
+
+    setAuthCookie("sid_valid_session");
+    mockReadSession.mockResolvedValue({
+      sessionId: "sid_valid_session",
+      keyFingerprint: fingerprint,
+      userId: 42,
+      userRole: "user",
+      createdAt: Date.now() - 1000,
+      expiresAt: Date.now() + 86400_000,
+    });
+    mockFindKeyList.mockResolvedValue([
+      {
+        id: 1,
+        userId: 42,
+        name: "key-1",
+        key: keyString,
+        isEnabled: true,
+        canLoginWebUi: true,
+        limit5hUsd: null,
+        limitDailyUsd: null,
+        dailyResetMode: "fixed",
+        dailyResetTime: "00:00",
+        limitWeeklyUsd: null,
+        limitMonthlyUsd: null,
+        limitTotalUsd: null,
+        limitConcurrentSessions: 0,
+        providerGroup: null,
+        cacheTtlPreference: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    mockValidateApiKeyAndGetUser.mockResolvedValue({
+      user: {
+        id: 42,
+        name: "user-42",
+        description: "test",
+        role: "user",
+        rpm: 100,
+        dailyQuota: 100,
+        providerGroup: null,
+        tags: [],
+        isEnabled: true,
+        expiresAt: null,
+        allowedClients: [],
+        allowedModels: [],
+        limit5hUsd: 0,
+        limitWeeklyUsd: 0,
+        limitMonthlyUsd: 0,
+        limitTotalUsd: null,
+        limitConcurrentSessions: 0,
+        dailyResetMode: "fixed",
+        dailyResetTime: "00:00",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      key: {
+        id: 1,
+        userId: 42,
+        name: "key-1",
+        key: keyString,
+        isEnabled: true,
+        canLoginWebUi: true,
+        limit5hUsd: null,
+        limitDailyUsd: null,
+        dailyResetMode: "fixed",
+        dailyResetTime: "00:00",
+        limitWeeklyUsd: null,
+        limitMonthlyUsd: null,
+        limitTotalUsd: null,
+        limitConcurrentSessions: 0,
+        providerGroup: null,
+        cacheTtlPreference: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    const { getSession } = await import("@/lib/auth");
+    const session = await getSession({ allowReadOnlyAccess: true });
+
+    expect(session).not.toBeNull();
+    expect(session!.user.id).toBe(42);
+  });
+
+  it("legacy mode -> behavior unchanged (admin token works via validateKey)", async () => {
+    setSessionMode("legacy");
+    setAuthCookie(ADMIN_TOKEN);
+
+    const { getSession } = await import("@/lib/auth");
+    const session = await getSession();
+
+    expect(session).not.toBeNull();
+    expect(session!.user.id).toBe(-1);
+    expect(session!.user.role).toBe("admin");
+    // Legacy mode should NOT touch opaque session store
+    expect(mockReadSession).not.toHaveBeenCalled();
+  });
+
+  it("opaque mode + admin token not configured -> auth fails for raw token", async () => {
+    mockConfig.auth.adminToken = "";
+    setAuthCookie("some-random-token");
+
+    const { getSession } = await import("@/lib/auth");
+    const session = await getSession();
+
+    expect(session).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a regression in v0.6 where `SESSION_TOKEN_MODE=opaque` (the default) broke programmatic API access using raw `ADMIN_TOKEN`. Adds secure fallback validation to restore backward compatibility for `/api/*` endpoints while maintaining the security posture of opaque session mode.

## Problem

In v0.6, the session token mode defaults to `opaque` as part of the security overhaul (#803). However, this broke a critical use case:

- Programmatic API calls using `ADMIN_TOKEN` via cookie or Bearer header were rejected
- `validateAuthToken()` only accepted opaque session IDs (`sid_*`) in opaque mode
- The raw `ADMIN_TOKEN` validation path was never reached when mode was `opaque`

This prevented server-side scripts and external integrations from authenticating with the admin token when the application was in opaque session mode.

## Solution

Added a `constantTimeEqual` check for the admin token in the opaque-mode path of `validateAuthToken()` before returning null:

```typescript
// Opaque mode: allow raw ADMIN_TOKEN for backward-compatible programmatic API access.
// Safe because admin token is a server-side env secret, not a user-issued DB key.
const adminToken = config.auth.adminToken;
if (adminToken && constantTimeEqual(token, adminToken)) {
  return validateKey(token, options);
}
```

**Security considerations:**
- Admin token is a server-side environment secret, not a user-issued database key
- Regular (non-admin) API keys remain correctly rejected in opaque mode
- Security posture is not degraded - the check uses constant-time comparison

## Changes

| File | Change |
|------|--------|
| `src/lib/auth.ts` | Added admin token fallback check in opaque mode path |
| `tests/unit/auth/admin-token-opaque-fallback.test.ts` | New comprehensive test suite (6 test cases) |

## Related

- Follow-up to #803 - Security auth & session overhaul (introduced opaque mode default)

## Testing

### New Unit Tests
- [x] `tests/unit/auth/admin-token-opaque-fallback.test.ts` (6 cases)
  - Opaque mode + admin cookie -> succeeds
  - Opaque mode + non-admin cookie -> fails (security)
  - Opaque mode + admin Bearer header -> succeeds
  - Opaque mode + valid opaque session -> succeeds (no regression)
  - Legacy mode -> unchanged behavior
  - Opaque mode + no admin token configured -> fails

### Regression Tests
- [x] `tests/security/auth-dual-read.test.ts` (6/6 pass)
- [x] `tests/unit/auth/opaque-admin-session.test.ts` (3/3 pass)

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] Security impact assessed

---
*Original description preserved below*

## Summary

- In v0.6, `SESSION_TOKEN_MODE` defaults to `opaque`. This broke programmatic API calls using raw `ADMIN_TOKEN` via cookie or Bearer header, since `validateAuthToken()` only accepted opaque session IDs (`sid_*`) and never fell back to key validation.
- Added a `constantTimeEqual` check for admin token in the opaque-mode path of `validateAuthToken()`, restoring backward-compatible access for all `/api/*` endpoints.
- Regular (non-admin) API keys remain correctly rejected in opaque mode -- security posture is not degraded.

## Test plan

- [x] New test: `tests/unit/auth/admin-token-opaque-fallback.test.ts` (6 cases)
  - opaque + admin cookie -> succeeds
  - opaque + non-admin cookie -> fails (security)
  - opaque + admin Bearer header -> succeeds
  - opaque + valid opaque session -> succeeds (no regression)
  - legacy mode -> unchanged behavior
  - opaque + no admin token configured -> fails
- [x] Regression: `tests/security/auth-dual-read.test.ts` (6/6 pass)
- [x] Regression: `tests/unit/auth/opaque-admin-session.test.ts` (3/3 pass)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores backward-compatible `ADMIN_TOKEN` access in opaque session mode by adding a `constantTimeEqual` fallback inside `validateAuthToken()` that executes when the opaque session store returns no match. Regular (non-admin) raw API keys remain correctly rejected in opaque mode, preserving security posture.

**Implementation:** Adds a 7-line admin-token fallback block at the bottom of `validateAuthToken()` (after the opaque session store lookup, after the `legacy`/`dual` mode branch) that delegates to the existing `validateKey()` function, which constructs the virtual admin user. Test coverage is comprehensive (6 cases covering cookie, Bearer header, opaque session, legacy mode, and unconfigured token paths).

**Security concern:** The raw `ADMIN_TOKEN` value is passed to `sessionStore.read(token)` (line 272) *before* the `constantTimeEqual` check fires (line 297). In production environments with Redis command logging or observability sidecars, this exposes the plaintext token in logs. Moving the admin-token check to run before the session-store call would eliminate this exposure and save a Redis round-trip for every programmatic admin request.
</details>


<details open><summary><h3>Confidence Score: 2/5</h3></summary>

- The admin-token fallback logic itself is correct and preserves security, but the raw token is sent to Redis before validation, risking exposure in command logs—resolve before production deployment.
- The functional implementation of the admin-token fallback is correct and test coverage is thorough. However, there is a concrete operational security concern: in opaque mode, the raw ADMIN_TOKEN is forwarded to Redis before the equality check, which can expose the secret in Redis command logs if logging is enabled (a common production practice). This is not a functional bug but a meaningful security issue that should be addressed before merging to production. The fix is straightforward: validate the admin token before calling sessionStore.read().
- src/lib/auth.ts — specifically the order of operations in validateAuthToken() around the session-store lookup (lines 269–301). The admin-token check should execute before the Redis call.
</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant VA as validateAuthToken()
    participant SS as SessionStore (Redis)
    participant VK as validateKey()

    C->>VA: token (cookie or Bearer)
    alt mode == legacy
        VA->>VK: validateKey(token)
        VK-->>VA: AuthSession | null
    else mode == dual
        VA->>SS: read(token)
        SS-->>VA: session | null
        alt session found & valid
            VA->>VK: validateKey via convertToAuthSession
            VK-->>VA: AuthSession
        else session not found
            VA->>VK: validateKey(token)
            VK-->>VA: AuthSession | null
        end
    else mode == opaque (current PR)
        VA->>SS: read(token) ⚠️ raw ADMIN_TOKEN sent here
        SS-->>VA: session | null
        alt session found & valid
            VA->>VK: convertToAuthSession → validateKey
            VK-->>VA: AuthSession
        else session not found
            VA->>VA: constantTimeEqual(token, adminToken)?
            alt token == ADMIN_TOKEN
                VA->>VK: validateKey(token)
                VK-->>VA: admin AuthSession (id=-1)
            else not admin token
                VA-->>C: null (rejected)
            end
        end
    end
    VA-->>C: AuthSession | null
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/auth.ts`, line 269-301 ([link](https://github.com/ding113/claude-code-hub/blob/171fa9c0b7fbd6f313a0e4567ee24ed5902a4337/src/lib/auth.ts#L269-L301)) 

   **Raw admin token forwarded to Redis before equality check**

   In opaque mode, the raw `token` string is passed to `sessionStore.read(token)` on line 272 *before* the `constantTimeEqual` guard on line 297. This means if a request includes a raw `ADMIN_TOKEN` in the cookie or Bearer header, it will be sent to Redis as a lookup key. If Redis command logging or any monitoring sidecar is enabled in production, the plaintext `ADMIN_TOKEN` will appear in those logs.

   Recommend moving the admin-token check to execute **before** the session-store lookup (guarded with `mode === "opaque"`). This would:
   1. Prevent the token from being sent to Redis as a key, eliminating exposure in Redis logs
   2. Preserve existing behavior for `legacy` and `dual` modes
   3. Save one Redis round-trip per admin-token request

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 171fa9c</sub>

<!-- /greptile_comment -->