### PR TITLE
fix(proxy): improve 499 handling and add hedge reason types

### DIFF
--- a/messages/en/provider-chain.json
+++ b/messages/en/provider-chain.json
@@ -56,7 +56,11 @@
     "initial_selection": "Initial Selection",
     "endpoint_pool_exhausted": "Endpoint Pool Exhausted",
     "vendor_type_all_timeout": "Vendor-Type All Endpoints Timeout",
-    "client_restriction_filtered": "Client Restricted"
+    "client_restriction_filtered": "Client Restricted",
+    "client_abort": "Client Aborted",
+    "hedge_triggered": "Hedge Triggered",
+    "hedge_winner": "Hedge Winner",
+    "hedge_loser_cancelled": "Hedge Loser Cancelled"
   },
   "filterReasons": {
     "rate_limited": "Rate Limited",

--- a/messages/zh-CN/provider-chain.json
+++ b/messages/zh-CN/provider-chain.json
@@ -56,7 +56,11 @@
     "initial_selection": "首次选择",
     "endpoint_pool_exhausted": "端点池耗尽",
     "vendor_type_all_timeout": "供应商类型全端点超时",
-    "client_restriction_filtered": "客户端受限"
+    "client_restriction_filtered": "客户端受限",
+    "client_abort": "客户端断开",
+    "hedge_triggered": "首字节超时触发 Hedge",
+    "hedge_winner": "Hedge 竞速胜出",
+    "hedge_loser_cancelled": "Hedge 竞速落败"
   },
   "filterReasons": {
     "rate_limited": "速率限制",

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -1022,10 +1022,23 @@ export class ProxyForwarder {
               totalProvidersAttempted,
             });
 
+            // 清理 session provider 绑定（仅在首次尝试时清理，避免清理已成功的绑定）
+            if (session.sessionId && attemptCount === 1) {
+              const { SessionManager } = await import("@/lib/session-manager");
+              await SessionManager.clearSessionProvider(session.sessionId);
+              logger.debug(
+                "ProxyForwarder: Cleared session binding due to client abort on first attempt",
+                {
+                  sessionId: session.sessionId,
+                  providerId: currentProvider.id,
+                }
+              );
+            }
+
             // 记录到决策链（标记为客户端中断）
             session.addProviderToChain(currentProvider, {
               ...endpointAudit,
-              reason: "system_error", // 使用 system_error 作为客户端中断的原因
+              reason: "client_abort", // 使用 client_abort 作为客户端中断的原因
               circuitState: getCircuitState(currentProvider.id),
               attemptNumber: attemptCount,
               errorMessage: "Client aborted request",

--- a/src/app/v1/_lib/proxy/session.ts
+++ b/src/app/v1/_lib/proxy/session.ts
@@ -453,7 +453,11 @@ export class ProxySession {
         | "http2_fallback" // HTTP/2 协议错误，回退到 HTTP/1.1（不切换供应商、不计入熔断器）
         | "endpoint_pool_exhausted" // 端点池耗尽（strict endpoint policy 阻止了 fallback）
         | "vendor_type_all_timeout" // 供应商类型全端点超时（524），触发 vendor-type 临时熔断
-        | "client_restriction_filtered"; // 供应商因客户端限制被跳过（会话复用路径）
+        | "client_restriction_filtered" // 供应商因客户端限制被跳过（会话复用路径）
+        | "client_abort" // 客户端主动断开连接（HTTP 499），首次尝试时清理 session 绑定，不计入熔断器
+        | "hedge_triggered" // 首字节超时触发 hedge 调度（并行发起下一个供应商连接）
+        | "hedge_winner" // hedge 竞速胜出（首个返回首字节的供应商）
+        | "hedge_loser_cancelled"; // hedge 竞速落败（被胜者取消的供应商连接）
       selectionMethod?:
         | "session_reuse"
         | "weighted_random"

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -35,7 +35,11 @@ export interface ProviderChainItem {
     | "http2_fallback" // HTTP/2 协议错误，回退到 HTTP/1.1（不切换供应商、不计入熔断器）
     | "endpoint_pool_exhausted" // 端点池耗尽（所有端点熔断或不可用，严格模式阻止降级）
     | "vendor_type_all_timeout" // 供应商类型全端点超时（524），触发 vendor-type 临时熔断
-    | "client_restriction_filtered"; // Provider skipped due to client restriction (neutral, no circuit breaker)
+    | "client_restriction_filtered" // Provider skipped due to client restriction (neutral, no circuit breaker)
+    | "client_abort" // 客户端主动断开连接（HTTP 499），首次尝试时清理 session 绑定，不计入熔断器
+    | "hedge_triggered" // 首字节超时触发 hedge 调度（并行发起下一个供应商连接）
+    | "hedge_winner" // hedge 竞速胜出（首个返回首字节的供应商）
+    | "hedge_loser_cancelled"; // hedge 竞速落败（被胜者取消的供应商连接）
 
   // === 选择方法（细化） ===
   selectionMethod?:


### PR DESCRIPTION
## Summary

Improves client abort (HTTP 499) handling and adds infrastructure for future hedge scheduling support.

## Changes

### 1. Enhanced 499 Handling
- **Conditional session clearing**: Only clear session provider binding on first attempt to avoid race condition
- **New reason type**: Added `client_abort` to distinguish from generic `system_error`
- **Detailed logging**: Added debug logging when session binding is cleared

### 2. Hedge Reason Types (Infrastructure)
- Added 3 new reason types for future hedge scheduling:
  - `hedge_triggered`: First-byte timeout triggers hedge (parallel provider attempt)
  - `hedge_winner`: Hedge race winner (first provider to return first byte)
  - `hedge_loser_cancelled`: Hedge race loser (cancelled by winner)
- Added comprehensive documentation for all new reason types
- Updated i18n translations (zh-CN, en)

## Technical Details

### Race Condition Fix
**Problem**: Original implementation unconditionally cleared session binding on 499, which could clear a successful binding if the provider responded after client disconnect.

**Solution**: Only clear binding on first attempt (`attemptCount === 1`), preserving session stickiness for retry scenarios.

### Type System Updates
- `src/types/message.ts`: Added 4 new `ProviderChainReason` types with detailed comments
- `src/app/v1/_lib/proxy/session.ts`: Synced reason types with message.ts
- `messages/*/provider-chain.json`: Added translations for all new reasons

## Testing

- ✅ All 3635 tests pass (377 test files)
- ✅ Type check passes
- ✅ Lint passes
- ✅ No regressions detected

## Related

- Addresses code review feedback from previous hedge scheduling exploration
- Lays groundwork for future hedge scheduling implementation (Phase 4-5 of original plan)
- Fixes P0 and P1 issues identified in code review

## Checklist

- [x] Code follows project conventions
- [x] All tests pass
- [x] Type check passes
- [x] Lint passes
- [x] i18n translations added
- [x] Documentation updated

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves HTTP 499 (client abort) handling in the proxy forwarder and lays infrastructure groundwork for future hedge scheduling support. The core behavioral change makes session provider binding cleanup conditional on `attemptCount === 1`, which correctly avoids clearing a binding that was successfully established by a prior attempt within the same retry loop.

Key changes:
- **Race condition fix**: Session binding is now only cleared on the first attempt of a 499, preserving stickiness when the abort happens on a retry.
- **New reason type**: `client_abort` replaces the generic `system_error` for HTTP 499 entries in the provider decision chain, improving observability.
- **Infrastructure types**: `hedge_triggered`, `hedge_winner`, and `hedge_loser_cancelled` are pre-defined for future hedge scheduling but are not yet wired to any logic.
- **Code quality**: The 499 handler uses a redundant dynamic import of `SessionManager` that is already statically available, adding unnecessary async overhead.

All four new reason types are properly synced across types, session, and i18n files (English and Chinese translations).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge after removing the redundant dynamic import; no correctness issues found.
- The logic change (conditional session clearing on attemptCount === 1) is well-reasoned and correctly addresses the described race condition. All four new reason types are properly synced across types, session, and i18n files. The only issue is a redundant dynamic import of a module already statically imported, which is a style/cleanup concern rather than a bug. This is easily fixed and improves code clarity and efficiency.
- src/app/v1/_lib/proxy/forwarder.ts — redundant dynamic import on line 1027 should be removed
</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request arrives] --> B{Session bound?}
    B -- Yes --> C[Attempt 1: session_reuse provider]
    B -- No --> D[Attempt 1: fresh provider selection]
    C --> E{Result?}
    D --> E
    E -- Success --> F[Record chain: request_success / retry_success]
    E -- 499 Client Abort --> G{attemptCount === 1?}
    G -- Yes --> H[clearSessionProvider\nRecord chain: client_abort\nThrow error]
    G -- No --> I[Keep existing session binding\nRecord chain: client_abort\nThrow error]
    E -- Retryable error --> J[Increment attemptCount\nSelect next provider]
    J --> E
```
</details>

<sub>Last reviewed commit: 8c9a8f5</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->