### PR TITLE
feat(i18n): add authenticated proxy format hints / 补充代理认证格式提示

### DIFF
--- a/messages/en/settings/providers/form/sections.json
+++ b/messages/en/settings/providers/form/sections.json
@@ -101,10 +101,10 @@
     },
     "title": "Proxy",
     "url": {
-      "formats": "Supported formats:",
+      "formats": "Supports http://, https://, socks5://, socks4:// protocols. For authenticated proxies use http://user:password@host:port (URL-encode special characters in password, e.g. # as %23)",
       "label": "Proxy URL",
       "optional": "(optional)",
-      "placeholder": "e.g. http://proxy.example.com:8080 or socks5://127.0.0.1:1080"
+      "placeholder": "e.g. http://proxy.example.com:8080 or http://user:pass@proxy:8080"
     }
   },
   "rateLimit": {

--- a/messages/ja/settings/providers/form/sections.json
+++ b/messages/ja/settings/providers/form/sections.json
@@ -101,10 +101,10 @@
     },
     "title": "プロキシ設定",
     "url": {
-      "formats": "対応フォーマット:",
+      "formats": "http://、https://、socks5://、socks4:// プロトコルに対応。認証が必要な場合は http://user:password@host:port 形式を使用してください（パスワード内の特殊文字は URL エンコードが必要です。例: # → %23）",
       "label": "プロキシ URL",
       "optional": "（任意）",
-      "placeholder": "例: http://proxy.example.com:8080 または socks5://127.0.0.1:1080"
+      "placeholder": "例: http://proxy.example.com:8080 または http://user:pass@proxy:8080"
     }
   },
   "rateLimit": {

--- a/messages/ru/settings/providers/form/sections.json
+++ b/messages/ru/settings/providers/form/sections.json
@@ -101,10 +101,10 @@
     },
     "title": "Прокси",
     "url": {
-      "formats": "Поддерживаемые форматы:",
+      "formats": "Поддерживаются протоколы http://, https://, socks5://, socks4://. Для прокси с аутентификацией используйте формат http://user:password@host:port (специальные символы в пароле кодируйте URL-кодировкой, например # как %23)",
       "label": "URL прокси",
       "optional": "(необязательно)",
-      "placeholder": "например: http://proxy.example.com:8080 или socks5://127.0.0.1:1080"
+      "placeholder": "например: http://proxy.example.com:8080 или http://user:pass@proxy:8080"
     }
   },
   "rateLimit": {

--- a/messages/zh-CN/settings/providers/form/sections.json
+++ b/messages/zh-CN/settings/providers/form/sections.json
@@ -351,8 +351,8 @@
     "url": {
       "label": "代理地址",
       "optional": "(可选)",
-      "placeholder": "例如: http://proxy.example.com:8080 或 socks5://127.0.0.1:1080",
-      "formats": "支持格式:"
+      "placeholder": "例如: http://proxy.example.com:8080 或 http://user:pass@proxy:8080",
+      "formats": "支持 http://、https://、socks5://、socks4:// 协议。需要认证时使用 http://user:password@host:port 格式（密码中的特殊字符需 URL 编码，如 # 编码为 %23）"
     },
     "fallback": {
       "label": "代理失败时降级到直连",

--- a/messages/zh-TW/settings/providers/form/sections.json
+++ b/messages/zh-TW/settings/providers/form/sections.json
@@ -101,10 +101,10 @@
     },
     "title": "代理設定",
     "url": {
-      "formats": "支援格式：",
+      "formats": "支援 http://、https://、socks5://、socks4:// 協定。需要認證時使用 http://user:password@host:port 格式（密碼中的特殊字元需 URL 編碼，如 # 編碼為 %23）",
       "label": "代理位址",
       "optional": "（選填）",
-      "placeholder": "例如：http://proxy.example.com:8080 或 socks5://127.0.0.1:1080"
+      "placeholder": "例如：http://proxy.example.com:8080 或 http://user:pass@proxy:8080"
     }
   },
   "rateLimit": {


### PR DESCRIPTION
## Summary / 概述

- Add authenticated proxy URL format example (`http://user:password@host:port`) to the provider proxy configuration hints
- Expand the incomplete "Supported formats:" description to list all supported protocols and URL encoding notes
- Updated all 5 languages: en, zh-CN, zh-TW, ja, ru

---

- 在供应商代理配置提示中补充带认证的代理 URL 格式示例（`http://user:password@host:port`）
- 将不完整的"支持格式："描述扩展为完整的协议列表和 URL 编码说明
- 已更新全部 5 种语言：en、zh-CN、zh-TW、ja、ru

**Supersedes #948** - Same changes, now targeting `dev` branch per repository guidelines.

## Motivation / 动机

When configuring a proxy that requires authentication, users have no guidance on how to include credentials in the proxy URL. The correct format `http://user:password@host:port` is not obvious — especially the need to URL-encode special characters in passwords (e.g. `#` as `%23`).

---

配置需要认证的代理时，用户没有任何关于如何在代理 URL 中包含凭证的提示。正确格式 `http://user:password@host:port` 并不直观——尤其是密码中特殊字符需要 URL 编码（如 `#` 编码为 `%23`）。

## Changes / 改动

**Files / 文件:** `messages/{en,zh-CN,zh-TW,ja,ru}/settings/providers/form/sections.json`

- `proxy.url.placeholder`: `socks5://127.0.0.1:1080` → `http://user:pass@proxy:8080`
- `proxy.url.formats`: `"Supported formats:"` → complete description with all protocols + auth format + encoding notes

## Before → After / 改动前后

**Before / 之前:**
> placeholder: `e.g. http://proxy.example.com:8080 or socks5://127.0.0.1:1080`
> formats: `Supported formats:`

**After / 之后:**
> placeholder: `e.g. http://proxy.example.com:8080 or http://user:pass@proxy:8080`
> formats: `Supports http://, https://, socks5://, socks4:// protocols. For authenticated proxies use http://user:password@host:port (URL-encode special characters in password, e.g. # as %23)`

## Checklist
- [x] Code follows project conventions
- [x] All 5 languages updated consistently
- [x] No code changes required (i18n only)

---
*Description enhanced by Claude AI*