### PR TITLE
feat: add K8s health check probes with DB/Redis/Proxy checks

### DIFF
--- a/src/app/api/actions/[...route]/route.ts
+++ b/src/app/api/actions/[...route]/route.ts
@@ -2157,14 +2157,16 @@ app.get(
   })
 );
 
-// 健康检查端点
-app.get("/health", (c) =>
-  c.json({
-    status: "ok",
-    timestamp: new Date().toISOString(),
-    version: "1.0.0",
-  })
-);
+// 健康检查端点 (委托给核心逻辑，支持 K8s 探针)
+app.get("/health", async (c) => {
+  try {
+    const { checkReadiness } = await import("@/lib/health/checker");
+    const health = await checkReadiness();
+    return c.json(health, health.status === "unhealthy" ? 503 : 200);
+  } catch {
+    return c.json({ status: "unhealthy", timestamp: new Date().toISOString() }, 503);
+  }
+});
 
 // 导出处理器 (Vercel Edge Functions 格式)
 export const GET = handle(app);

--- a/src/app/api/actions/[...route]/route.ts
+++ b/src/app/api/actions/[...route]/route.ts
@@ -2157,14 +2157,23 @@ app.get(
   })
 );
 
-// 健康检查端点 (委托给核心逻辑，支持 K8s 探针)
+// 健康检查端点 (保持旧格式兼容，详细探针请用 /api/health/ready)
 app.get("/health", async (c) => {
   try {
-    const { checkReadiness } = await import("@/lib/health/checker");
+    const { checkReadiness, getAppVersion } = await import("@/lib/health/checker");
     const health = await checkReadiness();
-    return c.json(health, health.status === "unhealthy" ? 503 : 200);
+    return c.json({
+      status: health.status === "unhealthy" ? "error" : "ok",
+      timestamp: health.timestamp,
+      version: getAppVersion(),
+      details: health,
+    });
   } catch {
-    return c.json({ status: "unhealthy", timestamp: new Date().toISOString() }, 503);
+    return c.json({
+      status: "error",
+      timestamp: new Date().toISOString(),
+      version: "unknown",
+    });
   }
 });
 

--- a/src/app/api/health/live/route.ts
+++ b/src/app/api/health/live/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(
+    { status: "alive", timestamp: new Date().toISOString() },
+    { status: 200 }
+  );
+}

--- a/src/app/api/health/ready/route.ts
+++ b/src/app/api/health/ready/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { checkReadiness } from "@/lib/health/checker";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const health = await checkReadiness();
+    const httpStatus = health.status === "unhealthy" ? 503 : 200;
+    return NextResponse.json(health, { status: httpStatus });
+  } catch (error) {
+    logger.error({
+      action: "health_readiness_check_failed",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { status: "unhealthy", timestamp: new Date().toISOString(), error: "Health check failed" },
+      { status: 503 }
+    );
+  }
+}

--- a/src/app/api/health/ready/route.ts
+++ b/src/app/api/health/ready/route.ts
@@ -1,23 +1,8 @@
-import { NextResponse } from "next/server";
-import { checkReadiness } from "@/lib/health/checker";
-import { logger } from "@/lib/logger";
+import { handleReadinessRequest } from "@/lib/health/checker";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
-  try {
-    const health = await checkReadiness();
-    const httpStatus = health.status === "unhealthy" ? 503 : 200;
-    return NextResponse.json(health, { status: httpStatus });
-  } catch (error) {
-    logger.error({
-      action: "health_readiness_check_failed",
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return NextResponse.json(
-      { status: "unhealthy", timestamp: new Date().toISOString(), error: "Health check failed" },
-      { status: 503 }
-    );
-  }
+export function GET() {
+  return handleReadinessRequest("health_readiness_check_failed");
 }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { checkReadiness } from "@/lib/health/checker";
+import { logger } from "@/lib/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const health = await checkReadiness();
+    const httpStatus = health.status === "unhealthy" ? 503 : 200;
+    return NextResponse.json(health, { status: httpStatus });
+  } catch (error) {
+    logger.error({
+      action: "health_check_failed",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { status: "unhealthy", timestamp: new Date().toISOString(), error: "Health check failed" },
+      { status: 503 }
+    );
+  }
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,23 +1,8 @@
-import { NextResponse } from "next/server";
-import { checkReadiness } from "@/lib/health/checker";
-import { logger } from "@/lib/logger";
+import { handleReadinessRequest } from "@/lib/health/checker";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
-  try {
-    const health = await checkReadiness();
-    const httpStatus = health.status === "unhealthy" ? 503 : 200;
-    return NextResponse.json(health, { status: httpStatus });
-  } catch (error) {
-    logger.error({
-      action: "health_check_failed",
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return NextResponse.json(
-      { status: "unhealthy", timestamp: new Date().toISOString(), error: "Health check failed" },
-      { status: 503 }
-    );
-  }
+export function GET() {
+  return handleReadinessRequest("health_check_failed");
 }

--- a/src/app/v1/[...route]/route.ts
+++ b/src/app/v1/[...route]/route.ts
@@ -40,8 +40,13 @@ app.post("/chat/completions", handleProxyRequest);
 // Response API 路由（支持 Codex）
 app.post("/responses", handleProxyRequest);
 
+// 内部健康自检端点（不走 proxy，仅验证 Hono 中间件链可用）
+app.get("/_ping", (c) => c.json({ status: "pong" }));
+
 // Claude API 和其他所有请求（fallback）
 app.all("*", handleProxyRequest);
+
+export { app as v1App };
 
 export const GET = handle(app);
 export const POST = handle(app);

--- a/src/lib/health/checker.ts
+++ b/src/lib/health/checker.ts
@@ -1,0 +1,129 @@
+import { sql } from "drizzle-orm";
+import { db } from "@/drizzle/db";
+import { getRedisClient } from "@/lib/redis/client";
+import { APP_VERSION } from "@/lib/version";
+import type { ComponentHealth, HealthCheckResponse } from "./types";
+
+// -- 版本 --
+
+const cachedVersion = APP_VERSION.replace(/^v/i, "");
+
+export function getAppVersion(): string {
+  return cachedVersion;
+}
+
+// -- 超时工具 --
+
+const DB_CHECK_TIMEOUT_MS = 3_000;
+const REDIS_CHECK_TIMEOUT_MS = 2_000;
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} health check timed out after ${timeoutMs}ms`)),
+      timeoutMs
+    );
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+// -- 数据库检查 --
+
+export async function checkDatabase(): Promise<ComponentHealth> {
+  const start = performance.now();
+  try {
+    await withTimeout(db.execute(sql`SELECT 1`), DB_CHECK_TIMEOUT_MS, "database");
+    return { status: "up", latencyMs: Math.round(performance.now() - start) };
+  } catch (error) {
+    return {
+      status: "down",
+      latencyMs: Math.round(performance.now() - start),
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// -- Redis 检查 --
+
+export async function checkRedis(): Promise<ComponentHealth> {
+  const start = performance.now();
+  try {
+    const client = getRedisClient({ allowWhenRateLimitDisabled: true });
+    if (!client) {
+      return { status: "unchecked", message: "Redis not configured" };
+    }
+    if (client.status === "end" || client.status === "close") {
+      return {
+        status: "down",
+        latencyMs: Math.round(performance.now() - start),
+        message: `Redis client status: ${client.status}`,
+      };
+    }
+    await withTimeout(client.ping(), REDIS_CHECK_TIMEOUT_MS, "redis");
+    return { status: "up", latencyMs: Math.round(performance.now() - start) };
+  } catch (error) {
+    return {
+      status: "down",
+      latencyMs: Math.round(performance.now() - start),
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// -- Hono 代理层自检 --
+
+const PROXY_CHECK_TIMEOUT_MS = 2_000;
+
+export async function checkProxy(): Promise<ComponentHealth> {
+  const start = performance.now();
+  try {
+    const { v1App } = await import("@/app/v1/[...route]/route");
+    const res = await withTimeout(
+      Promise.resolve(v1App.request("/v1/_ping", { method: "GET" })),
+      PROXY_CHECK_TIMEOUT_MS,
+      "proxy"
+    );
+    if (res.ok) {
+      return { status: "up", latencyMs: Math.round(performance.now() - start) };
+    }
+    return {
+      status: "down",
+      latencyMs: Math.round(performance.now() - start),
+      message: `Proxy returned HTTP ${res.status}`,
+    };
+  } catch (error) {
+    return {
+      status: "down",
+      latencyMs: Math.round(performance.now() - start),
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// -- 综合判定 --
+
+export async function checkReadiness(): Promise<HealthCheckResponse> {
+  const version = getAppVersion();
+  const [database, redis, proxy] = await Promise.all([checkDatabase(), checkRedis(), checkProxy()]);
+
+  // DB 必需，Redis/Proxy 可选（降级但不摘流量）
+  let status: HealthCheckResponse["status"] = "healthy";
+  if (database.status === "down") {
+    status = "unhealthy";
+  } else if (redis.status === "down" || proxy.status === "down") {
+    status = "degraded";
+  }
+
+  return {
+    status,
+    timestamp: new Date().toISOString(),
+    version,
+    uptime: Math.round(process.uptime()),
+    components: { database, redis, proxy },
+  };
+}

--- a/src/lib/health/checker.ts
+++ b/src/lib/health/checker.ts
@@ -1,4 +1,5 @@
 import { sql } from "drizzle-orm";
+import { NextResponse } from "next/server";
 import { db } from "@/drizzle/db";
 import { getRedisClient } from "@/lib/redis/client";
 import { APP_VERSION } from "@/lib/version";
@@ -18,7 +19,7 @@ const DB_CHECK_TIMEOUT_MS = 3_000;
 const REDIS_CHECK_TIMEOUT_MS = 2_000;
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
-  let timer: ReturnType<typeof setTimeout>;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(
       () => reject(new Error(`${label} health check timed out after ${timeoutMs}ms`)),
@@ -28,7 +29,7 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: str
   try {
     return await Promise.race([promise, timeout]);
   } finally {
-    clearTimeout(timer!);
+    clearTimeout(timer);
   }
 }
 
@@ -53,9 +54,18 @@ export async function checkDatabase(): Promise<ComponentHealth> {
 export async function checkRedis(): Promise<ComponentHealth> {
   const start = performance.now();
   try {
+    const redisUrl = process.env.REDIS_URL?.trim();
+    if (!redisUrl) {
+      return { status: "unchecked", message: "Redis not configured" };
+    }
+
     const client = getRedisClient({ allowWhenRateLimitDisabled: true });
     if (!client) {
-      return { status: "unchecked", message: "Redis not configured" };
+      return {
+        status: "down",
+        latencyMs: Math.round(performance.now() - start),
+        message: "Redis client initialization failed",
+      };
     }
     if (client.status === "end" || client.status === "close") {
       return {
@@ -126,4 +136,24 @@ export async function checkReadiness(): Promise<HealthCheckResponse> {
     uptime: Math.round(process.uptime()),
     components: { database, redis, proxy },
   };
+}
+
+// -- 共享路由 handler --
+
+export async function handleReadinessRequest(action: string): Promise<NextResponse> {
+  try {
+    const health = await checkReadiness();
+    const httpStatus = health.status === "unhealthy" ? 503 : 200;
+    return NextResponse.json(health, { status: httpStatus });
+  } catch (error) {
+    const { logger } = await import("@/lib/logger");
+    logger.error({
+      action,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { status: "unhealthy", timestamp: new Date().toISOString(), error: "Health check failed" },
+      { status: 503 }
+    );
+  }
 }

--- a/src/lib/health/types.ts
+++ b/src/lib/health/types.ts
@@ -1,0 +1,19 @@
+export type ComponentStatus = "up" | "down" | "degraded" | "unchecked";
+
+export interface ComponentHealth {
+  status: ComponentStatus;
+  latencyMs?: number;
+  message?: string;
+}
+
+export interface HealthCheckResponse {
+  status: "healthy" | "degraded" | "unhealthy";
+  timestamp: string;
+  version: string;
+  uptime: number;
+  components?: {
+    database?: ComponentHealth;
+    redis?: ComponentHealth;
+    proxy?: ComponentHealth;
+  };
+}

--- a/tests/unit/api/health-routes.test.ts
+++ b/tests/unit/api/health-routes.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// -- mocks --
+
+const mocks = vi.hoisted(() => ({
+  checkReadiness: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+vi.mock("@/lib/health/checker", () => ({
+  checkReadiness: mocks.checkReadiness,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: mocks.loggerError },
+}));
+
+// -- liveness --
+
+describe("GET /api/health/live", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns 200 with alive status", async () => {
+    const { GET } = await import("@/app/api/health/live/route");
+    const response = GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("alive");
+    expect(body.timestamp).toBeDefined();
+  });
+});
+
+// -- readiness --
+
+describe("GET /api/health/ready", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns 200 for healthy", async () => {
+    mocks.checkReadiness.mockResolvedValue({
+      status: "healthy",
+      timestamp: "2026-04-13T00:00:00.000Z",
+      version: "0.6.8",
+      uptime: 100,
+      components: {
+        database: { status: "up", latencyMs: 1 },
+        redis: { status: "up", latencyMs: 1 },
+        proxy: { status: "up", latencyMs: 1 },
+      },
+    });
+    const { GET } = await import("@/app/api/health/ready/route");
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("healthy");
+  });
+
+  it("returns 200 for degraded", async () => {
+    mocks.checkReadiness.mockResolvedValue({
+      status: "degraded",
+      timestamp: "2026-04-13T00:00:00.000Z",
+      version: "0.6.8",
+      uptime: 100,
+      components: {
+        database: { status: "up", latencyMs: 1 },
+        redis: { status: "down", message: "timeout" },
+        proxy: { status: "up", latencyMs: 1 },
+      },
+    });
+    const { GET } = await import("@/app/api/health/ready/route");
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("degraded");
+  });
+
+  it("returns 503 for unhealthy", async () => {
+    mocks.checkReadiness.mockResolvedValue({
+      status: "unhealthy",
+      timestamp: "2026-04-13T00:00:00.000Z",
+      version: "0.6.8",
+      uptime: 100,
+      components: {
+        database: { status: "down", message: "connection refused" },
+        redis: { status: "up", latencyMs: 1 },
+        proxy: { status: "up", latencyMs: 1 },
+      },
+    });
+    const { GET } = await import("@/app/api/health/ready/route");
+    const response = await GET();
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.status).toBe("unhealthy");
+  });
+
+  it("returns 503 when checkReadiness throws", async () => {
+    mocks.checkReadiness.mockRejectedValue(new Error("unexpected"));
+    const { GET } = await import("@/app/api/health/ready/route");
+    const response = await GET();
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.status).toBe("unhealthy");
+  });
+});
+
+// -- combined /api/health --
+
+describe("GET /api/health", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns 200 for healthy", async () => {
+    mocks.checkReadiness.mockResolvedValue({
+      status: "healthy",
+      timestamp: "2026-04-13T00:00:00.000Z",
+      version: "0.6.8",
+      uptime: 100,
+      components: {
+        database: { status: "up", latencyMs: 1 },
+        redis: { status: "up", latencyMs: 1 },
+        proxy: { status: "up", latencyMs: 1 },
+      },
+    });
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET();
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 503 for unhealthy", async () => {
+    mocks.checkReadiness.mockResolvedValue({
+      status: "unhealthy",
+      timestamp: "2026-04-13T00:00:00.000Z",
+      version: "0.6.8",
+      uptime: 100,
+      components: {
+        database: { status: "down", message: "connection refused" },
+        redis: { status: "down", message: "timeout" },
+        proxy: { status: "down", message: "middleware crashed" },
+      },
+    });
+    const { GET } = await import("@/app/api/health/route");
+    const response = await GET();
+    expect(response.status).toBe(503);
+  });
+});

--- a/tests/unit/api/health-routes.test.ts
+++ b/tests/unit/api/health-routes.test.ts
@@ -3,17 +3,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // -- mocks --
 
 const mocks = vi.hoisted(() => ({
-  checkReadiness: vi.fn(),
-  loggerError: vi.fn(),
+  handleReadinessRequest: vi.fn(),
 }));
 
 vi.mock("@/lib/health/checker", () => ({
-  checkReadiness: mocks.checkReadiness,
+  handleReadinessRequest: mocks.handleReadinessRequest,
 }));
 
-vi.mock("@/lib/logger", () => ({
-  logger: { error: mocks.loggerError },
-}));
+// helper: create NextResponse-like object
+function jsonResponse(body: Record<string, unknown>, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
 
 // -- liveness --
 
@@ -42,17 +45,9 @@ describe("GET /api/health/ready", () => {
   });
 
   it("returns 200 for healthy", async () => {
-    mocks.checkReadiness.mockResolvedValue({
-      status: "healthy",
-      timestamp: "2026-04-13T00:00:00.000Z",
-      version: "0.6.8",
-      uptime: 100,
-      components: {
-        database: { status: "up", latencyMs: 1 },
-        redis: { status: "up", latencyMs: 1 },
-        proxy: { status: "up", latencyMs: 1 },
-      },
-    });
+    mocks.handleReadinessRequest.mockResolvedValue(
+      jsonResponse({ status: "healthy", version: "0.6.8" }, 200)
+    );
     const { GET } = await import("@/app/api/health/ready/route");
     const response = await GET();
     expect(response.status).toBe(200);
@@ -61,17 +56,9 @@ describe("GET /api/health/ready", () => {
   });
 
   it("returns 200 for degraded", async () => {
-    mocks.checkReadiness.mockResolvedValue({
-      status: "degraded",
-      timestamp: "2026-04-13T00:00:00.000Z",
-      version: "0.6.8",
-      uptime: 100,
-      components: {
-        database: { status: "up", latencyMs: 1 },
-        redis: { status: "down", message: "timeout" },
-        proxy: { status: "up", latencyMs: 1 },
-      },
-    });
+    mocks.handleReadinessRequest.mockResolvedValue(
+      jsonResponse({ status: "degraded", version: "0.6.8" }, 200)
+    );
     const { GET } = await import("@/app/api/health/ready/route");
     const response = await GET();
     expect(response.status).toBe(200);
@@ -80,26 +67,7 @@ describe("GET /api/health/ready", () => {
   });
 
   it("returns 503 for unhealthy", async () => {
-    mocks.checkReadiness.mockResolvedValue({
-      status: "unhealthy",
-      timestamp: "2026-04-13T00:00:00.000Z",
-      version: "0.6.8",
-      uptime: 100,
-      components: {
-        database: { status: "down", message: "connection refused" },
-        redis: { status: "up", latencyMs: 1 },
-        proxy: { status: "up", latencyMs: 1 },
-      },
-    });
-    const { GET } = await import("@/app/api/health/ready/route");
-    const response = await GET();
-    expect(response.status).toBe(503);
-    const body = await response.json();
-    expect(body.status).toBe("unhealthy");
-  });
-
-  it("returns 503 when checkReadiness throws", async () => {
-    mocks.checkReadiness.mockRejectedValue(new Error("unexpected"));
+    mocks.handleReadinessRequest.mockResolvedValue(jsonResponse({ status: "unhealthy" }, 503));
     const { GET } = await import("@/app/api/health/ready/route");
     const response = await GET();
     expect(response.status).toBe(503);
@@ -117,34 +85,16 @@ describe("GET /api/health", () => {
   });
 
   it("returns 200 for healthy", async () => {
-    mocks.checkReadiness.mockResolvedValue({
-      status: "healthy",
-      timestamp: "2026-04-13T00:00:00.000Z",
-      version: "0.6.8",
-      uptime: 100,
-      components: {
-        database: { status: "up", latencyMs: 1 },
-        redis: { status: "up", latencyMs: 1 },
-        proxy: { status: "up", latencyMs: 1 },
-      },
-    });
+    mocks.handleReadinessRequest.mockResolvedValue(
+      jsonResponse({ status: "healthy", version: "0.6.8" }, 200)
+    );
     const { GET } = await import("@/app/api/health/route");
     const response = await GET();
     expect(response.status).toBe(200);
   });
 
   it("returns 503 for unhealthy", async () => {
-    mocks.checkReadiness.mockResolvedValue({
-      status: "unhealthy",
-      timestamp: "2026-04-13T00:00:00.000Z",
-      version: "0.6.8",
-      uptime: 100,
-      components: {
-        database: { status: "down", message: "connection refused" },
-        redis: { status: "down", message: "timeout" },
-        proxy: { status: "down", message: "middleware crashed" },
-      },
-    });
+    mocks.handleReadinessRequest.mockResolvedValue(jsonResponse({ status: "unhealthy" }, 503));
     const { GET } = await import("@/app/api/health/route");
     const response = await GET();
     expect(response.status).toBe(503);

--- a/tests/unit/lib/health-checker.test.ts
+++ b/tests/unit/lib/health-checker.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// -- mocks --
+
+const mocks = vi.hoisted(() => ({
+  dbExecute: vi.fn(),
+  getRedisClient: vi.fn(),
+  APP_VERSION: "v0.6.8",
+  v1App: {
+    request: vi.fn(),
+  },
+}));
+
+vi.mock("@/drizzle/db", () => ({
+  db: { execute: mocks.dbExecute },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  sql: (strings: TemplateStringsArray) => strings.join(""),
+}));
+
+vi.mock("@/lib/redis/client", () => ({
+  getRedisClient: mocks.getRedisClient,
+}));
+
+vi.mock("@/lib/version", () => ({
+  APP_VERSION: mocks.APP_VERSION,
+}));
+
+vi.mock("@/app/v1/[...route]/route", () => ({
+  v1App: mocks.v1App,
+}));
+
+// -- tests --
+
+describe("health/checker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  // -- getAppVersion --
+
+  describe("getAppVersion", () => {
+    it("returns version without v prefix", async () => {
+      const { getAppVersion } = await import("@/lib/health/checker");
+      expect(getAppVersion()).toBe("0.6.8");
+    });
+  });
+
+  // -- checkDatabase --
+
+  describe("checkDatabase", () => {
+    it("returns up when SELECT 1 succeeds", async () => {
+      mocks.dbExecute.mockResolvedValue([{ "?column?": 1 }]);
+      const { checkDatabase } = await import("@/lib/health/checker");
+      const result = await checkDatabase();
+      expect(result.status).toBe("up");
+      expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("returns down when query throws", async () => {
+      mocks.dbExecute.mockRejectedValue(new Error("connection refused"));
+      const { checkDatabase } = await import("@/lib/health/checker");
+      const result = await checkDatabase();
+      expect(result.status).toBe("down");
+      expect(result.message).toContain("connection refused");
+    });
+
+    it("returns down on timeout", async () => {
+      mocks.dbExecute.mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 5_000))
+      );
+      const { checkDatabase } = await import("@/lib/health/checker");
+      const result = await checkDatabase();
+      expect(result.status).toBe("down");
+      expect(result.message).toContain("timed out");
+    }, 10_000);
+  });
+
+  // -- checkRedis --
+
+  describe("checkRedis", () => {
+    it("returns up when ping succeeds", async () => {
+      mocks.getRedisClient.mockReturnValue({
+        status: "ready",
+        ping: vi.fn().mockResolvedValue("PONG"),
+      });
+      const { checkRedis } = await import("@/lib/health/checker");
+      const result = await checkRedis();
+      expect(result.status).toBe("up");
+    });
+
+    it("returns unchecked when client is null", async () => {
+      mocks.getRedisClient.mockReturnValue(null);
+      const { checkRedis } = await import("@/lib/health/checker");
+      const result = await checkRedis();
+      expect(result.status).toBe("unchecked");
+      expect(result.message).toContain("not configured");
+    });
+
+    it("returns down when client status is end", async () => {
+      mocks.getRedisClient.mockReturnValue({ status: "end" });
+      const { checkRedis } = await import("@/lib/health/checker");
+      const result = await checkRedis();
+      expect(result.status).toBe("down");
+      expect(result.message).toContain("end");
+    });
+
+    it("returns down when client status is close", async () => {
+      mocks.getRedisClient.mockReturnValue({ status: "close" });
+      const { checkRedis } = await import("@/lib/health/checker");
+      const result = await checkRedis();
+      expect(result.status).toBe("down");
+      expect(result.message).toContain("close");
+    });
+
+    it("returns down when ping throws", async () => {
+      mocks.getRedisClient.mockReturnValue({
+        status: "ready",
+        ping: vi.fn().mockRejectedValue(new Error("ECONNRESET")),
+      });
+      const { checkRedis } = await import("@/lib/health/checker");
+      const result = await checkRedis();
+      expect(result.status).toBe("down");
+      expect(result.message).toContain("ECONNRESET");
+    });
+
+    it("returns down on ping timeout", async () => {
+      mocks.getRedisClient.mockReturnValue({
+        status: "ready",
+        ping: vi.fn().mockImplementation(() => new Promise((r) => setTimeout(r, 5_000))),
+      });
+      const { checkRedis } = await import("@/lib/health/checker");
+      const result = await checkRedis();
+      expect(result.status).toBe("down");
+      expect(result.message).toContain("timed out");
+    }, 10_000);
+  });
+
+  // -- checkProxy --
+
+  describe("checkProxy", () => {
+    it("returns up when _ping returns 200", async () => {
+      mocks.v1App.request.mockResolvedValue(new Response('{"status":"pong"}', { status: 200 }));
+      const { checkProxy } = await import("@/lib/health/checker");
+      const result = await checkProxy();
+      expect(result.status).toBe("up");
+      expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("returns down when _ping returns non-200", async () => {
+      mocks.v1App.request.mockResolvedValue(new Response("error", { status: 500 }));
+      const { checkProxy } = await import("@/lib/health/checker");
+      const result = await checkProxy();
+      expect(result.status).toBe("down");
+      expect(result.message).toContain("HTTP 500");
+    });
+
+    it("returns down when request throws", async () => {
+      mocks.v1App.request.mockRejectedValue(new Error("middleware crashed"));
+      const { checkProxy } = await import("@/lib/health/checker");
+      const result = await checkProxy();
+      expect(result.status).toBe("down");
+      expect(result.message).toContain("middleware crashed");
+    });
+
+    it("returns down on timeout", async () => {
+      mocks.v1App.request.mockImplementation(() => new Promise((r) => setTimeout(r, 5_000)));
+      const { checkProxy } = await import("@/lib/health/checker");
+      const result = await checkProxy();
+      expect(result.status).toBe("down");
+      expect(result.message).toContain("timed out");
+    }, 10_000);
+  });
+
+  // -- checkReadiness --
+
+  describe("checkReadiness", () => {
+    it("returns healthy when all components are up", async () => {
+      mocks.dbExecute.mockResolvedValue([{ "?column?": 1 }]);
+      mocks.getRedisClient.mockReturnValue({
+        status: "ready",
+        ping: vi.fn().mockResolvedValue("PONG"),
+      });
+      mocks.v1App.request.mockResolvedValue(new Response('{"status":"pong"}', { status: 200 }));
+      const { checkReadiness } = await import("@/lib/health/checker");
+      const result = await checkReadiness();
+      expect(result.status).toBe("healthy");
+      expect(result.version).toBe("0.6.8");
+      expect(result.uptime).toBeGreaterThanOrEqual(0);
+      expect(result.components?.database?.status).toBe("up");
+      expect(result.components?.redis?.status).toBe("up");
+      expect(result.components?.proxy?.status).toBe("up");
+    });
+
+    it("returns degraded when Redis is down but DB and proxy are up", async () => {
+      mocks.dbExecute.mockResolvedValue([{ "?column?": 1 }]);
+      mocks.getRedisClient.mockReturnValue({
+        status: "ready",
+        ping: vi.fn().mockRejectedValue(new Error("ECONNRESET")),
+      });
+      mocks.v1App.request.mockResolvedValue(new Response('{"status":"pong"}', { status: 200 }));
+      const { checkReadiness } = await import("@/lib/health/checker");
+      const result = await checkReadiness();
+      expect(result.status).toBe("degraded");
+      expect(result.components?.database?.status).toBe("up");
+      expect(result.components?.redis?.status).toBe("down");
+    });
+
+    it("returns degraded when proxy is down but DB and Redis are up", async () => {
+      mocks.dbExecute.mockResolvedValue([{ "?column?": 1 }]);
+      mocks.getRedisClient.mockReturnValue({
+        status: "ready",
+        ping: vi.fn().mockResolvedValue("PONG"),
+      });
+      mocks.v1App.request.mockRejectedValue(new Error("middleware crashed"));
+      const { checkReadiness } = await import("@/lib/health/checker");
+      const result = await checkReadiness();
+      expect(result.status).toBe("degraded");
+      expect(result.components?.proxy?.status).toBe("down");
+    });
+
+    it("returns unhealthy when DB is down", async () => {
+      mocks.dbExecute.mockRejectedValue(new Error("connection refused"));
+      mocks.getRedisClient.mockReturnValue({
+        status: "ready",
+        ping: vi.fn().mockResolvedValue("PONG"),
+      });
+      mocks.v1App.request.mockResolvedValue(new Response('{"status":"pong"}', { status: 200 }));
+      const { checkReadiness } = await import("@/lib/health/checker");
+      const result = await checkReadiness();
+      expect(result.status).toBe("unhealthy");
+      expect(result.components?.database?.status).toBe("down");
+    });
+
+    it("returns healthy when Redis is unchecked (not configured)", async () => {
+      mocks.dbExecute.mockResolvedValue([{ "?column?": 1 }]);
+      mocks.getRedisClient.mockReturnValue(null);
+      mocks.v1App.request.mockResolvedValue(new Response('{"status":"pong"}', { status: 200 }));
+      const { checkReadiness } = await import("@/lib/health/checker");
+      const result = await checkReadiness();
+      expect(result.status).toBe("healthy");
+      expect(result.components?.redis?.status).toBe("unchecked");
+    });
+  });
+});

--- a/tests/unit/lib/health-checker.test.ts
+++ b/tests/unit/lib/health-checker.test.ts
@@ -82,6 +82,7 @@ describe("health/checker", () => {
 
   describe("checkRedis", () => {
     it("returns up when ping succeeds", async () => {
+      process.env.REDIS_URL = "redis://localhost:6379";
       mocks.getRedisClient.mockReturnValue({
         status: "ready",
         ping: vi.fn().mockResolvedValue("PONG"),
@@ -89,9 +90,11 @@ describe("health/checker", () => {
       const { checkRedis } = await import("@/lib/health/checker");
       const result = await checkRedis();
       expect(result.status).toBe("up");
+      delete process.env.REDIS_URL;
     });
 
-    it("returns unchecked when client is null", async () => {
+    it("returns unchecked when REDIS_URL is not set", async () => {
+      delete process.env.REDIS_URL;
       mocks.getRedisClient.mockReturnValue(null);
       const { checkRedis } = await import("@/lib/health/checker");
       const result = await checkRedis();
@@ -99,23 +102,38 @@ describe("health/checker", () => {
       expect(result.message).toContain("not configured");
     });
 
+    it("returns down when REDIS_URL is set but client is null", async () => {
+      process.env.REDIS_URL = "redis://localhost:6379";
+      mocks.getRedisClient.mockReturnValue(null);
+      const { checkRedis } = await import("@/lib/health/checker");
+      const result = await checkRedis();
+      expect(result.status).toBe("down");
+      expect(result.message).toContain("initialization failed");
+      delete process.env.REDIS_URL;
+    });
+
     it("returns down when client status is end", async () => {
+      process.env.REDIS_URL = "redis://localhost:6379";
       mocks.getRedisClient.mockReturnValue({ status: "end" });
       const { checkRedis } = await import("@/lib/health/checker");
       const result = await checkRedis();
       expect(result.status).toBe("down");
       expect(result.message).toContain("end");
+      delete process.env.REDIS_URL;
     });
 
     it("returns down when client status is close", async () => {
+      process.env.REDIS_URL = "redis://localhost:6379";
       mocks.getRedisClient.mockReturnValue({ status: "close" });
       const { checkRedis } = await import("@/lib/health/checker");
       const result = await checkRedis();
       expect(result.status).toBe("down");
       expect(result.message).toContain("close");
+      delete process.env.REDIS_URL;
     });
 
     it("returns down when ping throws", async () => {
+      process.env.REDIS_URL = "redis://localhost:6379";
       mocks.getRedisClient.mockReturnValue({
         status: "ready",
         ping: vi.fn().mockRejectedValue(new Error("ECONNRESET")),
@@ -124,9 +142,11 @@ describe("health/checker", () => {
       const result = await checkRedis();
       expect(result.status).toBe("down");
       expect(result.message).toContain("ECONNRESET");
+      delete process.env.REDIS_URL;
     });
 
     it("returns down on ping timeout", async () => {
+      process.env.REDIS_URL = "redis://localhost:6379";
       mocks.getRedisClient.mockReturnValue({
         status: "ready",
         ping: vi.fn().mockImplementation(() => new Promise((r) => setTimeout(r, 5_000))),
@@ -135,6 +155,7 @@ describe("health/checker", () => {
       const result = await checkRedis();
       expect(result.status).toBe("down");
       expect(result.message).toContain("timed out");
+      delete process.env.REDIS_URL;
     }, 10_000);
   });
 
@@ -178,6 +199,7 @@ describe("health/checker", () => {
 
   describe("checkReadiness", () => {
     it("returns healthy when all components are up", async () => {
+      process.env.REDIS_URL = "redis://localhost:6379";
       mocks.dbExecute.mockResolvedValue([{ "?column?": 1 }]);
       mocks.getRedisClient.mockReturnValue({
         status: "ready",
@@ -192,9 +214,11 @@ describe("health/checker", () => {
       expect(result.components?.database?.status).toBe("up");
       expect(result.components?.redis?.status).toBe("up");
       expect(result.components?.proxy?.status).toBe("up");
+      delete process.env.REDIS_URL;
     });
 
     it("returns degraded when Redis is down but DB and proxy are up", async () => {
+      process.env.REDIS_URL = "redis://localhost:6379";
       mocks.dbExecute.mockResolvedValue([{ "?column?": 1 }]);
       mocks.getRedisClient.mockReturnValue({
         status: "ready",
@@ -206,9 +230,11 @@ describe("health/checker", () => {
       expect(result.status).toBe("degraded");
       expect(result.components?.database?.status).toBe("up");
       expect(result.components?.redis?.status).toBe("down");
+      delete process.env.REDIS_URL;
     });
 
     it("returns degraded when proxy is down but DB and Redis are up", async () => {
+      process.env.REDIS_URL = "redis://localhost:6379";
       mocks.dbExecute.mockResolvedValue([{ "?column?": 1 }]);
       mocks.getRedisClient.mockReturnValue({
         status: "ready",
@@ -219,9 +245,11 @@ describe("health/checker", () => {
       const result = await checkReadiness();
       expect(result.status).toBe("degraded");
       expect(result.components?.proxy?.status).toBe("down");
+      delete process.env.REDIS_URL;
     });
 
     it("returns unhealthy when DB is down", async () => {
+      process.env.REDIS_URL = "redis://localhost:6379";
       mocks.dbExecute.mockRejectedValue(new Error("connection refused"));
       mocks.getRedisClient.mockReturnValue({
         status: "ready",
@@ -232,6 +260,7 @@ describe("health/checker", () => {
       const result = await checkReadiness();
       expect(result.status).toBe("unhealthy");
       expect(result.components?.database?.status).toBe("down");
+      delete process.env.REDIS_URL;
     });
 
     it("returns healthy when Redis is unchecked (not configured)", async () => {


### PR DESCRIPTION
## Summary

- Replace the static `/api/actions/health` endpoint (always returned `{ status: "ok" }`) with proper K8s-ready health probes
- Add liveness, readiness, and combined health endpoints with real dependency checks (DB, Redis, Hono proxy)
- Include timeout protection, correct HTTP status codes, and component-level status reporting

## Health Check Endpoints

### `GET /api/health/live` — Liveness Probe

Checks if the Node.js process is alive. No external dependencies. If this endpoint responds, the process is running.

- **K8s use**: `livenessProbe` — failure triggers pod restart
- **Always returns**: HTTP 200

```json
{
  "status": "alive",
  "timestamp": "2026-04-13T10:00:00.000Z"
}
```

---

### `GET /api/health/ready` — Readiness Probe

Checks all critical dependencies: **Database** (3s timeout), **Redis** (2s timeout), **Hono proxy layer** (2s timeout).

- **K8s use**: `readinessProbe` — failure removes pod from service (no restart)
- **Returns**: HTTP 200 (healthy/degraded) or HTTP 503 (unhealthy)

**Healthy** (all components up) → `200`:
```json
{
  "status": "healthy",
  "timestamp": "2026-04-13T10:00:00.000Z",
  "version": "0.6.8",
  "uptime": 3600,
  "components": {
    "database": { "status": "up", "latencyMs": 2 },
    "redis": { "status": "up", "latencyMs": 1 },
    "proxy": { "status": "up", "latencyMs": 3 }
  }
}
```

**Degraded** (Redis or Proxy down, DB up) → `200`:
```json
{
  "status": "degraded",
  "version": "0.6.8",
  "components": {
    "database": { "status": "up", "latencyMs": 2 },
    "redis": { "status": "down", "message": "redis health check timed out after 2000ms" },
    "proxy": { "status": "up", "latencyMs": 3 }
  }
}
```

**Unhealthy** (DB down) → `503`:
```json
{
  "status": "unhealthy",
  "version": "0.6.8",
  "components": {
    "database": { "status": "down", "message": "database health check timed out after 3000ms" },
    "redis": { "status": "up", "latencyMs": 1 },
    "proxy": { "status": "up", "latencyMs": 3 }
  }
}
```

---

### `GET /api/health` — Combined Endpoint

Same behavior as `/api/health/ready`. General-purpose health endpoint.

---

### `GET /api/actions/health` — Legacy Endpoint (Updated)

Backward-compatible. Now delegates to the same core logic as `/api/health/ready` via dynamic import.

---

## Component Status Logic

| Component | Required? | Down Effect | Check Method |
|-----------|-----------|-------------|--------------|
| Database (PostgreSQL) | **Yes** | `unhealthy` (503) | `SELECT 1` with 3s timeout |
| Redis | No | `degraded` (200) | `PING` with 2s timeout |
| Proxy (Hono) | No | `degraded` (200) | Internal `app.request("/_ping")` — no network |

## K8s Configuration Example

```yaml
livenessProbe:
  httpGet:
    path: /api/health/live
    port: 3000
  initialDelaySeconds: 10
  periodSeconds: 15
  timeoutSeconds: 3
  failureThreshold: 3

readinessProbe:
  httpGet:
    path: /api/health/ready
    port: 3000
  initialDelaySeconds: 5
  periodSeconds: 10
  timeoutSeconds: 5
  failureThreshold: 2

startupProbe:
  httpGet:
    path: /api/health/ready
    port: 3000
  periodSeconds: 5
  failureThreshold: 30
```

## Architecture Decisions

1. **Standalone Next.js routes** (not inside Hono `[...route]`) — probes work even if Hono has issues
2. **Hono self-check via `app.request()`** — in-memory call, no network overhead, validates the middleware chain
3. **DB required, Redis/Proxy optional** — matches existing design where Redis is opt-in
4. **`Promise.race` timeout** — drizzle `execute()` doesn't support `AbortSignal`
5. **Version from `APP_VERSION`** — no more hardcoded `"1.0.0"`

## Files Changed

**New:**
- `src/lib/health/types.ts` — TypeScript interfaces
- `src/lib/health/checker.ts` — Core check logic (DB/Redis/Proxy + timeout)
- `src/app/api/health/live/route.ts` — Liveness probe
- `src/app/api/health/ready/route.ts` — Readiness probe
- `src/app/api/health/route.ts` — Combined endpoint
- `tests/unit/lib/health-checker.test.ts` — 19 unit tests
- `tests/unit/api/health-routes.test.ts` — 7 unit tests

**Modified:**
- `src/app/v1/[...route]/route.ts` — Added `/_ping` endpoint + exported `v1App`
- `src/app/api/actions/[...route]/route.ts` — Updated Hono `/health` to use core logic

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors
- [x] 26/26 unit tests passing
- [ ] Manual: `curl /api/health/live` returns 200
- [ ] Manual: `curl /api/health/ready` returns 200 with component details
- [ ] Manual: Stop DB → `/api/health/ready` returns 503
- [ ] Manual: Stop Redis → `/api/health/ready` returns 200 + `degraded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces a static `{ status: "ok" }` health endpoint with proper K8s-ready liveness and readiness probes. DB is treated as a required dependency (503 on failure), while Redis and the Hono proxy layer are optional (200 + `degraded`). The proxy self-check uses `v1App.request("/v1/_ping")` which correctly resolves to the `/_ping` handler given the app's `.basePath("/v1")` configuration.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all previous review concerns have been addressed and the only remaining finding is a minor response-shape inconsistency in the error fallback.

The implementation is correct: basePath("/v1") makes v1App.request("/v1/_ping") resolve to the /_ping handler, timeout logic is sound, status classification matches the documented design, and 26 unit tests pass. The single remaining comment is a P2 style inconsistency that does not affect the normal health-check path.

src/lib/health/checker.ts — error fallback at line 154 is missing version and uptime fields.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/health/checker.ts | Core health-check logic: DB/Redis/Proxy checks with timeout wrappers and shared readiness handler; minor inconsistency in error-fallback response shape (missing version/uptime). |
| src/lib/health/types.ts | TypeScript interfaces for ComponentHealth and HealthCheckResponse; clean and well-typed. |
| src/app/api/health/live/route.ts | Liveness probe — always returns 200 with alive status; correct and minimal. |
| src/app/api/health/ready/route.ts | Readiness probe delegating to shared handleReadinessRequest; no duplication, correct. |
| src/app/api/health/route.ts | Combined health endpoint identical in behavior to ready probe; shares implementation correctly. |
| src/app/v1/[...route]/route.ts | Adds /_ping route (before the wildcard fallback) and exports v1App; path /v1/_ping used in checker is correct given .basePath("/v1"). |
| src/app/api/actions/[...route]/route.ts | Legacy /health endpoint updated to delegate to checkReadiness; backward-compatible (always HTTP 200, maps degraded to "ok"). |
| tests/unit/lib/health-checker.test.ts | 19 unit tests covering all check functions and status transitions; comprehensive and well-structured. |
| tests/unit/api/health-routes.test.ts | 7 route-level tests for live, ready, and combined endpoints; mocks handleReadinessRequest cleanly. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[K8s Probe] --> B{Endpoint}
    B -->|GET /api/health/live| C[200 alive always]
    B -->|GET /api/health/ready or /api/health| D[checkReadiness]
    D --> E[DB: SELECT 1 3s timeout]
    D --> F[Redis: PING 2s timeout]
    D --> G[Proxy: v1App.request /v1/_ping 2s timeout]
    E & F & G --> H{Evaluate}
    H -->|DB down| I[status = unhealthy HTTP 503]
    H -->|Redis or Proxy down DB up| J[status = degraded HTTP 200]
    H -->|All up or Redis unchecked| K[status = healthy HTTP 200]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/health/checker.ts
Line: 154-157

Comment:
**Error fallback missing `version` and `uptime` fields**

When `checkReadiness()` itself throws (not just returns "unhealthy"), the catch-path response omits `version` and `uptime`, which are required by `HealthCheckResponse` and are present in every normal response. Monitoring clients that unconditionally read `body.version` will get `undefined` here.

```suggestion
    return NextResponse.json(
      {
        status: "unhealthy",
        timestamp: new Date().toISOString(),
        version: cachedVersion,
        uptime: Math.round(process.uptime()),
        error: "Health check failed",
      },
      { status: 503 }
    );
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address code review findings from P..."](https://github.com/ding113/claude-code-hub/commit/173e460e65fc4efe6025811a7324d017c79c8816) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28198487)</sub>

<!-- /greptile_comment -->