### PR TITLE
fix: reclassify miscategorized network errors as SYSTEM_ERROR for retry/failover

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -1407,7 +1407,123 @@ export class ProxyForwarder {
                 },
               });
             } else {
-              // Plain Error path: omit ProxyError-only fields
+              // Non-ProxyError path: check if this is actually a network/transport
+              // error that was miscategorized. SocketError and similar network errors
+              // should trigger retry/failover, not be treated as client input errors.
+              // Detection logic aligned with isTransportError() in errors.ts.
+              // See: https://github.com/ding113/claude-code-hub/issues/909
+              const errCode =
+                (lastError as Error & { code?: string }).code ??
+                (lastError as Error & { cause?: { code?: string } }).cause?.code;
+
+              const TRANSPORT_CODES = new Set([
+                "ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "ENOTFOUND",
+                "EAI_AGAIN",
+                "UND_ERR_SOCKET", "UND_ERR_CONNECT_TIMEOUT",
+                "UND_ERR_HEADERS_TIMEOUT", "UND_ERR_BODY_TIMEOUT",
+              ]);
+
+              const isNetworkError =
+                lastError.name === "SocketError" ||
+                (errCode !== undefined && TRANSPORT_CODES.has(errCode)) ||
+                lastError.message?.toLowerCase().includes("fetch failed") ||
+                lastError.message?.toLowerCase().includes("other side closed");
+
+              if (isNetworkError) {
+                const err = lastError as Error & {
+                  code?: string;
+                  errno?: number;
+                  syscall?: string;
+                };
+
+                logger.warn(
+                  "ProxyForwarder: Network error miscategorized as NON_RETRYABLE_CLIENT_ERROR, handling as SYSTEM_ERROR for retry/failover",
+                  {
+                    providerId: currentProvider.id,
+                    providerName: currentProvider.name,
+                    errorType: err.constructor.name,
+                    errorMessage: err.message,
+                    errorCode: err.code,
+                    attemptNumber: attemptCount,
+                    totalProvidersAttempted,
+                    willRetry: attemptCount < maxAttemptsPerProvider,
+                    originalCategory: errorCategory,
+                  }
+                );
+
+                session.addProviderToChain(currentProvider, {
+                  ...endpointAudit,
+                  reason: "system_error",
+                  circuitState: getCircuitState(currentProvider.id),
+                  attemptNumber: attemptCount,
+                  errorMessage: errorMessage,
+                  errorDetails: {
+                    system: {
+                      errorType: err.constructor.name,
+                      errorName: err.name,
+                      errorMessage: err.message || err.name || "Unknown error",
+                      errorCode: err.code,
+                      errorSyscall: err.syscall,
+                    },
+                    request: buildRequestDetails(session),
+                  },
+                });
+
+                // Mirror endpoint-level circuit breaker recording (line ~1039)
+                // that SYSTEM_ERROR gets but our reclassified path skips
+                if (activeEndpoint.endpointId != null) {
+                  await recordEndpointFailure(activeEndpoint.endpointId, lastError);
+                }
+
+
+                if (attemptCount < maxAttemptsPerProvider) {
+                  currentEndpointIndex++;
+                  logger.debug("ProxyForwarder: Advancing endpoint index due to miscategorized network error", {
+                    providerId: currentProvider.id,
+                    previousEndpointIndex: currentEndpointIndex - 1,
+                    newEndpointIndex: currentEndpointIndex,
+                    maxEndpointIndex: endpointCandidates.length - 1,
+                  });
+
+                  await new Promise((resolve) => setTimeout(resolve, 100));
+                  continue;
+                }
+
+                logger.warn("ProxyForwarder: Misclassified network error persists, will switch provider", {
+                  providerId: currentProvider.id,
+                  providerName: currentProvider.name,
+                  totalProvidersAttempted,
+                });
+
+                const env = getEnvConfig();
+                failedProviderIds.push(currentProvider.id);
+
+                if (env.ENABLE_CIRCUIT_BREAKER_ON_NETWORK_ERRORS) {
+                  logger.warn(
+                    "ProxyForwarder: Network error will be counted towards circuit breaker (enabled by config)",
+                    {
+                      providerId: currentProvider.id,
+                      providerName: currentProvider.name,
+                      errorType: err.constructor.name,
+                      errorCode: err.code,
+                    }
+                  );
+
+                  await recordFailure(currentProvider.id, lastError);
+                } else {
+                  logger.debug(
+                    "ProxyForwarder: Network error not counted towards circuit breaker (disabled by default)",
+                    {
+                      providerId: currentProvider.id,
+                      providerName: currentProvider.name,
+                    }
+                  );
+                }
+
+                break;
+              }
+
+              // Genuine non-ProxyError client error: log and throw
               logger.warn(
                 "ProxyForwarder: Non-retryable client error (plain error), stopping immediately",
                 {


### PR DESCRIPTION
## Problem

When an upstream provider connection drops (e.g. `SocketError` from Node.js undici), the error can be miscategorized as `NON_RETRYABLE_CLIENT_ERROR` by `ErrorCategorizer`.

The `dev` branch already added `instanceof ProxyError` guards to prevent the `TypeError: getDetailedErrorMessage is not a function` crash. However, non-ProxyError network errors (SocketError, ECONNRESET, etc.) in the `else` branch still get **thrown immediately** without retry or failover, causing:

1. Streaming response truncation mid-output (terrible UX)
2. No failover to the next provider
3. User sees abruptly cut-off output with no error message

## Fix

In the `else` branch of the `NON_RETRYABLE_CLIENT_ERROR` handler, add network error detection before throwing:

- **SocketError**, **ECONNRESET**, **ECONNREFUSED**, **ETIMEDOUT**, **ENOTFOUND**, and transport message signatures (`fetch failed`, `other side closed`) are detected
- These are reclassified as `SYSTEM_ERROR` via `continue`, entering the retry/failover path
- Only genuine non-network client errors continue to throw immediately

This is consistent with how the existing `SYSTEM_ERROR` handler works — retry current provider once, then failover to next provider.

## Changes

- `src/app/v1/_lib/proxy/forwarder.ts`: Add `isNetworkError` check in the `else` (non-ProxyError) branch of `NON_RETRYABLE_CLIENT_ERROR` handler (+30 lines)

## Testing

- The fix is minimal and defensive — existing ProxyError handling is completely unchanged
- Network errors now correctly trigger provider failover instead of truncating output
- Non-network plain errors still throw immediately as before

Fixes #909

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a defensive network-error reclassification guard inside the `NON_RETRYABLE_CLIENT_ERROR` handler's `else` branch (non-`ProxyError` path) in `ProxyForwarder.send()`. When a SocketError or other transport-level error escapes `isTransportError()` classification (e.g. because a user-configured error rule matched its message content before the transport check could short-circuit it), the error previously caused immediate `throw`-and-abandon behaviour; the fix correctly reclassifies it as `SYSTEM_ERROR`, performs all required bookkeeping, and routes it into the retry/failover path.

- The `isNetworkError` detection set (`SocketError` name, `TRANSPORT_CODES`, `fetch failed` / `other side closed` message signatures) correctly mirrors the existing `isTransportError()` implementation in `errors.ts`, including `error.cause?.code` wrapping, `EAI_AGAIN`, and all undici-specific codes.
- All bookkeeping that the native `SYSTEM_ERROR` handler performs is explicitly replicated: `session.addProviderToChain(reason: "system_error")`, `recordEndpointFailure`, `currentEndpointIndex++`, `failedProviderIds.push`, conditional `recordFailure` guarded by `ENABLE_CIRCUIT_BREAKER_ON_NETWORK_ERRORS`.
- The `continue`/`break` placement correctly bypasses the `throw lastError` at the end of the `NON_RETRYABLE_CLIENT_ERROR` block.
- Minor: `TRANSPORT_CODES` is a `new Set(...)` literal allocated inside the catch block on every invocation rather than a module-level or shared constant, creating a silent drift risk if `errors.ts` gains new transport codes without updating this copy.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge — the fix is correct and well-structured with a single minor maintainability concern.
- The retry/failover semantics are correctly implemented, all required bookkeeping calls are present, and the detection logic faithfully mirrors the existing `isTransportError()` function. The only notable issue is a duplicated inline `TRANSPORT_CODES` Set that could drift from `errors.ts` over time, which is a maintainability concern rather than a runtime bug.
- src/app/v1/_lib/proxy/forwarder.ts — the inline `TRANSPORT_CODES` constant should ideally be unified with the one in `errors.ts`.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/forwarder.ts | Adds an `isNetworkError` guard inside the `NON_RETRYABLE_CLIENT_ERROR` else-branch that correctly replicates the `isTransportError()` detection logic from `errors.ts` and performs all required bookkeeping (`session.addProviderToChain`, `recordEndpointFailure`, `failedProviderIds.push`) before issuing `continue`/`break`. The retry/failover semantics are correct. Minor: `TRANSPORT_CODES` is a duplicated `Set` literal allocated inline rather than referencing the canonical constant from `errors.ts`. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Inner retry loop\nattemptCount++] --> B[HTTP request]
    B -->|success| C[Return response]
    B -->|error| D[categorizeErrorAsync]

    D -->|CLIENT_ABORT| E[throw immediately]
    D -->|SYSTEM_ERROR| F[SYSTEM_ERROR handler\nrecordChain + recordEndpointFailure]
    D -->|NON_RETRYABLE_CLIENT_ERROR| G{instanceof ProxyError?}
    D -->|RESOURCE_NOT_FOUND| H[retry / failover]
    D -->|PROVIDER_ERROR| I[circuit breaker + failover]

    G -->|yes| J[record chain\nthrow immediately]
    G -->|no| K{isNetworkError?\nSocketError / ECONNRESET\nECONNREFUSED / etc.}

    K -->|yes 🆕| L[record chain\nrecordEndpointFailure]
    K -->|no| M[log + record chain\nthrow immediately]

    L --> N{attemptCount <\nmaxAttempts?}
    N -->|yes| O[currentEndpointIndex++\ncontinue → retry]
    N -->|no| P[failedProviderIds.push\nrecordFailure if enabled\nbreak → provider failover]

    F --> N

    style K fill:#d4edda,stroke:#28a745
    style L fill:#d4edda,stroke:#28a745
    style N fill:#d4edda,stroke:#28a745
    style O fill:#d4edda,stroke:#28a745
    style P fill:#d4edda,stroke:#28a745
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/v1/_lib/proxy/forwarder.ts`, line 1566 ([link](https://github.com/ding113/claude-code-hub/blob/6bd347234e18aad57ab78fd60898abf447d649a4/src/app/v1/_lib/proxy/forwarder.ts#L1566)) 

   **Incomplete fix — two unsafe `as ProxyError` casts remain**

   The PR description states:
   > "Add `instanceof ProxyError` guards at all three unsafe cast sites in `forwarder.ts`"

   However, the diff only added a guard to the `NON_RETRYABLE_CLIENT_ERROR` handler. This line and the analogous cast at line 1672 still contain unguarded `as ProxyError` casts:

   - **Line 1566** (`RESOURCE_NOT_FOUND` handler): `const proxyError = lastError as ProxyError;` — if a non-`ProxyError` is categorized here, `proxyError.upstreamError?.statusCodeInferred` is safe due to optional chaining, but `proxyError.message` would return the plain error message rather than the ProxyError-formatted one, silently producing incorrect telemetry in `session.addProviderToChain`.

   - **Line 1672** (`PROVIDER_ERROR` handler): `const proxyError = lastError as ProxyError;` followed immediately by `const statusCode = proxyError.statusCode;` — `statusCode` will be `undefined` for any non-`ProxyError`. The `statusCode === 524` guard at line 1678 evaluates `undefined === 524 → false` (safe), but `statusCode: statusCode` stored in the chain audit at line 1752 will be `undefined`, corrupting the audit trail. Additionally `proxyError.upstreamError?.body/parsed` will be `undefined` instead of actual upstream body data.

   Both sites need the same `instanceof ProxyError` guard that was applied to the `NON_RETRYABLE_CLIENT_ERROR` handler.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/v1/_lib/proxy/forwarder.ts
   Line: 1566

   Comment:
   **Incomplete fix — two unsafe `as ProxyError` casts remain**

   The PR description states:
   > "Add `instanceof ProxyError` guards at all three unsafe cast sites in `forwarder.ts`"

   However, the diff only added a guard to the `NON_RETRYABLE_CLIENT_ERROR` handler. This line and the analogous cast at line 1672 still contain unguarded `as ProxyError` casts:

   - **Line 1566** (`RESOURCE_NOT_FOUND` handler): `const proxyError = lastError as ProxyError;` — if a non-`ProxyError` is categorized here, `proxyError.upstreamError?.statusCodeInferred` is safe due to optional chaining, but `proxyError.message` would return the plain error message rather than the ProxyError-formatted one, silently producing incorrect telemetry in `session.addProviderToChain`.

   - **Line 1672** (`PROVIDER_ERROR` handler): `const proxyError = lastError as ProxyError;` followed immediately by `const statusCode = proxyError.statusCode;` — `statusCode` will be `undefined` for any non-`ProxyError`. The `statusCode === 524` guard at line 1678 evaluates `undefined === 524 → false` (safe), but `statusCode: statusCode` stored in the chain audit at line 1752 will be `undefined`, corrupting the audit trail. Additionally `proxyError.upstreamError?.body/parsed` will be `undefined` instead of actual upstream body data.

   Both sites need the same `instanceof ProxyError` guard that was applied to the `NON_RETRYABLE_CLIENT_ERROR` handler.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/forwarder.ts
Line: 1419-1424

Comment:
**`TRANSPORT_CODES` Set allocated on every catch**

`TRANSPORT_CODES` is a `new Set(...)` literal inside the catch block, meaning it is reconstructed on every error that reaches this path. Since the same set is already defined as a module-level implementation detail inside `isTransportError()` in `errors.ts`, these two definitions are now diverged copies. Consider either:

1. Exporting a shared constant (or re-exporting the existing `isTransportError` function) from `errors.ts` and calling it here, or
2. At minimum, hoisting `TRANSPORT_CODES` to module scope in `forwarder.ts`.

This is a minor performance concern in an error path, but more importantly, keeping two separate copies risks them drifting if `errors.ts` adds new codes in the future.

```suggestion
              const TRANSPORT_CODES = NETWORK_ERROR_TRANSPORT_CODES; // import module-level constant
```
or simply call the exported helper directly:
```ts
// In errors.ts — export the existing private function:
export { isTransportError };

// In forwarder.ts — replace the inline block with:
const isNetworkError = isTransportError(lastError);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 01467ea</sub>

<!-- /greptile_comment -->