### PR TITLE
fix: honor disabled error rules during queued reloads

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -391,6 +391,100 @@ function addSpecialSettingForPersistence(
   }
 }
 
+type MatchedRuleDetails = NonNullable<
+  NonNullable<ProviderChainItem["errorDetails"]>["matchedRule"]
+>;
+
+function buildMatchedRuleDetails(
+  detectionResult: Awaited<ReturnType<typeof getErrorDetectionResultAsync>>
+): MatchedRuleDetails | undefined {
+  if (
+    !detectionResult.matched ||
+    detectionResult.ruleId === undefined ||
+    detectionResult.pattern === undefined ||
+    detectionResult.matchType === undefined ||
+    detectionResult.category === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    ruleId: detectionResult.ruleId,
+    pattern: detectionResult.pattern,
+    matchType: detectionResult.matchType,
+    category: detectionResult.category,
+    description: detectionResult.description,
+    hasOverrideResponse: detectionResult.overrideResponse !== undefined,
+    hasOverrideStatusCode: detectionResult.overrideStatusCode !== undefined,
+  };
+}
+
+function buildMatchedRuleLogContext(
+  matchedRule: MatchedRuleDetails | undefined
+): Record<string, unknown> {
+  if (!matchedRule) {
+    return {};
+  }
+
+  return {
+    matchedRuleId: matchedRule.ruleId,
+    matchedRuleName: matchedRule.description?.trim() || matchedRule.pattern,
+    matchedRulePattern: matchedRule.pattern,
+    matchedRuleCategory: matchedRule.category,
+    matchedRuleMatchType: matchedRule.matchType,
+    matchedRuleHasOverrideResponse: matchedRule.hasOverrideResponse,
+    matchedRuleHasOverrideStatusCode: matchedRule.hasOverrideStatusCode,
+  };
+}
+
+function buildClientErrorChainEntry(
+  provider: Provider,
+  endpointAudit: { endpointId: number | null; endpointUrl: string },
+  attemptNumber: number,
+  error: Error,
+  errorMessage: string,
+  requestDetails: ReturnType<typeof buildRequestDetails>,
+  matchedRule: MatchedRuleDetails | undefined
+): NonNullable<Parameters<ProxySession["addProviderToChain"]>[1]> {
+  if (error instanceof ProxyError) {
+    return {
+      ...endpointAudit,
+      reason: "client_error_non_retryable",
+      circuitState: getCircuitState(provider.id),
+      attemptNumber,
+      errorMessage,
+      statusCode: error.statusCode,
+      statusCodeInferred: error.upstreamError?.statusCodeInferred ?? false,
+      errorDetails: {
+        provider: {
+          id: provider.id,
+          name: provider.name,
+          statusCode: error.statusCode,
+          statusText: error.message,
+          upstreamBody: error.upstreamError?.body,
+          upstreamParsed: error.upstreamError?.parsed,
+        },
+        clientError: error.getDetailedErrorMessage(),
+        matchedRule,
+        request: requestDetails,
+      },
+    };
+  }
+
+  return {
+    ...endpointAudit,
+    reason: "client_error_non_retryable",
+    circuitState: getCircuitState(provider.id),
+    attemptNumber,
+    errorMessage,
+    errorDetails: {
+      clientError: error.message,
+      matchedRule,
+      request: requestDetails,
+    },
+  };
+}
+
 function buildRetryFailedChainEntry(
   provider: Provider,
   endpointAudit: { endpointId: number | null; endpointUrl: string },
@@ -1354,33 +1448,17 @@ export class ProxyForwarder {
           // ⭐ 3. 不可重试的客户端输入错误处理（不计入熔断器，不重试，立即返回）
           if (errorCategory === ErrorCategory.NON_RETRYABLE_CLIENT_ERROR) {
             const detectionResult = await getErrorDetectionResultAsync(lastError);
-            const matchedRule =
-              detectionResult.matched &&
-              detectionResult.ruleId !== undefined &&
-              detectionResult.pattern !== undefined &&
-              detectionResult.matchType !== undefined &&
-              detectionResult.category !== undefined
-                ? {
-                    ruleId: detectionResult.ruleId,
-                    pattern: detectionResult.pattern,
-                    matchType: detectionResult.matchType,
-                    category: detectionResult.category,
-                    description: detectionResult.description,
-                    hasOverrideResponse: detectionResult.overrideResponse !== undefined,
-                    hasOverrideStatusCode: detectionResult.overrideStatusCode !== undefined,
-                  }
-                : undefined;
-            const matchedRuleLogContext = matchedRule
-              ? {
-                  matchedRuleId: matchedRule.ruleId,
-                  matchedRuleName: matchedRule.description?.trim() || matchedRule.pattern,
-                  matchedRulePattern: matchedRule.pattern,
-                  matchedRuleCategory: matchedRule.category,
-                  matchedRuleMatchType: matchedRule.matchType,
-                  matchedRuleHasOverrideResponse: matchedRule.hasOverrideResponse,
-                  matchedRuleHasOverrideStatusCode: matchedRule.hasOverrideStatusCode,
-                }
-              : {};
+            const matchedRule = buildMatchedRuleDetails(detectionResult);
+            const matchedRuleLogContext = buildMatchedRuleLogContext(matchedRule);
+            const clientErrorChainEntry = buildClientErrorChainEntry(
+              currentProvider,
+              endpointAudit,
+              attemptCount,
+              lastError,
+              errorMessage,
+              buildRequestDetails(session),
+              matchedRule
+            );
 
             if (lastError instanceof ProxyError) {
               // Original path: full ProxyError fields available
@@ -1396,31 +1474,6 @@ export class ProxyForwarder {
                   "White-listed client error (prompt length, content filter, PDF limit, or thinking format)",
                 ...matchedRuleLogContext,
               });
-
-              // 记录到决策链（标记为不可重试的客户端错误）
-              // 注意：不调用 recordFailure()，因为这不是供应商的问题，是客户端输入问题
-              session.addProviderToChain(currentProvider, {
-                ...endpointAudit,
-                reason: "client_error_non_retryable", // 新增的 reason 值
-                circuitState: getCircuitState(currentProvider.id),
-                attemptNumber: attemptCount,
-                errorMessage: errorMessage,
-                statusCode: lastError.statusCode,
-                statusCodeInferred: lastError.upstreamError?.statusCodeInferred ?? false,
-                errorDetails: {
-                  provider: {
-                    id: currentProvider.id,
-                    name: currentProvider.name,
-                    statusCode: lastError.statusCode,
-                    statusText: lastError.message,
-                    upstreamBody: lastError.upstreamError?.body,
-                    upstreamParsed: lastError.upstreamError?.parsed,
-                  },
-                  clientError: lastError.getDetailedErrorMessage(),
-                  matchedRule,
-                  request: buildRequestDetails(session),
-                },
-              });
             } else {
               // Plain Error path: omit ProxyError-only fields
               logger.warn(
@@ -1435,20 +1488,11 @@ export class ProxyForwarder {
                   ...matchedRuleLogContext,
                 }
               );
-
-              session.addProviderToChain(currentProvider, {
-                ...endpointAudit,
-                reason: "client_error_non_retryable",
-                circuitState: getCircuitState(currentProvider.id),
-                attemptNumber: attemptCount,
-                errorMessage: lastError.message,
-                errorDetails: {
-                  clientError: lastError.message,
-                  matchedRule,
-                  request: buildRequestDetails(session),
-                },
-              });
             }
+
+            // 记录到决策链（标记为不可重试的客户端错误）
+            // 注意：不调用 recordFailure()，因为这不是供应商的问题，是客户端输入问题
+            session.addProviderToChain(currentProvider, clientErrorChainEntry);
 
             // 立即抛出错误，不重试，不切换供应商
             // 白名单错误不计入熔断器，因为是客户端输入问题，不是供应商故障
@@ -3234,6 +3278,8 @@ export class ProxyForwarder {
       const statusCode = error instanceof ProxyError ? error.statusCode : undefined;
       const errorMessage =
         error instanceof ProxyError ? error.getDetailedErrorMessage() : error.message;
+      let matchedRule: MatchedRuleDetails | undefined;
+      let matchedRuleLogContext: Record<string, unknown> = {};
 
       if (attempt.endpointAudit.endpointId != null) {
         const isTimeoutError = error instanceof ProxyError && error.statusCode === 524;
@@ -3334,6 +3380,21 @@ export class ProxyForwarder {
         }
       }
 
+      if (errorCategory === ErrorCategory.NON_RETRYABLE_CLIENT_ERROR) {
+        matchedRule = buildMatchedRuleDetails(await getErrorDetectionResultAsync(error));
+        matchedRuleLogContext = buildMatchedRuleLogContext(matchedRule);
+
+        logger.warn("ProxyForwarder: Non-retryable client error in hedge, aborting all attempts", {
+          providerId: attempt.provider.id,
+          providerName: attempt.provider.name,
+          statusCode,
+          error: errorMessage,
+          participantSequence: attempt.sequence,
+          attemptNumber: attempt.requestAttemptCount,
+          ...matchedRuleLogContext,
+        });
+      }
+
       attempt.settled = true;
       if (attempt.thresholdTimer) {
         clearTimeout(attempt.thresholdTimer);
@@ -3345,20 +3406,34 @@ export class ProxyForwarder {
         await recordFailure(attempt.provider.id, error);
       }
 
-      session.addProviderToChain(attempt.provider, {
-        ...attempt.endpointAudit,
-        reason:
-          errorCategory === ErrorCategory.RESOURCE_NOT_FOUND
-            ? "resource_not_found"
-            : errorCategory === ErrorCategory.NON_RETRYABLE_CLIENT_ERROR
-              ? "client_error_non_retryable"
-              : "retry_failed",
-        attemptNumber: attempt.sequence,
-        statusCode,
-        errorMessage,
-        circuitState: getCircuitState(attempt.provider.id),
-        modelRedirect: getAttemptModelRedirect(attempt),
-      });
+      session.addProviderToChain(
+        attempt.provider,
+        errorCategory === ErrorCategory.NON_RETRYABLE_CLIENT_ERROR
+          ? {
+              ...buildClientErrorChainEntry(
+                attempt.provider,
+                attempt.endpointAudit,
+                attempt.sequence,
+                error,
+                errorMessage,
+                buildRequestDetails(session),
+                matchedRule
+              ),
+              modelRedirect: getAttemptModelRedirect(attempt),
+            }
+          : {
+              ...attempt.endpointAudit,
+              reason:
+                errorCategory === ErrorCategory.RESOURCE_NOT_FOUND
+                  ? "resource_not_found"
+                  : "retry_failed",
+              attemptNumber: attempt.sequence,
+              statusCode,
+              errorMessage,
+              circuitState: getCircuitState(attempt.provider.id),
+              modelRedirect: getAttemptModelRedirect(attempt),
+            }
+      );
 
       if (errorCategory === ErrorCategory.NON_RETRYABLE_CLIENT_ERROR) {
         abortAllAttempts(undefined, "client_error_non_retryable");

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -1370,6 +1370,17 @@ export class ProxyForwarder {
                     hasOverrideStatusCode: detectionResult.overrideStatusCode !== undefined,
                   }
                 : undefined;
+            const matchedRuleLogContext = matchedRule
+              ? {
+                  matchedRuleId: matchedRule.ruleId,
+                  matchedRuleName: matchedRule.description?.trim() || matchedRule.pattern,
+                  matchedRulePattern: matchedRule.pattern,
+                  matchedRuleCategory: matchedRule.category,
+                  matchedRuleMatchType: matchedRule.matchType,
+                  matchedRuleHasOverrideResponse: matchedRule.hasOverrideResponse,
+                  matchedRuleHasOverrideStatusCode: matchedRule.hasOverrideStatusCode,
+                }
+              : {};
 
             if (lastError instanceof ProxyError) {
               // Original path: full ProxyError fields available
@@ -1383,6 +1394,7 @@ export class ProxyForwarder {
                 totalProvidersAttempted,
                 reason:
                   "White-listed client error (prompt length, content filter, PDF limit, or thinking format)",
+                ...matchedRuleLogContext,
               });
 
               // 记录到决策链（标记为不可重试的客户端错误）
@@ -1420,6 +1432,7 @@ export class ProxyForwarder {
                   attemptNumber: attemptCount,
                   totalProvidersAttempted,
                   reason: "White-listed client error matched by error rule",
+                  ...matchedRuleLogContext,
                 }
               );
 

--- a/src/lib/error-rule-detector.ts
+++ b/src/lib/error-rule-detector.ts
@@ -321,6 +321,9 @@ class ErrorRuleDetector {
     })();
 
     this.activeReloadPromise = reloadLoopPromise.finally(async () => {
+      // 这里处理的是极窄窗口：
+      // do/while 已经读到 "无需继续"，但 finally 微任务尚未执行时又收到新的 reload 请求。
+      // 若不在 finally 再检查一次，这个晚到的请求会看到已完成 promise 并被静默吞掉。
       const shouldRestartAfterSettle = this.reloadRequestedWhileLoading;
       this.activeReloadPromise = null;
 

--- a/src/lib/error-rule-detector.ts
+++ b/src/lib/error-rule-detector.ts
@@ -83,6 +83,8 @@ class ErrorRuleDetector {
   private isInitialized: boolean = false; // 跟踪初始化状态
   private initializationPromise: Promise<void> | null = null; // 防止并发初始化竞态
   private dbLoadedSuccessfully: boolean = false; // 是否成功从数据库加载过
+  private activeReloadPromise: Promise<void> | null = null; // 合并并发 reload
+  private reloadRequestedWhileLoading: boolean = false; // reload 期间收到的补跑请求
 
   constructor() {
     // 延迟初始化事件监听（仅在 Node.js runtime 中）
@@ -161,149 +163,174 @@ class ErrorRuleDetector {
    * - 成功加载后标记 dbLoadedSuccessfully，后续不再重试
    */
   async reload(): Promise<void> {
-    if (this.isLoading) {
-      logger.warn("[ErrorRuleDetector] Reload already in progress, skipping");
-      return;
+    if (this.activeReloadPromise) {
+      this.reloadRequestedWhileLoading = true;
+      logger.info("[ErrorRuleDetector] Reload already in progress, queueing another pass");
+      return this.activeReloadPromise;
     }
 
-    this.isLoading = true;
+    const reloadLoopPromise = (async () => {
+      do {
+        // 关键逻辑：reload 期间如果又收到事件，只做标记；当前轮完成后立刻补跑一轮，
+        // 避免“数据库已禁用，但内存快照仍是旧规则”的窗口被长期保留。
+        this.reloadRequestedWhileLoading = false;
+        this.isLoading = true;
 
-    try {
-      logger.info("[ErrorRuleDetector] Reloading error rules from database...");
+        try {
+          logger.info("[ErrorRuleDetector] Reloading error rules from database...");
 
-      let rules;
-      try {
-        rules = await getActiveErrorRules();
-        this.dbLoadedSuccessfully = true;
-      } catch (dbError) {
-        const errorMessage = (dbError as Error).message || "";
+          let rules;
+          try {
+            rules = await getActiveErrorRules();
+            this.dbLoadedSuccessfully = true;
+          } catch (dbError) {
+            const errorMessage = (dbError as Error).message || "";
 
-        // 记录数据库错误（区分表不存在和其他错误）
-        if (errorMessage.includes("relation") && errorMessage.includes("does not exist")) {
-          logger.warn(
-            "[ErrorRuleDetector] error_rules table does not exist yet (migration pending)"
-          );
-        } else {
-          logger.error("[ErrorRuleDetector] Database error while loading error rules:", dbError);
-        }
+            // 记录数据库错误（区分表不存在和其他错误）
+            if (errorMessage.includes("relation") && errorMessage.includes("does not exist")) {
+              logger.warn(
+                "[ErrorRuleDetector] error_rules table does not exist yet (migration pending)"
+              );
+            } else {
+              logger.error(
+                "[ErrorRuleDetector] Database error while loading error rules:",
+                dbError
+              );
+            }
 
-        // 保留现有缓存，下次检测时重试
-        this.lastReloadTime = Date.now();
-        return;
-      }
-
-      // 使用局部变量收集新数据，避免 reload 期间 detect() 返回空结果
-      const newRegexPatterns: RegexPattern[] = [];
-      const newContainsPatterns: ContainsPattern[] = [];
-      const newExactPatterns = new Map<string, ExactPattern>();
-
-      // 按类型分组加载规则
-      let validRegexCount = 0;
-      let skippedRedosCount = 0;
-      let skippedInvalidResponseCount = 0;
-
-      for (const rule of rules) {
-        // 在加载阶段验证 overrideResponse 格式，过滤畸形数据
-        let validatedOverrideResponse: ErrorOverrideResponse | undefined;
-        if (rule.overrideResponse) {
-          if (isValidErrorOverrideResponse(rule.overrideResponse)) {
-            validatedOverrideResponse = rule.overrideResponse;
-          } else {
-            logger.warn(
-              `[ErrorRuleDetector] Invalid override_response for rule ${rule.id} (pattern: ${rule.pattern}), skipping response override`
-            );
-            skippedInvalidResponseCount++;
-          }
-        }
-
-        switch (rule.matchType) {
-          case "contains": {
-            const lowerText = rule.pattern.toLowerCase();
-            newContainsPatterns.push({
-              ruleId: rule.id,
-              pattern: rule.pattern,
-              text: lowerText,
-              category: rule.category,
-              description: rule.description ?? undefined,
-              overrideResponse: validatedOverrideResponse,
-              overrideStatusCode: rule.overrideStatusCode ?? undefined,
-            });
-            break;
+            // 保留现有缓存，下次检测时重试
+            this.lastReloadTime = Date.now();
+            continue;
           }
 
-          case "exact": {
-            const lowerText = rule.pattern.toLowerCase();
-            newExactPatterns.set(lowerText, {
-              ruleId: rule.id,
-              pattern: rule.pattern,
-              text: lowerText,
-              category: rule.category,
-              description: rule.description ?? undefined,
-              overrideResponse: validatedOverrideResponse,
-              overrideStatusCode: rule.overrideStatusCode ?? undefined,
-            });
-            break;
-          }
+          // 使用局部变量收集新数据，避免 reload 期间 detect() 返回空结果
+          const newRegexPatterns: RegexPattern[] = [];
+          const newContainsPatterns: ContainsPattern[] = [];
+          const newExactPatterns = new Map<string, ExactPattern>();
 
-          case "regex": {
-            // 使用 safe-regex 检测 ReDoS 风险
-            try {
-              if (!safeRegex(rule.pattern)) {
+          // 按类型分组加载规则
+          let validRegexCount = 0;
+          let skippedRedosCount = 0;
+          let skippedInvalidResponseCount = 0;
+
+          for (const rule of rules) {
+            // 在加载阶段验证 overrideResponse 格式，过滤畸形数据
+            let validatedOverrideResponse: ErrorOverrideResponse | undefined;
+            if (rule.overrideResponse) {
+              if (isValidErrorOverrideResponse(rule.overrideResponse)) {
+                validatedOverrideResponse = rule.overrideResponse;
+              } else {
                 logger.warn(
-                  `[ErrorRuleDetector] ReDoS risk detected in pattern: ${rule.pattern}, skipping`
+                  `[ErrorRuleDetector] Invalid override_response for rule ${rule.id} (pattern: ${rule.pattern}), skipping response override`
                 );
-                skippedRedosCount++;
+                skippedInvalidResponseCount++;
+              }
+            }
+
+            switch (rule.matchType) {
+              case "contains": {
+                const lowerText = rule.pattern.toLowerCase();
+                newContainsPatterns.push({
+                  ruleId: rule.id,
+                  pattern: rule.pattern,
+                  text: lowerText,
+                  category: rule.category,
+                  description: rule.description ?? undefined,
+                  overrideResponse: validatedOverrideResponse,
+                  overrideStatusCode: rule.overrideStatusCode ?? undefined,
+                });
                 break;
               }
 
-              const pattern = new RegExp(rule.pattern, "i");
-              newRegexPatterns.push({
-                ruleId: rule.id,
-                rawPattern: rule.pattern,
-                pattern,
-                category: rule.category,
-                description: rule.description ?? undefined,
-                overrideResponse: validatedOverrideResponse,
-                overrideStatusCode: rule.overrideStatusCode ?? undefined,
-              });
-              validRegexCount++;
-            } catch (error) {
-              logger.error(`[ErrorRuleDetector] Invalid regex pattern: ${rule.pattern}`, error);
+              case "exact": {
+                const lowerText = rule.pattern.toLowerCase();
+                newExactPatterns.set(lowerText, {
+                  ruleId: rule.id,
+                  pattern: rule.pattern,
+                  text: lowerText,
+                  category: rule.category,
+                  description: rule.description ?? undefined,
+                  overrideResponse: validatedOverrideResponse,
+                  overrideStatusCode: rule.overrideStatusCode ?? undefined,
+                });
+                break;
+              }
+
+              case "regex": {
+                // 使用 safe-regex 检测 ReDoS 风险
+                try {
+                  if (!safeRegex(rule.pattern)) {
+                    logger.warn(
+                      `[ErrorRuleDetector] ReDoS risk detected in pattern: ${rule.pattern}, skipping`
+                    );
+                    skippedRedosCount++;
+                    break;
+                  }
+
+                  const pattern = new RegExp(rule.pattern, "i");
+                  newRegexPatterns.push({
+                    ruleId: rule.id,
+                    rawPattern: rule.pattern,
+                    pattern,
+                    category: rule.category,
+                    description: rule.description ?? undefined,
+                    overrideResponse: validatedOverrideResponse,
+                    overrideStatusCode: rule.overrideStatusCode ?? undefined,
+                  });
+                  validRegexCount++;
+                } catch (error) {
+                  logger.error(`[ErrorRuleDetector] Invalid regex pattern: ${rule.pattern}`, error);
+                }
+                break;
+              }
+
+              default:
+                logger.warn(`[ErrorRuleDetector] Unknown match type: ${rule.matchType}`);
             }
-            break;
           }
 
-          default:
-            logger.warn(`[ErrorRuleDetector] Unknown match type: ${rule.matchType}`);
+          // 原子替换：确保 detect() 始终看到一致的数据集
+          this.regexPatterns = newRegexPatterns;
+          this.containsPatterns = newContainsPatterns;
+          this.exactPatterns = newExactPatterns;
+
+          this.lastReloadTime = Date.now();
+          this.isInitialized = true; // 标记为已初始化
+
+          const skippedInfo = [
+            skippedRedosCount > 0 ? `${skippedRedosCount} ReDoS` : "",
+            skippedInvalidResponseCount > 0
+              ? `${skippedInvalidResponseCount} invalid response`
+              : "",
+          ]
+            .filter(Boolean)
+            .join(", ");
+
+          logger.info(
+            `[ErrorRuleDetector] Loaded ${rules.length} error rules: ` +
+              `contains=${newContainsPatterns.length}, exact=${newExactPatterns.size}, ` +
+              `regex=${validRegexCount}${skippedInfo ? ` (skipped: ${skippedInfo})` : ""}`
+          );
+        } catch (error) {
+          logger.error("[ErrorRuleDetector] Failed to reload error rules:", error);
+          // 失败时不清空现有缓存，保持降级可用
+        } finally {
+          this.isLoading = false;
         }
+      } while (this.reloadRequestedWhileLoading);
+    })();
+
+    this.activeReloadPromise = reloadLoopPromise.finally(async () => {
+      const shouldRestartAfterSettle = this.reloadRequestedWhileLoading;
+      this.activeReloadPromise = null;
+
+      if (shouldRestartAfterSettle) {
+        logger.info("[ErrorRuleDetector] Processing queued reload after promise settlement");
+        return this.reload();
       }
+    });
 
-      // 原子替换：确保 detect() 始终看到一致的数据集
-      this.regexPatterns = newRegexPatterns;
-      this.containsPatterns = newContainsPatterns;
-      this.exactPatterns = newExactPatterns;
-
-      this.lastReloadTime = Date.now();
-      this.isInitialized = true; // 标记为已初始化
-
-      const skippedInfo = [
-        skippedRedosCount > 0 ? `${skippedRedosCount} ReDoS` : "",
-        skippedInvalidResponseCount > 0 ? `${skippedInvalidResponseCount} invalid response` : "",
-      ]
-        .filter(Boolean)
-        .join(", ");
-
-      logger.info(
-        `[ErrorRuleDetector] Loaded ${rules.length} error rules: ` +
-          `contains=${newContainsPatterns.length}, exact=${newExactPatterns.size}, ` +
-          `regex=${validRegexCount}${skippedInfo ? ` (skipped: ${skippedInfo})` : ""}`
-      );
-    } catch (error) {
-      logger.error("[ErrorRuleDetector] Failed to reload error rules:", error);
-      // 失败时不清空现有缓存，保持降级可用
-    } finally {
-      this.isLoading = false;
-    }
+    return this.activeReloadPromise;
   }
 
   /**

--- a/src/lib/error-rule-detector.ts
+++ b/src/lib/error-rule-detector.ts
@@ -140,6 +140,13 @@ class ErrorRuleDetector {
    * 操作前缓存已初始化，解决新 worker 进程中缓存为空的问题
    */
   async ensureInitialized(): Promise<void> {
+    // 只要有进行中的 reload（含 queued rerun），普通调用方都应等待它完成，
+    // 否则会在补跑尚未落地时读取到旧快照。
+    if (this.activeReloadPromise) {
+      await this.activeReloadPromise;
+      return;
+    }
+
     // 只有成功从数据库加载过，才跳过初始化
     if (this.dbLoadedSuccessfully && this.isInitialized) {
       return;

--- a/src/lib/error-rule-detector.ts
+++ b/src/lib/error-rule-detector.ts
@@ -103,7 +103,7 @@ class ErrorRuleDetector {
           // 重置标记，强制下次从数据库重新加载
           this.dbLoadedSuccessfully = false;
           this.isInitialized = false;
-          this.reload().catch((error) => {
+          this.reload({ queueIfRunning: true }).catch((error) => {
             logger.error("[ErrorRuleDetector] Failed to reload cache on event:", error);
           });
         };
@@ -162,10 +162,12 @@ class ErrorRuleDetector {
    * - 保留现有缓存（如果有），下次检测时重试加载
    * - 成功加载后标记 dbLoadedSuccessfully，后续不再重试
    */
-  async reload(): Promise<void> {
+  async reload(options: { queueIfRunning?: boolean } = {}): Promise<void> {
     if (this.activeReloadPromise) {
-      this.reloadRequestedWhileLoading = true;
-      logger.info("[ErrorRuleDetector] Reload already in progress, queueing another pass");
+      if (options.queueIfRunning) {
+        this.reloadRequestedWhileLoading = true;
+        logger.info("[ErrorRuleDetector] Reload already in progress, queueing another pass");
+      }
       return this.activeReloadPromise;
     }
 

--- a/src/lib/error-rule-detector.ts
+++ b/src/lib/error-rule-detector.ts
@@ -198,9 +198,11 @@ class ErrorRuleDetector {
               );
             }
 
-            // 保留现有缓存，下次检测时重试
+            // 保留现有缓存；数据库持续故障时不要在同一轮里热重试，
+            // 让下一次事件/显式 reload 自然触发后续重试，避免日志风暴和无退避打库。
             this.lastReloadTime = Date.now();
-            continue;
+            this.reloadRequestedWhileLoading = false;
+            break;
           }
 
           // 使用局部变量收集新数据，避免 reload 期间 detect() 返回空结果

--- a/tests/unit/lib/error-rule-detector-reload-queue.test.ts
+++ b/tests/unit/lib/error-rule-detector-reload-queue.test.ts
@@ -185,4 +185,46 @@ describe("ErrorRuleDetector reload queue", () => {
     expect(mocks.getActiveErrorRules).toHaveBeenCalledTimes(1);
     expect(errorRuleDetector.detect("Your session is missing thinking fields").matched).toBe(true);
   });
+
+  test("should keep ensureInitialized waiting until a queued rerun finishes", async () => {
+    let resolveFirstLoad: ((value: ReturnType<typeof buildRule>[]) => void) | undefined;
+    let resolveSecondLoad: ((value: ReturnType<typeof buildRule>[]) => void) | undefined;
+
+    mocks.getActiveErrorRules
+      .mockImplementationOnce(
+        () =>
+          new Promise<ReturnType<typeof buildRule>[]>((resolve) => {
+            resolveFirstLoad = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<ReturnType<typeof buildRule>[]>((resolve) => {
+            resolveSecondLoad = resolve;
+          })
+      );
+
+    const { errorRuleDetector } = await import("@/lib/error-rule-detector");
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const runningReload = errorRuleDetector.reload();
+    mocks.eventEmitter.emit("errorRulesUpdated");
+
+    resolveFirstLoad?.([buildRule()]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    let waiterSettled = false;
+    const waiter = errorRuleDetector.ensureInitialized().then(() => {
+      waiterSettled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(waiterSettled).toBe(false);
+
+    resolveSecondLoad?.([]);
+    await Promise.all([runningReload, waiter]);
+
+    expect(errorRuleDetector.detect("Your session is missing thinking fields").matched).toBe(false);
+  });
 });

--- a/tests/unit/lib/error-rule-detector-reload-queue.test.ts
+++ b/tests/unit/lib/error-rule-detector-reload-queue.test.ts
@@ -98,9 +98,6 @@ describe("ErrorRuleDetector reload queue", () => {
     resolveFirstLoad?.([buildRule()]);
     await initialReload;
 
-    // 给事件触发的补跑 reload 一个完成机会
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
     expect(mocks.getActiveErrorRules).toHaveBeenCalledTimes(2);
     expect(errorRuleDetector.detect("Your session is missing thinking fields").matched).toBe(false);
   });

--- a/tests/unit/lib/error-rule-detector-reload-queue.test.ts
+++ b/tests/unit/lib/error-rule-detector-reload-queue.test.ts
@@ -161,4 +161,28 @@ describe("ErrorRuleDetector reload queue", () => {
 
     expect(mocks.getActiveErrorRules).toHaveBeenCalledTimes(2);
   });
+
+  test("should let ordinary waiters reuse an in-flight reload without forcing an extra pass", async () => {
+    let resolveFirstLoad: ((value: ReturnType<typeof buildRule>[]) => void) | undefined;
+
+    mocks.getActiveErrorRules.mockImplementationOnce(
+      () =>
+        new Promise<ReturnType<typeof buildRule>[]>((resolve) => {
+          resolveFirstLoad = resolve;
+        })
+    );
+
+    const { errorRuleDetector } = await import("@/lib/error-rule-detector");
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const runningReload = errorRuleDetector.reload();
+    const waiter = errorRuleDetector.ensureInitialized();
+
+    resolveFirstLoad?.([buildRule()]);
+    await Promise.all([runningReload, waiter]);
+
+    expect(mocks.getActiveErrorRules).toHaveBeenCalledTimes(1);
+    expect(errorRuleDetector.detect("Your session is missing thinking fields").matched).toBe(true);
+  });
 });

--- a/tests/unit/lib/error-rule-detector-reload-queue.test.ts
+++ b/tests/unit/lib/error-rule-detector-reload-queue.test.ts
@@ -131,4 +131,34 @@ describe("ErrorRuleDetector reload queue", () => {
     expect(mocks.getActiveErrorRules).toHaveBeenCalledTimes(2);
     expect(errorRuleDetector.detect("Your session is missing thinking fields").matched).toBe(false);
   });
+
+  test("should avoid hot retry loops when a queued reload hits persistent DB failure", async () => {
+    let rejectFirstLoad: ((reason?: unknown) => void) | undefined;
+
+    mocks.getActiveErrorRules
+      .mockImplementationOnce(
+        () =>
+          new Promise<ReturnType<typeof buildRule>[]>((_, reject) => {
+            rejectFirstLoad = reject;
+          })
+      )
+      .mockResolvedValueOnce([]);
+
+    const { errorRuleDetector } = await import("@/lib/error-rule-detector");
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const initialReload = errorRuleDetector.reload();
+    mocks.eventEmitter.emit("errorRulesUpdated");
+
+    rejectFirstLoad?.(new Error("DSN environment variable is not set"));
+    await initialReload;
+
+    expect(mocks.getActiveErrorRules).toHaveBeenCalledTimes(1);
+    expect(errorRuleDetector.getStats().isLoading).toBe(false);
+
+    await errorRuleDetector.reload();
+
+    expect(mocks.getActiveErrorRules).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/unit/lib/error-rule-detector-reload-queue.test.ts
+++ b/tests/unit/lib/error-rule-detector-reload-queue.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  return {
+    getActiveErrorRules: vi.fn(),
+    subscribeCacheInvalidation: vi.fn(async () => undefined),
+    eventEmitter: {
+      on(event: string, handler: (...args: unknown[]) => void) {
+        const current = listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
+        current.add(handler);
+        listeners.set(event, current);
+      },
+      emit(event: string, ...args: unknown[]) {
+        for (const handler of listeners.get(event) ?? []) {
+          handler(...args);
+        }
+      },
+      removeAllListeners() {
+        listeners.clear();
+      },
+    },
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      trace: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/repository/error-rules", () => ({
+  getActiveErrorRules: mocks.getActiveErrorRules,
+}));
+
+vi.mock("@/lib/event-emitter", () => ({
+  eventEmitter: mocks.eventEmitter,
+}));
+
+vi.mock("@/lib/redis/pubsub", () => ({
+  CHANNEL_ERROR_RULES_UPDATED: "errorRulesUpdated",
+  subscribeCacheInvalidation: mocks.subscribeCacheInvalidation,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: mocks.logger,
+}));
+
+function buildRule(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    id: 101,
+    pattern: "missing thinking fields",
+    matchType: "contains" as const,
+    category: "thinking_error",
+    description: "YesCode missing thinking fields",
+    overrideResponse: undefined,
+    overrideStatusCode: 400,
+    isEnabled: true,
+    isDefault: false,
+    priority: 10,
+    createdAt: new Date("2026-04-09T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-09T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("ErrorRuleDetector reload queue", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.eventEmitter.removeAllListeners();
+  });
+
+  test("should apply a queued reload after errorRulesUpdated arrives mid-reload", async () => {
+    let resolveFirstLoad: ((value: ReturnType<typeof buildRule>[]) => void) | undefined;
+
+    mocks.getActiveErrorRules
+      .mockImplementationOnce(
+        () =>
+          new Promise<ReturnType<typeof buildRule>[]>((resolve) => {
+            resolveFirstLoad = resolve;
+          })
+      )
+      .mockResolvedValueOnce([]);
+
+    const { errorRuleDetector } = await import("@/lib/error-rule-detector");
+
+    // 等待构造函数里的事件监听异步挂载完成
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const initialReload = errorRuleDetector.reload();
+
+    mocks.eventEmitter.emit("errorRulesUpdated");
+
+    resolveFirstLoad?.([buildRule()]);
+    await initialReload;
+
+    // 给事件触发的补跑 reload 一个完成机会
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.getActiveErrorRules).toHaveBeenCalledTimes(2);
+    expect(errorRuleDetector.detect("Your session is missing thinking fields").matched).toBe(false);
+  });
+
+  test("should restart reload when errorRulesUpdated lands after loading stops but before promise cleanup", async () => {
+    let resolveFirstLoad: ((value: ReturnType<typeof buildRule>[]) => void) | undefined;
+
+    mocks.getActiveErrorRules
+      .mockImplementationOnce(
+        () =>
+          new Promise<ReturnType<typeof buildRule>[]>((resolve) => {
+            resolveFirstLoad = (value) => {
+              resolve(value);
+              queueMicrotask(() => {
+                mocks.eventEmitter.emit("errorRulesUpdated");
+              });
+            };
+          })
+      )
+      .mockResolvedValueOnce([]);
+
+    const { errorRuleDetector } = await import("@/lib/error-rule-detector");
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const initialReload = errorRuleDetector.reload();
+
+    resolveFirstLoad?.([buildRule()]);
+    await initialReload;
+
+    expect(mocks.getActiveErrorRules).toHaveBeenCalledTimes(2);
+    expect(errorRuleDetector.detect("Your session is missing thinking fields").matched).toBe(false);
+  });
+});

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   isVendorTypeCircuitOpen: vi.fn(async () => false),
   recordVendorTypeAllEndpointsTimeout: vi.fn(async () => {}),
   categorizeErrorAsync: vi.fn(async () => 0),
+  getErrorDetectionResultAsync: vi.fn(async () => ({ matched: false })),
   getCachedSystemSettings: vi.fn(async () => ({
     enableThinkingSignatureRectifier: true,
     enableThinkingBudgetRectifier: true,
@@ -90,16 +91,19 @@ vi.mock("@/app/v1/_lib/proxy/errors", async (importOriginal) => {
   return {
     ...actual,
     categorizeErrorAsync: mocks.categorizeErrorAsync,
+    getErrorDetectionResultAsync: mocks.getErrorDetectionResultAsync,
   };
 });
 
 import {
   ErrorCategory as ProxyErrorCategory,
   ProxyError as UpstreamProxyError,
+  getErrorDetectionResultAsync,
 } from "@/app/v1/_lib/proxy/errors";
 import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
 import { ModelRedirector } from "@/app/v1/_lib/proxy/model-redirector";
 import { ProxySession } from "@/app/v1/_lib/proxy/session";
+import { logger } from "@/lib/logger";
 import type { Provider } from "@/types/provider";
 
 type AttemptRuntime = {
@@ -1288,6 +1292,15 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
 
     mocks.pickRandomProviderWithExclusion.mockResolvedValueOnce(provider2);
     mocks.categorizeErrorAsync.mockResolvedValueOnce(ProxyErrorCategory.NON_RETRYABLE_CLIENT_ERROR);
+    vi.mocked(getErrorDetectionResultAsync).mockResolvedValueOnce({
+      matched: true,
+      ruleId: 42,
+      category: "thinking_error",
+      pattern: "prompt too long",
+      matchType: "contains",
+      description: "Prompt too long",
+      overrideStatusCode: 400,
+    });
 
     const doForward = vi.spyOn(
       ProxyForwarder as unknown as {
@@ -1312,8 +1325,25 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
         expect.objectContaining({
           reason: "client_error_non_retryable",
           statusCode: 400,
+          errorDetails: expect.objectContaining({
+            matchedRule: expect.objectContaining({
+              ruleId: 42,
+            }),
+          }),
         }),
       ])
+    );
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      "ProxyForwarder: Non-retryable client error in hedge, aborting all attempts",
+      expect.objectContaining({
+        matchedRuleId: 42,
+        matchedRuleName: "Prompt too long",
+        matchedRulePattern: "prompt too long",
+        matchedRuleCategory: "thinking_error",
+        matchedRuleMatchType: "contains",
+        matchedRuleHasOverrideResponse: false,
+        matchedRuleHasOverrideStatusCode: true,
+      })
     );
   });
 

--- a/tests/unit/proxy/proxy-forwarder-retry-limit.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-retry-limit.test.ts
@@ -66,12 +66,19 @@ vi.mock("@/app/v1/_lib/proxy/errors", async (importOriginal) => {
   return {
     ...actual,
     categorizeErrorAsync: vi.fn(async () => actual.ErrorCategory.PROVIDER_ERROR),
+    getErrorDetectionResultAsync: vi.fn(async () => ({ matched: false })),
   };
 });
 
 import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
-import { ProxyError, ErrorCategory, categorizeErrorAsync } from "@/app/v1/_lib/proxy/errors";
+import {
+  ProxyError,
+  ErrorCategory,
+  categorizeErrorAsync,
+  getErrorDetectionResultAsync,
+} from "@/app/v1/_lib/proxy/errors";
 import { ProxySession } from "@/app/v1/_lib/proxy/session";
+import { logger } from "@/lib/logger";
 import type { Provider, ProviderEndpoint, ProviderType } from "@/types/provider";
 
 function makeEndpoint(input: {
@@ -1271,5 +1278,70 @@ describe("NON_RETRYABLE_CLIENT_ERROR regression tests", () => {
 
     const category = await realCategorize(socketErr);
     expect(category).toBe(RealErrorCategory.SYSTEM_ERROR);
+  });
+
+  test("NON_RETRYABLE_CLIENT_ERROR should log matched rule metadata when detection result is available", async () => {
+    const upstreamMessage =
+      "Your session is missing thinking fields juedged by Anthropic API. Please reopen a new session.";
+    const proxyError = new ProxyError("Provider returned 400", 400, {
+      body: JSON.stringify({
+        error: {
+          message: upstreamMessage,
+        },
+      }),
+      parsed: {
+        error: {
+          message: upstreamMessage,
+        },
+      },
+      providerId: 1,
+      providerName: "YesCode Team Claude",
+    });
+
+    const doForward = vi.spyOn(ProxyForwarder as unknown as { doForward: unknown }, "doForward");
+    doForward.mockRejectedValue(proxyError);
+
+    vi.mocked(categorizeErrorAsync).mockResolvedValue(ErrorCategory.NON_RETRYABLE_CLIENT_ERROR);
+    vi.mocked(getErrorDetectionResultAsync).mockResolvedValue({
+      matched: true,
+      ruleId: 42,
+      category: "thinking_error",
+      pattern: "missing thinking fields",
+      matchType: "contains",
+      description: "YesCode missing thinking fields",
+      overrideResponse: {
+        type: "error",
+        error: {
+          type: "thinking_error",
+          message: "thinking block 缺失",
+        },
+      },
+      overrideStatusCode: 400,
+    });
+
+    const session = createSession(new URL("https://example.com/v1/messages"));
+    const provider = createProvider({
+      id: 1,
+      name: "YesCode Team Claude",
+      providerType: "claude",
+      providerVendorId: 1,
+    });
+    session.setProvider(provider);
+
+    await expect(ProxyForwarder.send(session)).rejects.toBe(proxyError);
+
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      "ProxyForwarder: Non-retryable client error, stopping immediately",
+      expect.objectContaining({
+        matchedRuleId: 42,
+        matchedRuleName: "YesCode missing thinking fields",
+        matchedRulePattern: "missing thinking fields",
+        matchedRuleCategory: "thinking_error",
+        matchedRuleMatchType: "contains",
+        matchedRuleHasOverrideResponse: true,
+        matchedRuleHasOverrideStatusCode: true,
+      })
+    );
+    expect(session.getProviderChain()[0].errorDetails?.matchedRule?.ruleId).toBe(42);
   });
 });

--- a/tests/unit/proxy/proxy-forwarder-retry-limit.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-retry-limit.test.ts
@@ -1344,4 +1344,47 @@ describe("NON_RETRYABLE_CLIENT_ERROR regression tests", () => {
     );
     expect(session.getProviderChain()[0].errorDetails?.matchedRule?.ruleId).toBe(42);
   });
+
+  test("NON_RETRYABLE_CLIENT_ERROR should log matched rule metadata for plain Error branch", async () => {
+    const plainError = new Error("missing thinking fields");
+
+    const doForward = vi.spyOn(ProxyForwarder as unknown as { doForward: unknown }, "doForward");
+    doForward.mockRejectedValue(plainError);
+
+    vi.mocked(categorizeErrorAsync).mockResolvedValue(ErrorCategory.NON_RETRYABLE_CLIENT_ERROR);
+    vi.mocked(getErrorDetectionResultAsync).mockResolvedValue({
+      matched: true,
+      ruleId: 42,
+      category: "thinking_error",
+      pattern: "missing thinking fields",
+      matchType: "contains",
+      description: "YesCode missing thinking fields",
+      overrideStatusCode: 400,
+    });
+
+    const session = createSession(new URL("https://example.com/v1/messages"));
+    const provider = createProvider({
+      id: 1,
+      name: "YesCode Team Claude",
+      providerType: "claude",
+      providerVendorId: 1,
+    });
+    session.setProvider(provider);
+
+    await expect(ProxyForwarder.send(session)).rejects.toBe(plainError);
+
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      "ProxyForwarder: Non-retryable client error (plain error), stopping immediately",
+      expect.objectContaining({
+        matchedRuleId: 42,
+        matchedRuleName: "YesCode missing thinking fields",
+        matchedRulePattern: "missing thinking fields",
+        matchedRuleCategory: "thinking_error",
+        matchedRuleMatchType: "contains",
+        matchedRuleHasOverrideResponse: false,
+        matchedRuleHasOverrideStatusCode: true,
+      })
+    );
+    expect(session.getProviderChain()[0].errorDetails?.matchedRule?.ruleId).toBe(42);
+  });
 });


### PR DESCRIPTION
## Summary

Fix a race condition in `ErrorRuleDetector.reload()` where concurrent reload events (e.g. from `errorRulesUpdated` pubsub) could be silently dropped, leaving stale (including disabled) error rules active in memory. Also enrich non-retryable client error logs with matched rule metadata for easier debugging.

## Problem

When an `errorRulesUpdated` event fires while a reload is already in progress, the old implementation silently discards the new event (`"skipping"`). This creates a window where a rule disabled in the database remains active in the in-memory cache until the next organic reload trigger. In practice, this means disabling an error rule via the dashboard may not take effect promptly under concurrent updates.

**Related Issues/PRs:**
- Follow-up to #418 - extends matched rule detail recording to non-retryable client error log output

## Solution

### Queued reload mechanism
Replace the simple `isLoading` skip guard with a `do...while` loop driven by two new fields:
- `activeReloadPromise` - coalesces concurrent callers onto the same in-flight promise
- `reloadRequestedWhileLoading` - flags that a new reload pass is needed once the current one finishes

This covers two race windows:
1. **Mid-reload**: an event arrives while the DB query is in flight; the flag ensures a second pass runs immediately after the first completes.
2. **Post-settlement**: an event lands after the `do...while` exits but before the `finally` block clears `activeReloadPromise`; a `shouldRestartAfterSettle` check in `.finally()` triggers a fresh `reload()` call.

### Enhanced logging
Spread matched rule metadata (`ruleId`, `ruleName`, `pattern`, `category`, `matchType`, override flags) into the `logger.warn` context object for `NON_RETRYABLE_CLIENT_ERROR` paths, making it straightforward to correlate log entries with specific error rules.

## Changes

### Core Changes
- **`src/lib/error-rule-detector.ts`** - Rewrite `reload()` from skip-if-loading to queued-reload-loop with `activeReloadPromise` / `reloadRequestedWhileLoading` tracking
- **`src/app/v1/_lib/proxy/forwarder.ts`** - Add `matchedRuleLogContext` object and spread it into both non-retryable client error log call sites

### Tests
- **`tests/unit/lib/error-rule-detector-reload-queue.test.ts`** (new) - Two tests covering mid-reload and post-settlement race windows
- **`tests/unit/proxy/proxy-forwarder-retry-limit.test.ts`** - New test verifying matched rule metadata appears in log output; updated mock to include `getErrorDetectionResultAsync`

## Breaking Changes

None. The `reload()` method signature is unchanged. Internal-only fields were added.

## Testing

### Automated Tests
- [x] Unit tests added for both reload race windows
- [x] Unit test added for matched rule metadata logging
- [x] Existing test mock updated to accommodate new `getErrorDetectionResultAsync` import

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No breaking changes

---
*Description enhanced by Claude*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition in `ErrorRuleDetector.reload()` where concurrent `errorRulesUpdated` events during an in-flight DB reload were silently dropped, leaving stale (including disabled) rules active in memory. It replaces the old skip-if-loading guard with a `do...while` loop driven by `activeReloadPromise` and `reloadRequestedWhileLoading`, covering both the mid-reload and post-settlement race windows. Additionally, the `forwarder.ts` non-retryable client error paths are refactored into helper functions and now spread matched rule metadata into log context for easier debugging.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the race-condition fix is well-reasoned, the post-settlement window is covered, and five targeted tests validate each scenario including DB failure behaviour.

No P0 or P1 findings. The do-while queued-reload loop is correctly implemented: mid-reload events are coalesced, post-settlement events are caught in the finally check, and the intentional DB-failure drop prevents hot retry loops. The forwarder refactor is a pure extraction of inline code into helpers with no behaviour change. Test coverage is thorough.

No files require special attention.
</details>

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The changes are confined to in-memory cache invalidation logic and log enrichment; no user-controlled input flows into the new code paths.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/error-rule-detector.ts | Core fix: reload() rewritten from a skip-guard to a do...while queued-reload loop; activeReloadPromise/reloadRequestedWhileLoading fields added; post-settlement restart handled in finally; intentional drop of queued reload on DB failure prevents retry storms. |
| src/app/v1/_lib/proxy/forwarder.ts | Non-retryable client error handling extracted into buildMatchedRuleDetails, buildMatchedRuleLogContext, and buildClientErrorChainEntry helpers; matched rule metadata now spread into both logger.warn call sites. |
| tests/unit/lib/error-rule-detector-reload-queue.test.ts | New test file covering five scenarios: mid-reload event queuing, post-settlement restart, DB failure stops queued retry, plain-waiter reuse, and ensureInitialized waiting for the queued rerun to finish. |
| tests/unit/proxy/proxy-forwarder-retry-limit.test.ts | Mock updated to include getErrorDetectionResultAsync; new test verifies matched rule metadata appears in log output for NON_RETRYABLE_CLIENT_ERROR paths. |
| tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts | Minor mock update to add getErrorDetectionResultAsync for compatibility with the refactored forwarder import. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant E as eventEmitter
    participant H as handleUpdated
    participant R as reload()
    participant DB as getActiveErrorRules()
    participant D as detect()

    Note over R: activeReloadPromise = null
    H->>R: reload({ queueIfRunning: true })
    R->>R: start do-while loop
    R->>DB: getActiveErrorRules() [1st pass]
    Note over R: reloadRequestedWhileLoading = false, isLoading = true

    E-->>H: errorRulesUpdated (mid-reload)
    H->>R: reload({ queueIfRunning: true })
    R->>R: reloadRequestedWhileLoading = true (queued)
    R-->>H: return activeReloadPromise (same)

    DB-->>R: rules resolved
    R->>R: atomic swap patterns
    R->>R: isLoading = false (finally)
    R->>R: while(reloadRequestedWhileLoading) → true → loop again
    R->>R: reloadRequestedWhileLoading = false, isLoading = true
    R->>DB: getActiveErrorRules() [2nd pass]
    DB-->>R: rules resolved (disabled rule removed)
    R->>R: atomic swap patterns (stale rule gone)
    R->>R: isLoading = false (finally)
    R->>R: while(reloadRequestedWhileLoading) → false → exit

    Note over R: activeReloadPromise.finally runs
    R->>R: activeReloadPromise = null
    Note over R: shouldRestartAfterSettle = false → done

    D->>D: detect() → stale rule NOT matched ✓
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: await queued error rule reload comp..."](https://github.com/ding113/claude-code-hub/commit/4dd46c332f3dace30b5b5070ace5c8b437a4da4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27846221)</sub>

<!-- /greptile_comment -->