### PR TITLE
fix: sanitize db errors before toast display

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,14 +1,19 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
+import { useEffect } from "react";
 import { Toaster as Sonner, type ToasterProps, toast } from "sonner";
 
 import { installErrorToastSanitizer } from "@/lib/utils/user-visible-error";
 
-installErrorToastSanitizer(toast);
-
 const Toaster = ({ ...props }: ToasterProps) => {
+  const t = useTranslations("errors");
   const { theme = "system" } = useTheme();
+
+  useEffect(() => {
+    installErrorToastSanitizer(toast, t("INTERNAL_ERROR"));
+  }, [t]);
 
   return (
     <Sonner

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import { Toaster as Sonner, type ToasterProps } from "sonner";
+import { Toaster as Sonner, type ToasterProps, toast } from "sonner";
+
+import { installErrorToastSanitizer } from "@/lib/utils/user-visible-error";
+
+installErrorToastSanitizer(toast);
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme();

--- a/src/lib/hooks/use-server-action.ts
+++ b/src/lib/hooks/use-server-action.ts
@@ -89,7 +89,8 @@ export function useServerAction() {
 
             if (!result.ok) {
               // Action 返回失败
-              const message = errorMessage || getSafeErrorToastMessage(result.error, DEFAULT_ERROR);
+              const rawMessage = errorMessage ?? result.error;
+              const message = getSafeErrorToastMessage(rawMessage, DEFAULT_ERROR);
 
               if (showToast) {
                 toast.error(message);
@@ -167,7 +168,8 @@ export async function withErrorHandling<T>(
     const result = await action();
 
     if (!result.ok) {
-      const message = errorMessage || getSafeErrorToastMessage(result.error, DEFAULT_ERROR);
+      const rawMessage = errorMessage ?? result.error;
+      const message = getSafeErrorToastMessage(rawMessage, DEFAULT_ERROR);
 
       if (showToast) {
         toast.error(message);

--- a/src/lib/hooks/use-server-action.ts
+++ b/src/lib/hooks/use-server-action.ts
@@ -4,6 +4,7 @@ import { useCallback, useState, useTransition } from "react";
 import { toast } from "sonner";
 import type { ActionResult } from "@/actions/types";
 import { isNetworkError } from "@/lib/utils/error-detection";
+import { getSafeErrorToastMessage } from "@/lib/utils/user-visible-error";
 
 /**
  * Server Action 执行选项
@@ -88,7 +89,7 @@ export function useServerAction() {
 
             if (!result.ok) {
               // Action 返回失败
-              const message = errorMessage || result.error;
+              const message = errorMessage || getSafeErrorToastMessage(result.error, DEFAULT_ERROR);
 
               if (showToast) {
                 toast.error(message);
@@ -166,7 +167,7 @@ export async function withErrorHandling<T>(
     const result = await action();
 
     if (!result.ok) {
-      const message = errorMessage || result.error;
+      const message = errorMessage || getSafeErrorToastMessage(result.error, DEFAULT_ERROR);
 
       if (showToast) {
         toast.error(message);

--- a/src/lib/utils/user-visible-error.test.ts
+++ b/src/lib/utils/user-visible-error.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  getSafeErrorToastMessage,
+  installErrorToastSanitizer,
+  sanitizeUserVisibleErrorMessage,
+} from "./user-visible-error";
+
+describe("user-visible-error", () => {
+  test("preserves ordinary user-safe messages", () => {
+    expect(getSafeErrorToastMessage("Provider probe failed", "Operation failed")).toBe(
+      "Provider probe failed"
+    );
+    expect(getSafeErrorToastMessage("Please select from the list", "Operation failed")).toBe(
+      "Please select from the list"
+    );
+  });
+
+  test("falls back when database error includes query details", () => {
+    const rawMessage =
+      'db query error: query: SELECT * FROM keys WHERE key = \'sk-live-secret123456\'; result: [{"key":"sk-live-secret123456"}]';
+
+    expect(getSafeErrorToastMessage(rawMessage, "Operation failed")).toBe("Operation failed");
+  });
+
+  test("redacts secrets when no fallback is available", () => {
+    expect(
+      sanitizeUserVisibleErrorMessage("request failed for apiKey=sk-live-secret1234567890")
+    ).toContain("[REDACTED]");
+  });
+
+  test("installs a global toast sanitizer", () => {
+    const originalError = vi.fn();
+    const toastApi = {
+      error: originalError,
+    };
+
+    installErrorToastSanitizer(toastApi);
+
+    toastApi.error(
+      'db query error: query: SELECT * FROM keys WHERE key = \'sk-live-secret123456\'; result: [{"key":"sk-live-secret123456"}]'
+    );
+
+    expect(originalError).toHaveBeenCalledWith("db query error");
+  });
+
+  test("uses a generic fallback when the raw toast message starts with query details", () => {
+    const originalError = vi.fn();
+    const toastApi = {
+      error: originalError,
+    };
+
+    installErrorToastSanitizer(toastApi);
+
+    toastApi.error("query: SELECT * FROM keys WHERE key = 'sk-live-secret123456'");
+
+    expect(originalError).toHaveBeenCalledWith("Operation failed");
+  });
+
+  test("sanitizes toast descriptions too", () => {
+    const originalError = vi.fn();
+    const toastApi = {
+      error: originalError,
+    };
+
+    installErrorToastSanitizer(toastApi);
+
+    toastApi.error("Save failed", {
+      description:
+        'db query error: query: SELECT * FROM keys WHERE key = \'sk-live-secret123456\'; result: [{"key":"[REDACTED:sk-secret]"}]',
+    });
+
+    expect(originalError).toHaveBeenCalledWith("Save failed", {
+      description: "db query error",
+    });
+  });
+});

--- a/src/lib/utils/user-visible-error.test.ts
+++ b/src/lib/utils/user-visible-error.test.ts
@@ -35,7 +35,7 @@ describe("user-visible-error", () => {
       error: originalError,
     };
 
-    installErrorToastSanitizer(toastApi);
+    installErrorToastSanitizer(toastApi, "Operation failed");
 
     toastApi.error(
       'db query error: query: SELECT * FROM keys WHERE key = \'sk-live-secret123456\'; result: [{"key":"sk-live-secret123456"}]'
@@ -50,7 +50,7 @@ describe("user-visible-error", () => {
       error: originalError,
     };
 
-    installErrorToastSanitizer(toastApi);
+    installErrorToastSanitizer(toastApi, "Operation failed");
 
     toastApi.error("query: SELECT * FROM keys WHERE key = 'sk-live-secret123456'");
 
@@ -63,7 +63,7 @@ describe("user-visible-error", () => {
       error: originalError,
     };
 
-    installErrorToastSanitizer(toastApi);
+    installErrorToastSanitizer(toastApi, "Operation failed");
 
     toastApi.error("Save failed", {
       description:
@@ -73,5 +73,24 @@ describe("user-visible-error", () => {
     expect(originalError).toHaveBeenCalledWith("Save failed", {
       description: "db query error",
     });
+  });
+
+  test("keeps zero-argument toast calls unchanged", () => {
+    const originalError = vi.fn();
+    const toastApi = {
+      error: originalError,
+    };
+
+    installErrorToastSanitizer(toastApi, "Operation failed");
+
+    toastApi.error();
+
+    expect(originalError).toHaveBeenCalledWith();
+  });
+
+  test("redacts assignment secrets that contain spaces", () => {
+    expect(sanitizeUserVisibleErrorMessage("validation failed: password: my secret password")).toBe(
+      "validation failed: password: [REDACTED]"
+    );
   });
 });

--- a/src/lib/utils/user-visible-error.test.ts
+++ b/src/lib/utils/user-visible-error.test.ts
@@ -4,7 +4,7 @@ import {
   getSafeErrorToastMessage,
   installErrorToastSanitizer,
   sanitizeUserVisibleErrorMessage,
-} from "./user-visible-error";
+} from "@/lib/utils/user-visible-error";
 
 describe("user-visible-error", () => {
   test("preserves ordinary user-safe messages", () => {
@@ -92,5 +92,19 @@ describe("user-visible-error", () => {
     expect(sanitizeUserVisibleErrorMessage("validation failed: password: my secret password")).toBe(
       "validation failed: password: [REDACTED]"
     );
+  });
+
+  test("updates the fallback message when reinstalling for a new locale", () => {
+    const originalError = vi.fn();
+    const toastApi = {
+      error: originalError,
+    };
+
+    installErrorToastSanitizer(toastApi, "Operation failed");
+    installErrorToastSanitizer(toastApi, "操作失败");
+
+    toastApi.error("query: SELECT * FROM keys");
+
+    expect(originalError).toHaveBeenCalledWith("操作失败");
   });
 });

--- a/src/lib/utils/user-visible-error.ts
+++ b/src/lib/utils/user-visible-error.ts
@@ -1,0 +1,118 @@
+const DATABASE_DETAIL_MARKER = /\b(query|sql|statement|params?|result|rows?)\s*[:=]/i;
+const DATABASE_ERROR_PREFIX =
+  /\b(?:db\s+query\s+error|database\s+query\s+error|postgres(?:ql)?\s+error|sql\s+error)\b/i;
+const SQL_DETAIL_AFTER_MARKER = /\b(query|sql|statement)\s*[:=]\s*(select|insert|update|delete)\b/i;
+const STRUCTURED_DETAIL_VALUE = /\b(result|rows?|params?)\s*[:=]\s*[[{(]/i;
+const API_KEY_PATTERN = /\bsk-[A-Za-z0-9_-]{8,}\b/g;
+const BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}\b/gi;
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(api[_-]?key|access[_-]?token|refresh[_-]?token|authorization|secret|password|token)\b(\s*[:=]\s*)([^,\s;)}\]]+)/gi;
+const DEFAULT_SAFE_ERROR_MESSAGE = "Operation failed";
+
+function normalizeMessage(message: string): string {
+  return message.replace(/\s+/g, " ").trim();
+}
+
+function redactSecrets(message: string): string {
+  return message
+    .replace(API_KEY_PATTERN, "[REDACTED]")
+    .replace(BEARER_TOKEN_PATTERN, "Bearer [REDACTED]")
+    .replace(SECRET_ASSIGNMENT_PATTERN, (_match, key: string, separator: string) => {
+      return `${key}${separator}[REDACTED]`;
+    });
+}
+
+function hasStructuredDatabasePayload(message: string): boolean {
+  return (
+    SQL_DETAIL_AFTER_MARKER.test(message) ||
+    (DATABASE_ERROR_PREFIX.test(message) &&
+      (DATABASE_DETAIL_MARKER.test(message) || STRUCTURED_DETAIL_VALUE.test(message)))
+  );
+}
+
+function stripStructuredDatabasePayload(message: string): string {
+  const markerMatch = message.match(DATABASE_DETAIL_MARKER);
+  const cutIndexCandidates = [markerMatch?.index].filter(
+    (value): value is number => typeof value === "number" && value >= 0
+  );
+
+  if (cutIndexCandidates.length === 0) {
+    return message;
+  }
+
+  const cutIndex = Math.min(...cutIndexCandidates);
+  return message
+    .slice(0, cutIndex)
+    .replace(/[\s:;,-]+$/g, "")
+    .trim();
+}
+
+export function sanitizeUserVisibleErrorMessage(message: string): string {
+  const sanitized = normalizeMessage(redactSecrets(message));
+
+  if (!sanitized) {
+    return sanitized;
+  }
+
+  if (!hasStructuredDatabasePayload(sanitized)) {
+    return sanitized;
+  }
+
+  return stripStructuredDatabasePayload(sanitized);
+}
+
+export function getSafeErrorToastMessage(message: string, fallback: string): string {
+  const sanitized = sanitizeUserVisibleErrorMessage(message);
+
+  if (!sanitized) {
+    return fallback;
+  }
+
+  return hasStructuredDatabasePayload(message) ? fallback : sanitized;
+}
+
+function sanitizeToastText(message: string): string {
+  const sanitized = sanitizeUserVisibleErrorMessage(message);
+
+  return sanitized || DEFAULT_SAFE_ERROR_MESSAGE;
+}
+
+type ToastLike<TArgs extends unknown[] = unknown[]> = {
+  error: (...args: TArgs) => unknown;
+  __cchErrorSanitizerInstalled__?: boolean;
+};
+
+export function installErrorToastSanitizer<TArgs extends unknown[]>(
+  toastApi: ToastLike<TArgs>
+): void {
+  if (toastApi.__cchErrorSanitizerInstalled__) {
+    return;
+  }
+
+  const originalError = toastApi.error.bind(toastApi);
+
+  toastApi.error = ((...args: TArgs) => {
+    const [message, ...rest] = args;
+    const safeMessage = typeof message === "string" ? sanitizeToastText(message) : message;
+    const safeRest = rest.map((value, index) => {
+      if (
+        index === 0 &&
+        value &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        typeof (value as { description?: unknown }).description === "string"
+      ) {
+        return {
+          ...value,
+          description: sanitizeToastText((value as { description: string }).description),
+        };
+      }
+
+      return value;
+    });
+    const safeArgs = [safeMessage, ...safeRest] as TArgs;
+
+    return originalError(...safeArgs);
+  }) as ToastLike<TArgs>["error"];
+  toastApi.__cchErrorSanitizerInstalled__ = true;
+}

--- a/src/lib/utils/user-visible-error.ts
+++ b/src/lib/utils/user-visible-error.ts
@@ -85,12 +85,15 @@ function sanitizeToastText(message: string, fallbackMessage: string): string {
 type ToastLike<TArgs extends unknown[] = unknown[]> = {
   error: (...args: TArgs) => unknown;
   __cchErrorSanitizerInstalled__?: boolean;
+  __cchErrorSanitizerFallback__?: string;
 };
 
 export function installErrorToastSanitizer<TArgs extends unknown[]>(
   toastApi: ToastLike<TArgs>,
   fallbackMessage: string
 ): void {
+  toastApi.__cchErrorSanitizerFallback__ = fallbackMessage;
+
   if (toastApi.__cchErrorSanitizerInstalled__) {
     return;
   }
@@ -103,8 +106,9 @@ export function installErrorToastSanitizer<TArgs extends unknown[]>(
     }
 
     const [message, ...rest] = args;
+    const currentFallbackMessage = toastApi.__cchErrorSanitizerFallback__ || fallbackMessage;
     const safeMessage =
-      typeof message === "string" ? sanitizeToastText(message, fallbackMessage) : message;
+      typeof message === "string" ? sanitizeToastText(message, currentFallbackMessage) : message;
     const safeRest = rest.map((value, index) => {
       if (
         index === 0 &&
@@ -117,7 +121,7 @@ export function installErrorToastSanitizer<TArgs extends unknown[]>(
           ...value,
           description: sanitizeToastText(
             (value as { description: string }).description,
-            fallbackMessage
+            currentFallbackMessage
           ),
         };
       }

--- a/src/lib/utils/user-visible-error.ts
+++ b/src/lib/utils/user-visible-error.ts
@@ -6,8 +6,7 @@ const STRUCTURED_DETAIL_VALUE = /\b(result|rows?|params?)\s*[:=]\s*[[{(]/i;
 const API_KEY_PATTERN = /\bsk-[A-Za-z0-9_-]{8,}\b/g;
 const BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}\b/gi;
 const SECRET_ASSIGNMENT_PATTERN =
-  /\b(api[_-]?key|access[_-]?token|refresh[_-]?token|authorization|secret|password|token)\b(\s*[:=]\s*)([^,\s;)}\]]+)/gi;
-const DEFAULT_SAFE_ERROR_MESSAGE = "Operation failed";
+  /\b(api[_-]?key|access[_-]?token|refresh[_-]?token|authorization|secret|password|token)\b(\s*[:=]\s*)("[^"]*"|'[^']*'|[^,;)}\]\n\r]+)/gi;
 
 function normalizeMessage(message: string): string {
   return message.replace(/\s+/g, " ").trim();
@@ -47,34 +46,40 @@ function stripStructuredDatabasePayload(message: string): string {
     .trim();
 }
 
+function analyzeUserVisibleErrorMessage(message: string): {
+  hasStructuredDatabasePayload: boolean;
+  sanitizedMessage: string;
+} {
+  const redactedMessage = normalizeMessage(redactSecrets(message));
+  const structuredDatabasePayload = hasStructuredDatabasePayload(redactedMessage);
+
+  return {
+    hasStructuredDatabasePayload: structuredDatabasePayload,
+    sanitizedMessage: structuredDatabasePayload
+      ? stripStructuredDatabasePayload(redactedMessage)
+      : redactedMessage,
+  };
+}
+
 export function sanitizeUserVisibleErrorMessage(message: string): string {
-  const sanitized = normalizeMessage(redactSecrets(message));
-
-  if (!sanitized) {
-    return sanitized;
-  }
-
-  if (!hasStructuredDatabasePayload(sanitized)) {
-    return sanitized;
-  }
-
-  return stripStructuredDatabasePayload(sanitized);
+  return analyzeUserVisibleErrorMessage(message).sanitizedMessage;
 }
 
 export function getSafeErrorToastMessage(message: string, fallback: string): string {
-  const sanitized = sanitizeUserVisibleErrorMessage(message);
+  const { hasStructuredDatabasePayload: structuredDatabasePayload, sanitizedMessage } =
+    analyzeUserVisibleErrorMessage(message);
 
-  if (!sanitized) {
+  if (!sanitizedMessage) {
     return fallback;
   }
 
-  return hasStructuredDatabasePayload(message) ? fallback : sanitized;
+  return structuredDatabasePayload ? fallback : sanitizedMessage;
 }
 
-function sanitizeToastText(message: string): string {
-  const sanitized = sanitizeUserVisibleErrorMessage(message);
+function sanitizeToastText(message: string, fallbackMessage: string): string {
+  const sanitized = analyzeUserVisibleErrorMessage(message).sanitizedMessage;
 
-  return sanitized || DEFAULT_SAFE_ERROR_MESSAGE;
+  return sanitized || fallbackMessage;
 }
 
 type ToastLike<TArgs extends unknown[] = unknown[]> = {
@@ -83,7 +88,8 @@ type ToastLike<TArgs extends unknown[] = unknown[]> = {
 };
 
 export function installErrorToastSanitizer<TArgs extends unknown[]>(
-  toastApi: ToastLike<TArgs>
+  toastApi: ToastLike<TArgs>,
+  fallbackMessage: string
 ): void {
   if (toastApi.__cchErrorSanitizerInstalled__) {
     return;
@@ -92,8 +98,13 @@ export function installErrorToastSanitizer<TArgs extends unknown[]>(
   const originalError = toastApi.error.bind(toastApi);
 
   toastApi.error = ((...args: TArgs) => {
+    if (args.length === 0) {
+      return originalError(...args);
+    }
+
     const [message, ...rest] = args;
-    const safeMessage = typeof message === "string" ? sanitizeToastText(message) : message;
+    const safeMessage =
+      typeof message === "string" ? sanitizeToastText(message, fallbackMessage) : message;
     const safeRest = rest.map((value, index) => {
       if (
         index === 0 &&
@@ -104,7 +115,10 @@ export function installErrorToastSanitizer<TArgs extends unknown[]>(
       ) {
         return {
           ...value,
-          description: sanitizeToastText((value as { description: string }).description),
+          description: sanitizeToastText(
+            (value as { description: string }).description,
+            fallbackMessage
+          ),
         };
       }
 


### PR DESCRIPTION
## Summary
Add a user-visible error sanitizer that strips structured database query payloads and redacts secrets (API keys, bearer tokens, password fields) before displaying toast error messages in the dashboard UI.

## Problem
When a database operation fails, the raw error message propagated to the client-side toast can include sensitive details such as:
- Full SQL queries with parameter values (e.g., `SELECT * FROM keys WHERE key = 'sk-live-secret123456'`)
- Structured result sets containing API keys or tokens
- Secret values in assignment patterns (e.g., `apiKey=sk-live-secret1234567890`)

These details are exposed to any user seeing the toast notification, creating an information leakage risk.

Related to #937 - Both PRs address information leakage through error messages visible to end users (that PR masks client restriction details; this PR sanitizes DB error payloads).

## Solution
Implements a three-layer defense for error message sanitization:

1. **`sanitizeUserVisibleErrorMessage()`** - Core sanitizer that normalizes whitespace, redacts known secret patterns (`sk-*` keys, `Bearer` tokens, key/value assignments for sensitive fields), and strips structured database payloads (SQL queries, result sets, parameter dumps)
2. **`getSafeErrorToastMessage()`** - Fallback-aware wrapper used in `useServerAction` and `withErrorHandling` that returns the sanitized message for safe errors, or a generic fallback when structured DB content is detected
3. **`installErrorToastSanitizer()`** - Global last-line-of-defense monkey-patch on `toast.error()` that catches any unsanitized error that reaches the toast layer, including message and description fields

## Changes

### Core Changes
- `src/lib/utils/user-visible-error.ts` (new) - Error sanitizer module with regex-based detection of DB payloads and secret patterns
- `src/components/ui/sonner.tsx` - Install global toast sanitizer at the Sonner Toaster component level
- `src/lib/hooks/use-server-action.ts` - Route error messages through `getSafeErrorToastMessage()` in both `useServerAction` and `withErrorHandling`

### Supporting Changes
- `src/lib/utils/user-visible-error.test.ts` (new) - 6 unit tests covering ordinary messages, DB error fallback, secret redaction, global sanitizer installation, description sanitization

## Testing

### Automated Tests
- [x] Unit tests added (`src/lib/utils/user-visible-error.test.ts`)

### Manual Testing
1. Trigger a server action that produces a DB error with query details
2. Verify toast shows generic "Operation failed" instead of raw SQL/query
3. Trigger an error containing an `sk-*` key pattern
4. Verify secret is replaced with `[REDACTED]`

## Checklist
- [x] Code follows project conventions
- [x] Tests pass locally
- [x] No breaking changes
- [x] No database migrations required

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements a three-layer defense against exposing raw database error details and API secrets in user-visible toast notifications: a regex-based core sanitizer (`user-visible-error.ts`), a `getSafeErrorToastMessage` wrapper used in the server action hooks, and a global `toast.error()` monkey-patch installed via `useEffect` in the Sonner component with locale-aware fallback text via `next-intl`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both code paths prevent secret and SQL leakage; the remaining finding is a cosmetic UX inconsistency only

All remaining findings are P2. Previous concerns about module-level side effects and hardcoded i18n strings have been addressed in this version. The behavioral inconsistency between getSafeErrorToastMessage and sanitizeToastText is a UX-only divergence with no security impact.

user-visible-error.ts has the minor behavioral inconsistency between the two sanitization paths, but it is not a blocking concern
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/utils/user-visible-error.ts | Core sanitizer with regex-based DB payload detection and secret redaction; minor behavioral inconsistency between getSafeErrorToastMessage and sanitizeToastText for the same structured error input |
| src/lib/utils/user-visible-error.test.ts | 8 tests covering ordinary messages, DB fallback, secret redaction, global sanitizer installation, description sanitization, and locale switching |
| src/components/ui/sonner.tsx | Installs global toast sanitizer via useEffect with locale-aware fallback from next-intl; idiomatic React pattern |
| src/lib/hooks/use-server-action.ts | Routes both useServerAction and withErrorHandling through getSafeErrorToastMessage; clean integration |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Error in server action] --> B{Code path?}
    B -->|useServerAction / withErrorHandling| C[getSafeErrorToastMessage]
    B -->|Direct toast.error call| D[Global sanitizer patch]
    C --> E{hasStructuredDatabasePayload?}
    E -->|Yes| F[Return fallback\ne.g. 'Operation failed']
    E -->|No| G[Return sanitized message\nwith secrets redacted]
    D --> H[sanitizeToastText]
    H --> I{sanitizedMessage empty?}
    I -->|Yes| J[Return fallback]
    I -->|No| K[Return stripped prefix\ne.g. 'db query error']
    F --> L[toast.error safe message]
    G --> L
    J --> L
    K --> L
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/utils/user-visible-error.ts
Line: 68-83

Comment:
**Inconsistent fallback behavior between the two sanitization paths**

`getSafeErrorToastMessage` always returns `fallback` when a structured DB payload is detected, discarding even a safe stripped prefix like `"db query error"`. `sanitizeToastText` — called by the global `installErrorToastSanitizer` — returns the non-empty stripped prefix as-is. The same input `"db query error: query: SELECT * FROM keys"` therefore produces `"Operation failed"` when routed through `useServerAction`, and `"db query error"` when a direct `toast.error()` call reaches the global patch — confirmed by the tests on lines 23 and 44. If the intent is for the global sanitizer to share the fallback-only policy for DB payloads, `sanitizeToastText` should delegate to `getSafeErrorToastMessage` instead of calling `analyzeUserVisibleErrorMessage` directly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: refresh sanitized toast fallback by..."](https://github.com/ding113/claude-code-hub/commit/26ba579a9a43334869acd2a62e0a6cc801456c80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27349092)</sub>

<!-- /greptile_comment -->