### PR TITLE
feat: improve provider detection template selection

### DIFF
--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -2918,30 +2918,34 @@ type ProviderApiTestArgs = {
   timeoutMs?: number; // 自定义超时时间（毫秒）
 };
 
+export type ProviderApiTestSuccessDetails = {
+  responseTime?: number;
+  model?: string;
+  usage?: Record<string, unknown>;
+  content?: string;
+  rawResponse?: string;
+  streamInfo?: {
+    chunksReceived: number;
+    format: "sse" | "ndjson";
+  };
+};
+
+export type ProviderApiTestFailureDetails = {
+  responseTime?: number;
+  error?: string;
+  rawResponse?: string;
+};
+
 type ProviderApiTestResult = ActionResult<
   | {
       success: true;
       message: string;
-      details?: {
-        responseTime?: number;
-        model?: string;
-        usage?: Record<string, unknown>;
-        content?: string;
-        rawResponse?: string;
-        streamInfo?: {
-          chunksReceived: number;
-          format: "sse" | "ndjson";
-        };
-      };
+      details?: ProviderApiTestSuccessDetails;
     }
   | {
       success: false;
       message: string;
-      details?: {
-        responseTime?: number;
-        error?: string;
-        rawResponse?: string;
-      };
+      details?: ProviderApiTestFailureDetails;
     }
 >;
 

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -2927,6 +2927,7 @@ type ProviderApiTestResult = ActionResult<
         model?: string;
         usage?: Record<string, unknown>;
         content?: string;
+        rawResponse?: string;
         streamInfo?: {
           chunksReceived: number;
           format: "sse" | "ndjson";
@@ -2939,6 +2940,7 @@ type ProviderApiTestResult = ActionResult<
       details?: {
         responseTime?: number;
         error?: string;
+        rawResponse?: string;
       };
     }
 >;
@@ -3013,6 +3015,7 @@ type GeminiResponse = {
     };
     finishReason?: string;
   }>;
+  modelVersion?: string;
   usageMetadata?: {
     promptTokenCount?: number;
     candidatesTokenCount?: number;
@@ -3793,6 +3796,7 @@ async function executeProviderApiTest(
             details: {
               responseTime,
               error: finalErrorDetail,
+              rawResponse: errorText,
             },
           },
         };
@@ -3876,6 +3880,7 @@ async function executeProviderApiTest(
               details: {
                 responseTime,
                 ...extracted,
+                rawResponse: responseText,
                 streamInfo: {
                   chunksReceived: streamResult.chunksReceived,
                   format: streamResult.format,
@@ -3923,6 +3928,7 @@ async function executeProviderApiTest(
             details: {
               responseTime,
               error: `JSON 解析失败: ${jsonError instanceof Error ? jsonError.message : "未知错误"}`,
+              rawResponse: responseText,
             },
           },
         };
@@ -3938,6 +3944,7 @@ async function executeProviderApiTest(
           details: {
             responseTime,
             ...extracted,
+            rawResponse: responseText,
           },
         },
       };
@@ -4152,7 +4159,7 @@ export async function testProviderGemini(
     {
       path: (model) => {
         // 不在 URL 中放 key，仅用 header 认证
-        return `/v1beta/models/${model}:streamGenerateContent?alt=sse`;
+        return `/v1beta/models/${model}:generateContent`;
       },
       defaultModel: "gemini-2.5-pro",
       headers: (apiKey) => {
@@ -4170,9 +4177,13 @@ export async function testProviderGemini(
       body: (model) => {
         void model;
         return {
-          contents: [{ parts: [{ text: API_TEST_CONFIG.TEST_PROMPT }] }],
+          contents: [{ role: "user", parts: [{ text: API_TEST_CONFIG.TEST_PROMPT }] }],
           generationConfig: {
+            temperature: 0,
             maxOutputTokens: API_TEST_CONFIG.TEST_MAX_TOKENS,
+            thinkingConfig: {
+              thinkingBudget: 0,
+            },
           },
         };
       },
@@ -4182,7 +4193,7 @@ export async function testProviderGemini(
       extract: (result) => {
         const geminiResult = result as GeminiResponse;
         return {
-          model: undefined,
+          model: geminiResult.modelVersion,
           usage: geminiResult.usageMetadata as Record<string, unknown>,
           content: extractFirstTextSnippet(geminiResult),
         };
@@ -4226,7 +4237,7 @@ export async function testProviderGemini(
     { ...data, apiKey: processedApiKey },
     {
       path: (model, apiKey) =>
-        `/v1beta/models/${model}:streamGenerateContent?alt=sse&key=${encodeURIComponent(apiKey)}`,
+        `/v1beta/models/${model}:generateContent?key=${encodeURIComponent(apiKey)}`,
       defaultModel: "gemini-2.5-pro",
       headers: (apiKey) => ({
         "Content-Type": "application/json",
@@ -4236,9 +4247,13 @@ export async function testProviderGemini(
       body: (model) => {
         void model;
         return {
-          contents: [{ parts: [{ text: API_TEST_CONFIG.TEST_PROMPT }] }],
+          contents: [{ role: "user", parts: [{ text: API_TEST_CONFIG.TEST_PROMPT }] }],
           generationConfig: {
+            temperature: 0,
             maxOutputTokens: API_TEST_CONFIG.TEST_MAX_TOKENS,
+            thinkingConfig: {
+              thinkingBudget: 0,
+            },
           },
         };
       },
@@ -4248,7 +4263,7 @@ export async function testProviderGemini(
       extract: (result) => {
         const geminiResult = result as GeminiResponse;
         return {
-          model: undefined,
+          model: geminiResult.modelVersion,
           usage: geminiResult.usageMetadata as Record<string, unknown>,
           content: extractFirstTextSnippet(geminiResult),
         };
@@ -4313,6 +4328,7 @@ export type UnifiedTestResult = ActionResult<{
   httpStatusText?: string;
   model?: string;
   content?: string;
+  rawResponse?: string;
   usage?: {
     inputTokens: number;
     outputTokens: number;
@@ -4436,6 +4452,7 @@ export async function testProviderUnified(data: UnifiedTestArgs): Promise<Unifie
         httpStatusText: result.httpStatusText,
         model: result.model,
         content: result.content,
+        rawResponse: result.rawResponse,
         usage: result.usage,
         streamInfo: result.streamInfo,
         errorMessage: result.errorMessage,

--- a/src/app/[locale]/settings/providers/_components/forms/api-test-button.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/api-test-button.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
   getUnmaskedProviderKey,
+  type ProviderApiTestSuccessDetails,
   testProviderGemini,
   testProviderUnified,
 } from "@/actions/providers";
@@ -93,9 +94,8 @@ export function ApiTestButton({
   providerId,
   providerType,
   allowedModels = [],
-  enableMultiProviderTypes,
+  enableMultiProviderTypes: _enableMultiProviderTypes,
 }: ApiTestButtonProps) {
-  void enableMultiProviderTypes;
 
   const t = useTranslations("settings.providers.form.apiTest");
   const normalizedAllowedModels = useMemo(() => {
@@ -188,17 +188,7 @@ export function ApiTestButton({
         const cleanMessage = rawMessage.replace(" [FALLBACK:URL_PARAM]", "");
         const isSuccess = response.data.success === true;
         const details = (isSuccess ? response.data.details : undefined) as
-          | {
-              responseTime?: number;
-              model?: string;
-              usage?: Record<string, unknown>;
-              content?: string;
-              rawResponse?: string;
-              streamInfo?: {
-                chunksReceived: number;
-                format: "sse" | "ndjson";
-              };
-            }
+          | ProviderApiTestSuccessDetails
           | undefined;
         const latencyMs = response.data.details?.responseTime ?? 0;
 
@@ -400,7 +390,10 @@ export function ApiTestButton({
       </div>
 
       <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
-        <div className="font-medium mb-1">⚠️ {t("disclaimer.title")}</div>
+        <div className="font-medium mb-1 flex items-center gap-1">
+          <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+          {t("disclaimer.title")}
+        </div>
         <div className="space-y-1 text-amber-700 dark:text-amber-300">
           <div>• {t("disclaimer.resultReference")}</div>
           <div>• {t("disclaimer.realRequest")}</div>

--- a/src/app/[locale]/settings/providers/_components/forms/api-test-button.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/api-test-button.tsx
@@ -5,58 +5,72 @@ import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
-  getProviderTestPresets,
   getUnmaskedProviderKey,
-  type PresetConfigResponse,
   testProviderGemini,
   testProviderUnified,
 } from "@/actions/providers";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import { normalizeAllowedModelRules } from "@/lib/allowed-model-rules";
 import { isValidUrl } from "@/lib/utils/validation";
 import type { AllowedModelRuleInput, ProviderType } from "@/types/provider";
 import { TestResultCard, type UnifiedTestResultData } from "./test-result-card";
 
-type ApiFormat = "anthropic-messages" | "openai-chat" | "openai-responses" | "gemini";
-
-// UI 配置常量
 const API_TEST_UI_CONFIG = {
-  MAX_PREVIEW_LENGTH: 500, // 响应内容预览最大长度
-  BRIEF_PREVIEW_LENGTH: 200, // 简要预览最大长度
-  TOAST_SUCCESS_DURATION: 3000, // 成功 toast 显示时长（毫秒）
-  TOAST_ERROR_DURATION: 5000, // 错误 toast 显示时长（毫秒）
+  TOAST_SUCCESS_DURATION: 3000,
+  TOAST_ERROR_DURATION: 5000,
 } as const;
 
-const providerTypeToApiFormat: Partial<Record<ProviderType, ApiFormat>> = {
-  claude: "anthropic-messages",
-  "claude-auth": "anthropic-messages",
-  codex: "openai-responses",
-  "openai-compatible": "openai-chat",
-  gemini: "gemini",
-  "gemini-cli": "gemini",
+const DEFAULT_MODELS: Record<ProviderType, string> = {
+  claude: "claude-haiku-4-5-20251001",
+  "claude-auth": "claude-haiku-4-5-20251001",
+  codex: "gpt-5.3-codex",
+  "openai-compatible": "gpt-4.1-mini",
+  gemini: "gemini-2.5-flash",
+  "gemini-cli": "gemini-2.5-flash",
 };
 
-const apiFormatDefaultModel: Record<ApiFormat, string> = {
-  "anthropic-messages": "claude-sonnet-4-5-20250929",
-  "openai-chat": "gpt-5.1-codex",
-  "openai-responses": "gpt-5.1-codex",
-  gemini: "gemini-3-pro-preview",
-};
+function resolveProviderType(providerType?: ProviderType | null): ProviderType {
+  return providerType ?? "claude";
+}
 
-const resolveApiFormatFromProvider = (providerType?: ProviderType | null): ApiFormat =>
-  (providerType ? providerTypeToApiFormat[providerType] : undefined) ?? "anthropic-messages";
+function getDefaultModelForProvider(
+  providerType?: ProviderType | null,
+  whitelistDefault?: string
+): string {
+  return whitelistDefault ?? DEFAULT_MODELS[resolveProviderType(providerType)];
+}
 
-const getDefaultModelForFormat = (format: ApiFormat) => apiFormatDefaultModel[format];
+function getTimeoutMsForProvider(providerType: ProviderType): number {
+  return providerType === "gemini" || providerType === "gemini-cli" ? 60_000 : 15_000;
+}
+
+function normalizeUsage(usage?: Record<string, unknown>) {
+  if (!usage) {
+    return undefined;
+  }
+
+  const readNumber = (...keys: string[]) => {
+    for (const key of keys) {
+      const value = usage[key];
+      if (typeof value === "number") {
+        return value;
+      }
+    }
+    return undefined;
+  };
+
+  const inputTokens = readNumber("inputTokens", "promptTokenCount", "prompt_tokens") ?? 0;
+  const outputTokens = readNumber("outputTokens", "candidatesTokenCount", "completion_tokens") ?? 0;
+
+  return {
+    inputTokens,
+    outputTokens,
+    cacheCreationInputTokens: readNumber("cacheCreationInputTokens", "cache_creation_input_tokens"),
+    cacheReadInputTokens: readNumber("cacheReadInputTokens", "cache_read_input_tokens"),
+  };
+}
 
 interface ApiTestButtonProps {
   providerUrl: string;
@@ -70,14 +84,6 @@ interface ApiTestButtonProps {
   enableMultiProviderTypes: boolean;
 }
 
-/**
- * API 连通性测试按钮组件
- *
- * 支持测试三种API格式:
- * - Anthropic Messages API (v1/messages)
- * - OpenAI Chat Completions API (v1/chat/completions)
- * - OpenAI Responses API (v1/responses)
- */
 export function ApiTestButton({
   providerUrl,
   apiKey,
@@ -89,8 +95,9 @@ export function ApiTestButton({
   allowedModels = [],
   enableMultiProviderTypes,
 }: ApiTestButtonProps) {
+  void enableMultiProviderTypes;
+
   const t = useTranslations("settings.providers.form.apiTest");
-  const providerTypeT = useTranslations("settings.providers.form.providerTypes");
   const normalizedAllowedModels = useMemo(() => {
     const unique = new Set<string>();
     (normalizeAllowedModelRules(allowedModels) ?? []).forEach((rule) => {
@@ -101,90 +108,23 @@ export function ApiTestButton({
     return Array.from(unique);
   }, [allowedModels]);
 
-  const initialApiFormat = resolveApiFormatFromProvider(providerType);
+  const resolvedProviderType = resolveProviderType(providerType);
   const [isTesting, setIsTesting] = useState(false);
-  const [apiFormat, setApiFormat] = useState<ApiFormat>(initialApiFormat);
-  const [isApiFormatManuallySelected, setIsApiFormatManuallySelected] = useState(false);
-  const [testModel, setTestModel] = useState(() => {
-    const whitelistDefault = normalizedAllowedModels[0];
-    return whitelistDefault ?? getDefaultModelForFormat(initialApiFormat);
-  });
   const [isModelManuallyEdited, setIsModelManuallyEdited] = useState(false);
+  const [testModel, setTestModel] = useState(() =>
+    getDefaultModelForProvider(providerType, normalizedAllowedModels[0])
+  );
   const [testResult, setTestResult] = useState<UnifiedTestResultData | null>(null);
-
-  // Custom configuration state
-  const [configMode, setConfigMode] = useState<"preset" | "custom">("preset");
-  const [presets, setPresets] = useState<PresetConfigResponse[]>([]);
-  const [selectedPreset, setSelectedPreset] = useState<string>("");
-  const [customPayload, setCustomPayload] = useState("");
-  const [successContains, setSuccessContains] = useState("pong");
-  const [timeoutSeconds, setTimeoutSeconds] = useState(() =>
-    initialApiFormat === "gemini" ? 60 : 15
-  );
-
-  useEffect(() => {
-    if (isApiFormatManuallySelected) return;
-    const resolvedFormat = resolveApiFormatFromProvider(providerType);
-    if (resolvedFormat !== apiFormat) {
-      setApiFormat(resolvedFormat);
-    }
-  }, [apiFormat, isApiFormatManuallySelected, providerType]);
-
-  // Map API format to provider type (defined before useEffect that depends on it)
-  const apiFormatToProviderType: Record<ApiFormat, ProviderType> = useMemo(
-    () => ({
-      "anthropic-messages": providerType === "claude-auth" ? "claude-auth" : "claude",
-      "openai-chat": "openai-compatible",
-      "openai-responses": "codex",
-      gemini: providerType === "gemini-cli" ? "gemini-cli" : "gemini",
-    }),
-    [providerType]
-  );
-
-  // Load presets when provider type changes
-  useEffect(() => {
-    const currentProviderType = apiFormatToProviderType[apiFormat];
-    if (!currentProviderType) return;
-
-    getProviderTestPresets(currentProviderType)
-      .then((result) => {
-        if (result.ok && result.data) {
-          setPresets(result.data);
-          // Auto-select first preset if available
-          if (result.data.length > 0 && !selectedPreset) {
-            setSelectedPreset(result.data[0].id);
-            setSuccessContains(result.data[0].defaultSuccessContains);
-          }
-        } else {
-          if (!result.ok) {
-            console.error("[ApiTestButton] Failed to load presets:", result.error);
-          }
-          setPresets([]);
-        }
-      })
-      .catch((err) => {
-        console.error("[ApiTestButton] Failed to load presets:", err);
-        setPresets([]);
-      });
-  }, [apiFormat, apiFormatToProviderType, selectedPreset]);
 
   useEffect(() => {
     if (isModelManuallyEdited) {
       return;
     }
 
-    const whitelistDefault = normalizedAllowedModels[0];
-    const defaultModel = whitelistDefault ?? getDefaultModelForFormat(apiFormat);
-    setTestModel(defaultModel);
-  }, [apiFormat, isModelManuallyEdited, normalizedAllowedModels]);
-
-  // 根据 API 格式更新默认超时时间
-  useEffect(() => {
-    setTimeoutSeconds(apiFormat === "gemini" ? 60 : 15);
-  }, [apiFormat]);
+    setTestModel(getDefaultModelForProvider(providerType, normalizedAllowedModels[0]));
+  }, [isModelManuallyEdited, normalizedAllowedModels, providerType]);
 
   const handleTest = async () => {
-    // 验证必填字段
     if (!providerUrl.trim()) {
       toast.error(t("fillUrlFirst"));
       return;
@@ -199,7 +139,6 @@ export function ApiTestButton({
     setTestResult(null);
 
     try {
-      // 优先使用表单中的密钥，仅在为空且提供了 providerId 时才查询数据库
       let resolvedKey = apiKey.trim();
 
       if (!resolvedKey && providerId) {
@@ -222,18 +161,16 @@ export function ApiTestButton({
         return;
       }
 
-      const providerForTest = apiFormatToProviderType[apiFormat];
       let testResultData: UnifiedTestResultData | null = null;
 
-      // Gemini 类型使用专门的测试函数
-      if (providerForTest === "gemini" || providerForTest === "gemini-cli") {
+      if (resolvedProviderType === "gemini" || resolvedProviderType === "gemini-cli") {
         const response = await testProviderGemini({
           providerUrl: providerUrl.trim(),
           apiKey: resolvedKey,
           model: testModel.trim() || undefined,
           proxyUrl: proxyUrl?.trim() || null,
           proxyFallbackToDirect,
-          timeoutMs: timeoutSeconds * 1000,
+          timeoutMs: getTimeoutMsForProvider(resolvedProviderType),
         });
 
         if (!response.ok) {
@@ -246,12 +183,25 @@ export function ApiTestButton({
           return;
         }
 
-        const isSuccess = response.data.success === true;
         const rawMessage = response.data.message || t("testFailed");
         const usedFallback = rawMessage.includes("[FALLBACK:URL_PARAM]");
         const cleanMessage = rawMessage.replace(" [FALLBACK:URL_PARAM]", "");
+        const isSuccess = response.data.success === true;
+        const details = (isSuccess ? response.data.details : undefined) as
+          | {
+              responseTime?: number;
+              model?: string;
+              usage?: Record<string, unknown>;
+              content?: string;
+              rawResponse?: string;
+              streamInfo?: {
+                chunksReceived: number;
+                format: "sse" | "ndjson";
+              };
+            }
+          | undefined;
+        const latencyMs = response.data.details?.responseTime ?? 0;
 
-        // 根据错误消息推断 subStatus
         const inferSubStatus = ():
           | "success"
           | "auth_error"
@@ -296,22 +246,32 @@ export function ApiTestButton({
           return "client_error";
         };
 
-        const latencyMs = response.data.details?.responseTime ?? 0;
         testResultData = {
           success: isSuccess,
           status: isSuccess ? (usedFallback ? "yellow" : "green") : "red",
           subStatus: inferSubStatus(),
           message: cleanMessage,
           latencyMs,
+          model: details?.model,
+          content: details?.content,
+          rawResponse: details?.rawResponse,
+          usage: normalizeUsage(details?.usage),
+          streamInfo: details?.streamInfo
+            ? {
+                isStreaming: true,
+                chunksReceived: details.streamInfo.chunksReceived,
+              }
+            : undefined,
           testedAt: new Date().toISOString(),
           validationDetails: {
             httpPassed: isSuccess,
-            latencyPassed: isSuccess && latencyMs < 5000, // 5秒内算通过
+            latencyPassed: isSuccess && latencyMs < 5000,
+            latencyMs,
             contentPassed: isSuccess,
+            contentTarget: "pong",
           },
         };
 
-        // 如果使用了 fallback 认证方式，显示警告
         if (isSuccess && usedFallback) {
           toast.warning(t("geminiAuthFallback.warning"), {
             description: t("geminiAuthFallback.desc"),
@@ -319,19 +279,14 @@ export function ApiTestButton({
           });
         }
       } else {
-        // 其他类型使用统一测试服务
         const response = await testProviderUnified({
           providerUrl: providerUrl.trim(),
           apiKey: resolvedKey,
-          providerType: providerForTest,
+          providerType: resolvedProviderType,
           model: testModel.trim() || undefined,
           proxyUrl: proxyUrl?.trim() || null,
           proxyFallbackToDirect,
-          timeoutMs: timeoutSeconds * 1000,
-          // Custom configuration
-          preset: configMode === "preset" && selectedPreset ? selectedPreset : undefined,
-          customPayload: configMode === "custom" && customPayload ? customPayload : undefined,
-          successContains: successContains || undefined,
+          timeoutMs: getTimeoutMsForProvider(resolvedProviderType),
         });
 
         if (!response.ok) {
@@ -354,7 +309,6 @@ export function ApiTestButton({
 
       setTestResult(testResultData);
 
-      // 显示测试结果 toast
       const statusLabels = {
         green: t("testSuccess"),
         yellow: t("resultCard.status.yellow"),
@@ -385,7 +339,6 @@ export function ApiTestButton({
     }
   };
 
-  // 获取按钮内容
   const getButtonContent = () => {
     if (isTesting) {
       return (
@@ -404,21 +357,21 @@ export function ApiTestButton({
             {t("testSuccess")}
           </>
         );
-      } else if (testResult.status === "yellow") {
+      }
+      if (testResult.status === "yellow") {
         return (
           <>
             <AlertTriangle className="h-4 w-4 mr-2 text-yellow-600" />
             {t("resultCard.status.yellow")}
           </>
         );
-      } else {
-        return (
-          <>
-            <XCircle className="h-4 w-4 mr-2 text-red-600" />
-            {t("testFailed")}
-          </>
-        );
       }
+      return (
+        <>
+          <XCircle className="h-4 w-4 mr-2 text-red-600" />
+          {t("testFailed")}
+        </>
+      );
     }
 
     return (
@@ -432,150 +385,20 @@ export function ApiTestButton({
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label htmlFor="api-format">{t("apiFormat")}</Label>
-        <Select
-          value={apiFormat}
-          onValueChange={(value) => {
-            setIsApiFormatManuallySelected(true);
-            setApiFormat(value as ApiFormat);
-          }}
-        >
-          <SelectTrigger id="api-format">
-            <SelectValue placeholder={t("selectApiFormat")} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="anthropic-messages">{t("formatAnthropicMessages")}</SelectItem>
-            <SelectItem value="openai-chat" disabled={!enableMultiProviderTypes}>
-              {t("formatOpenAIChat")}
-              {!enableMultiProviderTypes && providerTypeT("openaiCompatibleDisabled")}
-            </SelectItem>
-            <SelectItem value="openai-responses">{t("formatOpenAIResponses")}</SelectItem>
-            <SelectItem value="gemini">Gemini API</SelectItem>
-          </SelectContent>
-        </Select>
-        <div className="text-xs text-muted-foreground">{t("apiFormatDesc")}</div>
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="test-model">{t("testModel")}</Label>
+        <Label htmlFor="test-model">{t("model")}</Label>
         <Input
           id="test-model"
           value={testModel}
-          onChange={(e) => {
-            const value = e.target.value;
+          onChange={(event) => {
             setIsModelManuallyEdited(true);
-            setTestModel(value);
+            setTestModel(event.target.value);
           }}
-          placeholder={getDefaultModelForFormat(apiFormat)}
+          placeholder={DEFAULT_MODELS[resolvedProviderType]}
           disabled={isTesting}
         />
         <div className="text-xs text-muted-foreground">{t("testModelDesc")}</div>
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="test-timeout">{t("timeout.label")}</Label>
-        <Input
-          id="test-timeout"
-          type="number"
-          min={5}
-          max={120}
-          value={timeoutSeconds}
-          onChange={(e) => {
-            const value = parseInt(e.target.value, 10);
-            if (!Number.isNaN(value) && value >= 5 && value <= 120) {
-              setTimeoutSeconds(value);
-            }
-          }}
-          disabled={isTesting}
-          className="w-24"
-        />
-        <div className="text-xs text-muted-foreground">
-          {t("timeout.desc")}
-          {apiFormat === "gemini" && t("timeout.geminiHint")}
-        </div>
-      </div>
-
-      {/* Request Configuration - Preset/Custom */}
-      {presets.length > 0 && (
-        <div className="space-y-3">
-          <Label>{t("requestConfig")}</Label>
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              variant={configMode === "preset" ? "default" : "outline"}
-              size="sm"
-              onClick={() => setConfigMode("preset")}
-              disabled={isTesting}
-            >
-              {t("presetConfig")}
-            </Button>
-            <Button
-              type="button"
-              variant={configMode === "custom" ? "default" : "outline"}
-              size="sm"
-              onClick={() => setConfigMode("custom")}
-              disabled={isTesting}
-            >
-              {t("customConfig")}
-            </Button>
-          </div>
-
-          {configMode === "preset" && (
-            <div className="space-y-2">
-              <Select
-                value={selectedPreset}
-                onValueChange={(value: string) => {
-                  setSelectedPreset(value);
-                  const preset = presets.find((p) => p.id === value);
-                  if (preset) {
-                    setSuccessContains(preset.defaultSuccessContains);
-                  }
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder={t("selectPreset")} />
-                </SelectTrigger>
-                <SelectContent>
-                  {presets.map((preset) => (
-                    <SelectItem key={preset.id} value={preset.id}>
-                      {preset.id} - {preset.description}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <div className="text-xs text-muted-foreground">{t("presetDesc")}</div>
-            </div>
-          )}
-
-          {configMode === "custom" && (
-            <div className="space-y-2">
-              <Textarea
-                value={customPayload}
-                onChange={(e) => setCustomPayload(e.target.value)}
-                placeholder={t("customPayloadPlaceholder")}
-                className="font-mono text-xs min-h-[120px]"
-                disabled={isTesting}
-              />
-              <div className="text-xs text-muted-foreground">{t("customPayloadDesc")}</div>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Success Detection Keyword */}
-      <div className="space-y-2">
-        <Label htmlFor="success-contains">{t("successContains")}</Label>
-        <Input
-          id="success-contains"
-          value={successContains}
-          onChange={(e) => setSuccessContains(e.target.value)}
-          placeholder={t("successContainsPlaceholder")}
-          disabled={isTesting}
-        />
-        <div className="text-xs text-muted-foreground">{t("successContainsDesc")}</div>
-      </div>
-
-      {/* 免责声明 */}
       <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
         <div className="font-medium mb-1">⚠️ {t("disclaimer.title")}</div>
         <div className="space-y-1 text-amber-700 dark:text-amber-300">
@@ -595,7 +418,6 @@ export function ApiTestButton({
         {getButtonContent()}
       </Button>
 
-      {/* 显示测试结果卡片 */}
       {testResult && !isTesting && <TestResultCard result={testResult} />}
     </div>
   );

--- a/src/app/[locale]/settings/providers/_components/forms/api-test-button.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/api-test-button.tsx
@@ -96,7 +96,6 @@ export function ApiTestButton({
   allowedModels = [],
   enableMultiProviderTypes: _enableMultiProviderTypes,
 }: ApiTestButtonProps) {
-
   const t = useTranslations("settings.providers.form.apiTest");
   const normalizedAllowedModels = useMemo(() => {
     const unique = new Set<string>();

--- a/src/lib/provider-testing/data/cc_beta_cli.json
+++ b/src/lib/provider-testing/data/cc_beta_cli.json
@@ -1,0 +1,26 @@
+{
+  "model": "claude-haiku-4-5-20251001",
+  "max_tokens": 20,
+  "stream": true,
+  "metadata": {
+    "user_id": "{\"device_id\":\"cch-probe-device\",\"account_uuid\":\"cch-probe-account\",\"session_id\":\"cch-probe-session\"}"
+  },
+  "system": [
+    {
+      "text": "You are Claude Code, Anthropic's official CLI for Claude.",
+      "type": "text"
+    }
+  ],
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "text": "ping, please reply 'pong'",
+          "type": "text"
+        }
+      ]
+    }
+  ],
+  "tools": []
+}

--- a/src/lib/provider-testing/data/cc_haiku_basic.json
+++ b/src/lib/provider-testing/data/cc_haiku_basic.json
@@ -1,0 +1,26 @@
+{
+  "model": "claude-haiku-4-5-20251001",
+  "max_tokens": 20,
+  "stream": true,
+  "metadata": {
+    "user_id": "cch_probe_test"
+  },
+  "system": [
+    {
+      "text": "You are Claude Code, Anthropic's official CLI for Claude.",
+      "type": "text"
+    }
+  ],
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "text": "ping, please reply 'pong'",
+          "type": "text"
+        }
+      ]
+    }
+  ],
+  "tools": []
+}

--- a/src/lib/provider-testing/data/cx_codex_basic.json
+++ b/src/lib/provider-testing/data/cx_codex_basic.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-5.3-codex",
+  "instructions": "You are Codex, based on GPT-5. You are running as a coding agent in the Codex CLI on a user's computer.",
+  "input": [
+    {
+      "type": "message",
+      "role": "user",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "ping"
+        }
+      ]
+    }
+  ],
+  "tools": [],
+  "tool_choice": "auto",
+  "parallel_tool_calls": false,
+  "reasoning": {
+    "effort": "low",
+    "summary": "auto"
+  },
+  "store": false,
+  "stream": true
+}

--- a/src/lib/provider-testing/data/cx_gpt_basic.json
+++ b/src/lib/provider-testing/data/cx_gpt_basic.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-5.4",
+  "instructions": "You are Codex, based on GPT-5. You are running as a coding agent in the Codex CLI on a user's computer.",
+  "input": [
+    {
+      "type": "message",
+      "role": "user",
+      "content": [
+        {
+          "type": "input_text",
+          "text": "ping"
+        }
+      ]
+    }
+  ],
+  "tools": [],
+  "tool_choice": "auto",
+  "parallel_tool_calls": false,
+  "reasoning": {
+    "effort": "low",
+    "summary": "auto"
+  },
+  "store": false,
+  "stream": true
+}

--- a/src/lib/provider-testing/data/gm_flash_basic.json
+++ b/src/lib/provider-testing/data/gm_flash_basic.json
@@ -1,0 +1,19 @@
+{
+  "contents": [
+    {
+      "role": "user",
+      "parts": [
+        {
+          "text": "ping"
+        }
+      ]
+    }
+  ],
+  "generationConfig": {
+    "temperature": 0,
+    "maxOutputTokens": 256,
+    "thinkingConfig": {
+      "thinkingBudget": 0
+    }
+  }
+}

--- a/src/lib/provider-testing/data/gm_pro_basic.json
+++ b/src/lib/provider-testing/data/gm_pro_basic.json
@@ -1,0 +1,19 @@
+{
+  "contents": [
+    {
+      "role": "user",
+      "parts": [
+        {
+          "text": "ping"
+        }
+      ]
+    }
+  ],
+  "generationConfig": {
+    "temperature": 0,
+    "maxOutputTokens": 256,
+    "thinkingConfig": {
+      "thinkingBudget": 0
+    }
+  }
+}

--- a/src/lib/provider-testing/data/oa_chat_basic.json
+++ b/src/lib/provider-testing/data/oa_chat_basic.json
@@ -1,0 +1,15 @@
+{
+  "model": "gpt-4.1-mini",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are an echo bot. Reply with exactly pong."
+    },
+    {
+      "role": "user",
+      "content": "ping"
+    }
+  ],
+  "max_tokens": 20,
+  "stream": false
+}

--- a/src/lib/provider-testing/data/oa_chat_stream.json
+++ b/src/lib/provider-testing/data/oa_chat_stream.json
@@ -1,0 +1,15 @@
+{
+  "model": "gpt-4.1-mini",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are an echo bot. Reply with exactly pong."
+    },
+    {
+      "role": "user",
+      "content": "ping"
+    }
+  ],
+  "max_tokens": 20,
+  "stream": true
+}

--- a/src/lib/provider-testing/presets.test.ts
+++ b/src/lib/provider-testing/presets.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { getDefaultPreset, getPresetsForProvider } from "./presets";
+
+describe("provider-testing presets", () => {
+  test("openai-compatible 应该使用独立的 OpenAI Compatible 模板，而不是复用 codex 模板", () => {
+    const ids = getPresetsForProvider("openai-compatible").map((preset) => preset.id);
+
+    expect(ids).toContain("oa_chat_basic");
+    expect(ids).toContain("oa_chat_stream");
+    expect(ids).not.toContain("cx_base");
+    expect(getDefaultPreset("openai-compatible")?.id).toBe("oa_chat_basic");
+  });
+
+  test("codex、openai-compatible、gemini 三套模板都应该各自独立且至少有两个可选模板", () => {
+    const codexIds = getPresetsForProvider("codex").map((preset) => preset.id);
+    const openaiCompatibleIds = getPresetsForProvider("openai-compatible").map(
+      (preset) => preset.id
+    );
+    const geminiIds = getPresetsForProvider("gemini").map((preset) => preset.id);
+
+    expect(codexIds).toEqual(expect.arrayContaining(["cx_codex_basic", "cx_gpt_basic"]));
+    expect(openaiCompatibleIds).toEqual(
+      expect.arrayContaining(["oa_chat_basic", "oa_chat_stream"])
+    );
+    expect(geminiIds).toEqual(expect.arrayContaining(["gm_flash_basic", "gm_pro_basic"]));
+
+    expect(codexIds.some((id) => openaiCompatibleIds.includes(id))).toBe(false);
+    expect(geminiIds.some((id) => codexIds.includes(id) || openaiCompatibleIds.includes(id))).toBe(
+      false
+    );
+  });
+
+  test("claude 应该提供多个 relay 风格模板，并默认选择最稳妥的基础模板", () => {
+    const ids = getPresetsForProvider("claude").map((preset) => preset.id);
+
+    expect(ids).toEqual(
+      expect.arrayContaining(["cc_haiku_basic", "cc_beta_cli", "cc_public_thinking"])
+    );
+    expect(getDefaultPreset("claude")?.id).toBe("cc_haiku_basic");
+  });
+});

--- a/src/lib/provider-testing/presets.ts
+++ b/src/lib/provider-testing/presets.ts
@@ -1,148 +1,265 @@
 /**
  * Preset Configuration Management
  *
- * Manages pre-configured test payloads from relay-pulse project.
- * These presets provide authentic CLI request patterns that pass
- * relay service client verification.
+ * 请求体主要参考 relay-pulse 的 templates 目录，OpenAI Compatible 套件则补充
+ * 官方 Chat Completions 兼容模板，避免继续复用 Codex Responses 模板。
  */
 
 import type { ProviderType } from "@/types/provider";
-
-// Import preset JSON files
-import ccBase from "./data/cc_base.json";
-import ccSonnet from "./data/cc_sonnet.json";
-import cxBase from "./data/cx_base.json";
+import ccBetaCli from "./data/cc_beta_cli.json";
+import ccHaikuBasic from "./data/cc_haiku_basic.json";
+import cxCodexBasic from "./data/cx_codex_basic.json";
+import cxGptBasic from "./data/cx_gpt_basic.json";
+import gmFlashBasic from "./data/gm_flash_basic.json";
+import gmProBasic from "./data/gm_pro_basic.json";
+import oaChatBasic from "./data/oa_chat_basic.json";
+import oaChatStream from "./data/oa_chat_stream.json";
 import publicCcBase from "./data/public_cc_base.json";
 
-// ============================================================================
-// Types
-// ============================================================================
-
 export interface PresetConfig {
-  /** Unique identifier for the preset */
   id: string;
-  /** Human-readable description */
   description: string;
-  /** Provider types this preset is compatible with */
   providerTypes: ProviderType[];
-  /** The request payload template */
   payload: Record<string, unknown>;
-  /** Default success detection keyword */
   defaultSuccessContains: string;
-  /** Default model used in this preset */
   defaultModel: string;
+  path: string;
+  userAgent?: string;
+  extraHeaders?: Record<string, string>;
+  score?: number;
+  modelHints?: string[];
+  urlHints?: string[];
 }
 
-// ============================================================================
-// Preset Definitions
-// ============================================================================
+export interface PresetSelectionContext {
+  providerType: ProviderType;
+  providerUrl?: string;
+  model?: string;
+}
 
-/**
- * All available preset configurations
- */
 export const PRESETS: Record<string, PresetConfig> = {
-  cc_base: {
-    id: "cc_base",
-    description: "Claude CLI base (haiku, fast)",
+  cc_haiku_basic: {
+    id: "cc_haiku_basic",
+    description: "Claude CLI haiku stream",
     providerTypes: ["claude", "claude-auth"],
-    payload: ccBase,
-    defaultSuccessContains: "isNewTopic",
-    defaultModel: "claude-haiku-4-5-20251001",
-  },
-  cc_sonnet: {
-    id: "cc_sonnet",
-    description: "Claude CLI sonnet (with cache)",
-    providerTypes: ["claude", "claude-auth"],
-    payload: ccSonnet,
+    payload: ccHaikuBasic,
     defaultSuccessContains: "pong",
-    defaultModel: "claude-sonnet-4-5-20250929",
+    defaultModel: "claude-haiku-4-5-20251001",
+    path: "/v1/messages",
+    userAgent: "claude-cli/2.1.84 (external, cli)",
+    extraHeaders: {
+      "Anthropic-Beta": "oauth-2025-04-20,interleaved-thinking-2025-05-14",
+      "Anthropic-Dangerous-Direct-Browser-Access": "true",
+      "X-App": "cli",
+    },
+    score: 100,
+    modelHints: ["haiku"],
   },
-  public_cc_base: {
-    id: "public_cc_base",
-    description: "Public/Community Claude (thinking enabled)",
+  cc_beta_cli: {
+    id: "cc_beta_cli",
+    description: "Claude CLI beta relay profile",
+    providerTypes: ["claude", "claude-auth"],
+    payload: ccBetaCli,
+    defaultSuccessContains: "pong",
+    defaultModel: "claude-haiku-4-5-20251001",
+    path: "/v1/messages?beta=true",
+    userAgent: "claude-cli/2.1.84 (external, cli)",
+    extraHeaders: {
+      "Anthropic-Beta":
+        "oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05",
+      "Anthropic-Dangerous-Direct-Browser-Access": "true",
+      "X-App": "cli",
+    },
+    score: 90,
+    urlHints: ["beta=true", "gateway", "relay", "router", "worker", "proxy"],
+  },
+  cc_public_thinking: {
+    id: "cc_public_thinking",
+    description: "Public Claude with thinking enabled",
     providerTypes: ["claude", "claude-auth"],
     payload: publicCcBase,
     defaultSuccessContains: "pong",
     defaultModel: "claude-sonnet-4-5-20250929",
+    path: "/v1/messages",
+    userAgent: "claude-cli/2.1.76 (external, cli)",
+    extraHeaders: {
+      "Anthropic-Beta": "interleaved-thinking-2025-05-14,context-management-2025-06-27",
+      "Anthropic-Dangerous-Direct-Browser-Access": "true",
+      "X-App": "cli",
+    },
+    score: 80,
+    modelHints: ["sonnet", "opus"],
   },
-  cx_base: {
-    id: "cx_base",
-    description: "Codex CLI (Response API)",
-    providerTypes: ["codex", "openai-compatible"],
-    payload: cxBase,
+  cx_codex_basic: {
+    id: "cx_codex_basic",
+    description: "Codex Responses stream",
+    providerTypes: ["codex"],
+    payload: cxCodexBasic,
     defaultSuccessContains: "pong",
-    defaultModel: "gpt-5-codex",
+    defaultModel: "gpt-5.3-codex",
+    path: "/v1/responses",
+    userAgent: "Codex-CLI/1.0",
+    extraHeaders: {
+      "openai-beta": "responses=experimental",
+    },
+    score: 100,
+    modelHints: ["codex"],
+  },
+  cx_gpt_basic: {
+    id: "cx_gpt_basic",
+    description: "Responses API GPT profile",
+    providerTypes: ["codex"],
+    payload: cxGptBasic,
+    defaultSuccessContains: "pong",
+    defaultModel: "gpt-5.4",
+    path: "/v1/responses",
+    userAgent: "Codex-CLI/1.0",
+    extraHeaders: {
+      "openai-beta": "responses=experimental",
+    },
+    score: 85,
+    modelHints: ["gpt-", "o1", "o3", "o4"],
+  },
+  oa_chat_basic: {
+    id: "oa_chat_basic",
+    description: "OpenAI compatible chat completion",
+    providerTypes: ["openai-compatible"],
+    payload: oaChatBasic,
+    defaultSuccessContains: "pong",
+    defaultModel: "gpt-4.1-mini",
+    path: "/v1/chat/completions",
+    userAgent: "OpenAI-Compatible/2026.04",
+    score: 100,
+  },
+  oa_chat_stream: {
+    id: "oa_chat_stream",
+    description: "OpenAI compatible chat completion stream",
+    providerTypes: ["openai-compatible"],
+    payload: oaChatStream,
+    defaultSuccessContains: "pong",
+    defaultModel: "gpt-4.1-mini",
+    path: "/v1/chat/completions",
+    userAgent: "OpenAI-Compatible/2026.04",
+    extraHeaders: {
+      Accept: "application/json, text/event-stream",
+    },
+    score: 85,
+  },
+  gm_flash_basic: {
+    id: "gm_flash_basic",
+    description: "Gemini generateContent flash",
+    providerTypes: ["gemini", "gemini-cli"],
+    payload: gmFlashBasic,
+    defaultSuccessContains: "pong",
+    defaultModel: "gemini-2.5-flash",
+    path: "/v1beta/models/{model}:generateContent",
+    userAgent: "GeminiCLI/v24.11.0 (linux; x64)",
+    extraHeaders: {
+      "x-goog-api-client": "google-genai-sdk/1.30.0 gl-node/v24.11.0",
+    },
+    score: 100,
+    modelHints: ["flash"],
+  },
+  gm_pro_basic: {
+    id: "gm_pro_basic",
+    description: "Gemini generateContent pro",
+    providerTypes: ["gemini", "gemini-cli"],
+    payload: gmProBasic,
+    defaultSuccessContains: "pong",
+    defaultModel: "gemini-2.5-pro",
+    path: "/v1beta/models/{model}:generateContent",
+    userAgent: "GeminiCLI/v24.11.0 (linux; x64)",
+    extraHeaders: {
+      "x-goog-api-client": "google-genai-sdk/1.30.0 gl-node/v24.11.0",
+    },
+    score: 90,
+    modelHints: ["pro", "thinking"],
   },
 };
 
-/**
- * Mapping of provider types to available presets
- */
 export const PRESET_MAPPING: Record<ProviderType, string[]> = {
-  claude: ["cc_base", "cc_sonnet", "public_cc_base"],
-  "claude-auth": ["cc_base", "cc_sonnet", "public_cc_base"],
-  codex: ["cx_base"],
-  "openai-compatible": ["cx_base"],
-  gemini: [], // Gemini uses its own format
-  "gemini-cli": [],
+  claude: ["cc_haiku_basic", "cc_beta_cli", "cc_public_thinking"],
+  "claude-auth": ["cc_haiku_basic", "cc_beta_cli", "cc_public_thinking"],
+  codex: ["cx_codex_basic", "cx_gpt_basic"],
+  "openai-compatible": ["oa_chat_basic", "oa_chat_stream"],
+  gemini: ["gm_flash_basic", "gm_pro_basic"],
+  "gemini-cli": ["gm_flash_basic", "gm_pro_basic"],
 };
 
-// ============================================================================
-// Functions
-// ============================================================================
-
-/**
- * Get available presets for a provider type
- */
 export function getPresetsForProvider(providerType: ProviderType): PresetConfig[] {
   const presetIds = PRESET_MAPPING[providerType] || [];
   return presetIds.map((id) => PRESETS[id]).filter(Boolean);
 }
 
-/**
- * Get a specific preset by ID
- */
 export function getPreset(presetId: string): PresetConfig | undefined {
   return PRESETS[presetId];
 }
 
-/**
- * Get preset payload with optional model override
- *
- * @param presetId - The preset identifier
- * @param model - Optional model to override the default
- * @returns The payload object with model applied
- */
 export function getPresetPayload(presetId: string, model?: string): Record<string, unknown> {
   const preset = PRESETS[presetId];
   if (!preset) {
     throw new Error(`Preset not found: ${presetId}`);
   }
 
-  // Deep clone to avoid mutating the original
   const payload = JSON.parse(JSON.stringify(preset.payload)) as Record<string, unknown>;
-
-  // Override model if provided
-  if (model) {
+  if (model && "model" in payload) {
     payload.model = model;
   }
 
   return payload;
 }
 
-/**
- * Check if a preset is compatible with a provider type
- */
 export function isPresetCompatible(presetId: string, providerType: ProviderType): boolean {
   const presetIds = PRESET_MAPPING[providerType] || [];
   return presetIds.includes(presetId);
 }
 
-/**
- * Get default preset for a provider type
- * Returns the first available preset or undefined
- */
 export function getDefaultPreset(providerType: ProviderType): PresetConfig | undefined {
   const presets = getPresetsForProvider(providerType);
   return presets[0];
+}
+
+function scorePreset(preset: PresetConfig, context: PresetSelectionContext): number {
+  let score = preset.score ?? 0;
+  const model = context.model?.toLowerCase() ?? "";
+  const url = context.providerUrl?.toLowerCase() ?? "";
+
+  if (preset.modelHints?.some((hint) => model.includes(hint))) {
+    score += 50;
+  }
+
+  if (preset.urlHints?.some((hint) => url.includes(hint))) {
+    score += 30;
+  }
+
+  if (!model) {
+    return score;
+  }
+
+  // 让 Codex / Gemini 能根据模型名优先选更贴近的模板。
+  if (context.providerType === "codex") {
+    if (model.includes("codex") && preset.id === "cx_codex_basic") {
+      score += 40;
+    }
+    if (!model.includes("codex") && preset.id === "cx_gpt_basic") {
+      score += 40;
+    }
+  }
+
+  if (context.providerType === "gemini" || context.providerType === "gemini-cli") {
+    if (model.includes("flash") && preset.id === "gm_flash_basic") {
+      score += 40;
+    }
+    if ((model.includes("pro") || model.includes("thinking")) && preset.id === "gm_pro_basic") {
+      score += 40;
+    }
+  }
+
+  return score;
+}
+
+export function getExecutionPresetCandidates(context: PresetSelectionContext): PresetConfig[] {
+  return getPresetsForProvider(context.providerType).sort(
+    (left, right) => scorePreset(right, context) - scorePreset(left, context)
+  );
 }

--- a/src/lib/provider-testing/presets.ts
+++ b/src/lib/provider-testing/presets.ts
@@ -201,7 +201,8 @@ export function getPresetPayload(presetId: string, model?: string): Record<strin
     throw new Error(`Preset not found: ${presetId}`);
   }
 
-  const payload = JSON.parse(JSON.stringify(preset.payload)) as Record<string, unknown>;
+  const payload = structuredClone(preset.payload) as Record<string, unknown>;
+  // Claude / Codex / OpenAI Compatible 会在 body 里带 model，Gemini 走 URL path，不应强塞回 body。
   if (model && "model" in payload) {
     payload.model = model;
   }
@@ -223,8 +224,9 @@ function scorePreset(preset: PresetConfig, context: PresetSelectionContext): num
   let score = preset.score ?? 0;
   const model = context.model?.toLowerCase() ?? "";
   const url = context.providerUrl?.toLowerCase() ?? "";
+  const matchedModelHint = preset.modelHints?.some((hint) => model.includes(hint)) ?? false;
 
-  if (preset.modelHints?.some((hint) => model.includes(hint))) {
+  if (matchedModelHint) {
     score += 50;
   }
 
@@ -236,21 +238,25 @@ function scorePreset(preset: PresetConfig, context: PresetSelectionContext): num
     return score;
   }
 
-  // 让 Codex / Gemini 能根据模型名优先选更贴近的模板。
+  // 命中 modelHints 后就不再额外叠加 provider-specific boost，避免同一信号被重复计分。
   if (context.providerType === "codex") {
-    if (model.includes("codex") && preset.id === "cx_codex_basic") {
+    if (!matchedModelHint && model.includes("codex") && preset.id === "cx_codex_basic") {
       score += 40;
     }
-    if (!model.includes("codex") && preset.id === "cx_gpt_basic") {
+    if (!matchedModelHint && !model.includes("codex") && preset.id === "cx_gpt_basic") {
       score += 40;
     }
   }
 
   if (context.providerType === "gemini" || context.providerType === "gemini-cli") {
-    if (model.includes("flash") && preset.id === "gm_flash_basic") {
+    if (!matchedModelHint && model.includes("flash") && preset.id === "gm_flash_basic") {
       score += 40;
     }
-    if ((model.includes("pro") || model.includes("thinking")) && preset.id === "gm_pro_basic") {
+    if (
+      !matchedModelHint &&
+      (model.includes("pro") || model.includes("thinking")) &&
+      preset.id === "gm_pro_basic"
+    ) {
       score += 40;
     }
   }

--- a/src/lib/provider-testing/test-service.test.ts
+++ b/src/lib/provider-testing/test-service.test.ts
@@ -202,4 +202,54 @@ describe("executeProviderTest", () => {
     };
     expect(secondBody.stream).toBe(true);
   });
+
+  test("内容校验应优先使用解析后的文本，不能被原始 JSON 字段名误判为成功", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({
+        "content-type": "application/json",
+      }),
+      text: async () =>
+        JSON.stringify({
+          model: "gpt-4.1-mini",
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "no match here",
+              },
+            },
+          ],
+        }),
+    } as Response);
+
+    const result = await executeProviderTest({
+      providerUrl: "https://api.example.com",
+      apiKey: "sk-test-openai-compatible",
+      providerType: "openai-compatible",
+      model: "gpt-4.1-mini",
+      successContains: "content",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.subStatus).toBe("content_mismatch");
+    expect(result.validationDetails.contentPassed).toBe(false);
+  });
+
+  test("网络错误时 latency 层不能被标记为通过", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const result = await executeProviderTest({
+      providerUrl: "https://api.example.com",
+      apiKey: "sk-test-openai-compatible",
+      providerType: "openai-compatible",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.subStatus).toBe("network_error");
+    expect(result.validationDetails.httpPassed).toBe(false);
+    expect(result.validationDetails.latencyPassed).toBe(false);
+  });
 });

--- a/src/lib/provider-testing/test-service.test.ts
+++ b/src/lib/provider-testing/test-service.test.ts
@@ -101,4 +101,50 @@ describe("executeProviderTest", () => {
     expect(result.rawResponse).toBe(responseBody);
     expect(result.rawResponse?.length).toBe(responseBody.length);
   });
+
+  test("指定 preset 但未显式传 model 时，应使用 preset 的默认模型构造 Gemini URL", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({
+        "content-type": "application/json",
+      }),
+      text: async () =>
+        JSON.stringify({
+          modelVersion: "gemini-2.5-pro",
+          candidates: [
+            {
+              content: {
+                parts: [{ text: "pong" }],
+              },
+            },
+          ],
+        }),
+    } as Response);
+
+    const result = await executeProviderTest({
+      providerUrl: "https://gemini.example.com",
+      apiKey: "AIza1234567890abcdefghijklmnopqrstuvwxyz",
+      providerType: "gemini",
+      preset: "gm_pro_basic",
+    });
+
+    expect(result.success).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gemini.example.com/v1beta/models/gemini-2.5-pro:generateContent",
+      expect.any(Object)
+    );
+  });
+
+  test("传入未知 preset 时，应直接报错而不是悄悄回退到默认模板", async () => {
+    await expect(
+      executeProviderTest({
+        providerUrl: "https://api.example.com",
+        apiKey: "sk-test-openai-compatible",
+        providerType: "openai-compatible",
+        preset: "cx_base",
+      })
+    ).rejects.toThrow("Preset not found: cx_base");
+  });
 });

--- a/src/lib/provider-testing/test-service.test.ts
+++ b/src/lib/provider-testing/test-service.test.ts
@@ -147,4 +147,57 @@ describe("executeProviderTest", () => {
       })
     ).rejects.toThrow("Preset not found: cx_base");
   });
+
+  test("openai-compatible 在首个模板返回 400 时，应自动回退到下一个模板", async () => {
+    const errorBody = JSON.stringify({
+      error: {
+        message: "bad request",
+      },
+    });
+    const okBody = JSON.stringify({
+      model: "gpt-4.1-mini",
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "pong",
+          },
+        },
+      ],
+    });
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        headers: new Headers({
+          "content-type": "application/json",
+        }),
+        text: async () => errorBody,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers({
+          "content-type": "application/json",
+        }),
+        text: async () => okBody,
+      } as Response);
+
+    const result = await executeProviderTest({
+      providerUrl: "https://api.example.com",
+      apiKey: "sk-test-openai-compatible",
+      providerType: "openai-compatible",
+      model: "gpt-4.1-mini",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+    expect(result.content).toBe("pong");
+
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)) as { stream?: boolean };
+    expect(secondBody.stream).toBe(true);
+  });
 });

--- a/src/lib/provider-testing/test-service.test.ts
+++ b/src/lib/provider-testing/test-service.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/proxy-agent", () => ({
+  createProxyAgentForProvider: vi.fn(() => null),
+}));
+
+import { executeProviderTest } from "./test-service";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+describe("executeProviderTest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = fetchMock as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("openai-compatible 应该把聊天内容解析为纯文本预览，而不是直接回显整段 JSON", async () => {
+    const responseBody = JSON.stringify({
+      id: "chatcmpl_test",
+      model: "gpt-4.1-mini",
+      choices: [
+        {
+          index: 0,
+          finish_reason: "stop",
+          message: {
+            role: "assistant",
+            content: "pong",
+          },
+        },
+      ],
+      usage: {
+        prompt_tokens: 4,
+        completion_tokens: 1,
+        total_tokens: 5,
+      },
+    });
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({
+        "content-type": "application/json",
+      }),
+      text: async () => responseBody,
+    } as Response);
+
+    const result = await executeProviderTest({
+      providerUrl: "https://api.example.com",
+      apiKey: "sk-test-openai-compatible",
+      providerType: "openai-compatible",
+      model: "gpt-4.1-mini",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.model).toBe("gpt-4.1-mini");
+    expect(result.content).toBe("pong");
+  });
+
+  test("rawResponse 应该保留完整响应体，不能在服务层被截断", async () => {
+    const assistantText = `pong-${"x".repeat(7000)}`;
+    const responseBody = JSON.stringify({
+      id: "resp_test",
+      model: "gpt-5-codex",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [
+            {
+              type: "output_text",
+              text: assistantText,
+            },
+          ],
+        },
+      ],
+    });
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({
+        "content-type": "application/json",
+      }),
+      text: async () => responseBody,
+    } as Response);
+
+    const result = await executeProviderTest({
+      providerUrl: "https://api.example.com",
+      apiKey: "sk-test-codex",
+      providerType: "codex",
+      model: "gpt-5-codex",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.rawResponse).toBe(responseBody);
+    expect(result.rawResponse?.length).toBe(responseBody.length);
+  });
+});

--- a/src/lib/provider-testing/test-service.test.ts
+++ b/src/lib/provider-testing/test-service.test.ts
@@ -197,7 +197,9 @@ describe("executeProviderTest", () => {
     expect(result.success).toBe(true);
     expect(result.content).toBe("pong");
 
-    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)) as { stream?: boolean };
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body)) as {
+      stream?: boolean;
+    };
     expect(secondBody.stream).toBe(true);
   });
 });

--- a/src/lib/provider-testing/test-service.ts
+++ b/src/lib/provider-testing/test-service.ts
@@ -1,15 +1,17 @@
 /**
  * Provider Testing Service
- * Main entry point for unified provider testing
  *
- * Implements three-tier validation from relay-pulse:
- * 1. HTTP Status Code validation
- * 2. Latency threshold validation
- * 3. Content validation (success_contains)
+ * 统一执行模板探测，并在协议不匹配时自动切换到同套件里的下一个模板。
  */
 
 import { createProxyAgentForProvider, type ProviderProxyConfig } from "@/lib/proxy-agent";
-import { getPreset, getPresetPayload } from "./presets";
+import { parseResponse } from "./parsers";
+import {
+  getExecutionPresetCandidates,
+  getPreset,
+  getPresetPayload,
+  type PresetConfig,
+} from "./presets";
 import type {
   ProviderTestConfig,
   ProviderTestResult,
@@ -27,62 +29,116 @@ import {
 import { evaluateContentValidation } from "./validators/content-validator";
 import { classifyHttpStatus } from "./validators/http-validator";
 
-/**
- * Execute a provider test with three-tier validation
- */
-export async function executeProviderTest(config: ProviderTestConfig): Promise<ProviderTestResult> {
-  const startTime = Date.now();
-  let firstByteMs: number | undefined;
+interface AttemptPlan {
+  preset?: PresetConfig;
+  body: Record<string, unknown>;
+  headers: Record<string, string>;
+  successContains: string;
+  url: string;
+}
 
-  // Build test configuration with defaults
-  const timeoutMs = config.timeoutMs ?? TEST_DEFAULTS.TIMEOUT_MS;
-  const slowThresholdMs = config.latencyThresholdMs ?? TEST_DEFAULTS.SLOW_LATENCY_MS;
-
-  // Determine success validation string (priority: config > preset > default)
-  let successContains = config.successContains;
-  if (!successContains && config.preset) {
-    const preset = getPreset(config.preset);
-    successContains = preset?.defaultSuccessContains;
-  }
-  successContains ??= DEFAULT_SUCCESS_CONTAINS[config.providerType];
-
-  // Build request URL
-  const url = getTestUrl(
-    config.providerUrl,
-    config.providerType,
-    config.model,
-    // Only pass API key for Gemini (URL parameter)
-    config.providerType === "gemini" || config.providerType === "gemini-cli"
-      ? config.apiKey
-      : undefined
-  );
-
-  // Build request body (priority: customPayload > preset > default)
-  let body: Record<string, unknown>;
-  if (config.customPayload) {
-    // User-provided custom payload
+function buildAttemptPlans(config: ProviderTestConfig): AttemptPlan[] {
+  const customPayload = config.customPayload?.trim();
+  if (customPayload) {
     try {
-      body = JSON.parse(config.customPayload);
+      const parsed = JSON.parse(customPayload) as Record<string, unknown>;
+      return [
+        {
+          body: parsed,
+          headers: {
+            ...getTestHeaders(config.providerType, config.apiKey, config.providerUrl),
+            ...(config.customHeaders || {}),
+          },
+          successContains: config.successContains ?? DEFAULT_SUCCESS_CONTAINS[config.providerType],
+          url: getTestUrl(config.providerUrl, config.providerType, config.model),
+        },
+      ];
     } catch {
       throw new Error("Invalid custom payload JSON");
     }
-  } else if (config.preset) {
-    // Use preset configuration
-    body = getPresetPayload(config.preset, config.model);
-  } else {
-    // Use default test body
-    body = getTestBody(config.providerType, config.model);
   }
 
-  // Build request headers (merge custom headers if provided)
-  const baseHeaders = getTestHeaders(config.providerType, config.apiKey);
-  const headers = config.customHeaders ? { ...baseHeaders, ...config.customHeaders } : baseHeaders;
+  const presets = config.preset
+    ? [getPreset(config.preset)].filter((preset): preset is PresetConfig => Boolean(preset))
+    : getExecutionPresetCandidates({
+        providerType: config.providerType,
+        providerUrl: config.providerUrl,
+        model: config.model,
+      });
 
-  // Track proxy usage (declared outside try for catch block access)
+  if (presets.length === 0) {
+    return [
+      {
+        body: getTestBody(config.providerType, config.model),
+        headers: {
+          ...getTestHeaders(config.providerType, config.apiKey, config.providerUrl),
+          ...(config.customHeaders || {}),
+        },
+        successContains: config.successContains ?? DEFAULT_SUCCESS_CONTAINS[config.providerType],
+        url: getTestUrl(config.providerUrl, config.providerType, config.model),
+      },
+    ];
+  }
+
+  return presets.map((preset) => ({
+    preset,
+    body: getPresetPayload(preset.id, config.model),
+    headers: {
+      ...getTestHeaders(config.providerType, config.apiKey, config.providerUrl, {
+        userAgent: preset.userAgent,
+        extraHeaders: preset.extraHeaders,
+      }),
+      ...(config.customHeaders || {}),
+    },
+    successContains:
+      config.successContains ??
+      preset.defaultSuccessContains ??
+      DEFAULT_SUCCESS_CONTAINS[config.providerType],
+    url: getTestUrl(config.providerUrl, config.providerType, config.model, undefined, preset.path),
+  }));
+}
+
+function shouldRetryWithNextTemplate(result: ProviderTestResult): boolean {
+  if (result.status !== "red") {
+    return false;
+  }
+
+  if (result.httpStatusCode && [400, 404, 405, 415, 422].includes(result.httpStatusCode)) {
+    return true;
+  }
+
+  return ["client_error", "invalid_request", "content_mismatch"].includes(result.subStatus);
+}
+
+function buildValidationDetails(
+  responseStatus: number | undefined,
+  latencyMs: number,
+  slowThresholdMs: number,
+  contentPassed: boolean,
+  successContains: string
+): ValidationDetails {
+  return {
+    httpPassed:
+      responseStatus !== undefined ? responseStatus >= 200 && responseStatus < 300 : false,
+    httpStatusCode: responseStatus,
+    latencyPassed: latencyMs <= slowThresholdMs,
+    latencyMs,
+    contentPassed,
+    contentTarget: successContains,
+  };
+}
+
+async function runSingleAttempt(
+  config: ProviderTestConfig,
+  plan: AttemptPlan,
+  timeoutMs: number,
+  slowThresholdMs: number
+): Promise<ProviderTestResult> {
+  const startTime = Date.now();
+  let firstByteMs: number | undefined;
   let usedProxy = false;
 
   try {
-    // Create proxy agent if proxy URL is configured
     let dispatcher: unknown | undefined;
     if (config.proxyUrl) {
       const tempProvider: ProviderProxyConfig = {
@@ -91,71 +147,43 @@ export async function executeProviderTest(config: ProviderTestConfig): Promise<P
         proxyUrl: config.proxyUrl,
         proxyFallbackToDirect: config.proxyFallbackToDirect ?? false,
       };
-      const proxyConfig = createProxyAgentForProvider(tempProvider, url);
+      const proxyConfig = createProxyAgentForProvider(tempProvider, plan.url);
       if (proxyConfig) {
         dispatcher = proxyConfig.agent;
         usedProxy = true;
       }
     }
 
-    // Create abort controller for timeout
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
-      // Execute request
       const fetchOptions: RequestInit & { dispatcher?: unknown } = {
         method: "POST",
-        headers,
-        body: JSON.stringify(body),
+        headers: plan.headers,
+        body: JSON.stringify(plan.body),
         signal: controller.signal,
       };
       if (dispatcher) {
         fetchOptions.dispatcher = dispatcher;
       }
-      const response = await fetch(url, fetchOptions);
 
+      const response = await fetch(plan.url, fetchOptions);
       firstByteMs = Date.now() - startTime;
 
-      // Read response body
       const responseBody = await response.text();
       const latencyMs = Date.now() - startTime;
-      const _contentType = response.headers.get("content-type") || undefined;
-
-      // Tier 1: HTTP Status validation
+      const contentType = response.headers.get("content-type") || undefined;
+      const parsed = parseResponse(config.providerType, responseBody, contentType);
+      const validationInput = parsed.content ? `${parsed.content}\n${responseBody}` : responseBody;
       const httpResult = classifyHttpStatus(response.status, latencyMs, slowThresholdMs);
-
-      // Tier 2 & 3: Content validation - SIMPLIFIED: directly match raw response body
-      // No SSE/JSON parsing needed - just check if successContains exists in raw response
-      // This is the most reliable approach as relay-pulse also falls back to raw body
       const contentResult = evaluateContentValidation(
         httpResult.status,
         httpResult.subStatus,
-        responseBody, // Use raw response body directly
-        successContains
+        validationInput,
+        plan.successContains
       );
 
-      // Try to extract model from response (simple JSON extraction)
-      let model: string | undefined;
-      try {
-        // Try to parse as JSON for model extraction only
-        const parsed = JSON.parse(responseBody);
-        model = parsed.model;
-      } catch {
-        // Not JSON or parsing failed - that's fine, model is optional
-      }
-
-      // Build validation details
-      const validationDetails: ValidationDetails = {
-        httpPassed: response.ok,
-        httpStatusCode: response.status,
-        latencyPassed: latencyMs <= slowThresholdMs,
-        latencyMs,
-        contentPassed: contentResult.contentPassed,
-        contentTarget: successContains,
-      };
-
-      // Build result with raw response for user inspection
       return {
         success: contentResult.status !== "red",
         status: contentResult.status,
@@ -164,11 +192,24 @@ export async function executeProviderTest(config: ProviderTestConfig): Promise<P
         firstByteMs,
         httpStatusCode: response.status,
         httpStatusText: response.statusText,
-        model,
-        content: responseBody.slice(0, 500), // Preview for quick view
-        rawResponse: responseBody.slice(0, 5000), // Full response for detailed inspection
+        model: parsed.model,
+        content: parsed.content || responseBody,
+        rawResponse: responseBody,
+        usage: parsed.usage,
+        streamInfo: parsed.isStreaming
+          ? {
+              isStreaming: true,
+              chunksReceived: parsed.chunksReceived,
+            }
+          : undefined,
         testedAt: new Date(),
-        validationDetails,
+        validationDetails: buildValidationDetails(
+          response.status,
+          latencyMs,
+          slowThresholdMs,
+          contentResult.contentPassed,
+          plan.successContains
+        ),
         usedProxy,
       };
     } finally {
@@ -176,18 +217,7 @@ export async function executeProviderTest(config: ProviderTestConfig): Promise<P
     }
   } catch (error) {
     const latencyMs = Date.now() - startTime;
-
-    // Classify error type
     const { subStatus, errorType, errorMessage } = classifyError(error);
-
-    // Build validation details for failure
-    const validationDetails: ValidationDetails = {
-      httpPassed: false,
-      latencyPassed: false,
-      latencyMs,
-      contentPassed: false,
-      contentTarget: successContains,
-    };
 
     return {
       success: false,
@@ -199,15 +229,39 @@ export async function executeProviderTest(config: ProviderTestConfig): Promise<P
       errorType,
       rawError: error,
       testedAt: new Date(),
-      validationDetails,
+      validationDetails: buildValidationDetails(
+        undefined,
+        latencyMs,
+        slowThresholdMs,
+        false,
+        plan.successContains
+      ),
       usedProxy,
     };
   }
 }
 
-/**
- * Classify error into sub-status and message
- */
+export async function executeProviderTest(config: ProviderTestConfig): Promise<ProviderTestResult> {
+  const timeoutMs = config.timeoutMs ?? TEST_DEFAULTS.TIMEOUT_MS;
+  const slowThresholdMs = config.latencyThresholdMs ?? TEST_DEFAULTS.SLOW_LATENCY_MS;
+  const plans = buildAttemptPlans(config);
+
+  let fallbackResult: ProviderTestResult | null = null;
+  for (const plan of plans) {
+    const result = await runSingleAttempt(config, plan, timeoutMs, slowThresholdMs);
+    if (result.success || !shouldRetryWithNextTemplate(result)) {
+      return result;
+    }
+    fallbackResult = result;
+  }
+
+  if (fallbackResult) {
+    return fallbackResult;
+  }
+
+  throw new Error("No provider testing plan could be constructed");
+}
+
 function classifyError(error: unknown): {
   subStatus: TestSubStatus;
   errorType: string;
@@ -216,7 +270,6 @@ function classifyError(error: unknown): {
   if (error instanceof Error) {
     const message = error.message.toLowerCase();
 
-    // Timeout errors
     if (error.name === "AbortError" || message.includes("timeout") || message.includes("aborted")) {
       return {
         subStatus: "network_error",
@@ -225,7 +278,6 @@ function classifyError(error: unknown): {
       };
     }
 
-    // DNS/connection errors
     if (
       message.includes("getaddrinfo") ||
       message.includes("enotfound") ||
@@ -238,7 +290,6 @@ function classifyError(error: unknown): {
       };
     }
 
-    // Connection refused
     if (message.includes("econnrefused") || message.includes("connection refused")) {
       return {
         subStatus: "network_error",
@@ -247,7 +298,6 @@ function classifyError(error: unknown): {
       };
     }
 
-    // Connection reset
     if (message.includes("econnreset") || message.includes("connection reset")) {
       return {
         subStatus: "network_error",
@@ -256,7 +306,6 @@ function classifyError(error: unknown): {
       };
     }
 
-    // SSL/TLS errors
     if (message.includes("ssl") || message.includes("tls") || message.includes("certificate")) {
       return {
         subStatus: "network_error",
@@ -265,7 +314,6 @@ function classifyError(error: unknown): {
       };
     }
 
-    // Generic network error
     return {
       subStatus: "network_error",
       errorType: "network_error",
@@ -273,7 +321,6 @@ function classifyError(error: unknown): {
     };
   }
 
-  // Unknown error type
   return {
     subStatus: "network_error",
     errorType: "unknown_error",
@@ -281,10 +328,6 @@ function classifyError(error: unknown): {
   };
 }
 
-/**
- * Get availability weight for a status
- * Used for calculating weighted availability scores
- */
 export function getStatusWeight(
   status: TestStatus,
   degradedWeight: number = TEST_DEFAULTS.DEGRADED_WEIGHT

--- a/src/lib/provider-testing/test-service.ts
+++ b/src/lib/provider-testing/test-service.ts
@@ -33,9 +33,12 @@ interface AttemptPlan {
   preset?: PresetConfig;
   body: Record<string, unknown>;
   headers: Record<string, string>;
+  model: string | undefined;
   successContains: string;
   url: string;
 }
+
+const RETRYABLE_HTTP_STATUS_CODES = [400, 404, 405, 415, 422] as const;
 
 function buildAttemptPlans(config: ProviderTestConfig): AttemptPlan[] {
   const customPayload = config.customPayload?.trim();
@@ -49,6 +52,7 @@ function buildAttemptPlans(config: ProviderTestConfig): AttemptPlan[] {
             ...getTestHeaders(config.providerType, config.apiKey, config.providerUrl),
             ...(config.customHeaders || {}),
           },
+          model: config.model,
           successContains: config.successContains ?? DEFAULT_SUCCESS_CONTAINS[config.providerType],
           url: getTestUrl(config.providerUrl, config.providerType, config.model),
         },
@@ -58,13 +62,20 @@ function buildAttemptPlans(config: ProviderTestConfig): AttemptPlan[] {
     }
   }
 
-  const presets = config.preset
-    ? [getPreset(config.preset)].filter((preset): preset is PresetConfig => Boolean(preset))
-    : getExecutionPresetCandidates({
-        providerType: config.providerType,
-        providerUrl: config.providerUrl,
-        model: config.model,
-      });
+  let presets: PresetConfig[];
+  if (config.preset) {
+    const preset = getPreset(config.preset);
+    if (!preset) {
+      throw new Error(`Preset not found: ${config.preset}`);
+    }
+    presets = [preset];
+  } else {
+    presets = getExecutionPresetCandidates({
+      providerType: config.providerType,
+      providerUrl: config.providerUrl,
+      model: config.model,
+    });
+  }
 
   if (presets.length === 0) {
     return [
@@ -74,28 +85,33 @@ function buildAttemptPlans(config: ProviderTestConfig): AttemptPlan[] {
           ...getTestHeaders(config.providerType, config.apiKey, config.providerUrl),
           ...(config.customHeaders || {}),
         },
+        model: config.model,
         successContains: config.successContains ?? DEFAULT_SUCCESS_CONTAINS[config.providerType],
         url: getTestUrl(config.providerUrl, config.providerType, config.model),
       },
     ];
   }
 
-  return presets.map((preset) => ({
-    preset,
-    body: getPresetPayload(preset.id, config.model),
-    headers: {
-      ...getTestHeaders(config.providerType, config.apiKey, config.providerUrl, {
-        userAgent: preset.userAgent,
-        extraHeaders: preset.extraHeaders,
-      }),
-      ...(config.customHeaders || {}),
-    },
-    successContains:
-      config.successContains ??
-      preset.defaultSuccessContains ??
-      DEFAULT_SUCCESS_CONTAINS[config.providerType],
-    url: getTestUrl(config.providerUrl, config.providerType, config.model, undefined, preset.path),
-  }));
+  return presets.map((preset) => {
+    const effectiveModel = config.model ?? preset.defaultModel;
+    return {
+      preset,
+      body: getPresetPayload(preset.id, effectiveModel),
+      headers: {
+        ...getTestHeaders(config.providerType, config.apiKey, config.providerUrl, {
+          userAgent: preset.userAgent,
+          extraHeaders: preset.extraHeaders,
+        }),
+        ...(config.customHeaders || {}),
+      },
+      model: effectiveModel,
+      successContains:
+        config.successContains ??
+        preset.defaultSuccessContains ??
+        DEFAULT_SUCCESS_CONTAINS[config.providerType],
+      url: getTestUrl(config.providerUrl, config.providerType, effectiveModel, preset.path),
+    };
+  });
 }
 
 function shouldRetryWithNextTemplate(result: ProviderTestResult): boolean {
@@ -103,7 +119,12 @@ function shouldRetryWithNextTemplate(result: ProviderTestResult): boolean {
     return false;
   }
 
-  if (result.httpStatusCode && [400, 404, 405, 415, 422].includes(result.httpStatusCode)) {
+  if (
+    result.httpStatusCode &&
+    RETRYABLE_HTTP_STATUS_CODES.includes(
+      result.httpStatusCode as (typeof RETRYABLE_HTTP_STATUS_CODES)[number]
+    )
+  ) {
     return true;
   }
 
@@ -245,10 +266,12 @@ export async function executeProviderTest(config: ProviderTestConfig): Promise<P
   const timeoutMs = config.timeoutMs ?? TEST_DEFAULTS.TIMEOUT_MS;
   const slowThresholdMs = config.latencyThresholdMs ?? TEST_DEFAULTS.SLOW_LATENCY_MS;
   const plans = buildAttemptPlans(config);
+  const deadline = Date.now() + timeoutMs;
 
   let fallbackResult: ProviderTestResult | null = null;
   for (const plan of plans) {
-    const result = await runSingleAttempt(config, plan, timeoutMs, slowThresholdMs);
+    const remainingTimeoutMs = Math.max(1000, deadline - Date.now());
+    const result = await runSingleAttempt(config, plan, remainingTimeoutMs, slowThresholdMs);
     if (result.success || !shouldRetryWithNextTemplate(result)) {
       return result;
     }

--- a/src/lib/provider-testing/test-service.ts
+++ b/src/lib/provider-testing/test-service.ts
@@ -142,7 +142,7 @@ function buildValidationDetails(
     httpPassed:
       responseStatus !== undefined ? responseStatus >= 200 && responseStatus < 300 : false,
     httpStatusCode: responseStatus,
-    latencyPassed: latencyMs <= slowThresholdMs,
+    latencyPassed: responseStatus !== undefined && latencyMs <= slowThresholdMs,
     latencyMs,
     contentPassed,
     contentTarget: successContains,
@@ -196,7 +196,7 @@ async function runSingleAttempt(
       const latencyMs = Date.now() - startTime;
       const contentType = response.headers.get("content-type") || undefined;
       const parsed = parseResponse(config.providerType, responseBody, contentType);
-      const validationInput = parsed.content ? `${parsed.content}\n${responseBody}` : responseBody;
+      const validationInput = parsed.content || responseBody;
       const httpResult = classifyHttpStatus(response.status, latencyMs, slowThresholdMs);
       const contentResult = evaluateContentValidation(
         httpResult.status,

--- a/src/lib/provider-testing/types.ts
+++ b/src/lib/provider-testing/types.ts
@@ -244,9 +244,11 @@ export interface CodexTestBody {
   }>;
   tools: unknown[];
   tool_choice: string;
+  parallel_tool_calls?: boolean;
   reasoning?: { effort: string; summary: string };
   store: boolean;
   stream: boolean;
+  prompt_cache_key?: string;
 }
 
 /**
@@ -267,6 +269,7 @@ export interface OpenAITestBody {
  */
 export interface GeminiTestBody {
   contents: Array<{
+    role?: "user" | "model";
     parts: Array<{ text: string }>;
   }>;
   systemInstruction?: {
@@ -274,5 +277,10 @@ export interface GeminiTestBody {
   };
   generationConfig?: {
     maxOutputTokens: number;
+    temperature?: number;
+    thinkingConfig?: {
+      thinkingBudget?: number;
+      includeThoughts?: boolean;
+    };
   };
 }

--- a/src/lib/provider-testing/utils/test-prompts.ts
+++ b/src/lib/provider-testing/utils/test-prompts.ts
@@ -143,7 +143,10 @@ function looksLikeAnthropicProxy(providerUrl?: string): boolean {
     if (hostname.endsWith("anthropic.com") || hostname.endsWith("claude.ai")) {
       return false;
     }
-    return /proxy|relay|gateway|router|worker|openrouter|api2d|oaipro|gpt/i.test(hostname);
+    // 只匹配常见 relay/proxy 标识，避免把普通业务域名里的 “gpt” 误识别成代理层。
+    return /(?:^|[.-])(proxy|relay|gateway|router|worker|openrouter|api2d|oaipro)(?:[.-]|$)/i.test(
+      hostname
+    );
   } catch {
     return false;
   }
@@ -165,6 +168,7 @@ function resolveClaudeHeaders(providerType: ProviderType, apiKey: string, provid
     return headers;
   }
 
+  // 对非代理 Anthropic 直连保留双头，兼容只认 x-api-key 或 Bearer 的 Anthropic-compatible 层。
   headers["x-api-key"] = apiKey;
   headers.Authorization = `Bearer ${apiKey}`;
   return headers;
@@ -245,7 +249,6 @@ export function getTestUrl(
   baseUrl: string,
   providerType: ProviderType,
   model?: string,
-  _apiKey?: string,
   pathOverride?: string
 ): string {
   const cleanBaseUrl = baseUrl.replace(/\/$/, "");

--- a/src/lib/provider-testing/utils/test-prompts.ts
+++ b/src/lib/provider-testing/utils/test-prompts.ts
@@ -1,95 +1,51 @@
 /**
  * Default Test Prompts for Provider Testing
- * Based on relay-pulse exact patterns
  *
- * These are minimal request bodies designed to:
- * 1. Minimize token consumption (small prompts, low max_tokens)
- * 2. Provide reliable content validation ("pong" response)
- * 3. Support both streaming and non-streaming modes
+ * 这里保留协议级兜底默认值；真正执行时会优先使用 presets.ts 里的模板定义。
  */
 
 import type { ProviderType } from "@/types/provider";
 import type { ClaudeTestBody, CodexTestBody, GeminiTestBody, OpenAITestBody } from "../types";
 
-// ============================================================================
-// User-Agent Configurations (Critical for relay service authentication)
-// ============================================================================
-
-/**
- * User-Agent strings for different provider types
- * These are required to pass relay service client verification
- */
 export const USER_AGENTS: Record<ProviderType, string> = {
-  claude: "claude-cli/2.0.50 (external, cli)",
-  "claude-auth": "claude-cli/2.0.50 (external, cli)",
-  codex: "codex_cli_rs/0.63.0",
-  "openai-compatible": "OpenAI/NodeJS/3.2.1",
-  gemini: "GeminiCLI/v0.17.1 (darwin; arm64)",
-  "gemini-cli": "GeminiCLI/v0.17.1 (darwin; arm64)",
+  claude: "claude-cli/2.1.84 (external, cli)",
+  "claude-auth": "claude-cli/2.1.84 (external, cli)",
+  codex: "Codex-CLI/1.0",
+  "openai-compatible": "OpenAI-Compatible/2026.04",
+  gemini: "GeminiCLI/v24.11.0 (linux; x64)",
+  "gemini-cli": "GeminiCLI/v24.11.0 (linux; x64)",
 };
 
-/**
- * Base headers for all API requests
- * These headers mimic real CLI client behavior
- */
 export const BASE_HEADERS = {
   Accept: "application/json, text/event-stream",
   "Accept-Language": "en-US,en;q=0.9",
-  "Accept-Encoding": "gzip, deflate, br",
+  "Accept-Encoding": "gzip, deflate, br, zstd",
   Connection: "keep-alive",
 };
 
-// ============================================================================
-// Claude / Claude-Auth Test Body
-// ============================================================================
-
-/**
- * Claude Messages API test request body
- * - Uses claude-sonnet-4-5-20250929 as default model
- * - Non-streaming for faster response validation
- * - Minimal token usage with echo bot pattern
- */
 export const CLAUDE_TEST_BODY: ClaudeTestBody = {
-  model: "claude-sonnet-4-5-20250929",
-  messages: [
-    {
-      role: "user",
-      content: [{ type: "text", text: "ping, please reply pong" }],
-    },
-  ],
+  model: "claude-haiku-4-5-20251001",
+  max_tokens: 20,
+  stream: true,
+  metadata: { user_id: "cch_probe_test" },
   system: [
     {
       type: "text",
-      text: "You are a echo bot. Always say pong.",
-      cache_control: { type: "ephemeral" },
+      text: "You are Claude Code, Anthropic's official CLI for Claude.",
     },
   ],
-  max_tokens: 20,
-  stream: false,
-  metadata: { user_id: "cch_probe_test" },
+  messages: [
+    {
+      role: "user",
+      content: [{ type: "text", text: "ping, please reply 'pong'" }],
+    },
+  ],
 };
 
-/**
- * Headers for Claude API
- */
-export const CLAUDE_TEST_HEADERS = {
-  "anthropic-version": "2023-06-01",
-  "content-type": "application/json",
-};
-
-// ============================================================================
-// Codex Test Body (Response API format)
-// ============================================================================
-
-/**
- * Codex Response API test request body
- * - Uses gpt-5-codex as default model
- * - Streaming enabled (Codex typically streams)
- * - Low reasoning effort for faster response
- */
 export const CODEX_TEST_BODY: CodexTestBody = {
-  model: "gpt-5-codex",
-  instructions: "You are a echo bot. Always say pong.",
+  model: "gpt-5.3-codex",
+  instructions:
+    "You are Codex, based on GPT-5. You are running as a coding agent in the Codex CLI on a user's computer.",
   input: [
     {
       type: "message",
@@ -99,93 +55,66 @@ export const CODEX_TEST_BODY: CodexTestBody = {
   ],
   tools: [],
   tool_choice: "auto",
+  parallel_tool_calls: false,
   reasoning: { effort: "low", summary: "auto" },
   store: false,
   stream: true,
 };
 
-/**
- * Headers for Codex API (uses Bearer token)
- */
-export const CODEX_TEST_HEADERS = {
-  "content-type": "application/json",
-};
-
-// ============================================================================
-// OpenAI-Compatible Test Body
-// ============================================================================
-
-/**
- * OpenAI Chat Completions test request body
- * - Uses gpt-4o as default model
- * - Non-streaming for simpler validation
- */
 export const OPENAI_TEST_BODY: OpenAITestBody = {
-  model: "gpt-4o",
+  model: "gpt-4.1-mini",
   messages: [
-    { role: "system", content: "You are a echo bot. Always say pong." },
+    { role: "system", content: "You are an echo bot. Reply with exactly pong." },
     { role: "user", content: "ping" },
   ],
   max_tokens: 20,
   stream: false,
 };
 
-/**
- * Headers for OpenAI-Compatible API (uses Bearer token)
- */
+export const GEMINI_TEST_BODY: GeminiTestBody = {
+  contents: [
+    {
+      role: "user",
+      parts: [{ text: "ping" }],
+    },
+  ],
+  generationConfig: {
+    temperature: 0,
+    maxOutputTokens: 256,
+    thinkingConfig: {
+      thinkingBudget: 0,
+    },
+  },
+};
+
+export const CLAUDE_TEST_HEADERS = {
+  "anthropic-version": "2023-06-01",
+  "content-type": "application/json",
+};
+
+export const CODEX_TEST_HEADERS = {
+  "content-type": "application/json",
+  "openai-beta": "responses=experimental",
+};
+
 export const OPENAI_TEST_HEADERS = {
   "content-type": "application/json",
 };
 
-// ============================================================================
-// Gemini Test Body
-// ============================================================================
-
-/**
- * Gemini GenerateContent test request body
- * - Uses gemini-2.0-flash as default model
- * - Simple content structure
- */
-export const GEMINI_TEST_BODY: GeminiTestBody = {
-  contents: [
-    {
-      parts: [{ text: "ping, please reply pong" }],
-    },
-  ],
-  systemInstruction: {
-    parts: [{ text: "You are a echo bot. Always say pong." }],
-  },
-  generationConfig: {
-    maxOutputTokens: 20,
-  },
-};
-
-/**
- * Headers for Gemini API
- */
 export const GEMINI_TEST_HEADERS = {
   "content-type": "application/json",
+  "x-goog-api-client": "google-genai-sdk/1.30.0 gl-node/v24.11.0",
 };
 
-// ============================================================================
-// Provider Type Mappings
-// ============================================================================
-
-/**
- * Default models per provider type
- */
 export const DEFAULT_MODELS: Record<ProviderType, string> = {
-  claude: "claude-sonnet-4-5-20250929",
-  "claude-auth": "claude-sonnet-4-5-20250929",
-  codex: "gpt-5-codex",
-  "openai-compatible": "gpt-4o",
-  gemini: "gemini-2.0-flash",
-  "gemini-cli": "gemini-2.0-flash",
+  claude: "claude-haiku-4-5-20251001",
+  "claude-auth": "claude-haiku-4-5-20251001",
+  codex: "gpt-5.3-codex",
+  "openai-compatible": "gpt-4.1-mini",
+  gemini: "gemini-2.5-flash",
+  "gemini-cli": "gemini-2.5-flash",
 };
 
-/**
- * Default success_contains patterns per provider type
- */
 export const DEFAULT_SUCCESS_CONTAINS: Record<ProviderType, string> = {
   claude: "pong",
   "claude-auth": "pong",
@@ -195,21 +124,52 @@ export const DEFAULT_SUCCESS_CONTAINS: Record<ProviderType, string> = {
   "gemini-cli": "pong",
 };
 
-/**
- * API endpoints per provider type
- */
 export const API_ENDPOINTS: Record<ProviderType, string> = {
   claude: "/v1/messages",
   "claude-auth": "/v1/messages",
   codex: "/v1/responses",
   "openai-compatible": "/v1/chat/completions",
-  gemini: "/v1beta/models/{model}:streamGenerateContent",
-  "gemini-cli": "/v1beta/models/{model}:streamGenerateContent",
+  gemini: "/v1beta/models/{model}:generateContent",
+  "gemini-cli": "/v1beta/models/{model}:generateContent",
 };
 
-/**
- * Get test body for a specific provider type
- */
+function looksLikeAnthropicProxy(providerUrl?: string): boolean {
+  if (!providerUrl) {
+    return false;
+  }
+
+  try {
+    const hostname = new URL(providerUrl).hostname.toLowerCase();
+    if (hostname.endsWith("anthropic.com") || hostname.endsWith("claude.ai")) {
+      return false;
+    }
+    return /proxy|relay|gateway|router|worker|openrouter|api2d|oaipro|gpt/i.test(hostname);
+  } catch {
+    return false;
+  }
+}
+
+function resolveClaudeHeaders(providerType: ProviderType, apiKey: string, providerUrl?: string) {
+  const headers: Record<string, string> = {
+    "anthropic-version": "2023-06-01",
+    "content-type": "application/json",
+  };
+
+  if (providerType === "claude-auth") {
+    headers.Authorization = `Bearer ${apiKey}`;
+    return headers;
+  }
+
+  if (looksLikeAnthropicProxy(providerUrl)) {
+    headers.Authorization = `Bearer ${apiKey}`;
+    return headers;
+  }
+
+  headers["x-api-key"] = apiKey;
+  headers.Authorization = `Bearer ${apiKey}`;
+  return headers;
+}
+
 export function getTestBody(providerType: ProviderType, model?: string): Record<string, unknown> {
   const targetModel = model || DEFAULT_MODELS[providerType];
 
@@ -217,94 +177,84 @@ export function getTestBody(providerType: ProviderType, model?: string): Record<
     case "claude":
     case "claude-auth":
       return { ...CLAUDE_TEST_BODY, model: targetModel };
-
     case "codex":
       return { ...CODEX_TEST_BODY, model: targetModel };
-
     case "openai-compatible":
       return { ...OPENAI_TEST_BODY, model: targetModel };
-
     case "gemini":
     case "gemini-cli":
-      // Gemini model is in URL, not body
       return { ...GEMINI_TEST_BODY };
-
     default:
       throw new Error(`Unsupported provider type: ${providerType}`);
   }
 }
 
-/**
- * Get test headers for a specific provider type
- * Includes User-Agent and base headers for relay service authentication
- */
-export function getTestHeaders(providerType: ProviderType, apiKey: string): Record<string, string> {
-  // Start with base headers and User-Agent (critical for relay services)
-  const baseHeaders = {
+export function getTestHeaders(
+  providerType: ProviderType,
+  apiKey: string,
+  providerUrl?: string,
+  overrides?: {
+    userAgent?: string;
+    extraHeaders?: Record<string, string>;
+  }
+): Record<string, string> {
+  const headers: Record<string, string> = {
     ...BASE_HEADERS,
-    "User-Agent": USER_AGENTS[providerType],
+    "User-Agent": overrides?.userAgent || USER_AGENTS[providerType],
   };
 
   switch (providerType) {
     case "claude":
-      return {
-        ...baseHeaders,
-        ...CLAUDE_TEST_HEADERS,
-        "x-api-key": apiKey,
-      };
-
     case "claude-auth":
-      // Claude-auth uses Bearer token
-      return {
-        ...baseHeaders,
-        ...CLAUDE_TEST_HEADERS,
-        Authorization: `Bearer ${apiKey}`,
-      };
-
+      Object.assign(
+        headers,
+        CLAUDE_TEST_HEADERS,
+        resolveClaudeHeaders(providerType, apiKey, providerUrl)
+      );
+      break;
     case "codex":
+      Object.assign(headers, {
+        ...CODEX_TEST_HEADERS,
+        Authorization: `Bearer ${apiKey}`,
+      });
+      break;
     case "openai-compatible":
-      return {
-        ...baseHeaders,
+      Object.assign(headers, {
         ...OPENAI_TEST_HEADERS,
         Authorization: `Bearer ${apiKey}`,
-      };
-
+      });
+      break;
     case "gemini":
     case "gemini-cli":
-      // Gemini: 同时使用 header 和 URL 参数认证（最大兼容性）
-      return {
-        ...baseHeaders,
+      Object.assign(headers, {
         ...GEMINI_TEST_HEADERS,
         "x-goog-api-key": apiKey,
-      };
-
+      });
+      break;
     default:
       throw new Error(`Unsupported provider type: ${providerType}`);
   }
+
+  return {
+    ...headers,
+    ...(overrides?.extraHeaders || {}),
+  };
 }
 
-/**
- * Get the full test URL for a provider
- */
 export function getTestUrl(
   baseUrl: string,
   providerType: ProviderType,
   model?: string,
-  _apiKey?: string // Gemini API key now passed via header, kept for backward compatibility
+  _apiKey?: string,
+  pathOverride?: string
 ): string {
-  // Remove trailing slash
   const cleanBaseUrl = baseUrl.replace(/\/$/, "");
-  const endpoint = API_ENDPOINTS[providerType];
+  const endpoint = pathOverride || API_ENDPOINTS[providerType];
   const targetModel = model || DEFAULT_MODELS[providerType];
-
   let url = `${cleanBaseUrl}${endpoint}`;
 
-  // Gemini needs model in URL
   if (providerType === "gemini" || providerType === "gemini-cli") {
     url = url.replace("{model}", targetModel);
-    // Only add alt=sse for streaming, API key is passed via header (x-goog-api-key)
-    // Note: Gemini tests now use dedicated testProviderGemini function
-    url += `?alt=sse`;
   }
 
   return url;

--- a/src/lib/request-filter-engine.ts
+++ b/src/lib/request-filter-engine.ts
@@ -285,20 +285,6 @@ export class RequestFilterEngine {
   private hasGroupBasedFilters = false;
   private hasGroupBasedFinalFilters = false;
 
-  // Backward-compat accessors used by existing code paths
-  private get globalFilters(): CachedRequestFilter[] {
-    return this.globalGuardFilters;
-  }
-  private set globalFilters(v: CachedRequestFilter[]) {
-    this.globalGuardFilters = v;
-  }
-  private get providerFilters(): CachedRequestFilter[] {
-    return this.providerGuardFilters;
-  }
-  private set providerFilters(v: CachedRequestFilter[]) {
-    this.providerGuardFilters = v;
-  }
-
   constructor() {
     this.setupEventListener();
   }

--- a/tests/unit/actions/providers-api-test.test.ts
+++ b/tests/unit/actions/providers-api-test.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+const executeProviderTestMock = vi.fn();
+const getPresetsForProviderMock = vi.fn();
+const validateProviderUrlForConnectivityMock = vi.fn();
+const createProxyAgentForProviderMock = vi.fn();
+const getAccessTokenMock = vi.fn();
+const isJsonMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+}));
+
+vi.mock("@/repository/provider", () => ({
+  createProvider: vi.fn(),
+  deleteProvider: vi.fn(),
+  findAllProviders: vi.fn(async () => []),
+  findAllProvidersFresh: vi.fn(async () => []),
+  findProviderById: vi.fn(),
+  getProviderStatistics: vi.fn(),
+  resetProviderTotalCostResetAt: vi.fn(async () => {}),
+  updateProvider: vi.fn(),
+  updateProviderPrioritiesBatch: vi.fn(),
+}));
+
+vi.mock("@/lib/cache/provider-cache", () => ({
+  publishProviderCacheInvalidation: vi.fn(),
+}));
+
+vi.mock("@/lib/redis/circuit-breaker-config", () => ({
+  deleteProviderCircuitConfig: vi.fn(),
+  saveProviderCircuitConfig: vi.fn(),
+}));
+
+vi.mock("@/lib/circuit-breaker", () => ({
+  clearConfigCache: vi.fn(),
+  clearProviderState: vi.fn(),
+  getAllHealthStatusAsync: vi.fn(async () => ({})),
+  publishCircuitBreakerConfigInvalidation: vi.fn(),
+  forceCloseCircuitState: vi.fn(),
+  resetCircuit: vi.fn(),
+}));
+
+vi.mock("@/lib/session-manager", () => ({
+  SessionManager: {
+    terminateProviderSessionsBatch: vi.fn(),
+    terminateStickySessionsForProviders: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/provider-testing", () => ({
+  executeProviderTest: executeProviderTestMock,
+}));
+
+vi.mock("@/lib/provider-testing/presets", () => ({
+  getPresetsForProvider: getPresetsForProviderMock,
+}));
+
+vi.mock("@/lib/validation/provider-url", () => ({
+  validateProviderUrlForConnectivity: validateProviderUrlForConnectivityMock,
+}));
+
+vi.mock("@/lib/proxy-agent", () => ({
+  createProxyAgentForProvider: createProxyAgentForProviderMock,
+  isValidProxyUrl: vi.fn(() => true),
+}));
+
+vi.mock("@/app/v1/_lib/gemini/auth", () => ({
+  GeminiAuth: {
+    getAccessToken: getAccessTokenMock,
+    isJson: isJsonMock,
+  },
+}));
+
+const fetchMock = vi.fn<typeof fetch>();
+
+describe("providers api test actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
+    validateProviderUrlForConnectivityMock.mockImplementation((providerUrl: string) => ({
+      valid: true,
+      normalizedUrl: providerUrl,
+    }));
+    createProxyAgentForProviderMock.mockReturnValue(null);
+    getAccessTokenMock.mockImplementation(async (apiKey: string) => apiKey);
+    isJsonMock.mockReturnValue(false);
+    getPresetsForProviderMock.mockReturnValue([]);
+    global.fetch = fetchMock as typeof fetch;
+  });
+
+  test("testProviderUnified 应该把 executeProviderTest 返回的完整 rawResponse 透传给前端", async () => {
+    executeProviderTestMock.mockResolvedValue({
+      success: true,
+      status: "green",
+      subStatus: "success",
+      message: "ok",
+      latencyMs: 123,
+      firstByteMs: 45,
+      httpStatusCode: 200,
+      httpStatusText: "OK",
+      model: "gpt-4.1-mini",
+      content: "pong",
+      rawResponse: '{"message":"pong"}',
+      usage: undefined,
+      streamInfo: undefined,
+      errorMessage: undefined,
+      errorType: undefined,
+      testedAt: new Date("2026-04-08T00:00:00.000Z"),
+      validationDetails: {
+        httpPassed: true,
+        latencyPassed: true,
+        contentPassed: true,
+      },
+    });
+
+    const { testProviderUnified } = await import("@/actions/providers");
+    const result = await testProviderUnified({
+      providerUrl: "https://api.example.com",
+      apiKey: "sk-test",
+      providerType: "openai-compatible",
+      model: "gpt-4.1-mini",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.data?.success).toBe(true);
+    expect((result.data as { rawResponse?: string } | undefined)?.rawResponse).toBe(
+      '{"message":"pong"}'
+    );
+  });
+
+  test("testProviderGemini 成功时也应该返回完整响应体，保证前端能展示原始 body", async () => {
+    const responseBody = JSON.stringify({
+      candidates: [
+        {
+          content: {
+            parts: [{ text: "pong" }],
+          },
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 2,
+        candidatesTokenCount: 1,
+        totalTokenCount: 3,
+      },
+    });
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({
+        "content-type": "application/json",
+      }),
+      text: async () => responseBody,
+    } as Response);
+
+    const { testProviderGemini } = await import("@/actions/providers");
+    const result = await testProviderGemini({
+      providerUrl: "https://gemini.example.com",
+      apiKey: "AIza1234567890abcdefghijklmnopqrstuvwxyz",
+      model: "gemini-2.5-pro",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.data?.success).toBe(true);
+    const details = result.data && "details" in result.data ? result.data.details : undefined;
+    expect((details as { rawResponse?: string } | undefined)?.rawResponse).toBe(responseBody);
+  });
+});

--- a/tests/unit/actions/providers-patch-contract.test.ts
+++ b/tests/unit/actions/providers-patch-contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { PROVIDER_RULE_LIMITS } from "@/lib/constants/provider.constants";
 import {
   buildProviderBatchApplyUpdates,
   hasProviderBatchPatchChanges,
@@ -145,7 +146,13 @@ describe("provider patch contract", () => {
   it("rejects model_redirects with overlong source", () => {
     const result = normalizeProviderBatchPatchDraft({
       model_redirects: {
-        set: [{ matchType: "exact", source: "a".repeat(256), target: "glm-4.6" }],
+        set: [
+          {
+            matchType: "exact",
+            source: "a".repeat(PROVIDER_RULE_LIMITS.MAX_TEXT_LENGTH + 1),
+            target: "glm-4.6",
+          },
+        ],
       },
     });
 

--- a/tests/unit/settings/providers/api-test-button.test.tsx
+++ b/tests/unit/settings/providers/api-test-button.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ApiTestButton } from "@/app/[locale]/settings/providers/_components/forms/api-test-button";
+import apiTestMessages from "../../../../messages/en/settings/providers/form/apiTest.json";
+import providerTypesMessages from "../../../../messages/en/settings/providers/form/providerTypes.json";
+
+const { getProviderTestPresetsMock } = vi.hoisted(() => ({
+  getProviderTestPresetsMock: vi.fn(),
+}));
+
+vi.mock("@/actions/providers", () => ({
+  getProviderTestPresets: getProviderTestPresetsMock,
+  testProviderGemini: vi.fn(),
+  testProviderUnified: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+function render(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(node);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+async function flushTicks(times = 1) {
+  for (let i = 0; i < times; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+function buildMessages() {
+  return {
+    settings: {
+      providers: {
+        form: {
+          apiTest: apiTestMessages,
+          providerTypes: providerTypesMessages,
+        },
+      },
+    },
+  };
+}
+
+describe("ApiTestButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getProviderTestPresetsMock.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: "cx_base",
+          description: "legacy preset",
+          defaultSuccessContains: "pong",
+          defaultModel: "gpt-5.1-codex",
+        },
+      ],
+    });
+  });
+
+  test("供应商检测 UI 不应再要求手动选择格式、模板、关键字或超时", async () => {
+    const { unmount } = render(
+      <NextIntlClientProvider locale="en" timeZone="UTC" messages={buildMessages()}>
+        <ApiTestButton
+          providerUrl="https://api.example.com"
+          apiKey="sk-test"
+          providerType="openai-compatible"
+          enableMultiProviderTypes
+        />
+      </NextIntlClientProvider>
+    );
+
+    await flushTicks(2);
+
+    const text = document.body.textContent || "";
+
+    expect(getProviderTestPresetsMock).not.toHaveBeenCalled();
+    expect(text).toContain(apiTestMessages.model);
+    expect(text).not.toContain(apiTestMessages.apiFormat);
+    expect(text).not.toContain(apiTestMessages.requestConfig);
+    expect(text).not.toContain(apiTestMessages.successContains);
+    expect(text).not.toContain(apiTestMessages.timeout.label);
+
+    unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- split provider detection into independent Claude, Codex, OpenAI Compatible, and Gemini template suites with relay-pulse-inspired built-in templates plus a dedicated OpenAI Compatible chat template
- add automatic template ordering/fallback, parser-based response extraction, and full raw-response passthrough so detection can show complete bodies consistently
- simplify the provider detection UI to only require model input, and align Gemini path/model handling with generateContent requests

## Verification
- bun run lint:fix
- bun run typecheck
- bun run test
- bun run build

## Notes
- updated a stale provider patch contract test to follow the live MAX_TEXT_LENGTH constant so the full test suite stays green
- removed an unused private accessor in request-filter-engine while clearing repo-wide lint noise encountered during verification

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the provider detection system by splitting it into independent per-protocol template suites (Claude, Codex, OpenAI Compatible, Gemini), adding a preset-based auto-selection/fallback mechanism, switching Gemini from streaming (`streamGenerateContent?alt=sse`) to non-streaming (`generateContent`), and simplifying the UI to require only a model input. The `rawResponse` field is propagated through to the frontend for inspection, and the architecture is clean. All remaining findings are P2 suggestions.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all remaining findings are P2 style suggestions that do not block correctness or reliability.

The core logic changes (Gemini non-streaming switch, preset auto-selection, rawResponse passthrough) are all covered by new tests that pass. The three findings are a stale JSDoc comment, a cosmetic latency-display inconsistency in the Gemini UI path, and a minor reliability suggestion for Gemini preset files. None affect runtime correctness.

src/app/[locale]/settings/providers/_components/forms/api-test-button.tsx (Gemini latency display), src/lib/provider-testing/types.ts (stale comment), src/lib/provider-testing/data/gm_flash_basic.json and gm_pro_basic.json (missing system instruction)
</details>


<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. `rawResponse` is gated behind an admin session check in `testProviderUnified` and `testProviderGemini`. The `looksLikeAnthropicProxy` heuristic uses hostname-segment matching and explicitly excludes `anthropic.com`/`claude.ai`, avoiding credential routing mistakes. API keys are not logged.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/provider-testing/presets.ts | New preset registry with per-suite templates, score-based selection, and fallback ordering — clean and well-structured. |
| src/lib/provider-testing/test-service.ts | New unified test runner with deadline-aware retry loop across preset candidates; logic is sound. |
| src/actions/providers.ts | Exports new ProviderApiTestSuccessDetails/ProviderApiTestFailureDetails types with rawResponse; switches Gemini to non-streaming generateContent; testProviderUnified correctly maps ProviderTestResult to UnifiedTestResult. |
| src/app/[locale]/settings/providers/_components/forms/api-test-button.tsx | UI simplified to model-only input; Gemini path builds synthetic validationDetails with a hardcoded 5 s latency threshold that doesn't match the 60 s Gemini timeout. |
| src/lib/provider-testing/types.ts | Adds optional fields to CodexTestBody and GeminiTestBody; existing JSDoc on rawResponse says 'truncated to 5000 chars' but the new test explicitly verifies the full body is preserved. |
| src/lib/provider-testing/utils/test-prompts.ts | Updated user-agents, defaults, and headers; adds resolveClaudeHeaders with smart proxy detection heuristic; clean refactor. |
| src/lib/request-filter-engine.ts | Removes unused backward-compat private getter/setter pairs; straightforward cleanup. |
| tests/unit/actions/providers-api-test.test.ts | New test file covering testProviderUnified rawResponse passthrough and testProviderGemini response body exposure; well-structured mocking. |
| tests/unit/actions/providers-patch-contract.test.ts | Updates hardcoded 256 to PROVIDER_RULE_LIMITS.MAX_TEXT_LENGTH + 1 to track the live constant; correct fix. |
| tests/unit/settings/providers/api-test-button.test.tsx | New UI smoke test verifying simplified form no longer exposes format/template/keyword/timeout fields. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["UI: ApiTestButton\n(model input only)"] --> B{providerType?}
    B -- "gemini / gemini-cli" --> C["testProviderGemini()\n(providers.ts)"]
    B -- "claude / codex / openai-compatible" --> D["testProviderUnified()\n(providers.ts)"]
    C --> C1["executeProviderApiTest()\nPOST /v1beta/models/{model}:generateContent\nreturns ProviderApiTestResult\n(details.rawResponse)"]
    D --> E["executeProviderTest()\n(test-service.ts)"]
    E --> F["buildAttemptPlans()"]
    F --> G{"custom payload?"}
    G -- yes --> H["Single plan from JSON"]
    G -- no --> I["getExecutionPresetCandidates()\nscore + sort presets"]
    I --> J["PresetConfig[]"]
    J --> K["runSingleAttempt() x N\ndeadline-aware loop"]
    K --> L{"success or\nnon-retryable?"}
    L -- yes --> M["Return ProviderTestResult\n(rawResponse at top-level)"]
    L -- "no, HTTP 400/404/405/415/422" --> K
    M --> N["UnifiedTestResult\n(rawResponse at data root)"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/provider-testing/types.ts`, line 164 ([link](https://github.com/ding113/claude-code-hub/blob/46bde198c18377acf3655a4459fdf5e546024317/src/lib/provider-testing/types.ts#L164)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale JSDoc comment contradicts implementation**

   The comment says `rawResponse` is "truncated to 5000 chars", but `test-service.ts` assigns `rawResponse: responseBody` with no truncation applied, and `test-service.test.ts` explicitly asserts that the full 7000+ character body is preserved. The description is actively misleading.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/provider-testing/types.ts
   Line: 164

   Comment:
   **Stale JSDoc comment contradicts implementation**

   The comment says `rawResponse` is "truncated to 5000 chars", but `test-service.ts` assigns `rawResponse: responseBody` with no truncation applied, and `test-service.test.ts` explicitly asserts that the full 7000+ character body is preserved. The description is actively misleading.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/provider-testing/types.ts
Line: 163-164

Comment:
**Stale JSDoc contradicts new test**

The comment says `rawResponse` is "truncated to 5000 chars", but `test-service.test.ts` (added in this PR, lines 64–103) explicitly asserts that a 7 000+ character response body is preserved in full (`expect(result.rawResponse?.length).toBe(responseBody.length)`). A developer reading this comment will likely add truncation in a future refactor, breaking that contract. Please update it to reflect the current, intended behaviour.

```suggestion
  /** Raw response body for user inspection (full body, not truncated) */
  rawResponse?: string;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/[locale]/settings/providers/_components/forms/api-test-button.tsx
Line: 256-259

Comment:
**Hardcoded 5 s latency threshold mismatches Gemini's 60 s timeout**

`getTimeoutMsForProvider("gemini")` returns `60_000` ms, but the synthetic `validationDetails` built here marks `latencyPassed: false` for any response that takes longer than 5 000 ms. A valid, slow Gemini response (e.g. 8 s) will show the latency check as failed in the `TestResultCard` even though the test overall succeeded. The `testProviderUnified` path avoids this because the threshold is evaluated on the backend. Consider using the same provider-aware threshold here:

```suggestion
          latencyPassed: isSuccess && latencyMs < getTimeoutMsForProvider(resolvedProviderType),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/lib/provider-testing/data/gm_flash_basic.json
Line: 1-19

Comment:
**No system instruction — "pong" content check may be flaky**

The same applies to `gm_pro_basic.json`. The old body included `"systemInstruction": { "parts": [{ "text": "You are a echo bot. Always say pong." }] }`, which made the `defaultSuccessContains: "pong"` check reliable. Without it, the model must infer the ping/pong convention from training data alone. At `temperature: 0` this typically works, but it's one less guard against a model rephrasing (e.g. "Pong!" or "I'm ready"). Adding back a `systemInstruction` (even a minimal one) would make the validation deterministic.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: tighten provider detection validati..."](https://github.com/ding113/claude-code-hub/commit/06e5a632be8f8b48f616d41742b455613bc2bec6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27756906)</sub>

<!-- /greptile_comment -->