### PR TITLE
fix: run reactive rectifiers during streaming hedge

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -3092,7 +3092,7 @@ export class ProxyForwarder {
         attempt.requestAttemptCount
       )
         .then(async (response) => {
-          if (settled || winnerCommitted) {
+          if (settled || winnerCommitted || attempt.settled) {
             const attemptRuntime = attempt.session as ProxySessionWithAttemptRuntime;
             try {
               attemptRuntime.responseController?.abort(new Error("hedge_loser"));
@@ -3241,13 +3241,17 @@ export class ProxyForwarder {
             buildRetryFailedChainEntry(
               attempt.provider,
               attempt.endpointAudit,
-              attempt.sequence,
+              attempt.requestAttemptCount,
               error,
               errorMessage,
               reactiveRectifierResult.requestDetailsBeforeRectify
             )
           );
 
+          if (attempt.thresholdTimer) {
+            clearTimeout(attempt.thresholdTimer);
+            attempt.thresholdTimer = null;
+          }
           attempt.requestAttemptCount += 1;
           runAttempt(attempt);
           return;
@@ -3670,7 +3674,15 @@ export class ProxyForwarder {
       }
     }
     targetState.providerChain = mergedProviderChain;
-    targetState.specialSettings = [...sourceState.specialSettings];
+    // 合并 specialSettings，避免覆盖已有的 rectifier audit 记录
+    const existingKeys = new Set(targetState.specialSettings.map((s) => JSON.stringify(s)));
+    const merged = [...targetState.specialSettings];
+    for (const setting of sourceState.specialSettings) {
+      if (!existingKeys.has(JSON.stringify(setting))) {
+        merged.push(setting);
+      }
+    }
+    targetState.specialSettings = merged;
     targetState.originalModelName = sourceState.originalModelName;
     targetState.originalUrlPathname = sourceState.originalUrlPathname;
     targetState.clearResponseTimeout = sourceRuntime.clearResponseTimeout;

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -39,7 +39,10 @@ import { updateMessageRequestDetails } from "@/repository/message";
 import type { CacheTtlPreference, CacheTtlResolved } from "@/types/cache";
 import type { ProviderChainItem } from "@/types/message";
 import type { Provider } from "@/types/provider";
-import type { ClaudeMetadataUserIdInjectionSpecialSetting } from "@/types/special-settings";
+import type {
+  ClaudeMetadataUserIdInjectionSpecialSetting,
+  SpecialSetting,
+} from "@/types/special-settings";
 
 import { GeminiAuth } from "../gemini/auth";
 import { GEMINI_PROTOCOL } from "../gemini/protocol";
@@ -93,17 +96,42 @@ type ProxySessionWithAttemptRuntime = ProxySession & {
 type StreamingHedgeAttempt = {
   provider: Provider;
   session: ProxySession;
+  baseUrl: string;
   endpointAudit: { endpointId: number | null; endpointUrl: string };
   responseController: AbortController | null;
   clearResponseTimeout: (() => void) | null;
   firstByteTimeoutMs: number;
   sequence: number;
+  requestAttemptCount: number;
+  reactiveRectifierRetryState: ReactiveRectifierRetryState;
   settled: boolean;
   thresholdTriggered: boolean;
   thresholdTimer: NodeJS.Timeout | null;
   reader: ReadableStreamDefaultReader<Uint8Array> | null;
   response: Response | null;
 };
+
+type ReactiveRectifierRetryState = {
+  thinkingSignatureRetried: boolean;
+  thinkingBudgetRetried: boolean;
+};
+
+type ReactiveRectifierResult =
+  | { matched: false }
+  | {
+      matched: true;
+      applied: false;
+      reason: "already_retried" | "not_applicable";
+      rectifierType: "thinking_signature_rectifier" | "thinking_budget_rectifier";
+      trigger: string;
+    }
+  | {
+      matched: true;
+      applied: true;
+      rectifierType: "thinking_signature_rectifier" | "thinking_budget_rectifier";
+      trigger: string;
+      requestDetailsBeforeRectify: ReturnType<typeof buildRequestDetails>;
+    };
 
 // 非流式响应体检查的上限（字节）：避免上游在 2xx 场景返回超大内容导致内存占用失控。
 // 说明：
@@ -351,6 +379,218 @@ async function persistSpecialSettings(session: ProxySession): Promise<void> {
   }
 }
 
+function addSpecialSettingForPersistence(
+  ownerSession: ProxySession,
+  persistSession: ProxySession,
+  setting: SpecialSetting
+): void {
+  ownerSession.addSpecialSetting(setting);
+  if (persistSession !== ownerSession) {
+    persistSession.addSpecialSetting(setting);
+  }
+}
+
+function buildRetryFailedChainEntry(
+  provider: Provider,
+  endpointAudit: { endpointId: number | null; endpointUrl: string },
+  attemptNumber: number,
+  error: Error,
+  errorMessage: string,
+  requestDetailsBeforeRectify: ReturnType<typeof buildRequestDetails>
+): NonNullable<Parameters<ProxySession["addProviderToChain"]>[1]> {
+  if (error instanceof ProxyError) {
+    return {
+      ...endpointAudit,
+      reason: "retry_failed",
+      circuitState: getCircuitState(provider.id),
+      attemptNumber,
+      errorMessage,
+      statusCode: error.statusCode,
+      statusCodeInferred: error.upstreamError?.statusCodeInferred ?? false,
+      errorDetails: {
+        provider: {
+          id: provider.id,
+          name: provider.name,
+          statusCode: error.statusCode,
+          statusText: error.message,
+          upstreamBody: error.upstreamError?.body,
+          upstreamParsed: error.upstreamError?.parsed,
+        },
+        request: requestDetailsBeforeRectify,
+      },
+    };
+  }
+
+  return {
+    ...endpointAudit,
+    reason: "retry_failed",
+    circuitState: getCircuitState(provider.id),
+    attemptNumber,
+    errorMessage,
+    errorDetails: {
+      system: {
+        errorType: error.constructor.name,
+        errorName: error.name,
+        errorMessage: error.message || error.name || "Unknown error",
+        errorStack: error.stack?.split("\n").slice(0, 3).join("\n"),
+      },
+      request: requestDetailsBeforeRectify,
+    },
+  };
+}
+
+function getReactiveRectifierDisplayName(
+  rectifierType: "thinking_signature_rectifier" | "thinking_budget_rectifier"
+): string {
+  return rectifierType === "thinking_signature_rectifier"
+    ? "Thinking signature rectifier"
+    : "Thinking budget rectifier";
+}
+
+async function tryApplyReactiveAnthropicRectifier(params: {
+  provider: Provider;
+  requestSession: ProxySession;
+  persistSession: ProxySession;
+  errorMessage: string;
+  attemptNumber: number;
+  retryAttemptNumber: number;
+  retryState: ReactiveRectifierRetryState;
+}): Promise<ReactiveRectifierResult> {
+  const {
+    provider,
+    requestSession,
+    persistSession,
+    errorMessage,
+    attemptNumber,
+    retryAttemptNumber,
+  } = params;
+  const isAnthropicProvider =
+    provider.providerType === "claude" || provider.providerType === "claude-auth";
+
+  if (!isAnthropicProvider) {
+    return { matched: false };
+  }
+
+  const signatureTrigger = detectThinkingSignatureRectifierTrigger(errorMessage);
+  if (signatureTrigger) {
+    const settings = await getCachedSystemSettings();
+    const enabled = settings.enableThinkingSignatureRectifier ?? true;
+
+    if (!enabled) {
+      return { matched: false };
+    }
+
+    if (params.retryState.thinkingSignatureRetried) {
+      return {
+        matched: true,
+        applied: false,
+        reason: "already_retried",
+        rectifierType: "thinking_signature_rectifier",
+        trigger: signatureTrigger,
+      };
+    }
+
+    const requestDetailsBeforeRectify = buildRequestDetails(requestSession);
+    const rectified = rectifyAnthropicRequestMessage(
+      requestSession.request.message as Record<string, unknown>
+    );
+
+    addSpecialSettingForPersistence(requestSession, persistSession, {
+      type: "thinking_signature_rectifier",
+      scope: "request",
+      hit: rectified.applied,
+      providerId: provider.id,
+      providerName: provider.name,
+      trigger: signatureTrigger,
+      attemptNumber,
+      retryAttemptNumber,
+      removedThinkingBlocks: rectified.removedThinkingBlocks,
+      removedRedactedThinkingBlocks: rectified.removedRedactedThinkingBlocks,
+      removedSignatureFields: rectified.removedSignatureFields,
+    });
+    await persistSpecialSettings(persistSession);
+
+    if (!rectified.applied) {
+      return {
+        matched: true,
+        applied: false,
+        reason: "not_applicable",
+        rectifierType: "thinking_signature_rectifier",
+        trigger: signatureTrigger,
+      };
+    }
+
+    params.retryState.thinkingSignatureRetried = true;
+    return {
+      matched: true,
+      applied: true,
+      rectifierType: "thinking_signature_rectifier",
+      trigger: signatureTrigger,
+      requestDetailsBeforeRectify,
+    };
+  }
+
+  const budgetTrigger = detectThinkingBudgetRectifierTrigger(errorMessage);
+  if (!budgetTrigger) {
+    return { matched: false };
+  }
+
+  const settings = await getCachedSystemSettings();
+  const enabled = settings.enableThinkingBudgetRectifier ?? true;
+
+  if (!enabled) {
+    return { matched: false };
+  }
+
+  if (params.retryState.thinkingBudgetRetried) {
+    return {
+      matched: true,
+      applied: false,
+      reason: "already_retried",
+      rectifierType: "thinking_budget_rectifier",
+      trigger: budgetTrigger,
+    };
+  }
+
+  const requestDetailsBeforeRectify = buildRequestDetails(requestSession);
+  const rectified = rectifyThinkingBudget(
+    requestSession.request.message as Record<string, unknown>
+  );
+
+  addSpecialSettingForPersistence(requestSession, persistSession, {
+    type: "thinking_budget_rectifier",
+    scope: "request",
+    hit: rectified.applied,
+    providerId: provider.id,
+    providerName: provider.name,
+    trigger: budgetTrigger,
+    attemptNumber,
+    retryAttemptNumber,
+    before: rectified.before,
+    after: rectified.after,
+  });
+  await persistSpecialSettings(persistSession);
+
+  if (!rectified.applied) {
+    return {
+      matched: true,
+      applied: false,
+      reason: "not_applicable",
+      rectifierType: "thinking_budget_rectifier",
+      trigger: budgetTrigger,
+    };
+  }
+
+  params.retryState.thinkingBudgetRetried = true;
+  return {
+    matched: true,
+    applied: true,
+    rectifierType: "thinking_budget_rectifier",
+    trigger: budgetTrigger,
+    requestDetailsBeforeRectify,
+  };
+}
+
 /**
  * 为 Claude 请求注入 metadata.user_id
  *
@@ -521,8 +761,10 @@ export class ProxyForwarder {
         currentProvider,
         envDefaultMaxAttempts
       );
-      let thinkingSignatureRectifierRetried = false;
-      let thinkingBudgetRectifierRetried = false;
+      const reactiveRectifierRetryState: ReactiveRectifierRetryState = {
+        thinkingSignatureRetried: false,
+        thinkingBudgetRetried: false,
+      };
 
       const requestPath = session.requestUrl.pathname;
       const providerVendorId = currentProvider.providerVendorId ?? 0;
@@ -1046,280 +1288,63 @@ export class ProxyForwarder {
             throw lastError;
           }
 
-          // 2.5 Thinking signature 整流器：命中后对同供应商“整流 + 重试一次”
-          // 目标：解决 Anthropic 与非 Anthropic 渠道切换导致的 thinking 签名不兼容问题
-          // 约束：
-          // - 仅对 Anthropic 类型供应商生效
-          // - 不依赖 error rules 开关（用户可能关闭规则，但仍希望整流生效）
-          // - 不计入熔断器、不触发供应商切换
-          const isAnthropicProvider =
-            currentProvider.providerType === "claude" ||
-            currentProvider.providerType === "claude-auth";
-          const rectifierTrigger = isAnthropicProvider
-            ? detectThinkingSignatureRectifierTrigger(errorMessage)
-            : null;
+          // 2.5 Reactive rectifier：命中后对同供应商“整流 + 重试一次”
+          const reactiveRectifierResult = await tryApplyReactiveAnthropicRectifier({
+            provider: currentProvider,
+            requestSession: session,
+            persistSession: session,
+            errorMessage,
+            attemptNumber: attemptCount,
+            retryAttemptNumber: attemptCount + 1,
+            retryState: reactiveRectifierRetryState,
+          });
 
-          if (rectifierTrigger) {
-            const settings = await getCachedSystemSettings();
-            const enabled = settings.enableThinkingSignatureRectifier ?? true;
-
-            if (enabled) {
-              // 已重试过仍失败：强制按“不可重试的客户端错误”处理，避免污染熔断器/触发供应商切换
-              if (thinkingSignatureRectifierRetried) {
-                errorCategory = ErrorCategory.NON_RETRYABLE_CLIENT_ERROR;
-              } else {
-                const requestDetailsBeforeRectify = buildRequestDetails(session);
-
-                // 整流请求体（原地修改 session.request.message）
-                const rectified = rectifyAnthropicRequestMessage(
-                  session.request.message as Record<string, unknown>
-                );
-
-                // 写入审计字段（specialSettings）
-                session.addSpecialSetting({
-                  type: "thinking_signature_rectifier",
-                  scope: "request",
-                  hit: rectified.applied,
-                  providerId: currentProvider.id,
-                  providerName: currentProvider.name,
-                  trigger: rectifierTrigger,
-                  attemptNumber: attemptCount,
-                  retryAttemptNumber: attemptCount + 1,
-                  removedThinkingBlocks: rectified.removedThinkingBlocks,
-                  removedRedactedThinkingBlocks: rectified.removedRedactedThinkingBlocks,
-                  removedSignatureFields: rectified.removedSignatureFields,
-                });
-
-                const specialSettings = session.getSpecialSettings();
-                if (specialSettings && session.sessionId) {
-                  try {
-                    await SessionManager.storeSessionSpecialSettings(
-                      session.sessionId,
-                      specialSettings,
-                      session.requestSequence
-                    );
-                  } catch (persistError) {
-                    logger.error("[ProxyForwarder] Failed to store special settings", {
-                      error: persistError,
-                      sessionId: session.sessionId,
-                    });
-                  }
-                }
-
-                if (specialSettings && session.messageContext?.id) {
-                  try {
-                    await updateMessageRequestDetails(session.messageContext.id, {
-                      specialSettings,
-                    });
-                  } catch (persistError) {
-                    logger.error("[ProxyForwarder] Failed to persist special settings", {
-                      error: persistError,
-                      messageRequestId: session.messageContext.id,
-                    });
-                  }
-                }
-
-                // 无任何可整流内容：不做无意义重试，直接走既有“不可重试客户端错误”分支
-                if (!rectified.applied) {
-                  logger.info(
-                    "ProxyForwarder: Thinking signature rectifier not applicable, skipping retry",
-                    {
-                      providerId: currentProvider.id,
-                      providerName: currentProvider.name,
-                      trigger: rectifierTrigger,
-                      attemptNumber: attemptCount,
-                    }
-                  );
-                  errorCategory = ErrorCategory.NON_RETRYABLE_CLIENT_ERROR;
-                } else {
-                  logger.info("ProxyForwarder: Thinking signature rectifier applied, retrying", {
+          if (reactiveRectifierResult.matched) {
+            if (!reactiveRectifierResult.applied) {
+              if (reactiveRectifierResult.reason === "not_applicable") {
+                logger.info(
+                  `ProxyForwarder: ${getReactiveRectifierDisplayName(
+                    reactiveRectifierResult.rectifierType
+                  )} not applicable, skipping retry`,
+                  {
                     providerId: currentProvider.id,
                     providerName: currentProvider.name,
-                    trigger: rectifierTrigger,
+                    trigger: reactiveRectifierResult.trigger,
                     attemptNumber: attemptCount,
-                    willRetryAttemptNumber: attemptCount + 1,
-                  });
-
-                  thinkingSignatureRectifierRetried = true;
-
-                  // 记录失败的第一次请求（以 retry_failed 体现“发生过一次重试”）
-                  if (lastError instanceof ProxyError) {
-                    session.addProviderToChain(currentProvider, {
-                      ...endpointAudit,
-                      reason: "retry_failed",
-                      circuitState: getCircuitState(currentProvider.id),
-                      attemptNumber: attemptCount,
-                      errorMessage,
-                      statusCode: lastError.statusCode,
-                      statusCodeInferred: lastError.upstreamError?.statusCodeInferred ?? false,
-                      errorDetails: {
-                        provider: {
-                          id: currentProvider.id,
-                          name: currentProvider.name,
-                          statusCode: lastError.statusCode,
-                          statusText: lastError.message,
-                          upstreamBody: lastError.upstreamError?.body,
-                          upstreamParsed: lastError.upstreamError?.parsed,
-                        },
-                        request: requestDetailsBeforeRectify,
-                      },
-                    });
-                  } else {
-                    session.addProviderToChain(currentProvider, {
-                      ...endpointAudit,
-                      reason: "retry_failed",
-                      circuitState: getCircuitState(currentProvider.id),
-                      attemptNumber: attemptCount,
-                      errorMessage,
-                      errorDetails: {
-                        system: {
-                          errorType: lastError.constructor.name,
-                          errorName: lastError.name,
-                          errorMessage: lastError.message || lastError.name || "Unknown error",
-                          errorStack: lastError.stack?.split("\n").slice(0, 3).join("\n"),
-                        },
-                        request: requestDetailsBeforeRectify,
-                      },
-                    });
                   }
-
-                  // 确保即使 maxAttemptsPerProvider=1 也能完成一次额外重试
-                  maxAttemptsPerProvider = Math.max(maxAttemptsPerProvider, attemptCount + 1);
-                  continue;
-                }
-              }
-            }
-          }
-
-          // 2.6 Thinking budget rectifier: fix budget_tokens < 1024 errors and retry once
-          const budgetRectifierTrigger = isAnthropicProvider
-            ? detectThinkingBudgetRectifierTrigger(errorMessage)
-            : null;
-
-          if (budgetRectifierTrigger) {
-            const settings = await getCachedSystemSettings();
-            const budgetRectifierEnabled = settings.enableThinkingBudgetRectifier ?? true;
-
-            if (budgetRectifierEnabled) {
-              if (thinkingBudgetRectifierRetried) {
-                errorCategory = ErrorCategory.NON_RETRYABLE_CLIENT_ERROR;
-              } else {
-                const requestDetailsBeforeRectify = buildRequestDetails(session);
-
-                const budgetRectified = rectifyThinkingBudget(
-                  session.request.message as Record<string, unknown>
                 );
+              }
 
-                session.addSpecialSetting({
-                  type: "thinking_budget_rectifier",
-                  scope: "request",
-                  hit: budgetRectified.applied,
+              errorCategory = ErrorCategory.NON_RETRYABLE_CLIENT_ERROR;
+            } else {
+              logger.info(
+                `ProxyForwarder: ${getReactiveRectifierDisplayName(
+                  reactiveRectifierResult.rectifierType
+                )} applied, retrying`,
+                {
                   providerId: currentProvider.id,
                   providerName: currentProvider.name,
-                  trigger: budgetRectifierTrigger,
+                  trigger: reactiveRectifierResult.trigger,
                   attemptNumber: attemptCount,
-                  retryAttemptNumber: attemptCount + 1,
-                  before: budgetRectified.before,
-                  after: budgetRectified.after,
-                });
-
-                const specialSettings = session.getSpecialSettings();
-                if (specialSettings && session.sessionId) {
-                  try {
-                    await SessionManager.storeSessionSpecialSettings(
-                      session.sessionId,
-                      specialSettings,
-                      session.requestSequence
-                    );
-                  } catch (persistError) {
-                    logger.error("[ProxyForwarder] Failed to store special settings", {
-                      error: persistError,
-                      sessionId: session.sessionId,
-                    });
-                  }
+                  willRetryAttemptNumber: attemptCount + 1,
                 }
+              );
 
-                if (specialSettings && session.messageContext?.id) {
-                  try {
-                    await updateMessageRequestDetails(session.messageContext.id, {
-                      specialSettings,
-                    });
-                  } catch (persistError) {
-                    logger.error("[ProxyForwarder] Failed to persist special settings", {
-                      error: persistError,
-                      messageRequestId: session.messageContext.id,
-                    });
-                  }
-                }
+              session.addProviderToChain(
+                currentProvider,
+                buildRetryFailedChainEntry(
+                  currentProvider,
+                  endpointAudit,
+                  attemptCount,
+                  lastError,
+                  errorMessage,
+                  reactiveRectifierResult.requestDetailsBeforeRectify
+                )
+              );
 
-                if (!budgetRectified.applied) {
-                  logger.info(
-                    "ProxyForwarder: Thinking budget rectifier not applicable, skipping retry",
-                    {
-                      providerId: currentProvider.id,
-                      providerName: currentProvider.name,
-                      trigger: budgetRectifierTrigger,
-                      attemptNumber: attemptCount,
-                    }
-                  );
-                  errorCategory = ErrorCategory.NON_RETRYABLE_CLIENT_ERROR;
-                } else {
-                  logger.info("ProxyForwarder: Thinking budget rectifier applied, retrying", {
-                    providerId: currentProvider.id,
-                    providerName: currentProvider.name,
-                    trigger: budgetRectifierTrigger,
-                    attemptNumber: attemptCount,
-                    willRetryAttemptNumber: attemptCount + 1,
-                    before: budgetRectified.before,
-                    after: budgetRectified.after,
-                  });
-
-                  thinkingBudgetRectifierRetried = true;
-
-                  if (lastError instanceof ProxyError) {
-                    session.addProviderToChain(currentProvider, {
-                      ...endpointAudit,
-                      reason: "retry_failed",
-                      circuitState: getCircuitState(currentProvider.id),
-                      attemptNumber: attemptCount,
-                      errorMessage,
-                      statusCode: lastError.statusCode,
-                      statusCodeInferred: lastError.upstreamError?.statusCodeInferred ?? false,
-                      errorDetails: {
-                        provider: {
-                          id: currentProvider.id,
-                          name: currentProvider.name,
-                          statusCode: lastError.statusCode,
-                          statusText: lastError.message,
-                          upstreamBody: lastError.upstreamError?.body,
-                          upstreamParsed: lastError.upstreamError?.parsed,
-                        },
-                        request: requestDetailsBeforeRectify,
-                      },
-                    });
-                  } else {
-                    session.addProviderToChain(currentProvider, {
-                      ...endpointAudit,
-                      reason: "retry_failed",
-                      circuitState: getCircuitState(currentProvider.id),
-                      attemptNumber: attemptCount,
-                      errorMessage,
-                      errorDetails: {
-                        system: {
-                          errorType: lastError.constructor.name,
-                          errorName: lastError.name,
-                          errorMessage: lastError.message || lastError.name || "Unknown error",
-                          errorStack: lastError.stack?.split("\n").slice(0, 3).join("\n"),
-                        },
-                        request: requestDetailsBeforeRectify,
-                      },
-                    });
-                  }
-
-                  maxAttemptsPerProvider = Math.max(maxAttemptsPerProvider, attemptCount + 1);
-                  continue;
-                }
-              }
+              // 确保即使 maxAttemptsPerProvider=1 也能完成一次额外重试
+              maxAttemptsPerProvider = Math.max(maxAttemptsPerProvider, attemptCount + 1);
+              continue;
             }
           }
 
@@ -3053,20 +3078,88 @@ export class ProxyForwarder {
       await launchingAlternative;
     };
 
+    const runAttempt = (attempt: StreamingHedgeAttempt) => {
+      const providerForRequest =
+        attempt.provider.firstByteTimeoutStreamingMs > 0
+          ? { ...attempt.provider, firstByteTimeoutStreamingMs: 0 }
+          : attempt.provider;
+
+      void ProxyForwarder.doForward(
+        attempt.session,
+        providerForRequest,
+        attempt.baseUrl,
+        attempt.endpointAudit,
+        attempt.requestAttemptCount
+      )
+        .then(async (response) => {
+          if (settled || winnerCommitted) {
+            const attemptRuntime = attempt.session as ProxySessionWithAttemptRuntime;
+            try {
+              attemptRuntime.responseController?.abort(new Error("hedge_loser"));
+            } catch {
+              // ignore
+            }
+            const cancelPromise = response.body?.cancel("hedge_loser");
+            cancelPromise?.catch(() => {
+              // ignore
+            });
+            return;
+          }
+
+          const attemptRuntime = attempt.session as ProxySessionWithAttemptRuntime;
+          attempt.responseController = attemptRuntime.responseController ?? null;
+          attempt.clearResponseTimeout = attemptRuntime.clearResponseTimeout ?? null;
+          attempt.clearResponseTimeout?.();
+          attempt.response = response;
+
+          if (!response.body) {
+            await handleAttemptFailure(
+              attempt,
+              new EmptyResponseError(attempt.provider.id, attempt.provider.name, "empty_body")
+            );
+            return;
+          }
+
+          attempt.reader = response.body.getReader();
+
+          try {
+            const firstChunk = await ProxyForwarder.readFirstReadableChunk(attempt.reader);
+            if (firstChunk.done) {
+              await handleAttemptFailure(
+                attempt,
+                new EmptyResponseError(attempt.provider.id, attempt.provider.name, "empty_body")
+              );
+              return;
+            }
+
+            await commitWinner(attempt, firstChunk.value);
+          } catch (firstChunkError) {
+            const normalizedError =
+              firstChunkError instanceof Error
+                ? firstChunkError
+                : new Error(String(firstChunkError));
+            if (settled || winnerCommitted) return;
+            await handleAttemptFailure(attempt, normalizedError);
+          }
+        })
+        .catch(async (attemptError) => {
+          const normalizedError =
+            attemptError instanceof Error ? attemptError : new Error(String(attemptError));
+          if (settled || winnerCommitted) return;
+          await handleAttemptFailure(attempt, normalizedError);
+        });
+    };
+
     const handleAttemptFailure = async (attempt: StreamingHedgeAttempt, error: Error) => {
       if (settled || winnerCommitted || attempt.settled) return;
 
-      attempt.settled = true;
-      if (attempt.thresholdTimer) {
-        clearTimeout(attempt.thresholdTimer);
-        attempt.thresholdTimer = null;
-      }
-      attempts.delete(attempt);
       lastError = error;
 
-      const errorCategory = await categorizeErrorAsync(error);
+      let errorCategory = await categorizeErrorAsync(error);
       lastErrorCategory = errorCategory;
       const statusCode = error instanceof ProxyError ? error.statusCode : undefined;
+      const errorMessage =
+        error instanceof ProxyError ? error.getDetailedErrorMessage() : error.message;
 
       if (attempt.endpointAudit.endpointId != null) {
         const isTimeoutError = error instanceof ProxyError && error.statusCode === 524;
@@ -3076,6 +3169,13 @@ export class ProxyForwarder {
       }
 
       if (errorCategory === ErrorCategory.CLIENT_ABORT) {
+        attempt.settled = true;
+        if (attempt.thresholdTimer) {
+          clearTimeout(attempt.thresholdTimer);
+          attempt.thresholdTimer = null;
+        }
+        attempts.delete(attempt);
+
         session.addProviderToChain(attempt.provider, {
           ...attempt.endpointAudit,
           reason: "client_abort",
@@ -3092,6 +3192,75 @@ export class ProxyForwarder {
         return;
       }
 
+      const reactiveRectifierResult = await tryApplyReactiveAnthropicRectifier({
+        provider: attempt.provider,
+        requestSession: attempt.session,
+        persistSession: session,
+        errorMessage,
+        attemptNumber: attempt.requestAttemptCount,
+        retryAttemptNumber: attempt.requestAttemptCount + 1,
+        retryState: attempt.reactiveRectifierRetryState,
+      });
+
+      if (reactiveRectifierResult.matched) {
+        if (!reactiveRectifierResult.applied) {
+          if (reactiveRectifierResult.reason === "not_applicable") {
+            logger.info(
+              `ProxyForwarder: ${getReactiveRectifierDisplayName(
+                reactiveRectifierResult.rectifierType
+              )} not applicable in hedge, skipping retry`,
+              {
+                providerId: attempt.provider.id,
+                providerName: attempt.provider.name,
+                trigger: reactiveRectifierResult.trigger,
+                participantSequence: attempt.sequence,
+                attemptNumber: attempt.requestAttemptCount,
+              }
+            );
+          }
+
+          errorCategory = ErrorCategory.NON_RETRYABLE_CLIENT_ERROR;
+          lastErrorCategory = errorCategory;
+        } else {
+          logger.info(
+            `ProxyForwarder: ${getReactiveRectifierDisplayName(
+              reactiveRectifierResult.rectifierType
+            )} applied in hedge, retrying same provider`,
+            {
+              providerId: attempt.provider.id,
+              providerName: attempt.provider.name,
+              trigger: reactiveRectifierResult.trigger,
+              participantSequence: attempt.sequence,
+              attemptNumber: attempt.requestAttemptCount,
+              willRetryAttemptNumber: attempt.requestAttemptCount + 1,
+            }
+          );
+
+          session.addProviderToChain(
+            attempt.provider,
+            buildRetryFailedChainEntry(
+              attempt.provider,
+              attempt.endpointAudit,
+              attempt.sequence,
+              error,
+              errorMessage,
+              reactiveRectifierResult.requestDetailsBeforeRectify
+            )
+          );
+
+          attempt.requestAttemptCount += 1;
+          runAttempt(attempt);
+          return;
+        }
+      }
+
+      attempt.settled = true;
+      if (attempt.thresholdTimer) {
+        clearTimeout(attempt.thresholdTimer);
+        attempt.thresholdTimer = null;
+      }
+      attempts.delete(attempt);
+
       if (errorCategory === ErrorCategory.PROVIDER_ERROR && statusCode !== 404) {
         await recordFailure(attempt.provider.id, error);
       }
@@ -3106,7 +3275,7 @@ export class ProxyForwarder {
               : "retry_failed",
         attemptNumber: attempt.sequence,
         statusCode,
-        errorMessage: error instanceof ProxyError ? error.getDetailedErrorMessage() : error.message,
+        errorMessage,
         circuitState: getCircuitState(attempt.provider.id),
       });
 
@@ -3240,6 +3409,7 @@ export class ProxyForwarder {
       const attempt: StreamingHedgeAttempt = {
         provider,
         session: attemptSession,
+        baseUrl: endpointSelection.baseUrl,
         endpointAudit: {
           endpointId: endpointSelection.endpointId,
           endpointUrl: endpointSelection.endpointUrl,
@@ -3249,6 +3419,11 @@ export class ProxyForwarder {
         firstByteTimeoutMs:
           provider.firstByteTimeoutStreamingMs > 0 ? provider.firstByteTimeoutStreamingMs : 0,
         sequence: launchedProviderCount,
+        requestAttemptCount: 1,
+        reactiveRectifierRetryState: {
+          thinkingSignatureRetried: false,
+          thinkingBudgetRetried: false,
+        },
         settled: false,
         thresholdTriggered: false,
         thresholdTimer: null,
@@ -3283,75 +3458,7 @@ export class ProxyForwarder {
         }, attempt.firstByteTimeoutMs);
       }
 
-      const providerForRequest =
-        provider.firstByteTimeoutStreamingMs > 0
-          ? { ...provider, firstByteTimeoutStreamingMs: 0 }
-          : provider;
-
-      void ProxyForwarder.doForward(
-        attemptSession,
-        providerForRequest,
-        endpointSelection.baseUrl,
-        attempt.endpointAudit,
-        1
-      )
-        .then(async (response) => {
-          if (settled || winnerCommitted) {
-            const attemptRuntime = attemptSession as ProxySessionWithAttemptRuntime;
-            try {
-              attemptRuntime.responseController?.abort(new Error("hedge_loser"));
-            } catch {
-              // ignore
-            }
-            const cancelPromise = response.body?.cancel("hedge_loser");
-            cancelPromise?.catch(() => {
-              // ignore
-            });
-            return;
-          }
-
-          const attemptRuntime = attemptSession as ProxySessionWithAttemptRuntime;
-          attempt.responseController = attemptRuntime.responseController ?? null;
-          attempt.clearResponseTimeout = attemptRuntime.clearResponseTimeout ?? null;
-          attempt.clearResponseTimeout?.();
-          attempt.response = response;
-
-          if (!response.body) {
-            await handleAttemptFailure(
-              attempt,
-              new EmptyResponseError(provider.id, provider.name, "empty_body")
-            );
-            return;
-          }
-
-          attempt.reader = response.body.getReader();
-
-          try {
-            const firstChunk = await ProxyForwarder.readFirstReadableChunk(attempt.reader);
-            if (firstChunk.done) {
-              await handleAttemptFailure(
-                attempt,
-                new EmptyResponseError(provider.id, provider.name, "empty_body")
-              );
-              return;
-            }
-
-            await commitWinner(attempt, firstChunk.value);
-          } catch (firstChunkError) {
-            const normalizedError =
-              firstChunkError instanceof Error
-                ? firstChunkError
-                : new Error(String(firstChunkError));
-            if (settled || winnerCommitted) return;
-            await handleAttemptFailure(attempt, normalizedError);
-          }
-        })
-        .catch(async (attemptError) => {
-          const normalizedError =
-            attemptError instanceof Error ? attemptError : new Error(String(attemptError));
-          if (settled || winnerCommitted) return;
-          await handleAttemptFailure(attempt, normalizedError);
-        });
+      runAttempt(attempt);
     };
 
     if (session.clientAbortSignal) {

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -21,6 +21,10 @@ const mocks = vi.hoisted(() => ({
   isVendorTypeCircuitOpen: vi.fn(async () => false),
   recordVendorTypeAllEndpointsTimeout: vi.fn(async () => {}),
   categorizeErrorAsync: vi.fn(async () => 0),
+  getCachedSystemSettings: vi.fn(async () => ({
+    enableThinkingSignatureRectifier: true,
+    enableThinkingBudgetRectifier: true,
+  })),
   storeSessionSpecialSettings: vi.fn(async () => {}),
 }));
 
@@ -39,6 +43,7 @@ vi.mock("@/lib/config", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/config")>();
   return {
     ...actual,
+    getCachedSystemSettings: mocks.getCachedSystemSettings,
     isHttp2Enabled: mocks.isHttp2Enabled,
   };
 });
@@ -274,6 +279,23 @@ function createDelayedFailure(params: {
       reject(params.error);
     }, params.delayMs);
   });
+}
+
+function withThinkingBlocks(session: ProxySession): void {
+  session.request.message = {
+    model: "claude-test",
+    stream: true,
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "t", signature: "sig_thinking" },
+          { type: "text", text: "hello", signature: "sig_text_should_remove" },
+          { type: "redacted_thinking", data: "r", signature: "sig_redacted" },
+        ],
+      },
+    ],
+  };
 }
 
 describe("ProxyForwarder - first-byte hedge scheduling", () => {
@@ -840,6 +862,223 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
         }),
       ])
     );
+  });
+
+  test("hedge 备选供应商命中 thinking signature 错误时，应整流后在同供应商重试并保留审计", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const provider1 = createProvider({ id: 1, name: "p1", firstByteTimeoutStreamingMs: 100 });
+      const provider2 = createProvider({ id: 2, name: "p2", firstByteTimeoutStreamingMs: 100 });
+      const session = createSession();
+      session.setProvider(provider1);
+      withThinkingBlocks(session);
+
+      mocks.pickRandomProviderWithExclusion.mockResolvedValueOnce(provider2);
+      mocks.categorizeErrorAsync.mockResolvedValue(ProxyErrorCategory.NON_RETRYABLE_CLIENT_ERROR);
+
+      const signatureError = new UpstreamProxyError(
+        "Invalid `signature` in `thinking` block",
+        400,
+        {
+          body: '{"error":"invalid_signature"}',
+          providerId: provider2.id,
+          providerName: provider2.name,
+        }
+      );
+
+      const doForward = vi.spyOn(
+        ProxyForwarder as unknown as {
+          doForward: (...args: unknown[]) => Promise<Response>;
+        },
+        "doForward"
+      );
+
+      const controller1 = new AbortController();
+      const controller2First = new AbortController();
+      const controller2Retry = new AbortController();
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = controller1;
+        runtime.clearResponseTimeout = vi.fn();
+        return createStreamingResponse({
+          label: "p1",
+          firstChunkDelayMs: 600,
+          controller: controller1,
+        });
+      });
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = controller2First;
+        runtime.clearResponseTimeout = vi.fn();
+        return createDelayedFailure({
+          delayMs: 50,
+          error: signatureError,
+          controller: controller2First,
+        });
+      });
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        const body = runtime.request.message as {
+          messages: Array<{ content: Array<Record<string, unknown>> }>;
+        };
+        const blocks = body.messages[0].content;
+
+        expect(blocks.some((block) => block.type === "thinking")).toBe(false);
+        expect(blocks.some((block) => block.type === "redacted_thinking")).toBe(false);
+        expect(blocks.some((block) => "signature" in block)).toBe(false);
+
+        runtime.responseController = controller2Retry;
+        runtime.clearResponseTimeout = vi.fn();
+        return createStreamingResponse({
+          label: "p2-rectified",
+          firstChunkDelayMs: 180,
+          controller: controller2Retry,
+        });
+      });
+
+      const responsePromise = ProxyForwarder.send(session);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(doForward).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(55);
+      expect(doForward).toHaveBeenCalledTimes(3);
+
+      await vi.advanceTimersByTimeAsync(200);
+      const response = await responsePromise;
+
+      expect(await response.text()).toContain('"provider":"p2-rectified"');
+      expect(session.provider?.id).toBe(2);
+      expect(controller1.signal.aborted).toBe(true);
+      expect(mocks.pickRandomProviderWithExclusion).toHaveBeenCalled();
+      expect(mocks.storeSessionSpecialSettings).toHaveBeenCalledWith(
+        "sess-hedge",
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "thinking_signature_rectifier",
+            hit: true,
+            providerId: 2,
+          }),
+        ]),
+        1
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("hedge 路径命中 thinking budget 错误时，应整流后在同供应商重试", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const provider1 = createProvider({ id: 1, name: "p1", firstByteTimeoutStreamingMs: 100 });
+      const provider2 = createProvider({ id: 2, name: "p2", firstByteTimeoutStreamingMs: 100 });
+      const session = createSession();
+      session.setProvider(provider1);
+      session.request.message = {
+        model: "claude-test",
+        stream: true,
+        max_tokens: 1000,
+        thinking: { type: "enabled", budget_tokens: 500 },
+        messages: [{ role: "user", content: "hi" }],
+      };
+
+      mocks.pickRandomProviderWithExclusion.mockResolvedValueOnce(provider2);
+      mocks.categorizeErrorAsync.mockResolvedValue(ProxyErrorCategory.NON_RETRYABLE_CLIENT_ERROR);
+
+      const budgetError = new UpstreamProxyError(
+        "thinking.enabled.budget_tokens: Input should be greater than or equal to 1024",
+        400,
+        {
+          body: '{"error":"budget_too_low"}',
+          providerId: provider1.id,
+          providerName: provider1.name,
+        }
+      );
+
+      const doForward = vi.spyOn(
+        ProxyForwarder as unknown as {
+          doForward: (...args: unknown[]) => Promise<Response>;
+        },
+        "doForward"
+      );
+
+      const controller1First = new AbortController();
+      const controller1Retry = new AbortController();
+      const controller2 = new AbortController();
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = controller1First;
+        runtime.clearResponseTimeout = vi.fn();
+        return createDelayedFailure({
+          delayMs: 140,
+          error: budgetError,
+          controller: controller1First,
+        });
+      });
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = controller2;
+        runtime.clearResponseTimeout = vi.fn();
+        return createStreamingResponse({
+          label: "p2",
+          firstChunkDelayMs: 500,
+          controller: controller2,
+        });
+      });
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        const body = runtime.request.message as {
+          max_tokens: number;
+          thinking: { type: string; budget_tokens: number };
+        };
+
+        expect(body.max_tokens).toBe(64000);
+        expect(body.thinking.type).toBe("enabled");
+        expect(body.thinking.budget_tokens).toBe(32000);
+
+        runtime.responseController = controller1Retry;
+        runtime.clearResponseTimeout = vi.fn();
+        return createStreamingResponse({
+          label: "p1-budget-rectified",
+          firstChunkDelayMs: 40,
+          controller: controller1Retry,
+        });
+      });
+
+      const responsePromise = ProxyForwarder.send(session);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(doForward).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(45);
+      expect(doForward).toHaveBeenCalledTimes(3);
+
+      await vi.advanceTimersByTimeAsync(50);
+      const response = await responsePromise;
+
+      expect(await response.text()).toContain('"provider":"p1-budget-rectified"');
+      expect(session.provider?.id).toBe(1);
+      expect(mocks.pickRandomProviderWithExclusion).toHaveBeenCalledTimes(1);
+      expect(session.getSpecialSettings()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "thinking_budget_rectifier",
+            hit: true,
+            providerId: 1,
+          }),
+        ])
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("endpoint resolution failure should not inflate launchedProviderCount, winner gets request_success not hedge_winner", async () => {


### PR DESCRIPTION
## Summary
- Reuse Anthropic reactive rectifier logic for both standard retries and streaming hedge attempts
- Allow hedge attempts to retry the same provider after thinking signature or thinking budget rectification
- Persist rectifier audit entries even when the rectified hedge attempt runs in a shadow session

## Problem
When streaming requests used the hedge-based provider race (introduced in #894), reactive rectifiers (thinking signature rectifier and thinking budget rectifier from #576) were not being applied. If a hedge attempt encountered a rectifiable error (e.g., invalid thinking signature or budget_tokens < 1024), the attempt would simply fail instead of applying the rectifier and retrying with the same provider.

**Related PRs:**
- Follow-up to #894 - hedge first-byte timeout failover mechanism
- Related to #576 - thinking signature rectifier feature
- Related to #924 - rectifier maxRetryAttempts handling

## Solution
Extract the reactive rectifier logic into a reusable `tryApplyReactiveAnthropicRectifier` function that can be called from both:
1. The standard retry loop (non-streaming path)
2. The streaming hedge `handleAttemptFailure` handler

Key design decisions:
- Each hedge attempt tracks its own `reactiveRectifierRetryState` to prevent infinite retry loops
- Rectifier audit entries are persisted to the main session even when the rectified attempt runs in a shadow session (using `persistSession` parameter)
- Refactored duplicate code into helper functions: `addSpecialSettingForPersistence`, `buildRetryFailedChainEntry`, `getReactiveRectifierDisplayName`

## Changes

### Core Changes (`src/app/v1/_lib/proxy/forwarder.ts`)
- Added `ReactiveRectifierRetryState` and `ReactiveRectifierResult` types for tracking rectifier state
- Created `tryApplyReactiveAnthropicRectifier()` function handling both signature and budget rectifiers
- Extended `StreamingHedgeAttempt` with `baseUrl`, `requestAttemptCount`, and `reactiveRectifierRetryState` fields
- Added reactive rectifier handling to `handleAttemptFailure()` in streaming hedge path
- Created `runAttempt()` helper for re-executing hedge attempts after rectification
- Refactored inline code into `addSpecialSettingForPersistence()` and `buildRetryFailedChainEntry()` helpers

### Test Coverage (`tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts`)
- Test: hedge alternative provider hits thinking signature error, rectifies, retries same provider with audit persistence
- Test: hedge primary provider hits thinking budget error, rectifies, retries same provider

## Testing
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] `bun run lint` (fails on pre-existing repository issues: Biome schema mismatch and existing unrelated lint findings)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the streaming hedge provider race (from #894) to run reactive Anthropic rectifiers (thinking-signature and thinking-budget rectifiers from #576) when a hedge attempt encounters a rectifiable 4xx error, instead of simply failing. The core approach — extracting `tryApplyReactiveAnthropicRectifier` into a shared helper called from both the standard retry loop and `handleAttemptFailure`, giving each hedge attempt its own `reactiveRectifierRetryState`, and persisting audit settings to the main session from a shadow session — is well-designed and consistent with the rest of the forwarder.

Key changes and observations:
- `tryApplyReactiveAnthropicRectifier` correctly guards against infinite loops via per-attempt `thinkingSignatureRetried` / `thinkingBudgetRetried` flags.
- The threshold timer is cleared before `runAttempt` is called for a rectifier retry, preventing spurious `hedge_triggered` audit entries (the scenario raised in a previous thread is addressed in this code).
- `mergeHedgeAttemptIntoSession` now deduplicates `specialSettings` by `JSON.stringify` key rather than overwriting, so audit entries pre-persisted to the main session are not lost.
- `handleAttemptFailure` invokes two `await` calls (`categorizeErrorAsync` and `tryApplyReactiveAnthropicRectifier`) before reaching `runAttempt`. There is no re-check of `settled || winnerCommitted || attempt.settled` at that point, meaning a winner committed during either async gap will still trigger a redundant upstream provider request.
- The `.catch()` handler inside `runAttempt` is still missing `attempt.settled` in its early-return guard (previously flagged thread), allowing `handleAttemptFailure` to be entered for an already-settled attempt if `settled`/`winnerCommitted` happen to be false at that moment — though `handleAttemptFailure`'s own entry guard will catch it.
- Two new test cases verify both rectifier types in the hedge path with realistic timer progression and audit-persistence assertions.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- The PR is functionally sound but has an open logic issue and unresolved thread items that should be addressed before merging.
- The design and timer-handling are correct, and tests adequately cover the new paths. However, the missing guard before `runAttempt` after two async awaits can cause redundant upstream requests when another hedge attempt wins concurrently, the `.catch()` guard in `runAttempt` still omits `attempt.settled` (flagged in a previous thread), and the `attemptNumber` field in the non-rectifier failure chain entry still uses `attempt.sequence` rather than `attempt.requestAttemptCount` (also previously flagged). These three issues together hold the score below 4.
- `src/app/v1/_lib/proxy/forwarder.ts` — specifically `handleAttemptFailure` (missing re-guard before `runAttempt`) and `runAttempt`'s `.catch()` handler (missing `attempt.settled` check).
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/forwarder.ts | Introduces reactive rectifier support for the streaming hedge path: new `ReactiveRectifierRetryState`/`ReactiveRectifierResult` types, `tryApplyReactiveAnthropicRectifier` helper, `runAttempt` refactor, and `handleAttemptFailure` extension. The timer-clearing and dedup logic look correct, but `handleAttemptFailure` is missing a re-guard before the `runAttempt` call after two async awaits, and the `.catch()` handler in `runAttempt` is still missing `attempt.settled` in its early-return guard (flagged in previous threads). |
| tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts | Adds two new test cases covering the thinking-signature rectifier and thinking-budget rectifier in the hedge path. Timer progression, `doForward` call counts, rectified message verification, and `storeSessionSpecialSettings` audit assertions are all well-structured and align with the expected timing model. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant PF as ProxyForwarder
    participant P1 as Provider 1 (primary)
    participant P2 as Provider 2 (hedge)

    C->>PF: send(session)
    PF->>P1: runAttempt(attempt1) [doForward]
    Note over PF,P1: firstByteTimeoutMs timer starts

    Note over PF: t = firstByteTimeoutMs<br/>threshold timer fires
    PF->>P2: launchAlternative → runAttempt(attempt2) [doForward]

    P2-->>PF: ERROR: thinking signature / budget error (4xx)
    PF->>PF: handleAttemptFailure(attempt2, error)
    Note over PF: await categorizeErrorAsync()
    Note over PF: await tryApplyReactiveAnthropicRectifier()<br/>↳ mutates attempt2.session.request.message<br/>↳ persists audit to main session<br/>↳ sets reactiveRectifierRetryState flag
    PF->>PF: clearThresholdTimer(attempt2)
    Note over PF: ⚠️ no re-guard for settled/winnerCommitted here
    PF->>P2: runAttempt(attempt2) [retry, requestAttemptCount=2]

    par P1 still running
        P1-->>PF: (slow / first-byte delayed)
    and P2 rectified retry
        P2-->>PF: SUCCESS (first chunk)
    end

    PF->>PF: commitWinner(attempt2)
    PF->>PF: syncWinningAttemptSession → mergeSpecialSettings (dedup)
    PF->>PF: abortAllAttempts (cancels P1)
    PF-->>C: streaming response from P2 (rectified)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/forwarder.ts
Line: 3195-3256

Comment:
**Stale guard before `runAttempt` after two async awaits**

`handleAttemptFailure` re-checks `settled || winnerCommitted || attempt.settled` only at the very top (line 3154). However, two `await` calls follow before `runAttempt(attempt)` is reached — `categorizeErrorAsync` (line 3158) and `tryApplyReactiveAnthropicRectifier` (line 3195, which itself awaits `getCachedSystemSettings`). During either of these async gaps another hedge attempt could win and set `winnerCommitted = true`.

As a result, `runAttempt(attempt)` at line 3256 is called even though a winner has already been committed. The new provider request cannot be cancelled until the response arrives (when the `.then()` guard at line 3095 finally catches it). This wastes a full round-trip to the upstream provider.

A re-guard immediately before the retry branch would prevent the redundant call:

```suggestion
          if (settled || winnerCommitted || attempt.settled) {
            return;
          }

          if (attempt.thresholdTimer) {
            clearTimeout(attempt.thresholdTimer);
            attempt.thresholdTimer = null;
          }
          attempt.requestAttemptCount += 1;
          runAttempt(attempt);
          return;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: address hedge r..."](https://github.com/ding113/claude-code-hub/commit/2409ecafb186e7f4078f301aee92db797c44cece)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->