### PR TITLE
fix: harden usage logs csv export

### DIFF
--- a/messages/en/dashboard.json
+++ b/messages/en/dashboard.json
@@ -95,6 +95,8 @@
       "exporting": "Exporting...",
       "exportSuccess": "Export completed successfully",
       "exportError": "Export failed",
+      "exportPreparing": "Preparing export...",
+      "exportProgress": "Exported {current} / {total}",
       "quickFilters": {
         "today": "Today",
         "thisWeek": "This Week",

--- a/messages/ja/dashboard.json
+++ b/messages/ja/dashboard.json
@@ -95,6 +95,8 @@
       "exporting": "エクスポート中...",
       "exportSuccess": "エクスポートが完了しました",
       "exportError": "エクスポートに失敗しました",
+      "exportPreparing": "エクスポートを準備中...",
+      "exportProgress": "{current} / {total} 件をエクスポート済み",
       "quickFilters": {
         "today": "今日",
         "thisWeek": "今週",

--- a/messages/ru/dashboard.json
+++ b/messages/ru/dashboard.json
@@ -95,6 +95,8 @@
       "exporting": "Экспорт...",
       "exportSuccess": "Экспорт завершен",
       "exportError": "Ошибка экспорта",
+      "exportPreparing": "Подготовка экспорта...",
+      "exportProgress": "Экспортировано {current} / {total}",
       "quickFilters": {
         "today": "Сегодня",
         "thisWeek": "Эта неделя",

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -95,6 +95,8 @@
       "exporting": "导出中...",
       "exportSuccess": "导出成功",
       "exportError": "导出失败",
+      "exportPreparing": "正在准备导出...",
+      "exportProgress": "已导出 {current} / {total} 条",
       "quickFilters": {
         "today": "今天",
         "thisWeek": "本周",

--- a/messages/zh-TW/dashboard.json
+++ b/messages/zh-TW/dashboard.json
@@ -95,6 +95,8 @@
       "exporting": "匯出中...",
       "exportSuccess": "匯出成功",
       "exportError": "匯出失敗",
+      "exportPreparing": "正在準備匯出...",
+      "exportProgress": "已匯出 {current} / {total} 筆",
       "quickFilters": {
         "today": "今天",
         "thisWeek": "本週",

--- a/src/actions/usage-logs.ts
+++ b/src/actions/usage-logs.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/constants/usage-logs.constants";
 import { logger } from "@/lib/logger";
 import { readLiveChainBatch } from "@/lib/redis/live-chain-store";
+import { RedisKVStore } from "@/lib/redis/redis-kv-store";
 import { getRetryCount } from "@/lib/utils/provider-chain-formatter";
 import { isProviderFinalized } from "@/lib/utils/provider-display";
 import {
@@ -38,6 +39,235 @@ let filterOptionsCache: {
   endpoints: string[];
   expiresAt: number;
 } | null = null;
+
+const USAGE_LOGS_EXPORT_BATCH_SIZE = 500;
+const USAGE_LOGS_EXPORT_JOB_TTL_MS = 15 * 60 * 1000;
+const USAGE_LOGS_EXPORT_JOB_TTL_SECONDS = Math.floor(USAGE_LOGS_EXPORT_JOB_TTL_MS / 1000);
+const CSV_HEADERS = [
+  "Time",
+  "User",
+  "Key",
+  "Provider",
+  "Model",
+  "Original Model",
+  "Endpoint",
+  "Status Code",
+  "Input Tokens",
+  "Output Tokens",
+  "Cache Write 5m",
+  "Cache Write 1h",
+  "Cache Read",
+  "Total Tokens",
+  "Cost (USD)",
+  "Duration (ms)",
+  "Session ID",
+  "Retry Count",
+] as const;
+
+type UsageLogsSession = NonNullable<Awaited<ReturnType<typeof getSession>>>;
+
+export interface UsageLogsExportStatus {
+  jobId: string;
+  status: "queued" | "running" | "completed" | "failed";
+  processedRows: number;
+  totalRows: number;
+  progressPercent: number;
+  error?: string;
+}
+
+interface UsageLogsExportJobRecord extends UsageLogsExportStatus {
+  ownerUserId: number;
+}
+
+const usageLogsExportStatusStore = new RedisKVStore<UsageLogsExportJobRecord>({
+  prefix: "cch:usage-logs:export:status:",
+  defaultTtlSeconds: USAGE_LOGS_EXPORT_JOB_TTL_SECONDS,
+});
+
+const usageLogsExportCsvStore = new RedisKVStore<string>({
+  prefix: "cch:usage-logs:export:csv:",
+  defaultTtlSeconds: USAGE_LOGS_EXPORT_JOB_TTL_SECONDS,
+});
+
+function usageLogsExportCsvKey(jobId: string): string {
+  return `${jobId}:csv`;
+}
+
+function resolveUsageLogFiltersForSession(
+  session: UsageLogsSession,
+  filters: Omit<UsageLogFilters, "userId" | "page" | "pageSize">
+): Omit<UsageLogFilters, "page" | "pageSize"> {
+  return session.user.role === "admin" ? filters : { ...filters, userId: session.user.id };
+}
+
+function toUsageLogsExportStatus(job: UsageLogsExportJobRecord): UsageLogsExportStatus {
+  return {
+    jobId: job.jobId,
+    status: job.status,
+    processedRows: job.processedRows,
+    totalRows: job.totalRows,
+    progressPercent: job.progressPercent,
+    error: job.error,
+  };
+}
+
+function getUsageLogsExportJob(
+  session: UsageLogsSession,
+  job: UsageLogsExportJobRecord | null,
+  _jobId: string
+): UsageLogsExportJobRecord | null {
+  if (!job || job.ownerUserId !== session.user.id) {
+    return null;
+  }
+  return job;
+}
+
+function buildCsvRows(logs: UsageLogRow[]): string[] {
+  return logs.map((log) => {
+    const retryCount = log.providerChain ? getRetryCount(log.providerChain) : 0;
+    return [
+      log.createdAt ? new Date(log.createdAt).toISOString() : "",
+      escapeCsvField(log.userName),
+      escapeCsvField(log.keyName),
+      escapeCsvField(log.providerName ?? ""),
+      escapeCsvField(log.model ?? ""),
+      escapeCsvField(log.originalModel ?? ""),
+      escapeCsvField(log.endpoint ?? ""),
+      log.statusCode?.toString() ?? "",
+      log.inputTokens?.toString() ?? "0",
+      log.outputTokens?.toString() ?? "0",
+      log.cacheCreation5mInputTokens?.toString() ?? "0",
+      log.cacheCreation1hInputTokens?.toString() ?? "0",
+      log.cacheReadInputTokens?.toString() ?? "0",
+      log.totalTokens.toString(),
+      log.costUsd ?? "0",
+      log.durationMs?.toString() ?? "",
+      escapeCsvField(log.sessionId ?? ""),
+      retryCount.toString(),
+    ].join(",");
+  });
+}
+
+function buildUsageLogsExportProgress(
+  processedRows: number,
+  totalRows: number,
+  hasMore: boolean
+): Pick<UsageLogsExportStatus, "processedRows" | "totalRows" | "progressPercent"> {
+  const effectiveTotalRows = Math.max(totalRows, hasMore ? processedRows + 1 : processedRows);
+  const progressPercent =
+    effectiveTotalRows <= 0
+      ? 100
+      : hasMore
+        ? Math.min(99, Math.floor((processedRows / effectiveTotalRows) * 100))
+        : 100;
+
+  return {
+    processedRows,
+    totalRows: effectiveTotalRows,
+    progressPercent,
+  };
+}
+
+async function buildUsageLogsExportCsv(
+  filters: Omit<UsageLogFilters, "page" | "pageSize">,
+  onProgress?: (
+    progress: Pick<UsageLogsExportStatus, "processedRows" | "totalRows" | "progressPercent">
+  ) => Promise<void> | void
+): Promise<string> {
+  const initialResult = await findUsageLogsWithDetails({ ...filters, page: 1, pageSize: 1 });
+  let estimatedTotalRows = initialResult.total;
+
+  if (estimatedTotalRows === 0) {
+    const stats = await findUsageLogsStats(filters);
+    estimatedTotalRows = stats.totalRequests;
+  }
+
+  const csvLines = [CSV_HEADERS.join(",")];
+  let cursor: UsageLogBatchFilters["cursor"] | undefined;
+  let processedRows = 0;
+
+  while (true) {
+    const batch = await findUsageLogsBatch({
+      ...filters,
+      cursor,
+      limit: USAGE_LOGS_EXPORT_BATCH_SIZE,
+    });
+
+    if (batch.logs.length > 0) {
+      csvLines.push(...buildCsvRows(batch.logs));
+      processedRows += batch.logs.length;
+    }
+
+    const progress = buildUsageLogsExportProgress(processedRows, estimatedTotalRows, batch.hasMore);
+    estimatedTotalRows = progress.totalRows;
+    await onProgress?.(progress);
+
+    if (!batch.hasMore || !batch.nextCursor) {
+      break;
+    }
+
+    cursor = batch.nextCursor;
+  }
+
+  return `\uFEFF${csvLines.join("\n")}`;
+}
+
+async function runUsageLogsExportJob(
+  jobId: string,
+  filters: Omit<UsageLogFilters, "page" | "pageSize">
+): Promise<void> {
+  const existingJob = await usageLogsExportStatusStore.get(jobId);
+  if (!existingJob) {
+    return;
+  }
+
+  await usageLogsExportStatusStore.set(jobId, {
+    ...existingJob,
+    status: "running",
+    error: undefined,
+  });
+
+  try {
+    const csv = await buildUsageLogsExportCsv(filters, async (progress) => {
+      const currentJob = await usageLogsExportStatusStore.get(jobId);
+      if (!currentJob) {
+        return;
+      }
+
+      await usageLogsExportStatusStore.set(jobId, {
+        ...currentJob,
+        status: "running",
+        ...progress,
+      });
+    });
+
+    const currentJob = await usageLogsExportStatusStore.get(jobId);
+    if (!currentJob) {
+      return;
+    }
+
+    await usageLogsExportCsvStore.set(usageLogsExportCsvKey(jobId), csv);
+    await usageLogsExportStatusStore.set(jobId, {
+      ...currentJob,
+      status: "completed",
+      progressPercent: 100,
+      error: undefined,
+    });
+  } catch (error) {
+    logger.error("生成使用日志导出任务失败:", error);
+    const currentJob = await usageLogsExportStatusStore.get(jobId);
+    if (!currentJob) {
+      return;
+    }
+
+    await usageLogsExportStatusStore.set(jobId, {
+      ...currentJob,
+      status: "failed",
+      progressPercent: 0,
+      error: error instanceof Error ? error.message : "导出使用日志失败",
+    });
+  }
+}
 
 /**
  * 获取使用日志（根据权限过滤）
@@ -77,16 +307,8 @@ export async function exportUsageLogs(
       return { ok: false, error: "未登录" };
     }
 
-    // 如果不是 admin，强制过滤为当前用户
-    const finalFilters: UsageLogFilters =
-      session.user.role === "admin"
-        ? { ...filters, page: 1, pageSize: 10000 }
-        : { ...filters, userId: session.user.id, page: 1, pageSize: 10000 };
-
-    const result = await findUsageLogsWithDetails(finalFilters);
-
-    // 生成 CSV
-    const csv = generateCsv(result.logs);
+    const finalFilters = resolveUsageLogFiltersForSession(session, filters);
+    const csv = await buildUsageLogsExportCsv(finalFilters);
 
     return { ok: true, data: csv };
   } catch (error) {
@@ -96,74 +318,115 @@ export async function exportUsageLogs(
   }
 }
 
-/**
- * 生成 CSV 字符串
- */
-function generateCsv(logs: UsageLogRow[]): string {
-  const headers = [
-    "Time",
-    "User",
-    "Key",
-    "Provider",
-    "Model",
-    "Original Model",
-    "Endpoint",
-    "Status Code",
-    "Input Tokens",
-    "Output Tokens",
-    "Cache Write 5m",
-    "Cache Write 1h",
-    "Cache Read",
-    "Total Tokens",
-    "Cost (USD)",
-    "Duration (ms)",
-    "Session ID",
-    "Retry Count",
-  ];
+export async function startUsageLogsExport(
+  filters: Omit<UsageLogFilters, "userId" | "page" | "pageSize">
+): Promise<ActionResult<{ jobId: string }>> {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return { ok: false, error: "未登录" };
+    }
 
-  const rows = logs.map((log) => {
-    const retryCount = log.providerChain ? getRetryCount(log.providerChain) : 0;
-    return [
-      log.createdAt ? new Date(log.createdAt).toISOString() : "",
-      escapeCsvField(log.userName),
-      escapeCsvField(log.keyName),
-      escapeCsvField(log.providerName ?? ""),
-      escapeCsvField(log.model ?? ""),
-      escapeCsvField(log.originalModel ?? ""),
-      escapeCsvField(log.endpoint ?? ""),
-      log.statusCode?.toString() ?? "",
-      log.inputTokens?.toString() ?? "0",
-      log.outputTokens?.toString() ?? "0",
-      log.cacheCreation5mInputTokens?.toString() ?? "0",
-      log.cacheCreation1hInputTokens?.toString() ?? "0",
-      log.cacheReadInputTokens?.toString() ?? "0",
-      log.totalTokens.toString(),
-      log.costUsd ?? "0",
-      log.durationMs?.toString() ?? "",
-      escapeCsvField(log.sessionId ?? ""),
-      retryCount.toString(),
-    ];
-  });
+    const jobId = crypto.randomUUID();
+    const finalFilters = resolveUsageLogFiltersForSession(session, filters);
 
-  // 添加 BOM 以支持 Excel 正确识别 UTF-8
-  const bom = "\uFEFF";
-  const csvContent = [headers.join(","), ...rows.map((row) => row.join(","))].join("\n");
+    const stored = await usageLogsExportStatusStore.set(jobId, {
+      jobId,
+      ownerUserId: session.user.id,
+      status: "queued",
+      processedRows: 0,
+      totalRows: 0,
+      progressPercent: 0,
+    });
 
-  return bom + csvContent;
+    if (!stored) {
+      return { ok: false, error: "导出任务初始化失败" };
+    }
+
+    setTimeout(() => {
+      void runUsageLogsExportJob(jobId, finalFilters);
+    }, 0);
+
+    return { ok: true, data: { jobId } };
+  } catch (error) {
+    logger.error("启动使用日志导出任务失败:", error);
+    const message = error instanceof Error ? error.message : "启动导出任务失败";
+    return { ok: false, error: message };
+  }
+}
+
+export async function getUsageLogsExportStatus(
+  jobId: string
+): Promise<ActionResult<UsageLogsExportStatus>> {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return { ok: false, error: "未登录" };
+    }
+
+    const job = getUsageLogsExportJob(session, await usageLogsExportStatusStore.get(jobId), jobId);
+    if (!job) {
+      return { ok: false, error: "导出任务不存在或已过期" };
+    }
+
+    return { ok: true, data: toUsageLogsExportStatus(job) };
+  } catch (error) {
+    logger.error("获取使用日志导出进度失败:", error);
+    const message = error instanceof Error ? error.message : "获取导出进度失败";
+    return { ok: false, error: message };
+  }
+}
+
+export async function downloadUsageLogsExport(jobId: string): Promise<ActionResult<string>> {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return { ok: false, error: "未登录" };
+    }
+
+    const job = getUsageLogsExportJob(session, await usageLogsExportStatusStore.get(jobId), jobId);
+    if (!job) {
+      return { ok: false, error: "导出任务不存在或已过期" };
+    }
+
+    if (job.status === "failed") {
+      return { ok: false, error: job.error || "导出使用日志失败" };
+    }
+
+    if (job.status !== "completed") {
+      return { ok: false, error: "导出尚未完成" };
+    }
+
+    const csv = await usageLogsExportCsvStore.get(usageLogsExportCsvKey(jobId));
+    if (!csv) {
+      return { ok: false, error: "导出文件不存在或已过期" };
+    }
+
+    return { ok: true, data: csv };
+  } catch (error) {
+    logger.error("下载使用日志导出文件失败:", error);
+    const message = error instanceof Error ? error.message : "下载导出文件失败";
+    return { ok: false, error: message };
+  }
 }
 
 /**
  * 转义 CSV 字段（防止 CSV 公式注入攻击）
  */
 function escapeCsvField(field: string): string {
-  // Prevent CSV formula injection by prefixing dangerous characters
-  const dangerousChars = ["=", "+", "-", "@", "\t", "\r"];
+  const dangerousChars = ["=", "+", "-", "@"];
+  const trimmedField = field.trimStart();
   let safeField = field;
-  if (dangerousChars.some((char) => field.startsWith(char))) {
-    safeField = `'${field}`; // Prefix with single quote to prevent formula execution
+  if (trimmedField && dangerousChars.some((char) => trimmedField.startsWith(char))) {
+    safeField = `'${field}`;
   }
 
-  if (safeField.includes(",") || safeField.includes('"') || safeField.includes("\n")) {
+  if (
+    safeField.includes(",") ||
+    safeField.includes('"') ||
+    safeField.includes("\n") ||
+    safeField.includes("\r")
+  ) {
     return `"${safeField.replace(/"/g, '""')}"`;
   }
   return safeField;

--- a/src/actions/usage-logs.ts
+++ b/src/actions/usage-logs.ts
@@ -246,7 +246,17 @@ async function runUsageLogsExportJob(
       return;
     }
 
-    await usageLogsExportCsvStore.set(usageLogsExportCsvKey(jobId), csv);
+    const csvStored = await usageLogsExportCsvStore.set(usageLogsExportCsvKey(jobId), csv);
+    if (!csvStored) {
+      await usageLogsExportStatusStore.set(jobId, {
+        ...currentJob,
+        status: "failed",
+        progressPercent: 0,
+        error: "Failed to persist CSV to Redis",
+      });
+      return;
+    }
+
     await usageLogsExportStatusStore.set(jobId, {
       ...currentJob,
       status: "completed",
@@ -254,7 +264,7 @@ async function runUsageLogsExportJob(
       error: undefined,
     });
   } catch (error) {
-    logger.error("生成使用日志导出任务失败:", error);
+    logger.error("Failed to run usage logs export job:", error);
     const currentJob = await usageLogsExportStatusStore.get(jobId);
     if (!currentJob) {
       return;
@@ -264,7 +274,7 @@ async function runUsageLogsExportJob(
       ...currentJob,
       status: "failed",
       progressPercent: 0,
-      error: error instanceof Error ? error.message : "导出使用日志失败",
+      error: error instanceof Error ? error.message : "Export failed",
     });
   }
 }
@@ -340,17 +350,19 @@ export async function startUsageLogsExport(
     });
 
     if (!stored) {
-      return { ok: false, error: "导出任务初始化失败" };
+      return { ok: false, error: "Export job initialization failed" };
     }
 
+    // Defer to next tick so the action returns the jobId immediately.
+    // Safe for self-hosted Bun server (long-lived process); NOT suitable for serverless.
     setTimeout(() => {
       void runUsageLogsExportJob(jobId, finalFilters);
     }, 0);
 
     return { ok: true, data: { jobId } };
   } catch (error) {
-    logger.error("启动使用日志导出任务失败:", error);
-    const message = error instanceof Error ? error.message : "启动导出任务失败";
+    logger.error("Failed to start usage logs export:", error);
+    const message = error instanceof Error ? error.message : "Failed to start export";
     return { ok: false, error: message };
   }
 }
@@ -366,13 +378,13 @@ export async function getUsageLogsExportStatus(
 
     const job = getUsageLogsExportJob(session, await usageLogsExportStatusStore.get(jobId), jobId);
     if (!job) {
-      return { ok: false, error: "导出任务不存在或已过期" };
+      return { ok: false, error: "Export job not found or expired" };
     }
 
     return { ok: true, data: toUsageLogsExportStatus(job) };
   } catch (error) {
-    logger.error("获取使用日志导出进度失败:", error);
-    const message = error instanceof Error ? error.message : "获取导出进度失败";
+    logger.error("Failed to get usage logs export status:", error);
+    const message = error instanceof Error ? error.message : "Failed to get export status";
     return { ok: false, error: message };
   }
 }
@@ -386,26 +398,26 @@ export async function downloadUsageLogsExport(jobId: string): Promise<ActionResu
 
     const job = getUsageLogsExportJob(session, await usageLogsExportStatusStore.get(jobId), jobId);
     if (!job) {
-      return { ok: false, error: "导出任务不存在或已过期" };
+      return { ok: false, error: "Export job not found or expired" };
     }
 
     if (job.status === "failed") {
-      return { ok: false, error: job.error || "导出使用日志失败" };
+      return { ok: false, error: job.error || "Export failed" };
     }
 
     if (job.status !== "completed") {
-      return { ok: false, error: "导出尚未完成" };
+      return { ok: false, error: "Export not yet completed" };
     }
 
     const csv = await usageLogsExportCsvStore.get(usageLogsExportCsvKey(jobId));
     if (!csv) {
-      return { ok: false, error: "导出文件不存在或已过期" };
+      return { ok: false, error: "Export file not found or expired" };
     }
 
     return { ok: true, data: csv };
   } catch (error) {
-    logger.error("下载使用日志导出文件失败:", error);
-    const message = error instanceof Error ? error.message : "下载导出文件失败";
+    logger.error("Failed to download usage logs export:", error);
+    const message = error instanceof Error ? error.message : "Failed to download export";
     return { ok: false, error: message };
   }
 }

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
@@ -203,9 +203,17 @@ export function UsageLogsFilters({
       }
 
       const jobId = startResult.data.jobId;
+      const EXPORT_TIMEOUT_MS = 5 * 60 * 1000;
+      const deadline = Date.now() + EXPORT_TIMEOUT_MS;
 
       while (true) {
         if (exportRunIdRef.current !== runId) {
+          return;
+        }
+
+        if (Date.now() > deadline) {
+          setExportStatus(null);
+          toast.error(t("logs.filters.exportError"));
           return;
         }
 

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
@@ -3,10 +3,16 @@
 import { format, startOfDay, startOfWeek } from "date-fns";
 import { Clock, Download, Network, Server, User } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { exportUsageLogs } from "@/actions/usage-logs";
+import {
+  downloadUsageLogsExport,
+  getUsageLogsExportStatus,
+  startUsageLogsExport,
+  type UsageLogsExportStatus,
+} from "@/actions/usage-logs";
 import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
 import type { Key } from "@/types/key";
 import type { ProviderDisplay } from "@/types/provider";
 import { ActiveFiltersDisplay } from "./filters/active-filters-display";
@@ -70,7 +76,9 @@ export function UsageLogsFilters({
 
   const [localFilters, setLocalFilters] = useState<UsageLogFilters>(filters);
   const [isExporting, setIsExporting] = useState(false);
+  const [exportStatus, setExportStatus] = useState<UsageLogsExportStatus | null>(null);
   const [activePreset, setActivePreset] = useState<FilterPreset | null>(null);
+  const exportRunIdRef = useRef(0);
 
   // Track users and keys for display name resolution
   const [availableUsers, setAvailableUsers] = useState<Array<{ id: number; name: string }>>([]);
@@ -133,42 +141,120 @@ export function UsageLogsFilters({
     return count;
   }, [localFilters.statusCode, localFilters.excludeStatusCode200, localFilters.minRetryCount]);
 
+  useEffect(() => {
+    setLocalFilters(filters);
+  }, [filters]);
+
+  useEffect(() => {
+    return () => {
+      exportRunIdRef.current += 1;
+    };
+  }, []);
+
   const handleApply = useCallback(() => {
     onChange(sanitizeFilters(localFilters));
   }, [localFilters, onChange]);
 
   const handleReset = useCallback(() => {
+    exportRunIdRef.current += 1;
     setLocalFilters({});
     setKeys([]);
     setActivePreset(null);
+    setIsExporting(false);
+    setExportStatus(null);
     onReset();
   }, [onReset]);
 
+  const downloadCsv = useCallback((csv: string) => {
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `usage-logs-${format(new Date(), "yyyy-MM-dd-HHmmss")}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    window.URL.revokeObjectURL(url);
+  }, []);
+
   const handleExport = async () => {
+    const runId = exportRunIdRef.current + 1;
+    exportRunIdRef.current = runId;
     setIsExporting(true);
+    setExportStatus({
+      jobId: "",
+      status: "queued",
+      processedRows: 0,
+      totalRows: 0,
+      progressPercent: 0,
+    });
+
     try {
-      const result = await exportUsageLogs(localFilters);
-      if (!result.ok) {
-        toast.error(result.error || t("logs.filters.exportError"));
+      const exportFilters = sanitizeFilters(filters);
+      const startResult = await startUsageLogsExport(exportFilters);
+      if (exportRunIdRef.current !== runId) {
         return;
       }
 
-      const blob = new Blob([result.data], { type: "text/csv;charset=utf-8;" });
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `usage-logs-${format(new Date(), "yyyy-MM-dd-HHmmss")}.csv`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      window.URL.revokeObjectURL(url);
+      if (!startResult.ok) {
+        setExportStatus(null);
+        toast.error(startResult.error || t("logs.filters.exportError"));
+        return;
+      }
+
+      const jobId = startResult.data.jobId;
+
+      while (true) {
+        if (exportRunIdRef.current !== runId) {
+          return;
+        }
+
+        const statusResult = await getUsageLogsExportStatus(jobId);
+        if (exportRunIdRef.current !== runId) {
+          return;
+        }
+
+        if (!statusResult.ok) {
+          setExportStatus(null);
+          toast.error(statusResult.error || t("logs.filters.exportError"));
+          return;
+        }
+
+        setExportStatus(statusResult.data);
+
+        if (statusResult.data.status === "failed") {
+          toast.error(statusResult.data.error || t("logs.filters.exportError"));
+          return;
+        }
+
+        if (statusResult.data.status === "completed") {
+          break;
+        }
+
+        await new Promise((resolve) => window.setTimeout(resolve, 800));
+      }
+
+      const downloadResult = await downloadUsageLogsExport(jobId);
+      if (exportRunIdRef.current !== runId) {
+        return;
+      }
+
+      if (!downloadResult.ok) {
+        toast.error(downloadResult.error || t("logs.filters.exportError"));
+        return;
+      }
+
+      downloadCsv(downloadResult.data);
 
       toast.success(t("logs.filters.exportSuccess"));
     } catch (error) {
       console.error("Export failed:", error);
       toast.error(t("logs.filters.exportError"));
     } finally {
-      setIsExporting(false);
+      if (exportRunIdRef.current === runId) {
+        setExportStatus(null);
+        setIsExporting(false);
+      }
     }
   };
 
@@ -326,6 +412,22 @@ export function UsageLogsFilters({
           <Download className="mr-2 h-4 w-4" aria-hidden="true" />
           {isExporting ? t("logs.filters.exporting") : t("logs.filters.export")}
         </Button>
+        {isExporting && exportStatus ? (
+          <div className="min-w-[220px] flex-1 space-y-1 rounded-md border border-border/60 bg-muted/30 p-3">
+            <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+              <span>
+                {exportStatus.totalRows > 0
+                  ? t("logs.filters.exportProgress", {
+                      current: exportStatus.processedRows,
+                      total: exportStatus.totalRows,
+                    })
+                  : t("logs.filters.exportPreparing")}
+              </span>
+              <span>{exportStatus.progressPercent}%</span>
+            </div>
+            <Progress value={Math.max(exportStatus.progressPercent, 2)} />
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
@@ -203,7 +203,7 @@ export function UsageLogsFilters({
       }
 
       const jobId = startResult.data.jobId;
-      const EXPORT_TIMEOUT_MS = 5 * 60 * 1000;
+      const EXPORT_TIMEOUT_MS = 10 * 60 * 1000;
       const deadline = Date.now() + EXPORT_TIMEOUT_MS;
 
       while (true) {

--- a/tests/unit/actions/usage-logs-export-retry-count.test.ts
+++ b/tests/unit/actions/usage-logs-export-retry-count.test.ts
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const getSessionMock = vi.fn();
 const findUsageLogsWithDetailsMock = vi.fn();
+const findUsageLogsBatchMock = vi.fn();
+const findUsageLogsStatsMock = vi.fn();
+const exportStatusStore = new Map<string, unknown>();
+const exportCsvStore = new Map<string, string>();
 
 vi.mock("@/lib/auth", () => {
   return {
@@ -9,27 +13,99 @@ vi.mock("@/lib/auth", () => {
   };
 });
 
+vi.mock("@/lib/redis/redis-kv-store", () => ({
+  RedisKVStore: class MockRedisKVStore<T> {
+    private readonly prefix: string;
+
+    constructor(options: { prefix: string }) {
+      this.prefix = options.prefix;
+    }
+
+    async set(key: string, value: T) {
+      if (this.prefix.includes(":status:")) {
+        exportStatusStore.set(key, value);
+      } else {
+        exportCsvStore.set(key, value as string);
+      }
+      return true;
+    }
+
+    async get(key: string) {
+      if (this.prefix.includes(":status:")) {
+        return (exportStatusStore.get(key) as T | undefined) ?? null;
+      }
+      return ((exportCsvStore.get(key) as T | undefined) ?? null) as T | null;
+    }
+
+    async getAndDelete(key: string) {
+      if (this.prefix.includes(":status:")) {
+        const value = (exportStatusStore.get(key) as T | undefined) ?? null;
+        exportStatusStore.delete(key);
+        return value;
+      }
+      const value = ((exportCsvStore.get(key) as T | undefined) ?? null) as T | null;
+      exportCsvStore.delete(key);
+      return value;
+    }
+
+    async delete(key: string) {
+      if (this.prefix.includes(":status:")) {
+        return exportStatusStore.delete(key);
+      }
+      return exportCsvStore.delete(key);
+    }
+  },
+}));
+
 vi.mock("@/repository/usage-logs", () => {
   return {
     findUsageLogSessionIdSuggestions: vi.fn(async () => []),
-    findUsageLogsBatch: vi.fn(async () => ({ logs: [], nextCursor: null, hasMore: false })),
-    findUsageLogsStats: vi.fn(async () => ({
-      totalRequests: 0,
-      totalCost: 0,
-      totalTokens: 0,
-      totalInputTokens: 0,
-      totalOutputTokens: 0,
-      totalCacheCreationTokens: 0,
-      totalCacheReadTokens: 0,
-      totalCacheCreation5mTokens: 0,
-      totalCacheCreation1hTokens: 0,
-    })),
+    findUsageLogsBatch: findUsageLogsBatchMock,
+    findUsageLogsStats: findUsageLogsStatsMock,
     findUsageLogsWithDetails: findUsageLogsWithDetailsMock,
     getUsedEndpoints: vi.fn(async () => []),
     getUsedModels: vi.fn(async () => []),
     getUsedStatusCodes: vi.fn(async () => []),
   };
 });
+
+function createSummary(totalRequests = 0) {
+  return {
+    totalRequests,
+    totalCost: 0,
+    totalTokens: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheCreationTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheCreation5mTokens: 0,
+    totalCacheCreation1hTokens: 0,
+  };
+}
+
+function createLog(overrides: Record<string, unknown> = {}) {
+  return {
+    createdAt: new Date("2026-03-16T00:00:00.000Z"),
+    userName: "u",
+    keyName: "k",
+    providerName: "p",
+    model: "m",
+    originalModel: "om",
+    endpoint: "/v1/messages",
+    statusCode: 200,
+    inputTokens: 1,
+    outputTokens: 2,
+    cacheCreation5mInputTokens: 0,
+    cacheCreation1hInputTokens: 0,
+    cacheReadInputTokens: 0,
+    totalTokens: 3,
+    costUsd: "0",
+    durationMs: 10,
+    sessionId: "s1",
+    providerChain: null,
+    ...overrides,
+  };
+}
 
 function parseCsvLine(line: string): string[] {
   const fields: string[] = [];
@@ -76,12 +152,28 @@ function parseCsvLine(line: string): string[] {
 
 describe("Usage logs CSV export retryCount", () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
+    vi.useRealTimers();
+    exportStatusStore.clear();
+    exportCsvStore.clear();
     getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
+    findUsageLogsWithDetailsMock.mockResolvedValue({
+      logs: [],
+      total: 0,
+      summary: createSummary(),
+    });
+    findUsageLogsBatchMock.mockResolvedValue({ logs: [], nextCursor: null, hasMore: false });
+    findUsageLogsStatsMock.mockResolvedValue(createSummary());
   });
 
   test("exportUsageLogs: Retry Count 应对齐 getRetryCount（hedge race 为 0）", async () => {
     findUsageLogsWithDetailsMock.mockResolvedValue({
+      logs: [],
+      total: 3,
+      summary: createSummary(3),
+    });
+    findUsageLogsBatchMock.mockResolvedValueOnce({
       logs: [
         {
           createdAt: new Date("2026-03-16T00:00:00.000Z"),
@@ -157,18 +249,8 @@ describe("Usage logs CSV export retryCount", () => {
           ],
         },
       ],
-      total: 3,
-      summary: {
-        totalRequests: 3,
-        totalCost: 0,
-        totalTokens: 9,
-        totalInputTokens: 3,
-        totalOutputTokens: 6,
-        totalCacheCreationTokens: 0,
-        totalCacheReadTokens: 0,
-        totalCacheCreation5mTokens: 0,
-        totalCacheCreation1hTokens: 0,
-      },
+      nextCursor: null,
+      hasMore: false,
     });
 
     const { exportUsageLogs } = await import("@/actions/usage-logs");
@@ -193,5 +275,89 @@ describe("Usage logs CSV export retryCount", () => {
     expect(row1[retryCountIndex]).toBe("0");
     expect(row2[retryCountIndex]).toBe("1");
     expect(row3[retryCountIndex]).toBe("0");
+  });
+
+  test("exportUsageLogs: 按批次全量导出，并拦截前导空白公式注入", async () => {
+    findUsageLogsWithDetailsMock.mockResolvedValue({
+      logs: [],
+      total: 3,
+      summary: createSummary(3),
+    });
+    findUsageLogsBatchMock
+      .mockResolvedValueOnce({
+        logs: [
+          createLog({ sessionId: "s1", model: " =1+1" }),
+          createLog({ sessionId: "s2", model: "+2+2" }),
+        ],
+        nextCursor: { createdAt: "2026-03-16T00:00:01.000000Z", id: 2 },
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        logs: [createLog({ sessionId: "s3", endpoint: " \t@SUM(A1:A2)" })],
+        nextCursor: null,
+        hasMore: false,
+      });
+
+    const { exportUsageLogs } = await import("@/actions/usage-logs");
+    const result = await exportUsageLogs({});
+
+    expect(result.ok).toBe(true);
+    expect(findUsageLogsBatchMock).toHaveBeenCalledTimes(2);
+
+    const csvNoBom = result.data.replace(/^\uFEFF/, "");
+    const lines = csvNoBom
+      .trim()
+      .split("\n")
+      .map((line) => line.replace(/\r$/, ""));
+
+    expect(lines).toHaveLength(4);
+    const header = parseCsvLine(lines[0] ?? "");
+    const modelIndex = header.indexOf("Model");
+    const endpointIndex = header.indexOf("Endpoint");
+    const row1 = parseCsvLine(lines[1] ?? "");
+    const row2 = parseCsvLine(lines[2] ?? "");
+    const row3 = parseCsvLine(lines[3] ?? "");
+
+    expect(row1[modelIndex]).toBe("' =1+1");
+    expect(row2[modelIndex]).toBe("'+2+2");
+    expect(row3[endpointIndex]).toBe("' \t@SUM(A1:A2)");
+  });
+
+  test("startUsageLogsExport: 异步导出任务完成后可轮询并下载", async () => {
+    vi.useFakeTimers();
+    findUsageLogsWithDetailsMock.mockResolvedValue({
+      logs: [],
+      total: 1,
+      summary: createSummary(1),
+    });
+    findUsageLogsBatchMock.mockResolvedValueOnce({
+      logs: [createLog({ sessionId: "job-session" })],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    const { downloadUsageLogsExport, getUsageLogsExportStatus, startUsageLogsExport } =
+      await import("@/actions/usage-logs");
+
+    const startResult = await startUsageLogsExport({});
+    expect(startResult.ok).toBe(true);
+    const jobId = startResult.data.jobId;
+
+    const queuedStatus = await getUsageLogsExportStatus(jobId);
+    expect(queuedStatus.ok).toBe(true);
+    expect(queuedStatus.data.status).toBe("queued");
+
+    await vi.runAllTimersAsync();
+
+    const completedStatus = await getUsageLogsExportStatus(jobId);
+    expect(completedStatus.ok).toBe(true);
+    expect(completedStatus.data.status).toBe("completed");
+    expect(completedStatus.data.progressPercent).toBe(100);
+    expect(completedStatus.data.processedRows).toBe(1);
+
+    const downloadResult = await downloadUsageLogsExport(jobId);
+    expect(downloadResult.ok).toBe(true);
+    expect(downloadResult.data).toContain("Session ID");
+    expect(downloadResult.data).toContain("job-session");
   });
 });

--- a/tests/unit/dashboard-logs-export-progress-ui.test.tsx
+++ b/tests/unit/dashboard-logs-export-progress-ui.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { UsageLogsFilters } from "@/app/[locale]/dashboard/logs/_components/usage-logs-filters";
+import dashboardMessages from "../../messages/en/dashboard.json";
+
+const {
+  downloadUsageLogsExportMock,
+  getUsageLogsExportStatusMock,
+  startUsageLogsExportMock,
+  toastErrorMock,
+  toastSuccessMock,
+} = vi.hoisted(() => ({
+  startUsageLogsExportMock: vi.fn(),
+  getUsageLogsExportStatusMock: vi.fn(),
+  downloadUsageLogsExportMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}));
+
+vi.mock("@/actions/usage-logs", () => ({
+  startUsageLogsExport: startUsageLogsExportMock,
+  getUsageLogsExportStatus: getUsageLogsExportStatusMock,
+  downloadUsageLogsExport: downloadUsageLogsExportMock,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
+}));
+
+vi.mock("@/app/[locale]/dashboard/logs/_components/filters/active-filters-display", () => ({
+  ActiveFiltersDisplay: () => <div data-testid="active-filters-display" />,
+}));
+
+vi.mock("@/app/[locale]/dashboard/logs/_components/filters/filter-section", () => ({
+  FilterSection: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/app/[locale]/dashboard/logs/_components/filters/identity-filters", () => ({
+  IdentityFilters: () => <div data-testid="identity-filters" />,
+}));
+
+vi.mock("@/app/[locale]/dashboard/logs/_components/filters/quick-filters-bar", () => ({
+  QuickFiltersBar: () => <div data-testid="quick-filters-bar" />,
+}));
+
+vi.mock("@/app/[locale]/dashboard/logs/_components/filters/request-filters", () => ({
+  RequestFilters: ({
+    onFiltersChange,
+  }: {
+    onFiltersChange: (filters: Record<string, unknown>) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="request-filters"
+      onClick={() => onFiltersChange({ sessionId: "draft-session" })}
+    >
+      Draft Request Filters
+    </button>
+  ),
+}));
+
+vi.mock("@/app/[locale]/dashboard/logs/_components/filters/status-filters", () => ({
+  StatusFilters: () => <div data-testid="status-filters" />,
+}));
+
+vi.mock("@/app/[locale]/dashboard/logs/_components/filters/time-filters", () => ({
+  TimeFilters: () => <div data-testid="time-filters" />,
+}));
+
+function renderWithIntl(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <NextIntlClientProvider
+        locale="en"
+        messages={{ dashboard: dashboardMessages }}
+        timeZone="UTC"
+      >
+        {node}
+      </NextIntlClientProvider>
+    );
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+async function actClick(el: Element | null) {
+  if (!el) throw new Error("element not found");
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("UsageLogsFilters export progress UI", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    globalThis.URL.createObjectURL = vi.fn(() => "blob:usage-logs");
+    globalThis.URL.revokeObjectURL = vi.fn();
+    HTMLAnchorElement.prototype.click = vi.fn();
+  });
+
+  test("shows export progress while polling and downloads when completed", async () => {
+    startUsageLogsExportMock.mockResolvedValue({ ok: true, data: { jobId: "job-1" } });
+    getUsageLogsExportStatusMock
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          jobId: "job-1",
+          status: "running",
+          processedRows: 50,
+          totalRows: 200,
+          progressPercent: 25,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          jobId: "job-1",
+          status: "completed",
+          processedRows: 200,
+          totalRows: 200,
+          progressPercent: 100,
+        },
+      });
+    downloadUsageLogsExportMock.mockResolvedValue({ ok: true, data: "\uFEFFTime,User\n" });
+
+    const { container, unmount } = renderWithIntl(
+      <UsageLogsFilters
+        isAdmin={true}
+        providers={[]}
+        initialKeys={[]}
+        filters={{}}
+        onChange={() => {}}
+        onReset={() => {}}
+      />
+    );
+
+    const exportButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => (button.textContent || "").trim() === "Export"
+    );
+
+    await actClick(exportButton ?? null);
+    await flushPromises();
+
+    expect(container.textContent).toContain("Exported 50 / 200");
+    expect(container.textContent).toContain("25%");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800);
+    });
+    await flushPromises();
+
+    expect(downloadUsageLogsExportMock).toHaveBeenCalledWith("job-1");
+    expect(toastSuccessMock).toHaveBeenCalledWith("Export completed successfully");
+    expect(toastErrorMock).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  test("exports the applied filters instead of unapplied local draft filters", async () => {
+    startUsageLogsExportMock.mockResolvedValue({ ok: true, data: { jobId: "job-2" } });
+    getUsageLogsExportStatusMock.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        jobId: "job-2",
+        status: "completed",
+        processedRows: 1,
+        totalRows: 1,
+        progressPercent: 100,
+      },
+    });
+    downloadUsageLogsExportMock.mockResolvedValue({ ok: true, data: "\uFEFFTime,User\n" });
+
+    const { container, unmount } = renderWithIntl(
+      <UsageLogsFilters
+        isAdmin={true}
+        providers={[]}
+        initialKeys={[]}
+        filters={{ sessionId: "applied-session" }}
+        onChange={() => {}}
+        onReset={() => {}}
+      />
+    );
+
+    await actClick(container.querySelector("[data-testid='request-filters']"));
+
+    const exportButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => (button.textContent || "").trim() === "Export"
+    );
+
+    await actClick(exportButton ?? null);
+    await flushPromises();
+
+    expect(startUsageLogsExportMock).toHaveBeenCalledWith({ sessionId: "applied-session" });
+
+    unmount();
+  });
+});


### PR DESCRIPTION
## Summary
Hardens the usage logs CSV export feature with three key improvements:
- **Backend full-data batching**: Moves export logic to backend with Redis-backed job state for reliable large exports
- **CSV formula injection fix**: Catches bypass where leading whitespace precedes dangerous formula prefixes (`=`, `+`, `-`, `@`)
- **Export progress UI**: Adds dashboard progress indicator and ensures export uses applied filters (not unapplied draft filters)

## Problem

1. **Large exports could fail**: The previous implementation fetched all data in a single query with a high `pageSize` limit, which could timeout or fail for large datasets.

2. **CSV formula injection bypass**: Values with leading whitespace before formula characters (e.g., `" =1+1"`, `"\t@SUM()"`) were not being escaped, leaving a security vulnerability.

3. **Filter mismatch**: Export used local (potentially unapplied) filter state instead of the currently applied filters shown in the UI.

## Solution

- Implements batched cursor-based export using `findUsageLogsBatch` (500 rows per batch)
- Stores export job state in Redis with 15-minute TTL via `RedisKVStore`
- Adds new server actions: `startUsageLogsExport`, `getUsageLogsExportStatus`, `downloadUsageLogsExport`
- Fixes `escapeCsvField` to trim-start before checking dangerous prefixes
- Export button now uses `sanitizeFilters(filters)` (applied filters) instead of `localFilters`

## Changes

### Core Changes
- `src/actions/usage-logs.ts` (+330/-67): New async export pipeline with Redis-backed job tracking
- `src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx` (+117/-15): Export progress UI with polling

### Supporting Changes
- `messages/*/dashboard.json` (+10/-0): i18n strings for `exportPreparing` and `exportProgress` (5 languages)
- `tests/unit/actions/usage-logs-export-retry-count.test.ts` (+190/-24): Tests for batched export and formula injection fix
- `tests/unit/dashboard-logs-export-progress-ui.test.tsx` (+225/-0): New UI tests for export progress component

## Breaking Changes
None. The existing `exportUsageLogs` action is preserved and now delegates to the new batched export internally.

## Test Plan
- [x] bunx vitest run tests/unit/actions/usage-logs-export-retry-count.test.ts tests/unit/dashboard-logs-export-progress-ui.test.tsx
- [x] bun run typecheck
- [x] bun run build
- [x] bun run test
- [x] bun run lint

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the usage-logs CSV export with three targeted fixes: a Redis-backed batched export pipeline to handle large datasets without timeouts, a `trimStart()`-based `escapeCsvField` fix that catches the leading-whitespace formula-injection bypass, and a UI polling loop (with a 10-minute deadline) that correctly uses the *applied* filters instead of unapplied draft state.

**Key changes:**
- `src/actions/usage-logs.ts`: New async export actions (`startUsageLogsExport`, `getUsageLogsExportStatus`, `downloadUsageLogsExport`) with cursor-based batching (500 rows/batch), Redis TTL-backed job state, and owner-scoped access control. The existing `exportUsageLogs` action is preserved and now delegates to the same `buildUsageLogsExportCsv` helper.
- `escapeCsvField`: Removes `\t`/`\r` from the dangerous-prefix list (they were never formula injection vectors on their own), adds `trimStart()` before the prefix check to catch the whitespace bypass, and adds `\r` to the quoting condition.
- `usage-logs-filters.tsx`: Adds a `runId` ref for cancellation safety, a 10-minute deadline in the polling loop, a new `downloadCsv` helper, and a `useEffect` that syncs `localFilters` with the applied `filters` prop.
- All five locale `dashboard.json` files receive the two new i18n keys (`exportPreparing`, `exportProgress`).
- Test coverage added for batched export, formula injection, async job lifecycle, and UI progress polling.

**Remaining concerns from prior review rounds (not yet fully resolved):**
- The `setTimeout` fire-and-forget is safe only on a persistent Bun/Node server; the added code comment acknowledges this, which is sufficient for the stated deployment target.
- Several `"未登录"` login-check errors are still hardcoded Chinese strings rather than i18n keys; the new actions (`startUsageLogsExport`, `getUsageLogsExportStatus`, `downloadUsageLogsExport`) inherit this pattern.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor cleanup; no new blocking issues introduced.
- The three headline fixes (batching, formula injection, filter mismatch) are correctly implemented and tested. Prior review concerns about the polling timeout and the serverless warning were addressed. The two remaining new comments are P2 style nits (unused parameter, useEffect stability assumption). The hardcoded Chinese error strings were flagged in a prior round and are an existing issue. No data-loss, security regression, or runtime breakage is introduced.
- No files require special attention beyond the two P2 comments on `src/actions/usage-logs.ts` and `src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx`.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/actions/usage-logs.ts | Core backend rewrite: adds Redis-backed batched export pipeline (startUsageLogsExport / getUsageLogsExportStatus / downloadUsageLogsExport), fixes formula injection bypass via trimStart, and preserves the original exportUsageLogs action. Serverless concern was addressed with an explicit code comment; hardcoded "未登录" strings remain but were previously flagged. Minor unused _jobId parameter noted. |
| src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx | Adds export progress UI with runId-based cancellation, 10-minute deadline guard, and correct use of sanitizeFilters(filters) instead of localFilters. New useEffect syncing localFilters to the filters prop is a behaviour change that could discard in-progress edits if the parent re-renders with a new object reference; likely safe given parent filter state management but worth documenting. handleExport still missing useCallback (previously flagged). |
| tests/unit/actions/usage-logs-export-retry-count.test.ts | Expanded test suite covering batched export, leading-whitespace formula injection bypass (space+tab+@ pattern), and async job lifecycle (queued → completed → download). In-memory mock of RedisKVStore is well-structured with prefix-based dispatch. |
| tests/unit/dashboard-logs-export-progress-ui.test.tsx | New UI test covering progress display during polling, correct use of applied vs. draft filters, and toast outcomes. Uses fake timers to control the 800 ms polling delay. |
| messages/en/dashboard.json | Adds exportPreparing and exportProgress i18n keys; all five locale files updated consistently. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as UsageLogsFilters (Client)
    participant SA as Server Actions
    participant Redis
    participant DB

    UI->>SA: startUsageLogsExport(filters)
    SA->>Redis: set job {status:"queued"}
    SA-->>UI: { jobId }
    SA-)SA: setTimeout → runUsageLogsExportJob

    Note over SA,DB: Background export job
    SA->>Redis: set job {status:"running"}
    loop Batch loop (500 rows/batch)
        SA->>DB: findUsageLogsBatch(cursor)
        DB-->>SA: batch rows
        SA->>Redis: set job {processedRows, progressPercent}
    end
    SA->>Redis: set CSV string (15 min TTL)
    SA->>Redis: set job {status:"completed"}

    loop Polling (800 ms interval, 10 min deadline)
        UI->>SA: getUsageLogsExportStatus(jobId)
        SA->>Redis: get job record
        Redis-->>SA: job status
        SA-->>UI: status + progress
        UI->>UI: update progress bar
    end

    UI->>SA: downloadUsageLogsExport(jobId)
    SA->>Redis: get CSV string
    Redis-->>SA: csv content
    SA-->>UI: csv string
    UI->>UI: trigger file download
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/actions/usage-logs.ts`, line 311-329 ([link](https://github.com/ding113/claude-code-hub/blob/802f05122be3fb6bff4727d78ca9dfd2d066b184/src/actions/usage-logs.ts#L311-L329)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Legacy `exportUsageLogs` is now unbounded**

   The preserved synchronous `exportUsageLogs` action previously capped the query at `pageSize: 10000`, keeping server action execution time bounded. It now delegates to `buildUsageLogsExportCsv`, which iterates all rows via cursor pagination with no upper limit.

   For any moderately large dataset this action will block in the server action context for an extended and unpredictable amount of time — until all batches are fetched, the full CSV is assembled in memory, and the whole string is returned over the wire. On a platform with a function timeout (e.g. 30 s on Vercel), the call silently times out with no useful feedback; on the self-hosted server it ties up a request handler thread for as long as the export takes.

   Because the UI has fully migrated to the async pipeline (`startUsageLogsExport` → polling → `downloadUsageLogsExport`), consider one of:
   1. Removing `exportUsageLogs` if it has no other callers.
   2. Restoring the row cap (`pageSize: 10000`) so it stays fast and bounded.
   3. Explicitly documenting that it is only safe to call from a background context (not a browser server action).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/actions/usage-logs.ts
   Line: 311-329

   Comment:
   **Legacy `exportUsageLogs` is now unbounded**

   The preserved synchronous `exportUsageLogs` action previously capped the query at `pageSize: 10000`, keeping server action execution time bounded. It now delegates to `buildUsageLogsExportCsv`, which iterates all rows via cursor pagination with no upper limit.

   For any moderately large dataset this action will block in the server action context for an extended and unpredictable amount of time — until all batches are fetched, the full CSV is assembled in memory, and the whole string is returned over the wire. On a platform with a function timeout (e.g. 30 s on Vercel), the call silently times out with no useful feedback; on the self-hosted server it ties up a request handler thread for as long as the export takes.

   Because the UI has fully migrated to the async pipeline (`startUsageLogsExport` → polling → `downloadUsageLogsExport`), consider one of:
   1. Removing `exportUsageLogs` if it has no other callers.
   2. Restoring the row cap (`pageSize: 10000`) so it stays fast and bounded.
   3. Explicitly documenting that it is only safe to call from a background context (not a browser server action).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
Line: 144-146

Comment:
**`useEffect` sync can silently discard in-progress filter edits**

This effect replaces `localFilters` with the applied `filters` prop every time the parent re-renders with a new object reference — even if the filter values haven't changed. If the parent component creates a fresh `filters` object on each render (e.g. due to a context update or unrelated state change), any draft edits the user typed but hasn't yet applied will be silently wiped.

Consider guarding the update with a deep-equality check, or using a ref flag to skip the sync while the user has unsaved edits:

```ts
useEffect(() => {
  setLocalFilters(filters);
}, [filters]);
```

If `filters` is always referentially stable when its values haven't changed (e.g. managed via `useState` in the parent and only updated on `handleApply`), this is safe as-is — but a comment explaining that assumption would help future readers.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/actions/usage-logs.ts
Line: 113-121

Comment:
**Unused `_jobId` parameter in `getUsageLogsExportJob`**

The `_jobId` parameter is passed to every call site but is never read inside the function body. If it was intended for future logging or auditing, a short comment would clarify the intent. Otherwise it can be removed to reduce noise.

```suggestion
function getUsageLogsExportJob(
  session: UsageLogsSession,
  job: UsageLogsExportJobRecord | null
): UsageLogsExportJobRecord | null {
```

(Both call sites pass the value positionally, so removing the parameter only requires dropping the third argument at each call.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: increase export polling timeout fro..."](https://github.com/ding113/claude-code-hub/commit/4a2f9e25db271fc78078decef6ce4c0ddbe1b94f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25965075)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->