### PR TITLE
新增用户缓存命中率排行榜

### DIFF
--- a/messages/en/dashboard.json
+++ b/messages/en/dashboard.json
@@ -425,6 +425,7 @@
       "users": "User Rankings",
       "keys": "Key Rankings",
       "userRanking": "User Rankings",
+      "userCacheHitRateRanking": "User Cache Hit Rate",
       "providerRanking": "Provider Rankings",
       "providerCacheHitRateRanking": "Provider Cache Hit Rate",
       "modelRanking": "Model Rankings",

--- a/messages/ja/dashboard.json
+++ b/messages/ja/dashboard.json
@@ -425,6 +425,7 @@
       "users": "ユーザー ランキング",
       "keys": "キー ランキング",
       "userRanking": "ユーザーランキング",
+      "userCacheHitRateRanking": "ユーザーキャッシュ命中率",
       "providerRanking": "プロバイダーランキング",
       "providerCacheHitRateRanking": "プロバイダーキャッシュ命中率",
       "modelRanking": "モデルランキング",

--- a/messages/ru/dashboard.json
+++ b/messages/ru/dashboard.json
@@ -425,6 +425,7 @@
       "users": "Рейтинг пользователей",
       "keys": "Рейтинг ключей",
       "userRanking": "Рейтинг пользователей",
+      "userCacheHitRateRanking": "Рейтинг пользователей по попаданиям в кэш",
       "providerRanking": "Рейтинг поставщиков",
       "providerCacheHitRateRanking": "Рейтинг по попаданиям в кэш",
       "modelRanking": "Рейтинг моделей",

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -425,6 +425,7 @@
       "users": "用户排行",
       "keys": "密钥排行",
       "userRanking": "用户排行",
+      "userCacheHitRateRanking": "用户缓存命中率排行",
       "providerRanking": "供应商排行",
       "providerCacheHitRateRanking": "供应商缓存命中率排行",
       "modelRanking": "模型排行",

--- a/messages/zh-TW/dashboard.json
+++ b/messages/zh-TW/dashboard.json
@@ -425,6 +425,7 @@
       "users": "使用者排名",
       "keys": "密鑰排名",
       "userRanking": "使用者排名",
+      "userCacheHitRateRanking": "使用者快取命中率排行",
       "providerRanking": "供應商排名",
       "providerCacheHitRateRanking": "供應商快取命中率排行",
       "modelRanking": "模型排名",

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
@@ -264,14 +264,9 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     {
       header: t("columns.consumedAmount"),
       className: "text-right font-mono",
-      cell: (row) =>
-        "userName" in row ? (
-          (row.totalCostFormatted ?? row.totalCost)
-        ) : (
-          <span className="text-muted-foreground">-</span>
-        ),
+      cell: (row) => row.totalCostFormatted ?? row.totalCost,
       sortKey: "totalCost",
-      getValue: (row) => ("userName" in row ? row.totalCost : 0),
+      getValue: (row) => row.totalCost,
       defaultBold: true,
     },
   ];

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
@@ -20,6 +20,8 @@ import type {
   ModelProviderStat,
   ProviderCacheHitRateLeaderboardEntry,
   ProviderLeaderboardEntry,
+  UserCacheHitModelStat,
+  UserCacheHitRateLeaderboardEntry,
   UserModelStat,
 } from "@/repository/leaderboard";
 import type { ProviderType } from "@/types/provider";
@@ -30,7 +32,7 @@ interface LeaderboardViewProps {
   isAdmin: boolean;
 }
 
-type LeaderboardScope = "user" | "provider" | "providerCacheHitRate" | "model";
+type LeaderboardScope = "user" | "userCacheHitRate" | "provider" | "providerCacheHitRate" | "model";
 type TotalCostFormattedFields = { totalCostFormatted?: string };
 type ProviderCostFormattedFields = {
   // API 额外返回的展示用字段（格式化后的字符串）
@@ -51,9 +53,20 @@ type ProviderEntry = Omit<ProviderLeaderboardEntry, "modelStats"> &
     modelStats?: ModelProviderStatClient[];
   };
 type ProviderTableRow = ProviderEntry | ModelProviderStatClient;
+type UserCacheHitModelStatClient = UserCacheHitModelStat;
+type UserCacheHitRateEntry = Omit<UserCacheHitRateLeaderboardEntry, "modelStats"> &
+  TotalCostFormattedFields & {
+    modelStats?: UserCacheHitModelStatClient[];
+  };
+type UserCacheHitRateTableRow = UserCacheHitRateEntry | UserCacheHitModelStatClient;
 type ProviderCacheHitRateEntry = ProviderCacheHitRateLeaderboardEntry;
 type ProviderCacheHitRateTableRow = ProviderCacheHitRateEntry | ModelCacheHitStat;
-type AnyEntry = UserEntry | ProviderEntry | ProviderCacheHitRateEntry | ModelEntry;
+type AnyEntry =
+  | UserEntry
+  | UserCacheHitRateEntry
+  | ProviderEntry
+  | ProviderCacheHitRateEntry
+  | ModelEntry;
 
 const VALID_PERIODS: LeaderboardPeriod[] = ["daily", "weekly", "monthly", "allTime", "custom"];
 
@@ -63,7 +76,10 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
 
   const urlScope = searchParams.get("scope") as LeaderboardScope | null;
   const initialScope: LeaderboardScope =
-    (urlScope === "provider" || urlScope === "providerCacheHitRate" || urlScope === "model") &&
+    (urlScope === "provider" ||
+      urlScope === "providerCacheHitRate" ||
+      urlScope === "userCacheHitRate" ||
+      urlScope === "model") &&
     isAdmin
       ? urlScope
       : "user";
@@ -104,6 +120,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     const urlScopeParam = searchParams.get("scope") as LeaderboardScope | null;
     const normalizedScope: LeaderboardScope =
       (urlScopeParam === "provider" ||
+        urlScopeParam === "userCacheHitRate" ||
         urlScopeParam === "providerCacheHitRate" ||
         urlScopeParam === "model") &&
       isAdmin
@@ -142,10 +159,10 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
         if (scope === "provider") {
           url += "&includeModelStats=1";
         }
-        if (scope === "user" && isAdmin) {
+        if ((scope === "user" || scope === "userCacheHitRate") && isAdmin) {
           url += "&includeUserModelStats=1";
         }
-        if (scope === "user") {
+        if (scope === "user" || scope === "userCacheHitRate") {
           if (userTagFilters.length > 0) {
             url += `&userTags=${encodeURIComponent(userTagFilters.join(","))}`;
           }
@@ -190,13 +207,15 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
   const skeletonColumns =
     scope === "user"
       ? 5
-      : scope === "provider"
-        ? 10
-        : scope === "providerCacheHitRate"
-          ? 8
-          : scope === "model"
-            ? 6
-            : 5;
+      : scope === "userCacheHitRate"
+        ? 6
+        : scope === "provider"
+          ? 10
+          : scope === "providerCacheHitRate"
+            ? 8
+            : scope === "model"
+              ? 6
+              : 5;
   const skeletonGridStyle = { gridTemplateColumns: `repeat(${skeletonColumns}, minmax(0, 1fr))` };
 
   // 列定义（根据 scope 动态切换）
@@ -245,9 +264,14 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     {
       header: t("columns.consumedAmount"),
       className: "text-right font-mono",
-      cell: (row) => row.totalCostFormatted ?? row.totalCost,
+      cell: (row) =>
+        "userName" in row ? (
+          (row.totalCostFormatted ?? row.totalCost)
+        ) : (
+          <span className="text-muted-foreground">-</span>
+        ),
       sortKey: "totalCost",
-      getValue: (row) => row.totalCost,
+      getValue: (row) => ("userName" in row ? row.totalCost : 0),
       defaultBold: true,
     },
   ];
@@ -382,6 +406,80 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     },
   ];
 
+  const userCacheHitRateColumns: ColumnDef<UserCacheHitRateTableRow>[] = [
+    {
+      header: t("columns.user"),
+      cell: (row) => {
+        if ("userName" in row) {
+          return isAdmin ? (
+            <Link
+              href={`/dashboard/leaderboard/user/${row.userId}`}
+              className="hover:text-muted-foreground transition-colors"
+              data-testid={`leaderboard-user-cache-link-${row.userId}`}
+            >
+              {row.userName}
+            </Link>
+          ) : (
+            row.userName
+          );
+        }
+        return renderSubModelLabel(row.model ?? t("columns.unknownModel"));
+      },
+      sortKey: "userName",
+      getValue: (row) => ("userName" in row ? row.userName : (row.model ?? "")),
+    },
+    {
+      header: t("columns.cacheHitRequests"),
+      className: "text-right",
+      cell: (row) => row.totalRequests.toLocaleString(),
+      sortKey: "totalRequests",
+      getValue: (row) => row.totalRequests,
+    },
+    {
+      header: t("columns.cacheHitRate"),
+      className: "text-right",
+      cell: (row) => {
+        const rate = Number(row.cacheHitRate || 0) * 100;
+        const colorClass =
+          rate >= 85
+            ? "text-green-600 dark:text-green-400"
+            : rate >= 60
+              ? "text-yellow-600 dark:text-yellow-400"
+              : "text-orange-600 dark:text-orange-400";
+        return <span className={colorClass}>{rate.toFixed(1)}%</span>;
+      },
+      sortKey: "cacheHitRate",
+      getValue: (row) => row.cacheHitRate,
+    },
+    {
+      header: t("columns.cacheReadTokens"),
+      className: "text-right",
+      cell: (row) => formatTokenAmount(row.cacheReadTokens),
+      sortKey: "cacheReadTokens",
+      getValue: (row) => row.cacheReadTokens,
+    },
+    {
+      header: t("columns.totalTokens"),
+      className: "text-right",
+      cell: (row) => formatTokenAmount(row.totalInputTokens),
+      sortKey: "totalInputTokens",
+      getValue: (row) => row.totalInputTokens,
+    },
+    {
+      header: t("columns.consumedAmount"),
+      className: "text-right font-mono",
+      cell: (row) => {
+        if ("userName" in row) {
+          return row.totalCostFormatted ?? row.totalCost;
+        }
+        return <span className="text-muted-foreground">-</span>;
+      },
+      sortKey: "totalCost",
+      getValue: (row) => ("userName" in row ? row.totalCost : 0),
+      defaultBold: true,
+    },
+  ];
+
   const modelColumns: ColumnDef<ModelEntry>[] = [
     {
       header: t("columns.model"),
@@ -457,6 +555,21 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     />
   );
 
+  const renderUserCacheHitRateTable = () => (
+    <LeaderboardTable<UserCacheHitRateEntry, UserCacheHitModelStat>
+      data={data as UserCacheHitRateEntry[]}
+      period={period}
+      columns={userCacheHitRateColumns}
+      getRowKey={(row) => row.userId}
+      {...(isAdmin
+        ? {
+            getSubRows: (row) => row.modelStats,
+            getSubRowKey: (subRow) => subRow.model ?? "__null__",
+          }
+        : {})}
+    />
+  );
+
   const renderModelTable = () => (
     <LeaderboardTable<ModelEntry>
       data={data as ModelEntry[]}
@@ -468,6 +581,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
 
   const renderTable = () => {
     if (scope === "user") return renderUserTable();
+    if (scope === "userCacheHitRate") return renderUserCacheHitRateTable();
     if (scope === "provider") return renderProviderTable();
     if (scope === "providerCacheHitRate") return renderProviderCacheHitRateTable();
     return renderModelTable();
@@ -478,8 +592,13 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
       {/* Scope toggle */}
       <div className="flex flex-wrap gap-4 items-center mb-4">
         <Tabs value={scope} onValueChange={(v) => setScope(v as LeaderboardScope)}>
-          <TabsList className={isAdmin ? "grid grid-cols-4" : ""}>
+          <TabsList className={isAdmin ? "grid grid-cols-5" : ""}>
             <TabsTrigger value="user">{t("tabs.userRanking")}</TabsTrigger>
+            {isAdmin && (
+              <TabsTrigger value="userCacheHitRate">
+                {t("tabs.userCacheHitRateRanking")}
+              </TabsTrigger>
+            )}
             {isAdmin && <TabsTrigger value="provider">{t("tabs.providerRanking")}</TabsTrigger>}
             {isAdmin && (
               <TabsTrigger value="providerCacheHitRate">
@@ -499,7 +618,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
         ) : null}
       </div>
 
-      {scope === "user" && isAdmin && (
+      {(scope === "user" || scope === "userCacheHitRate") && isAdmin && (
         <div className="flex flex-wrap gap-4 mb-4">
           <div className="flex-1 min-w-[200px] max-w-[300px]">
             <TagInput

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -32,8 +32,9 @@ export const runtime = "nodejs";
 
 /**
  * 获取排行榜数据
- * GET /api/leaderboard?period=daily|weekly|monthly|allTime|custom&scope=user|provider|providerCacheHitRate|model
+ * GET /api/leaderboard?period=daily|weekly|monthly|allTime|custom&scope=user|userCacheHitRate|provider|providerCacheHitRate|model
  * 当 period=custom 时，需要提供 startDate 和 endDate 参数 (YYYY-MM-DD 格式)
+ * 当 scope=userCacheHitRate 时，可选 includeUserModelStats=true|1，返回用户下各模型的缓存命中率拆分数据
  * 当 scope=providerCacheHitRate 时，可选 providerType=claude|claude-auth|codex|gemini|gemini-cli|openai-compatible
  * 当 scope=provider 时，可选 includeModelStats=true|1，返回供应商下各模型的拆分数据
  *
@@ -90,12 +91,16 @@ export async function GET(request: NextRequest) {
 
     if (
       scope !== "user" &&
+      scope !== "userCacheHitRate" &&
       scope !== "provider" &&
       scope !== "providerCacheHitRate" &&
       scope !== "model"
     ) {
       return NextResponse.json(
-        { error: "参数 scope 必须是 'user'、'provider'、'providerCacheHitRate' 或 'model'" },
+        {
+          error:
+            "参数 scope 必须是 'user'、'userCacheHitRate'、'provider'、'providerCacheHitRate' 或 'model'",
+        },
         { status: 400 }
       );
     }
@@ -137,7 +142,7 @@ export async function GET(request: NextRequest) {
         includeModelStatsParam === "yes");
 
     const includeUserModelStats =
-      scope === "user" &&
+      (scope === "user" || scope === "userCacheHitRate") &&
       (includeUserModelStatsParam === "1" ||
         includeUserModelStatsParam === "true" ||
         includeUserModelStatsParam === "yes");
@@ -161,7 +166,7 @@ export async function GET(request: NextRequest) {
 
     let userTags: string[] | undefined;
     let userGroups: string[] | undefined;
-    if (scope === "user") {
+    if (scope === "user" || scope === "userCacheHitRate") {
       userTags = parseListParam(userTagsParam);
       userGroups = parseListParam(userGroupsParam);
     }
@@ -247,15 +252,21 @@ export async function GET(request: NextRequest) {
           : undefined;
 
       const userModelStatsFormatted =
-        scope === "user" && Array.isArray(typedEntry.modelStats)
+        (scope === "user" || scope === "userCacheHitRate") && Array.isArray(typedEntry.modelStats)
           ? typedEntry.modelStats.map((ms) => {
               const stat = ms as {
-                totalCost: number;
                 model: string | null;
               } & Record<string, unknown>;
               return {
                 ...stat,
-                totalCostFormatted: formatCurrency(stat.totalCost, systemSettings.currencyDisplay),
+                ...("totalCost" in stat && typeof stat.totalCost === "number"
+                  ? {
+                      totalCostFormatted: formatCurrency(
+                        stat.totalCost,
+                        systemSettings.currencyDisplay
+                      ),
+                    }
+                  : {}),
               };
             })
           : undefined;

--- a/src/lib/redis/leaderboard-cache.ts
+++ b/src/lib/redis/leaderboard-cache.ts
@@ -7,37 +7,49 @@ import {
   findAllTimeModelLeaderboard,
   findAllTimeProviderCacheHitRateLeaderboard,
   findAllTimeProviderLeaderboard,
+  findAllTimeUserCacheHitRateLeaderboard,
   findCustomRangeLeaderboard,
   findCustomRangeModelLeaderboard,
   findCustomRangeProviderCacheHitRateLeaderboard,
   findCustomRangeProviderLeaderboard,
+  findCustomRangeUserCacheHitRateLeaderboard,
   findDailyLeaderboard,
   findDailyModelLeaderboard,
   findDailyProviderCacheHitRateLeaderboard,
   findDailyProviderLeaderboard,
+  findDailyUserCacheHitRateLeaderboard,
   findMonthlyLeaderboard,
   findMonthlyModelLeaderboard,
   findMonthlyProviderCacheHitRateLeaderboard,
   findMonthlyProviderLeaderboard,
+  findMonthlyUserCacheHitRateLeaderboard,
   findWeeklyLeaderboard,
   findWeeklyModelLeaderboard,
   findWeeklyProviderCacheHitRateLeaderboard,
   findWeeklyProviderLeaderboard,
+  findWeeklyUserCacheHitRateLeaderboard,
   type LeaderboardEntry,
   type LeaderboardPeriod,
   type ModelLeaderboardEntry,
   type ProviderCacheHitRateLeaderboardEntry,
   type ProviderLeaderboardEntry,
+  type UserCacheHitRateLeaderboardEntry,
   type UserLeaderboardFilters,
 } from "@/repository/leaderboard";
 import type { ProviderType } from "@/types/provider";
 import { getRedisClient } from "./client";
 
 export type { DateRangeParams, LeaderboardPeriod };
-export type LeaderboardScope = "user" | "provider" | "providerCacheHitRate" | "model";
+export type LeaderboardScope =
+  | "user"
+  | "userCacheHitRate"
+  | "provider"
+  | "providerCacheHitRate"
+  | "model";
 
 type LeaderboardData =
   | LeaderboardEntry[]
+  | UserCacheHitRateLeaderboardEntry[]
   | ProviderLeaderboardEntry[]
   | ProviderCacheHitRateLeaderboardEntry[]
   | ModelLeaderboardEntry[];
@@ -46,7 +58,7 @@ export interface LeaderboardFilters {
   providerType?: ProviderType;
   userTags?: string[];
   userGroups?: string[];
-  /** scope=provider 或 scope=user 时生效：是否包含按模型拆分的数据 */
+  /** scope=provider / user / userCacheHitRate 时生效：是否包含按模型拆分的数据 */
   includeModelStats?: boolean;
 }
 
@@ -65,12 +77,13 @@ function buildCacheKey(
   const now = new Date();
   const providerTypeSuffix = filters?.providerType ? `:providerType:${filters.providerType}` : "";
   const includeModelStatsSuffix =
-    (scope === "provider" || scope === "user") && filters?.includeModelStats
+    (scope === "provider" || scope === "user" || scope === "userCacheHitRate") &&
+    filters?.includeModelStats
       ? ":includeModelStats"
       : "";
 
   let userFilterSuffix = "";
-  if (scope === "user") {
+  if (scope === "user" || scope === "userCacheHitRate") {
     const tagsPart = filters?.userTags?.length
       ? `:tags:${[...filters.userTags].sort().join(",")}`
       : "";
@@ -111,7 +124,8 @@ async function queryDatabase(
   filters?: LeaderboardFilters
 ): Promise<LeaderboardData> {
   const userFilters: UserLeaderboardFilters | undefined =
-    scope === "user" && (filters?.userTags?.length || filters?.userGroups?.length)
+    (scope === "user" || scope === "userCacheHitRate") &&
+    (filters?.userTags?.length || filters?.userGroups?.length)
       ? { userTags: filters.userTags, userGroups: filters.userGroups }
       : undefined;
 
@@ -119,6 +133,13 @@ async function queryDatabase(
   if (period === "custom" && dateRange) {
     if (scope === "user") {
       return await findCustomRangeLeaderboard(dateRange, userFilters, filters?.includeModelStats);
+    }
+    if (scope === "userCacheHitRate") {
+      return await findCustomRangeUserCacheHitRateLeaderboard(
+        dateRange,
+        userFilters,
+        filters?.includeModelStats
+      );
     }
     if (scope === "provider") {
       return await findCustomRangeProviderLeaderboard(
@@ -145,6 +166,26 @@ async function queryDatabase(
         return await findAllTimeLeaderboard(userFilters, filters?.includeModelStats);
       default:
         return await findDailyLeaderboard(userFilters, filters?.includeModelStats);
+    }
+  }
+  if (scope === "userCacheHitRate") {
+    switch (period) {
+      case "daily":
+        return await findDailyUserCacheHitRateLeaderboard(userFilters, filters?.includeModelStats);
+      case "weekly":
+        return await findWeeklyUserCacheHitRateLeaderboard(userFilters, filters?.includeModelStats);
+      case "monthly":
+        return await findMonthlyUserCacheHitRateLeaderboard(
+          userFilters,
+          filters?.includeModelStats
+        );
+      case "allTime":
+        return await findAllTimeUserCacheHitRateLeaderboard(
+          userFilters,
+          filters?.includeModelStats
+        );
+      default:
+        return await findDailyUserCacheHitRateLeaderboard(userFilters, filters?.includeModelStats);
     }
   }
   if (scope === "provider") {

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -124,9 +124,14 @@ export interface UserCacheHitRateLeaderboardEntry {
   totalCost: number;
   cacheCreationCost: number;
   totalInputTokens: number;
-  /** @deprecated Use totalInputTokens instead */
+  /** 为与现有缓存命中率榜单前端保持字段一致而保留；值始终等于 totalInputTokens */
   totalTokens: number;
   cacheHitRate: number; // 0-1
+  /**
+   * 可选：按模型拆分
+   * - undefined: 未请求 includeModelStats
+   * - []: 已请求 includeModelStats，但该用户下无可用模型统计
+   */
   modelStats?: UserCacheHitModelStat[];
 }
 
@@ -285,7 +290,7 @@ function buildUserFilterCondition(userFilters?: UserLeaderboardFilters) {
   if (normalizedGroups.length > 0) {
     const groupConditions = normalizedGroups.map(
       (group) =>
-        sql`${group} = ANY(regexp_split_to_array(coalesce(${users.providerGroup}, ''), '\\s*,\\s*'))`
+        sql`${group} = ANY(regexp_split_to_array(coalesce(${users.providerGroup}, ''), '\\s*[,，\n\r]+\\s*'))`
     );
     groupFilterCondition = sql`(${sql.join(groupConditions, sql` OR `)})`;
   }

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { and, desc, eq, isNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, sql } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { providers, usageLedger, users } from "@/drizzle/schema";
 import { resolveSystemTimezone } from "@/lib/utils/timezone";
@@ -108,6 +108,28 @@ export interface ProviderCacheHitRateLeaderboardEntry {
 /**
  * 模型排行榜条目类型
  */
+export interface UserCacheHitModelStat {
+  model: string | null;
+  totalRequests: number;
+  cacheReadTokens: number;
+  totalInputTokens: number;
+  cacheHitRate: number; // 0-1
+}
+
+export interface UserCacheHitRateLeaderboardEntry {
+  userId: number;
+  userName: string;
+  totalRequests: number;
+  cacheReadTokens: number;
+  totalCost: number;
+  cacheCreationCost: number;
+  totalInputTokens: number;
+  /** @deprecated Use totalInputTokens instead */
+  totalTokens: number;
+  cacheHitRate: number; // 0-1
+  modelStats?: UserCacheHitModelStat[];
+}
+
 export interface ModelLeaderboardEntry {
   model: string;
   totalRequests: number;
@@ -250,18 +272,7 @@ function buildDateCondition(
 /**
  * 通用排行榜查询函数（使用 SQL AT TIME ZONE 确保时区正确）
  */
-async function findLeaderboardWithTimezone(
-  period: LeaderboardPeriod,
-  timezone: string,
-  dateRange?: DateRangeParams,
-  userFilters?: UserLeaderboardFilters,
-  includeModelStats?: boolean
-): Promise<LeaderboardEntry[]> {
-  const whereConditions = [
-    LEDGER_BILLING_CONDITION,
-    buildDateCondition(period, timezone, dateRange),
-  ];
-
+function buildUserFilterCondition(userFilters?: UserLeaderboardFilters) {
   const normalizedTags = (userFilters?.userTags ?? []).map((t) => t.trim()).filter(Boolean);
   let tagFilterCondition: ReturnType<typeof sql> | undefined;
   if (normalizedTags.length > 0) {
@@ -274,17 +285,33 @@ async function findLeaderboardWithTimezone(
   if (normalizedGroups.length > 0) {
     const groupConditions = normalizedGroups.map(
       (group) =>
-        sql`${group} = ANY(regexp_split_to_array(coalesce(${users.providerGroup}, ''), '\\s*[,，]+\\s*'))`
+        sql`${group} = ANY(regexp_split_to_array(coalesce(${users.providerGroup}, ''), '\\s*,\\s*'))`
     );
     groupFilterCondition = sql`(${sql.join(groupConditions, sql` OR `)})`;
   }
 
   if (tagFilterCondition && groupFilterCondition) {
-    whereConditions.push(sql`(${tagFilterCondition} OR ${groupFilterCondition})`);
-  } else if (tagFilterCondition) {
-    whereConditions.push(tagFilterCondition);
-  } else if (groupFilterCondition) {
-    whereConditions.push(groupFilterCondition);
+    return sql`(${tagFilterCondition} OR ${groupFilterCondition})`;
+  }
+
+  return tagFilterCondition ?? groupFilterCondition;
+}
+
+async function findLeaderboardWithTimezone(
+  period: LeaderboardPeriod,
+  timezone: string,
+  dateRange?: DateRangeParams,
+  userFilters?: UserLeaderboardFilters,
+  includeModelStats?: boolean
+): Promise<LeaderboardEntry[]> {
+  const whereConditions = [
+    LEDGER_BILLING_CONDITION,
+    buildDateCondition(period, timezone, dateRange),
+  ];
+
+  const userFilterCondition = buildUserFilterCondition(userFilters);
+  if (userFilterCondition) {
+    whereConditions.push(userFilterCondition);
   }
 
   const rankings = await db
@@ -510,6 +537,62 @@ export async function findAllTimeProviderCacheHitRateLeaderboard(
     timezone,
     undefined,
     providerType
+  );
+}
+
+export async function findDailyUserCacheHitRateLeaderboard(
+  userFilters?: UserLeaderboardFilters,
+  includeModelStats?: boolean
+): Promise<UserCacheHitRateLeaderboardEntry[]> {
+  const timezone = await resolveSystemTimezone();
+  return findUserCacheHitRateLeaderboardWithTimezone(
+    "daily",
+    timezone,
+    undefined,
+    userFilters,
+    includeModelStats
+  );
+}
+
+export async function findMonthlyUserCacheHitRateLeaderboard(
+  userFilters?: UserLeaderboardFilters,
+  includeModelStats?: boolean
+): Promise<UserCacheHitRateLeaderboardEntry[]> {
+  const timezone = await resolveSystemTimezone();
+  return findUserCacheHitRateLeaderboardWithTimezone(
+    "monthly",
+    timezone,
+    undefined,
+    userFilters,
+    includeModelStats
+  );
+}
+
+export async function findWeeklyUserCacheHitRateLeaderboard(
+  userFilters?: UserLeaderboardFilters,
+  includeModelStats?: boolean
+): Promise<UserCacheHitRateLeaderboardEntry[]> {
+  const timezone = await resolveSystemTimezone();
+  return findUserCacheHitRateLeaderboardWithTimezone(
+    "weekly",
+    timezone,
+    undefined,
+    userFilters,
+    includeModelStats
+  );
+}
+
+export async function findAllTimeUserCacheHitRateLeaderboard(
+  userFilters?: UserLeaderboardFilters,
+  includeModelStats?: boolean
+): Promise<UserCacheHitRateLeaderboardEntry[]> {
+  const timezone = await resolveSystemTimezone();
+  return findUserCacheHitRateLeaderboardWithTimezone(
+    "allTime",
+    timezone,
+    undefined,
+    userFilters,
+    includeModelStats
   );
 }
 
@@ -798,6 +881,124 @@ async function findProviderCacheHitRateLeaderboardWithTimezone(
  * 查询自定义日期范围供应商消耗排行榜
  * includeModelStats=true 时会额外返回按模型拆分的统计数据（modelStats）
  */
+async function findUserCacheHitRateLeaderboardWithTimezone(
+  period: LeaderboardPeriod,
+  timezone: string,
+  dateRange?: DateRangeParams,
+  userFilters?: UserLeaderboardFilters,
+  includeModelStats?: boolean
+): Promise<UserCacheHitRateLeaderboardEntry[]> {
+  const totalInputTokensExpr = sql<number>`(
+    COALESCE(${usageLedger.inputTokens}, 0)::double precision +
+    COALESCE(${usageLedger.cacheCreationInputTokens}, 0)::double precision +
+    COALESCE(${usageLedger.cacheReadInputTokens}, 0)::double precision
+  )`;
+
+  const cacheRequiredCondition = sql`(
+    COALESCE(${usageLedger.cacheCreationInputTokens}, 0) > 0
+    OR COALESCE(${usageLedger.cacheReadInputTokens}, 0) > 0
+  )`;
+
+  const sumTotalInputTokens = sql<number>`COALESCE(sum(${totalInputTokensExpr})::double precision, 0::double precision)`;
+  const sumCacheReadTokens = sql<number>`COALESCE(sum(COALESCE(${usageLedger.cacheReadInputTokens}, 0))::double precision, 0::double precision)`;
+  const sumCacheCreationCost = sql<string>`COALESCE(sum(CASE WHEN COALESCE(${usageLedger.cacheCreationInputTokens}, 0) > 0 THEN ${usageLedger.costUsd} ELSE 0 END), 0)`;
+
+  const cacheHitRateExpr = sql<number>`COALESCE(
+    ${sumCacheReadTokens} / NULLIF(${sumTotalInputTokens}, 0::double precision),
+    0::double precision
+  )`;
+
+  const whereConditions = [
+    LEDGER_BILLING_CONDITION,
+    buildDateCondition(period, timezone, dateRange),
+    cacheRequiredCondition,
+  ];
+
+  const userFilterCondition = buildUserFilterCondition(userFilters);
+  if (userFilterCondition) {
+    whereConditions.push(userFilterCondition);
+  }
+
+  const rankings = await db
+    .select({
+      userId: usageLedger.userId,
+      userName: users.name,
+      totalRequests: sql<number>`count(*)::double precision`,
+      totalCost: sql<string>`COALESCE(sum(${usageLedger.costUsd}), 0)`,
+      cacheReadTokens: sumCacheReadTokens,
+      cacheCreationCost: sumCacheCreationCost,
+      totalInputTokens: sumTotalInputTokens,
+      cacheHitRate: cacheHitRateExpr,
+    })
+    .from(usageLedger)
+    .innerJoin(users, and(sql`${usageLedger.userId} = ${users.id}`, isNull(users.deletedAt)))
+    .where(and(...whereConditions))
+    .groupBy(usageLedger.userId, users.name)
+    .orderBy(desc(cacheHitRateExpr), desc(sql`count(*)`), asc(users.name), asc(usageLedger.userId));
+
+  const baseEntries: UserCacheHitRateLeaderboardEntry[] = rankings.map((entry) => ({
+    userId: entry.userId,
+    userName: entry.userName,
+    totalRequests: entry.totalRequests,
+    totalCost: parseFloat(entry.totalCost),
+    cacheReadTokens: entry.cacheReadTokens,
+    cacheCreationCost: parseFloat(entry.cacheCreationCost),
+    totalInputTokens: entry.totalInputTokens,
+    totalTokens: entry.totalInputTokens,
+    cacheHitRate: clampRatio01(entry.cacheHitRate),
+  }));
+
+  if (!includeModelStats) return baseEntries;
+
+  const systemSettings = await getSystemSettings();
+  const billingModelSource = systemSettings.billingModelSource;
+  const rawModelField =
+    billingModelSource === "original"
+      ? sql<string>`COALESCE(${usageLedger.originalModel}, ${usageLedger.model})`
+      : sql<string>`COALESCE(${usageLedger.model}, ${usageLedger.originalModel})`;
+  const modelField = sql<string | null>`NULLIF(TRIM(${rawModelField}), '')`;
+
+  const modelTotalInput = sql<number>`COALESCE(sum(${totalInputTokensExpr})::double precision, 0::double precision)`;
+  const modelCacheRead = sql<number>`COALESCE(sum(COALESCE(${usageLedger.cacheReadInputTokens}, 0))::double precision, 0::double precision)`;
+  const modelCacheHitRate = sql<number>`COALESCE(
+    ${modelCacheRead} / NULLIF(${modelTotalInput}, 0::double precision),
+    0::double precision
+  )`;
+
+  const modelRows = await db
+    .select({
+      userId: usageLedger.userId,
+      model: modelField,
+      totalRequests: sql<number>`count(*)::double precision`,
+      cacheReadTokens: modelCacheRead,
+      totalInputTokens: modelTotalInput,
+      cacheHitRate: modelCacheHitRate,
+    })
+    .from(usageLedger)
+    .innerJoin(users, and(sql`${usageLedger.userId} = ${users.id}`, isNull(users.deletedAt)))
+    .where(and(...whereConditions))
+    .groupBy(usageLedger.userId, modelField)
+    .orderBy(desc(modelCacheHitRate), desc(sql`count(*)`), asc(modelField));
+
+  const modelStatsByUser = new Map<number, UserCacheHitModelStat[]>();
+  for (const row of modelRows) {
+    const stats = modelStatsByUser.get(row.userId) ?? [];
+    stats.push({
+      model: row.model,
+      totalRequests: row.totalRequests,
+      cacheReadTokens: row.cacheReadTokens,
+      totalInputTokens: row.totalInputTokens,
+      cacheHitRate: clampRatio01(row.cacheHitRate),
+    });
+    modelStatsByUser.set(row.userId, stats);
+  }
+
+  return baseEntries.map((entry) => ({
+    ...entry,
+    modelStats: modelStatsByUser.get(entry.userId) ?? [],
+  }));
+}
+
 export async function findCustomRangeProviderLeaderboard(
   dateRange: DateRangeParams,
   providerType?: ProviderType,
@@ -833,6 +1034,21 @@ export async function findCustomRangeProviderCacheHitRateLeaderboard(
  * 查询今日模型调用排行榜（不限制数量）
  * 使用 SQL AT TIME ZONE 进行时区转换，确保"今日"基于系统时区
  */
+export async function findCustomRangeUserCacheHitRateLeaderboard(
+  dateRange: DateRangeParams,
+  userFilters?: UserLeaderboardFilters,
+  includeModelStats?: boolean
+): Promise<UserCacheHitRateLeaderboardEntry[]> {
+  const timezone = await resolveSystemTimezone();
+  return findUserCacheHitRateLeaderboardWithTimezone(
+    "custom",
+    timezone,
+    dateRange,
+    userFilters,
+    includeModelStats
+  );
+}
+
 export async function findDailyModelLeaderboard(): Promise<ModelLeaderboardEntry[]> {
   const timezone = await resolveSystemTimezone();
   return findModelLeaderboardWithTimezone("daily", timezone);

--- a/tests/unit/api/leaderboard-route.test.ts
+++ b/tests/unit/api/leaderboard-route.test.ts
@@ -67,6 +67,22 @@ describe("GET /api/leaderboard", () => {
     expect(options.userGroups).toEqual(["a", "b", "c"]);
   });
 
+  it("applies userTags/userGroups to userCacheHitRate scope too", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: 1, name: "u", role: "admin" } });
+
+    const { GET } = await import("@/app/api/leaderboard/route");
+    const url =
+      "http://localhost/api/leaderboard?scope=userCacheHitRate&period=daily&userTags=vip, beta &userGroups=g1, g2";
+    const response = await GET({ nextUrl: new URL(url) } as any);
+
+    expect(response.status).toBe(200);
+
+    expect(mocks.getLeaderboardWithCache).toHaveBeenCalledTimes(1);
+    const options = mocks.getLeaderboardWithCache.mock.calls[0][4];
+    expect(options.userTags).toEqual(["vip", "beta"]);
+    expect(options.userGroups).toEqual(["g1", "g2"]);
+  });
+
   it("does not apply userTags/userGroups when scope is not user", async () => {
     mocks.getSession.mockResolvedValue({ user: { id: 1, name: "u", role: "admin" } });
 
@@ -196,6 +212,51 @@ describe("GET /api/leaderboard", () => {
       expect(entry.modelStats).toHaveLength(2);
       expect(entry.modelStats[0]).toHaveProperty("model", "claude-3-opus");
       expect(entry.modelStats[0]).toHaveProperty("cacheHitRate", 0.53);
+    });
+
+    it("includes modelStats in userCacheHitRate scope response", async () => {
+      mocks.getSession.mockResolvedValue({ user: { id: 1, name: "u", role: "admin" } });
+      mocks.getLeaderboardWithCache.mockResolvedValue([
+        {
+          userId: 7,
+          userName: "cache-user",
+          totalRequests: 50,
+          cacheReadTokens: 10000,
+          totalCost: 2.5,
+          cacheCreationCost: 1.0,
+          totalInputTokens: 20000,
+          totalTokens: 20000,
+          cacheHitRate: 0.5,
+          modelStats: [
+            {
+              model: "claude-3-opus",
+              totalRequests: 30,
+              cacheReadTokens: 8000,
+              totalInputTokens: 15000,
+              cacheHitRate: 0.53,
+            },
+            {
+              model: null,
+              totalRequests: 20,
+              cacheReadTokens: 2000,
+              totalInputTokens: 5000,
+              cacheHitRate: 0.4,
+            },
+          ],
+        },
+      ]);
+
+      const { GET } = await import("@/app/api/leaderboard/route");
+      const url = "http://localhost/api/leaderboard?scope=userCacheHitRate&period=daily";
+      const response = await GET({ nextUrl: new URL(url) } as any);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toHaveLength(1);
+      expect(body[0]).toHaveProperty("modelStats");
+      expect(body[0].modelStats).toHaveLength(2);
+      expect(body[0].modelStats[0]).toHaveProperty("model", "claude-3-opus");
+      expect(body[0].modelStats[1]).toHaveProperty("model", null);
     });
 
     it("passes includeModelStats to cache and formats provider modelStats entries", async () => {
@@ -350,6 +411,45 @@ describe("GET /api/leaderboard", () => {
       expect(response.status).toBe(403);
       const body = await response.json();
       expect(body.error).toBe("INCLUDE_USER_MODEL_STATS_ADMIN_REQUIRED");
+    });
+
+    it("admin + userCacheHitRate + includeUserModelStats=1 forwards includeModelStats to cache", async () => {
+      mocks.getSession.mockResolvedValue({ user: { id: 1, name: "admin", role: "admin" } });
+      mocks.getLeaderboardWithCache.mockResolvedValue([
+        {
+          userId: 1,
+          userName: "cache-user",
+          totalRequests: 20,
+          cacheReadTokens: 500,
+          totalCost: 1.5,
+          cacheCreationCost: 0.4,
+          totalInputTokens: 1000,
+          totalTokens: 1000,
+          cacheHitRate: 0.5,
+          modelStats: [
+            {
+              model: "claude-sonnet",
+              totalRequests: 20,
+              cacheReadTokens: 500,
+              totalInputTokens: 1000,
+              cacheHitRate: 0.5,
+            },
+          ],
+        },
+      ]);
+
+      const { GET } = await import("@/app/api/leaderboard/route");
+      const url =
+        "http://localhost/api/leaderboard?scope=userCacheHitRate&period=daily&includeUserModelStats=1";
+      const response = await GET({ nextUrl: new URL(url) } as any);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+      expect(mocks.getLeaderboardWithCache).toHaveBeenCalledTimes(1);
+      expect(mocks.getLeaderboardWithCache.mock.calls[0][4].includeModelStats).toBe(true);
+      expect(body[0].modelStats).toHaveLength(1);
+      expect(body[0].modelStats[0]).not.toHaveProperty("totalCostFormatted");
     });
   });
 });

--- a/tests/unit/dashboard/leaderboard-view-user-cache-hit-rate.test.tsx
+++ b/tests/unit/dashboard/leaderboard-view-user-cache-hit-rate.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LeaderboardView } from "@/app/[locale]/dashboard/leaderboard/_components/leaderboard-view";
+
+const fetchMock = vi.fn<typeof fetch>();
+const { getAllUserTagsMock, getAllUserKeyGroupsMock } = vi.hoisted(() => ({
+  getAllUserTagsMock: vi.fn(),
+  getAllUserKeyGroupsMock: vi.fn(),
+}));
+const searchParamsState = vi.hoisted(() => ({
+  value: new URLSearchParams(),
+}));
+const tMock = vi.hoisted(() => vi.fn((key: string) => key));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsState.value,
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => tMock,
+}));
+
+vi.mock("@/actions/users", () => ({
+  getAllUserTags: getAllUserTagsMock,
+  getAllUserKeyGroups: getAllUserKeyGroupsMock,
+}));
+
+vi.mock("@/app/[locale]/settings/providers/_components/provider-type-filter", () => ({
+  ProviderTypeFilter: ({ value }: { value: string }) => (
+    <div data-testid="provider-filter">{value}</div>
+  ),
+}));
+
+vi.mock("@/i18n/routing", () => ({
+  Link: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const globalFetch = global.fetch;
+
+describe("LeaderboardView user cache hit rate scope", () => {
+  let container: HTMLDivElement | null = null;
+  let root: ReturnType<typeof createRoot> | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParamsState.value = new URLSearchParams("scope=userCacheHitRate");
+    getAllUserTagsMock.mockResolvedValue({ ok: true, data: ["vip"] });
+    getAllUserKeyGroupsMock.mockResolvedValue({ ok: true, data: ["default"] });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("scope=userCacheHitRate")) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              userId: 9,
+              userName: "cache-user",
+              totalRequests: 15,
+              totalCost: 1.5,
+              totalCostFormatted: "$1.50",
+              cacheReadTokens: 500,
+              cacheCreationCost: 0.2,
+              totalInputTokens: 1000,
+              totalTokens: 1000,
+              cacheHitRate: 0.5,
+              modelStats: [
+                {
+                  model: "claude-sonnet-4",
+                  totalRequests: 15,
+                  cacheReadTokens: 500,
+                  totalInputTokens: 1000,
+                  cacheHitRate: 0.5,
+                },
+              ],
+            },
+          ],
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => [],
+      } as Response;
+    });
+
+    global.fetch = fetchMock as typeof fetch;
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root!.unmount());
+      root = null;
+    }
+    if (container) {
+      container.remove();
+      container = null;
+    }
+    global.fetch = globalFetch;
+  });
+
+  it("fetches and renders user cache hit rate leaderboard for admin", async () => {
+    await act(async () => {
+      root!.render(<LeaderboardView isAdmin />);
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    const requestedUrls = fetchMock.mock.calls.map((call) => String(call[0]));
+    expect(requestedUrls.some((url) => url.includes("scope=userCacheHitRate"))).toBe(true);
+    expect(
+      requestedUrls.some(
+        (url) => url.includes("scope=userCacheHitRate") && url.includes("includeUserModelStats=1")
+      )
+    ).toBe(true);
+    expect(container!.textContent).toContain("cache-user");
+    expect(container!.textContent).toContain("50.0%");
+  });
+});

--- a/tests/unit/dashboard/leaderboard-view-user-cache-hit-rate.test.tsx
+++ b/tests/unit/dashboard/leaderboard-view-user-cache-hit-rate.test.tsx
@@ -126,4 +126,57 @@ describe("LeaderboardView user cache hit rate scope", () => {
     expect(container!.textContent).toContain("cache-user");
     expect(container!.textContent).toContain("50.0%");
   });
+
+  it("keeps model cost visible in the existing user leaderboard drilldown", async () => {
+    searchParamsState.value = new URLSearchParams("scope=user");
+    fetchMock.mockImplementationOnce(async (input) => {
+      const url = String(input);
+      if (url.includes("scope=user")) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              userId: 3,
+              userName: "cost-user",
+              totalRequests: 12,
+              totalCost: 4.2,
+              totalCostFormatted: "$4.20",
+              totalTokens: 2400,
+              modelStats: [
+                {
+                  model: "claude-sonnet-4",
+                  totalRequests: 7,
+                  totalCost: 2.1,
+                  totalCostFormatted: "$2.10",
+                  totalTokens: 1400,
+                },
+              ],
+            },
+          ],
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => [],
+      } as Response;
+    });
+
+    await act(async () => {
+      root!.render(<LeaderboardView isAdmin />);
+    });
+
+    const expandButton = container!.querySelector(
+      'button[aria-label="expandModelStats"]'
+    ) as HTMLButtonElement | null;
+    expect(expandButton).toBeTruthy();
+
+    await act(async () => {
+      expandButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container!.textContent).toContain("cost-user");
+    expect(container!.textContent).toContain("claude-sonnet-4");
+    expect(container!.textContent).toContain("$2.10");
+  });
 });

--- a/tests/unit/redis/leaderboard-cache.test.ts
+++ b/tests/unit/redis/leaderboard-cache.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getRedisClient } from "@/lib/redis/client";
+import { getLeaderboardWithCache } from "@/lib/redis/leaderboard-cache";
+import {
+  findDailyUserCacheHitRateLeaderboard,
+  type UserCacheHitRateLeaderboardEntry,
+} from "@/repository/leaderboard";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/redis/client", () => ({
+  getRedisClient: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/timezone", () => ({
+  resolveSystemTimezone: vi.fn().mockResolvedValue("UTC"),
+}));
+
+vi.mock("@/repository/leaderboard", async () => {
+  const actual = await vi.importActual<typeof import("@/repository/leaderboard")>(
+    "@/repository/leaderboard"
+  );
+
+  return {
+    ...actual,
+    findDailyUserCacheHitRateLeaderboard: vi.fn(),
+  };
+});
+
+type RedisMock = {
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  setex: ReturnType<typeof vi.fn>;
+  del: ReturnType<typeof vi.fn>;
+};
+
+function createRedisMock(): RedisMock {
+  return {
+    get: vi.fn(),
+    set: vi.fn(),
+    setex: vi.fn(),
+    del: vi.fn(),
+  };
+}
+
+function createUserCacheHitRateRows(): UserCacheHitRateLeaderboardEntry[] {
+  return [
+    {
+      userId: 1,
+      userName: "alice",
+      totalRequests: 12,
+      totalCost: 1.23,
+      cacheReadTokens: 456,
+      cacheCreationCost: 0.45,
+      totalInputTokens: 789,
+      totalTokens: 789,
+      cacheHitRate: 0.577,
+    },
+  ];
+}
+
+describe("getLeaderboardWithCache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("passes user filters to userCacheHitRate queries on Redis cache miss", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-13T00:00:00Z"));
+
+    const redis = createRedisMock();
+    const rows = createUserCacheHitRateRows();
+    redis.get.mockResolvedValueOnce(null);
+    redis.set.mockResolvedValueOnce("OK");
+    redis.setex.mockResolvedValueOnce("OK");
+    redis.del.mockResolvedValueOnce(1);
+
+    vi.mocked(getRedisClient).mockReturnValue(
+      redis as unknown as NonNullable<ReturnType<typeof getRedisClient>>
+    );
+    vi.mocked(findDailyUserCacheHitRateLeaderboard).mockResolvedValueOnce(rows);
+
+    const result = await getLeaderboardWithCache("daily", "USD", "userCacheHitRate", undefined, {
+      userTags: ["vip", "team-a"],
+      userGroups: ["group-1"],
+      includeModelStats: true,
+    });
+
+    expect(result).toEqual(rows);
+    expect(findDailyUserCacheHitRateLeaderboard).toHaveBeenCalledWith(
+      { userTags: ["vip", "team-a"], userGroups: ["group-1"] },
+      true
+    );
+    expect(redis.setex).toHaveBeenCalledWith(
+      "leaderboard:userCacheHitRate:daily:2026-04-13:USD:includeModelStats:tags:team-a,vip:groups:group-1",
+      60,
+      JSON.stringify(rows)
+    );
+  });
+
+  it("falls back to direct query when Redis is unavailable and still preserves userCacheHitRate filters", async () => {
+    const rows = createUserCacheHitRateRows();
+    vi.mocked(getRedisClient).mockReturnValue(null);
+    vi.mocked(findDailyUserCacheHitRateLeaderboard).mockResolvedValueOnce(rows);
+
+    const result = await getLeaderboardWithCache("daily", "USD", "userCacheHitRate", undefined, {
+      userTags: ["vip"],
+      userGroups: ["group-1"],
+    });
+
+    expect(result).toEqual(rows);
+    expect(findDailyUserCacheHitRateLeaderboard).toHaveBeenCalledWith(
+      { userTags: ["vip"], userGroups: ["group-1"] },
+      undefined
+    );
+  });
+});

--- a/tests/unit/repository/leaderboard-user-model-stats.test.ts
+++ b/tests/unit/repository/leaderboard-user-model-stats.test.ts
@@ -29,6 +29,40 @@ const mocks = vi.hoisted(() => ({
   getSystemSettings: vi.fn(),
 }));
 
+function sqlToString(sqlObj: unknown): string {
+  const visited = new Set<unknown>();
+
+  const walk = (node: unknown): string => {
+    if (!node || visited.has(node)) return "";
+    visited.add(node);
+
+    if (typeof node === "string") return node;
+    if (typeof node === "number") return String(node);
+
+    if (typeof node === "object") {
+      const anyNode = node as Record<string, unknown>;
+      if (Array.isArray(anyNode)) {
+        return anyNode.map(walk).join("");
+      }
+
+      if (anyNode.value !== undefined) {
+        if (Array.isArray(anyNode.value)) {
+          return (anyNode.value as unknown[]).map(walk).join("");
+        }
+        return walk(anyNode.value);
+      }
+
+      if (anyNode.queryChunks) {
+        return walk(anyNode.queryChunks);
+      }
+    }
+
+    return "";
+  };
+
+  return walk(sqlObj);
+}
+
 vi.mock("@/drizzle/db", () => ({
   db: {
     select: (...args: unknown[]) => mockSelect(...args),
@@ -449,5 +483,30 @@ describe("User Cache Hit Rate Leaderboard", () => {
     expect(result).toHaveLength(1);
     expect(result[0].modelStats).toBeUndefined();
     expect(mockSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps chinese comma and newline support in providerGroup filter", async () => {
+    const whereArgs: unknown[] = [];
+    chainMocks = [
+      {
+        from: vi.fn().mockReturnThis(),
+        innerJoin: vi.fn().mockReturnThis(),
+        where: vi.fn((arg: unknown) => {
+          whereArgs.push(arg);
+          return {
+            groupBy: vi.fn().mockReturnThis(),
+            orderBy: vi.fn().mockResolvedValue([]),
+          };
+        }),
+      } as any,
+    ];
+
+    const { findDailyUserCacheHitRateLeaderboard } = await import("@/repository/leaderboard");
+    await findDailyUserCacheHitRateLeaderboard({ userGroups: ["研发"] }, false);
+
+    expect(whereArgs).toHaveLength(1);
+    const whereSql = sqlToString(whereArgs[0]).replace(/\r/g, "\\r").replace(/\n/g, "\\n");
+    expect(whereSql).toContain("regexp_split_to_array");
+    expect(whereSql).toContain("\\s*[,，\\n\\r]+\\s*");
   });
 });

--- a/tests/unit/repository/leaderboard-user-model-stats.test.ts
+++ b/tests/unit/repository/leaderboard-user-model-stats.test.ts
@@ -324,3 +324,130 @@ describe("User Leaderboard Model Stats", () => {
     expect(stats[1].model).toBe("cheap-model");
   });
 });
+
+describe("User Cache Hit Rate Leaderboard", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    selectCallIndex = 0;
+    chainMocks = [];
+    mockSelect.mockClear();
+    mocks.resolveSystemTimezone.mockResolvedValue("UTC");
+    mocks.getSystemSettings.mockResolvedValue({ billingModelSource: "redirected" });
+  });
+
+  it("returns user cache hit rankings with stable ordering and base fields", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          userId: 1,
+          userName: "alice",
+          totalRequests: 30,
+          totalCost: "3.0",
+          cacheReadTokens: 600,
+          cacheCreationCost: "1.0",
+          totalInputTokens: 1000,
+          cacheHitRate: 0.6,
+        },
+        {
+          userId: 2,
+          userName: "bob",
+          totalRequests: 30,
+          totalCost: "2.0",
+          cacheReadTokens: 300,
+          cacheCreationCost: "0.5",
+          totalInputTokens: 1000,
+          cacheHitRate: 0.3,
+        },
+      ]),
+    ];
+
+    const { findDailyUserCacheHitRateLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyUserCacheHitRateLeaderboard();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].cacheHitRate).toBeGreaterThanOrEqual(result[1].cacheHitRate);
+    expect(result[0]).toMatchObject({
+      userId: 1,
+      userName: "alice",
+      totalRequests: 30,
+      totalCost: 3,
+      cacheReadTokens: 600,
+      cacheCreationCost: 1,
+      totalInputTokens: 1000,
+      totalTokens: 1000,
+      cacheHitRate: 0.6,
+    });
+  });
+
+  it("includes modelStats when includeModelStats=true and preserves null model rows", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          userId: 1,
+          userName: "alice",
+          totalRequests: 30,
+          totalCost: "3.0",
+          cacheReadTokens: 600,
+          cacheCreationCost: "1.0",
+          totalInputTokens: 1000,
+          cacheHitRate: 0.6,
+        },
+      ]),
+      createChainMock([
+        {
+          userId: 1,
+          model: "claude-sonnet-4",
+          totalRequests: 20,
+          cacheReadTokens: 500,
+          totalInputTokens: 700,
+          cacheHitRate: 0.714,
+        },
+        {
+          userId: 1,
+          model: null,
+          totalRequests: 10,
+          cacheReadTokens: 100,
+          totalInputTokens: 300,
+          cacheHitRate: 0.333,
+        },
+      ]),
+    ];
+
+    const { findDailyUserCacheHitRateLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyUserCacheHitRateLeaderboard(undefined, true);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].modelStats).toHaveLength(2);
+    expect(result[0].modelStats?.[0].model).toBe("claude-sonnet-4");
+    expect(result[0].modelStats?.[0].cacheHitRate).toBeCloseTo(0.714, 3);
+
+    const nullModelStat = result[0].modelStats?.find((item) => item.model === null);
+    expect(nullModelStat).toBeDefined();
+    expect(nullModelStat?.totalRequests).toBe(10);
+    expect(nullModelStat?.cacheReadTokens).toBe(100);
+  });
+
+  it("does not query model breakdown when includeModelStats is false", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          userId: 1,
+          userName: "alice",
+          totalRequests: 10,
+          totalCost: "1.0",
+          cacheReadTokens: 100,
+          cacheCreationCost: "0.2",
+          totalInputTokens: 400,
+          cacheHitRate: 0.25,
+        },
+      ]),
+    ];
+
+    const { findDailyUserCacheHitRateLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyUserCacheHitRateLeaderboard(undefined, false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].modelStats).toBeUndefined();
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Add a new **User Cache Hit Rate** leaderboard tab (`userCacheHitRate` scope) that ranks users by their prompt-cache hit rate, with per-model drilldown for admins. This mirrors the existing provider-level cache hit rate ranking but aggregates at the user level.

## Problem

The leaderboard already supports provider-level cache hit rate rankings (#398, #753), but there is no way for admins to see which **users** are effectively utilizing prompt caching. This makes it hard to identify users who may need guidance on cache optimization or to recognize users with high cache efficiency.

**Related Issues/PRs:**
- Follow-up to #398 - extends the provider cache hit rate ranking pattern to user-level aggregation
- Follow-up to #753 - replicates the per-model drilldown feature for user cache hit rate
- Related to #856 - both touch `src/repository/leaderboard.ts`; may have merge conflicts

## Solution

Implement the full stack for a `userCacheHitRate` leaderboard scope following the same architecture as the existing `providerCacheHitRate` scope:

1. **Repository**: New `findUserCacheHitRateLeaderboardWithTimezone()` query that aggregates `usage_ledger` by user, computing cache hit rate as `cacheReadTokens / totalInputTokens`. Filters to rows with at least one cache-related token field > 0. Optional second query for per-model breakdown.
2. **Redis cache layer**: Route the new scope through the existing `getLeaderboardWithCache()` pipeline with proper cache key construction and user tag/group filter passthrough.
3. **API route**: Accept `scope=userCacheHitRate`, forward `userTags`/`userGroups` filters (previously only applied to `scope=user`).
4. **Frontend**: New tab (admin-only), column definitions, and expandable model drilldown table.

**Refactoring**: Extracted `buildUserFilterCondition()` from `findLeaderboardWithTimezone()` to share user tag/group filtering logic between the existing user scope and the new cache hit rate scope.

## Changes

### Core Changes
- `src/repository/leaderboard.ts` — New types (`UserCacheHitRateLeaderboardEntry`, `UserCacheHitModelStat`), new query function with per-model drilldown, extracted `buildUserFilterCondition()` helper (+235/-19)
- `src/lib/redis/leaderboard-cache.ts` — Extended `LeaderboardScope` type, added routing for `userCacheHitRate` in `queryDatabase()` and `buildCacheKey()`, ensured user filters are passed through (+46/-5)
- `src/app/api/leaderboard/route.ts` — Accept new scope, pass user tag/group filters for `userCacheHitRate`, handle `modelStats` formatting without assuming `totalCost` exists on sub-rows (+18/-7)
- `src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx` — New `userCacheHitRate` tab (admin-only), column definitions with color-coded hit rate display, expandable model detail rows, grid layout updated to 5-column for admins (+135/-16)

### Supporting Changes
- `messages/{en,ja,ru,zh-CN,zh-TW}/dashboard.json` — i18n strings for the new tab label in all 5 supported languages (+5/-0)

### Tests
- `tests/unit/api/leaderboard-route.test.ts` — API route tests: user tag/group filter passthrough, modelStats in response, admin includeUserModelStats forwarding (+100/-0)
- `tests/unit/dashboard/leaderboard-view-user-cache-hit-rate.test.tsx` — **New file**: UI test verifying fetch and render of user cache hit rate leaderboard for admin (+129/-0)
- `tests/unit/redis/leaderboard-cache.test.ts` — **New file**: Redis cache layer tests for user filter passthrough on cache miss and Redis-unavailable fallback (+125/-0)
- `tests/unit/repository/leaderboard-user-model-stats.test.ts` — Repository tests: base ranking with stable ordering, modelStats with null model handling, no model query when disabled (+127/-0)

## Breaking Changes

None. The `LeaderboardScope` type union is extended with a new member (`"userCacheHitRate"`), which is additive. No exports were removed. No database migrations are included.

## Testing

### Automated Tests
- [x] Unit tests added: API route, repository, Redis cache, and UI component (481 new test lines across 4 files)

### Manual Testing
1. Log in as admin
2. Navigate to Dashboard > Leaderboard
3. Click the "User Cache Hit Rate" tab
4. Verify users are ranked by cache hit rate with color-coded percentages (green >= 85%, yellow >= 60%, orange < 60%)
5. Expand a user row to see per-model cache hit rate breakdown
6. Switch time periods (daily/weekly/monthly/all time/custom) and verify data updates
7. Apply user tag and user group filters, verify filtering works
8. Log in as non-admin and verify the tab is not visible

## Checklist
- [x] Code follows project conventions
- [x] i18n strings added for all 5 languages
- [x] Tests added across all layers
- [ ] Self-review completed
- [ ] Lint passes (author notes existing biome.json version mismatch)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `userCacheHitRate` leaderboard scope that ranks users by prompt-cache hit rate, with per-model drilldown for admins, mirroring the existing `providerCacheHitRate` scope. The full stack — repository query, Redis cache routing, API route, and frontend tab — is implemented correctly and consistently with established patterns. The `buildUserFilterCondition` refactor correctly preserves the Chinese delimiter `，` while adding newline support, and the 481 new test lines provide solid layer-by-layer coverage.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after deciding whether `userCacheHitRate` should be gated to admins at the API level, not just in the UI.

All findings are P2 — no logic errors, crashes, or data corruption. The API scope-access question is a policy decision consistent with existing `scope=user` behaviour, but warrants a deliberate decision given the PR's admin-only intent.

src/app/api/leaderboard/route.ts — scope access guard for non-admin users; src/repository/leaderboard.ts — `totalCost` semantics in the new query.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/repository/leaderboard.ts | Adds `findUserCacheHitRateLeaderboardWithTimezone` with per-model drilldown; extracts `buildUserFilterCondition` helper shared with existing user scope. SQL logic, date conditions, and tie-breaking order match the established provider pattern. `cacheRequiredCondition` consistently applied to both the base and model stats queries. |
| src/lib/redis/leaderboard-cache.ts | Extends `LeaderboardScope` union, routes `userCacheHitRate` through all four period handlers and the custom-range path, propagates user tag/group filters into the cache key and DB query correctly. |
| src/app/api/leaderboard/route.ts | Accepts new scope, passes user filters, guards `includeUserModelStats` behind an admin check, and formats model stats without assuming `totalCost` exists on sub-rows. Non-admin users with `allowGlobalUsageView` can access `scope=userCacheHitRate` directly, which may be unintentional. |
| src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx | New `userCacheHitRate` tab with 6-column table, color-coded hit rate, and expandable model sub-rows for admins. URL scope normalization, filter passthrough, and skeleton column count all updated consistently. |
| tests/unit/api/leaderboard-route.test.ts | Adds coverage for `userCacheHitRate` tag/group filter passthrough, `modelStats` in response, null-model sub-rows, and admin `includeUserModelStats` forwarding. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/api/leaderboard/route.ts
Line: 91-106

Comment:
**`userCacheHitRate` scope accessible to non-admin users via the API**

The PR marks this tab as "admin-only" on the frontend, but the route's only gate is `isAdmin || allowGlobalUsageView`. A non-admin with `allowGlobalUsageView` can call `GET /api/leaderboard?scope=userCacheHitRate` directly and receive the full ranking. The existing `scope=user` has the same behavior (no per-scope admin gate), so this is not a regression, but if the intent is a stricter admin-only policy for this scope at the API level, a guard like the one used for `includeUserModelStats` is needed:

```ts
if (scope === "userCacheHitRate" && !isAdmin) {
  return NextResponse.json({ error: "ADMIN_REQUIRED" }, { status: 403 });
}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/repository/leaderboard.ts
Line: 914-942

Comment:
**`totalCost` reflects only cache-related rows, not the user's overall spend**

The `cacheRequiredCondition` in `whereConditions` limits the query to rows where at least one cache token field is non-zero. As a result, the `totalCost` summed here is the cost from cache-related requests only — it may be substantially less than what the `scope=user` leaderboard shows for the same user. Since the "consumedAmount" column in the UI doesn't distinguish this, admins comparing values across leaderboard tabs may be misled.

This matches the behaviour of `findProviderCacheHitRateLeaderboardWithTimezone`, so it is at least internally consistent. Consider adding a tooltip or column label that clarifies the cost covers cache-related requests only.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["修复排行榜审查反馈"](https://github.com/ding113/claude-code-hub/commit/7a52479b6a8f838829e7b1af8e4946cd924a3ae8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28169581)</sub>

<!-- /greptile_comment -->