### PR TITLE
feat(providers): polish provider management page visuals and performance

### DIFF
--- a/src/app/[locale]/settings/providers/_components/forms/provider-form/index.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/provider-form/index.tsx
@@ -28,6 +28,7 @@ import { Button } from "@/components/ui/button";
 import { PROVIDER_BATCH_PATCH_ERROR_CODES } from "@/lib/provider-batch-patch-error-codes";
 import { isValidUrl } from "@/lib/utils/validation";
 import type { ProviderDisplay, ProviderEndpoint, ProviderType } from "@/types/provider";
+import { invalidateProviderQueries } from "../../invalidate-provider-queries";
 import { FormTabNav, NAV_ORDER, PARENT_MAP, TAB_ORDER } from "./components/form-tab-nav";
 import { ProviderFormProvider, useProviderForm } from "./provider-form-context";
 import type { NavTargetId, SubTabId, TabId } from "./provider-form-types";
@@ -73,6 +74,8 @@ function ProviderFormContent({
   const isEdit = mode === "edit";
 
   const queryClient = useQueryClient();
+
+  const doInvalidate = useCallback(() => invalidateProviderQueries(queryClient), [queryClient]);
 
   const resolvedEndpointPoolVendorId = useMemo(() => {
     return isEdit ? (provider?.providerVendorId ?? null) : null;
@@ -134,6 +137,15 @@ function ProviderFormContent({
   const rafRef = useRef<number | null>(null);
   const scrollLockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollEndListenerRef = useRef<(() => void) | null>(null);
+
+  // Refs for scroll handler to avoid re-creating the callback on every tab change
+  const activeTabRef = useRef(state.ui.activeTab);
+  const activeSubTabRef = useRef(state.ui.activeSubTab);
+
+  useEffect(() => {
+    activeTabRef.current = state.ui.activeTab;
+    activeSubTabRef.current = state.ui.activeSubTab;
+  }, [state.ui.activeTab, state.ui.activeSubTab]);
 
   useEffect(() => {
     return () => {
@@ -201,11 +213,11 @@ function ProviderFormContent({
           ? PARENT_MAP[activeSection as SubTabId]
           : (activeSection as TabId);
       const subTab = activeSection in PARENT_MAP ? (activeSection as SubTabId) : null;
-      if (state.ui.activeTab !== parentTab || state.ui.activeSubTab !== subTab) {
+      if (activeTabRef.current !== parentTab || activeSubTabRef.current !== subTab) {
         dispatch({ type: "SET_ACTIVE_NAV", payload: { tab: parentTab, subTab } });
       }
     });
-  }, [dispatch, state.ui.activeSubTab, state.ui.activeTab]);
+  }, [dispatch]);
 
   const handleTabChange = (tab: TabId) => {
     dispatch({ type: "SET_ACTIVE_TAB", payload: tab });
@@ -359,10 +371,7 @@ function ProviderFormContent({
                   const undoResult = await undoProviderPatch({ undoToken, operationId });
                   if (undoResult.ok) {
                     toast.success(tBatchEdit("undo.singleEditUndone"));
-                    await queryClient.invalidateQueries({ queryKey: ["providers"] });
-                    await queryClient.invalidateQueries({ queryKey: ["providers-health"] });
-                    await queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
-                    await queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
+                    await doInvalidate();
                   } else if (
                     undoResult.errorCode === PROVIDER_BATCH_PATCH_ERROR_CODES.UNDO_EXPIRED
                   ) {
@@ -377,10 +386,7 @@ function ProviderFormContent({
             },
           });
 
-          void queryClient.invalidateQueries({ queryKey: ["providers"] });
-          void queryClient.invalidateQueries({ queryKey: ["providers-health"] });
-          void queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
-          void queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
+          void doInvalidate();
         } else {
           // For create: key is required
           const createFormData = { ...baseFormData, key: trimmedKey };
@@ -390,10 +396,7 @@ function ProviderFormContent({
             return;
           }
 
-          void queryClient.invalidateQueries({ queryKey: ["providers"] });
-          void queryClient.invalidateQueries({ queryKey: ["providers-health"] });
-          void queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
-          void queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
+          void doInvalidate();
 
           toast.success(t("success.created"));
           dispatch({ type: "RESET_FORM" });
@@ -451,10 +454,7 @@ function ProviderFormContent({
                 const undoResult = await undoProviderDelete({ undoToken, operationId });
                 if (undoResult.ok) {
                   toast.success(tBatchEdit("undo.singleDeleteUndone"));
-                  await queryClient.invalidateQueries({ queryKey: ["providers"] });
-                  await queryClient.invalidateQueries({ queryKey: ["providers-health"] });
-                  await queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
-                  await queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
+                  await doInvalidate();
                 } else if (undoResult.errorCode === PROVIDER_BATCH_PATCH_ERROR_CODES.UNDO_EXPIRED) {
                   toast.error(tBatchEdit("undo.expired"));
                 } else {
@@ -467,10 +467,7 @@ function ProviderFormContent({
           },
         });
 
-        void queryClient.invalidateQueries({ queryKey: ["providers"] });
-        void queryClient.invalidateQueries({ queryKey: ["providers-health"] });
-        void queryClient.invalidateQueries({ queryKey: ["providers-statistics"] });
-        void queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
+        void doInvalidate();
         onSuccess?.();
       } catch (e) {
         console.error("Delete error:", e);
@@ -479,8 +476,8 @@ function ProviderFormContent({
     });
   };
 
-  // Tab status indicators
-  const getTabStatus = (): Partial<Record<TabId, "default" | "warning" | "configured">> => {
+  // Tab status indicators (memoized to avoid object recreation per render)
+  const tabStatus = useMemo((): Partial<Record<TabId, "default" | "warning" | "configured">> => {
     const status: Partial<Record<TabId, "default" | "warning" | "configured">> = {};
 
     // Basic - warning if required fields missing
@@ -544,7 +541,15 @@ function ProviderFormContent({
     }
 
     return status;
-  };
+  }, [
+    state.basic,
+    state.routing,
+    state.rateLimit,
+    state.network,
+    state.mcp,
+    hideUrl,
+    endpointPoolHideLegacyUrlInput,
+  ]);
 
   return (
     <form
@@ -561,7 +566,7 @@ function ProviderFormContent({
             onTabChange={handleTabChange}
             onSubTabChange={handleSubTabChange}
             disabled={isPending}
-            tabStatus={getTabStatus()}
+            tabStatus={tabStatus}
           />
         </div>
 

--- a/src/app/[locale]/settings/providers/_components/invalidate-provider-queries.ts
+++ b/src/app/[locale]/settings/providers/_components/invalidate-provider-queries.ts
@@ -1,0 +1,16 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+/** Invalidate all provider-related queries in one batch */
+export function invalidateProviderQueries(queryClient: QueryClient): Promise<void> {
+  return queryClient.invalidateQueries({
+    predicate: (query) => {
+      const key = query.queryKey[0];
+      return (
+        key === "providers" ||
+        key === "providers-health" ||
+        key === "providers-statistics" ||
+        key === "provider-vendors"
+      );
+    },
+  });
+}

--- a/src/app/[locale]/settings/providers/_components/provider-list.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-list.tsx
@@ -11,6 +11,11 @@ import type { User } from "@/types/user";
 import type { EndpointCircuitInfoMap } from "./provider-manager";
 import { ProviderRichListItem } from "./provider-rich-list-item";
 
+// Stable default references to avoid re-creating on every render (defeats React.memo)
+const EMPTY_STRING_ARRAY: string[] = [];
+const EMPTY_OBJECT: Record<string, never> = {};
+const EMPTY_SET = new Set<number>();
+
 interface ProviderListProps {
   providers: ProviderDisplay[];
   currentUser?: User;
@@ -43,17 +48,17 @@ export function ProviderList({
   providers,
   currentUser,
   healthStatus,
-  endpointCircuitInfo = {},
-  statistics = {},
+  endpointCircuitInfo = EMPTY_OBJECT,
+  statistics = EMPTY_OBJECT,
   statisticsLoading = false,
   currencyCode = "USD",
   enableMultiProviderTypes,
   activeGroupFilter = null,
   isMultiSelectMode = false,
-  selectedProviderIds = new Set(),
+  selectedProviderIds = EMPTY_SET,
   onSelectProvider,
-  allGroups = [],
-  userGroups = [],
+  allGroups = EMPTY_STRING_ARRAY,
+  userGroups = EMPTY_STRING_ARRAY,
   isAdmin = false,
 }: ProviderListProps) {
   const t = useTranslations("settings.providers");

--- a/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
@@ -16,7 +16,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useEffect, useState, useTransition } from "react";
+import { memo, useCallback, useEffect, useState, useTransition } from "react";
 import { toast } from "sonner";
 import {
   editProvider,
@@ -64,6 +64,7 @@ import {
 } from "@/lib/constants/provider.constants";
 import { PROVIDER_BATCH_PATCH_ERROR_CODES } from "@/lib/provider-batch-patch-error-codes";
 import { getProviderTypeConfig, getProviderTypeTranslationKey } from "@/lib/provider-type-utils";
+import { cn } from "@/lib/utils";
 import { copyToClipboard, isClipboardSupported } from "@/lib/utils/clipboard";
 import { getContrastTextColor, getGroupColor } from "@/lib/utils/color";
 import type { CurrencyCode } from "@/lib/utils/currency";
@@ -73,6 +74,7 @@ import type { User } from "@/types/user";
 import { ProviderForm } from "./forms/provider-form";
 import { GroupEditCombobox } from "./group-edit-combobox";
 import { InlineEditPopover } from "./inline-edit-popover";
+import { invalidateProviderQueries } from "./invalidate-provider-queries";
 import { PriorityEditPopover } from "./priority-edit-popover";
 import { ProviderEndpointHover } from "./provider-endpoint-hover";
 
@@ -110,7 +112,7 @@ interface ProviderRichListItemProps {
   isAdmin?: boolean;
 }
 
-export function ProviderRichListItem({
+function ProviderRichListItemInner({
   provider,
   vendor,
   currentUser,
@@ -133,9 +135,47 @@ export function ProviderRichListItem({
 }: ProviderRichListItemProps) {
   const queryClient = useQueryClient();
 
+  const doInvalidate = useCallback(() => invalidateProviderQueries(queryClient), [queryClient]);
+
   const [openEdit, setOpenEdit] = useState(false);
   const [openClone, setOpenClone] = useState(false);
   const [showKeyDialog, setShowKeyDialog] = useState(false);
+
+  // Defer heavy ProviderForm mount so dialog animation doesn't compete with React work
+  const [editFormReady, setEditFormReady] = useState(false);
+  const [cloneFormReady, setCloneFormReady] = useState(false);
+
+  useEffect(() => {
+    if (openEdit) {
+      let cancelled = false;
+      const id = requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (!cancelled) setEditFormReady(true);
+        });
+      });
+      return () => {
+        cancelled = true;
+        cancelAnimationFrame(id);
+      };
+    }
+    setEditFormReady(false);
+  }, [openEdit]);
+
+  useEffect(() => {
+    if (openClone) {
+      let cancelled = false;
+      const id = requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (!cancelled) setCloneFormReady(true);
+        });
+      });
+      return () => {
+        cancelled = true;
+        cancelAnimationFrame(id);
+      };
+    }
+    setCloneFormReady(false);
+  }, [openClone]);
   const [mobileDeleteDialogOpen, setMobileDeleteDialogOpen] = useState(false);
   const [unmaskedKey, setUnmaskedKey] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -231,9 +271,7 @@ export function ProviderRichListItem({
                     const undoResult = await undoProviderDelete({ undoToken, operationId });
                     if (undoResult.ok) {
                       toast.success(tBatchEdit("undo.singleDeleteUndone"));
-                      await queryClient.invalidateQueries({ queryKey: ["providers"] });
-                      await queryClient.invalidateQueries({ queryKey: ["providers-health"] });
-                      await queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
+                      await doInvalidate();
                     } else if (
                       undoResult.errorCode === PROVIDER_BATCH_PATCH_ERROR_CODES.UNDO_EXPIRED
                     ) {
@@ -248,9 +286,7 @@ export function ProviderRichListItem({
               },
             });
 
-            queryClient.invalidateQueries({ queryKey: ["providers"] });
-            queryClient.invalidateQueries({ queryKey: ["providers-health"] });
-            queryClient.invalidateQueries({ queryKey: ["provider-vendors"] });
+            doInvalidate();
           } else {
             toast.error(tList("deleteFailed"), {
               description: res.error || tList("unknownError"),
@@ -319,8 +355,7 @@ export function ProviderRichListItem({
           toast.success(tList("resetCircuitSuccess"), {
             description: tList("resetCircuitSuccessDesc", { name: provider.name }),
           });
-          queryClient.invalidateQueries({ queryKey: ["providers"] });
-          queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+          doInvalidate();
         } else {
           toast.error(tList("resetCircuitFailed"), {
             description: res.error || tList("unknownError"),
@@ -344,8 +379,7 @@ export function ProviderRichListItem({
           toast.success(tList("resetUsageSuccess"), {
             description: tList("resetUsageSuccessDesc", { name: provider.name }),
           });
-          queryClient.invalidateQueries({ queryKey: ["providers"] });
-          queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+          doInvalidate();
         } else {
           toast.error(tList("resetUsageFailed"), {
             description: res.error || tList("unknownError"),
@@ -372,8 +406,7 @@ export function ProviderRichListItem({
           toast.success(tList("toggleSuccess", { status }), {
             description: tList("toggleSuccessDesc", { name: provider.name }),
           });
-          queryClient.invalidateQueries({ queryKey: ["providers"] });
-          queryClient.invalidateQueries({ queryKey: ["providers-health"] });
+          doInvalidate();
         } else {
           toast.error(tList("toggleFailed"), {
             description: res.error || tList("unknownError"),
@@ -396,7 +429,7 @@ export function ProviderRichListItem({
         >[1]);
         if (res.ok) {
           toast.success(tInline("saveSuccess"));
-          queryClient.invalidateQueries({ queryKey: ["providers"] });
+          doInvalidate();
           return true;
         }
         toast.error(tInline("saveFailed"), { description: res.error || tList("unknownError") });
@@ -462,9 +495,27 @@ export function ProviderRichListItem({
     }
   };
 
+  const hasKeyCircuitOpen = healthStatus?.circuitState === "open";
+  const hasEndpointCircuitOpen = endpointCircuitInfo?.some((ep) => ep.circuitState === "open");
+  const accentColor = hasKeyCircuitOpen
+    ? "border-l-red-500"
+    : hasEndpointCircuitOpen
+      ? "border-l-amber-500"
+      : provider.isEnabled
+        ? "border-l-emerald-500"
+        : "border-l-gray-300 dark:border-l-gray-600";
+
   return (
     <>
-      <div className="rounded-lg border bg-card p-4 md:rounded-none md:border-0 md:border-b md:bg-transparent md:p-0 md:py-3 md:px-4 flex flex-col gap-3 md:flex-row md:items-center md:gap-4 hover:bg-muted/50 transition-colors">
+      <div
+        className={cn(
+          "rounded-lg border border-l-[3px] bg-card shadow-sm p-4",
+          "md:shadow-none md:rounded-none md:border-0 md:border-b md:border-l-[3px] md:bg-transparent md:p-0 md:py-3 md:px-4",
+          "flex flex-col gap-3 md:flex-row md:items-center md:gap-4",
+          "hover:bg-muted/50 transition-colors",
+          accentColor
+        )}
+      >
         {/* Checkbox: shared between mobile and desktop */}
         {isMultiSelectMode && (
           <Checkbox
@@ -830,10 +881,12 @@ export function ProviderRichListItem({
         </div>
 
         {/* Desktop: metrics */}
-        <div className="hidden md:grid grid-cols-3 gap-4 text-center flex-shrink-0">
-          <div>
-            <div className="text-xs text-muted-foreground">{tList("priority")}</div>
-            <div className="font-medium">
+        <div className="hidden md:grid grid-cols-3 gap-2 text-center flex-shrink-0">
+          <div className="rounded-md bg-muted/30 px-2.5 py-1.5">
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+              {tList("priority")}
+            </div>
+            <div className="font-semibold text-sm">
               {canEdit ? (
                 <PriorityEditPopover
                   globalPriority={provider.priority}
@@ -848,9 +901,11 @@ export function ProviderRichListItem({
               )}
             </div>
           </div>
-          <div>
-            <div className="text-xs text-muted-foreground">{tList("weight")}</div>
-            <div className="font-medium">
+          <div className="rounded-md bg-muted/30 px-2.5 py-1.5">
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+              {tList("weight")}
+            </div>
+            <div className="font-semibold text-sm">
               {canEdit ? (
                 <InlineEditPopover
                   value={provider.weight}
@@ -864,9 +919,11 @@ export function ProviderRichListItem({
               )}
             </div>
           </div>
-          <div>
-            <div className="text-xs text-muted-foreground">{tList("costMultiplier")}</div>
-            <div className="font-medium">
+          <div className="rounded-md bg-muted/30 px-2.5 py-1.5">
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+              {tList("costMultiplier")}
+            </div>
+            <div className="font-semibold text-sm">
               {canEdit ? (
                 <InlineEditPopover
                   value={provider.costMultiplier}
@@ -884,8 +941,10 @@ export function ProviderRichListItem({
         </div>
 
         {/* Desktop: today usage */}
-        <div className="hidden lg:block text-center flex-shrink-0 min-w-[100px]">
-          <div className="text-xs text-muted-foreground">{tList("todayUsageLabel")}</div>
+        <div className="hidden lg:block text-center flex-shrink-0 min-w-[100px] rounded-md bg-muted/30 px-2.5 py-1.5">
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+            {tList("todayUsageLabel")}
+          </div>
           {statisticsLoading ? (
             <>
               <Skeleton className="h-5 w-16 mx-auto my-0.5" />
@@ -893,7 +952,7 @@ export function ProviderRichListItem({
             </>
           ) : (
             <>
-              <div className="font-medium">
+              <div className="font-semibold text-sm">
                 {tList("todayUsageCount", {
                   count: statistics?.todayCalls ?? provider.todayCallCount ?? 0,
                 })}
@@ -1009,41 +1068,49 @@ export function ProviderRichListItem({
         </div>
       </div>
 
-      {/* 编辑 Dialog */}
+      {/* Edit Dialog */}
       <Dialog open={openEdit} onOpenChange={setOpenEdit}>
         <DialogContent className="max-w-6xl max-h-[var(--cch-viewport-height-90)] flex flex-col overflow-hidden p-0 gap-0">
           <VisuallyHidden>
             <DialogTitle>{t("editProvider")}</DialogTitle>
           </VisuallyHidden>
-          <FormErrorBoundary>
-            <ProviderForm
-              mode="edit"
-              provider={provider}
-              onSuccess={() => {
-                setOpenEdit(false);
-              }}
-              enableMultiProviderTypes={enableMultiProviderTypes}
-            />
-          </FormErrorBoundary>
+          {editFormReady ? (
+            <FormErrorBoundary>
+              <ProviderForm
+                mode="edit"
+                provider={provider}
+                onSuccess={() => {
+                  setOpenEdit(false);
+                }}
+                enableMultiProviderTypes={enableMultiProviderTypes}
+              />
+            </FormErrorBoundary>
+          ) : (
+            <DialogFormSkeleton />
+          )}
         </DialogContent>
       </Dialog>
 
-      {/* 克隆 Dialog */}
+      {/* Clone Dialog */}
       <Dialog open={openClone} onOpenChange={setOpenClone}>
         <DialogContent className="max-w-6xl max-h-[var(--cch-viewport-height-90)] flex flex-col overflow-hidden p-0 gap-0">
           <VisuallyHidden>
             <DialogTitle>{t("clone")}</DialogTitle>
           </VisuallyHidden>
-          <FormErrorBoundary>
-            <ProviderForm
-              mode="create"
-              cloneProvider={provider}
-              onSuccess={() => {
-                setOpenClone(false);
-              }}
-              enableMultiProviderTypes={enableMultiProviderTypes}
-            />
-          </FormErrorBoundary>
+          {cloneFormReady ? (
+            <FormErrorBoundary>
+              <ProviderForm
+                mode="create"
+                cloneProvider={provider}
+                onSuccess={() => {
+                  setOpenClone(false);
+                }}
+                enableMultiProviderTypes={enableMultiProviderTypes}
+              />
+            </FormErrorBoundary>
+          ) : (
+            <DialogFormSkeleton />
+          )}
         </DialogContent>
       </Dialog>
 
@@ -1076,5 +1143,55 @@ export function ProviderRichListItem({
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+export const ProviderRichListItem = memo(ProviderRichListItemInner, (prev, next) => {
+  // Skip function props — they are safe to ignore because:
+  // - onSelectProvider (parent) uses useCallback + functional setState (prev => ...)
+  // - onSelectChange (ProviderList) binds stable provider.id to the above
+  // - onEdit/onClone/onDelete are undefined in ProviderList (use internal handlers)
+  // If any of these assumptions change, add the relevant prop to this comparison.
+  return (
+    prev.provider === next.provider &&
+    prev.vendor === next.vendor &&
+    prev.currentUser === next.currentUser &&
+    prev.healthStatus === next.healthStatus &&
+    prev.endpointCircuitInfo === next.endpointCircuitInfo &&
+    prev.statistics === next.statistics &&
+    prev.statisticsLoading === next.statisticsLoading &&
+    prev.currencyCode === next.currencyCode &&
+    prev.enableMultiProviderTypes === next.enableMultiProviderTypes &&
+    prev.isMultiSelectMode === next.isMultiSelectMode &&
+    prev.isSelected === next.isSelected &&
+    prev.activeGroupFilter === next.activeGroupFilter &&
+    prev.allGroups === next.allGroups &&
+    prev.userGroups === next.userGroups &&
+    prev.isAdmin === next.isAdmin
+  );
+});
+
+/** Lightweight placeholder shown while ProviderForm mounts (keeps dialog animation smooth) */
+function DialogFormSkeleton() {
+  return (
+    <div className="flex flex-col h-[60vh] animate-pulse">
+      <div className="flex flex-1 min-h-0">
+        <div className="hidden lg:block w-48 shrink-0 border-r p-4 space-y-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-full" />
+          ))}
+        </div>
+        <div className="flex-1 p-6 space-y-6">
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-6 w-36 mt-4" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      </div>
+      <div className="shrink-0 px-6 py-4 border-t">
+        <Skeleton className="h-10 w-24 ml-auto" />
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

供应商管理页面的视觉美化与性能优化。

### 视觉改进
- 列表项左侧增加 3px 状态色条（绿色=启用 / 灰色=禁用 / 红色=密钥熔断 / 琥珀色=端点熔断）
- 指标区域（优先级/权重/费率倍数）改为圆角卡片样式，标签使用 uppercase micro-label
- 今日用量列同步更新样式
- 移动端卡片增加 `shadow-sm` 微阴影

### 性能优化
- `handleScroll` 用 ref 追踪 activeTab/activeSubTab，打断 scroll → dispatch → re-render → handler recreation 循环
- `tabStatus` 从每帧函数调用改为 `useMemo`
- `ProviderRichListItem` 包裹 `React.memo` + 自定义比较函数（跳过函数属性，已文档化前提条件）
- `ProviderList` 默认参数使用模块级常量，避免空数组字面量击穿 memo
- 编辑/克隆 Dialog 延迟挂载 `ProviderForm`（双 `requestAnimationFrame`），解耦 CSS 动画与组件初始化
- 提取 `invalidateProviderQueries` 共享 utility，合并散落的多次 `invalidateQueries` 调用为单次 predicate 匹配

## Related Work

- **Follow-up to #789** - Previous provider page performance refactor (batch queries, caching, index optimization)
- **Follow-up to #782** - Initial provider page performance improvements (N+1 elimination, request coalescing)
- **Related to #850** - Ongoing UI performance optimization efforts for common pages

## Changes

| File | Changes |
|------|---------|
| `provider-form/index.tsx` | Refs for scroll handler, `useMemo` for `tabStatus`, consolidated query invalidation |
| `invalidate-provider-queries.ts` | **New**: Shared utility for batch query invalidation via predicate |
| `provider-list.tsx` | Stable module-level constants for default props (preserves `React.memo`) |
| `provider-rich-list-item.tsx` | `React.memo` with custom `areEqual`, deferred form mounting, status accent border styling |

## Test Plan

- [x] `bun run typecheck` 通过
- [x] `bun run lint` 无新增错误
- [x] `bun run build` 生产构建成功
- [x] `bun run test` 398 文件通过，无新增失败（1 个预先存在的无关失败）
- [x] 浏览器验证：供应商列表视觉效果（亮/暗模式）
- [x] 浏览器验证：编辑 Dialog 打开/关闭流畅度
- [x] 浏览器验证：移动端响应式布局

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR delivers visual polish (status accent borders, metric card styling, mobile shadow) and several React performance improvements (ref-based scroll handler, `useMemo` for `tabStatus`, `React.memo` on `ProviderRichListItem`, stable default constants) alongside a new `invalidateProviderQueries` shared utility.

**Key changes:**
- New `invalidateProviderQueries` utility consolidates 4 scattered `invalidateQueries` calls into one predicate-based batch — cleaner, but it silently expands the invalidation scope for several operations in `provider-rich-list-item.tsx` (see inline comments).
- `handleSaveGroups` was not migrated to `doInvalidate()`, leaving an inconsistency where group-tag saves skip health/statistics/vendor invalidation while every other mutation handler was updated.
- Double-rAF deferred mounting of `ProviderForm` decouples dialog animation from React initialization work, with a `DialogFormSkeleton` placeholder for smooth transitions.
- `React.memo` custom comparator correctly skips function props per documented caller contract, though the `onSelectChange` inline arrow concern was already raised in a prior review thread.
- `EMPTY_OBJECT` (`Record<string, never>`) is shared as the default for both `endpointCircuitInfo` and `statistics` — TypeScript accepts this structurally, but could be made more explicit with per-prop typed constants.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge after reviewing the unintended invalidation scope expansion and the missed `handleSaveGroups` migration.
- Two behavioral issues prevent a higher score: (1) `doInvalidate()` silently adds `providers-statistics` and `provider-vendors` to operations (reset-circuit, reset-usage, toggle, inline save) that previously didn't include them — this is an undocumented behavior change, not a pure refactor; (2) `handleSaveGroups` was not migrated and now invalidates only `providers`, inconsistent with all other handlers. The visual and core performance changes are well-implemented.
- Pay close attention to `provider-rich-list-item.tsx` — specifically the `handleSaveGroups` missed migration and the query invalidation scope expansion introduced by replacing targeted `invalidateQueries` calls with the broader `doInvalidate()` utility.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/settings/providers/_components/forms/provider-form/index.tsx | Adds ref-based scroll handler, memoizes `tabStatus` via `useMemo`, and replaces four scattered `invalidateQueries` calls with `doInvalidate()`. Changes are well-scoped; `tabStatus` dependency array looks complete. |
| src/app/[locale]/settings/providers/_components/invalidate-provider-queries.ts | New shared utility that batches all provider query invalidations via a single predicate. Clean implementation, but its one-size-fits-all scope (4 query keys) silently expands invalidation for callers in `provider-rich-list-item.tsx` that previously targeted fewer keys. |
| src/app/[locale]/settings/providers/_components/provider-list.tsx | Introduces module-level stable constants (`EMPTY_STRING_ARRAY`, `EMPTY_OBJECT`, `EMPTY_SET`) as default props to preserve `React.memo` effectiveness. Straightforward and correct change. |
| src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx | Adds `React.memo` with a custom comparator, deferred `ProviderForm` mounting via double-rAF, accent status border, and card styling. `handleSaveGroups` was not migrated to `doInvalidate()` unlike every other handler, and `doInvalidate()` silently expands invalidation scope for several operations. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant ProviderRichListItem
    participant ProviderForm
    participant invalidateProviderQueries
    participant ReactQuery

    User->>ProviderRichListItem: click Edit / Clone
    ProviderRichListItem->>ProviderRichListItem: setOpenEdit(true)
    Note over ProviderRichListItem: rAF 1 fires
    Note over ProviderRichListItem: rAF 2 fires → setEditFormReady(true)
    ProviderRichListItem->>ProviderForm: mount (deferred, after dialog animation)

    User->>ProviderRichListItem: toggle / delete / reset / inline save
    ProviderRichListItem->>invalidateProviderQueries: doInvalidate()
    invalidateProviderQueries->>ReactQuery: invalidate predicate match
    ReactQuery-->>ReactQuery: providers, providers-health,\nproviders-statistics, provider-vendors
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx`, line 455-463 ([link](https://github.com/ding113/claude-code-hub/blob/c1e52e26410ffa2f04e14ab1e611531be2452b10/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx#L455-L463)) 

   **`handleSaveGroups` not migrated to `doInvalidate`**

   Every other mutation handler in this component (delete, toggle, reset-circuit, reset-usage, inline save) was migrated to `doInvalidate()`, but `handleSaveGroups` at line 461 still calls `queryClient.invalidateQueries({ queryKey: ["providers"] })` directly. As a result, saving a group-tag change only invalidates `providers`, skipping `providers-health`, `providers-statistics`, and `provider-vendors` — inconsistent with the rest of the file.

   
   Replace with `doInvalidate()` to match every other handler, or document why the narrower invalidation is intentional here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
   Line: 455-463

   Comment:
   **`handleSaveGroups` not migrated to `doInvalidate`**

   Every other mutation handler in this component (delete, toggle, reset-circuit, reset-usage, inline save) was migrated to `doInvalidate()`, but `handleSaveGroups` at line 461 still calls `queryClient.invalidateQueries({ queryKey: ["providers"] })` directly. As a result, saving a group-tag change only invalidates `providers`, skipping `providers-health`, `providers-statistics`, and `provider-vendors` — inconsistent with the rest of the file.

   
   Replace with `doInvalidate()` to match every other handler, or document why the narrower invalidation is intentional here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
Line: 455-463

Comment:
**`handleSaveGroups` not migrated to `doInvalidate`**

Every other mutation handler in this component (delete, toggle, reset-circuit, reset-usage, inline save) was migrated to `doInvalidate()`, but `handleSaveGroups` at line 461 still calls `queryClient.invalidateQueries({ queryKey: ["providers"] })` directly. As a result, saving a group-tag change only invalidates `providers`, skipping `providers-health`, `providers-statistics`, and `provider-vendors` — inconsistent with the rest of the file.

```suggestion
        queryClient.invalidateQueries({ queryKey: ["providers"] });
```
Replace with `doInvalidate()` to match every other handler, or document why the narrower invalidation is intentional here.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
Line: 358

Comment:
**`doInvalidate()` silently expands invalidation scope**

The refactor to `doInvalidate()` is presented as a pure consolidation, but it actually adds new query keys to several operations that previously did not touch them:

| Handler | Previously invalidated | Now also invalidates |
|---|---|---|
| `handleResetCircuit` | `providers`, `providers-health` | `providers-statistics`, `provider-vendors` |
| `handleResetTotalUsage` | `providers`, `providers-health` | `providers-statistics`, `provider-vendors` |
| `handleToggle` | `providers`, `providers-health` | `providers-statistics`, `provider-vendors` |
| `createSaveHandler` (inline) | `providers` only | `providers-health`, `providers-statistics`, `provider-vendors` |

Most notable: every inline priority/weight/cost-multiplier save now triggers a vendor-data refetch (`provider-vendors`), which is unrelated to those fields. Resetting a circuit breaker also now refetches statistics unnecessarily.

This is a silent behavior change that could increase network traffic. If broader invalidation is intentional, document it in the utility; if not, consider a more targeted invalidation approach (e.g., only `providers` + `providers-health` for toggle/reset operations).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: c1e52e2</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->