### PR TITLE
Fix high-concurrency dashboard session stats

### DIFF
--- a/src/app/[locale]/dashboard/_components/bento/dashboard-bento.tsx
+++ b/src/app/[locale]/dashboard/_components/bento/dashboard-bento.tsx
@@ -30,6 +30,8 @@ const StatisticsChartCard = dynamic(
   { ssr: false }
 );
 
+const REFRESH_INTERVAL = 5000;
+
 interface DashboardBentoProps {
   isAdmin: boolean;
   currencyCode: CurrencyCode;
@@ -139,7 +141,7 @@ export function DashboardBento({
   const { data: sessions = [], isLoading: sessionsLoading } = useQuery<ActiveSessionInfo[]>({
     queryKey: ["active-sessions"],
     queryFn: fetchActiveSessions,
-    refetchInterval: 5000,
+    refetchInterval: REFRESH_INTERVAL,
     enabled: isAdmin && !enableHighConcurrencyMode,
   });
 

--- a/src/app/[locale]/dashboard/_components/bento/dashboard-bento.tsx
+++ b/src/app/[locale]/dashboard/_components/bento/dashboard-bento.tsx
@@ -30,12 +30,11 @@ const StatisticsChartCard = dynamic(
   { ssr: false }
 );
 
-const REFRESH_INTERVAL = 5000;
-
 interface DashboardBentoProps {
   isAdmin: boolean;
   currencyCode: CurrencyCode;
   allowGlobalUsageView: boolean;
+  enableHighConcurrencyMode: boolean;
   initialStatistics?: UserStatisticsData;
   initialOverview?: OverviewData;
 }
@@ -119,6 +118,7 @@ export function DashboardBento({
   isAdmin,
   currencyCode,
   allowGlobalUsageView,
+  enableHighConcurrencyMode,
   initialStatistics,
   initialOverview,
 }: DashboardBentoProps) {
@@ -136,12 +136,11 @@ export function DashboardBento({
     initialData: initialOverview,
   });
 
-  // Active sessions
   const { data: sessions = [], isLoading: sessionsLoading } = useQuery<ActiveSessionInfo[]>({
     queryKey: ["active-sessions"],
     queryFn: fetchActiveSessions,
-    refetchInterval: REFRESH_INTERVAL,
-    enabled: isAdmin,
+    refetchInterval: 5000,
+    enabled: isAdmin && !enableHighConcurrencyMode,
   });
 
   // Statistics
@@ -205,13 +204,14 @@ export function DashboardBento({
     metrics.yesterdaySamePeriodAvgResponseTime
   );
 
-  // Sessions with lastActivityAt for LiveSessionsPanel
-  const sessionsWithActivity = useMemo(() => {
-    return sessions.map((s) => ({
-      ...s,
-      lastActivityAt: s.startTime,
-    }));
-  }, [sessions]);
+  const sessionsWithActivity = useMemo(
+    () =>
+      sessions.map((session) => ({
+        ...session,
+        lastActivityAt: session.startTime,
+      })),
+    [sessions]
+  );
 
   const canViewLeaderboard = isAdmin || allowGlobalUsageView;
 
@@ -221,18 +221,24 @@ export function DashboardBento({
       {isAdmin && (
         <BentoGrid>
           <BentoMetricCard
-            title={t("metrics.concurrent")}
-            value={metrics.concurrentSessions}
+            title={enableHighConcurrencyMode ? t("metrics.rpm") : t("metrics.concurrent")}
+            value={
+              enableHighConcurrencyMode ? metrics.recentMinuteRequests : metrics.concurrentSessions
+            }
             icon={Activity}
             accentColor="emerald"
             className="min-h-[120px]"
-            comparisons={[
-              {
-                value: metrics.recentMinuteRequests,
-                label: t("metrics.rpm"),
-                isPercentage: false,
-              },
-            ]}
+            comparisons={
+              enableHighConcurrencyMode
+                ? undefined
+                : [
+                    {
+                      value: metrics.recentMinuteRequests,
+                      label: t("metrics.rpm"),
+                      isPercentage: false,
+                    },
+                  ]
+            }
           />
           <BentoMetricCard
             title={t("metrics.todayRequests")}
@@ -271,13 +277,13 @@ export function DashboardBento({
         />
       )}
 
-      {/* Section 3: Leaderboards + Live Sessions */}
+      {/* Section 3: Leaderboards */}
       {canViewLeaderboard && (
         <div
           data-testid={isAdmin ? "dashboard-home-layout" : undefined}
           className={cn(
             "grid gap-6",
-            isAdmin
+            isAdmin && !enableHighConcurrencyMode
               ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-[1fr_1fr_1fr_280px]"
               : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
           )}
@@ -312,13 +318,8 @@ export function DashboardBento({
             maxItems={3}
             accentColor="blue"
           />
-
-          {isAdmin && (
-            <LiveSessionsPanel
-              data-testid="dashboard-home-sidebar"
-              sessions={sessionsWithActivity}
-              isLoading={sessionsLoading}
-            />
+          {isAdmin && !enableHighConcurrencyMode && (
+            <LiveSessionsPanel sessions={sessionsWithActivity} isLoading={sessionsLoading} />
           )}
         </div>
       )}

--- a/src/app/[locale]/dashboard/_components/dashboard-bento-sections.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-bento-sections.tsx
@@ -23,6 +23,7 @@ export async function DashboardBentoSection({ isAdmin }: DashboardBentoSectionPr
       isAdmin={isAdmin}
       currencyCode={systemSettings.currencyDisplay}
       allowGlobalUsageView={systemSettings.allowGlobalUsageView}
+      enableHighConcurrencyMode={systemSettings.enableHighConcurrencyMode}
       initialStatistics={statistics.ok ? statistics.data : undefined}
       initialOverview={overviewResult.ok ? overviewResult.data : undefined}
     />

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
@@ -3,6 +3,7 @@ import { ActiveSessionsList } from "@/components/customs/active-sessions-list";
 import { getEnvConfig } from "@/lib/config/env.schema";
 import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import { getSystemSettings } from "@/repository/system-config";
+import type { SystemSettings } from "@/types/system-config";
 import { UsageLogsViewVirtualized } from "./usage-logs-view-virtualized";
 
 const getCachedSystemSettings = cache(getSystemSettings);
@@ -11,6 +12,7 @@ interface UsageLogsDataSectionProps {
   isAdmin: boolean;
   userId: number;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+  systemSettings?: Pick<SystemSettings, "billingModelSource" | "currencyDisplay">;
 }
 
 export async function UsageLogsActiveSessionsSection() {
@@ -28,10 +30,11 @@ export async function UsageLogsDataSection({
   isAdmin,
   userId,
   searchParams,
+  systemSettings: systemSettingsProp,
 }: UsageLogsDataSectionProps) {
   const resolvedSearchParams = await searchParams;
   const serverTimeZone = await resolveSystemTimezone();
-  const systemSettings = await getCachedSystemSettings();
+  const systemSettings = systemSettingsProp ?? (await getCachedSystemSettings());
 
   return (
     <UsageLogsViewVirtualized

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { ActiveSessionsList } from "@/components/customs/active-sessions-list";
 import { getEnvConfig } from "@/lib/config/env.schema";
+import type { CurrencyCode } from "@/lib/utils";
 import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import { getSystemSettings } from "@/repository/system-config";
 import type { SystemSettings } from "@/types/system-config";
@@ -15,14 +16,9 @@ interface UsageLogsDataSectionProps {
   systemSettings?: Pick<SystemSettings, "billingModelSource" | "currencyDisplay">;
 }
 
-export async function UsageLogsActiveSessionsSection() {
-  const systemSettings = await getCachedSystemSettings();
+export function UsageLogsActiveSessionsSection({ currencyCode }: { currencyCode: CurrencyCode }) {
   return (
-    <ActiveSessionsList
-      currencyCode={systemSettings.currencyDisplay}
-      maxHeight="200px"
-      showTokensCost={false}
-    />
+    <ActiveSessionsList currencyCode={currencyCode} maxHeight="200px" showTokensCost={false} />
   );
 }
 

--- a/src/app/[locale]/dashboard/logs/page.test.tsx
+++ b/src/app/[locale]/dashboard/logs/page.test.tsx
@@ -1,0 +1,85 @@
+import { Children, isValidElement, type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const authMocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSession: authMocks.getSession,
+}));
+
+vi.mock("@/i18n/routing", () => ({
+  redirect: vi.fn(),
+}));
+
+const systemConfigMocks = vi.hoisted(() => ({
+  getSystemSettings: vi.fn(),
+}));
+
+vi.mock("@/repository/system-config", () => ({
+  getSystemSettings: systemConfigMocks.getSystemSettings,
+}));
+
+vi.mock("./_components/active-sessions-skeleton", () => ({
+  ActiveSessionsSkeleton: () => null,
+}));
+
+vi.mock("./_components/usage-logs-skeleton", () => ({
+  UsageLogsSkeleton: () => null,
+}));
+
+vi.mock("./_components/usage-logs-sections", () => ({
+  UsageLogsActiveSessionsSection: () => null,
+  UsageLogsDataSection: () => null,
+}));
+
+describe("UsageLogsPage", () => {
+  it("only renders the logs data section in high concurrency mode", async () => {
+    authMocks.getSession.mockResolvedValue({
+      user: {
+        id: 7,
+        role: "admin",
+      },
+    });
+    systemConfigMocks.getSystemSettings.mockResolvedValue({
+      enableHighConcurrencyMode: true,
+    });
+
+    const { default: UsageLogsPage } = await import("./page");
+    const element = await UsageLogsPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(isValidElement<{ children?: ReactNode }>(element)).toBe(true);
+    if (!isValidElement<{ children?: ReactNode }>(element)) {
+      throw new Error("UsageLogsPage should return a React element");
+    }
+    expect(Children.toArray(element.props.children)).toHaveLength(1);
+  });
+
+  it("renders active sessions section and logs data section in normal mode", async () => {
+    authMocks.getSession.mockResolvedValue({
+      user: {
+        id: 7,
+        role: "admin",
+      },
+    });
+    systemConfigMocks.getSystemSettings.mockResolvedValue({
+      enableHighConcurrencyMode: false,
+    });
+
+    const { default: UsageLogsPage } = await import("./page");
+    const element = await UsageLogsPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(isValidElement<{ children?: ReactNode }>(element)).toBe(true);
+    if (!isValidElement<{ children?: ReactNode }>(element)) {
+      throw new Error("UsageLogsPage should return a React element");
+    }
+    expect(Children.toArray(element.props.children)).toHaveLength(2);
+  });
+});

--- a/src/app/[locale]/dashboard/logs/page.tsx
+++ b/src/app/[locale]/dashboard/logs/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { redirect } from "@/i18n/routing";
 import { getSession } from "@/lib/auth";
+import { getSystemSettings } from "@/repository/system-config";
 import { ActiveSessionsSkeleton } from "./_components/active-sessions-skeleton";
 import {
   UsageLogsActiveSessionsSection,
@@ -25,13 +26,15 @@ export default async function UsageLogsPage({
   }
 
   const isAdmin = session.user.role === "admin";
+  const systemSettings = await getSystemSettings();
 
   return (
     <div className="space-y-4">
-      {/* Active Sessions - Horizontal scrolling cards */}
-      <Suspense fallback={<ActiveSessionsSkeleton />}>
-        <UsageLogsActiveSessionsSection />
-      </Suspense>
+      {!systemSettings.enableHighConcurrencyMode && (
+        <Suspense fallback={<ActiveSessionsSkeleton />}>
+          <UsageLogsActiveSessionsSection />
+        </Suspense>
+      )}
 
       {/* Stats + Filters + Logs Table */}
       <Suspense fallback={<UsageLogsSkeleton />}>
@@ -39,6 +42,7 @@ export default async function UsageLogsPage({
           isAdmin={isAdmin}
           userId={session.user.id}
           searchParams={searchParams}
+          systemSettings={systemSettings}
         />
       </Suspense>
     </div>

--- a/src/app/[locale]/dashboard/logs/page.tsx
+++ b/src/app/[locale]/dashboard/logs/page.tsx
@@ -32,7 +32,7 @@ export default async function UsageLogsPage({
     <div className="space-y-4">
       {!systemSettings.enableHighConcurrencyMode && (
         <Suspense fallback={<ActiveSessionsSkeleton />}>
-          <UsageLogsActiveSessionsSection />
+          <UsageLogsActiveSessionsSection currencyCode={systemSettings.currencyDisplay} />
         </Suspense>
       )}
 

--- a/tests/unit/dashboard/dashboard-home-layout.test.tsx
+++ b/tests/unit/dashboard/dashboard-home-layout.test.tsx
@@ -204,12 +204,40 @@ describe("DashboardMain layout classes", () => {
 });
 
 describe("DashboardBento admin layout", () => {
-  test("renders four-column layout with LiveSessionsPanel in last column", async () => {
+  test("renders RPM metric and hides live sessions panel in high concurrency mode", async () => {
     const { container, unmount } = renderWithProviders(
       <DashboardBento
         isAdmin={true}
         currencyCode="USD"
         allowGlobalUsageView={false}
+        enableHighConcurrencyMode={true}
+        initialStatistics={mockStatisticsData}
+      />
+    );
+    await flushPromises();
+
+    const grid = findByClassToken(container, "lg:grid-cols-3");
+    expect(grid).toBeTruthy();
+    expect(findByClassToken(container, "lg:grid-cols-[1fr_1fr_1fr_280px]")).toBeFalsy();
+
+    expect(container.querySelector('[data-testid="live-sessions-panel"]')).toBeNull();
+    expect(activeSessionsMocks.getActiveSessions).not.toHaveBeenCalled();
+
+    const text = container.textContent ?? "";
+    expect(text).toContain("RPM");
+    expect(text).toContain("3");
+    expect(text).not.toContain("Active Sessions");
+
+    unmount();
+  });
+
+  test("renders active sessions metric and live sessions panel in normal mode", async () => {
+    const { container, unmount } = renderWithProviders(
+      <DashboardBento
+        isAdmin={true}
+        currencyCode="USD"
+        allowGlobalUsageView={false}
+        enableHighConcurrencyMode={false}
         initialStatistics={mockStatisticsData}
       />
     );
@@ -218,10 +246,11 @@ describe("DashboardBento admin layout", () => {
     const grid = findByClassToken(container, "lg:grid-cols-[1fr_1fr_1fr_280px]");
     expect(grid).toBeTruthy();
 
-    const livePanel = container.querySelector('[data-testid="live-sessions-panel"]');
-    expect(livePanel).toBeTruthy();
+    expect(container.querySelector('[data-testid="live-sessions-panel"]')).toBeTruthy();
+    expect(activeSessionsMocks.getActiveSessions).toHaveBeenCalled();
 
-    expect(grid?.contains(livePanel as HTMLElement)).toBe(true);
+    const text = container.textContent ?? "";
+    expect(text).toContain("Active Sessions");
 
     unmount();
   });

--- a/tests/unit/dashboard/logs/page.test.tsx
+++ b/tests/unit/dashboard/logs/page.test.tsx
@@ -21,15 +21,15 @@ vi.mock("@/repository/system-config", () => ({
   getSystemSettings: systemConfigMocks.getSystemSettings,
 }));
 
-vi.mock("./_components/active-sessions-skeleton", () => ({
+vi.mock("@/app/[locale]/dashboard/logs/_components/active-sessions-skeleton", () => ({
   ActiveSessionsSkeleton: () => null,
 }));
 
-vi.mock("./_components/usage-logs-skeleton", () => ({
+vi.mock("@/app/[locale]/dashboard/logs/_components/usage-logs-skeleton", () => ({
   UsageLogsSkeleton: () => null,
 }));
 
-vi.mock("./_components/usage-logs-sections", () => ({
+vi.mock("@/app/[locale]/dashboard/logs/_components/usage-logs-sections", () => ({
   UsageLogsActiveSessionsSection: () => null,
   UsageLogsDataSection: () => null,
 }));
@@ -46,7 +46,7 @@ describe("UsageLogsPage", () => {
       enableHighConcurrencyMode: true,
     });
 
-    const { default: UsageLogsPage } = await import("./page");
+    const { default: UsageLogsPage } = await import("@/app/[locale]/dashboard/logs/page");
     const element = await UsageLogsPage({
       params: Promise.resolve({ locale: "en" }),
       searchParams: Promise.resolve({}),
@@ -70,7 +70,7 @@ describe("UsageLogsPage", () => {
       enableHighConcurrencyMode: false,
     });
 
-    const { default: UsageLogsPage } = await import("./page");
+    const { default: UsageLogsPage } = await import("@/app/[locale]/dashboard/logs/page");
     const element = await UsageLogsPage({
       params: Promise.resolve({ locale: "en" }),
       searchParams: Promise.resolve({}),

--- a/tests/unit/dashboard/logs/page.test.tsx
+++ b/tests/unit/dashboard/logs/page.test.tsx
@@ -1,5 +1,5 @@
-import { Children, isValidElement, type ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { Children, isValidElement, type ReactElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const authMocks = vi.hoisted(() => ({
   getSession: vi.fn(),
@@ -29,10 +29,47 @@ vi.mock("@/app/[locale]/dashboard/logs/_components/usage-logs-skeleton", () => (
   UsageLogsSkeleton: () => null,
 }));
 
+function MockUsageLogsActiveSessionsSection() {
+  return null;
+}
+
+MockUsageLogsActiveSessionsSection.displayName = "UsageLogsActiveSessionsSection";
+
+function MockUsageLogsDataSection() {
+  return null;
+}
+
+MockUsageLogsDataSection.displayName = "UsageLogsDataSection";
+
 vi.mock("@/app/[locale]/dashboard/logs/_components/usage-logs-sections", () => ({
-  UsageLogsActiveSessionsSection: () => null,
-  UsageLogsDataSection: () => null,
+  UsageLogsActiveSessionsSection: MockUsageLogsActiveSessionsSection,
+  UsageLogsDataSection: MockUsageLogsDataSection,
 }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function getChildComponentNames(element: ReactElement<{ children?: ReactNode }>) {
+  return Children.toArray(element.props.children)
+    .filter(isValidElement)
+    .map((child) => {
+      const innerChild = child.props?.children;
+      if (isValidElement(innerChild)) {
+        if (typeof innerChild.type === "string") {
+          return innerChild.type;
+        }
+
+        return innerChild.type.displayName ?? innerChild.type.name ?? "unknown";
+      }
+
+      if (typeof child.type === "string") {
+        return child.type;
+      }
+
+      return child.type.displayName ?? child.type.name ?? "unknown";
+    });
+}
 
 describe("UsageLogsPage", () => {
   it("only renders the logs data section in high concurrency mode", async () => {
@@ -56,7 +93,7 @@ describe("UsageLogsPage", () => {
     if (!isValidElement<{ children?: ReactNode }>(element)) {
       throw new Error("UsageLogsPage should return a React element");
     }
-    expect(Children.toArray(element.props.children)).toHaveLength(1);
+    expect(getChildComponentNames(element)).toEqual(["UsageLogsDataSection"]);
   });
 
   it("renders active sessions section and logs data section in normal mode", async () => {
@@ -80,6 +117,9 @@ describe("UsageLogsPage", () => {
     if (!isValidElement<{ children?: ReactNode }>(element)) {
       throw new Error("UsageLogsPage should return a React element");
     }
-    expect(Children.toArray(element.props.children)).toHaveLength(2);
+    expect(getChildComponentNames(element)).toEqual([
+      "UsageLogsActiveSessionsSection",
+      "UsageLogsDataSection",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
In high-concurrency mode, replace the dashboard's top "Active Sessions" metric with RPM, hide the dashboard live-sessions panel, and hide the active-sessions section on the usage-logs page. Keep the normal-mode session UI unchanged by branching on `enableHighConcurrencyMode`.

**Follow-up to #979** - adapts the dashboard UI to the high-concurrency mode introduced there, where expensive real-time session observability writes are intentionally reduced.

## Problem
PR #979 added `enableHighConcurrencyMode`, but the dashboard and usage-logs pages still rendered session-dependent UI:
- the top dashboard metric still implied active session counts
- the dashboard sidebar still fetched and displayed live sessions
- the usage-logs page still rendered the active-sessions section

In high-concurrency mode those session figures are intentionally incomplete, so the existing UI became misleading and wasted work on queries that should not run.

## Solution
Gate the affected UI on `enableHighConcurrencyMode`:
- **High-concurrency mode**
  - show `RPM` (`recentMinuteRequests`) as the first dashboard card
  - hide `LiveSessionsPanel`
  - disable the dashboard active-sessions query
  - hide the usage-logs active-sessions section
- **Normal mode**
  - preserve the existing active-sessions metric, live panel, and logs-page section

## Changes
- `src/app/[locale]/dashboard/_components/dashboard-bento-sections.tsx`
  - pass `enableHighConcurrencyMode` from system settings into `DashboardBento`
- `src/app/[locale]/dashboard/_components/bento/dashboard-bento.tsx`
  - branch the first metric card between `RPM` and concurrent sessions
  - only fetch/render live sessions in normal mode
  - restore the shared `REFRESH_INTERVAL` constant for session polling
  - switch the lower grid from 4 columns to 3 columns in high-concurrency mode
- `src/app/[locale]/dashboard/logs/page.tsx`
  - only render `UsageLogsActiveSessionsSection` in normal mode
  - reuse the already-fetched `currencyDisplay` when rendering the logs active-sessions section
- `src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx`
  - keep `UsageLogsDataSection` request-scoped settings reuse
  - make `UsageLogsActiveSessionsSection` accept `currencyCode` directly to avoid an extra settings fetch in normal mode
- `tests/unit/dashboard/dashboard-home-layout.test.tsx`
  - cover both high-concurrency and normal-mode dashboard branches
- `tests/unit/dashboard/logs/page.test.tsx`
  - cover both high-concurrency and normal-mode logs-page branches
  - add mock isolation and assert the concrete section components rendered by each mode

## Local Verification
### Targeted regression checks
- `bunx vitest run tests/unit/dashboard/dashboard-home-layout.test.tsx tests/unit/dashboard/logs/page.test.tsx src/app/[locale]/dashboard/logs/_components/usage-logs-sections.test.tsx`
  - Result: `3 passed`, `9 passed`

### Full project checks
- `bun run lint`
  - Result: exit `0` (`10 warnings`, `1 info`, `0 errors`)
- `bun run typecheck`
  - Result: exit `0`
- `bun run build`
  - Result: exit `0`
- `bun run test`
  - Result: `420 passed | 1 skipped` test files, `4199 passed | 3 skipped` tests, exit `0`

### Local browser smoke
Using the repo dev stack at `http://127.0.0.1:23000`:
- logged in with local dev admin token `cch-dev-admin`
- verified local dev `system_settings.enable_high_concurrency_mode = true`
- verified `/en/dashboard` shows `RPM` as the first card and no live-sessions panel
- verified `/en/dashboard/logs` does not render the active-sessions section

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adapts the dashboard and usage-logs UI to the high-concurrency mode introduced in #979, ensuring that session-dependent UI elements (which are intentionally degraded in that mode) are hidden and replaced with more meaningful metrics.

**Key changes:**
- **`dashboard-bento.tsx`**: When `enableHighConcurrencyMode` is on, the first metric card now shows RPM (`recentMinuteRequests`) instead of concurrent sessions; the active-sessions React Query is disabled (`enabled: isAdmin && !enableHighConcurrencyMode`); and `LiveSessionsPanel` is not rendered. The grid drops from a 4-column to a 3-column layout to fill the space cleanly.
- **`dashboard-bento-sections.tsx`**: Passes `enableHighConcurrencyMode` from the server-fetched `systemSettings` into `DashboardBento`.
- **`usage-logs-sections.tsx`**: Converts `UsageLogsActiveSessionsSection` from an `async` component (which fetched its own `getSystemSettings()`) into a simple synchronous component that receives `currencyCode` as a prop. `UsageLogsDataSection` now accepts an optional `systemSettings` prop as a bypass for the internal cached fetch.
- **`logs/page.tsx`**: Fetches `systemSettings` once, passes `currencyDisplay` directly to `UsageLogsActiveSessionsSection`, conditionally renders it only in normal mode, and forwards the full settings object to `UsageLogsDataSection` — resolving the duplicate DB-query concern from the previous review thread.
- **Tests**: Full test coverage for both modes in two test files, with mock isolation and concrete assertion on which section components are rendered.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — changes are well-scoped, well-tested, and the previous double-DB-query concern is fully resolved.
- All changed paths have unit-test coverage for both high-concurrency and normal modes. No P0 or P1 issues found. The duplicate `getSystemSettings` call raised in the previous review thread is resolved by this PR: `UsageLogsActiveSessionsSection` now receives `currencyCode` as a prop, and `UsageLogsDataSection` receives the full settings object, so only one DB round-trip is made per request in both modes.
- No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/_components/bento/dashboard-bento.tsx | Accepts `enableHighConcurrencyMode` prop to conditionally show RPM vs concurrent-sessions metric, gate the active-sessions query, and hide `LiveSessionsPanel`; grid switches from 4- to 3-column in HCM. |
| src/app/[locale]/dashboard/logs/_components/usage-logs-sections.tsx | Converts `UsageLogsActiveSessionsSection` from async (fetching its own settings) to a pure sync component that accepts `currencyCode` as a prop; `UsageLogsDataSection` now accepts an optional `systemSettings` prop to avoid a redundant DB call. |
| src/app/[locale]/dashboard/logs/page.tsx | Fetches `systemSettings` once, conditionally renders `UsageLogsActiveSessionsSection` only in normal mode, and passes the settings object down to `UsageLogsDataSection`, eliminating the duplicate DB query flagged in the previous thread. |
| tests/unit/dashboard/logs/page.test.tsx | New test file covering both HCM and normal mode rendering of `UsageLogsPage`, using a JSX-tree helper to assert which section components are included in the output. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DashboardBentoSection / UsageLogsPage\nfetch systemSettings once] --> B{enableHighConcurrencyMode?}

    B -- Yes --> C[DashboardBento\nFirst card: RPM\nSessions query: disabled\nLiveSessionsPanel: hidden\nGrid: 3-column]
    B -- No --> D[DashboardBento\nFirst card: Concurrent Sessions\nSessions query: enabled\nLiveSessionsPanel: shown\nGrid: 4-column]

    A --> E{enableHighConcurrencyMode?}
    E -- Yes --> F[UsageLogsPage\nSkip UsageLogsActiveSessionsSection]
    E -- No --> G[UsageLogsPage\nRender UsageLogsActiveSessionsSection\ncurrencyCode passed as prop]

    F --> H[UsageLogsDataSection\nsystemSettings passed as prop]
    G --> H
```
</details>

<sub>Reviews (4): Last reviewed commit: ["refactor: polish high-concurrency dashbo..."](https://github.com/ding113/claude-code-hub/commit/0bad28a94af190f720d224270f80081cef8b031d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27062790)</sub>

<!-- /greptile_comment -->