### PR TITLE
fix: cover openai and gemini endpoint surfaces

### DIFF
--- a/src/app/v1/_lib/proxy/endpoint-family-catalog.ts
+++ b/src/app/v1/_lib/proxy/endpoint-family-catalog.ts
@@ -1,3 +1,5 @@
+import { normalizeEndpointPath } from "./endpoint-paths";
+
 export type EndpointClientFormat = "response" | "openai" | "claude" | "gemini" | "gemini-cli";
 
 export type EndpointAccountingTier = "required_usage" | "optional_usage" | "none";
@@ -13,35 +15,66 @@ export interface EndpointFamily {
 
 const GEMINI_GENERATION_ACTIONS = new Set(["generatecontent", "streamgeneratecontent"]);
 
-function normalizePathname(pathname: string): string {
-  const pathWithoutQuery = pathname.split("?")[0] ?? pathname;
-  const trimmedPath =
-    pathWithoutQuery.length > 1 && pathWithoutQuery.endsWith("/")
-      ? pathWithoutQuery.slice(0, -1)
-      : pathWithoutQuery;
-
-  return trimmedPath.toLowerCase();
-}
-
 function hasPrefix(pathname: string, prefix: string): boolean {
   return pathname === prefix || pathname.startsWith(`${prefix}/`);
 }
 
+type GeminiActionPrefix =
+  | "/v1beta/models/"
+  | "/v1/publishers/google/models/"
+  | "/v1/models/"
+  | "/v1internal/models/";
+
+const GEMINI_STANDARD_MODEL_PREFIXES = [
+  "/v1beta/models/",
+  "/v1/publishers/google/models/",
+  "/v1/models/",
+] as const satisfies readonly GeminiActionPrefix[];
+
+const GEMINI_PREDICT_MODEL_PREFIXES = [
+  "/v1beta/models/",
+  "/v1/publishers/google/models/",
+] as const satisfies readonly GeminiActionPrefix[];
+
+const GEMINI_CLI_MODEL_PREFIXES = [
+  "/v1internal/models/",
+] as const satisfies readonly GeminiActionPrefix[];
+
+/**
+ * 匹配受信任的 Gemini action 路径。
+ *
+ * 注意：`actions` 只能来自当前模块内的硬编码常量，绝不能接收用户输入。
+ */
 function matchGeminiModelAction(
   pathname: string,
-  prefix:
-    | "/v1beta/models/"
-    | "/v1/publishers/google/models/"
-    | "/v1/models/"
-    | "/v1internal/models/",
+  prefix: GeminiActionPrefix,
   actions: readonly string[]
 ): boolean {
-  const actionPattern = actions.join("|");
-  const regex = new RegExp(
-    `^${prefix.replaceAll("/", String.raw`\/`)}[^/:]+:(?:${actionPattern})$`,
-    "i"
-  );
-  return regex.test(pathname);
+  if (!pathname.startsWith(prefix)) {
+    return false;
+  }
+
+  const remainder = pathname.slice(prefix.length);
+  const separatorIndex = remainder.indexOf(":");
+  if (separatorIndex <= 0) {
+    return false;
+  }
+
+  const model = remainder.slice(0, separatorIndex);
+  const action = remainder.slice(separatorIndex + 1);
+  if (!model || model.includes("/") || model.includes(":")) {
+    return false;
+  }
+
+  return action.length > 0 && !action.includes("/") && actions.includes(action);
+}
+
+function matchGeminiModelActionOnPrefixes(
+  pathname: string,
+  prefixes: readonly GeminiActionPrefix[],
+  actions: readonly string[]
+): boolean {
+  return prefixes.some((prefix) => matchGeminiModelAction(pathname, prefix, actions));
 }
 
 const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
@@ -116,9 +149,9 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
     modelRequired: true,
     rawPassthrough: false,
     match: (pathname) =>
-      matchGeminiModelAction(pathname, "/v1beta/models/", ["generatecontent"]) ||
-      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["generatecontent"]) ||
-      matchGeminiModelAction(pathname, "/v1/models/", ["generatecontent"]),
+      matchGeminiModelActionOnPrefixes(pathname, GEMINI_STANDARD_MODEL_PREFIXES, [
+        "generatecontent",
+      ]),
   },
   {
     id: "gemini-stream-generate-content",
@@ -127,11 +160,9 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
     modelRequired: true,
     rawPassthrough: false,
     match: (pathname) =>
-      matchGeminiModelAction(pathname, "/v1beta/models/", ["streamgeneratecontent"]) ||
-      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", [
+      matchGeminiModelActionOnPrefixes(pathname, GEMINI_STANDARD_MODEL_PREFIXES, [
         "streamgeneratecontent",
-      ]) ||
-      matchGeminiModelAction(pathname, "/v1/models/", ["streamgeneratecontent"]),
+      ]),
   },
   {
     id: "gemini-count-tokens",
@@ -140,9 +171,7 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
     modelRequired: true,
     rawPassthrough: false,
     match: (pathname) =>
-      matchGeminiModelAction(pathname, "/v1beta/models/", ["counttokens"]) ||
-      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["counttokens"]) ||
-      matchGeminiModelAction(pathname, "/v1/models/", ["counttokens"]),
+      matchGeminiModelActionOnPrefixes(pathname, GEMINI_STANDARD_MODEL_PREFIXES, ["counttokens"]),
   },
   {
     id: "gemini-embed-content",
@@ -151,9 +180,7 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
     modelRequired: true,
     rawPassthrough: false,
     match: (pathname) =>
-      matchGeminiModelAction(pathname, "/v1beta/models/", ["embedcontent"]) ||
-      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["embedcontent"]) ||
-      matchGeminiModelAction(pathname, "/v1/models/", ["embedcontent"]),
+      matchGeminiModelActionOnPrefixes(pathname, GEMINI_STANDARD_MODEL_PREFIXES, ["embedcontent"]),
   },
   {
     id: "gemini-batch-generate-content",
@@ -162,9 +189,9 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
     modelRequired: true,
     rawPassthrough: false,
     match: (pathname) =>
-      matchGeminiModelAction(pathname, "/v1beta/models/", ["batchgeneratecontent"]) ||
-      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["batchgeneratecontent"]) ||
-      matchGeminiModelAction(pathname, "/v1/models/", ["batchgeneratecontent"]),
+      matchGeminiModelActionOnPrefixes(pathname, GEMINI_STANDARD_MODEL_PREFIXES, [
+        "batchgeneratecontent",
+      ]),
   },
   {
     id: "gemini-batch-embed-contents",
@@ -173,9 +200,9 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
     modelRequired: true,
     rawPassthrough: false,
     match: (pathname) =>
-      matchGeminiModelAction(pathname, "/v1beta/models/", ["batchembedcontents"]) ||
-      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["batchembedcontents"]) ||
-      matchGeminiModelAction(pathname, "/v1/models/", ["batchembedcontents"]),
+      matchGeminiModelActionOnPrefixes(pathname, GEMINI_STANDARD_MODEL_PREFIXES, [
+        "batchembedcontents",
+      ]),
   },
   {
     id: "gemini-async-batch-embed-content",
@@ -184,11 +211,9 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
     modelRequired: true,
     rawPassthrough: false,
     match: (pathname) =>
-      matchGeminiModelAction(pathname, "/v1beta/models/", ["asyncbatchembedcontent"]) ||
-      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", [
+      matchGeminiModelActionOnPrefixes(pathname, GEMINI_STANDARD_MODEL_PREFIXES, [
         "asyncbatchembedcontent",
-      ]) ||
-      matchGeminiModelAction(pathname, "/v1/models/", ["asyncbatchembedcontent"]),
+      ]),
   },
   {
     id: "gemini-predict",
@@ -197,8 +222,7 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
     modelRequired: true,
     rawPassthrough: false,
     match: (pathname) =>
-      matchGeminiModelAction(pathname, "/v1beta/models/", ["predict"]) ||
-      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["predict"]),
+      matchGeminiModelActionOnPrefixes(pathname, GEMINI_PREDICT_MODEL_PREFIXES, ["predict"]),
   },
   {
     id: "gemini-predict-long-running",
@@ -207,8 +231,9 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
     modelRequired: true,
     rawPassthrough: false,
     match: (pathname) =>
-      matchGeminiModelAction(pathname, "/v1beta/models/", ["predictlongrunning"]) ||
-      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["predictlongrunning"]),
+      matchGeminiModelActionOnPrefixes(pathname, GEMINI_PREDICT_MODEL_PREFIXES, [
+        "predictlongrunning",
+      ]),
   },
   {
     id: "gemini-files",
@@ -236,7 +261,7 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
     modelRequired: true,
     rawPassthrough: false,
     match: (pathname) =>
-      matchGeminiModelAction(pathname, "/v1internal/models/", ["generatecontent"]),
+      matchGeminiModelActionOnPrefixes(pathname, GEMINI_CLI_MODEL_PREFIXES, ["generatecontent"]),
   },
   {
     id: "gemini-cli-stream-generate-content",
@@ -245,7 +270,9 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
     modelRequired: true,
     rawPassthrough: false,
     match: (pathname) =>
-      matchGeminiModelAction(pathname, "/v1internal/models/", ["streamgeneratecontent"]),
+      matchGeminiModelActionOnPrefixes(pathname, GEMINI_CLI_MODEL_PREFIXES, [
+        "streamgeneratecontent",
+      ]),
   },
   {
     id: "openai-completions",
@@ -424,7 +451,7 @@ export function listKnownEndpointFamilies(): readonly EndpointFamily[] {
 }
 
 export function resolveEndpointFamilyByPath(pathname: string): EndpointFamily | null {
-  const normalizedPath = normalizePathname(pathname);
+  const normalizedPath = normalizeEndpointPath(pathname);
   return KNOWN_ENDPOINT_FAMILIES.find((family) => family.match(normalizedPath)) ?? null;
 }
 
@@ -437,7 +464,7 @@ export function isStandardProxyEndpointPath(pathname: string): boolean {
 }
 
 export function isGeminiGenerationEndpointPath(pathname: string): boolean {
-  const normalizedPath = normalizePathname(pathname);
+  const normalizedPath = normalizeEndpointPath(pathname);
   const matches = normalizedPath.match(/:([^/]+)$/);
   return matches?.[1] ? GEMINI_GENERATION_ACTIONS.has(matches[1]) : false;
 }

--- a/src/app/v1/_lib/proxy/endpoint-family-catalog.ts
+++ b/src/app/v1/_lib/proxy/endpoint-family-catalog.ts
@@ -1,0 +1,443 @@
+export type EndpointClientFormat = "response" | "openai" | "claude" | "gemini" | "gemini-cli";
+
+export type EndpointAccountingTier = "required_usage" | "optional_usage" | "none";
+
+export interface EndpointFamily {
+  readonly id: string;
+  readonly surface: EndpointClientFormat;
+  readonly accountingTier: EndpointAccountingTier;
+  readonly modelRequired: boolean;
+  readonly rawPassthrough: boolean;
+  readonly match: (normalizedPath: string) => boolean;
+}
+
+const GEMINI_GENERATION_ACTIONS = new Set(["generatecontent", "streamgeneratecontent"]);
+
+function normalizePathname(pathname: string): string {
+  const pathWithoutQuery = pathname.split("?")[0] ?? pathname;
+  const trimmedPath =
+    pathWithoutQuery.length > 1 && pathWithoutQuery.endsWith("/")
+      ? pathWithoutQuery.slice(0, -1)
+      : pathWithoutQuery;
+
+  return trimmedPath.toLowerCase();
+}
+
+function hasPrefix(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+function matchGeminiModelAction(
+  pathname: string,
+  prefix:
+    | "/v1beta/models/"
+    | "/v1/publishers/google/models/"
+    | "/v1/models/"
+    | "/v1internal/models/",
+  actions: readonly string[]
+): boolean {
+  const actionPattern = actions.join("|");
+  const regex = new RegExp(
+    `^${prefix.replaceAll("/", String.raw`\/`)}[^/:]+:(?:${actionPattern})$`,
+    "i"
+  );
+  return regex.test(pathname);
+}
+
+const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
+  {
+    id: "claude-messages",
+    surface: "claude",
+    accountingTier: "required_usage",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => pathname === "/v1/messages",
+  },
+  {
+    id: "claude-count-tokens",
+    surface: "claude",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: true,
+    match: (pathname) => pathname === "/v1/messages/count_tokens",
+  },
+  {
+    id: "response-compact",
+    surface: "response",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: true,
+    match: (pathname) => pathname === "/v1/responses/compact",
+  },
+  {
+    id: "response-execution",
+    surface: "response",
+    accountingTier: "required_usage",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => pathname === "/v1/responses",
+  },
+  {
+    id: "response-resources",
+    surface: "response",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/responses"),
+  },
+  {
+    id: "openai-chat-completions",
+    surface: "openai",
+    accountingTier: "required_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) => pathname === "/v1/chat/completions",
+  },
+  {
+    id: "openai-chat-completions-resources",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/chat/completions"),
+  },
+  {
+    id: "openai-models",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => /^\/v1\/models(?:\/[^/:]+)?$/i.test(pathname),
+  },
+  {
+    id: "gemini-generate-content",
+    surface: "gemini",
+    accountingTier: "required_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) =>
+      matchGeminiModelAction(pathname, "/v1beta/models/", ["generatecontent"]) ||
+      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["generatecontent"]) ||
+      matchGeminiModelAction(pathname, "/v1/models/", ["generatecontent"]),
+  },
+  {
+    id: "gemini-stream-generate-content",
+    surface: "gemini",
+    accountingTier: "required_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) =>
+      matchGeminiModelAction(pathname, "/v1beta/models/", ["streamgeneratecontent"]) ||
+      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", [
+        "streamgeneratecontent",
+      ]) ||
+      matchGeminiModelAction(pathname, "/v1/models/", ["streamgeneratecontent"]),
+  },
+  {
+    id: "gemini-count-tokens",
+    surface: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) =>
+      matchGeminiModelAction(pathname, "/v1beta/models/", ["counttokens"]) ||
+      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["counttokens"]) ||
+      matchGeminiModelAction(pathname, "/v1/models/", ["counttokens"]),
+  },
+  {
+    id: "gemini-embed-content",
+    surface: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) =>
+      matchGeminiModelAction(pathname, "/v1beta/models/", ["embedcontent"]) ||
+      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["embedcontent"]) ||
+      matchGeminiModelAction(pathname, "/v1/models/", ["embedcontent"]),
+  },
+  {
+    id: "gemini-batch-generate-content",
+    surface: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) =>
+      matchGeminiModelAction(pathname, "/v1beta/models/", ["batchgeneratecontent"]) ||
+      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["batchgeneratecontent"]) ||
+      matchGeminiModelAction(pathname, "/v1/models/", ["batchgeneratecontent"]),
+  },
+  {
+    id: "gemini-batch-embed-contents",
+    surface: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) =>
+      matchGeminiModelAction(pathname, "/v1beta/models/", ["batchembedcontents"]) ||
+      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["batchembedcontents"]) ||
+      matchGeminiModelAction(pathname, "/v1/models/", ["batchembedcontents"]),
+  },
+  {
+    id: "gemini-async-batch-embed-content",
+    surface: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) =>
+      matchGeminiModelAction(pathname, "/v1beta/models/", ["asyncbatchembedcontent"]) ||
+      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", [
+        "asyncbatchembedcontent",
+      ]) ||
+      matchGeminiModelAction(pathname, "/v1/models/", ["asyncbatchembedcontent"]),
+  },
+  {
+    id: "gemini-predict",
+    surface: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) =>
+      matchGeminiModelAction(pathname, "/v1beta/models/", ["predict"]) ||
+      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["predict"]),
+  },
+  {
+    id: "gemini-predict-long-running",
+    surface: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) =>
+      matchGeminiModelAction(pathname, "/v1beta/models/", ["predictlongrunning"]) ||
+      matchGeminiModelAction(pathname, "/v1/publishers/google/models/", ["predictlongrunning"]),
+  },
+  {
+    id: "gemini-files",
+    surface: "gemini",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1beta/files"),
+  },
+  {
+    id: "gemini-models-resource",
+    surface: "gemini",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) =>
+      pathname === "/v1beta/models" ||
+      /^\/v1beta\/models\/[^/:]+$/i.test(pathname) ||
+      /^\/v1\/publishers\/google\/models\/[^/:]+$/i.test(pathname),
+  },
+  {
+    id: "gemini-cli-generate-content",
+    surface: "gemini-cli",
+    accountingTier: "required_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) =>
+      matchGeminiModelAction(pathname, "/v1internal/models/", ["generatecontent"]),
+  },
+  {
+    id: "gemini-cli-stream-generate-content",
+    surface: "gemini-cli",
+    accountingTier: "required_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) =>
+      matchGeminiModelAction(pathname, "/v1internal/models/", ["streamgeneratecontent"]),
+  },
+  {
+    id: "openai-completions",
+    surface: "openai",
+    accountingTier: "required_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/completions"),
+  },
+  {
+    id: "openai-embeddings",
+    surface: "openai",
+    accountingTier: "required_usage",
+    modelRequired: true,
+    rawPassthrough: false,
+    match: (pathname) => pathname === "/v1/embeddings",
+  },
+  {
+    id: "openai-moderations",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/moderations"),
+  },
+  {
+    id: "openai-audio-generation",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => pathname === "/v1/audio/speech",
+  },
+  {
+    id: "openai-audio-transcription",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) =>
+      pathname === "/v1/audio/transcriptions" || pathname === "/v1/audio/translations",
+  },
+  {
+    id: "openai-audio-resources",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) =>
+      hasPrefix(pathname, "/v1/audio/voice_consents") || hasPrefix(pathname, "/v1/audio/voices"),
+  },
+  {
+    id: "openai-images",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/images"),
+  },
+  {
+    id: "openai-files",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/files"),
+  },
+  {
+    id: "openai-uploads",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/uploads"),
+  },
+  {
+    id: "openai-batches",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/batches"),
+  },
+  {
+    id: "openai-fine-tuning",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/fine_tuning"),
+  },
+  {
+    id: "openai-evals",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/evals"),
+  },
+  {
+    id: "openai-assistants",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/assistants"),
+  },
+  {
+    id: "openai-threads",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/threads"),
+  },
+  {
+    id: "openai-conversations",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/conversations"),
+  },
+  {
+    id: "openai-vector-stores",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/vector_stores"),
+  },
+  {
+    id: "openai-containers",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/containers"),
+  },
+  {
+    id: "openai-realtime-http",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/realtime"),
+  },
+  {
+    id: "openai-videos",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/videos"),
+  },
+  {
+    id: "openai-skills",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/skills"),
+  },
+  {
+    id: "openai-chatkit",
+    surface: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+    rawPassthrough: false,
+    match: (pathname) => hasPrefix(pathname, "/v1/chatkit"),
+  },
+]);
+
+export function listKnownEndpointFamilies(): readonly EndpointFamily[] {
+  return KNOWN_ENDPOINT_FAMILIES;
+}
+
+export function resolveEndpointFamilyByPath(pathname: string): EndpointFamily | null {
+  const normalizedPath = normalizePathname(pathname);
+  return KNOWN_ENDPOINT_FAMILIES.find((family) => family.match(normalizedPath)) ?? null;
+}
+
+export function detectEndpointFormat(pathname: string): EndpointClientFormat | null {
+  return resolveEndpointFamilyByPath(pathname)?.surface ?? null;
+}
+
+export function isStandardProxyEndpointPath(pathname: string): boolean {
+  return resolveEndpointFamilyByPath(pathname) !== null;
+}
+
+export function isGeminiGenerationEndpointPath(pathname: string): boolean {
+  const normalizedPath = normalizePathname(pathname);
+  const matches = normalizedPath.match(/:([^/]+)$/);
+  return matches?.[1] ? GEMINI_GENERATION_ACTIONS.has(matches[1]) : false;
+}

--- a/src/app/v1/_lib/proxy/format-mapper.ts
+++ b/src/app/v1/_lib/proxy/format-mapper.ts
@@ -1,3 +1,5 @@
+import { detectEndpointFormat, type EndpointClientFormat } from "./endpoint-family-catalog";
+
 /**
  * API 格式映射工具
  *
@@ -20,7 +22,7 @@
  * - "gemini": 检测到 Gemini API 直接格式的请求（通过 `contents` 字段）
  * - "gemini-cli": 检测到 Gemini CLI 格式的请求（通过 `request` envelope）
  */
-export type ClientFormat = "response" | "openai" | "claude" | "gemini" | "gemini-cli";
+export type ClientFormat = EndpointClientFormat;
 
 /**
  * 根据请求端点检测客户端格式（优先级最高）
@@ -47,48 +49,7 @@ export type ClientFormat = "response" | "openai" | "claude" | "gemini" | "gemini
  * ```
  */
 export function detectFormatByEndpoint(pathname: string): ClientFormat | null {
-  // 规范化路径：移除查询参数和末尾斜杠
-  const normalizedPath = pathname.split("?")[0].replace(/\/$/, "");
-
-  // 端点模式匹配（按优先级顺序）
-  const endpointPatterns: Array<{ pattern: RegExp; format: ClientFormat }> = [
-    // Claude Messages API
-    { pattern: /^\/v1\/messages(?:\/count_tokens)?$/i, format: "claude" },
-
-    // Codex / Response API
-    { pattern: /^\/v1\/responses$/i, format: "response" },
-
-    // OpenAI Chat Completions / Embeddings
-    { pattern: /^\/v1\/(?:chat\/completions|embeddings)$/i, format: "openai" },
-
-    // Gemini Vertex AI (publishers path)
-    {
-      pattern:
-        /^\/v1\/publishers\/google\/models\/[^/:]+:(?:generateContent|streamGenerateContent|countTokens|embedContent)$/i,
-      format: "gemini",
-    },
-
-    // Gemini Direct API
-    {
-      pattern:
-        /^\/v1beta\/models\/[^/:]+:(?:generateContent|streamGenerateContent|countTokens|embedContent)$/i,
-      format: "gemini",
-    },
-
-    // Gemini CLI (internal)
-    {
-      pattern: /^\/v1internal\/models\/[^/:]+:(?:generateContent|streamGenerateContent)$/i,
-      format: "gemini-cli",
-    },
-  ];
-
-  for (const { pattern, format } of endpointPatterns) {
-    if (pattern.test(normalizedPath)) {
-      return format;
-    }
-  }
-
-  return null; // 未知端点，需要回退到请求体检测
+  return detectEndpointFormat(pathname);
 }
 
 /**
@@ -121,13 +82,38 @@ export function detectClientFormat(requestBody: Record<string, unknown>): Client
     return "gemini-cli";
   }
 
-  // 3. 检测 Response API (Codex) 格式
+  // 3. 检测 Gemini batch 格式
+  if (Array.isArray(requestBody.requests)) {
+    const hasGeminiBatchShape = requestBody.requests.some((entry) => {
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+        return false;
+      }
+
+      const record = entry as Record<string, unknown>;
+      if (typeof record.model === "string" || typeof record.content === "object") {
+        return true;
+      }
+
+      if (typeof record.request === "object" && record.request !== null) {
+        const nestedRequest = record.request as Record<string, unknown>;
+        return typeof nestedRequest.model === "string" || typeof nestedRequest.content === "object";
+      }
+
+      return false;
+    });
+
+    if (hasGeminiBatchShape) {
+      return "gemini";
+    }
+  }
+
+  // 4. 检测 Response API (Codex) 格式
   // 仅通过 input 数组识别；字符串/单对象简写由 response-input-rectifier 在端点确认后规范化
   if (Array.isArray(requestBody.input)) {
     return "response";
   }
 
-  // 4. 检测 OpenAI Compatible 格式
+  // 5. 检测 OpenAI Compatible 格式
   if (Array.isArray(requestBody.messages)) {
     // 进一步区分 OpenAI 和 Claude
     // Claude 的 messages 可能包含 system，但 OpenAI 也可能有 system message
@@ -141,6 +127,6 @@ export function detectClientFormat(requestBody: Record<string, unknown>): Client
     return "openai";
   }
 
-  // 5. 默认为 Claude Messages API
+  // 6. 默认为 Claude Messages API
   return "claude";
 }

--- a/src/app/v1/_lib/proxy/format-mapper.ts
+++ b/src/app/v1/_lib/proxy/format-mapper.ts
@@ -84,19 +84,30 @@ export function detectClientFormat(requestBody: Record<string, unknown>): Client
 
   // 3. 检测 Gemini batch 格式
   if (Array.isArray(requestBody.requests)) {
+    const isGeminiContentPayload = (value: unknown): boolean => {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        return false;
+      }
+
+      const payload = value as Record<string, unknown>;
+      return Array.isArray(payload.parts) || Array.isArray(payload.contents);
+    };
+
     const hasGeminiBatchShape = requestBody.requests.some((entry) => {
       if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
         return false;
       }
 
       const record = entry as Record<string, unknown>;
-      if (typeof record.model === "string" || typeof record.content === "object") {
+      if (typeof record.model === "string" && isGeminiContentPayload(record.content)) {
         return true;
       }
 
       if (typeof record.request === "object" && record.request !== null) {
         const nestedRequest = record.request as Record<string, unknown>;
-        return typeof nestedRequest.model === "string" || typeof nestedRequest.content === "object";
+        return (
+          typeof nestedRequest.model === "string" && isGeminiContentPayload(nestedRequest.content)
+        );
       }
 
       return false;

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -43,6 +43,8 @@ import { GEMINI_PROTOCOL } from "../gemini/protocol";
 import { HeaderProcessor } from "../headers";
 import { buildProxyUrl } from "../url";
 import { rectifyBillingHeader } from "./billing-header-rectifier";
+import { isStandardProxyEndpointPath } from "./endpoint-family-catalog";
+import { isStrictStandardEndpointPath } from "./endpoint-paths";
 import {
   buildRequestDetails,
   categorizeErrorAsync,
@@ -72,23 +74,6 @@ import {
 /** Default User-Agent for Codex CLI requests when none is provided */
 export const DEFAULT_CODEX_USER_AGENT =
   "codex_cli_rs/0.93.0 (Windows 10.0.26200; x86_64) vscode/1.108.1";
-
-const STANDARD_ENDPOINTS = [
-  "/v1/messages",
-  "/v1/messages/count_tokens",
-  "/v1/responses",
-  "/v1/responses/compact",
-  "/v1/chat/completions",
-  "/v1/embeddings",
-  "/v1/models",
-];
-
-const STRICT_STANDARD_ENDPOINTS = [
-  "/v1/messages",
-  "/v1/responses",
-  "/v1/chat/completions",
-  "/v1/embeddings",
-];
 
 const OUTBOUND_TRANSPORT_HEADER_BLACKLIST = ["content-length", "connection", "transfer-encoding"];
 
@@ -567,9 +552,9 @@ export class ProxyForwarder {
       const isMcpRequest =
         currentProvider.providerType !== "gemini" &&
         currentProvider.providerType !== "gemini-cli" &&
-        !STANDARD_ENDPOINTS.includes(requestPath);
+        !isStandardProxyEndpointPath(requestPath);
       const shouldEnforceStrictEndpointPool =
-        !isMcpRequest && STRICT_STANDARD_ENDPOINTS.includes(requestPath) && providerVendorId > 0;
+        !isMcpRequest && isStrictStandardEndpointPath(requestPath) && providerVendorId > 0;
       let endpointSelectionError: Error | null = null;
 
       const endpointCandidates: Array<{ endpointId: number | null; baseUrl: string }> = [];
@@ -1878,7 +1863,11 @@ export class ProxyForwarder {
 
         // Apply Gemini Google Search override if configured
         const { request: overriddenBody, audit: googleSearchAudit } =
-          applyGeminiGoogleSearchOverrideWithAudit(provider, bodyToSerialize);
+          applyGeminiGoogleSearchOverrideWithAudit(
+            provider,
+            bodyToSerialize,
+            session.requestUrl.pathname
+          );
         if (googleSearchAudit) {
           session.addSpecialSetting(googleSearchAudit);
           bodyToSerialize = overriddenBody;
@@ -2164,8 +2153,7 @@ export class ProxyForwarder {
 
       // 检测是否为 MCP 请求（非标准 Claude/Codex/OpenAI 端点）
       const requestPath = session.requestUrl.pathname;
-      // pathname does not include query params, so exact match is sufficient
-      const isStandardRequest = STANDARD_ENDPOINTS.includes(requestPath);
+      const isStandardRequest = isStandardProxyEndpointPath(requestPath);
       const isMcpRequest = !isStandardRequest;
 
       if (isMcpRequest && provider.mcpPassthroughType && provider.mcpPassthroughType !== "none") {
@@ -3432,9 +3420,9 @@ export class ProxyForwarder {
     const isMcpRequest =
       provider.providerType !== "gemini" &&
       provider.providerType !== "gemini-cli" &&
-      !STANDARD_ENDPOINTS.includes(requestPath);
+      !isStandardProxyEndpointPath(requestPath);
     const shouldEnforceStrictEndpointPool =
-      !isMcpRequest && STRICT_STANDARD_ENDPOINTS.includes(requestPath) && providerVendorId > 0;
+      !isMcpRequest && isStrictStandardEndpointPath(requestPath) && providerVendorId > 0;
 
     if (
       !isMcpRequest &&

--- a/src/app/v1/_lib/proxy/provider-selector.ts
+++ b/src/app/v1/_lib/proxy/provider-selector.ts
@@ -843,10 +843,11 @@ export class ProxyProviderResolver {
         }
       }
 
-      // 2c. 模型匹配（保留原有逻辑）
+      // 2c. 模型匹配
       if (!requestedModel) {
-        // 没有模型信息时，只选择 Anthropic 提供商（向后兼容）
-        return provider.providerType === "claude";
+        // 资源类端点通常不携带 model，此时仅按格式兼容性筛选 provider，
+        // 不应再因为缺失模型而把请求错误收窄到 claude。
+        return true;
       }
 
       return providerSupportsModel(provider, requestedModel);

--- a/src/lib/gemini/provider-overrides.ts
+++ b/src/lib/gemini/provider-overrides.ts
@@ -1,3 +1,4 @@
+import { isGeminiGenerationEndpointPath } from "@/app/v1/_lib/proxy/endpoint-family-catalog";
 import { logger } from "@/lib/logger";
 import type { GeminiGoogleSearchPreference, ProviderType } from "@/types/provider";
 import type { GeminiGoogleSearchOverrideSpecialSetting } from "@/types/special-settings";
@@ -44,9 +45,14 @@ function removeGoogleSearchTools(tools: unknown[]): unknown[] {
  */
 export function applyGeminiGoogleSearchOverride(
   provider: GeminiProviderOverrideConfig,
-  request: Record<string, unknown>
+  request: Record<string, unknown>,
+  endpointPathname?: string | null
 ): Record<string, unknown> {
   if (provider.providerType !== "gemini" && provider.providerType !== "gemini-cli") {
+    return request;
+  }
+
+  if (endpointPathname && !isGeminiGenerationEndpointPath(endpointPathname)) {
     return request;
   }
 
@@ -95,9 +101,14 @@ export function applyGeminiGoogleSearchOverride(
  */
 export function applyGeminiGoogleSearchOverrideWithAudit(
   provider: GeminiProviderOverrideConfig,
-  request: Record<string, unknown>
+  request: Record<string, unknown>,
+  endpointPathname?: string | null
 ): { request: Record<string, unknown>; audit: GeminiGoogleSearchOverrideSpecialSetting | null } {
   if (provider.providerType !== "gemini" && provider.providerType !== "gemini-cli") {
+    return { request, audit: null };
+  }
+
+  if (endpointPathname && !isGeminiGenerationEndpointPath(endpointPathname)) {
     return { request, audit: null };
   }
 
@@ -125,7 +136,7 @@ export function applyGeminiGoogleSearchOverrideWithAudit(
     return { request, audit: null };
   }
 
-  const nextRequest = applyGeminiGoogleSearchOverride(provider, request);
+  const nextRequest = applyGeminiGoogleSearchOverride(provider, request, endpointPathname);
 
   const audit: GeminiGoogleSearchOverrideSpecialSetting = {
     type: "gemini_google_search_override",

--- a/tests/unit/lib/gemini/provider-overrides.test.ts
+++ b/tests/unit/lib/gemini/provider-overrides.test.ts
@@ -93,6 +93,19 @@ describe("applyGeminiGoogleSearchOverride", () => {
 
       expect(result.tools).toEqual([{ googleSearch: {} }]);
     });
+
+    test("should not inject googleSearch for non-generation Gemini actions when pathname is provided", () => {
+      const provider = { providerType: "gemini", geminiGoogleSearchPreference: "enabled" };
+      const request = { content: { parts: [{ text: "hello" }] } };
+
+      const result = applyGeminiGoogleSearchOverride(
+        provider,
+        request,
+        "/v1beta/models/gemini-embedding-001:embedContent"
+      );
+
+      expect(result).toBe(request);
+    });
   });
 
   describe("disabled preference", () => {
@@ -224,6 +237,25 @@ describe("applyGeminiGoogleSearchOverrideWithAudit", () => {
         preference: "enabled",
         hadGoogleSearchInRequest: true,
       });
+    });
+
+    test("should skip audit for non-generation Gemini actions when pathname is provided", () => {
+      const provider = {
+        id: 5,
+        name: "Gemini Embeddings",
+        providerType: "gemini",
+        geminiGoogleSearchPreference: "enabled",
+      };
+      const request = { content: { parts: [{ text: "hello" }] } };
+
+      const { request: result, audit } = applyGeminiGoogleSearchOverrideWithAudit(
+        provider,
+        request,
+        "/v1beta/models/gemini-embedding-001:embedContent"
+      );
+
+      expect(result).toBe(request);
+      expect(audit).toBeNull();
     });
   });
 

--- a/tests/unit/proxy/endpoint-family-catalog.test.ts
+++ b/tests/unit/proxy/endpoint-family-catalog.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, test } from "vitest";
+import {
+  isStandardProxyEndpointPath,
+  listKnownEndpointFamilies,
+  resolveEndpointFamilyByPath,
+} from "@/app/v1/_lib/proxy/endpoint-family-catalog";
+import { detectClientFormat, detectFormatByEndpoint } from "@/app/v1/_lib/proxy/format-mapper";
+
+const FAMILY_SAMPLES = [
+  {
+    id: "claude-messages",
+    path: "/v1/messages",
+    format: "claude",
+    accountingTier: "required_usage",
+    modelRequired: false,
+  },
+  {
+    id: "claude-count-tokens",
+    path: "/v1/messages/count_tokens",
+    format: "claude",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "response-execution",
+    path: "/v1/responses",
+    format: "response",
+    accountingTier: "required_usage",
+    modelRequired: false,
+  },
+  {
+    id: "response-resources",
+    path: "/v1/responses/resp_123/input_items",
+    format: "response",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "response-compact",
+    path: "/v1/responses/compact",
+    format: "response",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-chat-completions",
+    path: "/v1/chat/completions",
+    format: "openai",
+    accountingTier: "required_usage",
+    modelRequired: true,
+  },
+  {
+    id: "openai-chat-completions-resources",
+    path: "/v1/chat/completions/cmpl_123/messages",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-completions",
+    path: "/v1/completions",
+    format: "openai",
+    accountingTier: "required_usage",
+    modelRequired: true,
+  },
+  {
+    id: "openai-embeddings",
+    path: "/v1/embeddings",
+    format: "openai",
+    accountingTier: "required_usage",
+    modelRequired: true,
+  },
+  {
+    id: "openai-moderations",
+    path: "/v1/moderations",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-audio-generation",
+    path: "/v1/audio/speech",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-audio-transcription",
+    path: "/v1/audio/transcriptions",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-audio-resources",
+    path: "/v1/audio/voices",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-images",
+    path: "/v1/images/generations",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-files",
+    path: "/v1/files/file_123/content",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-uploads",
+    path: "/v1/uploads/upload_123/complete",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-batches",
+    path: "/v1/batches/batch_123/cancel",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-models",
+    path: "/v1/models/gpt-4o",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-fine-tuning",
+    path: "/v1/fine_tuning/jobs/job_123/events",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-evals",
+    path: "/v1/evals/eval_123/runs",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-assistants",
+    path: "/v1/assistants/asst_123",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-threads",
+    path: "/v1/threads/thread_123/runs",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-conversations",
+    path: "/v1/conversations/conv_123/items",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-vector-stores",
+    path: "/v1/vector_stores/vs_123/search",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-containers",
+    path: "/v1/containers/container_123/files",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-realtime-http",
+    path: "/v1/realtime/sessions",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-videos",
+    path: "/v1/videos/edits",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-skills",
+    path: "/v1/skills/skill_123/content",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-chatkit",
+    path: "/v1/chatkit/threads/thread_123/items",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "gemini-generate-content",
+    path: "/v1beta/models/gemini-2.5-flash:generateContent",
+    format: "gemini",
+    accountingTier: "required_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-stream-generate-content",
+    path: "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+    format: "gemini",
+    accountingTier: "required_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-count-tokens",
+    path: "/v1beta/models/gemini-2.5-flash:countTokens",
+    format: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-embed-content",
+    path: "/v1beta/models/gemini-embedding-001:embedContent",
+    format: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-batch-generate-content",
+    path: "/v1beta/models/gemini-2.5-flash:batchGenerateContent",
+    format: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-batch-embed-contents",
+    path: "/v1beta/models/gemini-embedding-001:batchEmbedContents",
+    format: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-async-batch-embed-content",
+    path: "/v1beta/models/gemini-embedding-001:asyncBatchEmbedContent",
+    format: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-predict",
+    path: "/v1beta/models/imagen-3.0-generate-002:predict",
+    format: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-predict-long-running",
+    path: "/v1beta/models/veo-3.0-generate-preview:predictLongRunning",
+    format: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-files",
+    path: "/v1beta/files/file-123",
+    format: "gemini",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "gemini-models-resource",
+    path: "/v1beta/models/gemini-2.5-flash",
+    format: "gemini",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "gemini-batch-embed-contents",
+    path: "/v1/publishers/google/models/gemini-embedding-001:batchEmbedContents",
+    format: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-batch-embed-contents",
+    path: "/v1/models/gemini-2.5-flash:batchEmbedContents",
+    format: "gemini",
+    accountingTier: "optional_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-cli-generate-content",
+    path: "/v1internal/models/gemini-2.5-flash:generateContent",
+    format: "gemini-cli",
+    accountingTier: "required_usage",
+    modelRequired: true,
+  },
+  {
+    id: "gemini-cli-stream-generate-content",
+    path: "/v1internal/models/gemini-2.5-flash:streamGenerateContent",
+    format: "gemini-cli",
+    accountingTier: "required_usage",
+    modelRequired: true,
+  },
+] as const;
+
+describe("endpoint family catalog", () => {
+  test("样例应覆盖所有已知端点族", () => {
+    expect(new Set(FAMILY_SAMPLES.map((entry) => entry.id))).toEqual(
+      new Set(listKnownEndpointFamilies().map((entry) => entry.id))
+    );
+  });
+
+  test.each(FAMILY_SAMPLES)("%s 应解析到正确端点族", ({ id, path, format, accountingTier }) => {
+    const family = resolveEndpointFamilyByPath(path);
+
+    expect(family?.id).toBe(id);
+    expect(family?.surface).toBe(format);
+    expect(family?.accountingTier).toBe(accountingTier);
+    expect(detectFormatByEndpoint(path)).toBe(format);
+    expect(isStandardProxyEndpointPath(path)).toBe(true);
+  });
+
+  test.each(FAMILY_SAMPLES.filter((entry) => entry.modelRequired))("%s 应要求模型", ({ path }) => {
+    expect(resolveEndpointFamilyByPath(path)?.modelRequired).toBe(true);
+  });
+
+  test.each(FAMILY_SAMPLES.filter((entry) => !entry.modelRequired))("%s 不应要求模型", ({
+    path,
+  }) => {
+    expect(resolveEndpointFamilyByPath(path)?.modelRequired).toBe(false);
+  });
+
+  test("Gemini batch body fallback 应识别为 gemini", () => {
+    expect(
+      detectClientFormat({
+        requests: [
+          {
+            model: "models/gemini-embedding-001",
+            content: {
+              parts: [{ text: "hello" }],
+            },
+          },
+        ],
+      })
+    ).toBe("gemini");
+  });
+
+  test.each([
+    "/v1/organization/users",
+    "/v1/projects/proj_123/service_accounts",
+    "/v1beta/upload/v1beta/files",
+    "/v1internal/models/gemini-2.5-flash:embedContent",
+  ])("%s 不应被误判为受支持代理端点", (path) => {
+    expect(resolveEndpointFamilyByPath(path)).toBeNull();
+    expect(detectFormatByEndpoint(path)).toBeNull();
+    expect(isStandardProxyEndpointPath(path)).toBe(false);
+  });
+});

--- a/tests/unit/proxy/endpoint-family-provider-routing.test.ts
+++ b/tests/unit/proxy/endpoint-family-provider-routing.test.ts
@@ -1,0 +1,382 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { listKnownEndpointFamilies } from "@/app/v1/_lib/proxy/endpoint-family-catalog";
+import { detectFormatByEndpoint } from "@/app/v1/_lib/proxy/format-mapper";
+import type { Provider } from "@/types/provider";
+
+const circuitBreakerMocks = vi.hoisted(() => ({
+  isCircuitOpen: vi.fn(async () => false),
+  getCircuitState: vi.fn(() => "closed"),
+}));
+
+vi.mock("@/lib/circuit-breaker", () => circuitBreakerMocks);
+
+const ENDPOINT_PROVIDER_CASES = [
+  {
+    id: "claude-messages",
+    path: "/v1/messages",
+    requestedModel: "claude-sonnet-4-20250514",
+    expectedProviderType: "claude",
+  },
+  {
+    id: "claude-count-tokens",
+    path: "/v1/messages/count_tokens",
+    requestedModel: "",
+    expectedProviderType: "claude",
+  },
+  {
+    id: "response-execution",
+    path: "/v1/responses",
+    requestedModel: "codex-mini-latest",
+    expectedProviderType: "codex",
+  },
+  {
+    id: "response-compact",
+    path: "/v1/responses/compact",
+    requestedModel: "",
+    expectedProviderType: "codex",
+  },
+  {
+    id: "response-resources",
+    path: "/v1/responses/resp_123/input_items",
+    requestedModel: "",
+    expectedProviderType: "codex",
+  },
+  {
+    id: "openai-chat-completions",
+    path: "/v1/chat/completions",
+    requestedModel: "gpt-4o",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-chat-completions-resources",
+    path: "/v1/chat/completions/cmpl_123/messages",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-completions",
+    path: "/v1/completions",
+    requestedModel: "gpt-3.5-turbo-instruct",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-embeddings",
+    path: "/v1/embeddings",
+    requestedModel: "text-embedding-3-large",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-moderations",
+    path: "/v1/moderations",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-audio-generation",
+    path: "/v1/audio/speech",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-audio-transcription",
+    path: "/v1/audio/transcriptions",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-audio-resources",
+    path: "/v1/audio/voices",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-images",
+    path: "/v1/images/generations",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-files",
+    path: "/v1/files/file_123/content",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-uploads",
+    path: "/v1/uploads/upload_123/complete",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-batches",
+    path: "/v1/batches/batch_123/cancel",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-models",
+    path: "/v1/models/gpt-4o",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-fine-tuning",
+    path: "/v1/fine_tuning/jobs/job_123/events",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-evals",
+    path: "/v1/evals/eval_123/runs",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-assistants",
+    path: "/v1/assistants/asst_123",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-threads",
+    path: "/v1/threads/thread_123/runs",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-conversations",
+    path: "/v1/conversations/conv_123/items",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-vector-stores",
+    path: "/v1/vector_stores/vs_123/search",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-containers",
+    path: "/v1/containers/container_123/files",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-realtime-http",
+    path: "/v1/realtime/sessions",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-videos",
+    path: "/v1/videos/edits",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-skills",
+    path: "/v1/skills/skill_123/content",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-chatkit",
+    path: "/v1/chatkit/threads/thread_123/items",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "gemini-generate-content",
+    path: "/v1beta/models/gemini-2.5-flash:generateContent",
+    requestedModel: "gemini-2.5-flash",
+    expectedProviderType: "gemini",
+  },
+  {
+    id: "gemini-stream-generate-content",
+    path: "/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+    requestedModel: "gemini-2.5-flash",
+    expectedProviderType: "gemini",
+  },
+  {
+    id: "gemini-count-tokens",
+    path: "/v1beta/models/gemini-2.5-flash:countTokens",
+    requestedModel: "gemini-2.5-flash",
+    expectedProviderType: "gemini",
+  },
+  {
+    id: "gemini-embed-content",
+    path: "/v1beta/models/gemini-embedding-001:embedContent",
+    requestedModel: "gemini-embedding-001",
+    expectedProviderType: "gemini",
+  },
+  {
+    id: "gemini-batch-generate-content",
+    path: "/v1beta/models/gemini-2.5-flash:batchGenerateContent",
+    requestedModel: "gemini-2.5-flash",
+    expectedProviderType: "gemini",
+  },
+  {
+    id: "gemini-batch-embed-contents",
+    path: "/v1beta/models/gemini-embedding-001:batchEmbedContents",
+    requestedModel: "gemini-embedding-001",
+    expectedProviderType: "gemini",
+  },
+  {
+    id: "gemini-async-batch-embed-content",
+    path: "/v1beta/models/gemini-embedding-001:asyncBatchEmbedContent",
+    requestedModel: "gemini-embedding-001",
+    expectedProviderType: "gemini",
+  },
+  {
+    id: "gemini-predict",
+    path: "/v1beta/models/imagen-3.0-generate-002:predict",
+    requestedModel: "imagen-3.0-generate-002",
+    expectedProviderType: "gemini",
+  },
+  {
+    id: "gemini-predict-long-running",
+    path: "/v1beta/models/veo-3.0-generate-preview:predictLongRunning",
+    requestedModel: "veo-3.0-generate-preview",
+    expectedProviderType: "gemini",
+  },
+  {
+    id: "gemini-files",
+    path: "/v1beta/files/file-123",
+    requestedModel: "",
+    expectedProviderType: "gemini",
+  },
+  {
+    id: "gemini-models-resource",
+    path: "/v1beta/models/gemini-2.5-flash",
+    requestedModel: "",
+    expectedProviderType: "gemini",
+  },
+  {
+    id: "gemini-cli-generate-content",
+    path: "/v1internal/models/gemini-2.5-flash:generateContent",
+    requestedModel: "gemini-2.5-flash",
+    expectedProviderType: "gemini-cli",
+  },
+  {
+    id: "gemini-cli-stream-generate-content",
+    path: "/v1internal/models/gemini-2.5-flash:streamGenerateContent",
+    requestedModel: "gemini-2.5-flash",
+    expectedProviderType: "gemini-cli",
+  },
+] as const;
+
+describe("endpoint family -> provider routing matrix", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createSessionStub(pathname: string, originalModel: string) {
+    return {
+      originalFormat: detectFormatByEndpoint(pathname),
+      authState: null,
+      getProvidersSnapshot: async () => [],
+      getOriginalModel: () => originalModel,
+      getCurrentModel: () => originalModel,
+      clientRequestsContext1m: () => false,
+    } as any;
+  }
+
+  function createProvider(
+    id: number,
+    providerType: Provider["providerType"],
+    overrides: Partial<Provider> = {}
+  ): Provider {
+    return {
+      id,
+      name: `provider-${id}`,
+      isEnabled: true,
+      providerType,
+      groupTag: null,
+      weight: 1,
+      priority: 0,
+      costMultiplier: 1,
+      allowedModels: null,
+      ...overrides,
+    } as unknown as Provider;
+  }
+
+  async function setupResolverMocks() {
+    const { ProxyProviderResolver } = await import("@/app/v1/_lib/proxy/provider-selector");
+
+    vi.spyOn(ProxyProviderResolver as any, "filterByLimits").mockImplementation(
+      async (...args: unknown[]) => args[0] as Provider[]
+    );
+    vi.spyOn(ProxyProviderResolver as any, "selectTopPriority").mockImplementation(
+      (...args: unknown[]) => args[0] as Provider[]
+    );
+    vi.spyOn(ProxyProviderResolver as any, "selectOptimal").mockImplementation(
+      (...args: unknown[]) => (args[0] as Provider[])[0] ?? null
+    );
+
+    return ProxyProviderResolver;
+  }
+
+  test("matrix should cover every known endpoint family id", () => {
+    expect(new Set(ENDPOINT_PROVIDER_CASES.map((entry) => entry.id))).toEqual(
+      new Set(listKnownEndpointFamilies().map((entry) => entry.id))
+    );
+  });
+
+  test.each(ENDPOINT_PROVIDER_CASES)("$id should route $path to $expectedProviderType", async ({
+    path,
+    expectedProviderType,
+    requestedModel,
+  }) => {
+    const ProxyProviderResolver = await setupResolverMocks();
+
+    const providers: Provider[] = [
+      createProvider(1, "claude"),
+      createProvider(2, "claude-auth"),
+      createProvider(3, "codex"),
+      createProvider(4, "openai-compatible"),
+      createProvider(5, "gemini"),
+      createProvider(6, "gemini-cli"),
+    ];
+
+    const preferredProviderId = providers.find(
+      (provider) => provider.providerType === expectedProviderType
+    )!.id;
+    const session = createSessionStub(path, requestedModel);
+    session.getProvidersSnapshot = async () => providers;
+
+    const { provider, context } = await (ProxyProviderResolver as any).pickRandomProvider(
+      session,
+      []
+    );
+
+    expect(provider?.providerType).toBe(expectedProviderType);
+    expect(provider?.id).toBe(preferredProviderId);
+    expect(context.requestedModel).toBe(requestedModel);
+  });
+
+  test("/v1/chat/completions should never select codex when openai-compatible is available", async () => {
+    const ProxyProviderResolver = await setupResolverMocks();
+    const session = createSessionStub("/v1/chat/completions", "gpt-4o");
+    session.getProvidersSnapshot = async () => [
+      createProvider(1, "codex"),
+      createProvider(2, "openai-compatible"),
+    ];
+
+    const { provider } = await (ProxyProviderResolver as any).pickRandomProvider(session, []);
+
+    expect(provider?.providerType).toBe("openai-compatible");
+  });
+
+  test("/v1/responses should never select openai-compatible when codex is available", async () => {
+    const ProxyProviderResolver = await setupResolverMocks();
+    const session = createSessionStub("/v1/responses", "codex-mini-latest");
+    session.getProvidersSnapshot = async () => [
+      createProvider(1, "openai-compatible"),
+      createProvider(2, "codex"),
+    ];
+
+    const { provider } = await (ProxyProviderResolver as any).pickRandomProvider(session, []);
+
+    expect(provider?.providerType).toBe("codex");
+  });
+});

--- a/tests/unit/proxy/endpoint-family-provider-routing.test.ts
+++ b/tests/unit/proxy/endpoint-family-provider-routing.test.ts
@@ -281,7 +281,7 @@ describe("endpoint family -> provider routing matrix", () => {
     } as any;
   }
 
-  function createProvider(
+  function createTestProvider(
     id: number,
     providerType: Provider["providerType"],
     overrides: Partial<Provider> = {}
@@ -289,15 +289,65 @@ describe("endpoint family -> provider routing matrix", () => {
     return {
       id,
       name: `provider-${id}`,
+      url: "https://provider.example.com",
+      key: "provider-key",
+      providerVendorId: null,
       isEnabled: true,
-      providerType,
-      groupTag: null,
       weight: 1,
       priority: 0,
+      groupPriorities: null,
       costMultiplier: 1,
+      groupTag: null,
+      providerType,
+      preserveClientIp: false,
+      modelRedirects: null,
+      activeTimeStart: null,
+      activeTimeEnd: null,
       allowedModels: null,
+      allowedClients: [],
+      blockedClients: [],
+      mcpPassthroughType: "none",
+      mcpPassthroughUrl: null,
+      limit5hUsd: null,
+      limitDailyUsd: null,
+      dailyResetMode: "fixed",
+      dailyResetTime: "00:00",
+      limitWeeklyUsd: null,
+      limitMonthlyUsd: null,
+      limitTotalUsd: null,
+      totalCostResetAt: null,
+      limitConcurrentSessions: 0,
+      maxRetryAttempts: null,
+      circuitBreakerFailureThreshold: 0,
+      circuitBreakerOpenDuration: 0,
+      circuitBreakerHalfOpenSuccessThreshold: 0,
+      proxyUrl: null,
+      proxyFallbackToDirect: false,
+      firstByteTimeoutStreamingMs: 0,
+      streamingIdleTimeoutMs: 0,
+      requestTimeoutNonStreamingMs: 0,
+      websiteUrl: null,
+      faviconUrl: null,
+      cacheTtlPreference: null,
+      swapCacheTtlBilling: false,
+      context1mPreference: null,
+      codexReasoningEffortPreference: null,
+      codexReasoningSummaryPreference: null,
+      codexTextVerbosityPreference: null,
+      codexParallelToolCallsPreference: null,
+      codexServiceTierPreference: null,
+      anthropicMaxTokensPreference: null,
+      anthropicThinkingBudgetPreference: null,
+      anthropicAdaptiveThinking: null,
+      geminiGoogleSearchPreference: null,
+      tpm: null,
+      rpm: null,
+      rpd: null,
+      cc: null,
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
       ...overrides,
-    } as unknown as Provider;
+    };
   }
 
   async function setupResolverMocks() {
@@ -330,17 +380,13 @@ describe("endpoint family -> provider routing matrix", () => {
     const ProxyProviderResolver = await setupResolverMocks();
 
     const providers: Provider[] = [
-      createProvider(1, "claude"),
-      createProvider(2, "claude-auth"),
-      createProvider(3, "codex"),
-      createProvider(4, "openai-compatible"),
-      createProvider(5, "gemini"),
-      createProvider(6, "gemini-cli"),
+      createTestProvider(1, "claude"),
+      createTestProvider(2, "claude-auth"),
+      createTestProvider(3, "codex"),
+      createTestProvider(4, "openai-compatible"),
+      createTestProvider(5, "gemini"),
+      createTestProvider(6, "gemini-cli"),
     ];
-
-    const preferredProviderId = providers.find(
-      (provider) => provider.providerType === expectedProviderType
-    )!.id;
     const session = createSessionStub(path, requestedModel);
     session.getProvidersSnapshot = async () => providers;
 
@@ -350,7 +396,6 @@ describe("endpoint family -> provider routing matrix", () => {
     );
 
     expect(provider?.providerType).toBe(expectedProviderType);
-    expect(provider?.id).toBe(preferredProviderId);
     expect(context.requestedModel).toBe(requestedModel);
   });
 
@@ -358,8 +403,8 @@ describe("endpoint family -> provider routing matrix", () => {
     const ProxyProviderResolver = await setupResolverMocks();
     const session = createSessionStub("/v1/chat/completions", "gpt-4o");
     session.getProvidersSnapshot = async () => [
-      createProvider(1, "codex"),
-      createProvider(2, "openai-compatible"),
+      createTestProvider(1, "codex"),
+      createTestProvider(2, "openai-compatible"),
     ];
 
     const { provider } = await (ProxyProviderResolver as any).pickRandomProvider(session, []);
@@ -371,8 +416,8 @@ describe("endpoint family -> provider routing matrix", () => {
     const ProxyProviderResolver = await setupResolverMocks();
     const session = createSessionStub("/v1/responses", "codex-mini-latest");
     session.getProvidersSnapshot = async () => [
-      createProvider(1, "openai-compatible"),
-      createProvider(2, "codex"),
+      createTestProvider(1, "openai-compatible"),
+      createTestProvider(2, "codex"),
     ];
 
     const { provider } = await (ProxyProviderResolver as any).pickRandomProvider(session, []);

--- a/tests/unit/proxy/extract-usage-metrics.test.ts
+++ b/tests/unit/proxy/extract-usage-metrics.test.ts
@@ -505,6 +505,28 @@ describe("extractUsageMetrics", () => {
       expect(result.usageMetrics?.output_image_tokens).toBe(2100);
       expect(result.usageMetrics?.output_tokens).toBe(240);
     });
+
+    it("Gemini 官方 embedContent 响应无 usageMetadata 时应保持保守语义", () => {
+      const response = JSON.stringify({
+        embedding: {
+          values: [0.1, 0.2, 0.3],
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "gemini");
+
+      expect(result.usageMetrics).toBeNull();
+    });
+
+    it("Gemini 官方 countTokens 响应只有 totalTokens 时不应伪造 usage", () => {
+      const response = JSON.stringify({
+        totalTokens: 128,
+      });
+
+      const result = parseUsageFromResponseText(response, "gemini");
+
+      expect(result.usageMetrics).toBeNull();
+    });
   });
 
   describe("OpenAI Response API 格式", () => {
@@ -571,6 +593,22 @@ describe("extractUsageMetrics", () => {
       const result = parseUsageFromResponseText(response, "openai");
 
       expect(result.usageMetrics?.cache_read_input_tokens).toBe(300);
+    });
+
+    it("应支持 OpenAI embeddings 响应的 prompt-only usage", () => {
+      const response = JSON.stringify({
+        object: "list",
+        data: [{ object: "embedding", embedding: [0.1, 0.2], index: 0 }],
+        usage: {
+          prompt_tokens: 12,
+          total_tokens: 12,
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "openai");
+
+      expect(result.usageMetrics?.input_tokens).toBe(12);
+      expect(result.usageMetrics?.output_tokens).toBeUndefined();
     });
   });
 

--- a/tests/unit/proxy/openai-official-standard-forwarder.test.ts
+++ b/tests/unit/proxy/openai-official-standard-forwarder.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
+import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
+import { ProxySession } from "@/app/v1/_lib/proxy/session";
+import type { Provider } from "@/types/provider";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+    warn: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/request-filter-engine", () => ({
+  requestFilterEngine: {
+    applyFinal: vi.fn(async () => {}),
+  },
+}));
+
+function createProvider(providerType: "openai-compatible" | "codex"): Provider {
+  return {
+    id: 1,
+    name: `${providerType}-upstream`,
+    providerType,
+    url:
+      providerType === "codex"
+        ? "https://codex.example.com/v1"
+        : "https://openai.example.com/openai",
+    key: "upstream-key",
+    preserveClientIp: false,
+    priority: 0,
+    costMultiplier: 1,
+    maxRetryAttempts: 1,
+    mcpPassthroughType: "minimax",
+    mcpPassthroughUrl: "https://mcp.example.com",
+  } as unknown as Provider;
+}
+
+function createSession(
+  pathname: string,
+  providerType: "openai-compatible" | "codex"
+): ProxySession {
+  const headers = new Headers({
+    "content-type": "application/json",
+    authorization: "Bearer proxy-user-key",
+  });
+  const session = Object.create(ProxySession.prototype);
+
+  Object.assign(session, {
+    startTime: Date.now(),
+    method: "GET",
+    requestUrl: new URL(`https://proxy.example.com${pathname}`),
+    headers,
+    originalHeaders: new Headers(headers),
+    headerLog: JSON.stringify(Object.fromEntries(headers.entries())),
+    request: {
+      model: null,
+      log: JSON.stringify({}),
+      message: {},
+    },
+    userAgent: "OpenAITest/1.0",
+    context: null,
+    clientAbortSignal: null,
+    userName: "test-user",
+    authState: { success: true, user: null, key: null, apiKey: null },
+    provider: null,
+    messageContext: null,
+    sessionId: null,
+    requestSequence: 1,
+    originalFormat: providerType === "codex" ? "response" : "openai",
+    providerType: null,
+    originalModelName: null,
+    originalUrlPathname: null,
+    providerChain: [],
+    cacheTtlResolved: null,
+    context1mApplied: false,
+    cachedPriceData: undefined,
+    cachedBillingModelSource: undefined,
+    forwardedRequestBody: null,
+    endpointPolicy: resolveEndpointPolicy(pathname),
+    setCacheTtlResolved: vi.fn(),
+    getCacheTtlResolved: vi.fn(() => null),
+    getCurrentModel: vi.fn(() => null),
+    clientRequestsContext1m: vi.fn(() => false),
+    setContext1mApplied: vi.fn(),
+    getContext1mApplied: vi.fn(() => false),
+    getEndpointPolicy: vi.fn(() => resolveEndpointPolicy(pathname)),
+    isHeaderModified: vi.fn(() => false),
+  });
+
+  return session as ProxySession;
+}
+
+describe("ProxyForwarder - official OpenAI endpoints stay on provider URL", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not route /v1/files through MCP passthrough URL", async () => {
+    const provider = createProvider("openai-compatible");
+    const session = createSession("/v1/files/file_123/content", "openai-compatible");
+    let capturedUrl: string | null = null;
+
+    const fetchWithoutAutoDecode = vi.spyOn(ProxyForwarder as never, "fetchWithoutAutoDecode");
+    fetchWithoutAutoDecode.mockImplementationOnce(async (url: string) => {
+      capturedUrl = url;
+      return new Response("ok", { status: 200, headers: { "content-type": "text/plain" } });
+    });
+
+    const { doForward } = ProxyForwarder as unknown as {
+      doForward: (session: ProxySession, provider: Provider, baseUrl: string) => Promise<Response>;
+    };
+
+    await doForward(session, provider, provider.url);
+
+    expect(capturedUrl).toBe("https://openai.example.com/openai/v1/files/file_123/content");
+    expect(capturedUrl?.startsWith("https://mcp.example.com")).toBe(false);
+  });
+
+  it("does not route /v1/responses/{id} through MCP passthrough URL", async () => {
+    const provider = createProvider("codex");
+    const session = createSession("/v1/responses/resp_123", "codex");
+    let capturedUrl: string | null = null;
+
+    const fetchWithoutAutoDecode = vi.spyOn(ProxyForwarder as never, "fetchWithoutAutoDecode");
+    fetchWithoutAutoDecode.mockImplementationOnce(async (url: string) => {
+      capturedUrl = url;
+      return new Response("ok", { status: 200, headers: { "content-type": "text/plain" } });
+    });
+
+    const { doForward } = ProxyForwarder as unknown as {
+      doForward: (session: ProxySession, provider: Provider, baseUrl: string) => Promise<Response>;
+    };
+
+    await doForward(session, provider, provider.url);
+
+    expect(capturedUrl).toBe("https://codex.example.com/v1/responses/resp_123");
+    expect(capturedUrl?.startsWith("https://mcp.example.com")).toBe(false);
+  });
+});

--- a/tests/unit/proxy/provider-selector-resource-endpoints.test.ts
+++ b/tests/unit/proxy/provider-selector-resource-endpoints.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { Provider } from "@/types/provider";
+
+const circuitBreakerMocks = vi.hoisted(() => ({
+  isCircuitOpen: vi.fn(async () => false),
+  getCircuitState: vi.fn(() => "closed"),
+}));
+
+vi.mock("@/lib/circuit-breaker", () => circuitBreakerMocks);
+
+describe("ProxyProviderResolver.pickRandomProvider - resource endpoints without model", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createSessionStub(originalFormat: string, providers: Provider[]) {
+    return {
+      originalFormat,
+      authState: null,
+      getProvidersSnapshot: async () => providers,
+      getOriginalModel: () => "",
+      getCurrentModel: () => null,
+      clientRequestsContext1m: () => false,
+    } as any;
+  }
+
+  function createProvider(
+    id: number,
+    providerType: string,
+    overrides: Partial<Provider> = {}
+  ): Provider {
+    return {
+      id,
+      name: `provider-${id}`,
+      isEnabled: true,
+      providerType,
+      groupTag: null,
+      weight: 1,
+      priority: 0,
+      costMultiplier: 1,
+      allowedModels: ["guarded-model"],
+      ...overrides,
+    } as unknown as Provider;
+  }
+
+  async function setupResolverMocks() {
+    const { ProxyProviderResolver } = await import("@/app/v1/_lib/proxy/provider-selector");
+
+    vi.spyOn(ProxyProviderResolver as any, "filterByLimits").mockImplementation(
+      async (...args: unknown[]) => args[0] as Provider[]
+    );
+    vi.spyOn(ProxyProviderResolver as any, "selectTopPriority").mockImplementation(
+      (...args: unknown[]) => args[0] as Provider[]
+    );
+    vi.spyOn(ProxyProviderResolver as any, "selectOptimal").mockImplementation(
+      (...args: unknown[]) => (args[0] as Provider[])[0] ?? null
+    );
+
+    return ProxyProviderResolver;
+  }
+
+  test("openai 资源端点在无 model 时仍应选择 openai-compatible provider", async () => {
+    const ProxyProviderResolver = await setupResolverMocks();
+
+    const incompatible = createProvider(1, "claude");
+    const compatible = createProvider(2, "openai-compatible");
+    const session = createSessionStub("openai", [incompatible, compatible]);
+
+    const { provider, context } = await (ProxyProviderResolver as any).pickRandomProvider(
+      session,
+      []
+    );
+
+    expect(provider?.id).toBe(2);
+    expect(provider?.providerType).toBe("openai-compatible");
+    expect(context.requestedModel).toBe("");
+  });
+
+  test("response 资源端点在无 model 时仍应选择 codex provider", async () => {
+    const ProxyProviderResolver = await setupResolverMocks();
+
+    const incompatible = createProvider(1, "openai-compatible");
+    const compatible = createProvider(2, "codex");
+    const session = createSessionStub("response", [incompatible, compatible]);
+
+    const { provider, context } = await (ProxyProviderResolver as any).pickRandomProvider(
+      session,
+      []
+    );
+
+    expect(provider?.id).toBe(2);
+    expect(provider?.providerType).toBe("codex");
+    expect(context.requestedModel).toBe("");
+  });
+
+  test("gemini 资源端点在无 model 时仍应选择 gemini provider", async () => {
+    const ProxyProviderResolver = await setupResolverMocks();
+
+    const incompatible = createProvider(1, "gemini-cli");
+    const compatible = createProvider(2, "gemini");
+    const session = createSessionStub("gemini", [incompatible, compatible]);
+
+    const { provider, context } = await (ProxyProviderResolver as any).pickRandomProvider(
+      session,
+      []
+    );
+
+    expect(provider?.id).toBe(2);
+    expect(provider?.providerType).toBe("gemini");
+    expect(context.requestedModel).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
Introduce a shared endpoint family catalog that centralizes endpoint classification for Claude, Response API, OpenAI, Gemini, and Gemini CLI surfaces. This classifies official OpenAI resource endpoints and additional Gemini model actions as standard proxy traffic instead of MCP passthrough, and gates Gemini Google Search provider overrides to generation-only actions.

## Problem
The codebase had endpoint classification logic duplicated across multiple files:
1. `format-mapper.ts` had inline regex patterns for endpoint format detection
2. `forwarder.ts` maintained its own `STANDARD_ENDPOINTS` and `STRICT_STANDARD_ENDPOINTS` arrays that diverged from `endpoint-paths.ts`
3. Gemini Google Search provider overrides were applied to all Gemini endpoints, including non-generation endpoints like `countTokens` and `embedContent`

This was noted in PR #931's review: "Duplicate endpoint lists risk drift - these two sources have already diverged."

**Related PRs:**
- Follow-up to #931 - Consolidates endpoint classification after embeddings passthrough addition
- Builds on #801 - Extends EndpointPolicy architecture with centralized endpoint catalog

## Solution
1. Create `endpoint-family-catalog.ts` with a declarative `EndpointFamily` interface that captures surface type, accounting tier, model requirement, and passthrough behavior
2. Replace scattered endpoint arrays in `forwarder.ts` with calls to `isStandardProxyEndpointPath()` from the catalog
3. Delegate format detection in `format-mapper.ts` to `detectEndpointFormat()` from the catalog
4. Gate Gemini Google Search overrides to generation-only endpoints (`generatecontent`, `streamgeneratecontent`)

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/endpoint-family-catalog.ts` (+443) - New centralized endpoint catalog with 25+ endpoint families
- `src/app/v1/_lib/proxy/format-mapper.ts` (+32/-46) - Delegate to catalog, add Gemini batch format detection
- `src/app/v1/_lib/proxy/forwarder.ts` (+12/-24) - Replace inline endpoint arrays with catalog functions
- `src/lib/gemini/provider-overrides.ts` (+14/-3) - Gate Google Search override to generation endpoints

### Supporting Changes
- `src/app/v1/_lib/proxy/provider-selector.ts` (+4/-3) - Minor import adjustment

### Tests
- `tests/unit/proxy/endpoint-family-catalog.test.ts` (+372) - Comprehensive catalog coverage
- `tests/unit/proxy/openai-official-standard-forwarder.test.ts` (+144) - OpenAI standard endpoint routing
- `tests/unit/proxy/provider-selector-resource-endpoints.test.ts` (+112) - Resource endpoint selection
- `tests/unit/lib/gemini/provider-overrides.test.ts` (+32) - Google Search override gating
- `tests/unit/proxy/extract-usage-metrics.test.ts` (+38) - Usage extraction edge cases

## Testing

### Automated Tests
- [x] Unit tests added for endpoint family catalog
- [x] Unit tests added for OpenAI standard forwarder routing
- [x] Unit tests added for provider selector resource endpoints
- [x] Unit tests added for Gemini Google Search override gating

### Verification Commands
```bash
bun run build
bun run lint
bun run lint:fix
bun run typecheck
bun run test
bunx vitest run tests/unit/proxy tests/unit/lib/gemini/provider-overrides.test.ts tests/unit/app/v1/url.test.ts
```

## Breaking Changes
None. This is an internal refactoring that maintains backward compatibility.

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No breaking changes

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates scattered endpoint-classification logic into a single `endpoint-family-catalog.ts` module, replacing two separate hard-coded arrays in `forwarder.ts`, ad-hoc inline regexes in `format-mapper.ts`, and an over-broad Google Search override application in `provider-overrides.ts`. The refactor correctly classifies ~35 previously-MCP-passthrough OpenAI resource endpoints and additional Gemini model actions as standard proxy traffic, and gates the Google Search tool injection/removal to generation-only Gemini endpoints.

Key changes:
- **`endpoint-family-catalog.ts`** — new declarative catalog of 42 `EndpointFamily` entries covering Claude, Response, OpenAI, Gemini, and Gemini-CLI surfaces; exports `resolveEndpointFamilyByPath`, `isStandardProxyEndpointPath`, `detectEndpointFormat`, and `isGeminiGenerationEndpointPath`.
- **`forwarder.ts`** — removes the `STANDARD_ENDPOINTS` / `STRICT_STANDARD_ENDPOINTS` arrays and delegates to catalog functions; passes `session.requestUrl.pathname` into the Google Search override audit.
- **`provider-selector.ts`** — changes the no-model fallback from "claude-only" to "any provider", safe because format-type compatibility is already enforced one step earlier (step 2b).
- **`provider-overrides.ts`** — gates Google Search overrides to paths where `isGeminiGenerationEndpointPath` returns `true`, preventing injection into `countTokens`/`embedContent` calls.
- The `GEMINI_GENERATION_ACTIONS` Set in `endpoint-family-catalog.ts` is a second source of truth that partially duplicates the generation-family definitions already present in the catalog, risking future drift.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge; behavioral changes are intentional and well-covered by new tests. Minor style concerns only.
- The core logic is sound: first-match-wins ordering in the catalog is correct for all overlapping matchers (response-compact before response-resources, exact endpoint entries before prefix entries), and the provider-selector change is guarded by the format-compatibility filter that runs earlier in the same function. The main residual risk is that `GEMINI_GENERATION_ACTIONS` is a second source of truth for generation action names that could drift from the catalog, but this does not affect current correctness.
- Pay close attention to `src/app/v1/_lib/proxy/endpoint-family-catalog.ts` — specifically the `GEMINI_GENERATION_ACTIONS` Set and `isGeminiGenerationEndpointPath` which maintain independent knowledge of which actions are "generation" endpoints.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/endpoint-family-catalog.ts | New centralized catalog of 42 endpoint families. Core logic is correct; minor issues: GEMINI_GENERATION_ACTIONS is a second source of truth that can drift from the catalog, /i regex flags are redundant after path normalization, and openai-completions uses an overly broad hasPrefix matcher. |
| src/app/v1/_lib/proxy/forwarder.ts | Replaces two hard-coded endpoint arrays with catalog-backed isStandardProxyEndpointPath / isStrictStandardEndpointPath, and passes the request pathname through to the Google Search override audit. Straightforward and low-risk. |
| src/app/v1/_lib/proxy/provider-selector.ts | Changes model-missing fallback from "claude providers only" to "any provider". Safe because the format-type filter (step 2b) already enforces provider-type compatibility before the model check is reached, as confirmed by the new resource-endpoint tests. |
| src/lib/gemini/provider-overrides.ts | Gates Google Search tool injection/removal to generation-only Gemini endpoints; non-generation paths and absent/null pathnames are handled correctly with early returns. |
| tests/unit/proxy/endpoint-family-catalog.test.ts | Good coverage of all 42 families; the Set-based coverage assertion is weakened by three duplicate gemini-batch-embed-contents entries that collapse to one ID in the Set comparison. |
| tests/unit/proxy/provider-selector-resource-endpoints.test.ts | Correctly validates that openai/response/gemini resource endpoints select the right provider type even without a model; provides solid regression coverage for the provider-selector change. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request\npathname] --> B[normalizeEndpointPath]
    B --> C[resolveEndpointFamilyByPath\nfind first matching family]

    C --> D{Family found?}
    D -- No --> E[null → MCP passthrough\n unless gemini/gemini-cli provider]
    D -- Yes --> F[EndpointFamily\nid · surface · accountingTier\nmodelRequired · rawPassthrough]

    F --> G[isStandardProxyEndpointPath\nforwarder: isMcpRequest=false]
    F --> H[detectEndpointFormat\nformat-mapper: surface type]
    F --> I[isStrictStandardEndpointPath\nforwarder: enforce strict pool]

    A --> J[isGeminiGenerationEndpointPath\nregex extract :action]
    J --> K{action in\nGEMINI_GENERATION_ACTIONS?}
    K -- Yes --> L[Apply Google Search\ntool override]
    K -- No --> M[Skip override\ncountTokens / embedContent]

    style E fill:#f9c,stroke:#c66
    style L fill:#cfc,stroke:#6c6
    style M fill:#eee,stroke:#999
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/endpoint-family-catalog.ts
Line: 16

Comment:
**`GEMINI_GENERATION_ACTIONS` duplicates catalog knowledge**

`GEMINI_GENERATION_ACTIONS` on line 16 is a second, independent source of truth that shadows the generation-family definitions already declared in `KNOWN_ENDPOINT_FAMILIES`. If a future generation action (e.g., `livegeneratecontent`) is added to the catalog as a new family, `isGeminiGenerationEndpointPath` will silently miss it unless this Set is updated in tandem — exactly the drift problem this PR was introduced to fix.

The `rawPassthrough`/`accountingTier` fields already live on `EndpointFamily`. Adding a boolean `isGenerationAction: boolean` (or a `role: "generation" | "embedding" | "resource"` discriminant) to the interface would let `isGeminiGenerationEndpointPath` derive its answer entirely from the catalog:

```ts
export function isGeminiGenerationEndpointPath(pathname: string): boolean {
  const family = resolveEndpointFamilyByPath(pathname);
  return (
    family !== null &&
    (family.surface === "gemini" || family.surface === "gemini-cli") &&
    family.isGenerationAction === true
  );
}
```

This keeps the catalog as the single source of truth and removes the risk of the two lists diverging again.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/endpoint-family-catalog.ts
Line: 143

Comment:
**Redundant `/i` flag on already-lowercased path**

`normalizeEndpointPath` (imported on line 1, called on every lookup in `resolveEndpointFamilyByPath`) lowercases the pathname before it reaches any `match` function. The `/i` flag in this regex — and in the two regexes inside the `gemini-models-resource` matcher at lines 254–255 — is therefore redundant. It adds no correctness benefit and creates a minor misleading impression that paths may arrive in mixed case at this point.

```suggestion
    match: (pathname) => /^\/v1\/models(?:\/[^/:]+)?$/.test(pathname),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/endpoint-family-catalog.ts
Line: 282-283

Comment:
**`openai-completions` over-matches with `hasPrefix`**

The legacy completions endpoint is a single action endpoint (`POST /v1/completions`) — there are no sub-resources under it. Using `hasPrefix(pathname, "/v1/completions")` means any hypothetical path like `/v1/completions/cmpl_123` would be matched as an `openai-completions` family with `modelRequired: true` and `accountingTier: "required_usage"`. A precise exact match would be more consistent with how `openai-embeddings` and the generation endpoints are handled:

```suggestion
    match: (pathname) => pathname === "/v1/completions",
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/unit/proxy/endpoint-family-catalog.test.ts
Line: 291-303

Comment:
**Duplicate `id` entries make the coverage assertion weaker than it looks**

`FAMILY_SAMPLES` includes three entries with `id: "gemini-batch-embed-contents"` (lines 249–255, 291–296, and 297–303). The "样例应覆盖所有已知端点族" test at line 321 uses `new Set(...)`, which silently collapses duplicates — so the equality check would still pass even if one of those three sample paths resolved to the wrong family, as long as the ID appears at least once.

The two extra entries are presumably testing the `/v1/publishers/google/models/` and `/v1/models/` prefix variants of the same family, which is a valuable scenario. Consider giving them distinct labels or a comment explaining they intentionally test alternate prefixes for the same family ID, so a future reader doesn't accidentally remove them as "duplicates".

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 4388404</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->