### PR TITLE
fix: restore legacy user search API compatibility

### DIFF
--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -70,9 +70,14 @@ const USER_LIST_DEFAULT_LIMIT = 50;
 const USER_LIST_MAX_LIMIT = 200;
 
 function normalizeLegacySearchTerm(params?: GetUsersBatchParams): string | undefined {
-  const candidate = params?.searchTerm ?? params?.query ?? params?.keyword;
-  const trimmed = candidate?.trim();
-  return trimmed ? trimmed : undefined;
+  for (const candidate of [params?.searchTerm, params?.query, params?.keyword]) {
+    const trimmed = candidate?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return undefined;
 }
 
 function normalizeUserListParams(params?: GetUsersBatchParams): GetUsersBatchParams {
@@ -112,34 +117,37 @@ function normalizeUserListParams(params?: GetUsersBatchParams): GetUsersBatchPar
   };
 }
 
-function hasExplicitPaginationParams(params?: GetUsersBatchParams): boolean {
+function hasExplicitPaginationParams(
+  params?: GetUsersBatchParams,
+  normalizedParams = normalizeUserListParams(params)
+): boolean {
   return Boolean(
-    params?.cursor ||
-      params?.limit !== undefined ||
+    normalizedParams.cursor !== undefined ||
+      normalizedParams.limit !== undefined ||
       params?.page !== undefined ||
       params?.offset !== undefined
   );
 }
 
-function hasSearchOrFilterOverrides(params?: GetUsersBatchParams): boolean {
-  const normalized = normalizeUserListParams(params);
+function hasSearchOrFilterOverrides(normalizedParams: GetUsersBatchParams): boolean {
   return Boolean(
-    normalized.searchTerm ||
-      (normalized.tagFilters?.length ?? 0) > 0 ||
-      (normalized.keyGroupFilters?.length ?? 0) > 0 ||
-      normalized.statusFilter ||
-      normalized.sortBy ||
-      normalized.sortOrder
+    normalizedParams.searchTerm ||
+      (normalizedParams.tagFilters?.length ?? 0) > 0 ||
+      (normalizedParams.keyGroupFilters?.length ?? 0) > 0 ||
+      normalizedParams.statusFilter ||
+      normalizedParams.sortBy ||
+      normalizedParams.sortOrder
   );
 }
 
 async function loadAllUsersForAdmin(baseParams?: GetUsersBatchParams): Promise<User[]> {
   const users: User[] = [];
-  let cursor = normalizeUserListParams(baseParams).cursor;
+  const normalizedBaseParams = normalizeUserListParams(baseParams);
+  let cursor = normalizedBaseParams.cursor;
 
   while (true) {
     const page = await findUserListBatch({
-      ...normalizeUserListParams(baseParams),
+      ...normalizedBaseParams,
       cursor,
       limit: USER_LIST_MAX_LIMIT,
     });
@@ -308,15 +316,15 @@ export async function getUsers(params?: GetUsersBatchParams): Promise<UserDispla
 
     // Treat any non-admin role as non-admin for safety.
     const isAdmin = session.user.role === "admin";
+    const normalizedParams = normalizeUserListParams(params);
 
     // 非 admin 用户只能看到自己的数据（从 DB 获取完整用户信息）
     let users: User[] = [];
     if (isAdmin) {
-      if (hasExplicitPaginationParams(params)) {
-        const normalizedParams = normalizeUserListParams(params);
+      if (hasExplicitPaginationParams(params, normalizedParams)) {
         users = (await findUserListBatch(normalizedParams)).users;
-      } else if (hasSearchOrFilterOverrides(params)) {
-        users = await loadAllUsersForAdmin(params);
+      } else if (hasSearchOrFilterOverrides(normalizedParams)) {
+        users = await loadAllUsersForAdmin(normalizedParams);
       } else {
         users = await loadAllUsersForAdmin();
       }

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -29,7 +29,6 @@ import {
   createUser,
   deleteUser,
   findUserById,
-  findUserList,
   findUserListBatch,
   getAllUserProviderGroups as getAllUserProviderGroupsRepository,
   getAllUserTags as getAllUserTagsRepository,
@@ -47,6 +46,10 @@ export interface GetUsersBatchParams {
   cursor?: string;
   limit?: number;
   searchTerm?: string;
+  query?: string;
+  keyword?: string;
+  page?: number;
+  offset?: number;
   tagFilters?: string[];
   keyGroupFilters?: string[];
   statusFilter?: "all" | "active" | "expired" | "expiringSoon" | "enabled" | "disabled";
@@ -61,6 +64,94 @@ export interface GetUsersBatchParams {
     | "limitMonthlyUsd"
     | "createdAt";
   sortOrder?: "asc" | "desc";
+}
+
+const USER_LIST_DEFAULT_LIMIT = 50;
+const USER_LIST_MAX_LIMIT = 200;
+
+function normalizeLegacySearchTerm(params?: GetUsersBatchParams): string | undefined {
+  const candidate = params?.searchTerm ?? params?.query ?? params?.keyword;
+  const trimmed = candidate?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeUserListParams(params?: GetUsersBatchParams): GetUsersBatchParams {
+  const limit =
+    typeof params?.limit === "number" && Number.isFinite(params.limit) && params.limit > 0
+      ? Math.min(Math.trunc(params.limit), USER_LIST_MAX_LIMIT)
+      : undefined;
+
+  let cursor = params?.cursor?.trim() || undefined;
+  if (!cursor) {
+    const offset =
+      typeof params?.offset === "number" && Number.isFinite(params.offset)
+        ? Math.max(0, Math.trunc(params.offset))
+        : undefined;
+    const page =
+      typeof params?.page === "number" && Number.isFinite(params.page)
+        ? Math.max(0, Math.trunc(params.page))
+        : undefined;
+
+    if (offset !== undefined) {
+      cursor = String(offset);
+    } else if (page !== undefined) {
+      const effectiveLimit = limit ?? USER_LIST_DEFAULT_LIMIT;
+      cursor = String(Math.max(page - 1, 0) * effectiveLimit);
+    }
+  }
+
+  return {
+    cursor,
+    limit,
+    searchTerm: normalizeLegacySearchTerm(params),
+    tagFilters: params?.tagFilters,
+    keyGroupFilters: params?.keyGroupFilters,
+    statusFilter: params?.statusFilter,
+    sortBy: params?.sortBy,
+    sortOrder: params?.sortOrder,
+  };
+}
+
+function hasExplicitPaginationParams(params?: GetUsersBatchParams): boolean {
+  return Boolean(
+    params?.cursor ||
+      params?.limit !== undefined ||
+      params?.page !== undefined ||
+      params?.offset !== undefined
+  );
+}
+
+function hasSearchOrFilterOverrides(params?: GetUsersBatchParams): boolean {
+  const normalized = normalizeUserListParams(params);
+  return Boolean(
+    normalized.searchTerm ||
+      (normalized.tagFilters?.length ?? 0) > 0 ||
+      (normalized.keyGroupFilters?.length ?? 0) > 0 ||
+      normalized.statusFilter ||
+      normalized.sortBy ||
+      normalized.sortOrder
+  );
+}
+
+async function loadAllUsersForAdmin(baseParams?: GetUsersBatchParams): Promise<User[]> {
+  const users: User[] = [];
+  let cursor = normalizeUserListParams(baseParams).cursor;
+
+  while (true) {
+    const page = await findUserListBatch({
+      ...normalizeUserListParams(baseParams),
+      cursor,
+      limit: USER_LIST_MAX_LIMIT,
+    });
+
+    users.push(...page.users);
+
+    if (!page.hasMore || !page.nextCursor) {
+      return users;
+    }
+
+    cursor = page.nextCursor;
+  }
 }
 
 /**
@@ -204,7 +295,7 @@ export async function syncUserProviderGroupFromKeys(userId: number): Promise<voi
 }
 
 // 获取用户数据
-export async function getUsers(): Promise<UserDisplay[]> {
+export async function getUsers(params?: GetUsersBatchParams): Promise<UserDisplay[]> {
   try {
     const session = await getSession();
     if (!session) {
@@ -221,7 +312,14 @@ export async function getUsers(): Promise<UserDisplay[]> {
     // 非 admin 用户只能看到自己的数据（从 DB 获取完整用户信息）
     let users: User[] = [];
     if (isAdmin) {
-      users = await findUserList(); // 管理员可以看到所有用户
+      if (hasExplicitPaginationParams(params)) {
+        const normalizedParams = normalizeUserListParams(params);
+        users = (await findUserListBatch(normalizedParams)).users;
+      } else if (hasSearchOrFilterOverrides(params)) {
+        users = await loadAllUsersForAdmin(params);
+      } else {
+        users = await loadAllUsersForAdmin();
+      }
     } else {
       const selfUser = await findUserById(session.user.id);
       users = selfUser ? [selfUser] : [];
@@ -394,6 +492,12 @@ export async function searchUsersForFilter(
   }
 }
 
+export async function searchUsers(
+  searchTerm?: string
+): Promise<ActionResult<Array<{ id: number; name: string }>>> {
+  return searchUsersForFilter(searchTerm);
+}
+
 /**
  * 获取所有用户标签（用于标签筛选下拉框）
  * 返回所有用户的标签，不受当前筛选条件影响
@@ -497,16 +601,8 @@ export async function getUsersBatch(
     const locale = await getLocale();
     const t = await getTranslations("users");
 
-    const { users, nextCursor, hasMore } = await findUserListBatch({
-      cursor: params.cursor,
-      limit: params.limit,
-      searchTerm: params.searchTerm,
-      tagFilters: params.tagFilters,
-      keyGroupFilters: params.keyGroupFilters,
-      statusFilter: params.statusFilter,
-      sortBy: params.sortBy,
-      sortOrder: params.sortOrder,
-    });
+    const normalizedParams = normalizeUserListParams(params);
+    const { users, nextCursor, hasMore } = await findUserListBatch(normalizedParams);
 
     if (users.length === 0) {
       return { ok: true, data: { users: [], nextCursor, hasMore } };
@@ -665,16 +761,8 @@ export async function getUsersBatchCore(
     const locale = await getLocale();
     const t = await getTranslations("users");
 
-    const { users, nextCursor, hasMore } = await findUserListBatch({
-      cursor: params.cursor,
-      limit: params.limit,
-      searchTerm: params.searchTerm,
-      tagFilters: params.tagFilters,
-      keyGroupFilters: params.keyGroupFilters,
-      statusFilter: params.statusFilter,
-      sortBy: params.sortBy,
-      sortOrder: params.sortOrder,
-    });
+    const normalizedParams = normalizeUserListParams(params);
+    const { users, nextCursor, hasMore } = await findUserListBatch(normalizedParams);
 
     if (users.length === 0) {
       return { ok: true, data: { users: [], nextCursor, hasMore } };

--- a/src/app/[locale]/dashboard/_components/rate-limit-top-users.tsx
+++ b/src/app/[locale]/dashboard/_components/rate-limit-top-users.tsx
@@ -3,7 +3,7 @@
 import { ArrowUpDown } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 import * as React from "react";
-import { getUsers } from "@/actions/users";
+import { searchUsers } from "@/actions/users";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -36,10 +36,28 @@ export function RateLimitTopUsers({ data }: RateLimitTopUsersProps) {
 
   // 加载用户详情
   React.useEffect(() => {
-    getUsers().then((userList) => {
-      setUsers(userList);
-      setLoading(false);
-    });
+    let cancelled = false;
+
+    void searchUsers()
+      .then((result) => {
+        if (!cancelled) {
+          setUsers(result.ok ? result.data : []);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setUsers([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // 组合数据：用户信息 + 事件计数

--- a/src/app/[locale]/dashboard/rate-limits/_components/rate-limit-filters.tsx
+++ b/src/app/[locale]/dashboard/rate-limits/_components/rate-limit-filters.tsx
@@ -5,7 +5,7 @@ import { Calendar, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import * as React from "react";
 import { getProviders } from "@/actions/providers";
-import { getUsers } from "@/actions/users";
+import { searchUsers } from "@/actions/users";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -61,10 +61,28 @@ export function RateLimitFilters({
 
   // 加载用户列表
   React.useEffect(() => {
-    getUsers().then((userList) => {
-      setUsers(userList);
-      setLoadingUsers(false);
-    });
+    let cancelled = false;
+
+    void searchUsers()
+      .then((result) => {
+        if (!cancelled) {
+          setUsers(result.ok ? result.data : []);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setUsers([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoadingUsers(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // 加载供应商列表

--- a/src/app/api/actions/[...route]/route.ts
+++ b/src/app/api/actions/[...route]/route.ts
@@ -68,39 +68,166 @@ app.openAPIRegistry.registerComponent("securitySchemes", "bearerAuth", {
 
 // ==================== 用户管理 ====================
 
+const userKeyListItemSchema = z.object({
+  id: z.number().describe("密钥 ID"),
+  name: z.string().describe("密钥名称"),
+  maskedKey: z.string().describe("脱敏后的密钥"),
+  fullKey: z.string().optional().describe("完整密钥（有权限时返回）"),
+  canCopy: z.boolean().describe("是否允许复制完整密钥"),
+  expiresAt: z.string().describe("过期时间展示值"),
+  status: z.enum(["enabled", "disabled"]).describe("密钥状态"),
+  todayUsage: z.number().describe("今日用量（美元）"),
+  todayCallCount: z.number().describe("今日调用次数"),
+  todayTokens: z.number().describe("今日 tokens"),
+  lastUsedAt: z.string().nullable().optional().describe("最后使用时间"),
+  lastProviderName: z.string().nullable().optional().describe("最后使用的供应商"),
+  modelStats: z.array(z.any()).describe("模型统计"),
+  createdAt: z.string().optional().describe("创建时间"),
+  createdAtFormatted: z.string().describe("格式化后的创建时间"),
+  canLoginWebUi: z.boolean().describe("是否允许登录 Web UI"),
+  limit5hUsd: z.number().nullable().describe("5 小时限额"),
+  limitDailyUsd: z.number().nullable().describe("每日限额"),
+  dailyResetMode: z.enum(["fixed", "rolling"]).describe("每日重置模式"),
+  dailyResetTime: z.string().describe("每日重置时间"),
+  limitWeeklyUsd: z.number().nullable().describe("周限额"),
+  limitMonthlyUsd: z.number().nullable().describe("月限额"),
+  limitTotalUsd: z.number().nullable().optional().describe("总限额"),
+  limitConcurrentSessions: z.number().describe("并发 Session 上限"),
+  costResetAt: z.string().nullable().optional().describe("限额重置时间"),
+  providerGroup: z.string().nullable().optional().describe("密钥供应商分组"),
+});
+
+const userListItemSchema = z.object({
+  id: z.number().describe("用户 ID"),
+  name: z.string().describe("用户名"),
+  note: z.string().nullable().optional().describe("备注"),
+  role: z.enum(["admin", "user"]).describe("用户角色"),
+  isEnabled: z.boolean().describe("是否启用"),
+  expiresAt: z.string().nullable().optional().describe("过期时间"),
+  rpm: z.number().nullable().describe("每分钟请求数限制"),
+  dailyQuota: z.number().nullable().describe("每日消费额度（美元）"),
+  providerGroup: z.string().nullable().optional().describe("供应商分组"),
+  tags: z.array(z.string()).optional().describe("用户标签"),
+  limit5hUsd: z.number().nullable().optional().describe("5小时消费上限"),
+  limitWeeklyUsd: z.number().nullable().optional().describe("周消费上限"),
+  limitMonthlyUsd: z.number().nullable().optional().describe("月消费上限"),
+  limitTotalUsd: z.number().nullable().optional().describe("总消费上限"),
+  costResetAt: z.string().nullable().optional().describe("限额重置时间"),
+  limitConcurrentSessions: z.number().nullable().optional().describe("并发Session上限"),
+  dailyResetMode: z.enum(["fixed", "rolling"]).optional().describe("每日重置模式"),
+  dailyResetTime: z.string().optional().describe("每日重置时间"),
+  allowedClients: z.array(z.string()).optional().describe("允许的客户端"),
+  blockedClients: z.array(z.string()).optional().describe("禁止的客户端"),
+  allowedModels: z.array(z.string()).optional().describe("允许的模型"),
+  keys: z.array(userKeyListItemSchema).describe("用户下的密钥列表"),
+});
+
+const getUsersBatchRequestSchema = z
+  .object({
+    cursor: z.string().optional(),
+    limit: z.number().int().positive().max(200).optional(),
+    searchTerm: z.string().optional(),
+    query: z.string().optional(),
+    keyword: z.string().optional(),
+    page: z.number().int().min(1).optional(),
+    offset: z.number().int().min(0).optional(),
+    tagFilters: z.array(z.string()).optional(),
+    keyGroupFilters: z.array(z.string()).optional(),
+    statusFilter: z
+      .enum(["all", "active", "expired", "expiringSoon", "enabled", "disabled"])
+      .optional(),
+    sortBy: z
+      .enum([
+        "name",
+        "tags",
+        "expiresAt",
+        "rpm",
+        "limit5hUsd",
+        "limitDailyUsd",
+        "limitWeeklyUsd",
+        "limitMonthlyUsd",
+        "createdAt",
+      ])
+      .optional(),
+    sortOrder: z.enum(["asc", "desc"]).optional(),
+  })
+  .passthrough();
+
+const getUsersBatchResponseSchema = z.object({
+  users: z.array(userListItemSchema),
+  nextCursor: z.string().nullable(),
+  hasMore: z.boolean(),
+});
+
 const { route: getUsersRoute, handler: getUsersHandler } = createActionRoute(
   "users",
   "getUsers",
   userActions.getUsers,
   {
-    requestSchema: z.object({}).describe("无需请求参数"),
-    responseSchema: z.array(
-      z.object({
-        id: z.number().describe("用户 ID"),
-        name: z.string().describe("用户名"),
-        note: z.string().nullable().describe("备注"),
-        role: z.enum(["admin", "user"]).describe("用户角色"),
-        isEnabled: z.boolean().describe("是否启用"),
-        expiresAt: z.string().nullable().describe("过期时间"),
-        rpm: z.number().describe("每分钟请求数限制"),
-        dailyQuota: z.number().describe("每日消费额度（美元）"),
-        providerGroup: z.string().nullable().describe("供应商分组"),
-        tags: z.array(z.string()).describe("用户标签"),
-        limit5hUsd: z.number().nullable().describe("5小时消费上限"),
-        limitWeeklyUsd: z.number().nullable().describe("周消费上限"),
-        limitMonthlyUsd: z.number().nullable().describe("月消费上限"),
-        limitTotalUsd: z.number().nullable().describe("总消费上限"),
-        limitConcurrentSessions: z.number().nullable().describe("并发Session上限"),
-        createdAt: z.string().describe("创建时间"),
+    requestSchema: z
+      .object({
+        cursor: z.string().optional().describe("游标，兼容旧 offset 游标"),
+        limit: z.number().int().positive().max(200).optional().describe("返回条数上限"),
+        searchTerm: z.string().optional().describe("搜索用户名/备注/标签/密钥"),
+        query: z.string().optional().describe("旧版搜索参数别名"),
+        keyword: z.string().optional().describe("旧版搜索参数别名"),
+        page: z.number().int().min(1).optional().describe("旧版页码，从 1 开始"),
+        offset: z.number().int().min(0).optional().describe("旧版偏移量"),
       })
-    ),
+      .passthrough()
+      .describe("兼容旧客户端的可选分页/搜索参数；不传时返回全部用户"),
+    responseSchema: z.array(userListItemSchema),
     description: "获取用户列表 (管理员获取所有用户，普通用户仅获取自己)",
     summary: "获取用户列表",
     tags: ["用户管理"],
     allowReadOnlyAccess: true,
+    argsMapper: (body) => [body],
   }
 );
 app.openapi(getUsersRoute, getUsersHandler);
+
+const { route: getUsersBatchRoute, handler: getUsersBatchHandler } = createActionRoute(
+  "users",
+  "getUsersBatch",
+  userActions.getUsersBatch,
+  {
+    requestSchema: getUsersBatchRequestSchema,
+    responseSchema: getUsersBatchResponseSchema,
+    description: "分页获取用户列表（兼容旧客户端 page/offset/query/keyword 参数）",
+    summary: "分页获取用户列表",
+    tags: ["用户管理"],
+    requiredRole: "admin",
+    argsMapper: (body) => [body],
+  }
+);
+app.openapi(getUsersBatchRoute, getUsersBatchHandler);
+
+const { route: searchUsersRoute, handler: searchUsersHandler } = createActionRoute(
+  "users",
+  "searchUsers",
+  userActions.searchUsers,
+  {
+    requestSchema: z
+      .object({
+        searchTerm: z.string().optional(),
+        query: z.string().optional(),
+        keyword: z.string().optional(),
+      })
+      .passthrough(),
+    responseSchema: z.array(
+      z.object({
+        id: z.number(),
+        name: z.string(),
+      })
+    ),
+    description: "搜索用户（兼容旧客户端 searchUsers 接口名）",
+    summary: "搜索用户",
+    tags: ["用户管理"],
+    requiredRole: "admin",
+    argsMapper: (body) => [body.searchTerm ?? body.query ?? body.keyword],
+  }
+);
+app.openapi(searchUsersRoute, searchUsersHandler);
 
 const { route: addUserRoute, handler: addUserHandler } = createActionRoute(
   "users",

--- a/src/app/api/actions/[...route]/route.ts
+++ b/src/app/api/actions/[...route]/route.ts
@@ -125,11 +125,11 @@ const userListItemSchema = z.object({
 const getUsersBatchRequestSchema = z
   .object({
     cursor: z.string().optional(),
-    limit: z.number().int().positive().max(200).optional(),
+    limit: z.number().int().positive().optional(),
     searchTerm: z.string().optional(),
     query: z.string().optional(),
     keyword: z.string().optional(),
-    page: z.number().int().min(1).optional(),
+    page: z.number().int().min(0).optional(),
     offset: z.number().int().min(0).optional(),
     tagFilters: z.array(z.string()).optional(),
     keyGroupFilters: z.array(z.string()).optional(),
@@ -167,11 +167,11 @@ const { route: getUsersRoute, handler: getUsersHandler } = createActionRoute(
     requestSchema: z
       .object({
         cursor: z.string().optional().describe("游标，兼容旧 offset 游标"),
-        limit: z.number().int().positive().max(200).optional().describe("返回条数上限"),
+        limit: z.number().int().positive().optional().describe("返回条数上限"),
         searchTerm: z.string().optional().describe("搜索用户名/备注/标签/密钥"),
         query: z.string().optional().describe("旧版搜索参数别名"),
         keyword: z.string().optional().describe("旧版搜索参数别名"),
-        page: z.number().int().min(1).optional().describe("旧版页码，从 1 开始"),
+        page: z.number().int().min(0).optional().describe("旧版页码，从 0 或 1 开始"),
         offset: z.number().int().min(0).optional().describe("旧版偏移量"),
       })
       .passthrough()
@@ -224,7 +224,13 @@ const { route: searchUsersRoute, handler: searchUsersHandler } = createActionRou
     summary: "搜索用户",
     tags: ["用户管理"],
     requiredRole: "admin",
-    argsMapper: (body) => [body.searchTerm ?? body.query ?? body.keyword],
+    argsMapper: (body) => {
+      const searchTerm = [body.searchTerm, body.query, body.keyword]
+        .map((value: string | undefined) => value?.trim())
+        .find((value): value is string => Boolean(value));
+
+      return [searchTerm];
+    },
   }
 );
 app.openapi(searchUsersRoute, searchUsersHandler);

--- a/tests/api/api-actions-integrity.test.ts
+++ b/tests/api/api-actions-integrity.test.ts
@@ -61,6 +61,8 @@ describe("OpenAPI 端点完整性检查", () => {
   test("用户管理模块的所有端点应该被注册", () => {
     const expectedPaths = [
       "/api/actions/users/getUsers",
+      "/api/actions/users/getUsersBatch",
+      "/api/actions/users/searchUsers",
       "/api/actions/users/addUser",
       "/api/actions/users/editUser",
       "/api/actions/users/removeUser",

--- a/tests/api/api-endpoints.test.ts
+++ b/tests/api/api-endpoints.test.ts
@@ -164,6 +164,8 @@ describe("API 端点可达性测试", () => {
   const criticalEndpoints = [
     // 用户管理
     { module: "users", action: "getUsers" },
+    { module: "users", action: "getUsersBatch" },
+    { module: "users", action: "searchUsers" },
     { module: "users", action: "addUser" },
     { module: "users", action: "editUser" },
     { module: "users", action: "removeUser" },

--- a/tests/api/api-openapi-spec.test.ts
+++ b/tests/api/api-openapi-spec.test.ts
@@ -46,6 +46,29 @@ type OpenAPIDocument = {
   };
 };
 
+type JsonSchemaProperty = {
+  minimum?: number;
+  maximum?: number;
+  properties?: Record<string, JsonSchemaProperty>;
+};
+
+function getJsonRequestSchema(
+  openApiDoc: OpenAPIDocument,
+  path: string
+): JsonSchemaProperty | undefined {
+  const requestBody = openApiDoc.paths[path]?.post?.requestBody as
+    | {
+        content?: {
+          "application/json"?: {
+            schema?: JsonSchemaProperty;
+          };
+        };
+      }
+    | undefined;
+
+  return requestBody?.content?.["application/json"]?.schema;
+}
+
 describe("OpenAPI 规范验证", () => {
   let openApiDoc: OpenAPIDocument;
 
@@ -217,5 +240,16 @@ describe("OpenAPI 规范验证", () => {
     // 允许部分端点 summary 和 description 相同（简单操作）
     // 但不应该太多（允许 35% 以内）
     expect(violations.length).toBeLessThan(totalPaths * 0.35);
+  });
+
+  test("users 列表请求 schema 应与兼容参数归一化保持一致", () => {
+    for (const path of ["/api/actions/users/getUsers", "/api/actions/users/getUsersBatch"]) {
+      const schema = getJsonRequestSchema(openApiDoc, path);
+      const pageSchema = schema?.properties?.page;
+      const limitSchema = schema?.properties?.limit;
+
+      expect(pageSchema?.minimum).toBe(0);
+      expect(limitSchema?.maximum).toBeUndefined();
+    }
   });
 });

--- a/tests/api/users-search-users-compat.test.ts
+++ b/tests/api/users-search-users-compat.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const searchUsersMock = vi.fn();
+const validateAuthTokenMock = vi.fn();
+const runWithAuthSessionMock = vi.fn();
+
+vi.mock("@/actions/users", () => ({
+  getUsers: vi.fn(),
+  getUsersBatch: vi.fn(),
+  searchUsers: searchUsersMock,
+  addUser: vi.fn(),
+  editUser: vi.fn(),
+  removeUser: vi.fn(),
+  getUserLimitUsage: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...actual,
+    AUTH_COOKIE_NAME: "auth-token",
+    validateAuthToken: validateAuthTokenMock,
+    runWithAuthSession: runWithAuthSessionMock,
+  };
+});
+
+describe("users searchUsers route compatibility", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    searchUsersMock.mockReset();
+    validateAuthTokenMock.mockReset();
+    runWithAuthSessionMock.mockReset();
+
+    validateAuthTokenMock.mockResolvedValue({
+      user: { id: 1, role: "admin" },
+      key: { canLoginWebUi: true },
+    });
+    runWithAuthSessionMock.mockImplementation(async (_session, callback) => callback());
+    searchUsersMock.mockResolvedValue({
+      ok: true,
+      data: [{ id: 1, name: "Alice" }],
+    });
+  });
+
+  test("falls back to trimmed query when searchTerm is blank", async () => {
+    const { POST } = await import("@/app/api/actions/[...route]/route");
+
+    const response = await POST(
+      new Request("http://localhost/api/actions/users/searchUsers", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-token",
+          cookie: "auth-token=test-token",
+        },
+        body: JSON.stringify({
+          searchTerm: "   ",
+          query: "  alice  ",
+          keyword: "bob",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(searchUsersMock).toHaveBeenCalledWith("alice");
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      data: [{ id: 1, name: "Alice" }],
+    });
+  });
+});

--- a/tests/unit/users-action-get-users-compat.test.ts
+++ b/tests/unit/users-action-get-users-compat.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { User } from "@/types/user";
+
+const getSessionMock = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const getTranslationsMock = vi.fn(async () => (key: string) => key);
+const getLocaleMock = vi.fn(async () => "en");
+vi.mock("next-intl/server", () => ({
+  getTranslations: getTranslationsMock,
+  getLocale: getLocaleMock,
+}));
+
+const findUserByIdMock = vi.fn();
+const findUserListBatchMock = vi.fn();
+vi.mock("@/repository/user", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/repository/user")>();
+  return {
+    ...actual,
+    findUserById: findUserByIdMock,
+    findUserListBatch: findUserListBatchMock,
+  };
+});
+
+const findKeyListBatchMock = vi.fn();
+const findKeyUsageTodayBatchMock = vi.fn();
+const findKeysStatisticsBatchFromKeysMock = vi.fn();
+vi.mock("@/repository/key", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/repository/key")>();
+  return {
+    ...actual,
+    findKeyListBatch: findKeyListBatchMock,
+    findKeyUsageTodayBatch: findKeyUsageTodayBatchMock,
+    findKeysStatisticsBatchFromKeys: findKeysStatisticsBatchFromKeysMock,
+  };
+});
+
+function makeUser(id: number, name = `user-${id}`): User {
+  return {
+    id,
+    name,
+    description: `${name}-desc`,
+    role: "user",
+    rpm: null,
+    dailyQuota: null,
+    providerGroup: null,
+    tags: [],
+    createdAt: new Date("2026-03-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-03-01T00:00:00.000Z"),
+    deletedAt: undefined,
+    dailyResetMode: "fixed",
+    dailyResetTime: "00:00",
+    isEnabled: true,
+    expiresAt: null,
+    allowedClients: [],
+    blockedClients: [],
+    allowedModels: [],
+  };
+}
+
+describe("getUsers compatibility", () => {
+  beforeEach(() => {
+    getSessionMock.mockReset();
+    findUserByIdMock.mockReset();
+    findUserListBatchMock.mockReset();
+    findKeyListBatchMock.mockReset();
+    findKeyUsageTodayBatchMock.mockReset();
+    findKeysStatisticsBatchFromKeysMock.mockReset();
+
+    getSessionMock.mockResolvedValue({
+      user: { id: 1, role: "admin" },
+      key: { canLoginWebUi: true },
+    });
+    findKeyListBatchMock.mockResolvedValue(new Map());
+    findKeyUsageTodayBatchMock.mockResolvedValue(new Map());
+    findKeysStatisticsBatchFromKeysMock.mockResolvedValue(new Map());
+  });
+
+  test("loads all admin users instead of stopping at the first 50", async () => {
+    const firstPageUsers = Array.from({ length: 200 }, (_, index) => makeUser(index + 1));
+    const secondPageUser = makeUser(201, "after-first-200");
+
+    findUserListBatchMock
+      .mockResolvedValueOnce({
+        users: firstPageUsers,
+        nextCursor: '{"v":"2026-03-01T00:00:00.000Z","id":200}',
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        users: [secondPageUser],
+        nextCursor: null,
+        hasMore: false,
+      });
+
+    const { getUsers } = await import("@/actions/users");
+
+    const result = await getUsers();
+
+    expect(findUserListBatchMock).toHaveBeenNthCalledWith(1, {
+      cursor: undefined,
+      searchTerm: undefined,
+      tagFilters: undefined,
+      keyGroupFilters: undefined,
+      statusFilter: undefined,
+      limit: 200,
+      sortBy: undefined,
+      sortOrder: undefined,
+    });
+    expect(findUserListBatchMock).toHaveBeenNthCalledWith(2, {
+      cursor: '{"v":"2026-03-01T00:00:00.000Z","id":200}',
+      searchTerm: undefined,
+      tagFilters: undefined,
+      keyGroupFilters: undefined,
+      statusFilter: undefined,
+      limit: 200,
+      sortBy: undefined,
+      sortOrder: undefined,
+    });
+    expect(result).toHaveLength(201);
+    expect(result.at(-1)?.name).toBe("after-first-200");
+  });
+
+  test("normalizes legacy getUsers page and query params", async () => {
+    findUserListBatchMock.mockResolvedValueOnce({
+      users: [makeUser(51, "xiaolunanbei")],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    const { getUsers } = await import("@/actions/users");
+
+    const result = await getUsers({
+      page: 2,
+      limit: 50,
+      query: "  小鹿楠贝  ",
+    });
+
+    expect(findUserListBatchMock).toHaveBeenCalledWith({
+      cursor: "50",
+      limit: 50,
+      searchTerm: "小鹿楠贝",
+      tagFilters: undefined,
+      keyGroupFilters: undefined,
+      statusFilter: undefined,
+      sortBy: undefined,
+      sortOrder: undefined,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("xiaolunanbei");
+  });
+
+  test("search-only getUsers requests keep paging until all matches are returned", async () => {
+    findUserListBatchMock
+      .mockResolvedValueOnce({
+        users: Array.from({ length: 200 }, (_, index) => makeUser(index + 1, `match-${index + 1}`)),
+        nextCursor: '{"v":"2026-03-01T00:00:00.000Z","id":200}',
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        users: [makeUser(201, "match-201")],
+        nextCursor: null,
+        hasMore: false,
+      });
+
+    const { getUsers } = await import("@/actions/users");
+
+    const result = await getUsers({ query: "match" });
+
+    expect(findUserListBatchMock).toHaveBeenNthCalledWith(1, {
+      cursor: undefined,
+      limit: 200,
+      searchTerm: "match",
+      tagFilters: undefined,
+      keyGroupFilters: undefined,
+      statusFilter: undefined,
+      sortBy: undefined,
+      sortOrder: undefined,
+    });
+    expect(findUserListBatchMock).toHaveBeenNthCalledWith(2, {
+      cursor: '{"v":"2026-03-01T00:00:00.000Z","id":200}',
+      limit: 200,
+      searchTerm: "match",
+      tagFilters: undefined,
+      keyGroupFilters: undefined,
+      statusFilter: undefined,
+      sortBy: undefined,
+      sortOrder: undefined,
+    });
+    expect(result).toHaveLength(201);
+    expect(result.at(-1)?.name).toBe("match-201");
+  });
+
+  test("normalizes legacy getUsersBatch keyword and offset params", async () => {
+    findUserListBatchMock.mockResolvedValueOnce({
+      users: [makeUser(88, "keyword-hit")],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    const { getUsersBatch } = await import("@/actions/users");
+
+    const result = await getUsersBatch({
+      offset: 75,
+      limit: 25,
+      keyword: "  key-word  ",
+    });
+
+    expect(findUserListBatchMock).toHaveBeenCalledWith({
+      cursor: "75",
+      limit: 25,
+      searchTerm: "key-word",
+      tagFilters: undefined,
+      keyGroupFilters: undefined,
+      statusFilter: undefined,
+      sortBy: undefined,
+      sortOrder: undefined,
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        users: [
+          expect.objectContaining({
+            id: 88,
+            name: "keyword-hit",
+          }),
+        ],
+        nextCursor: null,
+        hasMore: false,
+      },
+    });
+  });
+});

--- a/tests/unit/users-action-get-users-compat.test.ts
+++ b/tests/unit/users-action-get-users-compat.test.ts
@@ -155,6 +155,32 @@ describe("getUsers compatibility", () => {
     expect(result[0]?.name).toBe("xiaolunanbei");
   });
 
+  test("falls back to legacy query when searchTerm is blank", async () => {
+    findUserListBatchMock.mockResolvedValueOnce({
+      users: [makeUser(77, "legacy-query-hit")],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    const { getUsersBatch } = await import("@/actions/users");
+
+    await getUsersBatch({
+      searchTerm: "   ",
+      query: "  alice  ",
+    });
+
+    expect(findUserListBatchMock).toHaveBeenCalledWith({
+      cursor: undefined,
+      limit: undefined,
+      searchTerm: "alice",
+      tagFilters: undefined,
+      keyGroupFilters: undefined,
+      statusFilter: undefined,
+      sortBy: undefined,
+      sortOrder: undefined,
+    });
+  });
+
   test("search-only getUsers requests keep paging until all matches are returned", async () => {
     findUserListBatchMock
       .mockResolvedValueOnce({
@@ -194,6 +220,52 @@ describe("getUsers compatibility", () => {
     });
     expect(result).toHaveLength(201);
     expect(result.at(-1)?.name).toBe("match-201");
+  });
+
+  test("treats whitespace cursor as missing pagination and keeps loading matches", async () => {
+    findUserListBatchMock
+      .mockResolvedValueOnce({
+        users: Array.from({ length: 200 }, (_, index) =>
+          makeUser(index + 1, `cursor-match-${index + 1}`)
+        ),
+        nextCursor: '{"v":"2026-03-01T00:00:00.000Z","id":200}',
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        users: [makeUser(201, "cursor-match-201")],
+        nextCursor: null,
+        hasMore: false,
+      });
+
+    const { getUsers } = await import("@/actions/users");
+
+    const result = await getUsers({
+      cursor: "   ",
+      query: "cursor-match",
+    });
+
+    expect(findUserListBatchMock).toHaveBeenNthCalledWith(1, {
+      cursor: undefined,
+      limit: 200,
+      searchTerm: "cursor-match",
+      tagFilters: undefined,
+      keyGroupFilters: undefined,
+      statusFilter: undefined,
+      sortBy: undefined,
+      sortOrder: undefined,
+    });
+    expect(findUserListBatchMock).toHaveBeenNthCalledWith(2, {
+      cursor: '{"v":"2026-03-01T00:00:00.000Z","id":200}',
+      limit: 200,
+      searchTerm: "cursor-match",
+      tagFilters: undefined,
+      keyGroupFilters: undefined,
+      statusFilter: undefined,
+      sortBy: undefined,
+      sortOrder: undefined,
+    });
+    expect(result).toHaveLength(201);
+    expect(result.at(-1)?.name).toBe("cursor-match-201");
   });
 
   test("normalizes legacy getUsersBatch keyword and offset params", async () => {

--- a/tests/unit/users-action-search-users-for-filter.test.ts
+++ b/tests/unit/users-action-search-users-for-filter.test.ts
@@ -68,4 +68,16 @@ describe("searchUsersForFilter (action)", () => {
     expect(searchUsersForFilterRepositoryMock).toHaveBeenCalledWith("ali");
     expect(result).toEqual({ ok: true, data: [{ id: 1, name: "Alice" }] });
   });
+
+  test("searchUsers alias delegates to searchUsersForFilter", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
+    searchUsersForFilterRepositoryMock.mockResolvedValue([{ id: 9, name: "Bob" }]);
+
+    const { searchUsers } = await import("@/actions/users");
+
+    const result = await searchUsers("bob");
+
+    expect(searchUsersForFilterRepositoryMock).toHaveBeenCalledWith("bob");
+    expect(result).toEqual({ ok: true, data: [{ id: 9, name: "Bob" }] });
+  });
 });


### PR DESCRIPTION
## Summary
- restore legacy `/api/actions/users/getUsersBatch` and `/api/actions/users/searchUsers` HTTP endpoints
- make `/api/actions/users/getUsers` honor legacy pagination and search params instead of stopping at the first 50 users
- add regression coverage for OpenAPI registration, endpoint reachability, and legacy parameter normalization

## Root Cause
- `getUsersBatch` and `searchUsers` were implemented in actions but not registered in the OpenAPI route table, so HTTP callers got 404
- `getUsers` ignored pagination/search params and always read the repository default page of 50 users for admin calls
- legacy clients using `page`, `offset`, `query`, or `keyword` could not reach users outside the first page, which caused upstream misclassification of empty results

## Testing
- `bun run typecheck`
- `bun run build`
- `bun run test`
- `bunx vitest run tests/unit/users-action-search-users-for-filter.test.ts tests/unit/users-action-get-users-compat.test.ts tests/api/api-actions-integrity.test.ts tests/api/api-endpoints.test.ts`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores two missing HTTP endpoints (`getUsersBatch`, `searchUsers`) that were implemented in the action layer but never registered in the OpenAPI route table, and fixes `getUsers` so it honours legacy `page`/`offset`/`query`/`keyword` parameters rather than always returning the repository-default first page of 50 users. The changes are well-structured — a small set of pure normalisation helpers feeds a three-way routing strategy in `getUsers`, and the dashboard components are correctly migrated to the lighter `searchUsers` action with proper cleanup semantics.

Key changes:
- **New normalisation helpers** (`normalizeLegacySearchTerm`, `normalizeUserListParams`, `hasExplicitPaginationParams`, `hasSearchOrFilterOverrides`, `loadAllUsersForAdmin`) centralise all legacy-param handling in `src/actions/users.ts`.
- **`getUsers` routing** now selects single-page fetch (explicit pagination), full paginated scan (search/filter with no pagination), or full scan (no params at all) instead of calling the old `findUserList` which always stopped at 50.
- **`getUsersBatch` and `searchUsers`** are registered in the OpenAPI table, fixing the 404 that upstream callers were receiving.
- **Dashboard components** switch from the heavy `getUsers()` (`UserDisplay[]`) to `searchUsers()` (`{id,name}[]`) with a `cancelled`-flag cleanup, reducing payload size and avoiding stale-state after unmount.
- **Regression suite** covers OpenAPI registration, endpoint reachability, multi-page loading, and all three legacy-param alias paths.

Minor concerns:
- `page: 0` and `page: 1` both resolve to offset 0 (see inline comment); this is noted as intentional but will silently return the wrong page for strictly 0-indexed clients using `page ≥ 1`.
- The `argsMapper` for `searchUsersRoute` in `route.ts` duplicates the first-non-empty-wins trim logic already in `normalizeLegacySearchTerm`.
- `loadAllUsersForAdmin` has no upper page limit, which could be problematic on very large datasets.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge; the 404 fixes and pagination regression are well-tested, with only minor style and edge-case concerns remaining.
- The root-cause fixes are correct, the test coverage is thorough (unit + integration + OpenAPI integrity), and the component migration is type-safe. The three P2 findings (duplicated normalization logic, page-0/page-1 ambiguity, missing iteration ceiling in `loadAllUsersForAdmin`) are all non-blocking and do not affect normal usage paths.
- src/actions/users.ts (page-0/page-1 offset ambiguity and unbounded loop) and src/app/api/actions/[...route]/route.ts (duplicated search-term normalization in argsMapper)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/actions/users.ts | Core change: adds `normalizeUserListParams`, `loadAllUsersForAdmin`, and `searchUsers` alias; routes `getUsers` through a three-way strategy (single-page / load-all with filters / load-all without filters). Logic is sound but `page: 0` and `page: 1` both silently resolve to offset 0, and `loadAllUsersForAdmin` has no iteration ceiling. |
| src/app/api/actions/[...route]/route.ts | Registers `getUsersBatch` and `searchUsers` in the OpenAPI route table; updates `getUsers` request schema to accept legacy pagination fields. The `argsMapper` for `searchUsersRoute` duplicates the trim-and-first-non-empty logic already in `normalizeLegacySearchTerm`. |
| src/app/[locale]/dashboard/_components/rate-limit-top-users.tsx | Switches from `getUsers()` (full `UserDisplay[]`) to `searchUsers()` (`{id,name}[]`), matching the updated state type. Adds proper `cancelled` flag cleanup to prevent stale setState after unmount. No issues. |
| src/app/[locale]/dashboard/rate-limits/_components/rate-limit-filters.tsx | Same `getUsers` → `searchUsers` migration with `cancelled` cleanup pattern. The existing `getProviders` effect does not yet have the cleanup guard, but that is pre-existing and out of scope. |
| tests/unit/users-action-get-users-compat.test.ts | New unit tests covering multi-page load, legacy `page`/`query`/`offset`/`keyword` normalization, and whitespace-cursor handling. Good coverage of the new routing branches in `getUsers`. |
| tests/api/users-search-users-compat.test.ts | New integration test verifying the `searchUsers` HTTP endpoint correctly falls back through `searchTerm → query → keyword` via `argsMapper`. Covers the primary compatibility scenario. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["HTTP POST /api/actions/users/getUsers\n(with optional legacy params)"] --> B["argsMapper: body → [body]"]
    B --> C["getUsers(params?)"]
    C --> D["normalizeUserListParams(params)\n→ cursor, limit, searchTerm…"]
    D --> E{hasExplicitPaginationParams?}
    E -- "cursor/limit/page/offset present" --> F["findUserListBatch(normalizedParams)\n— single page returned"]
    E -- "no pagination params" --> G{hasSearchOrFilterOverrides?}
    G -- "searchTerm / tagFilters / etc." --> H["loadAllUsersForAdmin(normalizedParams)\n— loops until !hasMore"]
    G -- "no overrides" --> I["loadAllUsersForAdmin()\n— loops until !hasMore"]
    F --> J["Build UserDisplay[] with keys & usage"]
    H --> J
    I --> J

    K["HTTP POST /api/actions/users/getUsersBatch"] --> L["argsMapper: body → [body]"]
    L --> M["getUsersBatch(params)"]
    M --> N["normalizeUserListParams(params)"]
    N --> O["findUserListBatch(normalizedParams)\n— single page, returns cursor"]

    P["HTTP POST /api/actions/users/searchUsers"] --> Q["argsMapper: trim searchTerm/query/keyword"]
    Q --> R["searchUsers(searchTerm?)"]
    R --> S["searchUsersForFilter(searchTerm?)"]
    S --> T["DB query ILIKE, limit 200\n→ id + name only"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/api/actions/[...route]/route.ts`, line 483-489 ([link](https://github.com/ding113/claude-code-hub/blob/1211fca2cc06be41d86a69da6653ead54d7ec0ef/src/app/api/actions/[...route]/route.ts#L483-L489)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Duplicated search-term normalization logic**

   The `argsMapper` for `searchUsersRoute` re-implements the exact same trim-and-first-non-empty-wins logic that already exists in `normalizeLegacySearchTerm` in `src/actions/users.ts`. If the normalization rules ever change (e.g., adding a `q` alias), the two places will diverge silently.

   Consider exporting `normalizeLegacySearchTerm` (or a thin wrapper) from `users.ts` and reusing it here:

   ```
   argsMapper: (body) => {
     const searchTerm = normalizeLegacySearchTerm(body);
     return [searchTerm];
   },
   ```

   Or, simpler still, let `searchUsers` accept the full legacy bag and do its own normalization just like the other actions now do:

   ```
   argsMapper: (body) => [body.searchTerm, body.query, body.keyword],
   ```

   and update `searchUsers` to accept all three optional strings.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/api/actions/[...route]/route.ts
   Line: 483-489

   Comment:
   **Duplicated search-term normalization logic**

   The `argsMapper` for `searchUsersRoute` re-implements the exact same trim-and-first-non-empty-wins logic that already exists in `normalizeLegacySearchTerm` in `src/actions/users.ts`. If the normalization rules ever change (e.g., adding a `q` alias), the two places will diverge silently.

   Consider exporting `normalizeLegacySearchTerm` (or a thin wrapper) from `users.ts` and reusing it here:

   ```
   argsMapper: (body) => {
     const searchTerm = normalizeLegacySearchTerm(body);
     return [searchTerm];
   },
   ```

   Or, simpler still, let `searchUsers` accept the full legacy bag and do its own normalization just like the other actions now do:

   ```
   argsMapper: (body) => [body.searchTerm, body.query, body.keyword],
   ```

   and update `searchUsers` to accept all three optional strings.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/api/actions/[...route]/route.ts
Line: 483-489

Comment:
**Duplicated search-term normalization logic**

The `argsMapper` for `searchUsersRoute` re-implements the exact same trim-and-first-non-empty-wins logic that already exists in `normalizeLegacySearchTerm` in `src/actions/users.ts`. If the normalization rules ever change (e.g., adding a `q` alias), the two places will diverge silently.

Consider exporting `normalizeLegacySearchTerm` (or a thin wrapper) from `users.ts` and reusing it here:

```
argsMapper: (body) => {
  const searchTerm = normalizeLegacySearchTerm(body);
  return [searchTerm];
},
```

Or, simpler still, let `searchUsers` accept the full legacy bag and do its own normalization just like the other actions now do:

```
argsMapper: (body) => [body.searchTerm, body.query, body.keyword],
```

and update `searchUsers` to accept all three optional strings.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/actions/users.ts
Line: 102-104

Comment:
**`page: 0` and `page: 1` both resolve to the same offset**

With `Math.max(page - 1, 0) * effectiveLimit`:
- `page=0` → `Math.max(-1, 0) * limit = 0` → cursor `"0"` (first page)
- `page=1` → `Math.max(0, 0) * limit = 0`  → cursor `"0"` (first page again)

The comment says "from 0 or 1" which implies both conventions are supported, but in practice this is 1-indexed with `page=0` clamped to `page=1`. A strictly 0-indexed client sending `page=1` expecting the **second** page of results will silently receive the **first** page, and all subsequent pages will be shifted by one. Since both `page=0` and `page=1` land in the `hasExplicitPaginationParams` fast-path (via a non-undefined cursor), there will be no error — just wrong data.

If supporting genuine 0-indexed clients is in scope, consider accepting a `pageBase` parameter (0 or 1) or documenting explicitly that only 1-indexed pagination is honored.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/actions/users.ts
Line: 143-163

Comment:
**`loadAllUsersForAdmin` has no upper page limit**

The `while (true)` loop pages through every record in the database without any safeguard. On a large deployment (or if the repository returns a bug-free but ever-advancing cursor), this will spin indefinitely and accumulate all results in memory before returning.

Consider adding a configurable max-pages guard to limit unbounded iteration:

```ts
const MAX_PAGES = 50; // 50 × 200 = 10 000 users
let pagesLoaded = 0;

while (true) {
  if (++pagesLoaded > MAX_PAGES) {
    logger.warn("loadAllUsersForAdmin: page limit reached, results may be incomplete");
    break;
  }
  // ...existing fetch logic
}
```

This is especially relevant now that `getUsers` (called by server-rendered pages and background jobs) routes through this function for any search/filter request.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address user search review feedback"](https://github.com/ding113/claude-code-hub/commit/1211fca2cc06be41d86a69da6653ead54d7ec0ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25969786)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->