### PR TITLE
fix: make TagInput suggestion filter case-insensitive

### DIFF
--- a/src/components/ui/tag-input.tsx
+++ b/src/components/ui/tag-input.tsx
@@ -189,7 +189,10 @@ export function TagInput({
     return normalizedSuggestions.filter((s) => {
       const keywords = s.keywords?.join(" ") || "";
       const haystack = `${s.label} ${s.value} ${keywords}`.toLowerCase();
-      return haystack.includes(search) && (allowDuplicates || !value.includes(s.value));
+      return (
+        haystack.includes(search) &&
+        (allowDuplicates || !value.some((v) => v.toLowerCase() === s.value.toLowerCase()))
+      );
     });
   }, [normalizedSuggestions, inputValue, value, allowDuplicates]);
 


### PR DESCRIPTION
## Summary

Makes the TagInput suggestion filter case-insensitive to align with the duplicate check added in #940.

## Problem

**Follow-up to #940**

PR #940 made the TagInput duplicate validation case-insensitive, but the suggestion dropdown filter was still using case-sensitive matching. This caused confusing UX where:

1. User has tag "OpenAPI" selected
2. Suggestion dropdown shows "openapi" (different casing)
3. User clicks "openapi" suggestion
4. Selection fails with duplicate error (case-insensitive duplicate detected)

## Solution

Update the suggestion filter to use case-insensitive comparison when checking if a suggestion is already selected:

```diff
- return haystack.includes(search) && (allowDuplicates || !value.includes(s.value));
+ return (
+   haystack.includes(search) &&
+   (allowDuplicates || !value.some((v) => v.toLowerCase() === s.value.toLowerCase()))
+ );
```

## Changes

| File | Change |
|------|--------|
| `src/components/ui/tag-input.tsx` | Use case-insensitive comparison in suggestion filter |

## Testing

**Manual Testing:**
1. Open a form with TagInput that has suggestions
2. Add a tag (e.g., "OpenAPI")
3. Verify the suggestion dropdown no longer shows case variations of already-selected tags (e.g., "openapi", "OPENAPI")

## Checklist

- [x] Code follows project conventions
- [x] Self-review completed

---
*Description enhanced by Claude AI*