### PR TITLE
fix: harden proxy security fallbacks and passthrough guards

### DIFF
--- a/src/app/v1/_lib/proxy/billing-header-rectifier.ts
+++ b/src/app/v1/_lib/proxy/billing-header-rectifier.ts
@@ -17,6 +17,15 @@ export type BillingHeaderRectifierResult = {
 };
 
 const BILLING_HEADER_PATTERN = /^\s*x-anthropic-billing-header\s*:/i;
+const REDACTED_BILLING_HEADER_VALUE = "x-anthropic-billing-header: [REDACTED]";
+
+function redactBillingHeaderAuditValue(value: string): string {
+  if (!BILLING_HEADER_PATTERN.test(value)) {
+    return value.trim();
+  }
+
+  return REDACTED_BILLING_HEADER_VALUE;
+}
 
 /**
  * Remove x-anthropic-billing-header text blocks from the request system prompt.
@@ -35,7 +44,7 @@ export function rectifyBillingHeader(
   // Case 2: system is a plain string
   if (typeof system === "string") {
     if (BILLING_HEADER_PATTERN.test(system)) {
-      const extractedValues = [system.trim()];
+      const extractedValues = [redactBillingHeaderAuditValue(system)];
       delete message.system;
       return { applied: true, removedCount: 1, extractedValues };
     }
@@ -55,7 +64,9 @@ export function rectifyBillingHeader(
         typeof (block as Record<string, unknown>).text === "string" &&
         BILLING_HEADER_PATTERN.test((block as Record<string, unknown>).text as string)
       ) {
-        extractedValues.push(((block as Record<string, unknown>).text as string).trim());
+        extractedValues.push(
+          redactBillingHeaderAuditValue((block as Record<string, unknown>).text as string)
+        );
       } else {
         filtered.push(block);
       }

--- a/src/app/v1/_lib/proxy/circuit-breaker-accounting.ts
+++ b/src/app/v1/_lib/proxy/circuit-breaker-accounting.ts
@@ -1,0 +1,9 @@
+const PROVIDER_FAILURE_STATUSES = new Set([401, 402, 403, 408, 429, 451]);
+
+export function shouldRecordProviderCircuitFailure(statusCode: number): boolean {
+  if (statusCode >= 500) {
+    return true;
+  }
+
+  return PROVIDER_FAILURE_STATUSES.has(statusCode);
+}

--- a/src/app/v1/_lib/proxy/endpoint-family-catalog.ts
+++ b/src/app/v1/_lib/proxy/endpoint-family-catalog.ts
@@ -97,7 +97,7 @@ const KNOWN_ENDPOINT_FAMILIES: readonly EndpointFamily[] = Object.freeze([
   {
     id: "response-compact",
     surface: "response",
-    accountingTier: "none",
+    accountingTier: "required_usage",
     modelRequired: false,
     rawPassthrough: true,
     match: (pathname) => pathname === "/v1/responses/compact",

--- a/src/app/v1/_lib/proxy/endpoint-policy.ts
+++ b/src/app/v1/_lib/proxy/endpoint-policy.ts
@@ -5,7 +5,7 @@ export type EndpointGuardPreset = "chat" | "raw_passthrough";
 export type EndpointPoolStrictness = "inherit" | "strict";
 
 export interface EndpointPolicy {
-  readonly kind: "default" | "raw_passthrough";
+  readonly kind: "default" | "raw_passthrough" | "guarded_passthrough";
   readonly guardPreset: EndpointGuardPreset;
   readonly allowRetry: boolean;
   readonly allowProviderSwitch: boolean;
@@ -46,10 +46,22 @@ const RAW_PASSTHROUGH_ENDPOINT_POLICY: EndpointPolicy = Object.freeze({
   endpointPoolStrictness: "strict",
 });
 
-const rawPassthroughEndpointPathSet = new Set<string>([
-  V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS,
-  V1_ENDPOINT_PATHS.RESPONSES_COMPACT,
-]);
+const GUARDED_PASSTHROUGH_ENDPOINT_POLICY: EndpointPolicy = Object.freeze({
+  kind: "guarded_passthrough",
+  guardPreset: "chat",
+  allowRetry: false,
+  allowProviderSwitch: false,
+  allowCircuitBreakerAccounting: true,
+  trackConcurrentRequests: true,
+  bypassRequestFilters: false,
+  bypassForwarderPreprocessing: true,
+  bypassSpecialSettings: true,
+  bypassResponseRectifier: true,
+  endpointPoolStrictness: "strict",
+});
+
+const rawPassthroughEndpointPathSet = new Set<string>([V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS]);
+const guardedPassthroughEndpointPathSet = new Set<string>([V1_ENDPOINT_PATHS.RESPONSES_COMPACT]);
 
 export function isRawPassthroughEndpointPath(pathname: string): boolean {
   return rawPassthroughEndpointPathSet.has(normalizeEndpointPath(pathname));
@@ -62,6 +74,10 @@ export function isRawPassthroughEndpointPolicy(policy: EndpointPolicy): boolean 
 export function resolveEndpointPolicy(pathname: string): EndpointPolicy {
   if (isRawPassthroughEndpointPath(pathname)) {
     return RAW_PASSTHROUGH_ENDPOINT_POLICY;
+  }
+
+  if (guardedPassthroughEndpointPathSet.has(normalizeEndpointPath(pathname))) {
+    return GUARDED_PASSTHROUGH_ENDPOINT_POLICY;
   }
 
   return DEFAULT_ENDPOINT_POLICY;

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -39,6 +39,7 @@ import type { SessionUsageUpdate } from "@/types/session";
 import type { LongContextPricingSpecialSetting } from "@/types/special-settings";
 import { GeminiAdapter } from "../gemini/adapter";
 import type { GeminiResponse } from "../gemini/types";
+import { shouldRecordProviderCircuitFailure } from "./circuit-breaker-accounting";
 import { isClientAbortError, isTransportError } from "./errors";
 import type { ProxySession } from "./session";
 import { consumeDeferredStreamingFinalization } from "./stream-finalization";
@@ -507,10 +508,12 @@ async function finalizeDeferredStreamingFinalizationIfNeeded(
 
     const chainReason = effectiveStatusCode === 404 ? "resource_not_found" : "retry_failed";
 
-    // 计入熔断器：让后续请求能正确触发故障转移/熔断。
-    //
-    // 注意：404 语义在 forwarder 中属于 RESOURCE_NOT_FOUND，不计入熔断器（避免把“资源/模型不存在”当作供应商故障）。
-    if (effectiveStatusCode !== 404 && session.getEndpointPolicy().allowCircuitBreakerAccounting) {
+    // 计入熔断器：仅对 provider/key 侧故障计数；
+    // 客户端可诱发的 4xx（400/404/409/413/415/422）不应把全局 provider 熔断打爆。
+    if (
+      shouldRecordProviderCircuitFailure(effectiveStatusCode) &&
+      session.getEndpointPolicy().allowCircuitBreakerAccounting
+    ) {
       try {
         // 动态导入：避免 proxy 模块与熔断器模块之间潜在的循环依赖。
         const { recordFailure } = await import("@/lib/circuit-breaker");
@@ -559,9 +562,12 @@ async function finalizeDeferredStreamingFinalizationIfNeeded(
 
     const chainReason = effectiveStatusCode === 404 ? "resource_not_found" : "retry_failed";
 
-    // 计入熔断器：让后续请求能正确触发故障转移/熔断。
-    // 注意：与 forwarder 口径保持一致：404 不计入熔断器（资源不存在不是供应商故障）。
-    if (effectiveStatusCode !== 404 && session.getEndpointPolicy().allowCircuitBreakerAccounting) {
+    // 计入熔断器：仅对 provider/key 侧故障计数；
+    // 客户端可诱发的 4xx（400/404/409/413/415/422）不应把全局 provider 熔断打爆。
+    if (
+      shouldRecordProviderCircuitFailure(effectiveStatusCode) &&
+      session.getEndpointPolicy().allowCircuitBreakerAccounting
+    ) {
       try {
         const { recordFailure } = await import("@/lib/circuit-breaker");
         await recordFailure(meta.providerId, new Error(errorMessage));
@@ -780,8 +786,11 @@ export class ProxyResponseHandler {
               const detected = detectUpstreamErrorFromSseOrJsonText(responseText);
               errorMessageForFinalize = detected.isError ? detected.code : `HTTP ${statusCode}`;
 
-              // 计入熔断器
-              if (session.getEndpointPolicy().allowCircuitBreakerAccounting) {
+              // 计入熔断器：仅统计 provider/key 侧故障。
+              if (
+                shouldRecordProviderCircuitFailure(statusCode) &&
+                session.getEndpointPolicy().allowCircuitBreakerAccounting
+              ) {
                 try {
                   const { recordFailure } = await import("@/lib/circuit-breaker");
                   await recordFailure(provider.id, new Error(errorMessageForFinalize));
@@ -1106,8 +1115,11 @@ export class ProxyResponseHandler {
           const detected = detectUpstreamErrorFromSseOrJsonText(responseText);
           const errorMessageForDb = detected.isError ? detected.code : `HTTP ${statusCode}`;
 
-          // 计入熔断器
-          if (session.getEndpointPolicy().allowCircuitBreakerAccounting) {
+          // 计入熔断器：仅统计 provider/key 侧故障。
+          if (
+            shouldRecordProviderCircuitFailure(statusCode) &&
+            session.getEndpointPolicy().allowCircuitBreakerAccounting
+          ) {
             try {
               const { recordFailure } = await import("@/lib/circuit-breaker");
               await recordFailure(provider.id, new Error(errorMessageForDb));

--- a/src/lib/session-manager.ts
+++ b/src/lib/session-manager.ts
@@ -391,94 +391,13 @@ export class SessionManager {
       return clientSessionId;
     }
 
-    // 2. 降级方案：计算 messages 内容哈希（TC-047 警告：不可靠）
-    logger.warn(
-      "SessionManager: No client session ID, falling back to content hash (unreliable for compressed dialogs)",
-      {
-        keyId,
-        messagesLength: Array.isArray(messages) ? messages.length : 0,
-      }
-    );
-    const contentHash = SessionManager.calculateMessagesHash(messages);
-    if (!contentHash) {
-      // 降级：无法计算哈希，生成新 session
-      const newId = SessionManager.generateSessionId();
-      logger.warn("SessionManager: Cannot calculate hash, generating new session", {
-        sessionId: newId,
-      });
-      return newId;
-    }
-
-    // 3. 尝试从 Redis 查找已有 session
-    if (redis && redis.status === "ready") {
-      try {
-        const hashKey = `hash:${contentHash}:session`;
-        const existingSessionId = await redis.get(hashKey);
-
-        if (existingSessionId) {
-          // 找到已有 session，刷新 TTL
-          await SessionManager.refreshSessionTTL(existingSessionId);
-          logger.trace("SessionManager: Reusing session via hash", {
-            sessionId: existingSessionId,
-            hash: contentHash,
-          });
-          return existingSessionId;
-        }
-
-        // 未找到：创建新 session
-        const newSessionId = SessionManager.generateSessionId();
-
-        // 存储映射关系（异步，不阻塞）
-        void SessionManager.storeSessionMapping(contentHash, newSessionId, keyId);
-
-        logger.trace("SessionManager: Created new session with hash", {
-          sessionId: newSessionId,
-          hash: contentHash,
-        });
-        return newSessionId;
-      } catch (error) {
-        logger.error("SessionManager: Redis error", { error });
-        // 降级：Redis 错误，生成新 session
-        return SessionManager.generateSessionId();
-      }
-    }
-
-    // 4. Redis 不可用，降级生成新 session
+    // 2. 安全降级：客户端未提供 session_id 时，始终生成新的 opaque session。
+    // 旧的 content-hash 复用会把不同 key/user 的同构请求错误合并进同一 session。
+    logger.warn("SessionManager: No client session ID, generating fresh opaque session", {
+      keyId,
+      messagesLength,
+    });
     return SessionManager.generateSessionId();
-  }
-
-  /**
-   * 存储 hash → session 映射关系
-   */
-  private static async storeSessionMapping(
-    contentHash: string,
-    sessionId: string,
-    keyId: number
-  ): Promise<void> {
-    const redis = getRedisClient();
-    if (!redis || redis.status !== "ready") return;
-
-    try {
-      const pipeline = redis.pipeline();
-      const hashKey = `hash:${contentHash}:session`;
-
-      // 存储映射关系
-      pipeline.setex(hashKey, SessionManager.SESSION_TTL, sessionId);
-
-      // 初始化 session 元数据
-      pipeline.setex(`session:${sessionId}:key`, SessionManager.SESSION_TTL, keyId.toString());
-      pipeline.setex(
-        `session:${sessionId}:last_seen`,
-        SessionManager.SESSION_TTL,
-        Date.now().toString()
-      );
-
-      await pipeline.exec();
-    } catch (error) {
-      logger.error("SessionManager: Failed to store session mapping", {
-        error,
-      });
-    }
   }
 
   /**

--- a/src/lib/utils/sse.ts
+++ b/src/lib/utils/sse.ts
@@ -70,6 +70,7 @@ export function parseSSEData(sseText: string): ParsedSSEEvent[] {
  * 只认行首的 `event:` / `data:`（或前置注释行 `:`），避免 JSON 里包含 "data:" 误判。
  */
 export function isSSEText(text: string): boolean {
+  const sseFieldPrefixes = ["event:", "data:", "id:", "retry:"];
   let start = 0;
 
   for (let i = 0; i <= text.length; i += 1) {
@@ -81,7 +82,7 @@ export function isSSEText(text: string): boolean {
     if (!line) continue;
     if (line.startsWith(":")) continue;
 
-    return line.startsWith("event:") || line.startsWith("data:");
+    return sseFieldPrefixes.some((prefix) => line.startsWith(prefix));
   }
 
   return false;

--- a/tests/unit/lib/session-manager-session-id-fallback.test.ts
+++ b/tests/unit/lib/session-manager-session-id-fallback.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    trace: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const getRedisClientMock = vi.fn();
+
+vi.mock("@/lib/redis", () => ({
+  getRedisClient: getRedisClientMock,
+}));
+
+vi.mock("@/app/v1/_lib/proxy/errors", () => ({
+  sanitizeHeaders: vi.fn(() => "(empty)"),
+  sanitizeUrl: vi.fn((value: string) => value),
+}));
+
+vi.mock("@/lib/session-tracker", () => ({
+  SessionTracker: {
+    getActiveSessions: vi.fn(async () => []),
+  },
+}));
+
+describe("SessionManager.getOrCreateSessionId fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("without client session id, identical messages should not reuse the same derived session id even when Redis is ready", async () => {
+    const { SessionManager } = await import("@/lib/session-manager");
+    const messages = [{ role: "user", content: "hello" }];
+    const hashMapping = new Map<string, string>();
+
+    const pipeline = {
+      setex: vi.fn((key: string, _ttl: number, value: string) => {
+        hashMapping.set(key, value);
+        return pipeline;
+      }),
+      exec: vi.fn(async () => []),
+    };
+
+    getRedisClientMock.mockReturnValue({
+      status: "ready",
+      get: vi.fn(async (key: string) => hashMapping.get(key) ?? null),
+      pipeline: vi.fn(() => pipeline),
+    });
+
+    const first = await SessionManager.getOrCreateSessionId(11, messages, null);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const second = await SessionManager.getOrCreateSessionId(22, messages, null);
+
+    expect(first).toMatch(/^sess_/);
+    expect(second).toMatch(/^sess_/);
+    expect(first).not.toBe(second);
+  });
+});

--- a/tests/unit/proxy/billing-header-rectifier.test.ts
+++ b/tests/unit/proxy/billing-header-rectifier.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { rectifyBillingHeader } from "@/app/v1/_lib/proxy/billing-header-rectifier";
 
 describe("rectifyBillingHeader", () => {
-  test("system array with single billing header block - removes it and returns extractedValues", () => {
+  test("system array with single billing header block - removes it and redacts extractedValues", () => {
     const message: Record<string, unknown> = {
       system: [
         {
@@ -16,9 +16,7 @@ describe("rectifyBillingHeader", () => {
 
     expect(result.applied).toBe(true);
     expect(result.removedCount).toBe(1);
-    expect(result.extractedValues).toEqual([
-      "x-anthropic-billing-header: cc_version=2.1.36; cc_entrypoint=cli; cch=1;",
-    ]);
+    expect(result.extractedValues).toEqual(["x-anthropic-billing-header: [REDACTED]"]);
     expect(message.system).toEqual([]);
   });
 
@@ -74,7 +72,7 @@ describe("rectifyBillingHeader", () => {
     ]);
   });
 
-  test("system as plain string that IS a billing header - deletes system field", () => {
+  test("system as plain string that IS a billing header - deletes system field and redacts audit payload", () => {
     const message: Record<string, unknown> = {
       system: "x-anthropic-billing-header: cc_version=2.1.36;",
     };
@@ -83,7 +81,7 @@ describe("rectifyBillingHeader", () => {
 
     expect(result.applied).toBe(true);
     expect(result.removedCount).toBe(1);
-    expect(result.extractedValues).toEqual(["x-anthropic-billing-header: cc_version=2.1.36;"]);
+    expect(result.extractedValues).toEqual(["x-anthropic-billing-header: [REDACTED]"]);
     expect(message.system).toBeUndefined();
   });
 
@@ -179,6 +177,9 @@ describe("rectifyBillingHeader", () => {
     expect(result.applied).toBe(true);
     expect(result.removedCount).toBe(3);
     expect(result.extractedValues).toHaveLength(3);
+    expect(
+      result.extractedValues.every((value) => value === "x-anthropic-billing-header: [REDACTED]")
+    ).toBe(true);
     expect(message.system).toEqual([]);
   });
 

--- a/tests/unit/proxy/circuit-breaker-accounting.test.ts
+++ b/tests/unit/proxy/circuit-breaker-accounting.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import { shouldRecordProviderCircuitFailure } from "@/app/v1/_lib/proxy/circuit-breaker-accounting";
+
+describe("shouldRecordProviderCircuitFailure", () => {
+  test.each([
+    401, 402, 403, 408, 429, 451, 500, 502, 503, 504,
+  ])("counts upstream failure status %s", (statusCode) => {
+    expect(shouldRecordProviderCircuitFailure(statusCode)).toBe(true);
+  });
+
+  test.each([
+    400, 404, 409, 413, 415, 422,
+  ])("does not count client-driven status %s", (statusCode) => {
+    expect(shouldRecordProviderCircuitFailure(statusCode)).toBe(false);
+  });
+});

--- a/tests/unit/proxy/endpoint-family-catalog.test.ts
+++ b/tests/unit/proxy/endpoint-family-catalog.test.ts
@@ -39,7 +39,7 @@ const FAMILY_SAMPLES = [
     id: "response-compact",
     path: "/v1/responses/compact",
     format: "response",
-    accountingTier: "none",
+    accountingTier: "required_usage",
     modelRequired: false,
   },
   {

--- a/tests/unit/proxy/endpoint-policy-parity.test.ts
+++ b/tests/unit/proxy/endpoint-policy-parity.test.ts
@@ -11,10 +11,9 @@ import { V1_ENDPOINT_PATHS } from "@/app/v1/_lib/proxy/endpoint-paths";
 // Shared constants
 // ---------------------------------------------------------------------------
 
-const RAW_PASSTHROUGH_ENDPOINTS = [
-  V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS,
-  V1_ENDPOINT_PATHS.RESPONSES_COMPACT,
-] as const;
+const RAW_PASSTHROUGH_ENDPOINTS = [V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS] as const;
+
+const GUARDED_PASSTHROUGH_ENDPOINTS = [V1_ENDPOINT_PATHS.RESPONSES_COMPACT] as const;
 
 const DEFAULT_ENDPOINTS = [
   V1_ENDPOINT_PATHS.MESSAGES,
@@ -23,27 +22,22 @@ const DEFAULT_ENDPOINTS = [
 ] as const;
 
 // ---------------------------------------------------------------------------
-// T11: Endpoint parity -- count_tokens and responses/compact produce
-//      identical EndpointPolicy objects and exhibit identical behaviour
-//      under provider errors.
+// T11: Endpoint policy separation -- count_tokens stays strict raw passthrough,
+//      while responses/compact keeps raw forwarding but restores normal guards.
 // ---------------------------------------------------------------------------
 
-describe("T11: raw passthrough endpoint parity", () => {
-  test("count_tokens and responses/compact resolve to the exact same EndpointPolicy object", () => {
+describe("T11: passthrough endpoint policy separation", () => {
+  test("count_tokens and responses/compact no longer resolve to the same EndpointPolicy object", () => {
     const countTokensPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS);
     const compactPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.RESPONSES_COMPACT);
 
-    // Reference equality: same frozen singleton
-    expect(countTokensPolicy).toBe(compactPolicy);
-
-    // Both recognized as raw_passthrough
+    expect(countTokensPolicy).not.toBe(compactPolicy);
     expect(isRawPassthroughEndpointPolicy(countTokensPolicy)).toBe(true);
-    expect(isRawPassthroughEndpointPolicy(compactPolicy)).toBe(true);
+    expect(isRawPassthroughEndpointPolicy(compactPolicy)).toBe(false);
   });
 
-  test("both raw passthrough endpoints have identical strict policy fields", () => {
-    const countTokensPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS);
-    const compactPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.RESPONSES_COMPACT);
+  test("count_tokens keeps strict raw policy fields", () => {
+    const policy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS);
 
     const expectedPolicy: EndpointPolicy = {
       kind: "raw_passthrough",
@@ -59,11 +53,30 @@ describe("T11: raw passthrough endpoint parity", () => {
       endpointPoolStrictness: "strict",
     };
 
-    expect(countTokensPolicy).toEqual(expectedPolicy);
+    expect(policy).toEqual(expectedPolicy);
+  });
+
+  test("responses/compact keeps passthrough forwarding but restores normal guard fields", () => {
+    const compactPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.RESPONSES_COMPACT);
+
+    const expectedPolicy: EndpointPolicy = {
+      kind: "guarded_passthrough",
+      guardPreset: "chat",
+      allowRetry: false,
+      allowProviderSwitch: false,
+      allowCircuitBreakerAccounting: true,
+      trackConcurrentRequests: true,
+      bypassRequestFilters: false,
+      bypassForwarderPreprocessing: true,
+      bypassSpecialSettings: true,
+      bypassResponseRectifier: true,
+      endpointPoolStrictness: "strict",
+    };
+
     expect(compactPolicy).toEqual(expectedPolicy);
   });
 
-  test("under provider error, both endpoints result in no retry, no provider switch, no circuit breaker accounting", () => {
+  test("count_tokens remains fully bypassed under provider error", () => {
     for (const pathname of RAW_PASSTHROUGH_ENDPOINTS) {
       const policy = resolveEndpointPolicy(pathname);
 
@@ -73,9 +86,25 @@ describe("T11: raw passthrough endpoint parity", () => {
     }
   });
 
-  test("isRawPassthroughEndpointPath returns true for both raw passthrough canonical paths", () => {
+  test("responses/compact restores circuit breaker accounting and concurrent tracking", () => {
+    for (const pathname of GUARDED_PASSTHROUGH_ENDPOINTS) {
+      const policy = resolveEndpointPolicy(pathname);
+
+      expect(policy.allowRetry).toBe(false);
+      expect(policy.allowProviderSwitch).toBe(false);
+      expect(policy.allowCircuitBreakerAccounting).toBe(true);
+      expect(policy.trackConcurrentRequests).toBe(true);
+      expect(policy.bypassRequestFilters).toBe(false);
+    }
+  });
+
+  test("isRawPassthroughEndpointPath returns true only for count_tokens canonical path", () => {
     for (const pathname of RAW_PASSTHROUGH_ENDPOINTS) {
       expect(isRawPassthroughEndpointPath(pathname)).toBe(true);
+    }
+
+    for (const pathname of GUARDED_PASSTHROUGH_ENDPOINTS) {
+      expect(isRawPassthroughEndpointPath(pathname)).toBe(false);
     }
   });
 });
@@ -257,10 +286,10 @@ describe("T14: path edge-case normalization", () => {
     expect(policy.kind).toBe("raw_passthrough");
   });
 
-  test("trailing slash: /v1/responses/compact/ -> raw_passthrough", () => {
-    expect(isRawPassthroughEndpointPath("/v1/responses/compact/")).toBe(true);
+  test("trailing slash: /v1/responses/compact/ -> guarded_passthrough", () => {
+    expect(isRawPassthroughEndpointPath("/v1/responses/compact/")).toBe(false);
     const policy = resolveEndpointPolicy("/v1/responses/compact/");
-    expect(policy.kind).toBe("raw_passthrough");
+    expect(policy.kind).toBe("guarded_passthrough");
   });
 
   test("uppercase: /V1/MESSAGES/COUNT_TOKENS -> raw_passthrough", () => {
@@ -269,10 +298,10 @@ describe("T14: path edge-case normalization", () => {
     expect(policy.kind).toBe("raw_passthrough");
   });
 
-  test("uppercase: /V1/RESPONSES/COMPACT -> raw_passthrough", () => {
-    expect(isRawPassthroughEndpointPath("/V1/RESPONSES/COMPACT")).toBe(true);
+  test("uppercase: /V1/RESPONSES/COMPACT -> guarded_passthrough", () => {
+    expect(isRawPassthroughEndpointPath("/V1/RESPONSES/COMPACT")).toBe(false);
     const policy = resolveEndpointPolicy("/V1/RESPONSES/COMPACT");
-    expect(policy.kind).toBe("raw_passthrough");
+    expect(policy.kind).toBe("guarded_passthrough");
   });
 
   test("query string: /v1/messages/count_tokens?foo=bar -> raw_passthrough", () => {
@@ -281,20 +310,20 @@ describe("T14: path edge-case normalization", () => {
     expect(policy.kind).toBe("raw_passthrough");
   });
 
-  test("query string: /v1/responses/compact?foo=bar -> raw_passthrough", () => {
-    expect(isRawPassthroughEndpointPath("/v1/responses/compact?foo=bar")).toBe(true);
+  test("query string: /v1/responses/compact?foo=bar -> guarded_passthrough", () => {
+    expect(isRawPassthroughEndpointPath("/v1/responses/compact?foo=bar")).toBe(false);
     const policy = resolveEndpointPolicy("/v1/responses/compact?foo=bar");
-    expect(policy.kind).toBe("raw_passthrough");
+    expect(policy.kind).toBe("guarded_passthrough");
   });
 
   test("combined edge case: uppercase + trailing slash + query string", () => {
     expect(isRawPassthroughEndpointPath("/V1/MESSAGES/COUNT_TOKENS/?x=1")).toBe(true);
-    expect(isRawPassthroughEndpointPath("/V1/RESPONSES/COMPACT/?x=1")).toBe(true);
+    expect(isRawPassthroughEndpointPath("/V1/RESPONSES/COMPACT/?x=1")).toBe(false);
 
     const policy1 = resolveEndpointPolicy("/V1/MESSAGES/COUNT_TOKENS/?x=1");
     const policy2 = resolveEndpointPolicy("/V1/RESPONSES/COMPACT/?x=1");
     expect(policy1.kind).toBe("raw_passthrough");
-    expect(policy2.kind).toBe("raw_passthrough");
+    expect(policy2.kind).toBe("guarded_passthrough");
   });
 
   test("/v1/messages/ (with trailing slash) -> default, NOT raw_passthrough", () => {

--- a/tests/unit/proxy/endpoint-policy.test.ts
+++ b/tests/unit/proxy/endpoint-policy.test.ts
@@ -7,11 +7,9 @@ import {
 import { V1_ENDPOINT_PATHS } from "@/app/v1/_lib/proxy/endpoint-paths";
 
 describe("endpoint-policy", () => {
-  test("raw passthrough endpoints resolve to identical strict policy", () => {
+  test("count_tokens resolves to strict raw passthrough policy", () => {
     const countTokensPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS);
-    const compactPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.RESPONSES_COMPACT);
 
-    expect(countTokensPolicy).toBe(compactPolicy);
     expect(isRawPassthroughEndpointPolicy(countTokensPolicy)).toBe(true);
     expect(countTokensPolicy).toEqual({
       kind: "raw_passthrough",
@@ -28,14 +26,39 @@ describe("endpoint-policy", () => {
     });
   });
 
+  test("responses/compact keeps passthrough forwarding but restores normal guards", () => {
+    const compactPolicy = resolveEndpointPolicy(V1_ENDPOINT_PATHS.RESPONSES_COMPACT);
+
+    expect(isRawPassthroughEndpointPolicy(compactPolicy)).toBe(false);
+    expect(compactPolicy).toEqual({
+      kind: "guarded_passthrough",
+      guardPreset: "chat",
+      allowRetry: false,
+      allowProviderSwitch: false,
+      allowCircuitBreakerAccounting: true,
+      trackConcurrentRequests: true,
+      bypassRequestFilters: false,
+      bypassForwarderPreprocessing: true,
+      bypassSpecialSettings: true,
+      bypassResponseRectifier: true,
+      endpointPoolStrictness: "strict",
+    });
+  });
+
   test.each([
     "/v1/messages/count_tokens/",
     "/V1/MESSAGES/COUNT_TOKENS",
-    "/v1/responses/compact/",
-    "/V1/RESPONSES/COMPACT",
   ])("raw passthrough endpoints path helper matches variant %s", (pathname) => {
     expect(isRawPassthroughEndpointPath(pathname)).toBe(true);
     expect(isRawPassthroughEndpointPolicy(resolveEndpointPolicy(pathname))).toBe(true);
+  });
+
+  test.each([
+    "/v1/responses/compact/",
+    "/V1/RESPONSES/COMPACT",
+  ])("responses/compact variants no longer resolve as raw passthrough: %s", (pathname) => {
+    expect(isRawPassthroughEndpointPath(pathname)).toBe(false);
+    expect(isRawPassthroughEndpointPolicy(resolveEndpointPolicy(pathname))).toBe(false);
   });
 
   test("default policy stays on non-target endpoints", () => {

--- a/tests/unit/proxy/extract-usage-metrics.test.ts
+++ b/tests/unit/proxy/extract-usage-metrics.test.ts
@@ -635,6 +635,25 @@ describe("extractUsageMetrics", () => {
       expect(result.usageMetrics?.cache_read_input_tokens).toBe(100);
     });
 
+    it("应识别以 id/retry 开头的合法 SSE 并提取 usage", () => {
+      const sseResponse = [
+        "id: msg_123",
+        "retry: 1000",
+        "event: message_start",
+        'data: {"type":"message_start","message":{"usage":{"input_tokens":123,"cache_creation_input_tokens":10}}}',
+        "",
+        "event: message_delta",
+        'data: {"type":"message_delta","usage":{"output_tokens":45}}',
+        "",
+      ].join("\n");
+
+      const result = parseUsageFromResponseText(sseResponse, "claude");
+
+      expect(result.usageMetrics).not.toBeNull();
+      expect(result.usageMetrics?.input_tokens).toBe(123);
+      expect(result.usageMetrics?.output_tokens).toBe(45);
+    });
+
     it("message_delta 的值应优先于 message_start", () => {
       const sseResponse = [
         "event: message_start",

--- a/tests/unit/proxy/guard-pipeline-warmup.test.ts
+++ b/tests/unit/proxy/guard-pipeline-warmup.test.ts
@@ -216,34 +216,46 @@ describe("GuardPipeline：warmup 拦截点", () => {
     expect(callOrder).not.toContain("messageContext");
   });
 
-  test("count_tokens 和 responses/compact 应通过 endpoint policy 选择同一 raw preset", async () => {
+  test("count_tokens 和 responses/compact 应通过 endpoint policy 选择不同 preset", async () => {
     const { GuardPipelineBuilder } = await import("@/app/v1/_lib/proxy/guard-pipeline");
 
-    const endpoints = [
-      V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS,
-      V1_ENDPOINT_PATHS.RESPONSES_COMPACT,
-    ];
-    const orders: string[][] = [];
+    callOrder.length = 0;
+    const countTokensSession = {
+      getEndpointPolicy: () => resolveEndpointPolicy(V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS),
+      isProbeRequest: () => {
+        callOrder.push("probe");
+        return false;
+      },
+    } as any;
+    const countTokensPipeline = GuardPipelineBuilder.fromSession(countTokensSession);
+    const countTokensRes = await countTokensPipeline.run(countTokensSession);
+    expect(countTokensRes).toBeNull();
+    const countTokensOrder = [...callOrder];
 
-    for (const endpoint of endpoints) {
-      callOrder.length = 0;
-      const session = {
-        getEndpointPolicy: () => resolveEndpointPolicy(endpoint),
-        isProbeRequest: () => {
-          callOrder.push("probe");
-          return false;
-        },
-      } as any;
+    callOrder.length = 0;
+    const compactSession = {
+      getEndpointPolicy: () => resolveEndpointPolicy(V1_ENDPOINT_PATHS.RESPONSES_COMPACT),
+      isProbeRequest: () => {
+        callOrder.push("probe");
+        return false;
+      },
+    } as any;
+    const compactPipeline = GuardPipelineBuilder.fromSession(compactSession);
+    const compactRes = await compactPipeline.run(compactSession);
+    expect(compactRes).toBeInstanceOf(Response);
+    const compactOrder = [...callOrder];
 
-      const pipeline = GuardPipelineBuilder.fromSession(session);
-      const res = await pipeline.run(session);
-
-      expect(res).toBeNull();
-      orders.push([...callOrder]);
-    }
-
-    expect(orders[0]).toEqual(orders[1]);
-    expect(orders[0]).toEqual(["auth", "client", "model", "version", "probe", "provider"]);
+    expect(countTokensOrder).toEqual(["auth", "client", "model", "version", "probe", "provider"]);
+    expect(compactOrder).toEqual([
+      "auth",
+      "sensitive",
+      "client",
+      "model",
+      "version",
+      "probe",
+      "session",
+      "warmup",
+    ]);
   });
 
   test("/v1/messages 仍应通过 endpoint policy 选择现有 chat preset", async () => {

--- a/tests/unit/proxy/proxy-handler-session-id-error.test.ts
+++ b/tests/unit/proxy/proxy-handler-session-id-error.test.ts
@@ -176,19 +176,7 @@ describe("handleProxyRequest - session id on errors", async () => {
     expect(h.trackerCalls).toEqual(["inc", "startRequest", "dec"]);
   });
 
-  test.each([
-    {
-      pathname: V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS,
-      isCountTokensRequest: true,
-    },
-    {
-      pathname: V1_ENDPOINT_PATHS.RESPONSES_COMPACT,
-      isCountTokensRequest: false,
-    },
-  ])("RED: raw endpoint $pathname 应统一跳过并发计数（Wave2 未实现前会失败）", async ({
-    pathname,
-    isCountTokensRequest,
-  }) => {
+  test("count_tokens 应跳过并发计数", async () => {
     h.fromContextError = null;
     h.session.originalFormat = "claude";
     h.endpointFormat = "openai";
@@ -198,17 +186,40 @@ describe("handleProxyRequest - session id on errors", async () => {
     h.forwardResponse = new Response("ok", { status: 200 });
     h.dispatchedResponse = null;
 
-    h.session.requestUrl = new URL(`http://localhost${pathname}`);
+    h.session.requestUrl = new URL(`http://localhost${V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS}`);
     h.session.getEndpointPolicy = () => resolveEndpointPolicy(h.session.requestUrl.pathname);
     h.session.sessionId = "s_123";
     h.session.messageContext = { id: 1, user: { id: 1, name: "u" }, key: { name: "k" } };
     h.session.provider = { id: 1, name: "p" };
-    h.session.isCountTokensRequest = () => isCountTokensRequest;
+    h.session.isCountTokensRequest = () => true;
 
     const res = await handleProxyRequest({} as any);
 
     expect(res.status).toBe(200);
     expect(h.trackerCalls).toEqual(["startRequest"]);
+  });
+
+  test("responses/compact 应恢复并发计数", async () => {
+    h.fromContextError = null;
+    h.session.originalFormat = "claude";
+    h.endpointFormat = "openai";
+    h.trackerCalls.length = 0;
+    h.pipelineError = null;
+    h.earlyResponse = null;
+    h.forwardResponse = new Response("ok", { status: 200 });
+    h.dispatchedResponse = null;
+
+    h.session.requestUrl = new URL(`http://localhost${V1_ENDPOINT_PATHS.RESPONSES_COMPACT}`);
+    h.session.getEndpointPolicy = () => resolveEndpointPolicy(h.session.requestUrl.pathname);
+    h.session.sessionId = "s_123";
+    h.session.messageContext = { id: 1, user: { id: 1, name: "u" }, key: { name: "k" } };
+    h.session.provider = { id: 1, name: "p" };
+    h.session.isCountTokensRequest = () => false;
+
+    const res = await handleProxyRequest({} as any);
+
+    expect(res.status).toBe(200);
+    expect(h.trackerCalls).toEqual(["inc", "startRequest", "dec"]);
   });
 
   test("session not created and ProxyError thrown: returns buildError without session header", async () => {

--- a/tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts
+++ b/tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts
@@ -424,6 +424,29 @@ describe("Endpoint circuit breaker isolation", () => {
     expect(mockRecordEndpointFailure).not.toHaveBeenCalled();
   });
 
+  it("non-200 client-driven 400 should NOT call recordFailure", async () => {
+    const session = createSession();
+    setDeferredStreamingFinalization(session, {
+      providerId: 1,
+      providerName: "test-provider",
+      providerPriority: 10,
+      attemptNumber: 1,
+      totalProvidersAttempted: 1,
+      isFirstAttempt: true,
+      isFailoverSuccess: false,
+      endpointId: 42,
+      endpointUrl: "https://api.test.com",
+      upstreamStatusCode: 400,
+    });
+
+    const response = createNon200StreamResponse(400, '{"error":{"message":"Invalid request"}}');
+    await ProxyResponseHandler.dispatch(session, response);
+    await drainAsyncTasks();
+
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+    expect(mockRecordEndpointFailure).not.toHaveBeenCalled();
+  });
+
   it("streaming success DOES call recordEndpointSuccess (regression guard)", async () => {
     const session = createSession();
     setDeferredMeta(session, 42);

--- a/tests/unit/proxy/session.test.ts
+++ b/tests/unit/proxy/session.test.ts
@@ -104,18 +104,28 @@ function createSession({
 }
 
 describe("ProxySession endpoint policy", () => {
-  it.each([
-    V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS,
-    "/V1/RESPONSES/COMPACT/",
-  ])("应在创建时解析 raw passthrough policy: %s", (pathname) => {
+  it("应在创建时解析 count_tokens raw passthrough policy", () => {
     const session = createSession({
       redirectedModel: null,
-      requestUrl: new URL(`http://localhost${pathname}`),
+      requestUrl: new URL(`http://localhost${V1_ENDPOINT_PATHS.MESSAGES_COUNT_TOKENS}`),
     });
 
     const policy = session.getEndpointPolicy();
     expect(isRawPassthroughEndpointPolicy(policy)).toBe(true);
     expect(policy.trackConcurrentRequests).toBe(false);
+  });
+
+  it("应在创建时解析 responses/compact guarded passthrough policy", () => {
+    const session = createSession({
+      redirectedModel: null,
+      requestUrl: new URL("http://localhost/V1/RESPONSES/COMPACT/"),
+    });
+
+    const policy = session.getEndpointPolicy();
+    expect(isRawPassthroughEndpointPolicy(policy)).toBe(false);
+    expect(policy.kind).toBe("guarded_passthrough");
+    expect(policy.trackConcurrentRequests).toBe(true);
+    expect(policy.bypassForwarderPreprocessing).toBe(true);
   });
 
   it("应在请求路径后续变更后保持创建时 policy 不变", () => {


### PR DESCRIPTION
## Summary
Security hardening for the proxy layer that addresses three areas: endpoint policy separation for passthrough endpoints, session ID generation fallback, and circuit breaker accounting accuracy.

## Problem

This PR addresses several security and reliability concerns:

1. **Endpoint Policy Gap**: The `/v1/responses/compact` endpoint was using `raw_passthrough` policy, which bypassed essential guards (rate limiting, session tracking, request filters). This endpoint needs passthrough forwarding but should still enforce normal security guards.

2. **Session ID Content-Hash Collision Risk**: When clients did not provide a session ID, the system fell back to a content-hash based session ID, which could merge different users/keys with identical message content into the same session - a security and accounting risk.

3. **Circuit Breaker False Positives**: All non-200 status codes were being counted toward circuit breaker failures, including client-driven errors (400, 404, 422, etc.). This could incorrectly trip circuit breakers on provider health.

4. **Billing Header Exposure**: Billing header values were being logged in full during audit, potentially exposing sensitive information.

5. **SSE Parsing Gap**: The SSE detection only recognized `event:` and `data:` prefixes, missing legal SSE fields like `id:` and `retry:`.

## Solution

### 1. Endpoint Policy Separation
- Created a new `guarded_passthrough` policy kind
- `/v1/responses/compact` now uses `guarded_passthrough` instead of `raw_passthrough`
- `/v1/messages/count_tokens` keeps strict `raw_passthrough`
- `guarded_passthrough` enables: normal guard pipeline, rate limiting, session tracking, circuit breaker accounting, request filters
- `guarded_passthrough` preserves: raw forwarding (bypasses forwarder preprocessing, special settings, response rectifier)

### 2. Session ID Fallback Removal
- Removed content-hash based session ID derivation
- When no client session ID is provided, system now always generates a fresh opaque session ID
- Eliminates cross-user/session collision risk

### 3. Circuit Breaker Accounting Refinement
- Added `shouldRecordProviderCircuitFailure()` helper
- Only provider-side failures count toward circuit breaker: 401, 402, 403, 408, 429, 451, and all 5xx
- Client-driven errors excluded: 400, 404, 409, 413, 415, 422

### 4. Billing Header Redaction
- Billing header values in audit logs now show `[REDACTED]` instead of actual content

### 5. SSE Field Recognition
- `isSSEText()` now accepts `id:` and `retry:` as valid SSE field prefixes

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/endpoint-policy.ts` - Add `guarded_passthrough` policy kind
- `src/app/v1/_lib/proxy/endpoint-family-catalog.ts` - Change `response-compact` accountingTier to `required_usage`
- `src/app/v1/_lib/proxy/circuit-breaker-accounting.ts` - New helper for circuit breaker status filtering
- `src/app/v1/_lib/proxy/response-handler.ts` - Use refined circuit breaker accounting
- `src/lib/session-manager.ts` - Remove content-hash fallback, always generate fresh session
- `src/lib/utils/sse.ts` - Accept `id:` and `retry:` SSE prefixes
- `src/app/v1/_lib/proxy/billing-header-rectifier.ts` - Redact billing header values

### Supporting Changes
- Test updates across multiple test files to reflect new behavior

## Testing

### Automated Tests
- [x] Unit tests added for circuit breaker accounting (`circuit-breaker-accounting.test.ts`)
- [x] Unit tests added for session ID fallback (`session-manager-session-id-fallback.test.ts`)
- [x] Updated endpoint policy tests for new `guarded_passthrough` policy
- [x] Updated SSE parsing tests for `id:` and `retry:` recognition
- [x] Updated billing header tests for redaction verification

### Verification
- npm run typecheck
- npm run lint
- npm run build
- Targeted vitest suites covering passthrough, session fallback, SSE usage parsing, and circuit-breaker regressions

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens proxy security and reliability across five distinct areas: it splits `/v1/responses/compact` into a new `"guarded_passthrough"` policy that restores normal guards/rate-limiting/session tracking while keeping raw forwarding semantics; stops reusing content-hash-derived session IDs when no client session ID is provided (eliminating cross-user session merging); redacts billing header values in audit payloads; fixes SSE detection to accept legal `id:` and `retry:` field prefixes; and narrows circuit-breaker accounting to only fire on genuine provider-side failures (excluding client-driven 4xx codes).

- **`endpoint-policy.ts`**: New `"guarded_passthrough"` kind added; `/v1/responses/compact` moved from `rawPassthroughEndpointPathSet` to `guardedPassthroughEndpointPathSet` restoring `"chat"` guard preset, concurrent tracking, and circuit-breaker accounting while keeping `bypassForwarderPreprocessing: true`.
- **`circuit-breaker-accounting.ts`**: New `shouldRecordProviderCircuitFailure()` helper applied consistently at all four recording sites in `response-handler.ts`; prevents 400/404/409/413/415/422 from polluting circuit-breaker state. HTTP 403 is included as a provider-side failure — this is debatable as 403 can also be client-permission-driven.
- **`session-manager.ts`**: Content-hash fallback (Redis hash→session mapping) fully removed; fallback now always generates a fresh opaque session ID, closing the cross-user session merge vulnerability.
- **`billing-header-rectifier.ts`**: Extracted values in audit results are now always `[REDACTED]` instead of the raw header content. The new `redactBillingHeaderAuditValue` helper contains a dead-code branch (`if (!pattern.test(value))`) since every call site already verified the pattern.
- **`sse.ts`**: `isSSEText` extended to recognise `id:` and `retry:` prefixes; `parseSSEData` correctly ignores them per spec (connection-level fields), but this asymmetry is undocumented.
- All changes are covered by targeted unit tests, including regression guards for the session fallback, circuit-breaker filtering, SSE usage extraction, and endpoint policy separation.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- PR is safe to merge; all changes are well-tested and address real security/reliability gaps with no logic regressions observed.
- The five changes are independent, well-scoped, and each backed by targeted tests. No regressions to the primary request path are introduced. The two minor concerns — dead-code in `redactBillingHeaderAuditValue` and the debatable inclusion of HTTP 403 in the circuit-breaker failure set — are non-blocking style/design notes that do not affect runtime correctness.
- `circuit-breaker-accounting.ts` (403 classification) and `billing-header-rectifier.ts` (dead-code branch) warrant a quick look before merge, but neither blocks shipping.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/billing-header-rectifier.ts | Adds redaction of the extracted billing-header audit values; the new helper function contains a dead-code branch since all callers already verify the pattern before calling it. |
| src/app/v1/_lib/proxy/circuit-breaker-accounting.ts | New helper that filters which HTTP status codes should count toward the circuit breaker; correctly excludes client-driven 4xx errors, though HTTP 403 inclusion is debatable. |
| src/app/v1/_lib/proxy/endpoint-family-catalog.ts | Promotes `response-compact` accounting tier from `"none"` to `"required_usage"`, enabling usage tracking for `/v1/responses/compact`. |
| src/app/v1/_lib/proxy/endpoint-policy.ts | Introduces a new `"guarded_passthrough"` policy kind for `/v1/responses/compact` that restores normal guards, rate-limiting, session tracking, and circuit-breaker accounting while keeping passthrough forwarding semantics. |
| src/app/v1/_lib/proxy/response-handler.ts | Consistently applies `shouldRecordProviderCircuitFailure()` across all four circuit-breaker recording sites, replacing the previous ad-hoc `!== 404` guard. |
| src/lib/session-manager.ts | Removes the content-hash-based session reuse fallback, replacing it with a simple fresh-session generation when no client session ID is provided; eliminates the cross-user session-merging vulnerability. |
| src/lib/utils/sse.ts | Expands `isSSEText` to recognise `id:` and `retry:` as valid SSE field prefixes; `parseSSEData` intentionally does not parse these fields per SSE spec, but this asymmetry is undocumented. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    REQ[Incoming Request] --> RESOLVE[resolveEndpointPolicy]

    RESOLVE -->|/v1/messages/count_tokens| RAW[raw_passthrough policy\nguardPreset: raw_passthrough\nbypassRequestFilters: true\ntrackConcurrentRequests: false\nallowCircuitBreaker: false]
    RESOLVE -->|/v1/responses/compact| GUARDED[guarded_passthrough policy\nguardPreset: chat\nbypassForwarderPreprocessing: true\ntrackConcurrentRequests: true\nallowCircuitBreaker: true]
    RESOLVE -->|/v1/messages etc.| DEFAULT[default policy\nguardPreset: chat\nallowRetry: true\nallowProviderSwitch: true]

    GUARDED --> CB{shouldRecordProvider\nCircuitFailure?}
    DEFAULT --> CB

    CB -->|401,402,403,408,429,451,5xx| RECORD[recordFailure]
    CB -->|400,404,409,413,415,422| SKIP[skip circuit breaker]

    GUARDED --> SESSION{clientSessionId\nprovided?}
    SESSION -->|yes| REUSE[reuse / refresh TTL]
    SESSION -->|no| FRESH[generateSessionId\nfresh opaque session]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/billing-header-rectifier.ts
Line: 22-28

Comment:
**Dead-code branch in `redactBillingHeaderAuditValue`**

Every call site already guards with `BILLING_HEADER_PATTERN.test(...)` before invoking this function, so the `if (!BILLING_HEADER_PATTERN.test(value))` branch can never be reached in practice. The `return value.trim()` path is unreachable dead code. The function could be simplified to:

```suggestion
function redactBillingHeaderAuditValue(): string {
  return REDACTED_BILLING_HEADER_VALUE;
}
```

Or, alternatively, inline `REDACTED_BILLING_HEADER_VALUE` directly at the two call sites and remove the helper altogether. As-is, the function gives the misleading impression that it might return the original value, which could cause confusion during future refactors.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/circuit-breaker-accounting.ts
Line: 1-9

Comment:
**HTTP 403 classification as a provider-side failure**

`403 Forbidden` is included in `PROVIDER_FAILURE_STATUSES`, but 403 is ambiguous in a proxy context: it is often client-driven (e.g., a client API key that lacks permission for the requested resource / model), not a signal that the upstream provider itself is unhealthy. Treating every 403 as a provider circuit failure could trigger unnecessary failovers when many clients send permission-constrained requests.

The PR already correctly excludes clear client-error codes (400, 404, 409, 413, 415, 422), and the same reasoning applies to 403. If the intent is specifically to trip the circuit on upstream key-revocation responses, consider adding a comment explaining the reasoning, or narrow the check to only treat 403 as a provider failure when there is additional context (e.g., an upstream error body) indicating a key-level access denial rather than a scope/permission mismatch.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/lib/utils/sse.ts
Line: 73-85

Comment:
**`parseSSEData` silently drops `id:` and `retry:` fields**

`isSSEText` now correctly recognises responses whose first meaningful line starts with `id:` or `retry:`, which is good. However, `parseSSEData` does not handle these two fields — they fall through the if-else chain and are silently dropped. This matches the HTML SSE spec (these fields affect the connection-level reconnection state, not the event payload), but it is worth a comment to make the intent clear and to prevent a future contributor from treating the omission as a bug:

```suggestion
  const sseFieldPrefixes = ["event:", "data:", "id:", "retry:"];
  // Note: `id:` and `retry:` are valid SSE field prefixes and must be
  // recognised here so isSSEText returns true for responses that begin
  // with them. parseSSEData intentionally does NOT process these fields
  // because they control SSE reconnection state, not event data.
  let start = 0;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix(security): harde..."](https://github.com/ding113/claude-code-hub/commit/0a373518ea7ed59f4ca33e606179231eed118385)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->