### PR TITLE
fix: respect case-sensitive provider model ids

### DIFF
--- a/src/app/[locale]/settings/providers/_components/allowed-model-rule-editor.tsx
+++ b/src/app/[locale]/settings/providers/_components/allowed-model-rule-editor.tsx
@@ -49,7 +49,8 @@ function normalizeRule(rule: AllowedModelRule): AllowedModelRule {
 }
 
 function getRuleIdentity(rule: Pick<AllowedModelRule, "matchType" | "pattern">): string {
-  return `${rule.matchType}:${rule.pattern.trim().toLowerCase()}`;
+  // exact/prefix/suffix/contains/regex 的运行时匹配都区分大小写，这里去重也必须保持一致。
+  return `${rule.matchType}:${rule.pattern.trim()}`;
 }
 
 export function AllowedModelRuleEditor({

--- a/src/app/[locale]/settings/providers/_components/model-multi-select.tsx
+++ b/src/app/[locale]/settings/providers/_components/model-multi-select.tsx
@@ -61,7 +61,7 @@ function normalizeModelName(model: string): string {
 }
 
 function getModelKey(model: string): string {
-  return normalizeModelName(model).toLowerCase();
+  return normalizeModelName(model);
 }
 
 function getProviderTypeLabel(providerType: ProviderType, t: ReturnType<typeof useTranslations>) {

--- a/src/app/[locale]/settings/providers/_components/model-redirect-editor.tsx
+++ b/src/app/[locale]/settings/providers/_components/model-redirect-editor.tsx
@@ -47,7 +47,8 @@ function normalizeRule(rule: ProviderModelRedirectRule): ProviderModelRedirectRu
 }
 
 function getRuleIdentity(rule: Pick<ProviderModelRedirectRule, "matchType" | "source">): string {
-  return `${rule.matchType}:${rule.source.trim().toLowerCase()}`;
+  // 重定向规则的匹配层区分大小写，编辑器不能把不同大小写的 source 合并成同一条。
+  return `${rule.matchType}:${rule.source.trim()}`;
 }
 
 export function ModelRedirectEditor({

--- a/src/lib/provider-allowed-model-schema.ts
+++ b/src/lib/provider-allowed-model-schema.ts
@@ -72,7 +72,7 @@ export const PROVIDER_ALLOWED_MODEL_RULE_INPUT_LIST_SCHEMA = z
     (rules) => {
       const keys = new Set<string>();
       for (const rule of rules) {
-        const key = `${rule.matchType}:${rule.pattern.trim().toLowerCase()}`;
+        const key = `${rule.matchType}:${rule.pattern.trim()}`;
         if (keys.has(key)) {
           return false;
         }
@@ -95,7 +95,7 @@ export const PROVIDER_ALLOWED_MODEL_RULE_LIST_SCHEMA = z
     (rules) => {
       const keys = new Set<string>();
       for (const rule of rules) {
-        const key = `${rule.matchType}:${rule.pattern.trim().toLowerCase()}`;
+        const key = `${rule.matchType}:${rule.pattern.trim()}`;
         if (keys.has(key)) {
           return false;
         }

--- a/src/lib/provider-model-redirect-schema.ts
+++ b/src/lib/provider-model-redirect-schema.ts
@@ -73,7 +73,7 @@ export const PROVIDER_MODEL_REDIRECT_RULE_LIST_SCHEMA = z
     (rules) => {
       const keys = new Set<string>();
       for (const rule of rules) {
-        const key = `${rule.matchType}:${rule.source.trim().toLowerCase()}`;
+        const key = `${rule.matchType}:${rule.source.trim()}`;
         if (keys.has(key)) {
           return false;
         }

--- a/tests/unit/lib/provider-allowed-model-schema.test.ts
+++ b/tests/unit/lib/provider-allowed-model-schema.test.ts
@@ -40,4 +40,13 @@ describe("provider-allowed-model-schema", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("允许 exact allowlist 同时包含 GLM-5 和 glm-5", () => {
+    const result = PROVIDER_ALLOWED_MODEL_RULE_INPUT_LIST_SCHEMA.safeParse([
+      { matchType: "exact", pattern: "GLM-5" },
+      { matchType: "exact", pattern: "glm-5" },
+    ]);
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/tests/unit/lib/provider-model-redirect-schema.test.ts
+++ b/tests/unit/lib/provider-model-redirect-schema.test.ts
@@ -42,4 +42,13 @@ describe("provider-model-redirect-schema", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("允许 exact redirect 同时包含 GLM-5 和 glm-5 两个 source", () => {
+    const result = PROVIDER_MODEL_REDIRECT_RULE_LIST_SCHEMA.safeParse([
+      { matchType: "exact", source: "GLM-5", target: "GLM-5" },
+      { matchType: "exact", source: "glm-5", target: "GLM-5" },
+    ]);
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/tests/unit/settings/providers/allowed-model-rule-editor.test.tsx
+++ b/tests/unit/settings/providers/allowed-model-rule-editor.test.tsx
@@ -231,6 +231,53 @@ describe("AllowedModelRuleEditor", () => {
     unmount();
   });
 
+  test("允许 exact 规则同时保留 GLM-5 和 glm-5", async () => {
+    const messages = loadMessages();
+    const onChange = vi.fn();
+
+    const { unmount } = render(
+      <NextIntlClientProvider locale="en" messages={messages} timeZone="UTC">
+        <AllowedModelRuleEditor
+          value={[{ matchType: "exact", pattern: "GLM-5" }]}
+          onChange={onChange}
+          providerType="openai"
+        />
+      </NextIntlClientProvider>
+    );
+
+    const patternInput = document.querySelector(
+      "#new-allowed-model-pattern"
+    ) as HTMLInputElement | null;
+    expect(patternInput).toBeTruthy();
+
+    await act(async () => {
+      if (patternInput) {
+        patternInput.value = "glm-5";
+        patternInput.dispatchEvent(new Event("input", { bubbles: true }));
+        patternInput.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+    });
+    await flushTicks(2);
+
+    const addButton = document.querySelector(
+      "[data-allowed-model-add]"
+    ) as HTMLButtonElement | null;
+    expect(addButton).toBeTruthy();
+
+    await act(async () => {
+      addButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushTicks(2);
+
+    expect(onChange).toHaveBeenCalledWith([
+      { matchType: "exact", pattern: "GLM-5" },
+      { matchType: "exact", pattern: "glm-5" },
+    ]);
+    expect(document.querySelector("[data-allowed-model-error]")?.textContent || "").toBe("");
+
+    unmount();
+  });
+
   test("adds models from picker as exact rules without changing existing advanced rules", async () => {
     const messages = loadMessages();
     const onChange = vi.fn();

--- a/tests/unit/settings/providers/model-multi-select.test.tsx
+++ b/tests/unit/settings/providers/model-multi-select.test.tsx
@@ -305,4 +305,41 @@ describe("ModelMultiSelect", () => {
 
     unmount();
   });
+
+  test("取消一个 mixed-case exact 模型时不会连带移除另一个", async () => {
+    const messages = loadMessages();
+    const onChange = vi.fn();
+
+    const { unmount } = render(
+      <NextIntlClientProvider locale="en" messages={messages} timeZone="UTC">
+        <ModelMultiSelect
+          providerType="openai"
+          selectedModels={["GLM-5", "glm-5"]}
+          onChange={onChange}
+        />
+      </NextIntlClientProvider>
+    );
+
+    await openPicker();
+
+    const selectedItems = Array.from(
+      document.querySelectorAll('[data-model-group="selected"] [data-slot="command-item"]')
+    );
+    expect(selectedItems).toHaveLength(2);
+    expect(selectedItems.map((item) => item.textContent || "")).toEqual(
+      expect.arrayContaining(["GLM-5", "glm-5"])
+    );
+
+    const upperItem = selectedItems.find((item) => (item.textContent || "").includes("GLM-5"));
+    expect(upperItem).toBeTruthy();
+
+    await act(async () => {
+      upperItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushTicks(2);
+
+    expect(onChange).toHaveBeenLastCalledWith(["glm-5"]);
+
+    unmount();
+  });
 });

--- a/tests/unit/settings/providers/model-redirect-editor.test.tsx
+++ b/tests/unit/settings/providers/model-redirect-editor.test.tsx
@@ -217,4 +217,52 @@ describe("ModelRedirectEditor", () => {
 
     unmount();
   });
+
+  test("允许 exact 重定向同时保留 GLM-5 和 glm-5 两个 source", async () => {
+    const messages = loadMessages();
+    const onChange = vi.fn();
+
+    const { unmount } = render(
+      <NextIntlClientProvider locale="en" messages={messages} timeZone="UTC">
+        <ModelRedirectEditor
+          value={[{ matchType: "exact", source: "GLM-5", target: "GLM-5" }]}
+          onChange={onChange}
+        />
+      </NextIntlClientProvider>
+    );
+
+    const sourceInput = document.querySelector("#new-source") as HTMLInputElement | null;
+    const targetInput = document.querySelector("#new-target") as HTMLInputElement | null;
+    expect(sourceInput).toBeTruthy();
+    expect(targetInput).toBeTruthy();
+
+    await act(async () => {
+      if (sourceInput) {
+        sourceInput.value = "glm-5";
+        sourceInput.dispatchEvent(new Event("input", { bubbles: true }));
+        sourceInput.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+
+      if (targetInput) {
+        targetInput.value = "GLM-5";
+        targetInput.dispatchEvent(new Event("input", { bubbles: true }));
+        targetInput.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+    });
+
+    const addButton = document.querySelector("[data-redirect-add]") as HTMLButtonElement | null;
+    expect(addButton).toBeTruthy();
+
+    await act(async () => {
+      addButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onChange).toHaveBeenCalledWith([
+      { matchType: "exact", source: "GLM-5", target: "GLM-5" },
+      { matchType: "exact", source: "glm-5", target: "GLM-5" },
+    ]);
+    expect(document.querySelector("[data-redirect-error]")?.textContent || "").toBe("");
+
+    unmount();
+  });
 });


### PR DESCRIPTION
## Summary

Fix case-sensitive duplicate detection in provider allowlist and model redirect editors/schemas, so that model IDs differing only in case (e.g. `GLM-5` vs `glm-5`) can coexist as separate rules.

## Problem

The runtime matching logic in `model-pattern-matcher.ts` and `allowed-model-rules.ts` is case-sensitive -- `GLM-5` and `glm-5` are treated as distinct model IDs. However, the duplicate-detection code in both the Zod validation schemas and the editor UI components applied `.toLowerCase()` before comparing rule identities. This meant:

- Adding both `GLM-5` (exact) and `glm-5` (exact) in the allowlist editor would incorrectly flag them as duplicates
- The same issue applied to model redirect rules with different-cased sources
- Editor-side dedup semantics were inconsistent with runtime matching behavior

**Related Issues/PRs:**
- Follow-up to #996 - the allowlist schema dedup logic was introduced there
- Follow-up to #993 - the model redirect schema dedup logic was introduced there
- Related to #997 - the allowlist editor was updated there and also uses `getRuleIdentity`

## Solution

Remove `.toLowerCase()` from the identity/dedup key computation in four locations so that editor validation matches runtime matching semantics:

1. **Schema validation** -- `provider-allowed-model-schema.ts` (2 schemas) and `provider-model-redirect-schema.ts` (1 schema)
2. **Editor UI** -- `allowed-model-rule-editor.tsx` and `model-redirect-editor.tsx` (`getRuleIdentity` functions)

## Changes

### Core Changes
- `src/lib/provider-allowed-model-schema.ts` -- Remove `.toLowerCase()` from duplicate-check keys in both `INPUT_LIST_SCHEMA` and `LIST_SCHEMA`
- `src/lib/provider-model-redirect-schema.ts` -- Remove `.toLowerCase()` from duplicate-check key in `LIST_SCHEMA`
- `src/app/[locale]/settings/providers/_components/allowed-model-rule-editor.tsx` -- Remove `.toLowerCase()` from `getRuleIdentity`
- `src/app/[locale]/settings/providers/_components/model-redirect-editor.tsx` -- Remove `.toLowerCase()` from `getRuleIdentity`

### Test Coverage
- `tests/unit/lib/provider-allowed-model-schema.test.ts` -- Verify `GLM-5` and `glm-5` can coexist in allowlist schema
- `tests/unit/lib/provider-model-redirect-schema.test.ts` -- Verify `GLM-5` and `glm-5` can coexist as redirect sources
- `tests/unit/settings/providers/allowed-model-rule-editor.test.tsx` -- Verify editor accepts both cased variants without error
- `tests/unit/settings/providers/model-redirect-editor.test.tsx` -- Verify redirect editor accepts both cased variants

## Testing

```bash
bunx vitest run tests/unit/lib/provider-allowed-model-schema.test.ts tests/unit/lib/provider-model-redirect-schema.test.ts tests/unit/settings/providers/allowed-model-rule-editor.test.tsx tests/unit/settings/providers/model-redirect-editor.test.tsx
bunx vitest run tests/unit/proxy/provider-selector-allowed-model-rules.test.ts
bun run typecheck
bun run lint
bun run build
bun run test
```

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No breaking changes -- only relaxes a validation constraint

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes `.toLowerCase()` from duplicate-detection keys in schema validation and editor UI components so that model IDs differing only in case (e.g. `GLM-5` vs `glm-5`) can coexist as separate rules, aligning editor semantics with the runtime's case-sensitive matching behavior. The `normalizeAllowedModelRules` transform (which runs before schema dedup in `PROVIDER_ALLOWED_MODEL_RULE_INPUT_LIST_SCHEMA`) was confirmed to only trim whitespace — it does not lowercase — so the fix is effective end-to-end.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted one-line removals of `.toLowerCase()` across five files, all consistent with runtime behavior and covered by new tests.

All changed sites apply the same fix symmetrically. The `normalizeAllowedModelRules` transform (which precedes schema dedup) was confirmed to only trim whitespace, not lowercase, so the fix is effective end-to-end. New tests cover the primary regression case in every affected layer. No P0/P1 findings.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/provider-allowed-model-schema.ts | Removed `.toLowerCase()` from dedup keys in both `INPUT_LIST_SCHEMA` and `LIST_SCHEMA`; dedup logic is now case-sensitive and consistent with runtime behavior. |
| src/lib/provider-model-redirect-schema.ts | Removed `.toLowerCase()` from redirect rule dedup key; case-sensitive matching now applies consistently at both validation and runtime layers. |
| src/app/[locale]/settings/providers/_components/allowed-model-rule-editor.tsx | Removed `.toLowerCase()` from `getRuleIdentity`; handles add, edit, remove, move, and model-picker path — all consistent after the fix. |
| src/app/[locale]/settings/providers/_components/model-redirect-editor.tsx | Removed `.toLowerCase()` from `getRuleIdentity`; edit-while-delete test confirms index-based save still works correctly under the case-sensitive key scheme. |
| src/app/[locale]/settings/providers/_components/model-multi-select.tsx | Removed `.toLowerCase()` from `getModelKey`; search filtering intentionally remains case-insensitive (UX), while selection/dedup keys are now case-sensitive. |
| tests/unit/lib/provider-allowed-model-schema.test.ts | Adds GLM-5/glm-5 coexistence test for `PROVIDER_ALLOWED_MODEL_RULE_INPUT_LIST_SCHEMA`; `PROVIDER_ALLOWED_MODEL_RULE_LIST_SCHEMA` (also fixed) has no parallel case-sensitivity test, but both schemas use identical dedup logic so the fix is verifiable by inspection. |
| tests/unit/lib/provider-model-redirect-schema.test.ts | Adds GLM-5/glm-5 coexistence test for `PROVIDER_MODEL_REDIRECT_RULE_LIST_SCHEMA`; covers the redirect schema fix directly. |
| tests/unit/settings/providers/allowed-model-rule-editor.test.tsx | New test verifies the editor accepts both GLM-5 and glm-5 without a duplicate error; existing tests cover add, edit, and large-list scenarios. |
| tests/unit/settings/providers/model-redirect-editor.test.tsx | New test verifies the redirect editor accepts both GLM-5 and glm-5 as separate sources without error. |
| tests/unit/settings/providers/model-multi-select.test.tsx | New test confirms deselecting GLM-5 leaves glm-5 intact in the picker — covers the key UX regression introduced by the old lowercase key scheme. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User enters model ID\n(e.g. GLM-5 or glm-5)"] --> B["Editor UI\ngetRuleIdentity(rule)\nmatchType + ':' + pattern.trim()"]
    B --> C{Duplicate check\ncase-sensitive}
    C -- "GLM-5 ≠ glm-5 ✓" --> D["Rule accepted\nonChange called"]
    C -- "GLM-5 = GLM-5 ✗" --> E["Error: duplicate rule"]
    D --> F["Zod Schema Validation\nmatchType + ':' + pattern.trim()"]
    F --> G{Dedup refine\ncase-sensitive}
    G -- "GLM-5 ≠ glm-5 ✓" --> H["Schema valid\nRules persisted"]
    G -- "duplicate detected ✗" --> I["Validation error"]
    H --> J["Runtime matching\nmodel-pattern-matcher.ts\ncase-sensitive"]
    J -- "GLM-5 matches GLM-5" --> K["Request allowed"]
    J -- "glm-5 matches glm-5" --> K

    style C fill:#22c55e,color:#fff
    style G fill:#22c55e,color:#fff
    style J fill:#22c55e,color:#fff
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: keep model picker ids case-sensitiv..."](https://github.com/ding113/claude-code-hub/commit/ff94e4f890ede94a2e5072a113ae833f4862e91b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28074948)</sub>

<!-- /greptile_comment -->