### PR TITLE
fix: block fullKey exposure for readonly API key sessions

### DIFF
--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -281,8 +281,10 @@ export async function getUsers(): Promise<UserDisplay[]> {
           allowedModels: user.allowedModels ?? [],
           keys: keys.map((key) => {
             const stats = statisticsLookup.get(key.id);
-            // 用户可以查看和复制自己的密钥，管理员可以查看和复制所有密钥
-            const canUserManageKey = isAdmin || session.user.id === user.id;
+            // 仅允许具备 Web UI 登录权限的会话查看/复制完整密钥，避免只读 Key 通过
+            // allowReadOnlyAccess 进入 actions 后暴露 fullKey。
+            const canUserManageKey =
+              session.key.canLoginWebUi && (isAdmin || session.user.id === user.id);
             return {
               id: key.id,
               name: key.name,

--- a/tests/api/my-usage-readonly.test.ts
+++ b/tests/api/my-usage-readonly.test.ts
@@ -36,6 +36,11 @@ vi.mock("next/headers", () => ({
   }),
 }));
 
+vi.mock("next-intl/server", () => ({
+  getLocale: vi.fn(async () => "en"),
+  getTranslations: vi.fn(async () => (key: string) => key),
+}));
+
 type TestKey = { id: number; userId: number; key: string; name: string };
 type TestUser = { id: number; name: string };
 
@@ -208,9 +213,21 @@ describe("my-usage API：只读 Key 自助查询", () => {
     expect(usersApi.response.status).toBe(200);
     expect(usersApi.json).toMatchObject({ ok: true });
     // 验证只返回自己的数据
-    const usersData = (usersApi.json as { ok: boolean; data: Array<{ id: number }> }).data;
+    const usersData = (
+      usersApi.json as {
+        ok: boolean;
+        data: Array<{
+          id: number;
+          keys: Array<{ id: number; maskedKey: string; fullKey?: string; canCopy: boolean }>;
+        }>;
+      }
+    ).data;
     expect(usersData.length).toBe(1);
     expect(usersData[0].id).toBe(user.id);
+    expect(usersData[0].keys).toHaveLength(1);
+    expect(usersData[0].keys[0].maskedKey).toBeTruthy();
+    expect(usersData[0].keys[0].fullKey).toBeUndefined();
+    expect(usersData[0].keys[0].canCopy).toBe(false);
 
     const usageLogsApi = await callActionsRoute({
       method: "POST",


### PR DESCRIPTION
## Summary
- prevent `getUsers` from returning `fullKey`/`canCopy` when the calling session key has `canLoginWebUi=false`
- keep `allowReadOnlyAccess` endpoint availability intact while reducing sensitive data exposure
- add regression assertions in readonly API tests to ensure `maskedKey` remains visible but `fullKey` is never returned for readonly sessions
- add a local `next-intl/server` mock in the readonly API test to keep the action path stable under Vitest

## Verification
- `bun run build`
- `bun run lint` (passes with existing repo warnings)
- `bun run lint:fix` (no auto-fixes applied; existing repo warnings remain)
- `bun run typecheck`
- `bun run test`
- `bunx vitest run --config tests/configs/my-usage.config.ts tests/api/my-usage-readonly.test.ts tests/integration/auth.test.ts`

## Security Impact
This closes the path where read-only/API-only keys could call `/api/actions/users/getUsers` and exfiltrate raw API key values via `fullKey`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a data-exposure path where read-only/API-only keys (those with `canLoginWebUi = false`) could call `getUsers` and receive raw `fullKey` values in the response. The fix is a single-line guard in the key-mapping loop of `getUsers`, and a companion test adds regression assertions plus a `next-intl/server` mock to keep the Vitest action path stable.

**Key changes:**
- `src/actions/users.ts` — prepends `session.key.canLoginWebUi &&` to the `canUserManageKey` condition, so `fullKey` and `canCopy` are only populated when the calling session holds a Web-UI-capable key. Because `canLoginWebUi` is typed `boolean` (non-nullable, DB-defaults to `false`) and admin sessions via `ADMIN_TOKEN` already hardcode `canLoginWebUi: true`, there is no regression risk for standard flows.
- `tests/api/my-usage-readonly.test.ts` — adds a `vi.mock("next-intl/server", ...)` stub, and extends the cookie-based readonly test with explicit assertions that `maskedKey` is present, `fullKey` is `undefined`, and `canCopy` is `false`. The Bearer-only test makes the same `getUsers` call but currently lacks the same assertions (see inline comment).
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — the fix is minimal, correctly typed, and has no impact on normal Web-UI or admin flows.
- The implementation change is a single boolean short-circuit on a non-nullable field. Admin sessions (ADMIN_TOKEN) are hardcoded with canLoginWebUi: true, normal Web-UI keys remain unaffected, and the existing test suite now covers the primary cookie-based readonly path. The only open item is a P2 suggestion to mirror those assertions in the Bearer-only test path, which does not block merge.
- No files require special attention; the Bearer-only test path (lines 280-293 of the test file) could benefit from additional key-field assertions but is not a blocker.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/actions/users.ts | Security fix: gates fullKey/canCopy on session.key.canLoginWebUi before checking isAdmin or ownership; canLoginWebUi is typed as a non-nullable boolean and defaults to false in the DB schema, so no falsy-coercion risk. Admin sessions via ADMIN_TOKEN hardcode canLoginWebUi: true and are unaffected. |
| tests/api/my-usage-readonly.test.ts | Adds next-intl/server mock (needed to keep the action path stable under Vitest) and extends the first readonly-key test with maskedKey/fullKey/canCopy regression assertions. The Bearer-only test (second test) performs the same getUsers call but omits the new key-field assertions, leaving a minor coverage gap. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[API Client calls getUsers] --> B[Adapter: allowReadOnlyAccess=true]
    B --> C{Session valid?}
    C -- No --> D[Return 401]
    C -- Yes --> E[getUsers action runs]
    E --> F{session.key.canLoginWebUi?}
    F -- true --> G{isAdmin OR owns user?}
    F -- false --> H[canUserManageKey = false]
    G -- yes --> I[canUserManageKey = true]
    G -- no --> H
    I --> J[Return fullKey + canCopy=true]
    H --> K[Return maskedKey only, canCopy=false]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/api/my-usage-readonly.test.ts`, line 280-293 ([link](https://github.com/ding113/claude-code-hub/blob/b653e122250773f31371de84ba5bc051294fb779/tests/api/my-usage-readonly.test.ts#L280-L293)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing fullKey/canCopy assertions in Bearer-only test**

   The first test ("只读 Key：允许访问 my-usage 端点和其他 allowReadOnlyAccess 端点") now asserts `fullKey` is `undefined` and `canCopy` is `false` for readonly sessions. However, the "Bearer-only" test at lines 281-292 queries the same `getUsers` endpoint but only checks `usersData.length` and `usersData[0].id` — it skips the `maskedKey`/`fullKey`/`canCopy` assertions entirely.

   Since the Bearer auth path goes through the same action handler and the same `session.key.canLoginWebUi` gate, the fix should protect both paths identically. Adding equivalent assertions here would give end-to-end confidence that the security fix holds regardless of how the session is authenticated.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/api/my-usage-readonly.test.ts
   Line: 280-293

   Comment:
   **Missing fullKey/canCopy assertions in Bearer-only test**

   The first test ("只读 Key：允许访问 my-usage 端点和其他 allowReadOnlyAccess 端点") now asserts `fullKey` is `undefined` and `canCopy` is `false` for readonly sessions. However, the "Bearer-only" test at lines 281-292 queries the same `getUsers` endpoint but only checks `usersData.length` and `usersData[0].id` — it skips the `maskedKey`/`fullKey`/`canCopy` assertions entirely.

   Since the Bearer auth path goes through the same action handler and the same `session.key.canLoginWebUi` gate, the fix should protect both paths identically. Adding equivalent assertions here would give end-to-end confidence that the security fix holds regardless of how the session is authenticated.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/api/my-usage-readonly.test.ts
Line: 280-293

Comment:
**Missing fullKey/canCopy assertions in Bearer-only test**

The first test ("只读 Key：允许访问 my-usage 端点和其他 allowReadOnlyAccess 端点") now asserts `fullKey` is `undefined` and `canCopy` is `false` for readonly sessions. However, the "Bearer-only" test at lines 281-292 queries the same `getUsers` endpoint but only checks `usersData.length` and `usersData[0].id` — it skips the `maskedKey`/`fullKey`/`canCopy` assertions entirely.

Since the Bearer auth path goes through the same action handler and the same `session.key.canLoginWebUi` gate, the fix should protect both paths identically. Adding equivalent assertions here would give end-to-end confidence that the security fix holds regardless of how the session is authenticated.

```suggestion
    // 验证只返回自己的数据
    const usersData = (
      usersApi.json as {
        ok: boolean;
        data: Array<{
          id: number;
          keys: Array<{ id: number; maskedKey: string; fullKey?: string; canCopy: boolean }>;
        }>;
      }
    ).data;
    expect(usersData.length).toBe(1);
    expect(usersData[0].id).toBe(user.id);
    expect(usersData[0].keys).toHaveLength(1);
    expect(usersData[0].keys[0].maskedKey).toBeTruthy();
    expect(usersData[0].keys[0].fullKey).toBeUndefined();
    expect(usersData[0].keys[0].canCopy).toBe(false);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): prevent readonly key sess..."](https://github.com/ding113/claude-code-hub/commit/b653e122250773f31371de84ba5bc051294fb779) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25963917)</sub>

<!-- /greptile_comment -->