### PR TITLE
feat(i18n): add authenticated proxy format hints

### DIFF
--- a/messages/en/settings/providers/form/sections.json
+++ b/messages/en/settings/providers/form/sections.json
@@ -101,10 +101,10 @@
     },
     "title": "Proxy",
     "url": {
-      "formats": "Supported formats:",
+      "formats": "Supports http://, https://, socks5://, socks4:// protocols. For authenticated proxies use http://user:password@host:port (URL-encode special characters in password, e.g. # as %23)",
       "label": "Proxy URL",
       "optional": "(optional)",
-      "placeholder": "e.g. http://proxy.example.com:8080 or socks5://127.0.0.1:1080"
+      "placeholder": "e.g. http://proxy.example.com:8080 or http://user:pass@proxy:8080"
     }
   },
   "rateLimit": {

--- a/messages/ja/settings/providers/form/sections.json
+++ b/messages/ja/settings/providers/form/sections.json
@@ -101,10 +101,10 @@
     },
     "title": "プロキシ設定",
     "url": {
-      "formats": "対応フォーマット:",
+      "formats": "http://、https://、socks5://、socks4:// プロトコルに対応。認証が必要な場合は http://user:password@host:port 形式を使用してください（パスワード内の特殊文字は URL エンコードが必要です。例: # → %23）",
       "label": "プロキシ URL",
       "optional": "（任意）",
-      "placeholder": "例: http://proxy.example.com:8080 または socks5://127.0.0.1:1080"
+      "placeholder": "例: http://proxy.example.com:8080 または http://user:pass@proxy:8080"
     }
   },
   "rateLimit": {

--- a/messages/ru/settings/providers/form/sections.json
+++ b/messages/ru/settings/providers/form/sections.json
@@ -101,10 +101,10 @@
     },
     "title": "Прокси",
     "url": {
-      "formats": "Поддерживаемые форматы:",
+      "formats": "Поддерживаются протоколы http://, https://, socks5://, socks4://. Для прокси с аутентификацией используйте формат http://user:password@host:port (специальные символы в пароле кодируйте URL-кодировкой, например # как %23)",
       "label": "URL прокси",
       "optional": "(необязательно)",
-      "placeholder": "например: http://proxy.example.com:8080 или socks5://127.0.0.1:1080"
+      "placeholder": "например: http://proxy.example.com:8080 или http://user:pass@proxy:8080"
     }
   },
   "rateLimit": {

--- a/messages/zh-CN/settings/providers/form/sections.json
+++ b/messages/zh-CN/settings/providers/form/sections.json
@@ -351,8 +351,8 @@
     "url": {
       "label": "代理地址",
       "optional": "(可选)",
-      "placeholder": "例如: http://proxy.example.com:8080 或 socks5://127.0.0.1:1080",
-      "formats": "支持格式:"
+      "placeholder": "例如: http://proxy.example.com:8080 或 http://user:pass@proxy:8080",
+      "formats": "支持 http://、https://、socks5://、socks4:// 协议。需要认证时使用 http://user:password@host:port 格式（密码中的特殊字符需 URL 编码，如 # 编码为 %23）"
     },
     "fallback": {
       "label": "代理失败时降级到直连",

--- a/messages/zh-TW/settings/providers/form/sections.json
+++ b/messages/zh-TW/settings/providers/form/sections.json
@@ -101,10 +101,10 @@
     },
     "title": "代理設定",
     "url": {
-      "formats": "支援格式：",
+      "formats": "支援 http://、https://、socks5://、socks4:// 協定。需要認證時使用 http://user:password@host:port 格式（密碼中的特殊字元需 URL 編碼，如 # 編碼為 %23）",
       "label": "代理位址",
       "optional": "（選填）",
-      "placeholder": "例如：http://proxy.example.com:8080 或 socks5://127.0.0.1:1080"
+      "placeholder": "例如：http://proxy.example.com:8080 或 http://user:pass@proxy:8080"
     }
   },
   "rateLimit": {


### PR DESCRIPTION
## Summary

- Updated proxy URL placeholder and description in provider form to include authenticated proxy format example
- Added complete protocol list (http, https, socks5, socks4) to the description — previously it only said "Supported formats:" without listing them
- Added `http://user:password@host:port` format with URL encoding reminder for special characters (e.g. `#` as `%23`)
- Updated all 5 languages: en, zh-CN, zh-TW, ja, ru

## Motivation

When configuring a proxy that requires authentication, users have no guidance on how to include credentials in the proxy URL. This is a common use case (e.g. corporate proxies, authenticated SOCKS proxies) and the correct format `http://user:password@host:port` is not obvious — especially the need to URL-encode special characters in passwords.

## Changes

**Files modified:** `messages/{en,zh-CN,zh-TW,ja,ru}/settings/providers/form/sections.json`

For each language:
- `proxy.url.placeholder`: Changed from `socks5://127.0.0.1:1080` example to `http://user:pass@proxy:8080` to show auth format
- `proxy.url.formats`: Expanded from bare "Supported formats:" to a complete description listing all supported protocols and the authentication URL format with encoding notes

## Before / After

**Before:**
> Proxy URL placeholder: `e.g. http://proxy.example.com:8080 or socks5://127.0.0.1:1080`
> Description: `Supported formats:`

**After:**
> Proxy URL placeholder: `e.g. http://proxy.example.com:8080 or http://user:pass@proxy:8080`
> Description: `Supports http://, https://, socks5://, socks4:// protocols. For authenticated proxies use http://user:password@host:port (URL-encode special characters in password, e.g. # as %23)`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the proxy configuration UX across all 5 supported locales (en, ja, ru, zh-CN, zh-TW) by expanding the `proxy.url.formats` description to list all supported protocols and explain the authenticated proxy URL syntax, and by updating the placeholder to demonstrate the authenticated format.

**Key changes:**
- `proxy.url.formats`: Replaced the bare label prefix (e.g. "Supported formats:") with a complete sentence covering all four protocols and the authentication URL pattern with a URL-encoding note.
- `proxy.url.placeholder`: Replaced the `socks5://127.0.0.1:1080` example with an authenticated proxy example to match the new guidance.

**Issue found:**
- The legacy provider form (`provider-form.legacy.tsx`) treats `sections.proxy.url.formats` as a label prefix and appends hardcoded protocol badges (`http://`, `https://`, `socks4://`, `socks5://`) in JSX immediately after it. Now that `formats` is a complete description that already names all four protocols, the legacy form will render them twice — producing a visually broken, redundant string. The modern form (`network-section.tsx`) is not affected. The legacy component needs to be updated alongside these i18n changes.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

- The i18n changes are correct but incomplete — the legacy form component still appends duplicate hardcoded protocol badges after the now-expanded translation string, causing a visual regression.
- All five locale files are consistently updated and the translations themselves are accurate. However, the change breaks the rendering contract assumed by `provider-form.legacy.tsx`, which appends hardcoded protocol badges after the `formats` string. This creates duplicate content in the legacy UI and needs a coordinated fix in the component layer before merging.
- `src/app/[locale]/settings/providers/_components/forms/provider-form.legacy.tsx` (lines 1812–1818) needs to be updated to remove the hardcoded protocol badges that are now redundant.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| messages/en/settings/providers/form/sections.json | Updated proxy URL `formats` from a bare label prefix to a full description, and updated the placeholder. Causes duplicate content in the legacy form which appends hardcoded protocol badges after the translation string. |
| messages/ja/settings/providers/form/sections.json | Japanese translation updated correctly — `formats` expanded to full description and placeholder updated to show authenticated proxy syntax. |
| messages/ru/settings/providers/form/sections.json | Russian translation updated correctly — `formats` expanded to full description and placeholder updated to show authenticated proxy syntax. |
| messages/zh-CN/settings/providers/form/sections.json | Simplified Chinese translation updated correctly — `formats` expanded to full description and placeholder updated to show authenticated proxy syntax. |
| messages/zh-TW/settings/providers/form/sections.json | Traditional Chinese translation updated correctly — `formats` expanded to full description and placeholder updated to show authenticated proxy syntax. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["sections.proxy.url.formats\n(i18n key)"] --> B{Which form\ncomponent?}
    B --> C["network-section.tsx\n(modern form)"]
    B --> D["provider-form.legacy.tsx\n(legacy form)"]
    C --> E["Renders formats as description prop only\n✅ Correct — full description displayed"]
    D --> F["Renders: t('formats') + hardcoded badges\nhttp://, https://, socks4://, socks5://"]
    F --> G["⚠️ BEFORE PR: 'Supported formats: http:// https:// socks4:// socks5://'"]
    F --> H["❌ AFTER PR: Full description sentence\n+ duplicate hardcoded protocol badges"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: messages/en/settings/providers/form/sections.json
Line: 104

Comment:
**Duplicate protocol list in legacy form**

The legacy form (`provider-form.legacy.tsx`) uses `sections.proxy.url.formats` as a _label prefix_ and then appends hardcoded protocol badges directly in JSX (lines 1812–1818):

```tsx
<p className="text-xs text-muted-foreground">
  {t("sections.proxy.url.formats")}{" "}
  <code className="bg-muted px-1 rounded">http://</code>、
  <code className="bg-muted px-1 rounded">https://</code>、
  <code className="bg-muted px-1 rounded">socks4://</code>、
  <code className="bg-muted px-1 rounded">socks5://</code>
</p>
```

After this change the rendered output in the legacy form will be the full expanded description sentence (which already names all four protocols) immediately followed by the duplicate hardcoded `http://`, `https://`, `socks4://`, `socks5://` code badges.

The modern form (`network-section.tsx:142`) passes `formats` solely as a `description` prop, so it renders correctly there — but the legacy form is still active.

The PR should also update the legacy form to remove the redundant hardcoded badges, or keep `formats` as a short label prefix and introduce a separate key for the extended authentication hint.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat(i18n): add auth..."](https://github.com/ding113/claude-code-hub/commit/796c48672709cc2d0e2b7815ed1fc41c0e7995a3)</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->