### PR TITLE
fix: preserve hedge model redirect audit per attempt

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -3539,6 +3539,7 @@ export class ProxyForwarder {
                 reason: "client_abort",
                 attemptNumber: attempt.sequence,
                 errorMessage: "Client aborted request",
+                modelRedirect: getAttemptModelRedirect(attempt),
               });
             }
           }

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -98,6 +98,7 @@ type StreamingHedgeAttempt = {
   session: ProxySession;
   baseUrl: string;
   endpointAudit: { endpointId: number | null; endpointUrl: string };
+  modelRedirect?: ProviderChainItem["modelRedirect"];
   responseController: AbortController | null;
   clearResponseTimeout: (() => void) | null;
   firstByteTimeoutMs: number;
@@ -2994,6 +2995,19 @@ export class ProxyForwarder {
       resolveResult?.({ error });
     };
 
+    const getAttemptModelRedirect = (attempt: StreamingHedgeAttempt) => {
+      if (attempt.modelRedirect !== undefined) {
+        return attempt.modelRedirect;
+      }
+
+      const redirect = attempt.session.getCurrentModelRedirect(attempt.provider.id);
+      if (redirect) {
+        attempt.modelRedirect = structuredClone(redirect);
+      }
+
+      return attempt.modelRedirect;
+    };
+
     const abortAttempt = (attempt: StreamingHedgeAttempt, reason: string) => {
       if (attempt.settled) return;
       attempt.settled = true;
@@ -3007,6 +3021,7 @@ export class ProxyForwarder {
           ...attempt.endpointAudit,
           reason: "hedge_loser_cancelled",
           attemptNumber: attempt.sequence,
+          modelRedirect: getAttemptModelRedirect(attempt),
         });
       }
       try {
@@ -3228,6 +3243,7 @@ export class ProxyForwarder {
           attemptNumber: attempt.sequence,
           errorMessage: "Client aborted request",
           circuitState: getCircuitState(attempt.provider.id),
+          modelRedirect: getAttemptModelRedirect(attempt),
         });
         abortAllAttempts(undefined, "client_abort");
         await settleFailure(
@@ -3282,17 +3298,17 @@ export class ProxyForwarder {
             }
           );
 
-          session.addProviderToChain(
-            attempt.provider,
-            buildRetryFailedChainEntry(
+          session.addProviderToChain(attempt.provider, {
+            ...buildRetryFailedChainEntry(
               attempt.provider,
               attempt.endpointAudit,
               attempt.requestAttemptCount,
               error,
               errorMessage,
               reactiveRectifierResult.requestDetailsBeforeRectify
-            )
-          );
+            ),
+            modelRedirect: getAttemptModelRedirect(attempt),
+          });
 
           if (attempt.thresholdTimer) {
             clearTimeout(attempt.thresholdTimer);
@@ -3328,6 +3344,7 @@ export class ProxyForwarder {
         statusCode,
         errorMessage,
         circuitState: getCircuitState(attempt.provider.id),
+        modelRedirect: getAttemptModelRedirect(attempt),
       });
 
       if (errorCategory === ErrorCategory.NON_RETRYABLE_CLIENT_ERROR) {
@@ -3354,6 +3371,10 @@ export class ProxyForwarder {
       attempt.settled = true;
       attempts.delete(attempt);
 
+      for (const activeAttempt of attempts) {
+        getAttemptModelRedirect(activeAttempt);
+      }
+
       if (attempt.session !== session) {
         ProxyForwarder.syncWinningAttemptSession(session, attempt.session);
       }
@@ -3369,6 +3390,7 @@ export class ProxyForwarder {
         reason: isActualHedgeWin ? "hedge_winner" : "request_success",
         attemptNumber: attempt.sequence,
         statusCode: attempt.response.status,
+        modelRedirect: getAttemptModelRedirect(attempt),
       });
 
       abortAllAttempts(attempt, "hedge_loser");
@@ -3634,6 +3656,10 @@ export class ProxyForwarder {
       specialSettings: unknown[];
       originalModelName: string | null;
       originalUrlPathname: string | null;
+      currentModelRedirect: {
+        providerId: number;
+        redirect: NonNullable<ProviderChainItem["modelRedirect"]>;
+      } | null;
       providersSnapshot: Provider[] | null;
     };
     const shadowState = shadow as unknown as {
@@ -3644,6 +3670,10 @@ export class ProxyForwarder {
       specialSettings: unknown[];
       originalModelName: string | null;
       originalUrlPathname: string | null;
+      currentModelRedirect: {
+        providerId: number;
+        redirect: NonNullable<ProviderChainItem["modelRedirect"]>;
+      } | null;
       providersSnapshot: Provider[] | null;
     };
 
@@ -3659,6 +3689,12 @@ export class ProxyForwarder {
     shadowState.specialSettings = [...sourceState.specialSettings];
     shadowState.originalModelName = sourceState.originalModelName;
     shadowState.originalUrlPathname = sourceState.originalUrlPathname;
+    shadowState.currentModelRedirect = sourceState.currentModelRedirect
+      ? {
+          providerId: sourceState.currentModelRedirect.providerId,
+          redirect: structuredClone(sourceState.currentModelRedirect.redirect),
+        }
+      : null;
     shadowState.providersSnapshot = sourceState.providersSnapshot;
     shadow.setCacheTtlResolved(session.getCacheTtlResolved());
     shadow.setContext1mApplied(session.getContext1mApplied());
@@ -3686,12 +3722,20 @@ export class ProxyForwarder {
       specialSettings: unknown[];
       originalModelName: string | null;
       originalUrlPathname: string | null;
+      currentModelRedirect: {
+        providerId: number;
+        redirect: NonNullable<ProviderChainItem["modelRedirect"]>;
+      } | null;
     };
     const targetState = target as unknown as {
       providerChain: ProviderChainItem[];
       specialSettings: unknown[];
       originalModelName: string | null;
       originalUrlPathname: string | null;
+      currentModelRedirect: {
+        providerId: number;
+        redirect: NonNullable<ProviderChainItem["modelRedirect"]>;
+      } | null;
       clearResponseTimeout?: () => void;
       responseController?: AbortController;
     };
@@ -3722,6 +3766,12 @@ export class ProxyForwarder {
     targetState.specialSettings = merged;
     targetState.originalModelName = sourceState.originalModelName;
     targetState.originalUrlPathname = sourceState.originalUrlPathname;
+    targetState.currentModelRedirect = sourceState.currentModelRedirect
+      ? {
+          providerId: sourceState.currentModelRedirect.providerId,
+          redirect: structuredClone(sourceState.currentModelRedirect.redirect),
+        }
+      : null;
     targetState.clearResponseTimeout = sourceRuntime.clearResponseTimeout;
     targetState.responseController = sourceRuntime.responseController;
   }

--- a/src/app/v1/_lib/proxy/model-redirector.ts
+++ b/src/app/v1/_lib/proxy/model-redirector.ts
@@ -23,6 +23,7 @@ export class ModelRedirector {
 
     // 检查是否配置了模型重定向
     if (!provider.modelRedirects || Object.keys(provider.modelRedirects).length === 0) {
+      session.clearCurrentModelRedirect();
       // 如果新供应商没有重定向配置，且之前发生过重定向，需要重置
       if (session.isModelRedirected() && trueOriginalModel) {
         ModelRedirector.resetToOriginal(session, trueOriginalModel, provider);
@@ -43,6 +44,7 @@ export class ModelRedirector {
     // 检查是否有该模型的重定向配置
     const redirectedModel = provider.modelRedirects[originalModel];
     if (!redirectedModel) {
+      session.clearCurrentModelRedirect();
       // 如果新供应商对此模型没有重定向规则，且之前发生过重定向，需要重置
       if (session.isModelRedirected()) {
         ModelRedirector.resetToOriginal(session, originalModel, provider);
@@ -109,21 +111,22 @@ export class ModelRedirector {
     // 更新日志（记录重定向）
     session.request.note = `[Model Redirected: ${originalModel} → ${redirectedModel}] ${session.request.note || ""}`;
 
-    // 在决策链中记录模型重定向信息
-    const providerChain = session.getProviderChain();
-    if (providerChain.length > 0) {
-      const lastDecision = providerChain[providerChain.length - 1];
-      lastDecision.modelRedirect = {
-        originalModel: originalModel,
-        redirectedModel: redirectedModel,
-        billingModel: originalModel, // 始终使用原始模型计费
-      };
-      logger.debug("[ModelRedirector] Added modelRedirect to provider chain", {
-        providerId: provider.id,
-        originalModel,
-        redirectedModel,
-      });
-    }
+    const redirectInfo = {
+      originalModel,
+      redirectedModel,
+      billingModel: originalModel, // 始终使用原始模型计费
+    } as const;
+
+    // 记录当前 attempt 的 redirect 快照。
+    // 如果最后一条链路项本来就属于当前 provider（例如 initial_selection），顺手更新它；
+    // 否则保留快照，等待后续 hedge_winner / retry_failed 等真正属于该 provider 的链路项来消费。
+    session.setCurrentModelRedirect(provider.id, redirectInfo);
+    session.attachCurrentModelRedirectToLastChainItem(provider.id);
+    logger.debug("[ModelRedirector] Recorded modelRedirect for current provider attempt", {
+      providerId: provider.id,
+      originalModel,
+      redirectedModel,
+    });
 
     return true;
   }

--- a/src/app/v1/_lib/proxy/session.ts
+++ b/src/app/v1/_lib/proxy/session.ts
@@ -98,6 +98,13 @@ export class ProxySession {
   // 原始 URL 路径（用于 Gemini 模型重定向重置）
   private originalUrlPathname: string | null = null;
 
+  // 当前供应商 attempt 的模型重定向快照。
+  // 用于在 hedge shadow session 中延迟把 redirect 归属到真正的 winner/failed 链路项。
+  private currentModelRedirect: {
+    providerId: number;
+    redirect: NonNullable<ProviderChainItem["modelRedirect"]>;
+  } | null = null;
+
   // 上游决策链（记录尝试的供应商列表）
   private providerChain: ProviderChainItem[];
 
@@ -509,6 +516,7 @@ export class ProxySession {
       decisionContext?: ProviderChainItem["decisionContext"];
       strictBlockCause?: ProviderChainItem["strictBlockCause"]; // endpoint pool exhaustion cause
       endpointFilterStats?: ProviderChainItem["endpointFilterStats"]; // endpoint filter statistics
+      modelRedirect?: ProviderChainItem["modelRedirect"];
     }
   ): void {
     const item: ProviderChainItem = {
@@ -538,6 +546,7 @@ export class ProxySession {
       decisionContext: metadata?.decisionContext,
       strictBlockCause: metadata?.strictBlockCause,
       endpointFilterStats: metadata?.endpointFilterStats,
+      modelRedirect: metadata?.modelRedirect ?? this.getCurrentModelRedirect(provider.id),
     };
 
     // 避免重复添加同一个供应商
@@ -566,6 +575,42 @@ export class ProxySession {
    */
   getProviderChain(): ProviderChainItem[] {
     return this.providerChain;
+  }
+
+  setCurrentModelRedirect(
+    providerId: number,
+    redirect: NonNullable<ProviderChainItem["modelRedirect"]>
+  ): void {
+    this.currentModelRedirect = {
+      providerId,
+      redirect,
+    };
+  }
+
+  clearCurrentModelRedirect(): void {
+    this.currentModelRedirect = null;
+  }
+
+  getCurrentModelRedirect(providerId?: number): ProviderChainItem["modelRedirect"] | undefined {
+    if (!this.currentModelRedirect) return undefined;
+    if (providerId !== undefined && this.currentModelRedirect.providerId !== providerId) {
+      return undefined;
+    }
+    return this.currentModelRedirect.redirect;
+  }
+
+  attachCurrentModelRedirectToLastChainItem(providerId: number): boolean {
+    const redirect = this.getCurrentModelRedirect(providerId);
+    if (!redirect) return false;
+
+    const lastItem = this.providerChain[this.providerChain.length - 1];
+    if (!lastItem || lastItem.id !== providerId) {
+      return false;
+    }
+
+    lastItem.modelRedirect = redirect;
+    this.persistLiveChain();
+    return true;
   }
 
   /**

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -1010,10 +1010,27 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
     vi.useFakeTimers();
 
     try {
-      const provider1 = createProvider({ id: 1, name: "p1", firstByteTimeoutStreamingMs: 100 });
-      const provider2 = createProvider({ id: 2, name: "p2", firstByteTimeoutStreamingMs: 100 });
+      const requestedModel = "claude-haiku-4-5-20251001";
+      const provider1 = createProvider({
+        id: 1,
+        name: "p1",
+        firstByteTimeoutStreamingMs: 100,
+        modelRedirects: {
+          [requestedModel]: "accounts/fireworks/routers/kimi-k2p5-turbo",
+        },
+      });
+      const provider2 = createProvider({
+        id: 2,
+        name: "p2",
+        firstByteTimeoutStreamingMs: 100,
+        modelRedirects: {
+          [requestedModel]: "MiniMax-M2.7-highspeed",
+        },
+      });
       const clientAbortController = new AbortController();
       const session = createSession(clientAbortController.signal);
+      session.request.model = requestedModel;
+      session.request.message.model = requestedModel;
       session.setProvider(provider1);
 
       mocks.pickRandomProviderWithExclusion.mockResolvedValueOnce(provider2);
@@ -1028,10 +1045,13 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
       const controller1 = new AbortController();
       const controller2 = new AbortController();
 
-      doForward.mockImplementationOnce(async (attemptSession) => {
+      doForward.mockImplementationOnce(async (attemptSession, providerForRequest) => {
         const runtime = attemptSession as ProxySession & AttemptRuntime;
         runtime.responseController = controller1;
         runtime.clearResponseTimeout = vi.fn();
+        expect(
+          ModelRedirector.apply(attemptSession as ProxySession, providerForRequest as Provider)
+        ).toBe(true);
         return createStreamingResponse({
           label: "p1",
           firstChunkDelayMs: 500,
@@ -1039,10 +1059,13 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
         });
       });
 
-      doForward.mockImplementationOnce(async (attemptSession) => {
+      doForward.mockImplementationOnce(async (attemptSession, providerForRequest) => {
         const runtime = attemptSession as ProxySession & AttemptRuntime;
         runtime.responseController = controller2;
         runtime.clearResponseTimeout = vi.fn();
+        expect(
+          ModelRedirector.apply(attemptSession as ProxySession, providerForRequest as Provider)
+        ).toBe(true);
         return createStreamingResponse({
           label: "p2",
           firstChunkDelayMs: 500,
@@ -1067,6 +1090,24 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
       expect(mocks.clearSessionProvider).toHaveBeenCalledWith("sess-hedge");
       expect(mocks.recordFailure).not.toHaveBeenCalled();
       expect(mocks.recordSuccess).not.toHaveBeenCalled();
+
+      const chain = session.getProviderChain();
+      expect(
+        chain.find((item) => item.id === provider1.id && item.reason === "client_abort")
+          ?.modelRedirect
+      ).toMatchObject({
+        originalModel: requestedModel,
+        redirectedModel: "accounts/fireworks/routers/kimi-k2p5-turbo",
+        billingModel: requestedModel,
+      });
+      expect(
+        chain.find((item) => item.id === provider2.id && item.reason === "client_abort")
+          ?.modelRedirect
+      ).toMatchObject({
+        originalModel: requestedModel,
+        redirectedModel: "MiniMax-M2.7-highspeed",
+        billingModel: requestedModel,
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -98,6 +98,7 @@ import {
   ProxyError as UpstreamProxyError,
 } from "@/app/v1/_lib/proxy/errors";
 import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
+import { ModelRedirector } from "@/app/v1/_lib/proxy/model-redirector";
 import { ProxySession } from "@/app/v1/_lib/proxy/session";
 import type { Provider } from "@/types/provider";
 
@@ -301,6 +302,372 @@ function withThinkingBlocks(session: ProxySession): void {
 describe("ProxyForwarder - first-byte hedge scheduling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  test("shadow session redirect should not overwrite initial provider redirect and winner should keep its own redirect", () => {
+    const requestedModel = "claude-haiku-4-5-20251001";
+    const fireworksRedirect = "accounts/fireworks/routers/kimi-k2p5-turbo";
+    const minimaxRedirect = "MiniMax-M2.7-highspeed";
+
+    const fireworks = createProvider({
+      id: 383,
+      name: "fireworks",
+      modelRedirects: {
+        [requestedModel]: fireworksRedirect,
+      },
+    });
+    const minimax = createProvider({
+      id: 206,
+      name: "Minimax Max",
+      modelRedirects: {
+        [requestedModel]: minimaxRedirect,
+      },
+    });
+
+    const session = createSession();
+    session.request.model = requestedModel;
+    session.request.message.model = requestedModel;
+    session.setProvider(fireworks);
+    session.addProviderToChain(fireworks, { reason: "initial_selection" });
+
+    expect(ModelRedirector.apply(session, fireworks)).toBe(true);
+    expect(session.request.model).toBe(fireworksRedirect);
+    expect(session.getProviderChain()[0].modelRedirect).toMatchObject({
+      originalModel: requestedModel,
+      redirectedModel: fireworksRedirect,
+      billingModel: requestedModel,
+    });
+
+    const shadow = (
+      ProxyForwarder as unknown as {
+        createStreamingShadowSession: (session: ProxySession, provider: Provider) => ProxySession;
+      }
+    ).createStreamingShadowSession(session, minimax);
+
+    expect(shadow.request.model).toBe(fireworksRedirect);
+    expect(ModelRedirector.apply(shadow, minimax)).toBe(true);
+    expect(shadow.request.model).toBe(minimaxRedirect);
+
+    // Hedge 备选供应商的重定向只能影响自己的 attempt，不能污染初始供应商的链路项。
+    expect(session.getProviderChain()[0].modelRedirect).toMatchObject({
+      originalModel: requestedModel,
+      redirectedModel: fireworksRedirect,
+      billingModel: requestedModel,
+    });
+
+    (
+      ProxyForwarder as unknown as {
+        syncWinningAttemptSession: (target: ProxySession, source: ProxySession) => void;
+      }
+    ).syncWinningAttemptSession(session, shadow);
+
+    session.setProvider(minimax);
+    session.addProviderToChain(minimax, {
+      reason: "hedge_winner",
+      attemptNumber: 2,
+      statusCode: 200,
+    });
+
+    const hedgeWinner = session
+      .getProviderChain()
+      .find((item) => item.id === minimax.id && item.reason === "hedge_winner");
+
+    expect(hedgeWinner?.modelRedirect).toMatchObject({
+      originalModel: requestedModel,
+      redirectedModel: minimaxRedirect,
+      billingModel: requestedModel,
+    });
+  });
+
+  test("shadow session should clone current model redirect snapshot instead of sharing it", () => {
+    const requestedModel = "claude-haiku-4-5-20251001";
+    const fireworksRedirect = "accounts/fireworks/routers/kimi-k2p5-turbo";
+    const fireworks = createProvider({
+      id: 383,
+      name: "fireworks",
+      modelRedirects: {
+        [requestedModel]: fireworksRedirect,
+      },
+    });
+    const fallback = createProvider({
+      id: 206,
+      name: "Minimax Max",
+    });
+
+    const session = createSession();
+    session.request.model = requestedModel;
+    session.request.message.model = requestedModel;
+    session.setProvider(fireworks);
+    session.addProviderToChain(fireworks, { reason: "initial_selection" });
+    expect(ModelRedirector.apply(session, fireworks)).toBe(true);
+
+    const shadow = (
+      ProxyForwarder as unknown as {
+        createStreamingShadowSession: (session: ProxySession, provider: Provider) => ProxySession;
+      }
+    ).createStreamingShadowSession(session, fallback);
+
+    const sessionState = session as unknown as {
+      currentModelRedirect: {
+        providerId: number;
+        redirect: {
+          originalModel: string;
+          redirectedModel: string;
+          billingModel: string;
+        };
+      } | null;
+    };
+    const shadowState = shadow as unknown as {
+      currentModelRedirect: {
+        providerId: number;
+        redirect: {
+          originalModel: string;
+          redirectedModel: string;
+          billingModel: string;
+        };
+      } | null;
+    };
+
+    expect(shadowState.currentModelRedirect).toEqual(sessionState.currentModelRedirect);
+
+    if (!sessionState.currentModelRedirect || !shadowState.currentModelRedirect) {
+      throw new Error("expected currentModelRedirect to be copied into shadow session");
+    }
+
+    shadowState.currentModelRedirect.redirect.redirectedModel = "shadow-only-model";
+
+    expect(sessionState.currentModelRedirect.redirect.redirectedModel).toBe(fireworksRedirect);
+  });
+
+  test("switching to provider without redirect should clear stale redirect snapshot", () => {
+    const requestedModel = "claude-haiku-4-5-20251001";
+    const fireworksRedirect = "accounts/fireworks/routers/kimi-k2p5-turbo";
+    const fireworks = createProvider({
+      id: 383,
+      name: "fireworks",
+      modelRedirects: {
+        [requestedModel]: fireworksRedirect,
+      },
+    });
+    const plainProvider = createProvider({
+      id: 520,
+      name: "plain provider",
+      modelRedirects: null,
+    });
+
+    const session = createSession();
+    session.request.model = requestedModel;
+    session.request.message.model = requestedModel;
+    session.setProvider(fireworks);
+    session.addProviderToChain(fireworks, { reason: "initial_selection" });
+    expect(ModelRedirector.apply(session, fireworks)).toBe(true);
+
+    expect(ModelRedirector.apply(session, plainProvider)).toBe(false);
+    expect(session.request.model).toBe(requestedModel);
+
+    const sessionState = session as unknown as {
+      currentModelRedirect: unknown;
+    };
+    expect(sessionState.currentModelRedirect).toBeNull();
+
+    session.setProvider(plainProvider);
+    session.addProviderToChain(plainProvider, {
+      reason: "retry_success",
+      attemptNumber: 2,
+      statusCode: 200,
+    });
+
+    const plainEntry = session
+      .getProviderChain()
+      .find((item) => item.id === plainProvider.id && item.reason === "retry_success");
+
+    expect(plainEntry?.modelRedirect).toBeUndefined();
+  });
+
+  test("public hedge path should preserve redirect details for winner and loser attempts", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const requestedModel = "claude-haiku-4-5-20251001";
+      const fireworksRedirect = "accounts/fireworks/routers/kimi-k2p5-turbo";
+      const minimaxRedirect = "MiniMax-M2.7-highspeed";
+      const fireworks = createProvider({
+        id: 383,
+        name: "fireworks",
+        firstByteTimeoutStreamingMs: 100,
+        modelRedirects: {
+          [requestedModel]: fireworksRedirect,
+        },
+      });
+      const minimax = createProvider({
+        id: 206,
+        name: "Minimax Max",
+        firstByteTimeoutStreamingMs: 100,
+        modelRedirects: {
+          [requestedModel]: minimaxRedirect,
+        },
+      });
+      const session = createSession();
+      session.request.model = requestedModel;
+      session.request.message.model = requestedModel;
+      session.setProvider(fireworks);
+      session.addProviderToChain(fireworks, { reason: "initial_selection" });
+
+      mocks.pickRandomProviderWithExclusion.mockResolvedValueOnce(minimax);
+
+      const doForward = vi.spyOn(
+        ProxyForwarder as unknown as {
+          doForward: (...args: unknown[]) => Promise<Response>;
+        },
+        "doForward"
+      );
+
+      const controller1 = new AbortController();
+      const controller2 = new AbortController();
+
+      doForward.mockImplementationOnce(async (attemptSession, providerForRequest) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = controller1;
+        runtime.clearResponseTimeout = vi.fn();
+        expect(
+          ModelRedirector.apply(attemptSession as ProxySession, providerForRequest as Provider)
+        ).toBe(true);
+        return createStreamingResponse({
+          label: "fireworks",
+          firstChunkDelayMs: 220,
+          controller: controller1,
+        });
+      });
+
+      doForward.mockImplementationOnce(async (attemptSession, providerForRequest) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = controller2;
+        runtime.clearResponseTimeout = vi.fn();
+        expect(
+          ModelRedirector.apply(attemptSession as ProxySession, providerForRequest as Provider)
+        ).toBe(true);
+        return createStreamingResponse({
+          label: "minimax",
+          firstChunkDelayMs: 40,
+          controller: controller2,
+        });
+      });
+
+      const responsePromise = ProxyForwarder.send(session);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(doForward).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(50);
+      const response = await responsePromise;
+      expect(await response.text()).toContain('"provider":"minimax"');
+
+      const chain = session.getProviderChain();
+      expect(
+        chain.find((item) => item.id === minimax.id && item.reason === "hedge_winner")
+          ?.modelRedirect
+      ).toMatchObject({
+        originalModel: requestedModel,
+        redirectedModel: minimaxRedirect,
+        billingModel: requestedModel,
+      });
+      expect(
+        chain.find((item) => item.id === fireworks.id && item.reason === "hedge_loser_cancelled")
+          ?.modelRedirect
+      ).toMatchObject({
+        originalModel: requestedModel,
+        redirectedModel: fireworksRedirect,
+        billingModel: requestedModel,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("public hedge path should retain redirect on shadow retry_failed entries", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const requestedModel = "claude-haiku-4-5-20251001";
+      const fireworksRedirect = "accounts/fireworks/routers/kimi-k2p5-turbo";
+      const minimaxRedirect = "MiniMax-M2.7-highspeed";
+      const fireworks = createProvider({
+        id: 383,
+        name: "fireworks",
+        firstByteTimeoutStreamingMs: 100,
+        modelRedirects: {
+          [requestedModel]: fireworksRedirect,
+        },
+      });
+      const minimax = createProvider({
+        id: 206,
+        name: "Minimax Max",
+        firstByteTimeoutStreamingMs: 100,
+        modelRedirects: {
+          [requestedModel]: minimaxRedirect,
+        },
+      });
+      const session = createSession();
+      session.request.model = requestedModel;
+      session.request.message.model = requestedModel;
+      session.setProvider(fireworks);
+      session.addProviderToChain(fireworks, { reason: "initial_selection" });
+
+      mocks.pickRandomProviderWithExclusion
+        .mockResolvedValueOnce(minimax)
+        .mockResolvedValueOnce(null);
+      mocks.categorizeErrorAsync.mockResolvedValue(ProxyErrorCategory.PROVIDER_ERROR);
+
+      const doForward = vi.spyOn(
+        ProxyForwarder as unknown as {
+          doForward: (...args: unknown[]) => Promise<Response>;
+        },
+        "doForward"
+      );
+
+      const controller1 = new AbortController();
+
+      doForward.mockImplementationOnce(async (attemptSession, providerForRequest) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = controller1;
+        runtime.clearResponseTimeout = vi.fn();
+        expect(
+          ModelRedirector.apply(attemptSession as ProxySession, providerForRequest as Provider)
+        ).toBe(true);
+        return createStreamingResponse({
+          label: "fireworks",
+          firstChunkDelayMs: 220,
+          controller: controller1,
+        });
+      });
+
+      doForward.mockImplementationOnce(async (attemptSession, providerForRequest) => {
+        expect(
+          ModelRedirector.apply(attemptSession as ProxySession, providerForRequest as Provider)
+        ).toBe(true);
+        throw new UpstreamProxyError("minimax upstream failed", 500);
+      });
+
+      const responsePromise = ProxyForwarder.send(session);
+
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(150);
+
+      const response = await responsePromise;
+      expect(await response.text()).toContain('"provider":"fireworks"');
+
+      const retryFailed = session
+        .getProviderChain()
+        .find((item) => item.id === minimax.id && item.reason === "retry_failed");
+
+      expect(retryFailed?.modelRedirect).toMatchObject({
+        originalModel: requestedModel,
+        redirectedModel: minimaxRedirect,
+        billingModel: requestedModel,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("first provider exceeds first-byte threshold, second provider starts and wins by first chunk", async () => {


### PR DESCRIPTION
## Summary
- Keep model redirect audit bound to the provider attempt that actually used it instead of mutating the last provider-chain item
- Carry redirect snapshots across hedge shadow-session cloning and winner sync, and preserve loser/retry-failed audit metadata
- Add hedge regression coverage for winner, loser, retry_failed, snapshot cloning, and stale redirect clearing

## Problem
When streaming requests use the hedge-based provider race (introduced in #894), each attempt may apply a different model redirect for its assigned provider. However, the `ModelRedirector.apply()` was mutating the **last item in the provider chain** regardless of which provider attempt triggered the redirect. In a hedge scenario with shadow sessions, this caused:

1. **Cross-contamination**: A shadow session's redirect would overwrite the initial provider's redirect on the shared chain
2. **Lost audit metadata**: When a shadow attempt won the race (`hedge_winner`) or failed (`retry_failed`), its chain entry would lack `modelRedirect` since the redirect was attached to a different chain item
3. **Shared references**: The `currentModelRedirect` snapshot was not deep-cloned when creating shadow sessions, allowing mutation to leak across attempts

## Solution
Introduce a per-attempt redirect snapshot model that decouples the redirect audit from the chain's last item:

1. **`ProxySession.currentModelRedirect`** - New snapshot field that stores the redirect info keyed by `providerId`, independent of chain position
2. **`setCurrentModelRedirect()` / `getCurrentModelRedirect()` / `clearCurrentModelRedirect()`** - New session methods to manage the snapshot lifecycle
3. **`attachCurrentModelRedirectToLastChainItem()`** - Opportunistically attaches the snapshot to the chain if the last item matches the provider; otherwise defers until the real chain entry is created
4. **`getAttemptModelRedirect()` in forwarder** - Lazily captures and caches the redirect snapshot per `StreamingHedgeAttempt`, ensuring each attempt retains its own redirect
5. **Deep clone on shadow creation/sync** - `createStreamingShadowSession` and `syncWinningAttemptSession` now `structuredClone()` the redirect snapshot so shadow and original sessions never share object references
6. **Clear stale snapshots** - `ModelRedirector.apply()` now calls `clearCurrentModelRedirect()` when a provider has no matching redirect rule, preventing stale data from leaking to subsequent chain entries

## Changes

### Core Changes
- **`session.ts`** (+45): Add `currentModelRedirect` snapshot field and accessor methods (`setCurrentModelRedirect`, `getCurrentModelRedirect`, `clearCurrentModelRedirect`, `attachCurrentModelRedirectToLastChainItem`); wire `modelRedirect` into `addProviderToChain` metadata
- **`model-redirector.ts`** (+18/-15): Replace direct chain-mutation with snapshot-based approach; call `session.setCurrentModelRedirect()` and `attachCurrentModelRedirectToLastChainItem()` instead of mutating `lastDecision`; add `clearCurrentModelRedirect()` calls when no redirect applies
- **`forwarder.ts`** (+55/-5): Add `modelRedirect` to `StreamingHedgeAttempt` type; introduce `getAttemptModelRedirect()` helper for lazy snapshot capture; attach redirect to `hedge_loser_cancelled`, `retry_failed`, `hedge_winner`, `request_success`, and error chain entries; snapshot active attempts' redirects when a winner settles; deep-clone `currentModelRedirect` in `createStreamingShadowSession` and `syncWinningAttemptSession`

### Test Coverage
- **`proxy-forwarder-hedge-first-byte.test.ts`** (+367): 5 new test cases:
  - Shadow session redirect isolation + winner keeps its own redirect
  - Snapshot cloning (not shared reference) between session and shadow
  - Stale redirect clearing when switching to provider without redirect rules
  - Full hedge path: winner and loser both carry correct redirect metadata
  - Full hedge path: retry_failed shadow attempt retains redirect audit

## Related
- Follow-up to #894 (hedge first-byte timeout failover) - fixes redirect audit bugs in the hedge flow it introduced
- Related to #945 (reactive rectifiers during hedge) - similar pattern of propagating state across shadow sessions
- Related to #893 (hedge reason types) - uses the reason types added there (hedge_winner, hedge_loser_cancelled)
- Related to #633 (provider exhaustion after model redirect) - builds on the model redirect infrastructure it established

## Verification
- `bunx vitest run tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts`
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a redirect-audit correctness bug in the hedge streaming path: model redirect metadata was attached to whichever chain item happened to be last rather than to the attempt that actually performed the redirect, causing cross-contamination between concurrent shadow sessions.

The solution introduces a per-attempt `currentModelRedirect` snapshot on `ProxySession` with providerId-scoped accessors, a lazy-capture helper (`getAttemptModelRedirect`) that caches the snapshot per `StreamingHedgeAttempt`, and `structuredClone` at shadow-creation and winner-sync boundaries to prevent reference aliasing. Test coverage is thorough, exercising winner, loser, `retry_failed`, snapshot isolation, and stale-clearing paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the snapshot model, pre-capture loop timing, and structuredClone boundaries are all correct across every hedge race path.

All findings are P2 style/hardening suggestions. The core correctness of the per-attempt redirect snapshot, the providerId-scoped fallback in addProviderToChain, and the pre-capture loop ordering (before syncWinningAttemptSession) is sound. No data-loss, security, or runtime-error risks identified.

No files require special attention; the two P2 comments on forwarder.ts are non-blocking.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/session.ts | Adds currentModelRedirect snapshot field and four lifecycle methods (set/get/clear/attach); wires modelRedirect into addProviderToChain via providerId-gated fallback |
| src/app/v1/_lib/proxy/model-redirector.ts | Replaces direct chain-mutation with snapshot-based approach using setCurrentModelRedirect and attachCurrentModelRedirectToLastChainItem; adds clearCurrentModelRedirect on no-redirect paths to prevent stale snapshots |
| src/app/v1/_lib/proxy/forwarder.ts | Adds modelRedirect field to StreamingHedgeAttempt, getAttemptModelRedirect lazy-capture helper with pre-capture loop in commitWinner, structuredClone on shadow create/sync, and explicit redirect propagation to all chain entry points |
| tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts | Five new regression tests: shadow redirect isolation, snapshot clone vs reference, stale redirect clearing, full hedge winner/loser redirect audit, and retry_failed redirect retention |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Main Session
    participant F as Forwarder (hedge)
    participant R as ModelRedirector
    participant Sh as Shadow Session

    F->>R: apply(session, fireworks)
    R->>S: setCurrentModelRedirect(fireworks.id, fw_redirect)
    R->>S: attachCurrentModelRedirectToLastChainItem(fireworks.id)
    Note over S: chain[initial_selection].modelRedirect = fw_redirect

    F->>Sh: createStreamingShadowSession(session, minimax)
    Note over Sh: currentModelRedirect = structuredClone(fw_redirect)

    F->>R: apply(shadow, minimax)
    R->>Sh: setCurrentModelRedirect(minimax.id, mm_redirect)
    Note over Sh: attachToLastChainItem → no-op (last item id is fireworks)

    F->>F: minimax first chunk arrives → commitWinner(minimaxAttempt)
    Note over F: Pre-capture loop: getAttemptModelRedirect(fwAttempt)<br/>reads + caches fw_redirect BEFORE session sync
    F->>S: syncWinningAttemptSession(session, shadow)
    Note over S: currentModelRedirect = structuredClone(mm_redirect)

    F->>S: addProviderToChain(minimax, hedge_winner, mm_redirect)
    F->>F: abortAllAttempts → abortAttempt(fwAttempt)
    F->>S: addProviderToChain(fireworks, hedge_loser_cancelled, cached fw_redirect)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/forwarder.ts
Line: 2998-3008

Comment:
**`undefined` not cached in `getAttemptModelRedirect`**

When the attempt's provider has no redirect configured, `redirect` is `undefined` and `attempt.modelRedirect` stays unset on every call. After `syncWinningAttemptSession` overwrites `session.currentModelRedirect`, a subsequent call for a loser attempt whose `attemptSession` is the main session will re-query the now-mutated session. Correctness is preserved today by the `providerId` guard in `getCurrentModelRedirect`, but caching the absent case explicitly makes the intent clearer and guards against future refactors removing that guard.

```suggestion
    const getAttemptModelRedirect = (attempt: StreamingHedgeAttempt) => {
      if (attempt.modelRedirect !== undefined) {
        return attempt.modelRedirect;
      }

      const redirect = attempt.session.getCurrentModelRedirect(attempt.provider.id);
      // Cache even the absent case so post-sync re-queries cannot observe stale state.
      attempt.modelRedirect = redirect ? structuredClone(redirect) : null;

      return attempt.modelRedirect ?? undefined;
    };
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/forwarder.ts
Line: 3689

Comment:
**Shallow chain item copy allows mutation through shadow session**

`shadowState.providerChain = [...sourceState.providerChain]` is a shallow array copy: the `ProviderChainItem` objects themselves are shared references with the original session. `attachCurrentModelRedirectToLastChainItem` mutates `lastItem.modelRedirect` in-place, so if a shadow's provider id ever matched an existing chain item's id, both chains would be silently affected. This is prevented today by the `launchedProviderIds` uniqueness invariant, but that invariant is not encoded here. A comment documenting the assumption (or a defensive `structuredClone` of the items) would help future maintainers.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(proxy): cover hedge redirect audit ..."](https://github.com/ding113/claude-code-hub/commit/caf0e5dd721171b96c913a4d1e210d2607125c41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27350580)</sub>

<!-- /greptile_comment -->