### PR TITLE
fix: remove redundant provider model whitelist UI

### DIFF
--- a/messages/en/settings/providers/form/modelSelect.json
+++ b/messages/en/settings/providers/form/modelSelect.json
@@ -16,7 +16,6 @@
   "searchPlaceholder": "Search model name...",
   "selectAll": "Select All ({count})",
   "selectedCount": "Selected {count} models",
-  "selectedListHint": "Edit or remove without opening the dropdown",
   "selectedListLabel": "Selected whitelist ({count})",
   "sourceFallback": "Local",
   "sourceFallbackDesc": "Using local price list (upstream unavailable or unsupported)",

--- a/messages/ja/settings/providers/form/modelSelect.json
+++ b/messages/ja/settings/providers/form/modelSelect.json
@@ -16,7 +16,6 @@
   "searchPlaceholder": "モデル名を検索...",
   "selectAll": "すべて選択 ({count})",
   "selectedCount": "{count} 個のモデルを選択済み",
-  "selectedListHint": "ドロップダウンを開かずに編集・削除できます",
   "selectedListLabel": "選択済みホワイトリスト ({count})",
   "sourceFallback": "ローカル",
   "sourceFallbackDesc": "ローカル価格表のモデルリストを使用（上流が利用不可または未対応）",

--- a/messages/ru/settings/providers/form/modelSelect.json
+++ b/messages/ru/settings/providers/form/modelSelect.json
@@ -16,7 +16,6 @@
   "searchPlaceholder": "Поиск по названию модели...",
   "selectAll": "Выбрать все ({count})",
   "selectedCount": "Выбрано моделей: {count}",
-  "selectedListHint": "Можно редактировать и удалять без открытия списка",
   "selectedListLabel": "Белый список ({count})",
   "sourceFallback": "Локально",
   "sourceFallbackDesc": "Используется локальный прайс-лист (upstream недоступен или не поддерживается)",

--- a/messages/zh-CN/settings/providers/form/modelSelect.json
+++ b/messages/zh-CN/settings/providers/form/modelSelect.json
@@ -20,7 +20,6 @@
   "selectedEditEmpty": "模型名称不能为空",
   "selectedEditExists": "模型 \"{model}\" 已在白名单中",
   "selectedGroupLabel": "已选模型",
-  "selectedListHint": "无需展开下拉框即可直接编辑或删除",
   "selectedListLabel": "已选白名单 ({count})",
   "availableGroupLabel": "可选模型"
 }

--- a/messages/zh-TW/settings/providers/form/modelSelect.json
+++ b/messages/zh-TW/settings/providers/form/modelSelect.json
@@ -16,7 +16,6 @@
   "searchPlaceholder": "搜尋模型名稱...",
   "selectAll": "全選 ({count})",
   "selectedCount": "已選擇 {count} 個模型",
-  "selectedListHint": "無需展開下拉框即可直接編輯或刪除",
   "selectedListLabel": "已選白名單 ({count})",
   "sourceFallback": "本機",
   "sourceFallbackDesc": "使用本地價格表中的模型列表（上游獲取失敗或不支援）",

--- a/src/app/[locale]/settings/providers/_components/forms/provider-form/sections/routing-section.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/provider-form/sections/routing-section.tsx
@@ -214,22 +214,6 @@ export function RoutingSection({ subSectionRefs }: RoutingSectionProps) {
                 proxyFallbackToDirect={state.network.proxyFallbackToDirect}
                 providerId={isEdit ? provider?.id : undefined}
               />
-              {state.routing.allowedModels.length > 0 && (
-                <div className="flex flex-wrap gap-1 p-2 bg-muted/50 rounded-md">
-                  {state.routing.allowedModels.slice(0, 5).map((model) => (
-                    <Badge key={model} variant="outline" className="font-mono text-xs">
-                      {model}
-                    </Badge>
-                  ))}
-                  {state.routing.allowedModels.length > 5 && (
-                    <Badge variant="secondary" className="text-xs">
-                      {t("sections.routing.modelWhitelist.moreModels", {
-                        count: state.routing.allowedModels.length - 5,
-                      })}
-                    </Badge>
-                  )}
-                </div>
-              )}
               <p className="text-xs text-muted-foreground">
                 {state.routing.allowedModels.length === 0 ? (
                   <span className="text-green-600">

--- a/src/app/[locale]/settings/providers/_components/model-multi-select.tsx
+++ b/src/app/[locale]/settings/providers/_components/model-multi-select.tsx
@@ -449,7 +449,6 @@ export function ModelMultiSelect({
             <Label className="text-xs font-medium">
               {t("selectedListLabel", { count: selectedModels.length })}
             </Label>
-            <span className="text-xs text-muted-foreground">{t("selectedListHint")}</span>
           </div>
 
           <div className="space-y-1">


### PR DESCRIPTION
## Summary
Remove redundant UI elements from the provider model whitelist dialog left over from the model redirect rules rewrite.

## Problem
After #993 introduced an editable selected-models list in `ModelMultiSelect` (with inline edit/remove per model), two UI elements became redundant:
1. A compact Badge display in `routing-section.tsx` that showed up to 5 whitelisted models as badges
2. A `selectedListHint` hint text ("Edit or remove without opening the dropdown") that explained the old UI behavior

Both are now unnecessary since the new editable list makes the functionality self-evident.

**Related PRs:**
- Follow-up to #993 (feat: support provider model redirect rules) - introduced the new editable list that made these elements redundant
- Related to #593 (fix: allow removing custom whitelisted models) - earlier work on the same component

## Solution
Delete the redundant UI elements and clean up the now-unused `selectedListHint` i18n key from all 5 language packs.

## Changes

### Core Changes
- `routing-section.tsx` (-16): Removed Badge-based compact model whitelist display (showed up to 5 models as outline badges)
- `model-multi-select.tsx` (-1): Removed `selectedListHint` hint text span

### Supporting Changes
- 5 i18n files (-1 each): Removed unused `selectedListHint` translation key from en, ja, ru, zh-CN, zh-TW

## Testing

### Verification
- [x] `bun run lint:fix`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run test`
- [x] Manual: Add a custom model in the new provider dialog - only the new editable list is shown, no hint text, no old Badge list

## Checklist
- [x] Code follows project conventions
- [x] i18n keys cleaned up for all 5 languages
- [x] No new tests needed (pure deletion of unused UI elements)
- [x] Verified locally in browser

---
*Description enhanced by Claude AI*