### PR TITLE
feat: align provider group management with provider list

### DIFF
--- a/messages/en/settings/providers/providerGroups.json
+++ b/messages/en/settings/providers/providerGroups.json
@@ -31,9 +31,16 @@
   "invalidMultiplier": "Please enter a valid non-negative cost multiplier",
   "groupInUse": "Cannot delete a group that is still referenced by providers",
   "groupMembers": "Group Members",
+  "groupMembersHint": "Manage providers directly inside group \"{groupName}\".",
   "providerName": "Provider Name",
+  "providerType": "Type",
   "effectivePriority": "Priority in Group",
   "noMembers": "No members yet",
   "savePriorityFailed": "Failed to save priority",
-  "savePrioritySuccess": "Priority updated"
+  "savePrioritySuccess": "Priority updated",
+  "groupMultiplierLabel": "Group Cost Multiplier",
+  "groupDescriptionLabel": "Group Description",
+  "noDescription": "Add description",
+  "descriptionTooLong": "Description must be 500 characters or fewer",
+  "openProviderEditor": "Edit Provider"
 }

--- a/messages/ja/settings/providers/providerGroups.json
+++ b/messages/ja/settings/providers/providerGroups.json
@@ -31,9 +31,16 @@
   "invalidMultiplier": "有効な非負のコスト倍率を入力してください",
   "groupInUse": "プロバイダーから参照されているグループは削除できません",
   "groupMembers": "グループメンバー",
+  "groupMembersHint": "グループ「{groupName}」内でプロバイダーを直接管理できます。",
   "providerName": "プロバイダー名",
+  "providerType": "タイプ",
   "effectivePriority": "グループ内の優先度",
   "noMembers": "メンバーがいません",
   "savePriorityFailed": "優先度の保存に失敗しました",
-  "savePrioritySuccess": "優先度を更新しました"
+  "savePrioritySuccess": "優先度を更新しました",
+  "groupMultiplierLabel": "グループコスト倍率",
+  "groupDescriptionLabel": "グループ説明",
+  "noDescription": "説明を追加",
+  "descriptionTooLong": "説明は500文字以内で入力してください",
+  "openProviderEditor": "プロバイダーを編集"
 }

--- a/messages/ru/settings/providers/providerGroups.json
+++ b/messages/ru/settings/providers/providerGroups.json
@@ -31,9 +31,16 @@
   "invalidMultiplier": "Введите действительный неотрицательный коэффициент стоимости",
   "groupInUse": "Нельзя удалить группу, на которую ссылаются поставщики",
   "groupMembers": "Участники группы",
+  "groupMembersHint": "Управляйте поставщиками прямо внутри группы \"{groupName}\".",
   "providerName": "Имя поставщика",
+  "providerType": "Тип",
   "effectivePriority": "Приоритет в группе",
   "noMembers": "Нет участников",
   "savePriorityFailed": "Не удалось сохранить приоритет",
-  "savePrioritySuccess": "Приоритет обновлён"
+  "savePrioritySuccess": "Приоритет обновлён",
+  "groupMultiplierLabel": "Коэффициент стоимости группы",
+  "groupDescriptionLabel": "Описание группы",
+  "noDescription": "Добавить описание",
+  "descriptionTooLong": "Описание должно содержать не более 500 символов",
+  "openProviderEditor": "Редактировать поставщика"
 }

--- a/messages/zh-CN/settings/providers/providerGroups.json
+++ b/messages/zh-CN/settings/providers/providerGroups.json
@@ -31,9 +31,16 @@
   "invalidMultiplier": "请输入有效的非负成本倍率",
   "groupInUse": "该分组仍被供应商引用，无法删除",
   "groupMembers": "分组成员",
+  "groupMembersHint": "在分组 \"{groupName}\" 内直接管理供应商。",
   "providerName": "供应商名称",
+  "providerType": "类型",
   "effectivePriority": "本组优先级",
   "noMembers": "暂无成员",
   "savePriorityFailed": "保存优先级失败",
-  "savePrioritySuccess": "优先级已更新"
+  "savePrioritySuccess": "优先级已更新",
+  "groupMultiplierLabel": "分组成本倍率",
+  "groupDescriptionLabel": "分组描述",
+  "noDescription": "添加描述",
+  "descriptionTooLong": "描述不能超过500字符",
+  "openProviderEditor": "编辑供应商"
 }

--- a/messages/zh-TW/settings/providers/providerGroups.json
+++ b/messages/zh-TW/settings/providers/providerGroups.json
@@ -31,9 +31,16 @@
   "invalidMultiplier": "請輸入有效的非負成本倍率",
   "groupInUse": "該分組仍被供應商引用，無法刪除",
   "groupMembers": "分組成員",
+  "groupMembersHint": "可直接在分組「{groupName}」內管理供應商。",
   "providerName": "供應商名稱",
+  "providerType": "類型",
   "effectivePriority": "本組優先級",
   "noMembers": "暫無成員",
   "savePriorityFailed": "儲存優先級失敗",
-  "savePrioritySuccess": "優先級已更新"
+  "savePrioritySuccess": "優先級已更新",
+  "groupMultiplierLabel": "分組成本倍率",
+  "groupDescriptionLabel": "分組描述",
+  "noDescription": "新增描述",
+  "descriptionTooLong": "描述不能超過500個字元",
+  "openProviderEditor": "編輯供應商"
 }

--- a/src/app/[locale]/settings/providers/_components/batch-edit/provider-batch-toolbar.tsx
+++ b/src/app/[locale]/settings/providers/_components/batch-edit/provider-batch-toolbar.tsx
@@ -28,6 +28,7 @@ export interface ProviderBatchToolbarProps {
   providers: ProviderDisplay[];
   onSelectByType: (type: ProviderType) => void;
   onSelectByGroup: (group: string) => void;
+  showSelectByGroup?: boolean;
 }
 
 export function ProviderBatchToolbar({
@@ -43,6 +44,7 @@ export function ProviderBatchToolbar({
   providers,
   onSelectByType,
   onSelectByGroup,
+  showSelectByGroup = true,
 }: ProviderBatchToolbarProps) {
   const t = useTranslations("settings.providers.batchEdit");
 
@@ -130,7 +132,7 @@ export function ProviderBatchToolbar({
         </DropdownMenu>
       )}
 
-      {uniqueGroups.length > 0 && (
+      {showSelectByGroup && uniqueGroups.length > 0 && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button type="button" variant="ghost" size="sm">

--- a/src/app/[locale]/settings/providers/_components/provider-group-tab.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-group-tab.tsx
@@ -183,8 +183,13 @@ export function ProviderGroupTab({
     }
 
     const trimmedName = form.name.trim();
+    const trimmedDescription = form.description.trim();
     if (!editingGroup && !trimmedName) {
       toast.error(t("nameRequired"));
+      return;
+    }
+    if (trimmedDescription.length > 500) {
+      toast.error(t("descriptionTooLong"));
       return;
     }
 
@@ -192,7 +197,7 @@ export function ProviderGroupTab({
       if (editingGroup) {
         const ok = await saveGroupPatch(editingGroup.id, {
           costMultiplier,
-          description: form.description.trim() || null,
+          description: trimmedDescription || null,
         });
         if (ok) {
           closeDialog();
@@ -203,7 +208,7 @@ export function ProviderGroupTab({
       const result = await createProviderGroup({
         name: trimmedName,
         costMultiplier,
-        description: form.description.trim() || undefined,
+        description: trimmedDescription || undefined,
       });
       if (result.ok) {
         toast.success(t("createSuccess"));
@@ -273,10 +278,12 @@ export function ProviderGroupTab({
           </div>
           <p className="text-sm text-muted-foreground">{t("description")}</p>
         </div>
-        <Button onClick={openCreateDialog} size="sm">
-          <Plus className="mr-1.5 h-4 w-4" />
-          {t("addGroup")}
-        </Button>
+        {isAdmin ? (
+          <Button onClick={openCreateDialog} size="sm">
+            <Plus className="mr-1.5 h-4 w-4" />
+            {t("addGroup")}
+          </Button>
+        ) : null}
       </div>
 
       {isLoading && groups.length === 0 ? (
@@ -371,27 +378,29 @@ export function ProviderGroupTab({
                         </Badge>
                       </TableCell>
                       <TableCell>
-                        <div className="flex items-center justify-end gap-1">
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8"
-                            onClick={() => openEditDialog(group)}
-                            title={t("editGroup")}
-                          >
-                            <Pencil className="h-3.5 w-3.5" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8 text-destructive hover:text-destructive"
-                            onClick={() => openDeleteConfirm(group)}
-                            disabled={isDefault}
-                            title={isDefault ? t("cannotDeleteDefault") : t("deleteGroup")}
-                          >
-                            <Trash2 className="h-3.5 w-3.5" />
-                          </Button>
-                        </div>
+                        {isAdmin ? (
+                          <div className="flex items-center justify-end gap-1">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={() => openEditDialog(group)}
+                              title={t("editGroup")}
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 text-destructive hover:text-destructive"
+                              onClick={() => openDeleteConfirm(group)}
+                              disabled={isDefault}
+                              title={isDefault ? t("cannotDeleteDefault") : t("deleteGroup")}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        ) : null}
                       </TableCell>
                     </TableRow>
 
@@ -770,13 +779,17 @@ function MemberRow({
             <TypeIcon className="h-4 w-4" aria-hidden />
           </div>
           <div className="min-w-0">
-            <button
-              type="button"
-              className="truncate text-left font-medium underline-offset-4 hover:underline"
-              onClick={() => onRequestEditProvider(member.id)}
-            >
-              {member.name}
-            </button>
+            {canEdit ? (
+              <button
+                type="button"
+                className="truncate text-left font-medium underline-offset-4 hover:underline"
+                onClick={() => onRequestEditProvider(member.id)}
+              >
+                {member.name}
+              </button>
+            ) : (
+              <span className="truncate text-left font-medium">{member.name}</span>
+            )}
             <div className="truncate text-xs text-muted-foreground">{member.url}</div>
           </div>
         </div>
@@ -801,15 +814,18 @@ function MemberRow({
         )}
       </TableCell>
       <TableCell>
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-8 px-2"
-          onClick={() => onRequestEditProvider(member.id)}
-          title={t("openProviderEditor")}
-        >
-          <Edit className="h-4 w-4" />
-        </Button>
+        {canEdit ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-8 px-2"
+            onClick={() => onRequestEditProvider(member.id)}
+            title={t("openProviderEditor")}
+            aria-label={t("openProviderEditor")}
+          >
+            <Edit className="h-4 w-4" />
+          </Button>
+        ) : null}
       </TableCell>
     </TableRow>
   );

--- a/src/app/[locale]/settings/providers/_components/provider-group-tab.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-group-tab.tsx
@@ -1,8 +1,19 @@
 "use client";
 
-import { ChevronDown, ChevronRight, Loader2, Pencil, Plus, Trash2 } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  ChevronDown,
+  ChevronRight,
+  Edit,
+  Layers,
+  Loader2,
+  Pencil,
+  Plus,
+  Trash2,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
-import { Fragment, useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import type * as React from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 import type { ProviderGroupWithCount } from "@/actions/provider-groups";
 import {
@@ -11,9 +22,11 @@ import {
   getProviderGroups,
   updateProviderGroup,
 } from "@/actions/provider-groups";
-import { editProvider, getProviders } from "@/actions/providers";
+import { editProvider } from "@/actions/providers";
+import type { BatchActionMode } from "@/app/[locale]/settings/providers/_components/batch-edit/provider-batch-actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -22,7 +35,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
 import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Table,
   TableBody,
@@ -32,17 +47,25 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { PROVIDER_GROUP } from "@/lib/constants/provider.constants";
+import { useMediaQuery } from "@/lib/hooks/use-media-query";
+import { getProviderTypeConfig, getProviderTypeTranslationKey } from "@/lib/provider-type-utils";
+import { cn } from "@/lib/utils";
 import { parseProviderGroups } from "@/lib/utils/provider-group";
 import type { ProviderDisplay } from "@/types/provider";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import { ProviderBatchActions, ProviderBatchDialog, ProviderBatchToolbar } from "./batch-edit";
+import { InlineEditPopover } from "./inline-edit-popover";
+import { invalidateProviderQueries } from "./invalidate-provider-queries";
 
 interface GroupFormState {
   name: string;
   costMultiplier: string;
   description: string;
+}
+
+interface ProviderGroupTabProps {
+  providers: ProviderDisplay[];
+  isAdmin: boolean;
+  onRequestEditProvider: (providerId: number) => void;
 }
 
 const INITIAL_FORM: GroupFormState = {
@@ -51,45 +74,30 @@ const INITIAL_FORM: GroupFormState = {
   description: "",
 };
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
-
-export function ProviderGroupTab() {
+export function ProviderGroupTab({
+  providers,
+  isAdmin,
+  onRequestEditProvider,
+}: ProviderGroupTabProps) {
   const t = useTranslations("settings.providers.providerGroups");
-
-  // Data
   const [groups, setGroups] = useState<ProviderGroupWithCount[]>([]);
-  const [providers, setProviders] = useState<ProviderDisplay[]>([]);
   const [expandedGroups, setExpandedGroups] = useState<Set<number>>(new Set());
   const [isLoading, startLoadTransition] = useTransition();
-
-  // Dialog state
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingGroup, setEditingGroup] = useState<ProviderGroupWithCount | null>(null);
   const [form, setForm] = useState<GroupFormState>(INITIAL_FORM);
   const [isSaving, startSaveTransition] = useTransition();
-
-  // Delete confirmation
   const [deleteTarget, setDeleteTarget] = useState<ProviderGroupWithCount | null>(null);
   const [isDeleting, startDeleteTransition] = useTransition();
 
-  // ---------------------------------------------------------------------------
-  // Data fetching
-  // ---------------------------------------------------------------------------
-
   const fetchGroups = useCallback(() => {
     startLoadTransition(async () => {
-      const [groupsResult, providersResult] = await Promise.all([
-        getProviderGroups(),
-        getProviders(),
-      ]);
+      const groupsResult = await getProviderGroups();
       if (groupsResult.ok) {
         setGroups(groupsResult.data);
       } else {
         toast.error(groupsResult.error);
       }
-      setProviders(providersResult);
     });
   }, []);
 
@@ -108,10 +116,6 @@ export function ProviderGroupTab() {
       return next;
     });
   }, []);
-
-  // ---------------------------------------------------------------------------
-  // Dialog handlers
-  // ---------------------------------------------------------------------------
 
   const openCreateDialog = useCallback(() => {
     setEditingGroup(null);
@@ -135,8 +139,6 @@ export function ProviderGroupTab() {
     setForm(INITIAL_FORM);
   }, []);
 
-  // Map server-side error codes to localized toast messages. Falls back to
-  // the provided fallback when the code is unknown or absent.
   const mapSaveError = useCallback(
     (errorCode: string | undefined, fallback: string): string => {
       switch (errorCode) {
@@ -153,9 +155,27 @@ export function ProviderGroupTab() {
     [t]
   );
 
+  const saveGroupPatch = useCallback(
+    async (
+      groupId: number,
+      patch: {
+        costMultiplier?: number;
+        description?: string | null;
+      }
+    ): Promise<boolean> => {
+      const result = await updateProviderGroup(groupId, patch);
+      if (result.ok) {
+        toast.success(t("updateSuccess"));
+        fetchGroups();
+        return true;
+      }
+      toast.error(mapSaveError(result.errorCode, result.error ?? t("updateFailed")));
+      return false;
+    },
+    [fetchGroups, mapSaveError, t]
+  );
+
   const handleSave = useCallback(() => {
-    // All synchronous validation happens BEFORE the transition so that
-    // `isSaving` never briefly flips true for validation failures.
     const costMultiplier = Number.parseFloat(form.costMultiplier);
     if (!Number.isFinite(costMultiplier) || costMultiplier < 0) {
       toast.error(t("invalidMultiplier"));
@@ -170,39 +190,30 @@ export function ProviderGroupTab() {
 
     startSaveTransition(async () => {
       if (editingGroup) {
-        // Update
-        const result = await updateProviderGroup(editingGroup.id, {
+        const ok = await saveGroupPatch(editingGroup.id, {
           costMultiplier,
-          description: form.description || null,
+          description: form.description.trim() || null,
         });
-        if (result.ok) {
-          toast.success(t("updateSuccess"));
+        if (ok) {
           closeDialog();
-          fetchGroups();
-        } else {
-          toast.error(mapSaveError(result.errorCode, result.error ?? t("updateFailed")));
         }
+        return;
+      }
+
+      const result = await createProviderGroup({
+        name: trimmedName,
+        costMultiplier,
+        description: form.description.trim() || undefined,
+      });
+      if (result.ok) {
+        toast.success(t("createSuccess"));
+        closeDialog();
+        fetchGroups();
       } else {
-        // Create
-        const result = await createProviderGroup({
-          name: trimmedName,
-          costMultiplier,
-          description: form.description || undefined,
-        });
-        if (result.ok) {
-          toast.success(t("createSuccess"));
-          closeDialog();
-          fetchGroups();
-        } else {
-          toast.error(mapSaveError(result.errorCode, result.error ?? t("createFailed")));
-        }
+        toast.error(mapSaveError(result.errorCode, result.error ?? t("createFailed")));
       }
     });
-  }, [editingGroup, form, t, closeDialog, fetchGroups, mapSaveError]);
-
-  // ---------------------------------------------------------------------------
-  // Delete handlers
-  // ---------------------------------------------------------------------------
+  }, [closeDialog, editingGroup, fetchGroups, form, mapSaveError, saveGroupPatch, t]);
 
   const openDeleteConfirm = useCallback((group: ProviderGroupWithCount) => {
     setDeleteTarget(group);
@@ -221,29 +232,45 @@ export function ProviderGroupTab() {
         toast.success(t("deleteSuccess"));
         closeDeleteConfirm();
         fetchGroups();
+      } else if (result.errorCode === "GROUP_IN_USE") {
+        toast.error(t("groupInUse"));
+      } else if (result.errorCode === "CANNOT_DELETE_DEFAULT") {
+        toast.error(t("cannotDeleteDefault"));
       } else {
-        // Map known error codes to localized messages.
-        if (result.errorCode === "GROUP_IN_USE") {
-          toast.error(t("groupInUse"));
-        } else if (result.errorCode === "CANNOT_DELETE_DEFAULT") {
-          toast.error(t("cannotDeleteDefault"));
-        } else {
-          toast.error(result.error ?? t("deleteFailed"));
-        }
+        toast.error(result.error ?? t("deleteFailed"));
       }
     });
-  }, [deleteTarget, t, closeDeleteConfirm, fetchGroups]);
+  }, [closeDeleteConfirm, deleteTarget, fetchGroups, t]);
 
-  // ---------------------------------------------------------------------------
-  // Render
-  // ---------------------------------------------------------------------------
+  const validateCostMultiplier = useCallback(
+    (raw: string) => {
+      if (raw.length === 0) return t("invalidMultiplier");
+      const value = Number(raw);
+      if (!Number.isFinite(value) || value < 0) return t("invalidMultiplier");
+      return null;
+    },
+    [t]
+  );
+
+  const validateDescription = useCallback(
+    (raw: string) => {
+      if (raw.length > 500) return t("descriptionTooLong");
+      return null;
+    },
+    [t]
+  );
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h3 className="text-lg font-medium">{t("title")}</h3>
+      <div className="flex flex-col gap-3 rounded-xl border bg-card p-4 shadow-sm sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Layers className="h-4 w-4 text-muted-foreground" />
+            <h3 className="text-lg font-medium">{t("title")}</h3>
+            <Badge variant="secondary" className="tabular-nums">
+              {groups.length}
+            </Badge>
+          </div>
           <p className="text-sm text-muted-foreground">{t("description")}</p>
         </div>
         <Button onClick={openCreateDialog} size="sm">
@@ -252,27 +279,26 @@ export function ProviderGroupTab() {
         </Button>
       </div>
 
-      {/* Table */}
       {isLoading && groups.length === 0 ? (
-        <div className="flex items-center justify-center py-12">
+        <div className="flex items-center justify-center rounded-xl border bg-card py-12">
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
       ) : groups.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-12 text-center">
+        <div className="flex flex-col items-center justify-center rounded-xl border bg-card py-12 text-center">
           <p className="text-sm font-medium text-muted-foreground">{t("noGroups")}</p>
-          <p className="text-xs text-muted-foreground mt-1">{t("noGroupsDesc")}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{t("noGroupsDesc")}</p>
         </div>
       ) : (
-        <div className="border rounded-lg">
+        <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="w-[40px]" />
+                <TableHead className="w-[44px]" />
                 <TableHead>{t("groupName")}</TableHead>
-                <TableHead className="w-[140px]">{t("costMultiplier")}</TableHead>
+                <TableHead className="w-[180px]">{t("costMultiplier")}</TableHead>
                 <TableHead>{t("descriptionLabel")}</TableHead>
-                <TableHead className="w-[100px] text-center">{t("providerCount")}</TableHead>
-                <TableHead className="w-[100px]" />
+                <TableHead className="w-[120px] text-center">{t("providerCount")}</TableHead>
+                <TableHead className="w-[96px]" />
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -280,9 +306,10 @@ export function ProviderGroupTab() {
                 const isDefault = group.name === PROVIDER_GROUP.DEFAULT;
                 const isExpanded = expandedGroups.has(group.id);
                 const members = filterGroupMembers(providers, group.name);
+
                 return (
                   <Fragment key={group.id}>
-                    <TableRow>
+                    <TableRow className={cn("align-top", isExpanded && "bg-muted/20")}>
                       <TableCell>
                         <Button
                           variant="ghost"
@@ -298,20 +325,50 @@ export function ProviderGroupTab() {
                           )}
                         </Button>
                       </TableCell>
-                      <TableCell className="font-medium">
-                        {group.name}
-                        {isDefault && (
-                          <Badge variant="secondary" className="ml-2">
-                            {t("defaultGroup")}
-                          </Badge>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">{group.name}</span>
+                          {isDefault ? (
+                            <Badge variant="secondary">{t("defaultGroup")}</Badge>
+                          ) : null}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {isAdmin ? (
+                          <InlineEditPopover
+                            value={group.costMultiplier}
+                            label={t("groupMultiplierLabel")}
+                            validator={validateCostMultiplier}
+                            onSave={(value) => saveGroupPatch(group.id, { costMultiplier: value })}
+                            suffix="x"
+                            type="number"
+                          />
+                        ) : (
+                          <span className="font-mono">{group.costMultiplier}x</span>
                         )}
                       </TableCell>
-                      <TableCell className="font-mono">{group.costMultiplier}x</TableCell>
-                      <TableCell className="text-muted-foreground">
-                        {group.description || "-"}
+                      <TableCell className="max-w-[360px]">
+                        {isAdmin ? (
+                          <InlineTextEditPopover
+                            value={group.description ?? ""}
+                            emptyLabel={t("noDescription")}
+                            label={t("groupDescriptionLabel")}
+                            placeholder={t("descriptionPlaceholder")}
+                            validator={validateDescription}
+                            onSave={(value) =>
+                              saveGroupPatch(group.id, { description: value || null })
+                            }
+                          />
+                        ) : group.description ? (
+                          <span className="text-muted-foreground">{group.description}</span>
+                        ) : (
+                          <span className="text-muted-foreground">{t("noDescription")}</span>
+                        )}
                       </TableCell>
-                      <TableCell className="text-center tabular-nums">
-                        {group.providerCount}
+                      <TableCell className="text-center">
+                        <Badge variant="outline" className="tabular-nums">
+                          {group.providerCount}
+                        </Badge>
                       </TableCell>
                       <TableCell>
                         <div className="flex items-center justify-end gap-1">
@@ -337,17 +394,20 @@ export function ProviderGroupTab() {
                         </div>
                       </TableCell>
                     </TableRow>
-                    {isExpanded && (
+
+                    {isExpanded ? (
                       <TableRow>
-                        <TableCell colSpan={6} className="bg-muted/30 p-0">
-                          <GroupMembersTable
+                        <TableCell colSpan={6} className="bg-muted/20 p-0">
+                          <GroupMembersPanel
                             groupName={group.name}
                             members={members}
+                            canEdit={isAdmin}
                             onSaved={fetchGroups}
+                            onRequestEditProvider={onRequestEditProvider}
                           />
                         </TableCell>
                       </TableRow>
-                    )}
+                    ) : null}
                   </Fragment>
                 );
               })}
@@ -356,7 +416,6 @@ export function ProviderGroupTab() {
         </div>
       )}
 
-      {/* Create / Edit Dialog */}
       <Dialog open={dialogOpen} onOpenChange={(open) => !open && closeDialog()}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
@@ -365,7 +424,6 @@ export function ProviderGroupTab() {
           </DialogHeader>
 
           <div className="space-y-4 py-4">
-            {/* Name */}
             <div className="space-y-2">
               <label htmlFor="group-name" className="text-sm font-medium">
                 {t("groupName")}
@@ -380,7 +438,6 @@ export function ProviderGroupTab() {
               />
             </div>
 
-            {/* Cost Multiplier */}
             <div className="space-y-2">
               <label htmlFor="group-multiplier" className="text-sm font-medium">
                 {t("costMultiplier")}
@@ -395,7 +452,6 @@ export function ProviderGroupTab() {
               />
             </div>
 
-            {/* Description */}
             <div className="space-y-2">
               <label htmlFor="group-description" className="text-sm font-medium">
                 {t("descriptionLabel")}
@@ -421,7 +477,6 @@ export function ProviderGroupTab() {
         </DialogContent>
       </Dialog>
 
-      {/* Delete Confirmation Dialog */}
       <Dialog open={!!deleteTarget} onOpenChange={(open) => !open && closeDeleteConfirm()}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
@@ -445,10 +500,6 @@ export function ProviderGroupTab() {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Helpers & sub-components
-// ---------------------------------------------------------------------------
-
 function filterGroupMembers(providers: ProviderDisplay[], groupName: string): ProviderDisplay[] {
   return providers.filter((provider) => {
     const tags = parseProviderGroups(provider.groupTag);
@@ -458,14 +509,94 @@ function filterGroupMembers(providers: ProviderDisplay[], groupName: string): Pr
   });
 }
 
-interface GroupMembersTableProps {
+interface GroupMembersPanelProps {
   groupName: string;
   members: ProviderDisplay[];
+  canEdit: boolean;
   onSaved: () => void;
+  onRequestEditProvider: (providerId: number) => void;
 }
 
-function GroupMembersTable({ groupName, members, onSaved }: GroupMembersTableProps) {
+function GroupMembersPanel({
+  groupName,
+  members,
+  canEdit,
+  onSaved,
+  onRequestEditProvider,
+}: GroupMembersPanelProps) {
   const t = useTranslations("settings.providers.providerGroups");
+  const [isMultiSelectMode, setIsMultiSelectMode] = useState(false);
+  const [selectedProviderIds, setSelectedProviderIds] = useState<Set<number>>(new Set());
+  const [batchDialogOpen, setBatchDialogOpen] = useState(false);
+  const [batchActionMode, setBatchActionMode] = useState<BatchActionMode>(null);
+
+  const allSelected = members.length > 0 && selectedProviderIds.size === members.length;
+
+  const handleSelectAll = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        setSelectedProviderIds(new Set(members.map((member) => member.id)));
+      } else {
+        setSelectedProviderIds(new Set());
+      }
+    },
+    [members]
+  );
+
+  const handleInvertSelection = useCallback(() => {
+    const next = new Set(
+      members.map((member) => member.id).filter((id) => !selectedProviderIds.has(id))
+    );
+    setSelectedProviderIds(next);
+  }, [members, selectedProviderIds]);
+
+  const handleSelectByType = useCallback(
+    (type: ProviderDisplay["providerType"]) => {
+      setSelectedProviderIds((prev) => {
+        const next = new Set(prev);
+        for (const member of members) {
+          if (member.providerType === type) {
+            next.add(member.id);
+          }
+        }
+        return next;
+      });
+    },
+    [members]
+  );
+
+  const handleSelectMember = useCallback((providerId: number, checked: boolean) => {
+    setSelectedProviderIds((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(providerId);
+      } else {
+        next.delete(providerId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleOpenBatchEdit = useCallback(() => {
+    setBatchActionMode("edit");
+    setBatchDialogOpen(true);
+  }, []);
+
+  const handleBatchAction = useCallback((mode: BatchActionMode) => {
+    setBatchActionMode(mode);
+    setBatchDialogOpen(true);
+  }, []);
+
+  const handleBatchSuccess = useCallback(() => {
+    setSelectedProviderIds(new Set());
+    setIsMultiSelectMode(false);
+    onSaved();
+  }, [onSaved]);
+
+  const handleExitMultiSelectMode = useCallback(() => {
+    setSelectedProviderIds(new Set());
+    setIsMultiSelectMode(false);
+  }, []);
 
   if (members.length === 0) {
     return (
@@ -474,22 +605,80 @@ function GroupMembersTable({ groupName, members, onSaved }: GroupMembersTablePro
   }
 
   return (
-    <div className="px-6 py-3">
-      <div className="text-xs font-medium text-muted-foreground mb-2">{t("groupMembers")}</div>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>{t("providerName")}</TableHead>
-            <TableHead className="w-[180px]">{t("effectivePriority")}</TableHead>
-            <TableHead className="w-[120px]" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {members.map((member) => (
-            <MemberRow key={member.id} member={member} groupName={groupName} onSaved={onSaved} />
-          ))}
-        </TableBody>
-      </Table>
+    <div className="space-y-4 px-6 py-4">
+      <div className="flex flex-col gap-3 rounded-lg border bg-background/80 p-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">{t("groupMembers")}</span>
+              <Badge variant="outline" className="tabular-nums">
+                {members.length}
+              </Badge>
+            </div>
+            <p className="text-xs text-muted-foreground">{t("groupMembersHint", { groupName })}</p>
+          </div>
+          {canEdit ? (
+            <ProviderBatchToolbar
+              isMultiSelectMode={isMultiSelectMode}
+              allSelected={allSelected}
+              selectedCount={selectedProviderIds.size}
+              totalCount={members.length}
+              onEnterMode={() => setIsMultiSelectMode(true)}
+              onExitMode={handleExitMultiSelectMode}
+              onSelectAll={handleSelectAll}
+              onInvertSelection={handleInvertSelection}
+              onOpenBatchEdit={handleOpenBatchEdit}
+              providers={members}
+              onSelectByType={handleSelectByType}
+              onSelectByGroup={() => {}}
+              showSelectByGroup={false}
+            />
+          ) : null}
+        </div>
+
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {isMultiSelectMode ? <TableHead className="w-[44px]" /> : null}
+              <TableHead>{t("providerName")}</TableHead>
+              <TableHead className="w-[180px]">{t("providerType")}</TableHead>
+              <TableHead className="w-[180px]">{t("effectivePriority")}</TableHead>
+              <TableHead className="w-[88px]" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {members.map((member) => (
+              <MemberRow
+                key={member.id}
+                member={member}
+                groupName={groupName}
+                canEdit={canEdit}
+                isMultiSelectMode={isMultiSelectMode}
+                isSelected={selectedProviderIds.has(member.id)}
+                onSelectChange={(checked) => handleSelectMember(member.id, checked)}
+                onSaved={onSaved}
+                onRequestEditProvider={onRequestEditProvider}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <ProviderBatchActions
+        selectedCount={selectedProviderIds.size}
+        isVisible={isMultiSelectMode}
+        onAction={handleBatchAction}
+        onClose={handleExitMultiSelectMode}
+      />
+
+      <ProviderBatchDialog
+        open={batchDialogOpen}
+        mode={batchActionMode}
+        onOpenChange={setBatchDialogOpen}
+        selectedProviderIds={selectedProviderIds}
+        providers={members}
+        onSuccess={handleBatchSuccess}
+      />
     </div>
   );
 }
@@ -497,72 +686,326 @@ function GroupMembersTable({ groupName, members, onSaved }: GroupMembersTablePro
 interface MemberRowProps {
   member: ProviderDisplay;
   groupName: string;
+  canEdit: boolean;
+  isMultiSelectMode: boolean;
+  isSelected: boolean;
+  onSelectChange: (checked: boolean) => void;
   onSaved: () => void;
+  onRequestEditProvider: (providerId: number) => void;
 }
 
-function MemberRow({ member, groupName, onSaved }: MemberRowProps) {
+function MemberRow({
+  member,
+  groupName,
+  canEdit,
+  isMultiSelectMode,
+  isSelected,
+  onSelectChange,
+  onSaved,
+  onRequestEditProvider,
+}: MemberRowProps) {
   const t = useTranslations("settings.providers.providerGroups");
-  const effective = useMemo(() => {
+  const tTypes = useTranslations("settings.providers.types");
+  const queryClient = useQueryClient();
+
+  const effectivePriority = useMemo(() => {
     const groupPriorities = (member.groupPriorities ?? null) as Record<string, number> | null;
     return groupPriorities?.[groupName] ?? member.priority;
-  }, [member.groupPriorities, member.priority, groupName]);
+  }, [groupName, member.groupPriorities, member.priority]);
 
-  const [draft, setDraft] = useState<string>(String(effective));
-  const [isSaving, startSaveTransition] = useTransition();
+  const typeConfig = getProviderTypeConfig(member.providerType);
+  const TypeIcon = typeConfig.icon;
+  const typeKey = getProviderTypeTranslationKey(member.providerType);
+  const typeLabel = tTypes(`${typeKey}.label`);
 
-  useEffect(() => {
-    setDraft(String(effective));
-  }, [effective]);
-
-  const handleSave = useCallback(() => {
-    const trimmed = draft.trim();
-    if (trimmed === "") {
-      toast.error(t("savePriorityFailed"));
-      return;
-    }
-    const value = Number(trimmed);
-    if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
-      toast.error(t("savePriorityFailed"));
-      return;
-    }
-
-    const existing = (member.groupPriorities ?? null) as Record<string, number> | null;
-    const merged: Record<string, number> = { ...(existing ?? {}), [groupName]: value };
-
-    startSaveTransition(async () => {
-      const result = await editProvider(member.id, { group_priorities: merged });
-      if (result.ok) {
-        toast.success(t("savePrioritySuccess"));
-        onSaved();
-      } else {
-        toast.error(result.error ?? t("savePriorityFailed"));
+  const validatePriority = useCallback(
+    (raw: string) => {
+      if (raw.length === 0) return t("savePriorityFailed");
+      const value = Number(raw);
+      if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+        return t("savePriorityFailed");
       }
-    });
-  }, [draft, member.groupPriorities, member.id, groupName, onSaved, t]);
+      return null;
+    },
+    [t]
+  );
 
-  const isDirty = draft.trim() !== String(effective);
+  const handleSavePriority = useCallback(
+    async (value: number) => {
+      const existing = (member.groupPriorities ?? null) as Record<string, number> | null;
+      const merged: Record<string, number> = { ...(existing ?? {}), [groupName]: value };
+      const result = await editProvider(member.id, { group_priorities: merged });
+      if (!result.ok) {
+        toast.error(result.error ?? t("savePriorityFailed"));
+        return false;
+      }
+
+      toast.success(t("savePrioritySuccess"));
+      await invalidateProviderQueries(queryClient);
+      onSaved();
+      return true;
+    },
+    [groupName, member.groupPriorities, member.id, onSaved, queryClient, t]
+  );
 
   return (
     <TableRow>
-      <TableCell className="font-medium">{member.name}</TableCell>
+      {isMultiSelectMode ? (
+        <TableCell>
+          <Checkbox
+            checked={isSelected}
+            onCheckedChange={(checked) => onSelectChange(Boolean(checked))}
+          />
+        </TableCell>
+      ) : null}
       <TableCell>
-        <Input
-          type="number"
-          min={0}
-          step={1}
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          disabled={isSaving}
-          className="tabular-nums w-28"
-          aria-label={t("effectivePriority")}
-        />
+        <div className="flex min-w-0 items-center gap-3">
+          <div
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-md border bg-muted/40",
+              typeConfig.iconColor
+            )}
+            title={typeLabel}
+          >
+            <TypeIcon className="h-4 w-4" aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <button
+              type="button"
+              className="truncate text-left font-medium underline-offset-4 hover:underline"
+              onClick={() => onRequestEditProvider(member.id)}
+            >
+              {member.name}
+            </button>
+            <div className="truncate text-xs text-muted-foreground">{member.url}</div>
+          </div>
+        </div>
       </TableCell>
       <TableCell>
-        <Button size="sm" onClick={handleSave} disabled={isSaving || !isDirty}>
-          {isSaving && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
-          {t("save")}
+        <Badge variant="outline" className="gap-1.5">
+          <TypeIcon className={cn("h-3.5 w-3.5", typeConfig.iconColor)} aria-hidden />
+          <span>{typeLabel}</span>
+        </Badge>
+      </TableCell>
+      <TableCell>
+        {canEdit ? (
+          <InlineEditPopover
+            value={effectivePriority}
+            label={t("effectivePriority")}
+            validator={validatePriority}
+            onSave={handleSavePriority}
+            type="integer"
+          />
+        ) : (
+          <span className="tabular-nums font-medium">{effectivePriority}</span>
+        )}
+      </TableCell>
+      <TableCell>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-8 px-2"
+          onClick={() => onRequestEditProvider(member.id)}
+          title={t("openProviderEditor")}
+        >
+          <Edit className="h-4 w-4" />
         </Button>
       </TableCell>
     </TableRow>
+  );
+}
+
+interface InlineTextEditPopoverProps {
+  value: string;
+  emptyLabel: string;
+  label: string;
+  placeholder: string;
+  validator: (value: string) => string | null;
+  onSave: (value: string) => Promise<boolean>;
+}
+
+function InlineTextEditPopover({
+  value,
+  emptyLabel,
+  label,
+  placeholder,
+  validator,
+  onSave,
+}: InlineTextEditPopoverProps) {
+  const t = useTranslations("settings.providers.providerGroups");
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const trimmedDraft = draft.trim();
+  const validationError = useMemo(() => validator(trimmedDraft), [trimmedDraft, validator]);
+  const canSave = !saving && validationError == null;
+
+  useEffect(() => {
+    if (!open) return;
+    const raf = requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [open]);
+
+  const resetDraft = useCallback(() => {
+    setDraft(value);
+  }, [value]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        setDraft(value);
+      } else {
+        resetDraft();
+        setSaving(false);
+      }
+      setOpen(nextOpen);
+    },
+    [resetDraft, value]
+  );
+
+  const handleCancel = useCallback(() => {
+    resetDraft();
+    setOpen(false);
+  }, [resetDraft]);
+
+  const handleSave = useCallback(async () => {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      const ok = await onSave(trimmedDraft);
+      if (ok) {
+        setOpen(false);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }, [canSave, onSave, trimmedDraft]);
+
+  const stopPropagation = (event: React.SyntheticEvent) => {
+    event.stopPropagation();
+  };
+
+  const trigger = (
+    <button
+      type="button"
+      className={cn(
+        "max-w-full rounded-sm text-left underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+        value
+          ? "text-muted-foreground hover:underline"
+          : "text-muted-foreground/80 italic hover:underline"
+      )}
+      onPointerDown={stopPropagation}
+      onClick={(event) => {
+        event.stopPropagation();
+        if (!isDesktop) handleOpenChange(true);
+      }}
+    >
+      <span className="line-clamp-2">{value || emptyLabel}</span>
+    </button>
+  );
+
+  const inputProps = {
+    ref: inputRef,
+    value: draft,
+    placeholder,
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => setDraft(event.target.value),
+    disabled: saving,
+    "aria-label": label,
+    "aria-invalid": validationError != null,
+    onPointerDown: stopPropagation,
+    onClick: stopPropagation,
+    onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+      if (event.key === "Escape") {
+        event.preventDefault();
+        handleCancel();
+      }
+      if (event.key === "Enter") {
+        event.preventDefault();
+        void handleSave();
+      }
+    },
+  };
+
+  const content = (
+    <div className="grid gap-2">
+      <div className="hidden text-xs font-medium md:block">{label}</div>
+      <Input {...inputProps} className="w-full md:w-[320px]" />
+      {validationError ? <div className="text-xs text-destructive">{validationError}</div> : null}
+      <div className="flex items-center justify-end gap-2 pt-1">
+        <Button type="button" size="sm" variant="outline" onClick={handleCancel} disabled={saving}>
+          {t("cancel")}
+        </Button>
+        <Button type="button" size="sm" onClick={handleSave} disabled={!canSave}>
+          {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          {t("save")}
+        </Button>
+      </div>
+    </div>
+  );
+
+  if (!isDesktop) {
+    return (
+      <>
+        {trigger}
+        <Drawer open={open} onOpenChange={handleOpenChange}>
+          <DrawerContent>
+            <DrawerHeader>
+              <DrawerTitle>{label}</DrawerTitle>
+            </DrawerHeader>
+            <div className="px-4 pb-6">
+              <div className="grid gap-3">
+                <Input
+                  {...inputProps}
+                  className="text-base"
+                  onPointerDown={undefined}
+                  onClick={undefined}
+                />
+                {validationError ? (
+                  <div className="text-sm text-destructive">{validationError}</div>
+                ) : null}
+                <div className="flex gap-2 pt-2">
+                  <Button
+                    variant="outline"
+                    onClick={handleCancel}
+                    disabled={saving}
+                    className="flex-1"
+                    size="lg"
+                  >
+                    {t("cancel")}
+                  </Button>
+                  <Button onClick={handleSave} disabled={!canSave} className="flex-1" size="lg">
+                    {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                    {t("save")}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </DrawerContent>
+        </Drawer>
+      </>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent
+        align="start"
+        side="bottom"
+        sideOffset={6}
+        className="w-auto p-3"
+        onPointerDown={stopPropagation}
+        onClick={stopPropagation}
+      >
+        {content}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/app/[locale]/settings/providers/_components/provider-list.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-list.tsx
@@ -39,6 +39,7 @@ interface ProviderListProps {
   isMultiSelectMode?: boolean;
   selectedProviderIds?: Set<number>;
   onSelectProvider?: (providerId: number, checked: boolean) => void;
+  onEditProvider?: (provider: ProviderDisplay) => void;
   allGroups?: string[];
   userGroups?: string[];
   isAdmin?: boolean;
@@ -57,6 +58,7 @@ export function ProviderList({
   isMultiSelectMode = false,
   selectedProviderIds = EMPTY_SET,
   onSelectProvider,
+  onEditProvider,
   allGroups = EMPTY_STRING_ARRAY,
   userGroups = EMPTY_STRING_ARRAY,
   isAdmin = false,
@@ -109,6 +111,7 @@ export function ProviderList({
             onSelectChange={
               onSelectProvider ? (checked) => onSelectProvider(provider.id, checked) : undefined
             }
+            onEdit={onEditProvider ? () => onEditProvider(provider) : undefined}
             allGroups={allGroups}
             userGroups={userGroups}
             isAdmin={isAdmin}

--- a/src/app/[locale]/settings/providers/_components/provider-manager.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-manager.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import {
   AlertTriangle,
   Filter,
@@ -12,6 +13,7 @@ import { useTranslations } from "next-intl";
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -34,6 +36,7 @@ import {
   ProviderBatchDialog,
   ProviderBatchToolbar,
 } from "./batch-edit";
+import { ProviderForm } from "./forms/provider-form";
 import { ProviderGroupTab } from "./provider-group-tab";
 import { ProviderList } from "./provider-list";
 import { ProviderSortDropdown, type SortKey } from "./provider-sort-dropdown";
@@ -109,6 +112,7 @@ export function ProviderManager({
   const [selectedProviderIds, setSelectedProviderIds] = useState<Set<number>>(new Set());
   const [batchDialogOpen, setBatchDialogOpen] = useState(false);
   const [batchActionMode, setBatchActionMode] = useState<BatchActionMode>(null);
+  const [editingProviderId, setEditingProviderId] = useState<number | null>(null);
 
   // Helper: check if a provider has any circuit open (key-level or endpoint-level)
   const hasAnyCircuitOpen = useCallback(
@@ -269,6 +273,11 @@ export function ProviderManager({
     hasAnyCircuitOpen,
   ]);
 
+  const editingProvider = useMemo(() => {
+    if (editingProviderId == null) return null;
+    return providers.find((provider) => provider.id === editingProviderId) ?? null;
+  }, [editingProviderId, providers]);
+
   // Batch selection handlers
   const handleSelectAll = useCallback(
     (checked: boolean) => {
@@ -353,6 +362,20 @@ export function ProviderManager({
     setSelectedProviderIds(new Set());
     setIsMultiSelectMode(false);
   }, []);
+
+  const handleOpenProviderEditor = useCallback((provider: ProviderDisplay) => {
+    setViewMode("list");
+    setEditingProviderId(provider.id);
+  }, []);
+
+  const handleRequestEditProvider = useCallback(
+    (providerId: number) => {
+      const provider = providers.find((item) => item.id === providerId);
+      if (!provider) return;
+      handleOpenProviderEditor(provider);
+    },
+    [handleOpenProviderEditor, providers]
+  );
 
   const allSelected =
     filteredProviders.length > 0 && selectedProviderIds.size === filteredProviders.length;
@@ -640,7 +663,11 @@ export function ProviderManager({
 
       {/* Provider list / vendor view / groups tab */}
       {viewMode === "groups" ? (
-        <ProviderGroupTab />
+        <ProviderGroupTab
+          providers={providers}
+          isAdmin={isAdmin}
+          onRequestEditProvider={handleRequestEditProvider}
+        />
       ) : loading && providers.length === 0 ? (
         <ProviderListSkeleton label={tCommon("loading")} />
       ) : (
@@ -661,6 +688,7 @@ export function ProviderManager({
               isMultiSelectMode={isMultiSelectMode}
               selectedProviderIds={selectedProviderIds}
               onSelectProvider={handleSelectProvider}
+              onEditProvider={handleOpenProviderEditor}
               allGroups={allGroups}
               userGroups={userGroups}
               isAdmin={isAdmin}
@@ -694,6 +722,27 @@ export function ProviderManager({
         providers={filteredProviders}
         onSuccess={handleBatchSuccess}
       />
+
+      <Dialog
+        open={editingProvider != null}
+        onOpenChange={(open) => !open && setEditingProviderId(null)}
+      >
+        <DialogContent className="max-w-6xl max-h-[var(--cch-viewport-height-90)] flex flex-col overflow-hidden p-0 gap-0">
+          <VisuallyHidden>
+            <DialogTitle>{tStrings("editProvider")}</DialogTitle>
+          </VisuallyHidden>
+          {editingProvider ? (
+            <ProviderForm
+              mode="edit"
+              provider={editingProvider}
+              enableMultiProviderTypes={enableMultiProviderTypes}
+              onSuccess={() => {
+                setEditingProviderId(null);
+              }}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/[locale]/settings/providers/_components/provider-manager.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-manager.tsx
@@ -364,7 +364,6 @@ export function ProviderManager({
   }, []);
 
   const handleOpenProviderEditor = useCallback((provider: ProviderDisplay) => {
-    setViewMode("list");
     setEditingProviderId(provider.id);
   }, []);
 

--- a/tests/unit/settings/providers/provider-batch-toolbar-selection.test.tsx
+++ b/tests/unit/settings/providers/provider-batch-toolbar-selection.test.tsx
@@ -243,4 +243,26 @@ describe("ProviderBatchToolbar - Selection enhancements", () => {
 
     unmount();
   });
+
+  it("does NOT render group dropdown when group selector is explicitly hidden", () => {
+    const providers = [
+      createProvider(1, "claude", "production"),
+      createProvider(2, "openai-compatible", "staging"),
+    ];
+
+    const { container, unmount } = render(
+      <ProviderBatchToolbar
+        {...defaultProps}
+        isMultiSelectMode={true}
+        providers={providers}
+        showSelectByGroup={false}
+      />
+    );
+
+    const buttons = container.querySelectorAll("button");
+    const groupButton = Array.from(buttons).find((b) => b.textContent?.includes("selectByGroup"));
+    expect(groupButton).toBeFalsy();
+
+    unmount();
+  });
 });

--- a/tests/unit/settings/providers/provider-group-tab.test.tsx
+++ b/tests/unit/settings/providers/provider-group-tab.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderDisplay } from "@/types/provider";
+
+const mockGetProviderGroups = vi.fn();
+const mockUpdateProviderGroup = vi.fn();
+const mockCreateProviderGroup = vi.fn();
+const mockDeleteProviderGroup = vi.fn();
+const mockEditProvider = vi.fn();
+
+vi.mock("@/actions/provider-groups", () => ({
+  getProviderGroups: () => mockGetProviderGroups(),
+  updateProviderGroup: (...args: unknown[]) => mockUpdateProviderGroup(...args),
+  createProviderGroup: (...args: unknown[]) => mockCreateProviderGroup(...args),
+  deleteProviderGroup: (...args: unknown[]) => mockDeleteProviderGroup(...args),
+}));
+
+vi.mock("@/actions/providers", () => ({
+  editProvider: (...args: unknown[]) => mockEditProvider(...args),
+}));
+
+vi.mock("@/app/[locale]/settings/providers/_components/batch-edit", () => ({
+  ProviderBatchToolbar: () => <div data-testid="member-batch-toolbar" />,
+  ProviderBatchActions: () => null,
+  ProviderBatchDialog: () => null,
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+function makeProvider(overrides: Partial<ProviderDisplay> = {}): ProviderDisplay {
+  return {
+    id: 1,
+    name: "Provider A",
+    url: "https://api.example.com",
+    maskedKey: "sk-***",
+    isEnabled: true,
+    weight: 1,
+    priority: 1,
+    costMultiplier: 1.5,
+    groupTag: "premium",
+    groupPriorities: { premium: 3 },
+    providerType: "claude",
+    providerVendorId: null,
+    preserveClientIp: false,
+    modelRedirects: null,
+    allowedModels: null,
+    mcpPassthroughType: "none",
+    mcpPassthroughUrl: null,
+    limit5hUsd: null,
+    limitDailyUsd: null,
+    dailyResetMode: "fixed",
+    dailyResetTime: "00:00",
+    limitWeeklyUsd: null,
+    limitMonthlyUsd: null,
+    limitTotalUsd: null,
+    limitConcurrentSessions: 1,
+    maxRetryAttempts: null,
+    circuitBreakerFailureThreshold: 1,
+    circuitBreakerOpenDuration: 60,
+    circuitBreakerHalfOpenSuccessThreshold: 1,
+    proxyUrl: null,
+    proxyFallbackToDirect: false,
+    firstByteTimeoutStreamingMs: 0,
+    streamingIdleTimeoutMs: 0,
+    requestTimeoutNonStreamingMs: 0,
+    websiteUrl: null,
+    faviconUrl: null,
+    cacheTtlPreference: null,
+    context1mPreference: null,
+    codexReasoningEffortPreference: null,
+    codexReasoningSummaryPreference: null,
+    codexTextVerbosityPreference: null,
+    codexParallelToolCallsPreference: null,
+    anthropicMaxTokensPreference: null,
+    anthropicThinkingBudgetPreference: null,
+    geminiGoogleSearchPreference: null,
+    tpm: null,
+    rpm: null,
+    rpd: null,
+    cc: null,
+    createdAt: "2026-01-01",
+    updatedAt: "2026-01-01",
+    ...overrides,
+  };
+}
+
+function render(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient();
+
+  act(() => {
+    root.render(<QueryClientProvider client={queryClient}>{node}</QueryClientProvider>);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+      queryClient.clear();
+    },
+  };
+}
+
+import { ProviderGroupTab } from "@/app/[locale]/settings/providers/_components/provider-group-tab";
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+
+  mockGetProviderGroups.mockResolvedValue({
+    ok: true,
+    data: [
+      {
+        id: 11,
+        name: "premium",
+        costMultiplier: 1.5,
+        description: "Priority group",
+        providerCount: 1,
+      },
+    ],
+  });
+  mockUpdateProviderGroup.mockResolvedValue({ ok: true });
+  mockCreateProviderGroup.mockResolvedValue({ ok: true });
+  mockDeleteProviderGroup.mockResolvedValue({ ok: true });
+  mockEditProvider.mockResolvedValue({ ok: true });
+
+  await Promise.resolve();
+});
+
+describe("ProviderGroupTab", () => {
+  it("opens group members and forwards provider edit requests", async () => {
+    const onRequestEditProvider = vi.fn();
+    const { container, unmount } = render(
+      <ProviderGroupTab
+        providers={[makeProvider()]}
+        isAdmin={true}
+        onRequestEditProvider={onRequestEditProvider}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const expandButton = container.querySelector('button[aria-label="groupMembers"]');
+    expect(expandButton).toBeTruthy();
+
+    act(() => {
+      expandButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const memberButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Provider A")
+    );
+    expect(memberButton).toBeTruthy();
+
+    act(() => {
+      memberButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onRequestEditProvider).toHaveBeenCalledWith(1);
+    expect(container.textContent).toContain("providerType");
+
+    unmount();
+  });
+});

--- a/tests/unit/settings/providers/provider-group-tab.test.tsx
+++ b/tests/unit/settings/providers/provider-group-tab.test.tsx
@@ -177,4 +177,37 @@ describe("ProviderGroupTab", () => {
 
     unmount();
   });
+
+  it("hides mutating controls for non-admin users", async () => {
+    const onRequestEditProvider = vi.fn();
+    const { container, unmount } = render(
+      <ProviderGroupTab
+        providers={[makeProvider()]}
+        isAdmin={false}
+        onRequestEditProvider={onRequestEditProvider}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(
+      Array.from(container.querySelectorAll("button")).some((button) =>
+        button.textContent?.includes("addGroup")
+      )
+    ).toBe(false);
+
+    const expandButton = container.querySelector('button[aria-label="groupMembers"]');
+    expect(expandButton).toBeTruthy();
+
+    act(() => {
+      expandButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.querySelector('button[aria-label="openProviderEditor"]')).toBeNull();
+    expect(onRequestEditProvider).not.toHaveBeenCalled();
+
+    unmount();
+  });
 });

--- a/tests/unit/settings/providers/provider-manager.test.tsx
+++ b/tests/unit/settings/providers/provider-manager.test.tsx
@@ -269,7 +269,7 @@ describe("ProviderManager circuitBrokenCount with endpoint circuits", () => {
     unmount();
   });
 
-  test("switches back to list view and opens the shared editor when group tab requests edit", () => {
+  test("keeps the current groups view and opens the shared editor when group tab requests edit", () => {
     const { unmount, container } = renderWithProviders(
       <ProviderManager providers={providers} healthStatus={{}} enableMultiProviderTypes={true} />
     );
@@ -290,7 +290,7 @@ describe("ProviderManager circuitBrokenCount with endpoint circuits", () => {
       requestButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
-    expect(container.querySelector('[data-testid="provider-list"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="group-edit-request"]')).toBeTruthy();
     expect(container.querySelector('[data-testid="provider-form"]')?.textContent).toContain(
       "Provider A"
     );

--- a/tests/unit/settings/providers/provider-manager.test.tsx
+++ b/tests/unit/settings/providers/provider-manager.test.tsx
@@ -37,6 +37,18 @@ vi.mock("@/app/[locale]/settings/providers/_components/provider-list", () => ({
   ),
 }));
 
+vi.mock("@/app/[locale]/settings/providers/_components/provider-group-tab", () => ({
+  ProviderGroupTab: ({
+    onRequestEditProvider,
+  }: {
+    onRequestEditProvider: (providerId: number) => void;
+  }) => (
+    <button data-testid="group-edit-request" onClick={() => onRequestEditProvider(1)}>
+      open-group-editor
+    </button>
+  ),
+}));
+
 // ProviderVendorView -- not under test
 vi.mock("@/app/[locale]/settings/providers/_components/provider-vendor-view", () => ({
   ProviderVendorView: () => null,
@@ -50,6 +62,23 @@ vi.mock("@/app/[locale]/settings/providers/_components/provider-type-filter", ()
 // ProviderSortDropdown
 vi.mock("@/app/[locale]/settings/providers/_components/provider-sort-dropdown", () => ({
   ProviderSortDropdown: () => null,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div data-testid="dialog-root">{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@radix-ui/react-visually-hidden", () => ({
+  VisuallyHidden: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/app/[locale]/settings/providers/_components/forms/provider-form", () => ({
+  ProviderForm: ({ provider }: { provider: ProviderDisplay }) => (
+    <div data-testid="provider-form">mock-provider-form:{provider.name}</div>
+  ),
 }));
 
 // ---------------------------------------------------------------------------
@@ -236,6 +265,35 @@ describe("ProviderManager circuitBrokenCount with endpoint circuits", () => {
     // Count should be 2: Provider A (key open) + Provider B (endpoint open)
     const text = container.textContent || "";
     expect(text).toContain("(2)");
+
+    unmount();
+  });
+
+  test("switches back to list view and opens the shared editor when group tab requests edit", () => {
+    const { unmount, container } = renderWithProviders(
+      <ProviderManager providers={providers} healthStatus={{}} enableMultiProviderTypes={true} />
+    );
+
+    const groupsButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.getAttribute("title") === enMessages.settings.providers.viewModeGroups
+    );
+    expect(groupsButton).toBeTruthy();
+
+    act(() => {
+      groupsButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const requestButton = container.querySelector('[data-testid="group-edit-request"]');
+    expect(requestButton).toBeTruthy();
+
+    act(() => {
+      requestButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.querySelector('[data-testid="provider-list"]')).toBeTruthy();
+    expect(container.querySelector('[data-testid="provider-form"]')?.textContent).toContain(
+      "Provider A"
+    );
 
     unmount();
   });


### PR DESCRIPTION
## Summary
- Make provider group rows support inline cost multiplier and description editing
- Bring provider-type icons, shared edit entry, and batch management into expanded group members
- Keep group-tab editing aligned with the provider list interaction model (as introduced in PR #486 and #701)

## Related PRs
- Follow-up to #1025 — PR #1025 introduced the provider_groups table and basic group management tab; this PR enhances the tab with inline editing capabilities
- Follow-up to #1030 — PR #1030 fixed data sync and added basic member priority editing; this PR extends that with full inline popover editing and batch management
- Aligns with #486 — Uses the same inline popover editing pattern from the provider list for group rows and member priorities
- Aligns with #701 — Brings the same batch selection and provider type icon patterns to group member management

## Changes

### Core Changes (provider-group-tab.tsx)
- **Inline editing for group rows**: Cost multiplier and description now editable inline via popover (desktop) or drawer (mobile)
- **Provider type icons**: Group member rows now show provider type icons and badges like the main provider list
- **Shared provider editor**: Clicking a provider name in group members opens the same editor dialog used in the main list
- **Batch management in members**: Full batch toolbar support (select all, invert, select by type) inside expanded group panels
- **Responsive UX**: Uses popover on desktop, drawer on mobile for all inline edits

### Supporting Changes
- **provider-batch-toolbar.tsx**: Added `showSelectByGroup` prop to hide group dropdown when inside a group context
- **provider-list.tsx**: Added `onEditProvider` callback prop for external edit triggers
- **provider-manager.tsx**: Manages shared provider editor dialog; handles edit requests from both list and group tab views
- **i18n updates**: New translation keys for group multiplier, description editing, and provider type labels (5 languages)

### Test Coverage
- **New test file**: `provider-group-tab.test.tsx` - Tests provider edit request forwarding from group tab
- **Extended existing tests**: Batch toolbar group selection hiding, provider manager group tab integration

## Testing

### Automated Tests
```bash
bun run build
bun run lint
bun run lint:fix
bun run typecheck
bun run test
bunx vitest run tests/unit/settings/providers/provider-manager.test.tsx tests/unit/settings/providers/provider-batch-toolbar-selection.test.tsx tests/unit/settings/providers/provider-group-tab.test.tsx
```

### Manual Testing
1. Navigate to Settings > Providers > Groups tab
2. Expand a group with members by clicking the chevron
3. Verify provider type icons and badges appear in member rows
4. Click a provider name → should open shared provider editor dialog
5. Click cost multiplier in group row → inline popover should open
6. Test batch selection in member panel: "Select All", "Invert", "Select by Type"
7. On mobile: verify inline edits use drawer instead of popover

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] i18n updated (5 languages)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the provider group management tab with inline editing for cost multiplier and description, provider type icons/badges in member rows, shared provider editor forwarding, and batch selection within expanded group panels — aligning the group tab UX with the main provider list.

The view-mode preservation bug noted in the previous review thread (where opening the provider editor from the groups tab would switch the view to "list") has been addressed in the accompanying fix commit by removing the `setViewMode("list")` call from `handleOpenProviderEditor`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the view-mode preservation bug from the prior review thread is resolved, all i18n keys are present across 5 languages, and the new inline editing and batch-management paths are logically consistent with the existing provider list patterns.

Both remaining findings are P2: an i18n namespace reuse nit in InlineTextEditPopover and a potential test-flakiness note for the async useTransition flush. Neither affects production correctness or data integrity.

No files require special attention. provider-group-tab.tsx is the largest change but is well-structured and correctly mirrors existing patterns.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/settings/providers/_components/provider-group-tab.tsx | Core file: adds InlineTextEditPopover for description editing, provider type icons in MemberRow, edit forwarding via onRequestEditProvider, and batch management inside GroupMembersPanel. Logic is sound and consistent with the main provider list patterns. |
| src/app/[locale]/settings/providers/_components/provider-manager.tsx | handleOpenProviderEditor no longer calls setViewMode("list"), preserving the groups view when editing a provider from the group tab. handleRequestEditProvider bridges the group tab callback to the shared dialog. |
| src/app/[locale]/settings/providers/_components/batch-edit/provider-batch-toolbar.tsx | Adds showSelectByGroup prop (default true) to hide the group dropdown when inside a group context; correctly gates rendering behind the flag. |
| src/app/[locale]/settings/providers/_components/provider-list.tsx | Adds optional onEditProvider callback prop; no functional changes to existing behavior. |
| tests/unit/settings/providers/provider-group-tab.test.tsx | New test file covering provider edit forwarding and admin/non-admin visibility. Test uses a single Promise.resolve() tick to flush async group loading via useTransition, which may be fragile on slower environments. |
| tests/unit/settings/providers/provider-manager.test.tsx | Adds test verifying that the groups view is preserved when a provider editor is opened from the group tab; covers the view-mode bug fix. |
| tests/unit/settings/providers/provider-batch-toolbar-selection.test.tsx | Extends existing batch toolbar tests with a case for showSelectByGroup=false hiding the group dropdown; clean and sufficient. |
| messages/en/settings/providers/providerGroups.json | Adds new i18n keys: groupMultiplierLabel, groupDescriptionLabel, noDescription, descriptionTooLong, openProviderEditor; all present and correctly translated across all 5 language files. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant ProviderGroupTab
    participant GroupMembersPanel
    participant MemberRow
    participant ProviderManager
    participant ProviderForm

    User->>ProviderGroupTab: Click chevron (expand group)
    ProviderGroupTab->>GroupMembersPanel: Render with members[]

    User->>MemberRow: Click provider name / Edit icon
    MemberRow->>GroupMembersPanel: onRequestEditProvider(providerId)
    GroupMembersPanel->>ProviderGroupTab: onRequestEditProvider(providerId)
    ProviderGroupTab->>ProviderManager: onRequestEditProvider(providerId)
    ProviderManager->>ProviderManager: setEditingProviderId(id) [viewMode stays groups]
    ProviderManager->>ProviderForm: Open Dialog with provider

    User->>MemberRow: Click cost multiplier cell
    MemberRow->>MemberRow: InlineEditPopover opens
    User->>MemberRow: Enter new value, Save
    MemberRow->>MemberRow: editProvider(id, group_priorities)
    MemberRow->>ProviderGroupTab: onSaved() → fetchGroups()

    User->>GroupMembersPanel: Enter batch mode, select members
    GroupMembersPanel->>GroupMembersPanel: ProviderBatchToolbar showSelectByGroup=false
    User->>GroupMembersPanel: Open batch edit
    GroupMembersPanel->>GroupMembersPanel: ProviderBatchDialog providers=members
    GroupMembersPanel->>ProviderGroupTab: onSuccess → onSaved()
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/[locale]/settings/providers/_components/provider-group-tab.tsx
Line: 851

Comment:
**i18n namespace reuse for common labels**

`InlineTextEditPopover` borrows `save` and `cancel` from the `providerGroups` namespace while the existing `InlineEditPopover` uses the dedicated `settings.providers.inlineEdit` namespace for the same labels. The translations happen to match today, but if either namespace is updated independently (e.g. a different button label style), the two components will diverge silently.

Consider reusing the `inlineEdit` namespace here:
```suggestion
  const t = useTranslations("settings.providers.inlineEdit");
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/unit/settings/providers/provider-group-tab.test.tsx
Line: 154-157

Comment:
**Single microtask tick may not flush useTransition async work**

`startLoadTransition(async () => { const result = await getProviderGroups(); ... })` schedules an async transition. A single `await Promise.resolve()` flushes one microtask level but may not be enough to settle the state update that follows the `await getProviderGroups()` call — meaning the groups table (and therefore the expand button) might not yet be in the DOM when the assertion runs.

If this test ever becomes flaky, replace with:
```ts
await act(async () => {
  await new Promise((resolve) => setTimeout(resolve, 0));
});
```
or use `await vi.runAllTimersAsync()` if fake timers are configured.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: preserve group view context in prov..."](https://github.com/ding113/claude-code-hub/commit/01335fdb003116a2254fc9484142264bd221ea21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28861201)</sub>

<!-- /greptile_comment -->