### PR TITLE
fix: 修正 Retry Count 过滤与导出（#925）

### DIFF
--- a/src/actions/usage-logs.ts
+++ b/src/actions/usage-logs.ts
@@ -121,7 +121,7 @@ function generateCsv(logs: UsageLogRow[]): string {
   ];
 
   const rows = logs.map((log) => {
-    const retryCount = log.providerChain ? Math.max(0, log.providerChain.length - 1) : 0;
+    const retryCount = log.providerChain ? Math.max(0, log.providerChain.length - 2) : 0;
     return [
       log.createdAt ? new Date(log.createdAt).toISOString() : "",
       escapeCsvField(log.userName),

--- a/src/actions/usage-logs.ts
+++ b/src/actions/usage-logs.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/constants/usage-logs.constants";
 import { logger } from "@/lib/logger";
 import { readLiveChainBatch } from "@/lib/redis/live-chain-store";
+import { getRetryCount } from "@/lib/utils/provider-chain-formatter";
 import { isProviderFinalized } from "@/lib/utils/provider-display";
 import {
   findUsageLogSessionIdSuggestions,
@@ -121,7 +122,7 @@ function generateCsv(logs: UsageLogRow[]): string {
   ];
 
   const rows = logs.map((log) => {
-    const retryCount = log.providerChain ? Math.max(0, log.providerChain.length - 2) : 0;
+    const retryCount = log.providerChain ? getRetryCount(log.providerChain) : 0;
     return [
       log.createdAt ? new Date(log.createdAt).toISOString() : "",
       escapeCsvField(log.userName),

--- a/src/repository/_shared/usage-log-filters.ts
+++ b/src/repository/_shared/usage-log-filters.ts
@@ -13,6 +13,10 @@ export interface UsageLogFilterParams {
   minRetryCount?: number;
 }
 
+// 重试次数计算：provider_chain 长度 - 2（排除 selection 记录 + 最终结果），并做下限 0 保护
+export const RETRY_COUNT_EXPR: SQL =
+  sql`GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 2, 0), 0)`;
+
 export function buildUsageLogConditions(filters: UsageLogFilterParams): SQL[] {
   const conditions: SQL[] = [];
 
@@ -49,7 +53,7 @@ export function buildUsageLogConditions(filters: UsageLogFilterParams): SQL[] {
 
   if (filters.minRetryCount !== undefined) {
     conditions.push(
-      sql`GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 2, 0), 0) >= ${filters.minRetryCount}`
+      sql`${RETRY_COUNT_EXPR} >= ${filters.minRetryCount}`
     );
   }
 

--- a/src/repository/_shared/usage-log-filters.ts
+++ b/src/repository/_shared/usage-log-filters.ts
@@ -14,20 +14,56 @@ export interface UsageLogFilterParams {
 }
 
 // 重试次数计算：
-// - 基本公式：provider_chain 长度 - 2（排除 index 0 的 selection 记录 + index 1 的首次请求）
-// - Hedge Race（并发尝试）按 0 处理（对齐前端 getRetryCount/isHedgeRace 语义）
-// - 下限 0 保护
-const IS_HEDGE_RACE_EXPR: SQL = sql`(
-  COALESCE(${messageRequest.providerChain} @> '[{"reason": "hedge_triggered"}]'::jsonb, false)
-  OR COALESCE(${messageRequest.providerChain} @> '[{"reason": "hedge_launched"}]'::jsonb, false)
-  OR COALESCE(${messageRequest.providerChain} @> '[{"reason": "hedge_winner"}]'::jsonb, false)
-  OR COALESCE(${messageRequest.providerChain} @> '[{"reason": "hedge_loser_cancelled"}]'::jsonb, false)
+// - 对齐前端 getRetryCount/isActualRequest：只统计“实际请求”的次数，再 - 1 得到重试次数
+// - Hedge Race（并发尝试）按 0 处理（并发不算顺序重试，且 UI 优先展示 Hedge Race）
+// - provider_chain 为空/NULL 时按 0 处理
+export const RETRY_COUNT_EXPR: SQL = sql`(
+  SELECT
+    CASE
+      WHEN COALESCE(
+        bool_or(
+          (elem->>'reason') IN (
+            'hedge_triggered',
+            'hedge_launched',
+            'hedge_winner',
+            'hedge_loser_cancelled'
+          )
+        ),
+        false
+      )
+      THEN 0
+      ELSE GREATEST(
+        COALESCE(
+          sum(
+            CASE
+              WHEN (
+                (elem->>'reason') IN (
+                  'concurrent_limit_failed',
+                  'retry_failed',
+                  'system_error',
+                  'resource_not_found',
+                  'client_error_non_retryable',
+                  'endpoint_pool_exhausted',
+                  'vendor_type_all_timeout',
+                  'client_abort',
+                  'http2_fallback'
+                )
+                OR (
+                  (elem->>'reason') IN ('request_success', 'retry_success')
+                  AND (elem->>'statusCode') IS NOT NULL
+                )
+              )
+              THEN 1
+              ELSE 0
+            END
+          ),
+          0
+        ) - 1,
+        0
+      )
+    END
+  FROM jsonb_array_elements(COALESCE(${messageRequest.providerChain}, '[]'::jsonb)) AS elem
 )`;
-
-export const RETRY_COUNT_EXPR: SQL = sql`CASE
-  WHEN ${IS_HEDGE_RACE_EXPR} THEN 0
-  ELSE GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 2, 0), 0)
-END`;
 
 export function buildUsageLogConditions(filters: UsageLogFilterParams): SQL[] {
   const conditions: SQL[] = [];

--- a/src/repository/_shared/usage-log-filters.ts
+++ b/src/repository/_shared/usage-log-filters.ts
@@ -14,8 +14,7 @@ export interface UsageLogFilterParams {
 }
 
 // 重试次数计算：provider_chain 长度 - 2（排除 selection 记录 + 最终结果），并做下限 0 保护
-export const RETRY_COUNT_EXPR: SQL =
-  sql`GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 2, 0), 0)`;
+export const RETRY_COUNT_EXPR: SQL = sql`GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 2, 0), 0)`;
 
 export function buildUsageLogConditions(filters: UsageLogFilterParams): SQL[] {
   const conditions: SQL[] = [];
@@ -52,9 +51,7 @@ export function buildUsageLogConditions(filters: UsageLogFilterParams): SQL[] {
   }
 
   if (filters.minRetryCount !== undefined) {
-    conditions.push(
-      sql`${RETRY_COUNT_EXPR} >= ${filters.minRetryCount}`
-    );
+    conditions.push(sql`${RETRY_COUNT_EXPR} >= ${filters.minRetryCount}`);
   }
 
   return conditions;

--- a/src/repository/_shared/usage-log-filters.ts
+++ b/src/repository/_shared/usage-log-filters.ts
@@ -13,7 +13,7 @@ export interface UsageLogFilterParams {
   minRetryCount?: number;
 }
 
-// 重试次数计算：provider_chain 长度 - 2（排除 selection 记录 + 最终结果），并做下限 0 保护
+// 重试次数计算：provider_chain 长度 - 2（排除 index 0 的 selection 记录 + index 1 的首次请求），并做下限 0 保护
 export const RETRY_COUNT_EXPR: SQL = sql`GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 2, 0), 0)`;
 
 export function buildUsageLogConditions(filters: UsageLogFilterParams): SQL[] {
@@ -50,8 +50,9 @@ export function buildUsageLogConditions(filters: UsageLogFilterParams): SQL[] {
     conditions.push(eq(messageRequest.endpoint, filters.endpoint));
   }
 
-  if (filters.minRetryCount !== undefined) {
-    conditions.push(sql`${RETRY_COUNT_EXPR} >= ${filters.minRetryCount}`);
+  const minRetryCount = filters.minRetryCount ?? 0;
+  if (minRetryCount > 0) {
+    conditions.push(sql`${RETRY_COUNT_EXPR} >= ${minRetryCount}`);
   }
 
   return conditions;

--- a/src/repository/_shared/usage-log-filters.ts
+++ b/src/repository/_shared/usage-log-filters.ts
@@ -49,7 +49,7 @@ export function buildUsageLogConditions(filters: UsageLogFilterParams): SQL[] {
 
   if (filters.minRetryCount !== undefined) {
     conditions.push(
-      sql`GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 1, 0), 0) >= ${filters.minRetryCount}`
+      sql`GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 2, 0), 0) >= ${filters.minRetryCount}`
     );
   }
 

--- a/src/repository/_shared/usage-log-filters.ts
+++ b/src/repository/_shared/usage-log-filters.ts
@@ -13,8 +13,21 @@ export interface UsageLogFilterParams {
   minRetryCount?: number;
 }
 
-// 重试次数计算：provider_chain 长度 - 2（排除 index 0 的 selection 记录 + index 1 的首次请求），并做下限 0 保护
-export const RETRY_COUNT_EXPR: SQL = sql`GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 2, 0), 0)`;
+// 重试次数计算：
+// - 基本公式：provider_chain 长度 - 2（排除 index 0 的 selection 记录 + index 1 的首次请求）
+// - Hedge Race（并发尝试）按 0 处理（对齐前端 getRetryCount/isHedgeRace 语义）
+// - 下限 0 保护
+const IS_HEDGE_RACE_EXPR: SQL = sql`(
+  COALESCE(${messageRequest.providerChain} @> '[{"reason": "hedge_triggered"}]'::jsonb, false)
+  OR COALESCE(${messageRequest.providerChain} @> '[{"reason": "hedge_launched"}]'::jsonb, false)
+  OR COALESCE(${messageRequest.providerChain} @> '[{"reason": "hedge_winner"}]'::jsonb, false)
+  OR COALESCE(${messageRequest.providerChain} @> '[{"reason": "hedge_loser_cancelled"}]'::jsonb, false)
+)`;
+
+export const RETRY_COUNT_EXPR: SQL = sql`CASE
+  WHEN ${IS_HEDGE_RACE_EXPR} THEN 0
+  ELSE GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 2, 0), 0)
+END`;
 
 export function buildUsageLogConditions(filters: UsageLogFilterParams): SQL[] {
   const conditions: SQL[] = [];

--- a/src/repository/usage-logs.ts
+++ b/src/repository/usage-logs.ts
@@ -29,7 +29,7 @@ export interface UsageLogFilters {
   excludeStatusCode200?: boolean;
   model?: string;
   endpoint?: string;
-  /** 最低重试次数（provider_chain 长度 - 2；<= 0 视为不筛选） */
+  /** 最低重试次数（按 provider_chain 中“实际请求”数量 - 1 计算；<= 0 视为不筛选） */
   minRetryCount?: number;
   page?: number;
   pageSize?: number;
@@ -83,6 +83,18 @@ export interface UsageLogSummary {
   totalCacheCreation5mTokens: number;
   totalCacheCreation1hTokens: number;
 }
+
+const EMPTY_USAGE_LOG_SUMMARY: UsageLogSummary = {
+  totalRequests: 0,
+  totalCost: 0,
+  totalTokens: 0,
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  totalCacheCreationTokens: 0,
+  totalCacheReadTokens: 0,
+  totalCacheCreation5mTokens: 0,
+  totalCacheCreation1hTokens: 0,
+};
 
 export interface UsageLogsResult {
   logs: UsageLogRow[];
@@ -405,7 +417,7 @@ interface UsageLogSlimFilters {
   excludeStatusCode200?: boolean;
   model?: string;
   endpoint?: string;
-  /** 最低重试次数（provider_chain 长度 - 2；<= 0 视为不筛选） */
+  /** 最低重试次数（按 provider_chain 中“实际请求”数量 - 1 计算；<= 0 视为不筛选） */
   minRetryCount?: number;
   page?: number;
   pageSize?: number;
@@ -1015,17 +1027,7 @@ export async function findUsageLogsStats(
   const ledgerOnly = await isLedgerOnlyMode();
   const minRetryCount = filters.minRetryCount ?? 0;
   if (ledgerOnly && minRetryCount > 0) {
-    return {
-      totalRequests: 0,
-      totalCost: 0,
-      totalTokens: 0,
-      totalInputTokens: 0,
-      totalOutputTokens: 0,
-      totalCacheCreationTokens: 0,
-      totalCacheReadTokens: 0,
-      totalCacheCreation5mTokens: 0,
-      totalCacheCreation1hTokens: 0,
-    };
+    return EMPTY_USAGE_LOG_SUMMARY;
   }
 
   const conditions = [LEDGER_BILLING_CONDITION];

--- a/src/repository/usage-logs.ts
+++ b/src/repository/usage-logs.ts
@@ -12,7 +12,7 @@ import type { SpecialSetting } from "@/types/special-settings";
 import { LEDGER_BILLING_CONDITION } from "./_shared/ledger-conditions";
 import { escapeLike } from "./_shared/like";
 import { EXCLUDE_WARMUP_CONDITION } from "./_shared/message-request-conditions";
-import { buildUsageLogConditions } from "./_shared/usage-log-filters";
+import { buildUsageLogConditions, RETRY_COUNT_EXPR } from "./_shared/usage-log-filters";
 
 export interface UsageLogFilters {
   userId?: number;
@@ -29,7 +29,7 @@ export interface UsageLogFilters {
   excludeStatusCode200?: boolean;
   model?: string;
   endpoint?: string;
-  /** 最低重试次数（provider_chain 长度 - 2） */
+  /** 最低重试次数（provider_chain 长度 - 2；<= 0 视为不筛选） */
   minRetryCount?: number;
   page?: number;
   pageSize?: number;
@@ -405,7 +405,7 @@ interface UsageLogSlimFilters {
   excludeStatusCode200?: boolean;
   model?: string;
   endpoint?: string;
-  /** 最低重试次数（provider_chain 长度 - 2） */
+  /** 最低重试次数（provider_chain 长度 - 2；<= 0 视为不筛选） */
   minRetryCount?: number;
   page?: number;
   pageSize?: number;
@@ -1011,6 +1011,23 @@ export async function findUsageLogsStats(
 ): Promise<UsageLogSummary> {
   const { userId, keyId, providerId } = filters;
 
+  // 在 ledger-only 模式下，message_request 为空 —— 依赖它的筛选条件必须短路处理。
+  const ledgerOnly = await isLedgerOnlyMode();
+  const minRetryCount = filters.minRetryCount ?? 0;
+  if (ledgerOnly && minRetryCount > 0) {
+    return {
+      totalRequests: 0,
+      totalCost: 0,
+      totalTokens: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCacheCreationTokens: 0,
+      totalCacheReadTokens: 0,
+      totalCacheCreation5mTokens: 0,
+      totalCacheCreation1hTokens: 0,
+    };
+  }
+
   const conditions = [LEDGER_BILLING_CONDITION];
 
   if (userId !== undefined) {
@@ -1052,10 +1069,8 @@ export async function findUsageLogsStats(
     conditions.push(eq(usageLedger.endpoint, filters.endpoint));
   }
 
-  if (filters.minRetryCount !== undefined) {
-    conditions.push(
-      sql`GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 2, 0), 0) >= ${filters.minRetryCount}`
-    );
+  if (minRetryCount > 0 && !ledgerOnly) {
+    conditions.push(sql`${RETRY_COUNT_EXPR} >= ${minRetryCount}`);
   }
 
   const baseQuery = db
@@ -1076,10 +1091,8 @@ export async function findUsageLogsStats(
       ? baseQuery.innerJoin(keysTable, eq(usageLedger.key, keysTable.key))
       : baseQuery;
 
-  // In ledger-only mode, message_request is empty — skip the innerJoin to avoid zeroing all results
-  const ledgerOnly = await isLedgerOnlyMode();
   const query =
-    filters.minRetryCount !== undefined && !ledgerOnly
+    minRetryCount > 0 && !ledgerOnly
       ? queryByKey.innerJoin(messageRequest, eq(usageLedger.requestId, messageRequest.id))
       : queryByKey;
 

--- a/src/repository/usage-logs.ts
+++ b/src/repository/usage-logs.ts
@@ -29,7 +29,7 @@ export interface UsageLogFilters {
   excludeStatusCode200?: boolean;
   model?: string;
   endpoint?: string;
-  /** 最低重试次数（provider_chain 长度 - 1） */
+  /** 最低重试次数（provider_chain 长度 - 2） */
   minRetryCount?: number;
   page?: number;
   pageSize?: number;
@@ -405,7 +405,7 @@ interface UsageLogSlimFilters {
   excludeStatusCode200?: boolean;
   model?: string;
   endpoint?: string;
-  /** 最低重试次数（provider_chain 长度 - 1） */
+  /** 最低重试次数（provider_chain 长度 - 2） */
   minRetryCount?: number;
   page?: number;
   pageSize?: number;
@@ -1054,7 +1054,7 @@ export async function findUsageLogsStats(
 
   if (filters.minRetryCount !== undefined) {
     conditions.push(
-      sql`GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 1, 0), 0) >= ${filters.minRetryCount}`
+      sql`GREATEST(COALESCE(jsonb_array_length(${messageRequest.providerChain}) - 2, 0), 0) >= ${filters.minRetryCount}`
     );
   }
 

--- a/tests/unit/actions/usage-logs-export-retry-count.test.ts
+++ b/tests/unit/actions/usage-logs-export-retry-count.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+const findUsageLogsWithDetailsMock = vi.fn();
+
+vi.mock("@/lib/auth", () => {
+  return {
+    getSession: getSessionMock,
+  };
+});
+
+vi.mock("@/repository/usage-logs", () => {
+  return {
+    findUsageLogSessionIdSuggestions: vi.fn(async () => []),
+    findUsageLogsBatch: vi.fn(async () => ({ logs: [], nextCursor: null, hasMore: false })),
+    findUsageLogsStats: vi.fn(async () => ({
+      totalRequests: 0,
+      totalCost: 0,
+      totalTokens: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCacheCreationTokens: 0,
+      totalCacheReadTokens: 0,
+      totalCacheCreation5mTokens: 0,
+      totalCacheCreation1hTokens: 0,
+    })),
+    findUsageLogsWithDetails: findUsageLogsWithDetailsMock,
+    getUsedEndpoints: vi.fn(async () => []),
+    getUsedModels: vi.fn(async () => []),
+    getUsedStatusCodes: vi.fn(async () => []),
+  };
+});
+
+describe("Usage logs CSV export retryCount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
+  });
+
+  test("exportUsageLogs: Retry Count 应为 provider_chain.length - 2（最小为 0）", async () => {
+    findUsageLogsWithDetailsMock.mockResolvedValue({
+      logs: [
+        {
+          createdAt: new Date("2026-03-16T00:00:00.000Z"),
+          userName: "u",
+          keyName: "k",
+          providerName: "p",
+          model: "m",
+          originalModel: "om",
+          endpoint: "/v1/messages",
+          statusCode: 200,
+          inputTokens: 1,
+          outputTokens: 2,
+          cacheCreation5mInputTokens: 0,
+          cacheCreation1hInputTokens: 0,
+          cacheReadInputTokens: 0,
+          totalTokens: 3,
+          costUsd: "0",
+          durationMs: 10,
+          sessionId: "s1",
+          providerChain: [
+            { reason: "initial_selection" },
+            { reason: "request_success", statusCode: 200 },
+          ],
+        },
+        {
+          createdAt: new Date("2026-03-16T00:00:01.000Z"),
+          userName: "u",
+          keyName: "k",
+          providerName: "p",
+          model: "m",
+          originalModel: "om",
+          endpoint: "/v1/messages",
+          statusCode: 200,
+          inputTokens: 1,
+          outputTokens: 2,
+          cacheCreation5mInputTokens: 0,
+          cacheCreation1hInputTokens: 0,
+          cacheReadInputTokens: 0,
+          totalTokens: 3,
+          costUsd: "0",
+          durationMs: 10,
+          sessionId: "s2",
+          providerChain: [
+            { reason: "initial_selection" },
+            { reason: "retry_failed", attemptNumber: 1 },
+            { reason: "retry_success", statusCode: 200, attemptNumber: 1 },
+          ],
+        },
+      ],
+      total: 2,
+      summary: {
+        totalRequests: 2,
+        totalCost: 0,
+        totalTokens: 6,
+        totalInputTokens: 2,
+        totalOutputTokens: 4,
+        totalCacheCreationTokens: 0,
+        totalCacheReadTokens: 0,
+        totalCacheCreation5mTokens: 0,
+        totalCacheCreation1hTokens: 0,
+      },
+    });
+
+    const { exportUsageLogs } = await import("@/actions/usage-logs");
+    const result = await exportUsageLogs({});
+
+    expect(result.ok).toBe(true);
+    const csv = result.data;
+    const csvNoBom = csv.replace(/^\uFEFF/, "");
+    const lines = csvNoBom.trim().split("\n");
+
+    expect(lines).toHaveLength(3);
+    const row1 = lines[1]?.split(",") ?? [];
+    const row2 = lines[2]?.split(",") ?? [];
+    expect(row1[row1.length - 1]).toBe("0");
+    expect(row2[row2.length - 1]).toBe("1");
+  });
+});

--- a/tests/unit/actions/usage-logs-export-retry-count.test.ts
+++ b/tests/unit/actions/usage-logs-export-retry-count.test.ts
@@ -177,7 +177,10 @@ describe("Usage logs CSV export retryCount", () => {
     expect(result.ok).toBe(true);
     const csv = result.data;
     const csvNoBom = csv.replace(/^\uFEFF/, "");
-    const lines = csvNoBom.trim().split("\n").map((line) => line.replace(/\r$/, ""));
+    const lines = csvNoBom
+      .trim()
+      .split("\n")
+      .map((line) => line.replace(/\r$/, ""));
 
     expect(lines).toHaveLength(4);
     const header = parseCsvLine(lines[0] ?? "");

--- a/tests/unit/actions/usage-logs-export-retry-count.test.ts
+++ b/tests/unit/actions/usage-logs-export-retry-count.test.ts
@@ -31,13 +31,56 @@ vi.mock("@/repository/usage-logs", () => {
   };
 });
 
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (!char) continue;
+
+    if (inQuotes) {
+      if (char === '"') {
+        const next = line[i + 1];
+        if (next === '"') {
+          current += '"';
+          i += 1;
+          continue;
+        }
+        inQuotes = false;
+        continue;
+      }
+
+      current += char;
+      continue;
+    }
+
+    if (char === ",") {
+      fields.push(current);
+      current = "";
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+      continue;
+    }
+
+    current += char;
+  }
+
+  fields.push(current);
+  return fields;
+}
+
 describe("Usage logs CSV export retryCount", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
   });
 
-  test("exportUsageLogs: Retry Count 应为 provider_chain.length - 2（最小为 0）", async () => {
+  test("exportUsageLogs: Retry Count 应对齐 getRetryCount（hedge race 为 0）", async () => {
     findUsageLogsWithDetailsMock.mockResolvedValue({
       logs: [
         {
@@ -87,14 +130,40 @@ describe("Usage logs CSV export retryCount", () => {
             { reason: "retry_success", statusCode: 200, attemptNumber: 1 },
           ],
         },
+        {
+          createdAt: new Date("2026-03-16T00:00:02.000Z"),
+          userName: "u",
+          keyName: "k",
+          providerName: "p",
+          model: "m",
+          originalModel: "om",
+          endpoint: "/v1/messages",
+          statusCode: 200,
+          inputTokens: 1,
+          outputTokens: 2,
+          cacheCreation5mInputTokens: 0,
+          cacheCreation1hInputTokens: 0,
+          cacheReadInputTokens: 0,
+          totalTokens: 3,
+          costUsd: "0",
+          durationMs: 10,
+          sessionId: "s3",
+          providerChain: [
+            { reason: "initial_selection" },
+            { reason: "hedge_triggered" },
+            { reason: "hedge_launched" },
+            { reason: "hedge_winner", statusCode: 200 },
+            { reason: "hedge_loser_cancelled" },
+          ],
+        },
       ],
-      total: 2,
+      total: 3,
       summary: {
-        totalRequests: 2,
+        totalRequests: 3,
         totalCost: 0,
-        totalTokens: 6,
-        totalInputTokens: 2,
-        totalOutputTokens: 4,
+        totalTokens: 9,
+        totalInputTokens: 3,
+        totalOutputTokens: 6,
         totalCacheCreationTokens: 0,
         totalCacheReadTokens: 0,
         totalCacheCreation5mTokens: 0,
@@ -108,12 +177,18 @@ describe("Usage logs CSV export retryCount", () => {
     expect(result.ok).toBe(true);
     const csv = result.data;
     const csvNoBom = csv.replace(/^\uFEFF/, "");
-    const lines = csvNoBom.trim().split("\n");
+    const lines = csvNoBom.trim().split("\n").map((line) => line.replace(/\r$/, ""));
 
-    expect(lines).toHaveLength(3);
-    const row1 = lines[1]?.split(",") ?? [];
-    const row2 = lines[2]?.split(",") ?? [];
-    expect(row1[row1.length - 1]).toBe("0");
-    expect(row2[row2.length - 1]).toBe("1");
+    expect(lines).toHaveLength(4);
+    const header = parseCsvLine(lines[0] ?? "");
+    const retryCountIndex = header.indexOf("Retry Count");
+    expect(retryCountIndex).toBeGreaterThanOrEqual(0);
+
+    const row1 = parseCsvLine(lines[1] ?? "");
+    const row2 = parseCsvLine(lines[2] ?? "");
+    const row3 = parseCsvLine(lines[3] ?? "");
+    expect(row1[retryCountIndex]).toBe("0");
+    expect(row2[retryCountIndex]).toBe("1");
+    expect(row3[retryCountIndex]).toBe("0");
   });
 });

--- a/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
+++ b/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
@@ -1,38 +1,17 @@
 import { describe, expect, test, vi } from "vitest";
 
 import { buildUsageLogConditions } from "@/repository/_shared/usage-log-filters";
+import type { SQL } from "drizzle-orm";
+import { CasingCache } from "drizzle-orm/casing";
 
-function sqlToString(sqlObj: unknown): string {
-  const visited = new Set<unknown>();
-
-  const walk = (node: unknown): string => {
-    if (!node || visited.has(node)) return "";
-    visited.add(node);
-
-    if (typeof node === "string") return node;
-
-    if (typeof node === "object") {
-      const anyNode = node as any;
-      if (Array.isArray(anyNode)) {
-        return anyNode.map(walk).join("");
-      }
-
-      if (anyNode.value) {
-        if (Array.isArray(anyNode.value)) {
-          return anyNode.value.map(String).join("");
-        }
-        return String(anyNode.value);
-      }
-
-      if (anyNode.queryChunks) {
-        return walk(anyNode.queryChunks);
-      }
-    }
-
-    return "";
-  };
-
-  return walk(sqlObj);
+function sqlToString(sqlObj: SQL): string {
+  return sqlObj.toQuery({
+    escapeName: (name: string) => `"${name}"`,
+    escapeParam: (num: number, _value: unknown) => `$${num}`,
+    escapeString: (value: string) => `'${value}'`,
+    casing: new CasingCache(),
+    paramStartIndex: { value: 1 },
+  }).sql;
 }
 
 function createThenableQuery<T>(result: T, whereArgs?: unknown[]) {
@@ -97,7 +76,7 @@ describe("Usage logs minRetryCount filter", () => {
     await findUsageLogsStats({ minRetryCount: 1 });
 
     expect(whereArgs).toHaveLength(1);
-    const whereSql = sqlToString(whereArgs[0]).toLowerCase();
+    const whereSql = sqlToString(whereArgs[0] as SQL).toLowerCase();
     expect(whereSql).toContain("jsonb_array_length");
     expect(whereSql).toMatch(/-\s*2/);
     expect(whereSql).not.toMatch(/-\s*1\b/);

--- a/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
+++ b/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
@@ -59,7 +59,7 @@ describe("Usage logs minRetryCount filter", () => {
     const whereSql = sqlToString(condition).toLowerCase();
     expect(whereSql).toContain("jsonb_array_length");
     expect(whereSql).toMatch(/-\s*2/);
-    expect(whereSql).not.toMatch(/-\s*1/);
+    expect(whereSql).not.toMatch(/-\s*1\b/);
   });
 
   test("findUsageLogsStats: 应使用 provider_chain 长度 - 2", async () => {
@@ -100,6 +100,39 @@ describe("Usage logs minRetryCount filter", () => {
     const whereSql = sqlToString(whereArgs[0]).toLowerCase();
     expect(whereSql).toContain("jsonb_array_length");
     expect(whereSql).toMatch(/-\s*2/);
-    expect(whereSql).not.toMatch(/-\s*1/);
+    expect(whereSql).not.toMatch(/-\s*1\b/);
+  });
+
+  test("findUsageLogsStats: ledger-only 且 minRetryCount > 0 时应短路返回 0", async () => {
+    vi.resetModules();
+
+    const selectMock = vi.fn(() => {
+      throw new Error("ledger-only 且 minRetryCount > 0 时不应触发 db 查询");
+    });
+
+    vi.doMock("@/drizzle/db", () => ({
+      db: {
+        select: selectMock,
+      },
+    }));
+    vi.doMock("@/lib/ledger-fallback", () => ({
+      isLedgerOnlyMode: vi.fn(async () => true),
+    }));
+
+    const { findUsageLogsStats } = await import("@/repository/usage-logs");
+    const summary = await findUsageLogsStats({ minRetryCount: 1 });
+
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(summary).toEqual({
+      totalRequests: 0,
+      totalCost: 0,
+      totalTokens: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCacheCreationTokens: 0,
+      totalCacheReadTokens: 0,
+      totalCacheCreation5mTokens: 0,
+      totalCacheCreation1hTokens: 0,
+    });
   });
 });

--- a/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
+++ b/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
@@ -37,8 +37,10 @@ describe("Usage logs minRetryCount filter", () => {
     const [condition] = buildUsageLogConditions({ minRetryCount: 1 });
     const whereSql = sqlToString(condition).toLowerCase();
     expect(whereSql).toContain("jsonb_array_length");
-    expect(whereSql).toMatch(/-\s*2/);
+    expect(whereSql).toMatch(/-\s*2\b/);
     expect(whereSql).not.toMatch(/-\s*1\b/);
+    expect(whereSql).toContain("greatest");
+    expect(whereSql).toContain("coalesce");
     expect(whereSql).toContain("hedge_triggered");
   });
 
@@ -79,8 +81,10 @@ describe("Usage logs minRetryCount filter", () => {
     expect(whereArgs).toHaveLength(1);
     const whereSql = sqlToString(whereArgs[0] as SQL).toLowerCase();
     expect(whereSql).toContain("jsonb_array_length");
-    expect(whereSql).toMatch(/-\s*2/);
+    expect(whereSql).toMatch(/-\s*2\b/);
     expect(whereSql).not.toMatch(/-\s*1\b/);
+    expect(whereSql).toContain("greatest");
+    expect(whereSql).toContain("coalesce");
     expect(whereSql).toContain("hedge_triggered");
   });
 

--- a/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
+++ b/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
@@ -4,6 +4,8 @@ import { buildUsageLogConditions } from "@/repository/_shared/usage-log-filters"
 import type { SQL } from "drizzle-orm";
 import { CasingCache } from "drizzle-orm/casing";
 
+// 注意：CasingCache 来自 drizzle-orm/casing 子路径导出；若未来 drizzle-orm 升级导致接口调整，
+// 这里的 SQL 渲染 helper 需要同步更新。
 function sqlToString(sqlObj: SQL): string {
   return sqlObj.toQuery({
     escapeName: (name: string) => `"${name}"`,
@@ -33,37 +35,52 @@ function createThenableQuery<T>(result: T, whereArgs?: unknown[]) {
 }
 
 describe("Usage logs minRetryCount filter", () => {
-  test("buildUsageLogConditions: 应使用 provider_chain 长度 - 2", () => {
-    const [condition] = buildUsageLogConditions({ minRetryCount: 1 });
-    const whereSql = sqlToString(condition).toLowerCase();
-    expect(whereSql).toContain("jsonb_array_length");
-    expect(whereSql).toMatch(/-\s*2\b/);
-    expect(whereSql).not.toMatch(/-\s*1\b/);
-    expect(whereSql).toContain("greatest");
-    expect(whereSql).toContain("coalesce");
-    expect(whereSql).toContain("hedge_triggered");
+  test("buildUsageLogConditions: minRetryCount <= 0 视为不筛选", () => {
+    expect(buildUsageLogConditions({})).toHaveLength(0);
+    expect(buildUsageLogConditions({ minRetryCount: 0 })).toHaveLength(0);
+    expect(buildUsageLogConditions({ minRetryCount: -1 })).toHaveLength(0);
   });
 
-  test("findUsageLogsStats: 应使用 provider_chain 长度 - 2", async () => {
+  test("buildUsageLogConditions: 重试次数表达式应对齐 getRetryCount/isActualRequest", () => {
+    const [condition] = buildUsageLogConditions({ minRetryCount: 1 });
+    const whereSql = sqlToString(condition).toLowerCase();
+    expect(whereSql).toContain("jsonb_array_elements");
+    expect(whereSql).toContain("bool_or");
+    expect(whereSql).toContain("sum");
+    expect(whereSql).toMatch(/-\s*1\b/);
+    expect(whereSql).not.toMatch(/-\s*2\b/);
+    expect(whereSql).toContain("greatest");
+    expect(whereSql).toContain("coalesce");
+    expect(whereSql).toContain("request_success");
+    expect(whereSql).toContain("retry_success");
+    expect(whereSql).toContain("retry_failed");
+    expect(whereSql).toContain("statuscode");
+    expect(whereSql).toContain("hedge_triggered");
+    expect(whereSql).not.toContain("jsonb_array_length");
+  });
+
+  test("findUsageLogsStats: 重试次数表达式应对齐 getRetryCount/isActualRequest", async () => {
     vi.resetModules();
 
     const whereArgs: unknown[] = [];
-    const selectMock = vi.fn(() =>
-      createThenableQuery(
-        [
-          {
-            totalRequests: 0,
-            totalCost: "0",
-            totalInputTokens: 0,
-            totalOutputTokens: 0,
-            totalCacheCreationTokens: 0,
-            totalCacheReadTokens: 0,
-            totalCacheCreation5mTokens: 0,
-            totalCacheCreation1hTokens: 0,
-          },
-        ],
-        whereArgs
-      )
+    let query: any;
+    const selectMock = vi.fn(
+      () =>
+        (query = createThenableQuery(
+          [
+            {
+              totalRequests: 0,
+              totalCost: "0",
+              totalInputTokens: 0,
+              totalOutputTokens: 0,
+              totalCacheCreationTokens: 0,
+              totalCacheReadTokens: 0,
+              totalCacheCreation5mTokens: 0,
+              totalCacheCreation1hTokens: 0,
+            },
+          ],
+          whereArgs
+        ))
     );
 
     vi.doMock("@/drizzle/db", () => ({
@@ -80,12 +97,54 @@ describe("Usage logs minRetryCount filter", () => {
 
     expect(whereArgs).toHaveLength(1);
     const whereSql = sqlToString(whereArgs[0] as SQL).toLowerCase();
-    expect(whereSql).toContain("jsonb_array_length");
-    expect(whereSql).toMatch(/-\s*2\b/);
-    expect(whereSql).not.toMatch(/-\s*1\b/);
+    expect(whereSql).toContain("jsonb_array_elements");
+    expect(whereSql).toContain("bool_or");
+    expect(whereSql).toContain("sum");
+    expect(whereSql).toMatch(/-\s*1\b/);
+    expect(whereSql).not.toMatch(/-\s*2\b/);
     expect(whereSql).toContain("greatest");
     expect(whereSql).toContain("coalesce");
+    expect(whereSql).toContain("request_success");
+    expect(whereSql).toContain("retry_success");
+    expect(whereSql).toContain("retry_failed");
+    expect(whereSql).toContain("statuscode");
     expect(whereSql).toContain("hedge_triggered");
+    expect(query?.innerJoin).toHaveBeenCalled();
+  });
+
+  test("findUsageLogsStats: minRetryCount <= 0 时不应 join messageRequest", async () => {
+    vi.resetModules();
+
+    let query: any;
+    const selectMock = vi.fn(
+      () =>
+        (query = createThenableQuery([
+          {
+            totalRequests: 0,
+            totalCost: "0",
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
+            totalCacheCreationTokens: 0,
+            totalCacheReadTokens: 0,
+            totalCacheCreation5mTokens: 0,
+            totalCacheCreation1hTokens: 0,
+          },
+        ]))
+    );
+
+    vi.doMock("@/drizzle/db", () => ({
+      db: {
+        select: selectMock,
+      },
+    }));
+    vi.doMock("@/lib/ledger-fallback", () => ({
+      isLedgerOnlyMode: vi.fn(async () => false),
+    }));
+
+    const { findUsageLogsStats } = await import("@/repository/usage-logs");
+    await findUsageLogsStats({ minRetryCount: 0 });
+
+    expect(query?.innerJoin).not.toHaveBeenCalled();
   });
 
   test("findUsageLogsStats: ledger-only 且 minRetryCount > 0 时应短路返回 0", async () => {

--- a/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
+++ b/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
@@ -39,6 +39,7 @@ describe("Usage logs minRetryCount filter", () => {
     expect(whereSql).toContain("jsonb_array_length");
     expect(whereSql).toMatch(/-\s*2/);
     expect(whereSql).not.toMatch(/-\s*1\b/);
+    expect(whereSql).toContain("hedge_triggered");
   });
 
   test("findUsageLogsStats: 应使用 provider_chain 长度 - 2", async () => {
@@ -80,6 +81,7 @@ describe("Usage logs minRetryCount filter", () => {
     expect(whereSql).toContain("jsonb_array_length");
     expect(whereSql).toMatch(/-\s*2/);
     expect(whereSql).not.toMatch(/-\s*1\b/);
+    expect(whereSql).toContain("hedge_triggered");
   });
 
   test("findUsageLogsStats: ledger-only 且 minRetryCount > 0 时应短路返回 0", async () => {

--- a/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
+++ b/tests/unit/repository/usage-logs-min-retry-count-filter.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { buildUsageLogConditions } from "@/repository/_shared/usage-log-filters";
+
+function sqlToString(sqlObj: unknown): string {
+  const visited = new Set<unknown>();
+
+  const walk = (node: unknown): string => {
+    if (!node || visited.has(node)) return "";
+    visited.add(node);
+
+    if (typeof node === "string") return node;
+
+    if (typeof node === "object") {
+      const anyNode = node as any;
+      if (Array.isArray(anyNode)) {
+        return anyNode.map(walk).join("");
+      }
+
+      if (anyNode.value) {
+        if (Array.isArray(anyNode.value)) {
+          return anyNode.value.map(String).join("");
+        }
+        return String(anyNode.value);
+      }
+
+      if (anyNode.queryChunks) {
+        return walk(anyNode.queryChunks);
+      }
+    }
+
+    return "";
+  };
+
+  return walk(sqlObj);
+}
+
+function createThenableQuery<T>(result: T, whereArgs?: unknown[]) {
+  const query: any = Promise.resolve(result);
+
+  query.from = vi.fn(() => query);
+  query.innerJoin = vi.fn(() => query);
+  query.leftJoin = vi.fn(() => query);
+  query.orderBy = vi.fn(() => query);
+  query.limit = vi.fn(() => query);
+  query.offset = vi.fn(() => query);
+  query.groupBy = vi.fn(() => query);
+  query.where = vi.fn((arg: unknown) => {
+    whereArgs?.push(arg);
+    return query;
+  });
+
+  return query;
+}
+
+describe("Usage logs minRetryCount filter", () => {
+  test("buildUsageLogConditions: 应使用 provider_chain 长度 - 2", () => {
+    const [condition] = buildUsageLogConditions({ minRetryCount: 1 });
+    const whereSql = sqlToString(condition).toLowerCase();
+    expect(whereSql).toContain("jsonb_array_length");
+    expect(whereSql).toMatch(/-\s*2/);
+    expect(whereSql).not.toMatch(/-\s*1/);
+  });
+
+  test("findUsageLogsStats: 应使用 provider_chain 长度 - 2", async () => {
+    vi.resetModules();
+
+    const whereArgs: unknown[] = [];
+    const selectMock = vi.fn(() =>
+      createThenableQuery(
+        [
+          {
+            totalRequests: 0,
+            totalCost: "0",
+            totalInputTokens: 0,
+            totalOutputTokens: 0,
+            totalCacheCreationTokens: 0,
+            totalCacheReadTokens: 0,
+            totalCacheCreation5mTokens: 0,
+            totalCacheCreation1hTokens: 0,
+          },
+        ],
+        whereArgs
+      )
+    );
+
+    vi.doMock("@/drizzle/db", () => ({
+      db: {
+        select: selectMock,
+      },
+    }));
+    vi.doMock("@/lib/ledger-fallback", () => ({
+      isLedgerOnlyMode: vi.fn(async () => false),
+    }));
+
+    const { findUsageLogsStats } = await import("@/repository/usage-logs");
+    await findUsageLogsStats({ minRetryCount: 1 });
+
+    expect(whereArgs).toHaveLength(1);
+    const whereSql = sqlToString(whereArgs[0]).toLowerCase();
+    expect(whereSql).toContain("jsonb_array_length");
+    expect(whereSql).toMatch(/-\s*2/);
+    expect(whereSql).not.toMatch(/-\s*1/);
+  });
+});


### PR DESCRIPTION
## 背景
- Issue #925 指出：日志页的「Retry Count ≥」筛选几乎无效（`minRetryCount=1` 基本命中全部记录）。
- 根因是后端 SQL 过滤/统计/导出对 `provider_chain` 的重试次数计算与前端展示逻辑（`getRetryCount`/`isActualRequest`）不一致。

## 变更
- SQL：`RETRY_COUNT_EXPR` 改为按 `provider_chain` 中“实际请求”（语义对齐 `isActualRequest`）计数，再 `- 1` 得到 retry count；同时 hedge race 直接视为 0（对齐 `getRetryCount/isHedgeRace`）。
- 统计：`findUsageLogsStats` 复用同一表达式；`ledgerOnly && minRetryCount > 0` 时短路返回全 0，避免在 ledger-only 下引用 `message_request` 导致 SQL 崩溃。
- CSV：导出 `Retry Count` 直接复用 `getRetryCount(providerChain)`（hedge race 输出 0，与 UI 一致）。

## 测试
- 新增/增强单测覆盖：SQL retry count 语义（含 hedge 与边界）、`findUsageLogsStats` 的 join 分支、ledger-only 短路、CSV 导出对齐前端。

Closes #925

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `minRetryCount` filter and CSV export by replacing the incorrect `provider_chain.length - 1` heuristic with logic that correctly mirrors the frontend's `getRetryCount`/`isActualRequest` TypeScript functions — counting only actual HTTP request attempts and short-circuiting hedge races to zero.

**Key changes:**
- `RETRY_COUNT_EXPR` — new PostgreSQL correlated scalar subquery using `bool_or` (hedge-race guard) + `sum` over `jsonb_array_elements`, replacing the broken `jsonb_array_length - 2` formula
- `generateCsv` — delegates to `getRetryCount()` so exported CSV values are consistent with the UI
- `EMPTY_USAGE_LOG_SUMMARY` — shared constant extracted to avoid duplicated zero-fill objects (addressing a previous review comment)
- `findUsageLogsStats` — `isLedgerOnlyMode()` moved to the top of the function for an early return when `minRetryCount > 0` in ledger-only mode
- `minRetryCount <= 0` is now treated as "no filter" across all query paths, eliminating the unnecessary `GREATEST(... - 2, 0) >= 0` no-op condition
- New unit tests cover the SQL expression shape, `innerJoin` assertion, ledger-only short-circuit, and CSV export for normal/retry/hedge-race chains

**Remaining concerns:**
- `RETRY_COUNT_EXPR` is a correlated scalar subquery evaluated per row — significantly more expensive than the previous O(1) `jsonb_array_length` formula; a functional index or GIN index on `provider_chain` should be tracked as follow-up work
- `EMPTY_USAGE_LOG_SUMMARY` is returned by reference from the early-return path; it is not frozen, so accidental mutation by a caller would corrupt the shared constant
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- Correctness fix is sound, but the correlated scalar subquery introduces a meaningful performance regression for large datasets that should be addressed before merging to production.
- The logic correctly aligns SQL with the TypeScript `getRetryCount`/`isActualRequest` functions, hedge-race and empty-chain edge cases are handled, and the new tests are thorough. However, the `RETRY_COUNT_EXPR` correlated subquery is O(rows × chain_length) — a significant step back in query performance for the stats and batch paths without a supporting index. The `EMPTY_USAGE_LOG_SUMMARY` shared reference is also not frozen. These are not blockers for correctness but are worth resolving or tracking before shipping to a high-volume environment.
- Pay close attention to `src/repository/_shared/usage-log-filters.ts` — the new `RETRY_COUNT_EXPR` expression drives query performance for every `minRetryCount`-filtered request.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/repository/_shared/usage-log-filters.ts | Replaces the simple `jsonb_array_length - 2` formula with a correlated scalar subquery that correctly mirrors `getRetryCount`/`isActualRequest` semantics (hedge-race short-circuit, statusCode guard). Logic is correct, but the new expression is O(rows × chain_length) in the WHERE path — a noticeable performance regression for large datasets without a GIN index. |
| src/actions/usage-logs.ts | CSV export now delegates to `getRetryCount` instead of the incorrect `providerChain.length - 1` formula. Change is clean and correct. |
| src/repository/usage-logs.ts | Adds `EMPTY_USAGE_LOG_SUMMARY` constant (addressing a previous review concern), moves `isLedgerOnlyMode()` to the top of `findUsageLogsStats` for an early-return when in ledger-only mode with a non-zero retry filter. The constant is returned by reference and is not frozen. |
| tests/unit/repository/usage-logs-min-retry-count-filter.test.ts | New unit tests verify the SQL expression shape, the `innerJoin` call, the ledger-only short-circuit, and the `minRetryCount <= 0` no-op behavior. Tests use Drizzle internals (`CasingCache`) for SQL rendering, which was flagged in a previous review; that concern still applies but is pre-existing. |
| tests/unit/actions/usage-logs-export-retry-count.test.ts | New integration-style test for CSV export validates retry count for normal, retry, and hedge-race chains against the mocked `findUsageLogsWithDetails`. Coverage is thorough for the three representative cases. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["minRetryCount filter requested"] --> B{minRetryCount > 0?}
    B -- No --> C["No WHERE condition added\nNo messageRequest JOIN needed"]
    B -- Yes --> D{ledgerOnly mode?}
    D -- Yes --> E["Early return\nEMPTY_USAGE_LOG_SUMMARY"]
    D -- No --> F["Add RETRY_COUNT_EXPR >= N\nto WHERE conditions"]
    F --> G["innerJoin messageRequest\non usageLedger.requestId"]
    G --> H["RETRY_COUNT_EXPR scalar subquery\nper row in FROM jsonb_array_elements"]
    H --> I{Any hedge reason\nin provider_chain?}
    I -- Yes --> J["Return 0\n(Hedge Race)"]
    I -- No --> K["COUNT isActualRequest items\nbool_or + sum in single pass"]
    K --> L["GREATEST(count - 1, 0)\n= retry count"]
    L --> M{retry count >= N?}
    M -- Yes --> N["Row included in results"]
    M -- No --> O["Row excluded"]

    style E fill:#f9a,stroke:#c00
    style J fill:#adf,stroke:#06c
    style N fill:#afa,stroke:#060
    style O fill:#faa,stroke:#c00
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/repository/_shared/usage-log-filters.ts`, line 54-58 ([link](https://github.com/ding113/claude-code-hub/blob/cb2c57695cac27c873242d9239f1d99eefa2a1f2/src/repository/_shared/usage-log-filters.ts#L54-L58)) 

   **`minRetryCount: 0` triggers a no-op SQL condition**

   The interface JSDoc comment on `minRetryCount` now says `<= 0 视为不筛选`, but `buildUsageLogConditions` still uses `!== undefined` as the guard. This means callers such as `findUsageLogsBatch` and `findUsageLogsForKeySlim` will inject `RETRY_COUNT_EXPR >= 0` into the WHERE clause when `minRetryCount: 0` is passed, even though the comment promises this is a no-op filter. `findUsageLogsStats` was updated to use `> 0` correctly, but these callers were not.

   The condition is always true (GREATEST can never be negative), so results are still correct — but it adds an unnecessary predicate to the query and violates the documented contract.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/repository/_shared/usage-log-filters.ts
   Line: 54-58

   Comment:
   **`minRetryCount: 0` triggers a no-op SQL condition**

   The interface JSDoc comment on `minRetryCount` now says `<= 0 视为不筛选`, but `buildUsageLogConditions` still uses `!== undefined` as the guard. This means callers such as `findUsageLogsBatch` and `findUsageLogsForKeySlim` will inject `RETRY_COUNT_EXPR >= 0` into the WHERE clause when `minRetryCount: 0` is passed, even though the comment promises this is a no-op filter. `findUsageLogsStats` was updated to use `> 0` correctly, but these callers were not.

   The condition is always true (GREATEST can never be negative), so results are still correct — but it adds an unnecessary predicate to the query and violates the documented contract.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/repository/_shared/usage-log-filters.ts
Line: 20-66

Comment:
**Correlated scalar subquery evaluated per outer row**

`RETRY_COUNT_EXPR` is a correlated subquery: for every row examined by `findUsageLogsStats` (or any function using `buildUsageLogConditions`), PostgreSQL must expand `provider_chain` via `jsonb_array_elements`, then compute both `bool_or` and `sum` over the resulting rows. In the stats path this runs across every row in the `usageLedger ⟶ messageRequest` join before the aggregation collapses them.

The previous `jsonb_array_length(provider_chain) - 2` formula was O(1) per row (single JSONB metadata read). The new expression is O(m) per row, where m is the average chain length.

For production deployments with millions of ledger rows and a tight `minRetryCount` filter, this will cause a noticeable slowdown unless:
- A GIN index exists on `message_request.provider_chain`, or
- A generated/functional column pre-computes the retry count, or
- The caller-side filter is only exposed on pages where the result set is already small (e.g., filtered by `userId` + time range).

Consider adding a comment or a query hint to document this trade-off, and track adding a functional index as follow-up work.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/repository/usage-logs.ts
Line: 87-97

Comment:
**`EMPTY_USAGE_LOG_SUMMARY` is a shared mutable reference**

`findUsageLogsStats` returns the module-level constant directly (not a copy) from the early-return path. Any caller that accidentally mutates a field on the returned object (e.g., `summary.totalCost = 5`) would corrupt the constant for all future callers in the same process.

Consider freezing the object to make this safe:

```suggestion
const EMPTY_USAGE_LOG_SUMMARY: UsageLogSummary = Object.freeze({
  totalRequests: 0,
  totalCost: 0,
  totalTokens: 0,
  totalInputTokens: 0,
  totalOutputTokens: 0,
  totalCacheCreationTokens: 0,
  totalCacheReadTokens: 0,
  totalCacheCreation5mTokens: 0,
  totalCacheCreation1hTokens: 0,
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 379e65b</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->