### PR TITLE
fix: 端点 Dialog 表单 submit 事件冒泡导致外层编辑 Dialog 意外关闭

### DIFF
--- a/src/app/[locale]/settings/providers/_components/provider-endpoints-table.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-endpoints-table.tsx
@@ -511,6 +511,7 @@ export function AddEndpointButton({
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    e.stopPropagation();
     setIsSubmitting(true);
     const formData = new FormData(e.currentTarget);
     const endpointUrl = formData.get("url") as string;
@@ -680,6 +681,7 @@ function EditEndpointDialog({ endpoint }: { endpoint: ProviderEndpoint }) {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    e.stopPropagation();
     setIsSubmitting(true);
     const formData = new FormData(e.currentTarget);
     const url = formData.get("url") as string;


### PR DESCRIPTION
## Summary
Fixes nested dialog form submit event bubbling that caused the outer edit dialog to unexpectedly close when submitting the inner endpoint add/edit dialog in the provider management UI.

## Problem

In the provider management interface, when editing a provider and clicking "Add Endpoint" to open the nested dialog, filling in the form and clicking "Create" would unexpectedly close the outer edit dialog and return to the provider list. The expected behavior is for only the inner dialog to close, keeping the edit dialog open.

**Root Cause:** React synthetic events bubble through the **component tree** (not the DOM tree). The `<form>` elements in `AddEndpointButton` and `EditEndpointDialog` are rendered to `document.body` via Radix UI Portal, but in React's virtual tree they remain descendants of the outer `ProviderFormContent`'s `<form>`. The inner form's `handleSubmit` only called `e.preventDefault()` without `e.stopPropagation()`, causing the `submit` event to bubble to the outer `<form onSubmit={handleSubmit}>`, triggering the provider save flow which called `onSuccess()` to close the edit dialog.

## Solution

Add `e.stopPropagation()` to the `handleSubmit` functions in both `AddEndpointButton` and `EditEndpointDialog` to prevent submit events from bubbling up.

## Changes

| File | Change |
|------|--------|
| `src/app/[locale]/settings/providers/_components/provider-endpoints-table.tsx` | Added `e.stopPropagation()` to two `handleSubmit` functions (+2 lines) |

## Testing

### Manual Testing
1. Navigate to provider management page (list view)
2. Click the edit button on a provider to open the edit dialog
3. In the endpoint pool section within the edit dialog, click "Add Endpoint"
4. Fill in endpoint information and click "Create"
5. **Expected:** Inner add endpoint dialog closes, outer edit dialog remains open
6. Similarly verify the endpoint edit dialog behavior

## Checklist
- [x] Target branch is `dev`
- [x] `bun run typecheck` passed
- [x] `bun run lint` passed
- [x] No direct conflicts with `main`

---

**Note:** This PR modifies `provider-endpoints-table.tsx` which is also modified in PR #919. Reviewers should be aware of potential merge conflicts.

---
*Description enhanced by Claude AI*