### PR TITLE
feat: hide IP column by default and reuse VirtualizedLogsTable in my-usage page

### DIFF
--- a/src/actions/my-usage.ts
+++ b/src/actions/my-usage.ts
@@ -89,6 +89,7 @@ export interface MyUsageMetadata {
   dailyResetMode: "fixed" | "rolling";
   dailyResetTime: string;
   currencyCode: CurrencyCode;
+  billingModelSource: BillingModelSource;
 }
 
 export interface MyUsageQuota {
@@ -227,6 +228,7 @@ export async function getMyUsageMetadata(): Promise<ActionResult<MyUsageMetadata
       dailyResetMode: key.dailyResetMode ?? "fixed",
       dailyResetTime: key.dailyResetTime ?? "00:00",
       currencyCode: settings.currencyDisplay,
+      billingModelSource: settings.billingModelSource,
     };
 
     return { ok: true, data: metadata };
@@ -653,8 +655,9 @@ export async function getMyUsageLogsBatchFull(
     const session = await getSession({ allowReadOnlyAccess: true });
     if (!session) return { ok: false, error: "Unauthorized" };
 
+    const { userId: _u, keyId: _k, providerId: _p, ...safeParams } = params as UsageLogBatchFilters;
     const result = await findUsageLogsBatch({
-      ...params,
+      ...safeParams,
       keyId: session.key.id,
     });
 

--- a/src/actions/my-usage.ts
+++ b/src/actions/my-usage.ts
@@ -16,12 +16,15 @@ import { LEDGER_BILLING_CONDITION } from "@/repository/_shared/ledger-conditions
 import { EXCLUDE_WARMUP_CONDITION } from "@/repository/_shared/message-request-conditions";
 import { getSystemSettings } from "@/repository/system-config";
 import {
+  findUsageLogsBatch,
   findUsageLogsForKeyBatch,
   findUsageLogsForKeySlim,
   getDistinctEndpointsForKey,
   getDistinctModelsForKey,
+  type UsageLogBatchFilters,
   type UsageLogSlimBatchResult,
   type UsageLogSummary,
+  type UsageLogsBatchResult,
 } from "@/repository/usage-logs";
 import type { BillingModelSource } from "@/types/system-config";
 import type { ActionResult } from "./types";
@@ -634,6 +637,30 @@ export async function getMyUsageLogsBatch(
     };
   } catch (error) {
     logger.error("[my-usage] getMyUsageLogsBatch failed", error);
+    return { ok: false, error: "Failed to get usage logs" };
+  }
+}
+
+/**
+ * Full-format batch fetch for VirtualizedLogsTable on my-usage page.
+ * Scoped to the current key (not just user) and uses allowReadOnlyAccess.
+ * Returns UsageLogsBatchResult (same shape as admin getUsageLogsBatch).
+ */
+export async function getMyUsageLogsBatchFull(
+  params: Omit<UsageLogBatchFilters, "userId" | "keyId" | "providerId">
+): Promise<ActionResult<UsageLogsBatchResult>> {
+  try {
+    const session = await getSession({ allowReadOnlyAccess: true });
+    if (!session) return { ok: false, error: "Unauthorized" };
+
+    const result = await findUsageLogsBatch({
+      ...params,
+      keyId: session.key.id,
+    });
+
+    return { ok: true, data: result };
+  } catch (error) {
+    logger.error("[my-usage] getMyUsageLogsBatchFull failed", error);
     return { ok: false, error: "Failed to get usage logs" };
   }
 }

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -69,20 +69,20 @@ export interface VirtualizedLogsTableFilters {
   minRetryCount?: number;
 }
 
+const STATUS_BADGE_FALLBACK =
+  "bg-gray-100 text-gray-700 border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600";
+
 function getStatusBadgeClassName(statusCode: number | null): string {
-  if (statusCode === null || !statusCode) {
-    return "bg-gray-100 text-gray-700 border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600";
-  }
-  if (statusCode >= 200 && statusCode < 300) {
+  if (statusCode != null && statusCode >= 200 && statusCode < 300) {
     return "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700";
   }
-  if (statusCode >= 400 && statusCode < 500) {
+  if (statusCode != null && statusCode >= 400 && statusCode < 500) {
     return "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700";
   }
-  if (statusCode >= 500) {
+  if (statusCode != null && statusCode >= 500) {
     return "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700";
   }
-  return "bg-gray-100 text-gray-700 border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600";
+  return STATUS_BADGE_FALLBACK;
 }
 
 function StatusBadgeOnly({ statusCode }: { statusCode: number | null }) {
@@ -620,8 +620,11 @@ export function VirtualizedLogsTable({
                                 originalModel={log.originalModel}
                                 currentModel={log.model}
                                 billingModelSource={billingModelSource}
-                                onRedirectClick={() =>
-                                  setDialogState({ logId: log.id, scrollToRedirect: true })
+                                onRedirectClick={
+                                  disableDetailDialog
+                                    ? undefined
+                                    : () =>
+                                        setDialogState({ logId: log.id, scrollToRedirect: true })
                                 }
                               />
                             </div>

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -13,6 +13,7 @@ import {
   useState,
 } from "react";
 import { toast } from "sonner";
+import type { ActionResult } from "@/actions/types";
 import { getUsageLogsBatch } from "@/actions/usage-logs";
 import { IpDetailsDialog } from "@/app/[locale]/dashboard/_components/ip-details-dialog";
 import { Badge } from "@/components/ui/badge";
@@ -38,6 +39,7 @@ import {
   getPricingResolutionSpecialSetting,
   hasPriorityServiceTierSpecialSetting,
 } from "@/lib/utils/special-settings";
+import type { UsageLogsBatchResult } from "@/repository/usage-logs";
 import type { BillingModelSource } from "@/types/system-config";
 import { ErrorDetailsDialog } from "./error-details-dialog";
 import { ModelDisplayWithRedirect } from "./model-display-with-redirect";
@@ -45,6 +47,13 @@ import { ProviderChainPopover } from "./provider-chain-popover";
 
 const BATCH_SIZE = 50;
 const ROW_HEIGHT = 52; // Estimated row height in pixels
+
+export type LogsFetchFn = (
+  params: VirtualizedLogsTableFilters & {
+    cursor?: { createdAt: string; id: number };
+    limit: number;
+  }
+) => Promise<ActionResult<UsageLogsBatchResult>>;
 
 export interface VirtualizedLogsTableFilters {
   userId?: number;
@@ -60,6 +69,30 @@ export interface VirtualizedLogsTableFilters {
   minRetryCount?: number;
 }
 
+function getStatusBadgeClassName(statusCode: number | null): string {
+  if (statusCode === null || !statusCode) {
+    return "bg-gray-100 text-gray-700 border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600";
+  }
+  if (statusCode >= 200 && statusCode < 300) {
+    return "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700";
+  }
+  if (statusCode >= 400 && statusCode < 500) {
+    return "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700";
+  }
+  if (statusCode >= 500) {
+    return "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700";
+  }
+  return "bg-gray-100 text-gray-700 border-gray-300 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600";
+}
+
+function StatusBadgeOnly({ statusCode }: { statusCode: number | null }) {
+  return (
+    <Badge variant="outline" className={getStatusBadgeClassName(statusCode)}>
+      {statusCode ?? "-"}
+    </Badge>
+  );
+}
+
 interface VirtualizedLogsTableProps {
   filters: VirtualizedLogsTableFilters;
   currencyCode?: CurrencyCode;
@@ -71,6 +104,12 @@ interface VirtualizedLogsTableProps {
   hiddenColumns?: LogsTableColumn[];
   bodyClassName?: string;
   serverTimeZone?: string;
+  /** Custom fetch function (defaults to getUsageLogsBatch) */
+  fetchFn?: LogsFetchFn;
+  /** Custom query key prefix (defaults to "usage-logs-batch") */
+  queryKeyPrefix?: string;
+  /** Disable the detail side-panel dialog on status badge click */
+  disableDetailDialog?: boolean;
 }
 
 export function VirtualizedLogsTable({
@@ -84,6 +123,9 @@ export function VirtualizedLogsTable({
   hiddenColumns,
   bodyClassName,
   serverTimeZone: _serverTimeZone,
+  fetchFn,
+  queryKeyPrefix = "usage-logs-batch",
+  disableDetailDialog = false,
 }: VirtualizedLogsTableProps) {
   const t = useTranslations("dashboard");
   const getPricingSourceLabel = (source: string) =>
@@ -128,9 +170,10 @@ export function VirtualizedLogsTable({
   // Infinite query with cursor-based pagination
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, error } =
     useInfiniteQuery({
-      queryKey: ["usage-logs-batch", filters],
+      queryKey: [queryKeyPrefix, filters],
       queryFn: async ({ pageParam }) => {
-        const result = await getUsageLogsBatch({
+        const fetcher = fetchFn ?? getUsageLogsBatch;
+        const result = await fetcher({
           ...filters,
           cursor: pageParam,
           limit: BATCH_SIZE,
@@ -820,51 +863,57 @@ export function VirtualizedLogsTable({
 
                     {/* Status */}
                     <div className="flex-[0.7] min-w-[70px] pr-3">
-                      <ErrorDetailsDialog
-                        statusCode={log.statusCode}
-                        errorMessage={log.errorMessage}
-                        providerChain={log.providerChain}
-                        sessionId={log.sessionId}
-                        requestSequence={log.requestSequence}
-                        blockedBy={log.blockedBy}
-                        blockedReason={log.blockedReason}
-                        originalModel={log.originalModel}
-                        currentModel={log.model}
-                        userAgent={log.userAgent}
-                        clientIp={log.clientIp}
-                        messagesCount={log.messagesCount}
-                        endpoint={log.endpoint}
-                        billingModelSource={billingModelSource}
-                        specialSettings={log.specialSettings}
-                        inputTokens={log.inputTokens}
-                        outputTokens={log.outputTokens}
-                        cacheCreationInputTokens={log.cacheCreationInputTokens}
-                        cacheCreation5mInputTokens={log.cacheCreation5mInputTokens}
-                        cacheCreation1hInputTokens={log.cacheCreation1hInputTokens}
-                        cacheReadInputTokens={log.cacheReadInputTokens}
-                        cacheTtlApplied={log.cacheTtlApplied}
-                        swapCacheTtlApplied={log.swapCacheTtlApplied}
-                        costUsd={log.costUsd}
-                        costMultiplier={log.costMultiplier}
-                        groupCostMultiplier={log.groupCostMultiplier}
-                        costBreakdown={log.costBreakdown}
-                        context1mApplied={log.context1mApplied}
-                        durationMs={log.durationMs}
-                        ttfbMs={log.ttfbMs}
-                        externalOpen={dialogState.logId === log.id ? true : undefined}
-                        onExternalOpenChange={(open) => {
-                          if (!open) setDialogState({ logId: null, scrollToRedirect: false });
-                        }}
-                        scrollToRedirect={
-                          dialogState.logId === log.id && dialogState.scrollToRedirect
-                        }
-                        initialTab={
-                          dialogState.logId === log.id ? dialogState.targetTab : undefined
-                        }
-                        initialExpandedChainIndex={
-                          dialogState.logId === log.id ? dialogState.expandedChainIndex : undefined
-                        }
-                      />
+                      {disableDetailDialog ? (
+                        <StatusBadgeOnly statusCode={log.statusCode} />
+                      ) : (
+                        <ErrorDetailsDialog
+                          statusCode={log.statusCode}
+                          errorMessage={log.errorMessage}
+                          providerChain={log.providerChain}
+                          sessionId={log.sessionId}
+                          requestSequence={log.requestSequence}
+                          blockedBy={log.blockedBy}
+                          blockedReason={log.blockedReason}
+                          originalModel={log.originalModel}
+                          currentModel={log.model}
+                          userAgent={log.userAgent}
+                          clientIp={log.clientIp}
+                          messagesCount={log.messagesCount}
+                          endpoint={log.endpoint}
+                          billingModelSource={billingModelSource}
+                          specialSettings={log.specialSettings}
+                          inputTokens={log.inputTokens}
+                          outputTokens={log.outputTokens}
+                          cacheCreationInputTokens={log.cacheCreationInputTokens}
+                          cacheCreation5mInputTokens={log.cacheCreation5mInputTokens}
+                          cacheCreation1hInputTokens={log.cacheCreation1hInputTokens}
+                          cacheReadInputTokens={log.cacheReadInputTokens}
+                          cacheTtlApplied={log.cacheTtlApplied}
+                          swapCacheTtlApplied={log.swapCacheTtlApplied}
+                          costUsd={log.costUsd}
+                          costMultiplier={log.costMultiplier}
+                          groupCostMultiplier={log.groupCostMultiplier}
+                          costBreakdown={log.costBreakdown}
+                          context1mApplied={log.context1mApplied}
+                          durationMs={log.durationMs}
+                          ttfbMs={log.ttfbMs}
+                          externalOpen={dialogState.logId === log.id ? true : undefined}
+                          onExternalOpenChange={(open) => {
+                            if (!open) setDialogState({ logId: null, scrollToRedirect: false });
+                          }}
+                          scrollToRedirect={
+                            dialogState.logId === log.id && dialogState.scrollToRedirect
+                          }
+                          initialTab={
+                            dialogState.logId === log.id ? dialogState.targetTab : undefined
+                          }
+                          initialExpandedChainIndex={
+                            dialogState.logId === log.id
+                              ? dialogState.expandedChainIndex
+                              : undefined
+                          }
+                        />
+                      )}
                     </div>
                   </div>
                 );

--- a/src/app/[locale]/my-usage/_components/usage-logs-section.test.tsx
+++ b/src/app/[locale]/my-usage/_components/usage-logs-section.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   getMyAvailableModels: vi.fn(),
   getMyAvailableEndpoints: vi.fn(),
   getMyUsageLogsBatchFull: vi.fn(),
+  getMyUsageMetadata: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
@@ -19,6 +20,7 @@ vi.mock("@/actions/my-usage", () => ({
   getMyAvailableModels: mocks.getMyAvailableModels,
   getMyAvailableEndpoints: mocks.getMyAvailableEndpoints,
   getMyUsageLogsBatchFull: mocks.getMyUsageLogsBatchFull,
+  getMyUsageMetadata: mocks.getMyUsageMetadata,
 }));
 
 vi.mock("@/app/[locale]/dashboard/logs/_components/logs-date-range-picker", () => ({
@@ -82,6 +84,10 @@ describe("my-usage usage logs section", () => {
   test("renders VirtualizedLogsTable with correct restrictions", async () => {
     mocks.getMyAvailableModels.mockResolvedValue({ ok: true, data: [] });
     mocks.getMyAvailableEndpoints.mockResolvedValue({ ok: true, data: [] });
+    mocks.getMyUsageMetadata.mockResolvedValue({
+      ok: true,
+      data: { currencyCode: "USD", billingModelSource: "original" },
+    });
 
     const container = document.createElement("div");
     document.body.appendChild(container);

--- a/src/app/[locale]/my-usage/_components/usage-logs-section.test.tsx
+++ b/src/app/[locale]/my-usage/_components/usage-logs-section.test.tsx
@@ -4,11 +4,9 @@ import { act } from "react";
 import { describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  useInfiniteQuery: vi.fn(),
-  getMyUsageLogs: vi.fn(),
-  getMyUsageLogsBatch: vi.fn(),
   getMyAvailableModels: vi.fn(),
   getMyAvailableEndpoints: vi.fn(),
+  getMyUsageLogsBatchFull: vi.fn(),
 }));
 
 vi.mock("next-intl", () => ({
@@ -17,19 +15,31 @@ vi.mock("next-intl", () => ({
   useTimeZone: () => "UTC",
 }));
 
-vi.mock("@tanstack/react-query", () => ({
-  useInfiniteQuery: mocks.useInfiniteQuery,
-}));
-
 vi.mock("@/actions/my-usage", () => ({
-  getMyUsageLogs: mocks.getMyUsageLogs,
-  getMyUsageLogsBatch: mocks.getMyUsageLogsBatch,
   getMyAvailableModels: mocks.getMyAvailableModels,
   getMyAvailableEndpoints: mocks.getMyAvailableEndpoints,
+  getMyUsageLogsBatchFull: mocks.getMyUsageLogsBatchFull,
 }));
 
 vi.mock("@/app/[locale]/dashboard/logs/_components/logs-date-range-picker", () => ({
   LogsDateRangePicker: () => <div data-testid="logs-date-range-picker" />,
+}));
+
+vi.mock("@/app/[locale]/dashboard/logs/_components/virtualized-logs-table", () => ({
+  VirtualizedLogsTable: (props: {
+    hiddenColumns?: string[];
+    disableDetailDialog?: boolean;
+    fetchFn?: unknown;
+    queryKeyPrefix?: string;
+  }) => (
+    <div
+      data-testid="virtualized-logs-table"
+      data-hidden-columns={JSON.stringify(props.hiddenColumns)}
+      data-disable-detail-dialog={String(props.disableDetailDialog)}
+      data-query-key-prefix={props.queryKeyPrefix}
+      data-has-fetch-fn={String(!!props.fetchFn)}
+    />
+  ),
 }));
 
 vi.mock("@/components/ui/collapsible", () => ({
@@ -66,46 +76,10 @@ vi.mock("@/components/ui/label", () => ({
   Label: ({ children }: { children?: ReactNode }) => <label>{children}</label>,
 }));
 
-vi.mock("./usage-logs-table", () => ({
-  UsageLogsTable: () => <div data-testid="usage-logs-table" />,
-}));
-
 import { UsageLogsSection } from "./usage-logs-section";
 
 describe("my-usage usage logs section", () => {
-  test("uses infinite query instead of the old page-based getMyUsageLogs flow", async () => {
-    let capturedQueryFn:
-      | ((context: {
-          pageParam?: { createdAt: string; id: number } | undefined;
-        }) => Promise<unknown>)
-      | undefined;
-
-    mocks.useInfiniteQuery.mockImplementation((options: { queryFn: typeof capturedQueryFn }) => {
-      capturedQueryFn = options.queryFn;
-      return {
-        data: { pages: [{ logs: [], nextCursor: null, hasMore: false }] },
-        fetchNextPage: vi.fn(),
-        hasNextPage: false,
-        isFetchingNextPage: false,
-        isLoading: false,
-        isError: false,
-        error: null,
-      };
-    });
-    mocks.getMyUsageLogsBatch.mockResolvedValue({
-      ok: true,
-      data: {
-        logs: [],
-        nextCursor: null,
-        hasMore: false,
-        currencyCode: "USD",
-        billingModelSource: "original",
-      },
-    });
-    mocks.getMyUsageLogs.mockResolvedValue({
-      ok: true,
-      data: { logs: [], total: 0, page: 1, pageSize: 20, currencyCode: "USD" },
-    });
+  test("renders VirtualizedLogsTable with correct restrictions", async () => {
     mocks.getMyAvailableModels.mockResolvedValue({ ok: true, data: [] });
     mocks.getMyAvailableEndpoints.mockResolvedValue({ ok: true, data: [] });
 
@@ -117,13 +91,21 @@ describe("my-usage usage logs section", () => {
       root.render(<UsageLogsSection defaultOpen />);
     });
 
-    await act(async () => {
-      await capturedQueryFn?.({ pageParam: undefined });
-    });
+    const table = container.querySelector('[data-testid="virtualized-logs-table"]');
+    expect(table).toBeTruthy();
 
-    expect(mocks.useInfiniteQuery).toHaveBeenCalled();
-    expect(mocks.getMyUsageLogsBatch).toHaveBeenCalled();
-    expect(mocks.getMyUsageLogs).not.toHaveBeenCalled();
+    // Verify user/key/provider columns are hidden
+    const hiddenColumns = JSON.parse(table!.getAttribute("data-hidden-columns") ?? "[]");
+    expect(hiddenColumns).toContain("user");
+    expect(hiddenColumns).toContain("key");
+    expect(hiddenColumns).toContain("provider");
+
+    // Verify detail dialog is disabled
+    expect(table!.getAttribute("data-disable-detail-dialog")).toBe("true");
+
+    // Verify custom fetch function and query key
+    expect(table!.getAttribute("data-has-fetch-fn")).toBe("true");
+    expect(table!.getAttribute("data-query-key-prefix")).toBe("my-usage-logs-batch");
 
     await act(async () => {
       root.unmount();

--- a/src/app/[locale]/my-usage/_components/usage-logs-section.tsx
+++ b/src/app/[locale]/my-usage/_components/usage-logs-section.tsx
@@ -1,15 +1,20 @@
 "use client";
 
-import { useInfiniteQuery } from "@tanstack/react-query";
-import { Check, ChevronDown, Filter, Loader2, RefreshCw, ScrollText, X } from "lucide-react";
+import { fromZonedTime } from "date-fns-tz";
+import { ChevronDown, Filter, RefreshCw, ScrollText } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   getMyAvailableEndpoints,
   getMyAvailableModels,
-  getMyUsageLogsBatch,
+  getMyUsageLogsBatchFull,
 } from "@/actions/my-usage";
 import { LogsDateRangePicker } from "@/app/[locale]/dashboard/logs/_components/logs-date-range-picker";
+import {
+  type LogsFetchFn,
+  VirtualizedLogsTable,
+  type VirtualizedLogsTableFilters,
+} from "@/app/[locale]/dashboard/logs/_components/virtualized-logs-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
@@ -22,10 +27,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import type { LogsTableColumn } from "@/lib/column-visibility";
 import { cn } from "@/lib/utils";
-import { UsageLogsTable } from "./usage-logs-table";
 
-const BATCH_SIZE = 20;
+/** Columns always hidden on my-usage page (user/key/provider not available) */
+const MY_USAGE_HIDDEN_COLUMNS: LogsTableColumn[] = ["user", "key", "provider"];
 
 interface UsageLogsSectionProps {
   autoRefreshSeconds?: number;
@@ -43,13 +49,43 @@ interface Filters {
   minRetryCount?: number;
 }
 
+/**
+ * Convert date strings (YYYY-MM-DD) to timestamps using server timezone.
+ */
+function parseDateRange(
+  startDate?: string,
+  endDate?: string,
+  timezone?: string
+): { startTime?: number; endTime?: number } {
+  const tz = timezone ?? "UTC";
+  let startTime: number | undefined;
+  let endTime: number | undefined;
+
+  if (startDate && /^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
+    startTime = fromZonedTime(`${startDate}T00:00:00`, tz).getTime();
+  }
+  if (endDate && /^\d{4}-\d{2}-\d{2}$/.test(endDate)) {
+    // End date is exclusive (next day midnight)
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(endDate);
+    if (match) {
+      const next = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
+      next.setUTCDate(next.getUTCDate() + 1);
+      const nextStr = next.toISOString().slice(0, 10);
+      endTime = fromZonedTime(`${nextStr}T00:00:00`, tz).getTime();
+    }
+  }
+
+  return { startTime, endTime };
+}
+
+const myUsageFetchFn: LogsFetchFn = (params) => getMyUsageLogsBatchFull(params);
+
 export function UsageLogsSection({
   autoRefreshSeconds,
   defaultOpen = false,
   serverTimeZone,
 }: UsageLogsSectionProps) {
   const t = useTranslations("myUsage.logs");
-  const tCollapsible = useTranslations("myUsage.logsCollapsible");
   const tDashboard = useTranslations("dashboard");
   const tCommon = useTranslations("common");
   const [isOpen, setIsOpen] = useState(defaultOpen);
@@ -59,7 +95,6 @@ export function UsageLogsSection({
   const [isEndpointsLoading, setIsEndpointsLoading] = useState(true);
   const [draftFilters, setDraftFilters] = useState<Filters>({});
   const [appliedFilters, setAppliedFilters] = useState<Filters>({});
-  const [isBrowsingHistory, setIsBrowsingHistory] = useState(false);
 
   useEffect(() => {
     setIsModelsLoading(true);
@@ -82,44 +117,23 @@ export function UsageLogsSection({
       .finally(() => setIsEndpointsLoading(false));
   }, []);
 
-  const query = useInfiniteQuery({
-    queryKey: ["my-usage-logs-batch", appliedFilters],
-    queryFn: async ({ pageParam }) => {
-      const result = await getMyUsageLogsBatch({
-        ...appliedFilters,
-        cursor: pageParam,
-        limit: BATCH_SIZE,
-      });
-      if (!result.ok) {
-        throw new Error(result.error);
-      }
-      return result.data;
-    },
-    initialPageParam: undefined as { createdAt: string; id: number } | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-    staleTime: 30000,
-    refetchOnWindowFocus: false,
-    refetchInterval: autoRefreshSeconds
-      ? (query) => {
-          if (isBrowsingHistory) return false;
-          if (query.state.fetchStatus !== "idle") return false;
-          return autoRefreshSeconds * 1000;
-        }
-      : false,
-  });
-  const {
-    data,
-    fetchNextPage,
-    hasNextPage = false,
-    isFetchingNextPage,
-    isLoading,
-    isError,
-    error,
-    isRefetching = false,
-  } = query;
-
-  const logs = useMemo(() => data?.pages.flatMap((page) => page.logs) ?? [], [data]);
-  const latestPage = data?.pages[0];
+  // Convert date-based filters to VirtualizedLogsTable format (timestamps)
+  const tableFilters = useMemo<VirtualizedLogsTableFilters>(() => {
+    const { startTime, endTime } = parseDateRange(
+      appliedFilters.startDate,
+      appliedFilters.endDate,
+      serverTimeZone
+    );
+    return {
+      startTime,
+      endTime,
+      model: appliedFilters.model,
+      statusCode: appliedFilters.statusCode,
+      excludeStatusCode200: appliedFilters.excludeStatusCode200,
+      endpoint: appliedFilters.endpoint,
+      minRetryCount: appliedFilters.minRetryCount,
+    };
+  }, [appliedFilters, serverTimeZone]);
 
   const activeFiltersCount = useMemo(() => {
     let count = 0;
@@ -131,65 +145,32 @@ export function UsageLogsSection({
     return count;
   }, [appliedFilters]);
 
-  const lastLog = logs[0] ?? null;
-
-  const lastStatusText = useMemo(() => {
-    if (!lastLog?.createdAt) return null;
-    const now = new Date();
-    const logTime = new Date(lastLog.createdAt);
-    const diffMs = now.getTime() - logTime.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-
-    if (diffMins < 1) return "now";
-    if (diffMins < 60) return `${diffMins}m ago`;
-    const diffHours = Math.floor(diffMins / 60);
-    if (diffHours < 24) return `${diffHours}h ago`;
-    return `${Math.floor(diffHours / 24)}d ago`;
-  }, [lastLog]);
-
-  const successRate = useMemo(() => {
-    if (logs.length === 0) return null;
-    const successCount = logs.filter((log) => log.statusCode && log.statusCode < 400).length;
-    return Math.round((successCount / logs.length) * 100);
-  }, [logs]);
-
-  const lastStatusColor = useMemo(() => {
-    if (!lastLog?.statusCode) return "";
-    if (lastLog.statusCode === 200) return "text-green-600 dark:text-green-400";
-    if (lastLog.statusCode >= 400) return "text-red-600 dark:text-red-400";
-    return "";
-  }, [lastLog]);
-
-  const handleFilterChange = (changes: Partial<Filters>) => {
+  const handleFilterChange = useCallback((changes: Partial<Filters>) => {
     setDraftFilters((prev) => ({ ...prev, ...changes }));
-  };
+  }, []);
 
-  const handleApply = () => {
+  const handleApply = useCallback(() => {
     const nextFilters = { ...draftFilters };
     if (JSON.stringify(nextFilters) === JSON.stringify(appliedFilters)) {
       return;
     }
     setAppliedFilters(nextFilters);
-  };
+  }, [draftFilters, appliedFilters]);
 
-  const handleReset = () => {
+  const handleReset = useCallback(() => {
     setDraftFilters({});
     if (Object.keys(appliedFilters).length === 0) {
       return;
     }
     setAppliedFilters({});
-  };
+  }, [appliedFilters]);
 
-  const handleDateRangeChange = (range: { startDate?: string; endDate?: string }) => {
-    handleFilterChange(range);
-  };
-
-  const handleLoadMore = useCallback(() => {
-    void fetchNextPage();
-  }, [fetchNextPage]);
-
-  const isRefreshing = isRefetching && !isFetchingNextPage && logs.length > 0;
-  const errorMessage = isError ? (error instanceof Error ? error.message : t("loadFailed")) : null;
+  const handleDateRangeChange = useCallback(
+    (range: { startDate?: string; endDate?: string }) => {
+      handleFilterChange(range);
+    },
+    [handleFilterChange]
+  );
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -206,92 +187,23 @@ export function UsageLogsSection({
               <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
                 <ScrollText className="h-4 w-4" />
               </div>
-              <span className="text-sm font-semibold">{tCollapsible("title")}</span>
+              <span className="text-sm font-semibold">{t("title")}</span>
             </div>
 
             <div className="flex items-center gap-3">
               <div className="hidden sm:flex items-center gap-2 text-sm">
-                {lastLog ? (
-                  <span className={cn("font-mono", lastStatusColor)}>
-                    {tCollapsible("lastStatus", {
-                      code: lastLog.statusCode ?? "-",
-                      time: lastStatusText ?? "-",
-                    })}
-                  </span>
-                ) : (
-                  <span className="text-muted-foreground">{tCollapsible("noData")}</span>
-                )}
-
-                <span className="text-muted-foreground">|</span>
-
-                {successRate !== null ? (
-                  <span
-                    className={cn(
-                      "flex items-center gap-1",
-                      successRate >= 80
-                        ? "text-green-600 dark:text-green-400"
-                        : "text-red-600 dark:text-red-400"
-                    )}
-                  >
-                    {successRate >= 80 ? <Check className="h-3 w-3" /> : <X className="h-3 w-3" />}
-                    {tCollapsible("successRate", { rate: successRate })}
-                  </span>
-                ) : null}
-
                 {activeFiltersCount > 0 && (
-                  <>
-                    <span className="text-muted-foreground">|</span>
-                    <Badge variant="secondary" className="h-5 px-1.5 text-xs">
-                      <Filter className="h-3 w-3 mr-1" />
-                      {activeFiltersCount}
-                    </Badge>
-                  </>
+                  <Badge variant="secondary" className="h-5 px-1.5 text-xs">
+                    <Filter className="h-3 w-3 mr-1" />
+                    {activeFiltersCount}
+                  </Badge>
                 )}
 
                 {autoRefreshSeconds && (
                   <>
-                    <span className="text-muted-foreground">|</span>
-                    <RefreshCw className={cn("h-3.5 w-3.5", isRefreshing && "animate-spin")} />
+                    {activeFiltersCount > 0 && <span className="text-muted-foreground">|</span>}
+                    <RefreshCw className="h-3.5 w-3.5" />
                     <span className="text-xs text-muted-foreground">{autoRefreshSeconds}s</span>
-                  </>
-                )}
-              </div>
-
-              <div className="flex items-center gap-1.5 text-xs sm:hidden">
-                {lastLog ? (
-                  <span className={cn("font-mono", lastStatusColor)}>
-                    {lastLog.statusCode ?? "-"} ({lastStatusText ?? "-"})
-                  </span>
-                ) : (
-                  <span className="text-muted-foreground">{tCollapsible("noData")}</span>
-                )}
-
-                <span className="text-muted-foreground">|</span>
-
-                {successRate !== null ? (
-                  <span
-                    className={cn(
-                      "flex items-center gap-0.5",
-                      successRate >= 80 ? "text-green-600" : "text-red-600"
-                    )}
-                  >
-                    {successRate >= 80 ? <Check className="h-3 w-3" /> : <X className="h-3 w-3" />}
-                    {successRate}%
-                  </span>
-                ) : null}
-
-                {activeFiltersCount > 0 && (
-                  <>
-                    <span className="text-muted-foreground">|</span>
-                    <Badge variant="secondary" className="h-4 px-1 text-[10px]">
-                      {activeFiltersCount}
-                    </Badge>
-                  </>
-                )}
-                {autoRefreshSeconds && (
-                  <>
-                    <span className="text-muted-foreground">|</span>
-                    <RefreshCw className={cn("h-3 w-3", isRefreshing && "animate-spin")} />
                   </>
                 )}
               </div>
@@ -426,33 +338,25 @@ export function UsageLogsSection({
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
-              <Button size="sm" onClick={handleApply} disabled={isLoading}>
+              <Button size="sm" onClick={handleApply}>
                 {t("filters.apply")}
               </Button>
-              <Button size="sm" variant="outline" onClick={handleReset} disabled={isLoading}>
+              <Button size="sm" variant="outline" onClick={handleReset}>
                 {t("filters.reset")}
               </Button>
             </div>
 
-            {isRefreshing ? (
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                <span>{tCommon("loading")}</span>
-              </div>
-            ) : null}
-
-            <UsageLogsTable
-              logs={logs}
-              hasNextPage={hasNextPage}
-              isFetchingNextPage={isFetchingNextPage}
-              currencyCode={latestPage?.currencyCode}
-              loading={isLoading}
-              loadingLabel={tCommon("loading")}
-              errorMessage={errorMessage}
-              onLoadMore={handleLoadMore}
-              resetScrollKey={appliedFilters}
-              onHistoryBrowsingChange={setIsBrowsingHistory}
-            />
+            <div className="rounded-lg border border-border/60 overflow-hidden">
+              <VirtualizedLogsTable
+                filters={tableFilters}
+                hiddenColumns={MY_USAGE_HIDDEN_COLUMNS}
+                disableDetailDialog
+                fetchFn={myUsageFetchFn}
+                queryKeyPrefix="my-usage-logs-batch"
+                autoRefreshEnabled={!!autoRefreshSeconds}
+                autoRefreshIntervalMs={autoRefreshSeconds ? autoRefreshSeconds * 1000 : undefined}
+              />
+            </div>
           </div>
         </CollapsibleContent>
       </div>

--- a/src/app/[locale]/my-usage/_components/usage-logs-section.tsx
+++ b/src/app/[locale]/my-usage/_components/usage-logs-section.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { fromZonedTime } from "date-fns-tz";
 import { ChevronDown, Filter, RefreshCw, ScrollText } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -8,6 +7,7 @@ import {
   getMyAvailableEndpoints,
   getMyAvailableModels,
   getMyUsageLogsBatchFull,
+  getMyUsageMetadata,
 } from "@/actions/my-usage";
 import { LogsDateRangePicker } from "@/app/[locale]/dashboard/logs/_components/logs-date-range-picker";
 import {
@@ -29,6 +29,9 @@ import {
 } from "@/components/ui/select";
 import type { LogsTableColumn } from "@/lib/column-visibility";
 import { cn } from "@/lib/utils";
+import type { CurrencyCode } from "@/lib/utils/currency";
+import { parseDateRangeToTimestamps } from "@/lib/utils/date-range";
+import type { BillingModelSource } from "@/types/system-config";
 
 /** Columns always hidden on my-usage page (user/key/provider not available) */
 const MY_USAGE_HIDDEN_COLUMNS: LogsTableColumn[] = ["user", "key", "provider"];
@@ -49,35 +52,6 @@ interface Filters {
   minRetryCount?: number;
 }
 
-/**
- * Convert date strings (YYYY-MM-DD) to timestamps using server timezone.
- */
-function parseDateRange(
-  startDate?: string,
-  endDate?: string,
-  timezone?: string
-): { startTime?: number; endTime?: number } {
-  const tz = timezone ?? "UTC";
-  let startTime: number | undefined;
-  let endTime: number | undefined;
-
-  if (startDate && /^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
-    startTime = fromZonedTime(`${startDate}T00:00:00`, tz).getTime();
-  }
-  if (endDate && /^\d{4}-\d{2}-\d{2}$/.test(endDate)) {
-    // End date is exclusive (next day midnight)
-    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(endDate);
-    if (match) {
-      const next = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
-      next.setUTCDate(next.getUTCDate() + 1);
-      const nextStr = next.toISOString().slice(0, 10);
-      endTime = fromZonedTime(`${nextStr}T00:00:00`, tz).getTime();
-    }
-  }
-
-  return { startTime, endTime };
-}
-
 const myUsageFetchFn: LogsFetchFn = (params) => getMyUsageLogsBatchFull(params);
 
 export function UsageLogsSection({
@@ -95,6 +69,8 @@ export function UsageLogsSection({
   const [isEndpointsLoading, setIsEndpointsLoading] = useState(true);
   const [draftFilters, setDraftFilters] = useState<Filters>({});
   const [appliedFilters, setAppliedFilters] = useState<Filters>({});
+  const [currencyCode, setCurrencyCode] = useState<CurrencyCode>("USD");
+  const [billingModelSource, setBillingModelSource] = useState<BillingModelSource>("original");
 
   useEffect(() => {
     setIsModelsLoading(true);
@@ -115,11 +91,18 @@ export function UsageLogsSection({
         }
       })
       .finally(() => setIsEndpointsLoading(false));
+
+    void getMyUsageMetadata().then((metaResult) => {
+      if (metaResult.ok && metaResult.data) {
+        setCurrencyCode(metaResult.data.currencyCode);
+        setBillingModelSource(metaResult.data.billingModelSource);
+      }
+    });
   }, []);
 
   // Convert date-based filters to VirtualizedLogsTable format (timestamps)
   const tableFilters = useMemo<VirtualizedLogsTableFilters>(() => {
-    const { startTime, endTime } = parseDateRange(
+    const { startTime, endTime } = parseDateRangeToTimestamps(
       appliedFilters.startDate,
       appliedFilters.endDate,
       serverTimeZone
@@ -349,6 +332,8 @@ export function UsageLogsSection({
             <div className="rounded-lg border border-border/60 overflow-hidden">
               <VirtualizedLogsTable
                 filters={tableFilters}
+                currencyCode={currencyCode}
+                billingModelSource={billingModelSource}
                 hiddenColumns={MY_USAGE_HIDDEN_COLUMNS}
                 disableDetailDialog
                 fetchFn={myUsageFetchFn}

--- a/src/lib/column-visibility.test.ts
+++ b/src/lib/column-visibility.test.ts
@@ -77,7 +77,7 @@ describe("column-visibility", () => {
       mockStorage[storageKey] = "not-valid-json";
 
       const result = getHiddenColumns(userId, tableId);
-      expect(result).toEqual([]);
+      expect(result).toEqual([...DEFAULT_HIDDEN_COLUMNS]);
     });
 
     test("scopes by user ID", () => {

--- a/src/lib/column-visibility.test.ts
+++ b/src/lib/column-visibility.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
+  DEFAULT_HIDDEN_COLUMNS,
   DEFAULT_VISIBLE_COLUMNS,
   getHiddenColumns,
   getVisibleColumns,
@@ -51,9 +52,9 @@ describe("column-visibility", () => {
   });
 
   describe("getHiddenColumns", () => {
-    test("returns empty array when no data stored", () => {
+    test("returns default hidden columns when no data stored", () => {
       const result = getHiddenColumns(userId, tableId);
-      expect(result).toEqual([]);
+      expect(result).toEqual(DEFAULT_HIDDEN_COLUMNS);
     });
 
     test("returns stored hidden columns", () => {
@@ -103,9 +104,10 @@ describe("column-visibility", () => {
   });
 
   describe("getVisibleColumns", () => {
-    test("returns all columns when none hidden", () => {
+    test("returns all columns except default hidden when none explicitly hidden", () => {
       const result = getVisibleColumns(userId, tableId);
-      expect(result).toEqual(DEFAULT_VISIBLE_COLUMNS);
+      const expected = DEFAULT_VISIBLE_COLUMNS.filter((c) => !DEFAULT_HIDDEN_COLUMNS.includes(c));
+      expect(result).toEqual(expected);
     });
 
     test("excludes hidden columns", () => {
@@ -129,14 +131,14 @@ describe("column-visibility", () => {
       expect(mockStorage[storageKey]).toBe(JSON.stringify(hidden));
     });
 
-    test("removes storage key when array is empty", () => {
+    test("stores empty array when set to empty", () => {
       // First set some hidden columns
       mockStorage[storageKey] = JSON.stringify(["user"]);
 
       // Then reset to empty
       setHiddenColumns(userId, tableId, []);
 
-      expect(mockStorage[storageKey]).toBeUndefined();
+      expect(mockStorage[storageKey]).toBe(JSON.stringify([]));
     });
 
     test("handles localStorage errors gracefully", () => {
@@ -170,6 +172,9 @@ describe("column-visibility", () => {
     });
 
     test("returns updated hidden columns array", () => {
+      // Start fresh - set explicit empty to override defaults
+      setHiddenColumns(userId, tableId, []);
+
       const result1 = toggleColumn(userId, tableId, "user");
       expect(result1).toEqual(["user"]);
 
@@ -192,7 +197,7 @@ describe("column-visibility", () => {
   });
 
   describe("resetColumns", () => {
-    test("removes all hidden columns", () => {
+    test("removes all hidden columns from storage", () => {
       // Set some hidden columns
       setHiddenColumns(userId, tableId, ["user", "key", "provider"]);
       expect(getHiddenColumns(userId, tableId)).toHaveLength(3);
@@ -200,11 +205,11 @@ describe("column-visibility", () => {
       // Reset
       resetColumns(userId, tableId);
 
+      // After reset, storage has explicit empty array
       expect(getHiddenColumns(userId, tableId)).toEqual([]);
-      expect(mockStorage[storageKey]).toBeUndefined();
     });
 
-    test("is idempotent when no columns hidden", () => {
+    test("is idempotent when no columns explicitly hidden", () => {
       resetColumns(userId, tableId);
       resetColumns(userId, tableId);
 
@@ -222,6 +227,18 @@ describe("column-visibility", () => {
       expect(DEFAULT_VISIBLE_COLUMNS).toContain("cost");
       expect(DEFAULT_VISIBLE_COLUMNS).toContain("cache");
       expect(DEFAULT_VISIBLE_COLUMNS).toContain("performance");
+    });
+  });
+
+  describe("DEFAULT_HIDDEN_COLUMNS", () => {
+    test("contains ip column", () => {
+      expect(DEFAULT_HIDDEN_COLUMNS).toContain("ip");
+    });
+
+    test("all default hidden columns are valid toggleable columns", () => {
+      for (const col of DEFAULT_HIDDEN_COLUMNS) {
+        expect(DEFAULT_VISIBLE_COLUMNS).toContain(col);
+      }
     });
   });
 });

--- a/src/lib/column-visibility.ts
+++ b/src/lib/column-visibility.ts
@@ -74,7 +74,7 @@ export function getHiddenColumns(userId: number, tableId: string): LogsTableColu
     // Validate that all items are valid column names
     return parsed.filter((col) => DEFAULT_VISIBLE_COLUMNS.includes(col));
   } catch {
-    return [];
+    return [...DEFAULT_HIDDEN_COLUMNS];
   }
 }
 

--- a/src/lib/column-visibility.ts
+++ b/src/lib/column-visibility.ts
@@ -37,6 +37,11 @@ export const DEFAULT_VISIBLE_COLUMNS: LogsTableColumn[] = [
 ];
 
 /**
+ * Columns hidden by default when no user preference is stored
+ */
+export const DEFAULT_HIDDEN_COLUMNS: LogsTableColumn[] = ["ip"];
+
+/**
  * Columns that cannot be hidden (always visible)
  */
 export const ALWAYS_VISIBLE_COLUMNS = ["time", "model", "status"] as const;
@@ -63,7 +68,7 @@ export function getHiddenColumns(userId: number, tableId: string): LogsTableColu
   try {
     const stored = localStorage.getItem(getStorageKey(userId, tableId));
     if (!stored) {
-      return [];
+      return [...DEFAULT_HIDDEN_COLUMNS];
     }
     const parsed = JSON.parse(stored) as LogsTableColumn[];
     // Validate that all items are valid column names
@@ -103,11 +108,7 @@ export function setHiddenColumns(
 
   try {
     const key = getStorageKey(userId, tableId);
-    if (hiddenColumns.length === 0) {
-      localStorage.removeItem(key);
-    } else {
-      localStorage.setItem(key, JSON.stringify(hiddenColumns));
-    }
+    localStorage.setItem(key, JSON.stringify(hiddenColumns));
   } catch {
     // localStorage not available, silently fail
   }

--- a/src/lib/utils/date-range.ts
+++ b/src/lib/utils/date-range.ts
@@ -1,0 +1,31 @@
+import { fromZonedTime } from "date-fns-tz";
+
+/**
+ * Convert date strings (YYYY-MM-DD) to timestamps using a given timezone.
+ * startTime = midnight of startDate in the timezone.
+ * endTime = midnight of the day AFTER endDate (exclusive upper bound).
+ */
+export function parseDateRangeToTimestamps(
+  startDate?: string,
+  endDate?: string,
+  timezone?: string
+): { startTime?: number; endTime?: number } {
+  const tz = timezone ?? "UTC";
+  let startTime: number | undefined;
+  let endTime: number | undefined;
+
+  if (startDate && /^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
+    startTime = fromZonedTime(`${startDate}T00:00:00`, tz).getTime();
+  }
+  if (endDate && /^\d{4}-\d{2}-\d{2}$/.test(endDate)) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(endDate);
+    if (match) {
+      const next = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
+      next.setUTCDate(next.getUTCDate() + 1);
+      const nextStr = next.toISOString().slice(0, 10);
+      endTime = fromZonedTime(`${nextStr}T00:00:00`, tz).getTime();
+    }
+  }
+
+  return { startTime, endTime };
+}


### PR DESCRIPTION
## Summary

Hide the IP column by default in the request logs table (users can still toggle it via the column visibility dropdown), and replace the my-usage page's custom `UsageLogsTable` with the shared `VirtualizedLogsTable` component for consistent UX and reduced maintenance burden.

## Problem

1. **IP column privacy/usability**: PR #1027 introduced IP logging and display in the logs table. IP addresses should not be prominently displayed by default — they are sensitive data that most users don't need to see on every page load.

2. **Duplicated my-usage table logic**: The my-usage page used a separate `UsageLogsTable` component with its own pagination, rendering, and auto-refresh logic, duplicating much of what `VirtualizedLogsTable` already handles. PR #959 partially addressed this with virtual scrolling, but the my-usage page still had its own implementation rather than reusing the shared component.

**Related PRs:**
- Follow-up to #1027 — IP column was added there; this PR hides it by default for privacy
- Follow-up to #959 — completes the my-usage virtual scroll migration by adopting the shared `VirtualizedLogsTable`
- Related to #715 — extends the column visibility toggle system with `DEFAULT_HIDDEN_COLUMNS`

## Solution

### IP column hidden by default
- Introduce a `DEFAULT_HIDDEN_COLUMNS` constant in `column-visibility.ts` (initially `["ip"]`)
- When no user preference is stored, `getHiddenColumns()` returns the defaults instead of an empty array
- Explicit user preferences (including reset-to-default) are persisted and always override the defaults
- `setHiddenColumns()` now always writes to localStorage (even empty arrays) to distinguish "no preference" from "explicitly chose to show all"

### my-usage page uses VirtualizedLogsTable
- Replace the custom `UsageLogsTable` with the shared `VirtualizedLogsTable` component
- User, Key, and Provider columns are always hidden (not applicable to self-service view)
- Detail side-panel dialog is disabled (no decision chain or grouping info exposed to end users)
- New `getMyUsageLogsBatchFull` server action scoped to the current key with `allowReadOnlyAccess`, returning the full `UsageLogsBatchResult` shape expected by `VirtualizedLogsTable`

### VirtualizedLogsTable new props
- `fetchFn`: custom data fetch function (defaults to `getUsageLogsBatch`)
- `queryKeyPrefix`: custom react-query key prefix (defaults to `"usage-logs-batch"`)
- `disableDetailDialog`: renders a plain status badge without the Sheet trigger

## Changes

| File | Change | Lines |
|------|--------|-------|
| `src/lib/column-visibility.ts` | Add `DEFAULT_HIDDEN_COLUMNS`, update `getHiddenColumns`/`setHiddenColumns` | +7/-6 |
| `src/lib/column-visibility.test.ts` | Update tests for default-hidden behavior | +26/-9 |
| `src/app/.../virtualized-logs-table.tsx` | Add `fetchFn`, `queryKeyPrefix`, `disableDetailDialog` props; extract `StatusBadgeOnly` | +96/-47 |
| `src/app/.../usage-logs-section.tsx` | Replace `UsageLogsTable` with `VirtualizedLogsTable`; simplify filters and header | +91/-187 |
| `src/app/.../usage-logs-section.test.tsx` | Rewrite test to verify `VirtualizedLogsTable` integration | +34/-52 |
| `src/actions/my-usage.ts` | Add `getMyUsageLogsBatchFull` server action | +27/-0 |

## Testing

- **Unit tests updated**: `column-visibility.test.ts` — verifies `DEFAULT_HIDDEN_COLUMNS` behavior, empty-array persistence, and toggle interactions with defaults
- **Unit tests rewritten**: `usage-logs-section.test.tsx` — verifies `VirtualizedLogsTable` is rendered with correct `hiddenColumns` (user/key/provider), `disableDetailDialog`, custom `fetchFn`, and `queryKeyPrefix`
- **Manual testing**: Verify IP column is hidden on first load of dashboard logs; toggle it visible via column dropdown; verify my-usage page shows virtualized table without user/key/provider columns and without detail dialog on status badge click

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes two focused improvements: it hides the IP column by default using a new `DEFAULT_HIDDEN_COLUMNS` constant in `column-visibility.ts`, and replaces the my-usage page's custom `UsageLogsTable` with the shared `VirtualizedLogsTable` by adding `fetchFn`, `queryKeyPrefix`, and `disableDetailDialog` props. A new `getMyUsageLogsBatchFull` server action scopes data to the current session's key and a shared `parseDateRangeToTimestamps` utility is extracted to `@/lib/utils/date-range`. The implementation is clean with no P0/P1 issues found.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; no P0 or P1 issues found. The IP-hiding default and my-usage VirtualizedLogsTable migration are both correctly implemented.

All findings are P2: a naming ambiguity for DEFAULT_VISIBLE_COLUMNS and a code-duplication opportunity between the extracted date-range utility and the older private helper in my-usage.ts. The authorization scoping in getMyUsageLogsBatchFull is correct (keyId forced from session, userId/keyId/providerId stripped at runtime), test coverage for the changed logic is thorough, and the serverTimeZone dependency in useMemo correctly recomputes tableFilters when the timezone loads.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/column-visibility.ts | Adds DEFAULT_HIDDEN_COLUMNS (["ip"]) and updates getHiddenColumns to return defaults when no preference stored; setHiddenColumns always writes to distinguish "no preference" from explicit empty; logic is correct. |
| src/lib/column-visibility.test.ts | Tests comprehensively cover the new DEFAULT_HIDDEN_COLUMNS behavior, including empty-array persistence distinction and toggle interactions. |
| src/actions/my-usage.ts | New getMyUsageLogsBatchFull server action correctly scopes to session.key.id and strips userId/keyId/providerId from client params as defense-in-depth; safe. |
| src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx | Adds fetchFn/queryKeyPrefix/disableDetailDialog props cleanly; extracts StatusBadgeOnly for the dialog-disabled path; STATUS_BADGE_FALLBACK constant simplifies getStatusBadgeClassName. |
| src/app/[locale]/my-usage/_components/usage-logs-section.tsx | Replaces custom UsageLogsTable with VirtualizedLogsTable; fetches currencyCode/billingModelSource from getMyUsageMetadata; serverTimeZone is correctly plumbed as a useMemo dependency for date conversion. |
| src/lib/utils/date-range.ts | New shared utility extracting date-to-timestamp conversion; correct regex validation, handles exclusive upper bound, defaults to UTC. |
| src/app/[locale]/my-usage/_components/usage-logs-section.test.tsx | Tests verify VirtualizedLogsTable receives correct hiddenColumns, disableDetailDialog, fetchFn, and queryKeyPrefix; adequate coverage for the new integration. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getHiddenColumns called] --> B{localStorage entry exists?}
    B -- No --> C[return DEFAULT_HIDDEN_COLUMNS copy]
    B -- Yes --> D[JSON.parse stored value]
    D --> E{Parse error?}
    E -- Yes --> C
    E -- No --> F[filter against all toggleable columns]
    F --> G[return filtered array]

    H[setHiddenColumns called] --> I[always write to localStorage\neven empty array]
    I --> J[distinguishes no-pref from show-all]

    K[resetColumns] --> L[setHiddenColumns with empty array]
    L --> M[next getHiddenColumns returns empty\nnot DEFAULT_HIDDEN_COLUMNS]

    subgraph my-usage page
        N[UsageLogsSection] --> O[VirtualizedLogsTable\nfetchFn=getMyUsageLogsBatchFull\nhiddenColumns=user,key,provider\ndisableDetailDialog=true]
        O --> P[getMyUsageLogsBatchFull\nserver action]
        P --> Q[strip userId/keyId/providerId\nfrom params]
        Q --> R[findUsageLogsBatch\nkeyId = session.key.id]
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/column-visibility.ts`, line 76-78 ([link](https://github.com/ding113/claude-code-hub/blob/19a22abf1d06c9108c81e06708cd5b709d839561/src/lib/column-visibility.ts#L76-L78)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Inconsistent fallback on parse error**

   When `localStorage` contains corrupt data, the `catch` block returns `[]` (all columns visible), while the "no data stored" path returns `[...DEFAULT_HIDDEN_COLUMNS]` (IP hidden). A user whose storage is silently corrupted would see the IP column appear unexpectedly without ever having changed a preference.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/column-visibility.ts
   Line: 76-78

   Comment:
   **Inconsistent fallback on parse error**

   When `localStorage` contains corrupt data, the `catch` block returns `[]` (all columns visible), while the "no data stored" path returns `[...DEFAULT_HIDDEN_COLUMNS]` (IP hidden). A user whose storage is silently corrupted would see the IP column appear unexpectedly without ever having changed a preference.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/lib/column-visibility.ts`, line 147-149 ([link](https://github.com/ding113/claude-code-hub/blob/19a22abf1d06c9108c81e06708cd5b709d839561/src/lib/column-visibility.ts#L147-L149)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Reset makes IP visible, overriding the new default**

   `resetColumns` persists `[]`, so `getHiddenColumns` returns `[]` afterward — IP becomes visible even though `DEFAULT_HIDDEN_COLUMNS` establishes IP as hidden for first-time users. Users clicking "Reset" may expect to return to the configured default (IP hidden), not an "all columns visible" state.

   If "reset to default" is the desired semantic, delete the stored key instead of writing `[]`:

   

   If "show everything" is intentional (as described in the PR), consider renaming to `showAllColumns` or adding a comment to make the intent clear to future contributors.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/column-visibility.ts
   Line: 147-149

   Comment:
   **Reset makes IP visible, overriding the new default**

   `resetColumns` persists `[]`, so `getHiddenColumns` returns `[]` afterward — IP becomes visible even though `DEFAULT_HIDDEN_COLUMNS` establishes IP as hidden for first-time users. Users clicking "Reset" may expect to return to the configured default (IP hidden), not an "all columns visible" state.

   If "reset to default" is the desired semantic, delete the stored key instead of writing `[]`:

   

   If "show everything" is intentional (as described in the PR), consider renaming to `showAllColumns` or adding a comment to make the intent clear to future contributors.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/column-visibility.ts
Line: 27-37

Comment:
**`DEFAULT_VISIBLE_COLUMNS` name is misleading with `DEFAULT_HIDDEN_COLUMNS` now present**

`DEFAULT_VISIBLE_COLUMNS` includes `"ip"` but `"ip"` is also in `DEFAULT_HIDDEN_COLUMNS`, so this array actually represents all toggleable columns, not the columns that are visible by default. A future developer reading both constants side by side may assume `DEFAULT_VISIBLE_COLUMNS` describes the initial UI state. Consider renaming to `ALL_TOGGLEABLE_COLUMNS` (or similar) to clarify its role as a validation/enumeration list rather than a default-visibility declaration.

```suggestion
export const ALL_TOGGLEABLE_COLUMNS: LogsTableColumn[] = [
  "user",
  "key",
  "sessionId",
  "ip",
  "provider",
  "tokens",
  "cache",
  "performance",
  "cost",
];
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/lib/utils/date-range.ts
Line: 1-31

Comment:
**Duplicate of `parseDateRangeInServerTimezone` still in `my-usage.ts`**

`parseDateRangeToTimestamps` was extracted as a shared utility, but the private `parseDateRangeInServerTimezone` function in `src/actions/my-usage.ts` (used by `getMyUsageLogs`, `getMyUsageLogsBatch`, and `getMyStatsSummary`) implements the same logic and also accepts `timezone` as a parameter. The two functions are equivalent and the older private helper could be replaced with this shared utility to eliminate the duplication.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address PR review comments"](https://github.com/ding113/claude-code-hub/commit/5a083ec8cbc5d9e0a51d5d2138a4206e09495008) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28765811)</sub>

<!-- /greptile_comment -->