### PR TITLE
fix: prevent STREAM_PROCESSING_ERROR from premature agent pool eviction

### DIFF
--- a/src/app/v1/_lib/proxy/errors.ts
+++ b/src/app/v1/_lib/proxy/errors.ts
@@ -739,6 +739,8 @@ export function isTransportError(error: Error): boolean {
     "UND_ERR_CONNECT_TIMEOUT",
     "UND_ERR_HEADERS_TIMEOUT",
     "UND_ERR_BODY_TIMEOUT",
+    "UND_ERR_DESTROYED", // agent destroyed while request in flight
+    "UND_ERR_CLOSED", // agent closed while request in flight
     "ECONNREFUSED",
     "ECONNRESET",
     "ETIMEDOUT",
@@ -749,7 +751,12 @@ export function isTransportError(error: Error): boolean {
   const TRANSPORT_MESSAGE_SIGNATURES = ["other side closed", "fetch failed"];
 
   // Check error name
-  if (error.name === "SocketError") return true;
+  if (
+    error.name === "SocketError" ||
+    error.name === "ClientDestroyedError" ||
+    error.name === "ClientClosedError"
+  )
+    return true;
 
   // Check error code on error itself or cause
   const code =
@@ -760,6 +767,9 @@ export function isTransportError(error: Error): boolean {
   // Check message for known transport signatures
   const msg = error.message.toLowerCase();
   if (TRANSPORT_MESSAGE_SIGNATURES.some((sig) => msg.includes(sig))) return true;
+
+  // Check for HTTP/2 protocol errors (stream resets, GOAWAY, etc.)
+  if (isHttp2Error(error)) return true;
 
   return false;
 }

--- a/src/app/v1/_lib/proxy/errors.ts
+++ b/src/app/v1/_lib/proxy/errors.ts
@@ -746,6 +746,9 @@ export function isTransportError(error: Error): boolean {
     "ETIMEDOUT",
     "ENOTFOUND",
     "EAI_AGAIN",
+    // Node.js HTTP/2 stream errors —— 常被 undici/fetch 包装后放到 cause 链上
+    // 必须在这里登记，才能在 cause.code 分支里正确识别为 transport 错误
+    "ERR_HTTP2_STREAM_ERROR",
   ]);
 
   const TRANSPORT_MESSAGE_SIGNATURES = ["other side closed", "fetch failed"];

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -2483,7 +2483,7 @@ export class ProxyForwarder {
     const enableHttp2 = await isHttp2Enabled();
 
     // ⭐ 应用代理配置（如果配置了）- 使用 Agent Pool 缓存连接
-    const proxyConfig = await getProxyAgentForProvider(provider, proxyUrl, enableHttp2);
+    let proxyConfig = await getProxyAgentForProvider(provider, proxyUrl, enableHttp2);
     // 用于直连场景的 cacheKey（SSL 错误时标记不健康）
     let directConnectionCacheKey: string | null = null;
 
@@ -2553,6 +2553,12 @@ export class ProxyForwarder {
       // ⭐ fetch 失败：清除所有超时定时器
       if (responseTimeoutId) {
         clearTimeout(responseTimeoutId);
+      }
+
+      // Release agent ref count on fetch failure (request never started streaming)
+      const releaseKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
+      if (releaseKey) {
+        getGlobalAgentPool().releaseAgent(releaseKey);
       }
 
       // 捕获 fetch 原始错误（网络错误、DNS 解析失败、连接失败等）
@@ -2737,8 +2743,9 @@ export class ProxyForwarder {
         }
 
         // 如果使用了代理，创建不支持 HTTP/2 的代理 Agent
+        let http1ProxyConfig: typeof proxyConfig = null;
         if (proxyConfig) {
-          const http1ProxyConfig = await getProxyAgentForProvider(provider, proxyUrl, false);
+          http1ProxyConfig = await getProxyAgentForProvider(provider, proxyUrl, false);
           if (http1ProxyConfig) {
             http1FallbackInit.dispatcher = http1ProxyConfig.agent;
           }
@@ -2761,6 +2768,10 @@ export class ProxyForwarder {
             providerName: provider.name,
           });
 
+          // Update tracking to the H1 fallback agent (H2 agent was already released at catch-block top)
+          proxyConfig = http1ProxyConfig;
+          directConnectionCacheKey = null;
+
           // 重新启动响应超时计时器（如果之前有配置超时时间）
           // 注意：responseTimeoutId 在 catch 块开头已被清除，这里只需检查 responseTimeoutMs
           if (responseTimeoutMs > 0) {
@@ -2776,6 +2787,11 @@ export class ProxyForwarder {
 
           // 成功后跳过 throw，继续执行后续逻辑（不计入熔断器）
         } catch (http1Error) {
+          // Release H1 fallback agent ref count before re-throwing
+          if (http1ProxyConfig?.cacheKey) {
+            getGlobalAgentPool().releaseAgent(http1ProxyConfig.cacheKey);
+          }
+
           // HTTP/1.1 也失败，记录并抛出原始错误
           logger.error("ProxyForwarder: HTTP/1.1 fallback also failed", {
             providerId: provider.id,
@@ -2935,9 +2951,9 @@ export class ProxyForwarder {
     // 注意：用户要求所有 4xx 都重试，包括 401、403、429 等
     if (!response.ok) {
       // ⚠️ HTTP 错误：不要在读取响应体之前清除响应超时定时器
-      // 原因：某些上游会在返回 4xx/5xx 后“卡住不结束 body”，
+      // 原因：某些上游会在返回 4xx/5xx 后”卡住不结束 body”，
       // 若提前 clearTimeout，会导致 ProxyError.fromUpstreamResponse() 的 response.text() 无限等待，
-      // 从而让整条请求链路（含客户端）悬挂，前端表现为一直“请求中”。
+      // 从而让整条请求链路（含客户端）悬挂，前端表现为一直”请求中”。
       //
       // 正确策略：保留 response timeout 继续监控 body 读取，并在 finally 里清理定时器。
       try {
@@ -2949,6 +2965,11 @@ export class ProxyForwarder {
         if (responseTimeoutId) {
           clearTimeout(responseTimeoutId);
         }
+        // Release agent ref count (response-handler will never run for error responses)
+        const errorReleaseKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
+        if (errorReleaseKey) {
+          getGlobalAgentPool().releaseAgent(errorReleaseKey);
+        }
       }
     }
 
@@ -2957,6 +2978,7 @@ export class ProxyForwarder {
     const sessionWithTimeout = session as ProxySession & {
       clearResponseTimeout?: () => void;
       responseController?: AbortController;
+      releaseAgent?: () => void;
     };
 
     sessionWithTimeout.clearResponseTimeout = () => {
@@ -2972,6 +2994,16 @@ export class ProxyForwarder {
 
     // 传递 responseController 引用，让 response-handler 能区分超时和客户端中断
     sessionWithTimeout.responseController = responseController;
+
+    // Attach agent release callback for in-flight reference counting.
+    // response-handler must call this in its finally block after the stream is fully consumed.
+    const agentCacheKeyToRelease = proxyConfig?.cacheKey ?? directConnectionCacheKey;
+    if (agentCacheKeyToRelease) {
+      const pool = getGlobalAgentPool();
+      sessionWithTimeout.releaseAgent = () => {
+        pool.releaseAgent(agentCacheKeyToRelease);
+      };
+    }
 
     return response;
   }

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -2483,38 +2483,12 @@ export class ProxyForwarder {
     const enableHttp2 = await isHttp2Enabled();
 
     // ⭐ 应用代理配置（如果配置了）- 使用 Agent Pool 缓存连接
-    let proxyConfig = await getProxyAgentForProvider(provider, proxyUrl, enableHttp2);
-    // 用于直连场景的 cacheKey（SSL 错误时标记不健康）
+    // 注意：proxyConfig 与 directConnectionCacheKey 的声明保持在 try 外部，
+    // 以便 catch 块可以根据它们做 fallback / SSL 不健康标记 / ref 释放。
+    let proxyConfig: Awaited<ReturnType<typeof getProxyAgentForProvider>> = null;
+    // 用于直连场景的 cacheKey + dispatcher id（SSL 错误时标记不健康 / release 校验）
     let directConnectionCacheKey: string | null = null;
-
-    if (proxyConfig) {
-      init.dispatcher = proxyConfig.agent;
-      logger.info("ProxyForwarder: Using proxy", {
-        providerId: provider.id,
-        providerName: provider.name,
-        proxyUrl: proxyConfig.proxyUrl,
-        fallbackToDirect: proxyConfig.fallbackToDirect,
-        targetUrl: new URL(proxyUrl).origin,
-        http2Enabled: proxyConfig.http2Enabled,
-      });
-    } else if (enableHttp2) {
-      // 直连场景：使用 Agent Pool 获取缓存的 HTTP/2 Agent（避免内存泄漏）
-      const pool = getGlobalAgentPool();
-      const { agent, cacheKey } = await pool.getAgent({
-        endpointUrl: proxyUrl,
-        proxyUrl: null,
-        enableHttp2: true,
-      });
-      init.dispatcher = agent;
-      directConnectionCacheKey = cacheKey;
-      logger.debug("ProxyForwarder: Using cached HTTP/2 Agent for direct connection", {
-        providerId: provider.id,
-        providerName: provider.name,
-        cacheKey,
-      });
-    }
-
-    (init as Record<string, unknown>).verbose = true;
+    let directConnectionDispatcherId: string | null = null;
 
     // ⭐ 始终使用容错流处理以减少 "TypeError: terminated" 错误
     // 背景：undici fetch 的自动解压在流被提前终止时会抛出 "TypeError: terminated"
@@ -2526,6 +2500,40 @@ export class ProxyForwarder {
     let response: Response;
     const fetchStartTime = Date.now();
     try {
+      // ⭐ 把 agent 获取 & 配置日志放进 try 块，确保获取后到 fetch 之前任何异常
+      // （例如 URL 解析失败）都会走 catch 的统一释放逻辑，避免泄漏 activeRequests。
+      proxyConfig = await getProxyAgentForProvider(provider, proxyUrl, enableHttp2);
+
+      if (proxyConfig) {
+        init.dispatcher = proxyConfig.agent;
+        logger.info("ProxyForwarder: Using proxy", {
+          providerId: provider.id,
+          providerName: provider.name,
+          proxyUrl: proxyConfig.proxyUrl,
+          fallbackToDirect: proxyConfig.fallbackToDirect,
+          targetUrl: new URL(proxyUrl).origin,
+          http2Enabled: proxyConfig.http2Enabled,
+        });
+      } else if (enableHttp2) {
+        // 直连场景：使用 Agent Pool 获取缓存的 HTTP/2 Agent（避免内存泄漏）
+        const pool = getGlobalAgentPool();
+        const { agent, cacheKey, dispatcherId } = await pool.getAgent({
+          endpointUrl: proxyUrl,
+          proxyUrl: null,
+          enableHttp2: true,
+        });
+        init.dispatcher = agent;
+        directConnectionCacheKey = cacheKey;
+        directConnectionDispatcherId = dispatcherId;
+        logger.debug("ProxyForwarder: Using cached HTTP/2 Agent for direct connection", {
+          providerId: provider.id,
+          providerName: provider.name,
+          cacheKey,
+        });
+      }
+
+      (init as Record<string, unknown>).verbose = true;
+
       // ⭐ 所有供应商使用 undici.request 绕过 fetch 的自动解压
       // 原因：undici fetch 无法关闭自动解压，上游可能无视 accept-encoding: identity 返回 gzip
       // 当 gzip 流被提前终止时（如连接关闭），undici Gunzip 会抛出 "TypeError: terminated"
@@ -2557,8 +2565,9 @@ export class ProxyForwarder {
 
       // Release agent ref count on fetch failure (request never started streaming)
       const releaseKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
-      if (releaseKey) {
-        getGlobalAgentPool().releaseAgent(releaseKey);
+      const releaseDispatcherId = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
+      if (releaseKey && releaseDispatcherId) {
+        getGlobalAgentPool().releaseAgent(releaseKey, releaseDispatcherId);
       }
 
       // 捕获 fetch 原始错误（网络错误、DNS 解析失败、连接失败等）
@@ -2771,6 +2780,7 @@ export class ProxyForwarder {
           // Update tracking to the H1 fallback agent (H2 agent was already released at catch-block top)
           proxyConfig = http1ProxyConfig;
           directConnectionCacheKey = null;
+          directConnectionDispatcherId = null;
 
           // 重新启动响应超时计时器（如果之前有配置超时时间）
           // 注意：responseTimeoutId 在 catch 块开头已被清除，这里只需检查 responseTimeoutMs
@@ -2788,8 +2798,11 @@ export class ProxyForwarder {
           // 成功后跳过 throw，继续执行后续逻辑（不计入熔断器）
         } catch (http1Error) {
           // Release H1 fallback agent ref count before re-throwing
-          if (http1ProxyConfig?.cacheKey) {
-            getGlobalAgentPool().releaseAgent(http1ProxyConfig.cacheKey);
+          if (http1ProxyConfig?.cacheKey && http1ProxyConfig?.dispatcherId) {
+            getGlobalAgentPool().releaseAgent(
+              http1ProxyConfig.cacheKey,
+              http1ProxyConfig.dispatcherId
+            );
           }
 
           // HTTP/1.1 也失败，记录并抛出原始错误
@@ -2844,6 +2857,15 @@ export class ProxyForwarder {
                 providerId: provider.id,
                 providerName: provider.name,
               });
+
+              // ⚠️ 关键：catch 入口已经释放了代理 agent 的 ref count（见本 catch 块顶部），
+              // 而 fallback 后走的是"无 dispatcher 直连"，不再持有 agent pool 的引用。
+              // 如果保留 proxyConfig，后续 session.releaseAgent 会对同一个 cacheKey 再减 1，
+              // 把其他正在共享这个 agent 的请求计数吃掉，导致新连接被提前驱逐。
+              // 此处必须同 H2→H1 fallback 一样清空跟踪信息。
+              proxyConfig = null;
+              directConnectionCacheKey = null;
+              directConnectionDispatcherId = null;
 
               // 重新启动响应超时计时器（如果之前有配置超时时间）
               // 注意：responseTimeoutId 在 catch 块开头已被清除，这里只需检查 responseTimeoutMs
@@ -2967,8 +2989,9 @@ export class ProxyForwarder {
         }
         // Release agent ref count (response-handler will never run for error responses)
         const errorReleaseKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
-        if (errorReleaseKey) {
-          getGlobalAgentPool().releaseAgent(errorReleaseKey);
+        const errorReleaseDispatcherId = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
+        if (errorReleaseKey && errorReleaseDispatcherId) {
+          getGlobalAgentPool().releaseAgent(errorReleaseKey, errorReleaseDispatcherId);
         }
       }
     }
@@ -2998,10 +3021,11 @@ export class ProxyForwarder {
     // Attach agent release callback for in-flight reference counting.
     // response-handler must call this in its finally block after the stream is fully consumed.
     const agentCacheKeyToRelease = proxyConfig?.cacheKey ?? directConnectionCacheKey;
-    if (agentCacheKeyToRelease) {
+    const agentDispatcherIdToRelease = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
+    if (agentCacheKeyToRelease && agentDispatcherIdToRelease) {
       const pool = getGlobalAgentPool();
       sessionWithTimeout.releaseAgent = () => {
-        pool.releaseAgent(agentCacheKeyToRelease);
+        pool.releaseAgent(agentCacheKeyToRelease, agentDispatcherIdToRelease);
       };
     }
 

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -40,6 +40,22 @@ import { isClientAbortError, isTransportError } from "./errors";
 import type { ProxySession } from "./session";
 import { consumeDeferredStreamingFinalization } from "./stream-finalization";
 
+/**
+ * Idempotent helper to release the agent pool reference count attached to a session.
+ * Prevents double-release by clearing the callback after first invocation.
+ */
+function releaseSessionAgent(session: ProxySession): void {
+  const s = session as ProxySession & { releaseAgent?: () => void };
+  if (s.releaseAgent) {
+    try {
+      s.releaseAgent();
+    } catch {
+      // ignore - agent may already be evicted
+    }
+    s.releaseAgent = undefined;
+  }
+}
+
 export type UsageMetrics = {
   input_tokens?: number;
   output_tokens?: number;
@@ -881,6 +897,7 @@ export class ProxyResponseHandler {
               );
             }
           } finally {
+            releaseSessionAgent(session);
             AsyncTaskManager.cleanup(taskId);
           }
         })();
@@ -1324,6 +1341,7 @@ export class ProxyResponseHandler {
           });
         }
       } finally {
+        releaseSessionAgent(session);
         AsyncTaskManager.cleanup(taskId);
       }
     })();
@@ -1815,6 +1833,7 @@ export class ProxyResponseHandler {
                 error: e instanceof Error ? e.message : String(e),
               });
             }
+            releaseSessionAgent(session);
             AsyncTaskManager.cleanup(taskId);
           }
         })();
@@ -2502,6 +2521,7 @@ export class ProxyResponseHandler {
             releaseError,
           });
         }
+        releaseSessionAgent(session);
         AsyncTaskManager.cleanup(taskId);
       }
     })();

--- a/src/lib/proxy-agent.ts
+++ b/src/lib/proxy-agent.ts
@@ -257,6 +257,8 @@ export {
 export interface ProxyConfigWithCacheKey extends ProxyConfig {
   /** Cache key for marking agent as unhealthy on SSL errors */
   cacheKey: string;
+  /** Dispatcher generation id —— 必须在 releaseAgent 时回传，避免跨代误减 */
+  dispatcherId: string;
 }
 
 /**
@@ -289,7 +291,7 @@ export async function getProxyAgentForProvider(
 
   const pool = getPool();
 
-  const { agent, cacheKey } = await pool.getAgent({
+  const { agent, cacheKey, dispatcherId } = await pool.getAgent({
     endpointUrl: targetUrl,
     proxyUrl,
     enableHttp2,
@@ -306,5 +308,6 @@ export async function getProxyAgentForProvider(
     proxyUrl: maskProxyUrl(proxyUrl),
     http2Enabled: actualHttp2Enabled,
     cacheKey,
+    dispatcherId,
   };
 }

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -30,6 +30,14 @@ export interface AgentPoolConfig {
  * Cached Agent entry
  */
 interface CachedAgent {
+  /**
+   * Unique dispatcher identity (generation token).
+   *
+   * 与 cacheKey 不同：cacheKey 只代表"哪个端点 + 代理 + 协议"，同一个 key 在驱逐/硬过期后
+   * 会对应新的 dispatcher 实例。为了避免旧请求的 release 把新实例的 activeRequests 错减，
+   * 每次创建都生成新的 id，release 时必须校验归属。
+   */
+  id: string;
   agent: Dispatcher;
   endpointKey: string;
   createdAt: number;
@@ -71,6 +79,11 @@ export interface GetAgentResult {
   agent: Dispatcher;
   isNew: boolean;
   cacheKey: string;
+  /**
+   * Dispatcher generation id. 必须在 releaseAgent 时回传，防止跨代误减。
+   * 若调用者拿到的 dispatcher 被驱逐后重建，release 会基于 id 校验并忽略无效请求。
+   */
+  dispatcherId: string;
 }
 
 /**
@@ -84,9 +97,12 @@ export interface AgentPool {
 
   /**
    * Release an agent after a request (including streaming body) has completed.
-   * Decrements the in-flight reference count so the agent can be evicted when idle.
+   *
+   * 必须同时传入 dispatcherId —— 仅当当前缓存条目的 id 与传入值完全匹配时才会减 1。
+   * 这样即便 cacheKey 对应的 dispatcher 在驱逐/硬过期后被重建，旧请求的 release
+   * 也不会误减新实例的 activeRequests，从而避免"新连接刚建起就被提前驱逐"。
    */
-  releaseAgent(cacheKey: string): void;
+  releaseAgent(cacheKey: string, dispatcherId: string): void;
 
   /**
    * Mark an Agent as unhealthy (will be replaced on next getAgent call)
@@ -175,6 +191,8 @@ export class AgentPoolImpl implements AgentPool {
   };
   /** Pending agent creation promises to prevent race conditions */
   private pendingCreations: Map<string, Promise<GetAgentResult>> = new Map();
+  /** Monotonic counter for generating unique dispatcher ids per creation */
+  private dispatcherIdCounter = 0;
   /**
    * Pending destroy/close promises (best-effort).
    *
@@ -218,7 +236,7 @@ export class AgentPoolImpl implements AgentPool {
       cached.requestCount++;
       cached.activeRequests++;
       this.stats.cacheHits++;
-      return { agent: cached.agent, isNew: false, cacheKey };
+      return { agent: cached.agent, isNew: false, cacheKey, dispatcherId: cached.id };
     }
 
     // Check if there's a pending creation for this key (race condition prevention)
@@ -226,6 +244,15 @@ export class AgentPoolImpl implements AgentPool {
     if (pending) {
       // Wait for the pending creation and return its result
       const result = await pending;
+      // ⚠️ 关键：等待 pending 创建的调用者也必须计入 activeRequests。
+      // 创建者在 createAgentWithCache 里把 activeRequests 初始化为 1（只代表它自己），
+      // 这里的每个等待者都要再 +1，否则一旦创建者完成并减到 0，cleanup/LRU 会在其它
+      // 仍在飞行中的请求头上把共享 agent 驱逐掉，又会把 STREAM_PROCESSING_ERROR 带回来。
+      const currentCached = this.cache.get(cacheKey);
+      if (currentCached && currentCached.id === result.dispatcherId) {
+        currentCached.activeRequests++;
+        currentCached.lastUsedAt = Date.now();
+      }
       // Count as cache hit - we're reusing the pending result, not creating a new agent
       // Note: Don't decrement cacheMisses here since we never incremented it for this request
       this.stats.cacheHits++;
@@ -264,8 +291,10 @@ export class AgentPoolImpl implements AgentPool {
     // Create new agent
     const agent = await this.createAgent(params);
     const url = new URL(params.endpointUrl);
+    const dispatcherId = `disp-${++this.dispatcherIdCounter}`;
 
     const newCached: CachedAgent = {
+      id: dispatcherId,
       agent,
       endpointKey: url.origin,
       createdAt: Date.now(),
@@ -280,12 +309,15 @@ export class AgentPoolImpl implements AgentPool {
     // Enforce max size (LRU eviction)
     await this.enforceMaxSize();
 
-    return { agent, isNew: true, cacheKey };
+    return { agent, isNew: true, cacheKey, dispatcherId };
   }
 
-  releaseAgent(cacheKey: string): void {
+  releaseAgent(cacheKey: string, dispatcherId: string): void {
     const cached = this.cache.get(cacheKey);
-    if (cached && cached.activeRequests > 0) {
+    // 必须校验 dispatcher 身份：如果 cacheKey 已经指向新生成的 dispatcher，
+    // 说明调用者对应的老 dispatcher 已经被驱逐（30 分钟硬过期 / markUnhealthy / LRU），
+    // 这时候直接忽略，避免把新实例的 activeRequests 错减 1 触发提前驱逐。
+    if (cached && cached.id === dispatcherId && cached.activeRequests > 0) {
       cached.activeRequests--;
       cached.lastUsedAt = Date.now(); // refresh TTL from stream completion
     }

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -36,6 +36,8 @@ interface CachedAgent {
   lastUsedAt: number;
   requestCount: number;
   healthy: boolean;
+  /** Number of in-flight requests using this agent (prevents premature eviction) */
+  activeRequests: number;
 }
 
 /**
@@ -49,6 +51,8 @@ export interface AgentPoolStats {
   hitRate: number;
   unhealthyAgents: number;
   evictedAgents: number;
+  /** Total in-flight requests across all cached agents */
+  activeRequests: number;
 }
 
 /**
@@ -77,6 +81,12 @@ export interface AgentPool {
    * Get or create an Agent for the given parameters
    */
   getAgent(params: GetAgentParams): Promise<GetAgentResult>;
+
+  /**
+   * Release an agent after a request (including streaming body) has completed.
+   * Decrements the in-flight reference count so the agent can be evicted when idle.
+   */
+  releaseAgent(cacheKey: string): void;
 
   /**
    * Mark an Agent as unhealthy (will be replaced on next getAgent call)
@@ -206,6 +216,7 @@ export class AgentPoolImpl implements AgentPool {
     if (cached && !this.isExpired(cached)) {
       cached.lastUsedAt = Date.now();
       cached.requestCount++;
+      cached.activeRequests++;
       this.stats.cacheHits++;
       return { agent: cached.agent, isNew: false, cacheKey };
     }
@@ -261,6 +272,7 @@ export class AgentPoolImpl implements AgentPool {
       lastUsedAt: Date.now(),
       requestCount: 1,
       healthy: true,
+      activeRequests: 1,
     };
 
     this.cache.set(cacheKey, newCached);
@@ -269,6 +281,14 @@ export class AgentPoolImpl implements AgentPool {
     await this.enforceMaxSize();
 
     return { agent, isNew: true, cacheKey };
+  }
+
+  releaseAgent(cacheKey: string): void {
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.activeRequests > 0) {
+      cached.activeRequests--;
+      cached.lastUsedAt = Date.now(); // refresh TTL from stream completion
+    }
   }
 
   markUnhealthy(cacheKey: string, reason: string): void {
@@ -298,6 +318,11 @@ export class AgentPoolImpl implements AgentPool {
     const hitRate =
       this.stats.totalRequests > 0 ? this.stats.cacheHits / this.stats.totalRequests : 0;
 
+    let activeRequests = 0;
+    for (const cached of this.cache.values()) {
+      activeRequests += cached.activeRequests;
+    }
+
     return {
       cacheSize: this.cache.size,
       totalRequests: this.stats.totalRequests,
@@ -306,6 +331,7 @@ export class AgentPoolImpl implements AgentPool {
       hitRate,
       unhealthyAgents: unhealthyCount,
       evictedAgents: this.stats.evictedAgents,
+      activeRequests,
     };
   }
 
@@ -370,6 +396,14 @@ export class AgentPoolImpl implements AgentPool {
   }
 
   private isExpired(cached: CachedAgent, now: number = Date.now()): boolean {
+    // Hard upper bound: force-expire after 30 minutes regardless of active requests
+    // Prevents permanent pinning if releaseAgent is never called (caller bug)
+    const MAX_AGENT_LIFETIME_MS = 30 * 60 * 1000;
+    if (now - cached.createdAt > MAX_AGENT_LIFETIME_MS) return true;
+
+    // Never expire agents with in-flight requests
+    if (cached.activeRequests > 0) return false;
+
     return now - cached.lastUsedAt > this.config.agentTtlMs;
   }
 

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -343,13 +343,16 @@ describe("AgentPool", () => {
         agentTtlMs: 1000, // 1 second TTL
       });
 
-      await shortTtlPool.getAgent({
+      const { cacheKey } = await shortTtlPool.getAgent({
         endpointUrl: "https://api.anthropic.com/v1/messages",
         proxyUrl: null,
         enableHttp2: false,
       });
 
       expect(shortTtlPool.getPoolStats().cacheSize).toBe(1);
+
+      // Release the agent (simulates request completion)
+      shortTtlPool.releaseAgent(cacheKey);
 
       // Advance time past TTL
       vi.advanceTimersByTime(2000);
@@ -425,6 +428,200 @@ describe("AgentPool", () => {
       expect(stats.cacheSize).toBeLessThanOrEqual(2);
 
       await smallPool.shutdown();
+    });
+  });
+
+  describe("reference counting", () => {
+    it("should prevent expiration of agents with active requests", async () => {
+      const shortTtlPool = new AgentPoolImpl({
+        ...defaultConfig,
+        agentTtlMs: 1000,
+      });
+
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      // getAgent increments activeRequests
+      await shortTtlPool.getAgent(params);
+      expect(shortTtlPool.getPoolStats().activeRequests).toBe(1);
+
+      // Advance past TTL
+      vi.advanceTimersByTime(2000);
+
+      // Should NOT be evicted because activeRequests > 0
+      const cleaned = await shortTtlPool.cleanup();
+      expect(cleaned).toBe(0);
+      expect(shortTtlPool.getPoolStats().cacheSize).toBe(1);
+
+      await shortTtlPool.shutdown();
+    });
+
+    it("should allow expiration after all requests are released", async () => {
+      const shortTtlPool = new AgentPoolImpl({
+        ...defaultConfig,
+        agentTtlMs: 1000,
+      });
+
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      const { cacheKey } = await shortTtlPool.getAgent(params);
+      shortTtlPool.releaseAgent(cacheKey);
+      expect(shortTtlPool.getPoolStats().activeRequests).toBe(0);
+
+      // Advance past TTL
+      vi.advanceTimersByTime(2000);
+
+      const cleaned = await shortTtlPool.cleanup();
+      expect(cleaned).toBe(1);
+      expect(shortTtlPool.getPoolStats().cacheSize).toBe(0);
+
+      await shortTtlPool.shutdown();
+    });
+
+    it("should track multiple concurrent requests correctly", async () => {
+      const shortTtlPool = new AgentPoolImpl({
+        ...defaultConfig,
+        agentTtlMs: 1000,
+      });
+
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      // 3 concurrent requests to same agent
+      const r1 = await shortTtlPool.getAgent(params);
+      await shortTtlPool.getAgent(params);
+      await shortTtlPool.getAgent(params);
+      expect(shortTtlPool.getPoolStats().activeRequests).toBe(3);
+
+      // Release 2
+      shortTtlPool.releaseAgent(r1.cacheKey);
+      shortTtlPool.releaseAgent(r1.cacheKey);
+      expect(shortTtlPool.getPoolStats().activeRequests).toBe(1);
+
+      // Advance past TTL - should NOT be evicted
+      vi.advanceTimersByTime(2000);
+      const cleaned1 = await shortTtlPool.cleanup();
+      expect(cleaned1).toBe(0);
+
+      // Release last request
+      shortTtlPool.releaseAgent(r1.cacheKey);
+      expect(shortTtlPool.getPoolStats().activeRequests).toBe(0);
+
+      // Now advance past TTL - should be evicted
+      vi.advanceTimersByTime(2000);
+      const cleaned2 = await shortTtlPool.cleanup();
+      expect(cleaned2).toBe(1);
+
+      await shortTtlPool.shutdown();
+    });
+
+    it("should refresh lastUsedAt on release", async () => {
+      const shortTtlPool = new AgentPoolImpl({
+        ...defaultConfig,
+        agentTtlMs: 1000,
+      });
+
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      const { cacheKey } = await shortTtlPool.getAgent(params);
+
+      // Advance 800ms (close to TTL but not past)
+      vi.advanceTimersByTime(800);
+
+      // Release refreshes lastUsedAt
+      shortTtlPool.releaseAgent(cacheKey);
+
+      // Advance another 500ms (total 1300ms from start, but only 500ms from release)
+      vi.advanceTimersByTime(500);
+
+      // Should NOT be evicted (TTL reset by release)
+      const cleaned = await shortTtlPool.cleanup();
+      expect(cleaned).toBe(0);
+
+      await shortTtlPool.shutdown();
+    });
+
+    it("should force-expire after hard upper bound regardless of active requests", async () => {
+      const pool2 = new AgentPoolImpl({
+        ...defaultConfig,
+        agentTtlMs: 1000,
+      });
+
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      // getAgent increments activeRequests (never released)
+      await pool2.getAgent(params);
+      expect(pool2.getPoolStats().activeRequests).toBe(1);
+
+      // Advance past 30-minute hard upper bound
+      vi.advanceTimersByTime(31 * 60 * 1000);
+
+      const cleaned = await pool2.cleanup();
+      expect(cleaned).toBe(1);
+      expect(pool2.getPoolStats().cacheSize).toBe(0);
+
+      await pool2.shutdown();
+    });
+
+    it("should be a no-op when releasing non-existent key", () => {
+      // Should not throw
+      pool.releaseAgent("nonexistent-key");
+      expect(pool.getPoolStats().activeRequests).toBe(0);
+    });
+
+    it("should not go below zero on over-release", async () => {
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      const { cacheKey } = await pool.getAgent(params);
+      pool.releaseAgent(cacheKey);
+      // Release again when already at 0
+      pool.releaseAgent(cacheKey);
+
+      expect(pool.getPoolStats().activeRequests).toBe(0);
+    });
+
+    it("should include activeRequests in pool stats", async () => {
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      expect(pool.getPoolStats().activeRequests).toBe(0);
+
+      await pool.getAgent(params);
+      expect(pool.getPoolStats().activeRequests).toBe(1);
+
+      await pool.getAgent(params);
+      expect(pool.getPoolStats().activeRequests).toBe(2);
+
+      const { cacheKey } = await pool.getAgent(params);
+      expect(pool.getPoolStats().activeRequests).toBe(3);
+
+      pool.releaseAgent(cacheKey);
+      expect(pool.getPoolStats().activeRequests).toBe(2);
     });
   });
 

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -343,7 +343,7 @@ describe("AgentPool", () => {
         agentTtlMs: 1000, // 1 second TTL
       });
 
-      const { cacheKey } = await shortTtlPool.getAgent({
+      const { cacheKey, dispatcherId } = await shortTtlPool.getAgent({
         endpointUrl: "https://api.anthropic.com/v1/messages",
         proxyUrl: null,
         enableHttp2: false,
@@ -352,7 +352,7 @@ describe("AgentPool", () => {
       expect(shortTtlPool.getPoolStats().cacheSize).toBe(1);
 
       // Release the agent (simulates request completion)
-      shortTtlPool.releaseAgent(cacheKey);
+      shortTtlPool.releaseAgent(cacheKey, dispatcherId);
 
       // Advance time past TTL
       vi.advanceTimersByTime(2000);
@@ -471,8 +471,8 @@ describe("AgentPool", () => {
         enableHttp2: false,
       };
 
-      const { cacheKey } = await shortTtlPool.getAgent(params);
-      shortTtlPool.releaseAgent(cacheKey);
+      const { cacheKey, dispatcherId } = await shortTtlPool.getAgent(params);
+      shortTtlPool.releaseAgent(cacheKey, dispatcherId);
       expect(shortTtlPool.getPoolStats().activeRequests).toBe(0);
 
       // Advance past TTL
@@ -485,7 +485,7 @@ describe("AgentPool", () => {
       await shortTtlPool.shutdown();
     });
 
-    it("should track multiple concurrent requests correctly", async () => {
+    it("should track multiple sequential requests correctly", async () => {
       const shortTtlPool = new AgentPoolImpl({
         ...defaultConfig,
         agentTtlMs: 1000,
@@ -497,15 +497,15 @@ describe("AgentPool", () => {
         enableHttp2: false,
       };
 
-      // 3 concurrent requests to same agent
+      // 3 sequential requests to same agent (exercises the cache-hit path)
       const r1 = await shortTtlPool.getAgent(params);
       await shortTtlPool.getAgent(params);
       await shortTtlPool.getAgent(params);
       expect(shortTtlPool.getPoolStats().activeRequests).toBe(3);
 
       // Release 2
-      shortTtlPool.releaseAgent(r1.cacheKey);
-      shortTtlPool.releaseAgent(r1.cacheKey);
+      shortTtlPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
+      shortTtlPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
       expect(shortTtlPool.getPoolStats().activeRequests).toBe(1);
 
       // Advance past TTL - should NOT be evicted
@@ -514,7 +514,7 @@ describe("AgentPool", () => {
       expect(cleaned1).toBe(0);
 
       // Release last request
-      shortTtlPool.releaseAgent(r1.cacheKey);
+      shortTtlPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
       expect(shortTtlPool.getPoolStats().activeRequests).toBe(0);
 
       // Now advance past TTL - should be evicted
@@ -523,6 +523,113 @@ describe("AgentPool", () => {
       expect(cleaned2).toBe(1);
 
       await shortTtlPool.shutdown();
+    });
+
+    it("should count pending-creation waiters in activeRequests", async () => {
+      // ⭐ 回归用例：真正模拟"首次创建阶段的并发请求"
+      // 使用 vi.useRealTimers() 并通过 spy 阻塞 createAgent 以强制等待者走 pendingCreations 路径。
+      // 如果 waiter 未正确递增 activeRequests，下面 expect(3) 会退化为 1 或 2。
+      vi.useRealTimers();
+      try {
+        const concurrentPool = new AgentPoolImpl({
+          ...defaultConfig,
+          agentTtlMs: 60_000,
+        });
+
+        const params = {
+          endpointUrl: "https://api.anthropic.com/v1/messages",
+          proxyUrl: null,
+          enableHttp2: false,
+        };
+
+        // 用 deferred 控制 createAgent 的完成时机，保证后续 getAgent 都落入 pendingCreations
+        let releaseCreate: (() => void) | null = null;
+        const createBlocker = new Promise<void>((resolve) => {
+          releaseCreate = resolve;
+        });
+
+        // biome-ignore lint/suspicious/noExplicitAny: private 方法 spy
+        const createSpy = vi.spyOn(concurrentPool as any, "createAgent");
+        createSpy.mockImplementationOnce(async () => {
+          await createBlocker;
+          return {
+            close: vi.fn().mockResolvedValue(undefined),
+            destroy: vi.fn().mockResolvedValue(undefined),
+            options: {},
+          };
+        });
+
+        // 同时发起 3 个请求：首个进入 createAgentWithCache；后两个必须走 pendingCreations
+        const p1 = concurrentPool.getAgent(params);
+        const p2 = concurrentPool.getAgent(params);
+        const p3 = concurrentPool.getAgent(params);
+
+        // 稍微等一个 microtask，确保 p2/p3 已经进入 await pending 分支
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // 放行创建
+        releaseCreate?.();
+
+        const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+        // 三个调用应拿到相同的 cacheKey 与 dispatcherId
+        expect(r2.cacheKey).toBe(r1.cacheKey);
+        expect(r3.cacheKey).toBe(r1.cacheKey);
+        expect(r2.dispatcherId).toBe(r1.dispatcherId);
+        expect(r3.dispatcherId).toBe(r1.dispatcherId);
+
+        // 关键断言：所有 3 个并发 waiter 都应计入 activeRequests
+        expect(concurrentPool.getPoolStats().activeRequests).toBe(3);
+
+        // 释放 3 次后归零，且仍能再多释一次（no-op）
+        concurrentPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
+        concurrentPool.releaseAgent(r2.cacheKey, r2.dispatcherId);
+        concurrentPool.releaseAgent(r3.cacheKey, r3.dispatcherId);
+        expect(concurrentPool.getPoolStats().activeRequests).toBe(0);
+
+        createSpy.mockRestore();
+        await concurrentPool.shutdown();
+      } finally {
+        vi.useFakeTimers();
+      }
+    });
+
+    it("should ignore releaseAgent from stale dispatcher generation", async () => {
+      // ⭐ 回归用例：cacheKey 相同但 dispatcher 已被重建时，旧 release 不应误减新实例
+      const regenPool = new AgentPoolImpl({
+        ...defaultConfig,
+        agentTtlMs: 1000,
+      });
+
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      // 第一代 dispatcher
+      const r1 = await regenPool.getAgent(params);
+      expect(regenPool.getPoolStats().activeRequests).toBe(1);
+
+      // 模拟外部强制驱逐（例如 markUnhealthy 后下次 getAgent 触发 evictByKey）
+      regenPool.markUnhealthy(r1.cacheKey, "simulated SSL failure");
+
+      // 第二代 dispatcher（同 cacheKey，但 dispatcherId 必须不同）
+      const r2 = await regenPool.getAgent(params);
+      expect(r2.cacheKey).toBe(r1.cacheKey);
+      expect(r2.dispatcherId).not.toBe(r1.dispatcherId);
+      expect(regenPool.getPoolStats().activeRequests).toBe(1);
+
+      // 用第一代 dispatcherId 释放 —— 必须被忽略
+      regenPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
+      expect(regenPool.getPoolStats().activeRequests).toBe(1);
+
+      // 用第二代 dispatcherId 释放 —— 正常减到 0
+      regenPool.releaseAgent(r2.cacheKey, r2.dispatcherId);
+      expect(regenPool.getPoolStats().activeRequests).toBe(0);
+
+      await regenPool.shutdown();
     });
 
     it("should refresh lastUsedAt on release", async () => {
@@ -537,13 +644,13 @@ describe("AgentPool", () => {
         enableHttp2: false,
       };
 
-      const { cacheKey } = await shortTtlPool.getAgent(params);
+      const { cacheKey, dispatcherId } = await shortTtlPool.getAgent(params);
 
       // Advance 800ms (close to TTL but not past)
       vi.advanceTimersByTime(800);
 
       // Release refreshes lastUsedAt
-      shortTtlPool.releaseAgent(cacheKey);
+      shortTtlPool.releaseAgent(cacheKey, dispatcherId);
 
       // Advance another 500ms (total 1300ms from start, but only 500ms from release)
       vi.advanceTimersByTime(500);
@@ -583,7 +690,7 @@ describe("AgentPool", () => {
 
     it("should be a no-op when releasing non-existent key", () => {
       // Should not throw
-      pool.releaseAgent("nonexistent-key");
+      pool.releaseAgent("nonexistent-key", "disp-1");
       expect(pool.getPoolStats().activeRequests).toBe(0);
     });
 
@@ -594,10 +701,10 @@ describe("AgentPool", () => {
         enableHttp2: false,
       };
 
-      const { cacheKey } = await pool.getAgent(params);
-      pool.releaseAgent(cacheKey);
+      const { cacheKey, dispatcherId } = await pool.getAgent(params);
+      pool.releaseAgent(cacheKey, dispatcherId);
       // Release again when already at 0
-      pool.releaseAgent(cacheKey);
+      pool.releaseAgent(cacheKey, dispatcherId);
 
       expect(pool.getPoolStats().activeRequests).toBe(0);
     });
@@ -617,10 +724,10 @@ describe("AgentPool", () => {
       await pool.getAgent(params);
       expect(pool.getPoolStats().activeRequests).toBe(2);
 
-      const { cacheKey } = await pool.getAgent(params);
+      const { cacheKey, dispatcherId } = await pool.getAgent(params);
       expect(pool.getPoolStats().activeRequests).toBe(3);
 
-      pool.releaseAgent(cacheKey);
+      pool.releaseAgent(cacheKey, dispatcherId);
       expect(pool.getPoolStats().activeRequests).toBe(2);
     });
   });

--- a/tests/unit/transport-error-detection.test.ts
+++ b/tests/unit/transport-error-detection.test.ts
@@ -102,6 +102,18 @@ describe("isTransportError", () => {
       (err as Error & { cause: Error }).cause = cause;
       expect(isTransportError(err)).toBe(true);
     });
+
+    it("should detect ERR_HTTP2_STREAM_ERROR on cause", () => {
+      // ⭐ 回归：undici/fetch 会把底层 HTTP/2 错误包在 cause 里
+      // 之前 isTransportError 只看顶层 code，漏检后会把真正的 transport 故障
+      // 误判为供应商错误，直接把 agent 踢掉，反复触发 STREAM_PROCESSING_ERROR。
+      // 注意：外层使用不匹配任何 message/name 签名的描述，确保走 cause.code 路径。
+      const cause = new Error("Stream closed with error code");
+      (cause as NodeJS.ErrnoException).code = "ERR_HTTP2_STREAM_ERROR";
+      const err = new Error("request failed");
+      (err as Error & { cause: Error }).cause = cause;
+      expect(isTransportError(err)).toBe(true);
+    });
   });
 });
 

--- a/tests/unit/transport-error-detection.test.ts
+++ b/tests/unit/transport-error-detection.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Transport Error Detection Tests
+ *
+ * Validates that isTransportError correctly classifies errors from:
+ * - Agent pool destruction (UND_ERR_DESTROYED)
+ * - HTTP/2 stream errors (ERR_HTTP2_STREAM_ERROR, NGHTTP2_INTERNAL_ERROR)
+ * - Existing transport errors (ECONNRESET, etc.)
+ */
+import { describe, expect, it } from "vitest";
+import { isTransportError, isHttp2Error } from "@/app/v1/_lib/proxy/errors";
+
+describe("isTransportError", () => {
+  describe("existing transport errors (regression)", () => {
+    it("should detect ECONNRESET", () => {
+      const err = new Error("read ECONNRESET");
+      (err as NodeJS.ErrnoException).code = "ECONNRESET";
+      expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should detect UND_ERR_SOCKET", () => {
+      const err = new Error("Socket error");
+      (err as NodeJS.ErrnoException).code = "UND_ERR_SOCKET";
+      expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should detect SocketError by name", () => {
+      const err = new Error("Socket closed");
+      err.name = "SocketError";
+      expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should detect 'other side closed' message", () => {
+      const err = new Error("other side closed");
+      expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should detect 'fetch failed' message", () => {
+      const err = new Error("fetch failed");
+      expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should not detect generic errors", () => {
+      const err = new Error("Something went wrong");
+      expect(isTransportError(err)).toBe(false);
+    });
+  });
+
+  describe("agent destruction errors", () => {
+    it("should detect UND_ERR_DESTROYED by code", () => {
+      const err = new Error("The client is destroyed");
+      (err as NodeJS.ErrnoException).code = "UND_ERR_DESTROYED";
+      expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should detect ClientDestroyedError by name", () => {
+      const err = new Error("The client is destroyed");
+      err.name = "ClientDestroyedError";
+      expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should detect UND_ERR_CLOSED by code", () => {
+      const err = new Error("The client is closed");
+      (err as NodeJS.ErrnoException).code = "UND_ERR_CLOSED";
+      expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should detect ClientClosedError by name", () => {
+      const err = new Error("The client is closed");
+      err.name = "ClientClosedError";
+      expect(isTransportError(err)).toBe(true);
+    });
+  });
+
+  describe("HTTP/2 stream errors", () => {
+    it("should detect ERR_HTTP2_STREAM_ERROR via code", () => {
+      const err = new Error("Stream closed with error code NGHTTP2_INTERNAL_ERROR");
+      (err as NodeJS.ErrnoException).code = "ERR_HTTP2_STREAM_ERROR";
+      expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should detect NGHTTP2_INTERNAL_ERROR in message", () => {
+      const err = new Error("Stream closed with error code NGHTTP2_INTERNAL_ERROR");
+      expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should detect GOAWAY errors", () => {
+      const err = new Error("GOAWAY session");
+      expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should detect RST_STREAM errors", () => {
+      const err = new Error("RST_STREAM received");
+      expect(isTransportError(err)).toBe(true);
+    });
+  });
+
+  describe("error code on cause", () => {
+    it("should detect UND_ERR_DESTROYED on cause", () => {
+      const cause = new Error("destroyed");
+      (cause as NodeJS.ErrnoException).code = "UND_ERR_DESTROYED";
+      const err = new Error("fetch failed");
+      (err as Error & { cause: Error }).cause = cause;
+      expect(isTransportError(err)).toBe(true);
+    });
+  });
+});
+
+describe("isHttp2Error", () => {
+  it("should detect ERR_HTTP2_GOAWAY_SESSION", () => {
+    const err = new Error("ERR_HTTP2_GOAWAY_SESSION");
+    expect(isHttp2Error(err)).toBe(true);
+  });
+
+  it("should detect NGHTTP2_INTERNAL_ERROR in message", () => {
+    const err = new Error("Stream closed with error code NGHTTP2_INTERNAL_ERROR");
+    expect(isHttp2Error(err)).toBe(true);
+  });
+
+  it("should detect ERR_HTTP2_STREAM_ERROR by code", () => {
+    const err = new Error("Stream error");
+    (err as NodeJS.ErrnoException).code = "ERR_HTTP2_STREAM_ERROR";
+    expect(isHttp2Error(err)).toBe(true);
+  });
+
+  it("should not detect non-HTTP/2 errors", () => {
+    const err = new Error("Connection refused");
+    expect(isHttp2Error(err)).toBe(false);
+  });
+});


### PR DESCRIPTION
The agent pool cleanup timer was destroying HTTP agents after 5min TTL with no awareness of in-flight streaming requests, causing `ClientDestroyedError` and `ERR_HTTP2_STREAM_ERROR` for long-running responses. These errors were also misclassified because `isTransportError` did not recognize them.

## Problem

When streaming responses (e.g., Claude API long conversations) take longer than the agent pool's 5-minute TTL, the cleanup timer evicts and destroys the underlying HTTP agent mid-flight. This causes:
- `ClientDestroyedError` / `ClientClosedError` when the destroyed agent is used
- `ERR_HTTP2_STREAM_ERROR` / `NGHTTP2_INTERNAL_ERROR` for HTTP/2 connections
- These errors were misclassified (not caught by `isTransportError`), leading to incorrect retry behavior

## Solution

Three-part fix:

1. **Error classification** - Extend `isTransportError()` to recognize `UND_ERR_DESTROYED`, `UND_ERR_CLOSED`, `ClientDestroyedError`, `ClientClosedError`, and HTTP/2 protocol errors via `isHttp2Error()`. This ensures these errors classify as `STREAM_UPSTREAM_ABORTED` and trigger proper retry logic.

2. **Reference counting** - Add `activeRequests` counter to `AgentPool`. Agents with in-flight requests are protected from TTL-based eviction. A 30-minute hard upper bound prevents permanent pinning if `releaseAgent` is never called (caller bug).

3. **Lifecycle wiring** - Attach `releaseAgent` callback to the session object in `ProxyForwarder`, invoke it in `ProxyResponseHandler` finally blocks after stream completion. All code paths covered: successful stream, error response, fetch failure, and HTTP/1.1 fallback.

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/errors.ts` - Add `UND_ERR_DESTROYED`, `UND_ERR_CLOSED` codes; add `ClientDestroyedError`, `ClientClosedError` name checks; call `isHttp2Error()` for HTTP/2 protocol error detection
- `src/lib/proxy-agent/agent-pool.ts` - Add `activeRequests` field to `CachedAgent`, `releaseAgent()` method, reference counting in `getAgent()`, and 30-minute hard expiry upper bound in `isExpired()`
- `src/app/v1/_lib/proxy/forwarder.ts` - Wire `releaseAgent` on fetch failure, error responses, HTTP/1.1 fallback paths; attach `releaseAgent` callback to session for response-handler to call
- `src/app/v1/_lib/proxy/response-handler.ts` - Add `releaseSessionAgent()` helper (idempotent, double-release safe); call it in all finally blocks (4 streaming handler paths)

### Tests
- `tests/unit/transport-error-detection.test.ts` - New test file (129 lines): validates `isTransportError` classification for agent destruction errors, HTTP/2 stream errors, and existing transport errors (regression)
- `tests/unit/lib/proxy-agent/agent-pool.test.ts` - New "reference counting" test suite (198 lines): validates active request tracking, multi-request counting, TTL refresh on release, 30-minute hard upper bound, and edge cases (non-existent key, over-release)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes premature agent-pool eviction during long-running streams by adding `activeRequests` ref-counting to `AgentPoolImpl`, extending `isTransportError` to classify `ClientDestroyedError`/HTTP-2 destruction errors correctly, and wiring `releaseAgent` callbacks through all forwarder and response-handler code paths.

- **P1 gap in `enforceMaxSize()`**: The LRU size-pressure eviction path sorts purely by `lastUsedAt` and calls `evictByKey` without checking `activeRequests`. Long-running streams acquire an agent at time T; when the pool fills with newer agents, the streaming agent becomes the LRU candidate and is destroyed mid-flight — reproducing the same `ClientDestroyedError` the TTL fix prevents. The `isExpired()` guard added here is bypassed by this path.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with low-to-moderate risk; TTL-based and lifecycle eviction paths are well-protected, but the LRU size-pressure path retains the original race condition.

The three-part fix (error classification, ref-counting, lifecycle wiring) is well-designed and has good test coverage. The P1 `enforceMaxSize()` gap only triggers when the pool exceeds `maxTotalAgents` (100 by default) with concurrent long-running streams and many distinct endpoints — an uncommon production scenario — but it is a real defect that should be fixed before the fix is considered complete.

src/lib/proxy-agent/agent-pool.ts — `enforceMaxSize()` method needs an `activeRequests > 0` guard mirroring the one in `isExpired()`.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/proxy-agent/agent-pool.ts | Adds `activeRequests` ref-counting to `CachedAgent` and protects TTL expiry via `isExpired()`, but `enforceMaxSize()` still evicts active agents by LRU without checking `activeRequests`. |
| src/app/v1/_lib/proxy/errors.ts | Adds `UND_ERR_DESTROYED`, `UND_ERR_CLOSED`, `ERR_HTTP2_STREAM_ERROR` to transport error codes and name checks for `ClientDestroyedError`/`ClientClosedError`; delegates to `isHttp2Error()` for broader HTTP/2 pattern matching — good coverage with a minor gap in `cause.name` propagation. |
| src/app/v1/_lib/proxy/forwarder.ts | Wires agent acquisition into the try block, releases on fetch-failure, HTTP error, H2→H1 fallback, and proxy→direct fallback; correctly clears `proxyConfig` on fallback to prevent double-release; attaches `releaseAgent` callback to session for the response handler. |
| src/app/v1/_lib/proxy/response-handler.ts | Adds idempotent `releaseSessionAgent()` helper and calls it in all four streaming `finally` blocks; implementation is safe against double-invocation. |
| src/lib/proxy-agent.ts | Re-exports `ProxyConfigWithCacheKey` with `dispatcherId` field and extends `getProxyAgentForProvider` to thread `cacheKey` and `dispatcherId` from the pool result; no issues. |
| tests/unit/lib/proxy-agent/agent-pool.test.ts | Adds thorough reference-counting tests (TTL protection, stale-dispatcher guard, concurrent waiter counting, hard upper bound) but does not cover the LRU eviction path when `activeRequests > 0`. |
| tests/unit/transport-error-detection.test.ts | Good coverage of new error codes, name-based detection, and cause-chain detection for both agent destruction and HTTP/2 errors; regression suite for existing transport errors included. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getAgent] --> B{Cache hit?}
    B -- Yes --> C[activeRequests++
lastUsedAt=now]
    B -- No --> D{Pending creation?}
    D -- Yes --> E[await pending
activeRequests++]
    D -- No --> F[createAgentWithCache
activeRequests=1]
    F --> G[enforceMaxSize - LRU]
    G --> H{activeRequests > 0
on LRU candidate?}
    H -- Not checked --> I[evictByKey regardless
Destroys in-flight stream]
    H -- Should skip --> J[Skip eviction]
    C --> K[Attach releaseAgent
to session]
    E --> K
    F --> K
    K --> L[Response handler finally]
    L --> M[releaseSessionAgent
activeRequests--]
    M --> N{activeRequests == 0?}
    N -- Yes --> O[isExpired check passes
TTL cleanup ok]
    N -- No --> P[isExpired returns false
Agent protected from TTL eviction]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `src/lib/proxy-agent/agent-pool.ts`, line 472-487 ([link](https://github.com/ding113/claude-code-hub/blob/c5feb5cc35b264a365e86792746ad4533f58974f/src/lib/proxy-agent/agent-pool.ts#L472-L487)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **LRU eviction ignores `activeRequests`, defeating the pin-protection**

   `enforceMaxSize` calls `evictByKey` without checking whether an agent has in-flight requests. When the pool reaches `maxTotalAgents` (default 100), the oldest agent is force-destroyed via `agent.destroy()` even if `activeRequests > 0`, which will throw `ClientDestroyedError` / `UND_ERR_DESTROYED` on any streaming connection currently using that agent — the exact failure this PR is trying to eliminate.

   `isExpired` correctly guards:
   ```ts
   if (cached.activeRequests > 0) return false;
   ```

   The same guard needs to be applied in the LRU path:

   ```ts
   private async enforceMaxSize(): Promise<void> {
     if (this.cache.size <= this.config.maxTotalAgents) return;

     // Sort by lastUsedAt, skipping agents with active in-flight requests
     const entries = Array.from(this.cache.entries())
       .filter(([, cached]) => cached.activeRequests === 0)
       .sort(([, a], [, b]) => a.lastUsedAt - b.lastUsedAt);

     const toEvict = entries.slice(0, this.cache.size - this.config.maxTotalAgents);
     for (const [key] of toEvict) {
       await this.evictByKey(key);
     }
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/proxy-agent/agent-pool.ts
   Line: 472-487

   Comment:
   **LRU eviction ignores `activeRequests`, defeating the pin-protection**

   `enforceMaxSize` calls `evictByKey` without checking whether an agent has in-flight requests. When the pool reaches `maxTotalAgents` (default 100), the oldest agent is force-destroyed via `agent.destroy()` even if `activeRequests > 0`, which will throw `ClientDestroyedError` / `UND_ERR_DESTROYED` on any streaming connection currently using that agent — the exact failure this PR is trying to eliminate.

   `isExpired` correctly guards:
   ```ts
   if (cached.activeRequests > 0) return false;
   ```

   The same guard needs to be applied in the LRU path:

   ```ts
   private async enforceMaxSize(): Promise<void> {
     if (this.cache.size <= this.config.maxTotalAgents) return;

     // Sort by lastUsedAt, skipping agents with active in-flight requests
     const entries = Array.from(this.cache.entries())
       .filter(([, cached]) => cached.activeRequests === 0)
       .sort(([, a], [, b]) => a.lastUsedAt - b.lastUsedAt);

     const toEvict = entries.slice(0, this.cache.size - this.config.maxTotalAgents);
     for (const [key] of toEvict) {
       await this.evictByKey(key);
     }
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/app/v1/_lib/proxy/forwarder.ts`, line 2824-2860 ([link](https://github.com/ding113/claude-code-hub/blob/c5feb5cc35b264a365e86792746ad4533f58974f/src/app/v1/_lib/proxy/forwarder.ts#L2824-L2860)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale `proxyConfig` causes a double-release of the proxy agent refcount after `fallbackToDirect` succeeds**

   When the proxy fetch fails and `proxyConfig.fallbackToDirect` is true:

   1. The proxy agent's refcount is decremented at line 2561 (`getGlobalAgentPool().releaseAgent(releaseKey)`) — correct, because this request no longer uses the proxy.
   2. The direct-connection fallback fetch succeeds.
   3. However, `proxyConfig` is **not** cleared here (unlike the H2→H1 path which explicitly does `proxyConfig = http1ProxyConfig` and `directConnectionCacheKey = null` at lines 2772–2773).
   4. Downstream at line 3000, `agentCacheKeyToRelease = proxyConfig?.cacheKey` still points to the original proxy's cache key.
   5. The response-handler will later call `releaseAgent(proxyConfig.cacheKey)` — a second decrement that no longer belongs to this request. If any concurrent streaming request shares that proxy agent, its refcount is silently stolen, and the agent can be prematurely evicted mid-stream.

   Add a parallel to the H2 fix:
   ```ts
   // After fallback direct connection succeeds:
   proxyConfig = null;  // direct fallback uses no pooled agent
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/v1/_lib/proxy/forwarder.ts
   Line: 2824-2860

   Comment:
   **Stale `proxyConfig` causes a double-release of the proxy agent refcount after `fallbackToDirect` succeeds**

   When the proxy fetch fails and `proxyConfig.fallbackToDirect` is true:

   1. The proxy agent's refcount is decremented at line 2561 (`getGlobalAgentPool().releaseAgent(releaseKey)`) — correct, because this request no longer uses the proxy.
   2. The direct-connection fallback fetch succeeds.
   3. However, `proxyConfig` is **not** cleared here (unlike the H2→H1 path which explicitly does `proxyConfig = http1ProxyConfig` and `directConnectionCacheKey = null` at lines 2772–2773).
   4. Downstream at line 3000, `agentCacheKeyToRelease = proxyConfig?.cacheKey` still points to the original proxy's cache key.
   5. The response-handler will later call `releaseAgent(proxyConfig.cacheKey)` — a second decrement that no longer belongs to this request. If any concurrent streaming request shares that proxy agent, its refcount is silently stolen, and the agent can be prematurely evicted mid-stream.

   Add a parallel to the H2 fix:
   ```ts
   // After fallback direct connection succeeds:
   proxyConfig = null;  // direct fallback uses no pooled agent
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `src/lib/proxy-agent/agent-pool.ts`, line 225-233 ([link](https://github.com/ding113/claude-code-hub/blob/c5feb5cc35b264a365e86792746ad4533f58974f/src/lib/proxy-agent/agent-pool.ts#L225-L233)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Concurrent callers waiting on `pendingCreations` are not counted in `activeRequests`**

   When a second (or third) caller arrives while an agent is still being created, it awaits the `pendingCreations` promise and returns without incrementing `activeRequests` on the newly-created entry. The refcount will be under-reported for however many concurrent callers land in this narrow window.

   The cache-hit path (line 219) correctly does `cached.activeRequests++`. The pending path should do the same after the promise resolves:

   ```ts
   const pending = this.pendingCreations.get(cacheKey);
   if (pending) {
     const result = await pending;
     this.stats.cacheHits++;
     // Increment refcount for this caller too
     const cached = this.cache.get(result.cacheKey);
     if (cached) cached.activeRequests++;
     return { ...result, isNew: false };
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/proxy-agent/agent-pool.ts
   Line: 225-233

   Comment:
   **Concurrent callers waiting on `pendingCreations` are not counted in `activeRequests`**

   When a second (or third) caller arrives while an agent is still being created, it awaits the `pendingCreations` promise and returns without incrementing `activeRequests` on the newly-created entry. The refcount will be under-reported for however many concurrent callers land in this narrow window.

   The cache-hit path (line 219) correctly does `cached.activeRequests++`. The pending path should do the same after the promise resolves:

   ```ts
   const pending = this.pendingCreations.get(cacheKey);
   if (pending) {
     const result = await pending;
     this.stats.cacheHits++;
     // Increment refcount for this caller too
     const cached = this.cache.get(result.cacheKey);
     if (cached) cached.activeRequests++;
     return { ...result, isNew: false };
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

4. `src/lib/proxy-agent/agent-pool.ts`, line 504-519 ([link](https://github.com/ding113/claude-code-hub/blob/b48a6269946010b1ae1f83066a2d74d42e7d4a05/src/lib/proxy-agent/agent-pool.ts#L504-L519)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **LRU eviction ignores `activeRequests`, defeating ref-count protection**

   `enforceMaxSize()` sorts purely by `lastUsedAt` and evicts the oldest entries without checking whether they have in-flight requests. Long-running streams acquire an agent at time T, leaving `lastUsedAt = T`. When the pool fills up later with new short-lived agents (each with a more recent `lastUsedAt`), the streaming agent becomes the LRU candidate and gets forcibly destroyed — reproducing exactly the `ClientDestroyedError` / `UND_ERR_DESTROYED` this PR fixes in the TTL path.

   The `isExpired()` guard added in this PR is bypassed entirely here since `enforceMaxSize` calls `evictByKey` directly.

   ```typescript
   // Skip agents that have in-flight requests (same guard as isExpired)
   const toEvict = entries
     .filter(([, a]) => a.activeRequests === 0)
     .slice(0, this.cache.size - this.config.maxTotalAgents);
   ```

   If no evictable agents exist (all are active), the pool temporarily exceeds `maxTotalAgents`, which is safer than destroying live streams.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/proxy-agent/agent-pool.ts
   Line: 504-519

   Comment:
   **LRU eviction ignores `activeRequests`, defeating ref-count protection**

   `enforceMaxSize()` sorts purely by `lastUsedAt` and evicts the oldest entries without checking whether they have in-flight requests. Long-running streams acquire an agent at time T, leaving `lastUsedAt = T`. When the pool fills up later with new short-lived agents (each with a more recent `lastUsedAt`), the streaming agent becomes the LRU candidate and gets forcibly destroyed — reproducing exactly the `ClientDestroyedError` / `UND_ERR_DESTROYED` this PR fixes in the TTL path.

   The `isExpired()` guard added in this PR is bypassed entirely here since `enforceMaxSize` calls `evictByKey` directly.

   ```typescript
   // Skip agents that have in-flight requests (same guard as isExpired)
   const toEvict = entries
     .filter(([, a]) => a.activeRequests === 0)
     .slice(0, this.cache.size - this.config.maxTotalAgents);
   ```

   If no evictable agents exist (all are active), the pool temporarily exceeds `maxTotalAgents`, which is safer than destroying live streams.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/proxy-agent/agent-pool.ts
Line: 504-519

Comment:
**LRU eviction ignores `activeRequests`, defeating ref-count protection**

`enforceMaxSize()` sorts purely by `lastUsedAt` and evicts the oldest entries without checking whether they have in-flight requests. Long-running streams acquire an agent at time T, leaving `lastUsedAt = T`. When the pool fills up later with new short-lived agents (each with a more recent `lastUsedAt`), the streaming agent becomes the LRU candidate and gets forcibly destroyed — reproducing exactly the `ClientDestroyedError` / `UND_ERR_DESTROYED` this PR fixes in the TTL path.

The `isExpired()` guard added in this PR is bypassed entirely here since `enforceMaxSize` calls `evictByKey` directly.

```typescript
// Skip agents that have in-flight requests (same guard as isExpired)
const toEvict = entries
  .filter(([, a]) => a.activeRequests === 0)
  .slice(0, this.cache.size - this.config.maxTotalAgents);
```

If no evictable agents exist (all are active), the pool temporarily exceeds `maxTotalAgents`, which is safer than destroying live streams.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/errors.ts
Line: 756-775

Comment:
**`cause.name` not checked for name-based transport errors**

The error-name check (`ClientDestroyedError`, `ClientClosedError`, `SocketError`) only inspects the top-level error. The cause-chain walk only extracts `cause.code`. If undici wraps a `ClientDestroyedError` as the `.cause` of a generic `TypeError: fetch failed` — a legal pattern — and the cause happens to have `name = "ClientDestroyedError"` but no `code` property, it won't be detected here.

In practice undici always sets `code = "UND_ERR_DESTROYED"` alongside the name, so the code-based path covers it. But the symmetry would be cleaner as:

```typescript
const cause = (error as Error & { cause?: { code?: string; name?: string } }).cause;
if (
  cause?.name === "ClientDestroyedError" ||
  cause?.name === "ClientClosedError" ||
  cause?.name === "SocketError"
)
  return true;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: harden agent pool refcount against ..."](https://github.com/ding113/claude-code-hub/commit/b48a6269946010b1ae1f83066a2d74d42e7d4a05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27987859)</sub>

<!-- /greptile_comment -->