### PR TITLE
fix: propagate upstream stream errors to prevent truncated responses marked as success

### DIFF
--- a/src/app/v1/_lib/proxy/errors.ts
+++ b/src/app/v1/_lib/proxy/errors.ts
@@ -733,7 +733,7 @@ export function isClientAbortError(error: Error): boolean {
  * @param error - Error to check
  * @returns true if error is a transport error
  */
-function isTransportError(error: Error): boolean {
+export function isTransportError(error: Error): boolean {
   const TRANSPORT_ERROR_CODES = new Set([
     "UND_ERR_SOCKET",
     "UND_ERR_CONNECT_TIMEOUT",

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -4019,18 +4019,18 @@ export class ProxyForwarder {
           }
         });
 
-        // ⭐ 关键：吞掉错误事件，避免 "terminated" 冒泡
+        // ⭐ 关键：将上游流错误传播到下游 reader，确保 ResponseHandler 能检测到截断
         nodeStream.on("error", (err) => {
-          logger.warn("ProxyForwarder: Upstream stream error (gracefully closed)", {
+          logger.warn("ProxyForwarder: Upstream stream error (signaling downstream)", {
             providerId,
             providerName,
             error: err.message,
             errorName: err.name,
           });
           try {
-            controller.close();
+            controller.error(err);
           } catch {
-            // 如果已关闭，忽略
+            // 如果已关闭或已出错，忽略
           }
         });
       },

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -39,7 +39,7 @@ import type { SessionUsageUpdate } from "@/types/session";
 import type { LongContextPricingSpecialSetting } from "@/types/special-settings";
 import { GeminiAdapter } from "../gemini/adapter";
 import type { GeminiResponse } from "../gemini/types";
-import { isClientAbortError } from "./errors";
+import { isClientAbortError, isTransportError } from "./errors";
 import type { ProxySession } from "./session";
 import { consumeDeferredStreamingFinalization } from "./stream-finalization";
 
@@ -2370,6 +2370,39 @@ export class ProxyResponseHandler {
                 finalizeError,
               });
             }
+          }
+        } else if (isTransportError(err)) {
+          // 上游流传输错误（SocketError, ECONNRESET 等）：与 upstream abort 相同处理
+          // 参见 #916 — controller.error(err) 传播的 transport error
+          logger.error("ResponseHandler: Upstream stream transport error", {
+            taskId,
+            providerId: provider.id,
+            providerName: provider.name,
+            messageId: messageContext.id,
+            chunksCollected: chunks.length,
+            errorName: err.name,
+            errorMessage: err.message || "(empty message)",
+            errorCode: (err as NodeJS.ErrnoException).code,
+          });
+
+          try {
+            const allContent = flushAndJoin();
+            await finalizeStream(allContent, false, false, "STREAM_UPSTREAM_ABORTED");
+          } catch (finalizeError) {
+            logger.error("ResponseHandler: Failed to finalize transport-error stream", {
+              taskId,
+              messageId: messageContext.id,
+              finalizeError,
+            });
+
+            await persistRequestFailure({
+              session,
+              messageContext,
+              statusCode: 502,
+              error: err,
+              taskId,
+              phase: "stream",
+            });
           }
         } else {
           logger.error("Failed to save SSE content:", error);


### PR DESCRIPTION
## Problem

When a SocketError (`other side closed` / `UND_ERR_SOCKET`) occurs **during an active streaming response**, the stream is silently truncated and **marked as success**. The client (e.g. Claude Code) receives a partial response with no error signal, causing it to stop mid-operation.

**Log evidence:**
```
12:24:03.409Z WARN  "Upstream stream error (gracefully closed)" error: "other side closed"
12:24:03.411Z INFO  "Streaming request finalized as success"  ← WRONG
```

## Root Cause

In `forwarder.ts`, `nodeStreamToWebStreamSafe()` handles upstream stream errors by calling `controller.close()` — which signals a **normal** end-of-stream. The downstream `ResponseHandler` reader gets `{ done: true }`, sets `streamEndedNormally = true`, and finalizes as success.

## Fix

### 1. `forwarder.ts` — Signal error instead of normal close

```diff
- controller.close();
+ controller.error(err);
```

This causes `reader.read()` in `ResponseHandler` to reject with the original error.

### 2. `errors.ts` — Export `isTransportError()`

The function was already implemented but not exported. Now available for `response-handler.ts`.

### 3. `response-handler.ts` — Route transport errors correctly

Added `isTransportError()` check in the catch block so SocketError/ECONNRESET errors are routed to the `STREAM_UPSTREAM_ABORTED` path with proper:
- Circuit breaker failure recording
- 502 status code in internal bookkeeping
- Error logging with error name/code/message

## Relationship to #911

| Aspect | PR #911 | This PR |
|--------|---------|---------|
| **Phase** | Connection/request phase | Mid-stream (after data flowing) |
| **Code path** | Error categorizer else-branch | Stream error propagation → finalization |
| **Symptom** | No retry/failover on SocketError | Truncated output marked as success |

These are independent bugs in different code paths.

## Changes

- `src/app/v1/_lib/proxy/forwarder.ts`: `controller.close()` → `controller.error(err)` in nodeStream error handler (+4/-4)
- `src/app/v1/_lib/proxy/errors.ts`: Export `isTransportError()` (+1/-1)
- `src/app/v1/_lib/proxy/response-handler.ts`: Add `isTransportError` import and catch branch (+34/-1)

## Testing

- `tsc --noEmit`: ✅ Pass
- `biome check`: ✅ Pass
- The fix is defensive — only changes error propagation path, existing success paths are unchanged
- Transport errors now correctly trigger `STREAM_UPSTREAM_ABORTED` instead of being silently swallowed

Fixes #916

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where upstream transport errors (SocketError, ECONNRESET) during active streaming were silently swallowed, causing truncated responses to be marked as successful. The fix has three parts: (1) `forwarder.ts` now propagates stream errors via `controller.error(err)` instead of `controller.close()`, (2) `errors.ts` exports the existing `isTransportError()` utility, and (3) `response-handler.ts` adds a new catch branch that routes transport errors to `STREAM_UPSTREAM_ABORTED` finalization with proper circuit breaker failure recording and 502 status codes.

- The change is well-scoped and defensive — only the error propagation path is affected; normal success paths remain unchanged
- The new `isTransportError` branch correctly mirrors the existing upstream abort handling logic, including fallback to `persistRequestFailure` if finalization itself fails
- The JSDoc on `nodeStreamToWebStreamSafe` is now outdated and should be updated to reflect the new error-propagation behavior
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- This PR is safe to merge — it only changes the error propagation path and does not affect normal success flows.
- The fix is well-motivated by a clear root cause analysis, the code changes are minimal and defensive, and the new transport error branch mirrors existing patterns in the codebase. The only concern is a stale JSDoc comment, which is non-blocking.
- Pay attention to `src/app/v1/_lib/proxy/forwarder.ts` — the `close` event fires after `error` in Node.js, and while the try/catch handles this safely, the outdated JSDoc may confuse future maintainers.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/forwarder.ts | Changes `controller.close()` to `controller.error(err)` in the Node stream error handler, correctly propagating upstream errors to the downstream reader instead of silently swallowing them. The `close` event handler's try/catch safely handles the subsequent call. Outdated JSDoc on the method. |
| src/app/v1/_lib/proxy/errors.ts | Adds `export` keyword to the existing `isTransportError()` function to make it available for `response-handler.ts`. No logic changes. |
| src/app/v1/_lib/proxy/response-handler.ts | Adds an `isTransportError` catch branch that routes transport errors (SocketError, ECONNRESET) to `STREAM_UPSTREAM_ABORTED` finalization with proper circuit breaker accounting, mirroring the existing upstream abort handling path. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant US as Upstream Provider
    participant NS as Node Stream
    participant WS as Web ReadableStream (forwarder.ts)
    participant RH as ResponseHandler (reader)

    US->>NS: data chunks...
    NS->>WS: controller.enqueue(chunk)
    WS->>RH: reader.read() → {value, done:false}

    Note over US,NS: SocketError / ECONNRESET occurs

    rect rgb(255, 230, 230)
        Note right of NS: Before this PR
        NS->>WS: error event → controller.close()
        WS->>RH: reader.read() → {done:true}
        RH->>RH: streamEndedNormally = true
        Note over RH: Finalized as SUCCESS ❌
    end

    rect rgb(230, 255, 230)
        Note right of NS: After this PR
        NS->>WS: error event → controller.error(err)
        WS->>RH: reader.read() rejects with err
        RH->>RH: catch → isTransportError(err) = true
        RH->>RH: finalizeStream(STREAM_UPSTREAM_ABORTED)
        Note over RH: Finalized as FAILURE ✅
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/v1/_lib/proxy/forwarder.ts`, line 3966 ([link](https://github.com/ding113/claude-code-hub/blob/b968b1d6c526620ac585b85393aaa211d5efad9b/src/app/v1/_lib/proxy/forwarder.ts#L3966)) 

   **Outdated JSDoc after behavior change**

   The comment says "吞掉上游流的错误事件，避免 'terminated' 错误冒泡到调用者" (swallow upstream stream errors), but this PR intentionally changes the behavior to **propagate** errors via `controller.error(err)`. The JSDoc should be updated to reflect the new semantics.

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/forwarder.ts
Line: 3966

Comment:
**Outdated JSDoc after behavior change**

The comment says "吞掉上游流的错误事件，避免 'terminated' 错误冒泡到调用者" (swallow upstream stream errors), but this PR intentionally changes the behavior to **propagate** errors via `controller.error(err)`. The JSDoc should be updated to reflect the new semantics.

```suggestion
   * 关键特性：将上游流错误传播到下游 reader，确保 ResponseHandler 能正确检测到截断
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: b968b1d</sub>

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->