### PR TITLE
fix: scope my-usage ip geo lookups

### DIFF
--- a/src/actions/my-usage.ts
+++ b/src/actions/my-usage.ts
@@ -5,6 +5,7 @@ import { and, eq, gte, isNull, lt, sql } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { messageRequest, usageLedger } from "@/drizzle/schema";
 import { getSession } from "@/lib/auth";
+import { lookupIp } from "@/lib/ip-geo/client";
 import { logger } from "@/lib/logger";
 import { resolveKeyConcurrentSessionLimit } from "@/lib/rate-limit/concurrent-session-limit";
 import { resolveKeyCostResetAt } from "@/lib/rate-limit/cost-reset-utils";
@@ -26,6 +27,7 @@ import {
   type UsageLogSummary,
   type UsageLogsBatchResult,
 } from "@/repository/usage-logs";
+import type { IpGeoLookupResult, IpGeoPrivateMarker } from "@/types/ip-geo";
 import type { BillingModelSource } from "@/types/system-config";
 import type { ActionResult } from "./types";
 
@@ -691,6 +693,60 @@ export async function getMyAvailableEndpoints(): Promise<ActionResult<string[]>>
   } catch (error) {
     logger.error("[my-usage] getMyAvailableEndpoints failed", error);
     return { ok: false, error: "Failed to get endpoint list" };
+  }
+}
+
+export async function getMyIpGeoDetails(params: { ip: string; lang?: string }): Promise<
+  ActionResult<{
+    status: "ok" | "private" | "error";
+    data?: IpGeoLookupResult | IpGeoPrivateMarker;
+    error?: string;
+  }>
+> {
+  try {
+    const session = await getSession({ allowReadOnlyAccess: true });
+    if (!session) return { ok: false, error: "Unauthorized" };
+
+    const ip = params.ip.trim();
+    if (!ip) return { ok: false, error: "IP is required" };
+
+    // 仅允许查询当前 key 在 my-usage 可见日志中真实出现过的 IP。
+    const [visibleLog] = await db
+      .select({ id: messageRequest.id })
+      .from(messageRequest)
+      .where(
+        and(
+          isNull(messageRequest.deletedAt),
+          eq(messageRequest.key, session.key.key),
+          eq(messageRequest.clientIp, ip)
+        )
+      )
+      .limit(1);
+
+    if (!visibleLog) {
+      return { ok: false, error: "IP not found in current key usage logs" };
+    }
+
+    const settings = await getSystemSettings();
+    if (!settings.ipGeoLookupEnabled) {
+      return { ok: false, error: "IP geolocation disabled" };
+    }
+
+    const result = await lookupIp(ip, { lang: params.lang });
+    if (result.status === "error") {
+      logger.warn("[my-usage] getMyIpGeoDetails lookup returned error", {
+        ip,
+        lang: params.lang,
+        userId: session.user.id,
+        keyId: session.key.id,
+        error: result.error,
+      });
+    }
+
+    return { ok: true, data: result };
+  } catch (error) {
+    logger.error("[my-usage] getMyIpGeoDetails failed", { error, ip: params.ip });
+    return { ok: false, error: "Failed to get IP details" };
   }
 }
 

--- a/src/actions/my-usage.ts
+++ b/src/actions/my-usage.ts
@@ -710,6 +710,11 @@ export async function getMyIpGeoDetails(params: { ip: string; lang?: string }): 
     const ip = params.ip.trim();
     if (!ip) return { ok: false, error: "IP is required" };
 
+    const settings = await getSystemSettings();
+    if (!settings.ipGeoLookupEnabled) {
+      return { ok: false, error: "IP geolocation disabled" };
+    }
+
     // 仅允许查询当前 key 在 my-usage 可见日志中真实出现过的 IP。
     const [visibleLog] = await db
       .select({ id: messageRequest.id })
@@ -717,6 +722,7 @@ export async function getMyIpGeoDetails(params: { ip: string; lang?: string }): 
       .where(
         and(
           isNull(messageRequest.deletedAt),
+          EXCLUDE_WARMUP_CONDITION,
           eq(messageRequest.key, session.key.key),
           eq(messageRequest.clientIp, ip)
         )
@@ -725,11 +731,6 @@ export async function getMyIpGeoDetails(params: { ip: string; lang?: string }): 
 
     if (!visibleLog) {
       return { ok: false, error: "IP not found in current key usage logs" };
-    }
-
-    const settings = await getSystemSettings();
-    if (!settings.ipGeoLookupEnabled) {
-      return { ok: false, error: "IP geolocation disabled" };
     }
 
     const result = await lookupIp(ip, { lang: params.lang });

--- a/src/actions/my-usage.ts
+++ b/src/actions/my-usage.ts
@@ -6,6 +6,7 @@ import { db } from "@/drizzle/db";
 import { messageRequest, usageLedger } from "@/drizzle/schema";
 import { getSession } from "@/lib/auth";
 import { lookupIp } from "@/lib/ip-geo/client";
+import { isLedgerOnlyMode } from "@/lib/ledger-fallback";
 import { logger } from "@/lib/logger";
 import { resolveKeyConcurrentSessionLimit } from "@/lib/rate-limit/concurrent-session-limit";
 import { resolveKeyCostResetAt } from "@/lib/rate-limit/cost-reset-utils";
@@ -716,7 +717,7 @@ export async function getMyIpGeoDetails(params: { ip: string; lang?: string }): 
     }
 
     // 仅允许查询当前 key 在 my-usage 可见日志中真实出现过的 IP。
-    const [visibleLog] = await db
+    const [messageRequestMatch] = await db
       .select({ id: messageRequest.id })
       .from(messageRequest)
       .where(
@@ -729,14 +730,26 @@ export async function getMyIpGeoDetails(params: { ip: string; lang?: string }): 
       )
       .limit(1);
 
-    if (!visibleLog) {
+    let visibleLogId = messageRequestMatch?.id ?? null;
+
+    if (!visibleLogId && (await isLedgerOnlyMode())) {
+      const [ledgerMatch] = await db
+        .select({ id: usageLedger.requestId })
+        .from(usageLedger)
+        .where(and(eq(usageLedger.key, session.key.key), eq(usageLedger.clientIp, ip)))
+        .limit(1);
+
+      visibleLogId = ledgerMatch?.id ?? null;
+    }
+
+    if (!visibleLogId) {
       return { ok: false, error: "IP not found in current key usage logs" };
     }
 
     const result = await lookupIp(ip, { lang: params.lang });
     if (result.status === "error") {
       logger.warn("[my-usage] getMyIpGeoDetails lookup returned error", {
-        ip,
+        messageRequestId: visibleLogId,
         lang: params.lang,
         userId: session.user.id,
         keyId: session.key.id,
@@ -746,7 +759,7 @@ export async function getMyIpGeoDetails(params: { ip: string; lang?: string }): 
 
     return { ok: true, data: result };
   } catch (error) {
-    logger.error("[my-usage] getMyIpGeoDetails failed", { error, ip: params.ip });
+    logger.error("[my-usage] getMyIpGeoDetails failed", { error });
     return { ok: false, error: "Failed to get IP details" };
   }
 }

--- a/src/app/[locale]/dashboard/_components/ip-details-dialog.tsx
+++ b/src/app/[locale]/dashboard/_components/ip-details-dialog.tsx
@@ -14,7 +14,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
-import { useIpGeo } from "@/hooks/use-ip-geo";
+import { type IpGeoLookupMode, useIpGeo } from "@/hooks/use-ip-geo";
 import { copyTextToClipboard } from "@/lib/utils/clipboard";
 import { AbuseSection, hasAbuseContent } from "./ip-details/abuse-section";
 import { hasMeaningfulCoordinates } from "./ip-details/atoms";
@@ -29,9 +29,15 @@ interface IpDetailsDialogProps {
   ip: string | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  lookupMode?: IpGeoLookupMode;
 }
 
-export function IpDetailsDialog({ ip, open, onOpenChange }: IpDetailsDialogProps) {
+export function IpDetailsDialog({
+  ip,
+  open,
+  onOpenChange,
+  lookupMode = "default",
+}: IpDetailsDialogProps) {
   const t = useTranslations("ipDetails");
   const [copied, setCopied] = useState(false);
 
@@ -83,15 +89,15 @@ export function IpDetailsDialog({ ip, open, onOpenChange }: IpDetailsDialogProps
         {/* Only mount the content (and its useQuery) when the dialog is open.
             This keeps tests that never open the dialog free of a QueryClient
             dependency. */}
-        {open && <IpDetailsContent ip={ip} />}
+        {open && <IpDetailsContent ip={ip} lookupMode={lookupMode} />}
       </DialogContent>
     </Dialog>
   );
 }
 
-function IpDetailsContent({ ip }: { ip: string | null }) {
+function IpDetailsContent({ ip, lookupMode }: { ip: string | null; lookupMode: IpGeoLookupMode }) {
   const t = useTranslations("ipDetails");
-  const { data, isLoading, isError } = useIpGeo(ip);
+  const { data, isLoading, isError } = useIpGeo(ip, { mode: lookupMode });
 
   if (isLoading) {
     return <p className="py-8 text-center text-sm text-muted-foreground">{t("loading")}</p>;

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -21,6 +21,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import type { IpGeoLookupMode } from "@/hooks/use-ip-geo";
 import { useVirtualizedInfiniteList } from "@/hooks/use-virtualized-infinite-list";
 import type { LogsTableColumn } from "@/lib/column-visibility";
 import { cn, formatTokenAmount } from "@/lib/utils";
@@ -111,6 +112,8 @@ interface VirtualizedLogsTableProps {
   queryKeyPrefix?: string;
   /** Disable the detail side-panel dialog on status badge click */
   disableDetailDialog?: boolean;
+  /** Select which IP lookup authorization model the detail dialog should use */
+  ipLookupMode?: IpGeoLookupMode;
 }
 
 export function VirtualizedLogsTable({
@@ -127,6 +130,7 @@ export function VirtualizedLogsTable({
   fetchFn,
   queryKeyPrefix = "usage-logs-batch",
   disableDetailDialog = false,
+  ipLookupMode = "default",
 }: VirtualizedLogsTableProps) {
   const t = useTranslations("dashboard");
   const getPricingSourceLabel = (source: string) =>
@@ -933,7 +937,12 @@ export function VirtualizedLogsTable({
         </Button>
       ) : null}
 
-      <IpDetailsDialog ip={ipDialogValue} open={ipDialogOpen} onOpenChange={setIpDialogOpen} />
+      <IpDetailsDialog
+        ip={ipDialogValue}
+        open={ipDialogOpen}
+        onOpenChange={setIpDialogOpen}
+        lookupMode={ipLookupMode}
+      />
     </div>
   );
 }

--- a/src/app/[locale]/my-usage/_components/usage-logs-section.test.tsx
+++ b/src/app/[locale]/my-usage/_components/usage-logs-section.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@/app/[locale]/dashboard/logs/_components/virtualized-logs-table", () =
     disableDetailDialog?: boolean;
     fetchFn?: unknown;
     queryKeyPrefix?: string;
+    ipLookupMode?: string;
   }) => (
     <div
       data-testid="virtualized-logs-table"
@@ -40,6 +41,7 @@ vi.mock("@/app/[locale]/dashboard/logs/_components/virtualized-logs-table", () =
       data-disable-detail-dialog={String(props.disableDetailDialog)}
       data-query-key-prefix={props.queryKeyPrefix}
       data-has-fetch-fn={String(!!props.fetchFn)}
+      data-ip-lookup-mode={props.ipLookupMode}
     />
   ),
 }));
@@ -112,6 +114,7 @@ describe("my-usage usage logs section", () => {
     // Verify custom fetch function and query key
     expect(table!.getAttribute("data-has-fetch-fn")).toBe("true");
     expect(table!.getAttribute("data-query-key-prefix")).toBe("my-usage-logs-batch");
+    expect(table!.getAttribute("data-ip-lookup-mode")).toBe("my-usage");
 
     await act(async () => {
       root.unmount();

--- a/src/app/[locale]/my-usage/_components/usage-logs-section.tsx
+++ b/src/app/[locale]/my-usage/_components/usage-logs-section.tsx
@@ -338,6 +338,7 @@ export function UsageLogsSection({
                 disableDetailDialog
                 fetchFn={myUsageFetchFn}
                 queryKeyPrefix="my-usage-logs-batch"
+                ipLookupMode="my-usage"
                 autoRefreshEnabled={!!autoRefreshSeconds}
                 autoRefreshIntervalMs={autoRefreshSeconds ? autoRefreshSeconds * 1000 : undefined}
               />

--- a/src/app/api/actions/[...route]/route.ts
+++ b/src/app/api/actions/[...route]/route.ts
@@ -1313,6 +1313,30 @@ const { route: getMyAvailableEndpointsRoute, handler: getMyAvailableEndpointsHan
   });
 app.openapi(getMyAvailableEndpointsRoute, getMyAvailableEndpointsHandler);
 
+const { route: getMyIpGeoDetailsRoute, handler: getMyIpGeoDetailsHandler } = createActionRoute(
+  "my-usage",
+  "getMyIpGeoDetails",
+  myUsageActions.getMyIpGeoDetails,
+  {
+    requestSchema: z.object({
+      ip: z.string().min(1).describe("要查询的客户端 IP"),
+      lang: z.string().optional().describe("界面 locale，用于本地化地理名称"),
+    }),
+    responseSchema: z
+      .object({
+        status: z.enum(["ok", "private", "error"]),
+        data: z.unknown().optional(),
+        error: z.string().optional(),
+      })
+      .passthrough(),
+    description: "仅查询当前 key 使用日志中真实出现过的 IP 详情",
+    summary: "获取我的 IP 详情",
+    tags: ["使用日志"],
+    allowReadOnlyAccess: true,
+  }
+);
+app.openapi(getMyIpGeoDetailsRoute, getMyIpGeoDetailsHandler);
+
 const { route: getMyStatsSummaryRoute, handler: getMyStatsSummaryHandler } = createActionRoute(
   "my-usage",
   "getMyStatsSummary",

--- a/src/hooks/use-ip-geo.ts
+++ b/src/hooks/use-ip-geo.ts
@@ -27,12 +27,16 @@ export function useIpGeo(ip: string | null | undefined, options?: UseIpGeoOption
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ ip, lang: locale }),
         });
-        if (!response.ok) throw new Error(`my-ip-geo fetch failed: ${response.status}`);
 
         const result = (await response.json()) as ActionResult<IpGeoLookupResponse>;
         if (!result.ok) {
-          throw new Error(result.error);
+          return { status: "error", error: result.error ?? "my-ip-geo fetch failed" };
         }
+
+        if (!response.ok) {
+          return { status: "error", error: `my-ip-geo fetch failed: ${response.status}` };
+        }
+
         return result.data;
       }
 

--- a/src/hooks/use-ip-geo.ts
+++ b/src/hooks/use-ip-geo.ts
@@ -2,16 +2,40 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useLocale } from "next-intl";
+import type { ActionResult } from "@/actions/types";
 import type { IpGeoLookupResponse } from "@/types/ip-geo";
 
-export function useIpGeo(ip: string | null | undefined) {
+export type IpGeoLookupMode = "default" | "my-usage";
+
+interface UseIpGeoOptions {
+  mode?: IpGeoLookupMode;
+}
+
+export function useIpGeo(ip: string | null | undefined, options?: UseIpGeoOptions) {
   // Pass the dashboard UI locale to the upstream so country / city names come
   // back localized rather than always in English.
   const locale = useLocale();
+  const mode = options?.mode ?? "default";
   return useQuery<IpGeoLookupResponse>({
-    queryKey: ["ip-geo", ip, locale],
+    queryKey: ["ip-geo", mode, ip, locale],
     queryFn: async () => {
       if (!ip) throw new Error("no ip");
+
+      if (mode === "my-usage") {
+        const response = await fetch("/api/actions/my-usage/getMyIpGeoDetails", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ ip, lang: locale }),
+        });
+        if (!response.ok) throw new Error(`my-ip-geo fetch failed: ${response.status}`);
+
+        const result = (await response.json()) as ActionResult<IpGeoLookupResponse>;
+        if (!result.ok) {
+          throw new Error(result.error);
+        }
+        return result.data;
+      }
+
       const qs = new URLSearchParams({ lang: locale });
       const response = await fetch(`/api/ip-geo/${encodeURIComponent(ip)}?${qs}`);
       if (!response.ok) throw new Error(`ip-geo fetch failed: ${response.status}`);

--- a/tests/api/api-actions-integrity.test.ts
+++ b/tests/api/api-actions-integrity.test.ts
@@ -153,6 +153,7 @@ describe("OpenAPI 端点完整性检查", () => {
       "/api/actions/my-usage/getMyUsageLogsBatch",
       "/api/actions/my-usage/getMyAvailableModels",
       "/api/actions/my-usage/getMyAvailableEndpoints",
+      "/api/actions/my-usage/getMyIpGeoDetails",
     ];
 
     for (const path of expectedPaths) {
@@ -293,7 +294,7 @@ describe("OpenAPI 端点完整性检查", () => {
 
     for (const [path, methods] of Object.entries(openApiDoc.paths)) {
       const postOperation = methods.post;
-      if (!postOperation || !postOperation.tags) continue;
+      if (!postOperation?.tags) continue;
 
       // 查找对应的标签
       const expectedTag = Object.entries(moduleTagMapping).find(([prefix]) =>

--- a/tests/api/my-usage-readonly.test.ts
+++ b/tests/api/my-usage-readonly.test.ts
@@ -95,6 +95,7 @@ async function createMessage(params: {
   inputTokens?: number | null;
   outputTokens?: number | null;
   blockedBy?: string | null;
+  clientIp?: string | null;
   createdAt: Date;
 }): Promise<number> {
   const [row] = await db
@@ -110,6 +111,7 @@ async function createMessage(params: {
       inputTokens: params.inputTokens ?? 0,
       outputTokens: params.outputTokens ?? 0,
       blockedBy: params.blockedBy ?? null,
+      clientIp: params.clientIp ?? null,
       createdAt: params.createdAt,
       updatedAt: params.createdAt,
     })
@@ -290,6 +292,75 @@ describe("my-usage API：只读 Key 自助查询", () => {
     const usersData = (usersApi.json as { ok: boolean; data: Array<{ id: number }> }).data;
     expect(usersData.length).toBe(1);
     expect(usersData[0].id).toBe(user.id);
+  });
+
+  test("只读 Key：只能查询当前 key 日志里出现过的 IP 详情", async () => {
+    const unique = `my-usage-ip-geo-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const userA = await createTestUser(`Test ${unique}-A`);
+    createdUserIds.push(userA.id);
+    const keyA = await createTestKey({
+      userId: userA.id,
+      key: `test-ip-geo-key-A-${unique}`,
+      name: `ip-geo-A-${unique}`,
+      canLoginWebUi: false,
+    });
+    createdKeyIds.push(keyA.id);
+
+    const userB = await createTestUser(`Test ${unique}-B`);
+    createdUserIds.push(userB.id);
+    const keyB = await createTestKey({
+      userId: userB.id,
+      key: `test-ip-geo-key-B-${unique}`,
+      name: `ip-geo-B-${unique}`,
+      canLoginWebUi: false,
+    });
+    createdKeyIds.push(keyB.id);
+
+    const now = new Date();
+    const visibleIp = "203.0.113.9";
+    const hiddenIp = "198.51.100.88";
+
+    createdMessageIds.push(
+      await createMessage({
+        userId: userA.id,
+        key: keyA.key,
+        model: "gpt-4.1-mini",
+        clientIp: visibleIp,
+        createdAt: now,
+      })
+    );
+    createdMessageIds.push(
+      await createMessage({
+        userId: userB.id,
+        key: keyB.key,
+        model: "gpt-4.1-mini",
+        clientIp: hiddenIp,
+        createdAt: now,
+      })
+    );
+
+    currentAuthToken = keyA.key;
+
+    const visible = await callActionsRoute({
+      method: "POST",
+      pathname: "/api/actions/my-usage/getMyIpGeoDetails",
+      authToken: keyA.key,
+      body: { ip: visibleIp, lang: "en" },
+    });
+    expect(visible.response.status).toBe(200);
+    expect(visible.json).toMatchObject({ ok: true });
+
+    const hidden = await callActionsRoute({
+      method: "POST",
+      pathname: "/api/actions/my-usage/getMyIpGeoDetails",
+      authToken: keyA.key,
+      body: { ip: hiddenIp, lang: "en" },
+    });
+    expect(hidden.response.status).toBe(200);
+    expect(hidden.json).toMatchObject({
+      ok: false,
+      error: "IP not found in current key usage logs",
+    });
   });
 
   test("今日统计：应与 message_request 数据一致，并排除 warmup 与其他 Key 数据", async () => {

--- a/tests/api/my-usage-readonly.test.ts
+++ b/tests/api/my-usage-readonly.test.ts
@@ -348,7 +348,10 @@ describe("my-usage API：只读 Key 自助查询", () => {
       body: { ip: visibleIp, lang: "en" },
     });
     expect(visible.response.status).toBe(200);
-    expect(visible.json).toMatchObject({ ok: true });
+    expect(visible.json).not.toMatchObject({
+      ok: false,
+      error: "IP not found in current key usage logs",
+    });
 
     const hidden = await callActionsRoute({
       method: "POST",

--- a/tests/api/my-usage-readonly.test.ts
+++ b/tests/api/my-usage-readonly.test.ts
@@ -347,7 +347,6 @@ describe("my-usage API：只读 Key 自助查询", () => {
       authToken: keyA.key,
       body: { ip: visibleIp, lang: "en" },
     });
-    expect(visible.response.status).toBe(200);
     expect(visible.json).not.toMatchObject({
       ok: false,
       error: "IP not found in current key usage logs",
@@ -359,7 +358,7 @@ describe("my-usage API：只读 Key 自助查询", () => {
       authToken: keyA.key,
       body: { ip: hiddenIp, lang: "en" },
     });
-    expect(hidden.response.status).toBe(200);
+    expect(hidden.response.status).toBe(400);
     expect(hidden.json).toMatchObject({
       ok: false,
       error: "IP not found in current key usage logs",

--- a/tests/unit/actions/my-usage-ip-geo.test.ts
+++ b/tests/unit/actions/my-usage-ip-geo.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   getSystemSettings: vi.fn(),
+  isLedgerOnlyMode: vi.fn(),
   lookupIp: vi.fn(),
   loggerWarn: vi.fn(),
   loggerError: vi.fn(),
@@ -18,6 +19,10 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("@/repository/system-config", () => ({
   getSystemSettings: mocks.getSystemSettings,
+}));
+
+vi.mock("@/lib/ledger-fallback", () => ({
+  isLedgerOnlyMode: mocks.isLedgerOnlyMode,
 }));
 
 vi.mock("@/lib/ip-geo/client", () => ({
@@ -52,6 +57,7 @@ describe("getMyIpGeoDetails", () => {
     mocks.getSystemSettings.mockResolvedValue({
       ipGeoLookupEnabled: true,
     });
+    mocks.isLedgerOnlyMode.mockResolvedValue(false);
     mocks.lookupIp.mockResolvedValue({
       status: "ok",
       data: {
@@ -135,5 +141,54 @@ describe("getMyIpGeoDetails", () => {
       },
     });
     expect(mocks.lookupIp).toHaveBeenCalledWith("203.0.113.9", { lang: "ja" });
+  });
+
+  it("ledger-only 模式下也允许查询 usage_ledger 中可见的 IP", async () => {
+    mocks.getSession.mockResolvedValueOnce({
+      user: { id: 7 },
+      key: { id: 10, key: "sk-readonly" },
+    });
+    mocks.dbLimit.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: 99 }]);
+    mocks.isLedgerOnlyMode.mockResolvedValueOnce(true);
+
+    const { getMyIpGeoDetails } = await import("@/actions/my-usage");
+    const result = await getMyIpGeoDetails({ ip: "203.0.113.9", lang: "ja" });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        status: "ok",
+      },
+    });
+    expect(mocks.lookupIp).toHaveBeenCalledWith("203.0.113.9", { lang: "ja" });
+  });
+
+  it("lookup error 日志不记录原始 IP，只记录内部日志 ID", async () => {
+    mocks.getSession.mockResolvedValueOnce({
+      user: { id: 7 },
+      key: { id: 10, key: "sk-readonly" },
+    });
+    mocks.dbLimit.mockResolvedValueOnce([{ id: 42 }]);
+    mocks.lookupIp.mockResolvedValueOnce({
+      status: "error",
+      error: "upstream down",
+    });
+
+    const { getMyIpGeoDetails } = await import("@/actions/my-usage");
+    await getMyIpGeoDetails({ ip: "203.0.113.9", lang: "ja" });
+
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      "[my-usage] getMyIpGeoDetails lookup returned error",
+      expect.objectContaining({
+        messageRequestId: 42,
+        keyId: 10,
+        userId: 7,
+        error: "upstream down",
+      })
+    );
+    expect(mocks.loggerWarn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ip: "203.0.113.9" })
+    );
   });
 });

--- a/tests/unit/actions/my-usage-ip-geo.test.ts
+++ b/tests/unit/actions/my-usage-ip-geo.test.ts
@@ -114,6 +114,7 @@ describe("getMyIpGeoDetails", () => {
     const result = await getMyIpGeoDetails({ ip: "203.0.113.9", lang: "en" });
 
     expect(result).toEqual({ ok: false, error: "IP geolocation disabled" });
+    expect(mocks.dbLimit).not.toHaveBeenCalled();
     expect(mocks.lookupIp).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/actions/my-usage-ip-geo.test.ts
+++ b/tests/unit/actions/my-usage-ip-geo.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getSystemSettings: vi.fn(),
+  lookupIp: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerError: vi.fn(),
+  dbSelect: vi.fn(),
+  dbFrom: vi.fn(),
+  dbWhere: vi.fn(),
+  dbLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSession: mocks.getSession,
+}));
+
+vi.mock("@/repository/system-config", () => ({
+  getSystemSettings: mocks.getSystemSettings,
+}));
+
+vi.mock("@/lib/ip-geo/client", () => ({
+  lookupIp: mocks.lookupIp,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: mocks.loggerWarn,
+    error: mocks.loggerError,
+  },
+}));
+
+vi.mock("@/drizzle/db", () => ({
+  db: {
+    select: mocks.dbSelect,
+  },
+}));
+
+describe("getMyIpGeoDetails", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.dbSelect.mockReturnValue({
+      from: mocks.dbFrom,
+    });
+    mocks.dbFrom.mockReturnValue({
+      where: mocks.dbWhere,
+    });
+    mocks.dbWhere.mockReturnValue({
+      limit: mocks.dbLimit,
+    });
+    mocks.getSystemSettings.mockResolvedValue({
+      ipGeoLookupEnabled: true,
+    });
+    mocks.lookupIp.mockResolvedValue({
+      status: "ok",
+      data: {
+        ip: "203.0.113.9",
+        version: "ipv4",
+        hostname: null,
+      },
+    });
+  });
+
+  it("未认证时返回 Unauthorized", async () => {
+    mocks.getSession.mockResolvedValueOnce(null);
+
+    const { getMyIpGeoDetails } = await import("@/actions/my-usage");
+    const result = await getMyIpGeoDetails({ ip: "203.0.113.9", lang: "en" });
+
+    expect(result).toEqual({ ok: false, error: "Unauthorized" });
+    expect(mocks.getSession).toHaveBeenCalledWith({ allowReadOnlyAccess: true });
+    expect(mocks.lookupIp).not.toHaveBeenCalled();
+  });
+
+  it("空 IP 返回校验错误", async () => {
+    mocks.getSession.mockResolvedValueOnce({
+      user: { id: 1 },
+      key: { id: 10, key: "sk-test" },
+    });
+
+    const { getMyIpGeoDetails } = await import("@/actions/my-usage");
+    const result = await getMyIpGeoDetails({ ip: "   " });
+
+    expect(result).toEqual({ ok: false, error: "IP is required" });
+    expect(mocks.lookupIp).not.toHaveBeenCalled();
+  });
+
+  it("当前 key 日志里不存在该 IP 时拒绝查询", async () => {
+    mocks.getSession.mockResolvedValueOnce({
+      user: { id: 1 },
+      key: { id: 10, key: "sk-test" },
+    });
+    mocks.dbLimit.mockResolvedValueOnce([]);
+
+    const { getMyIpGeoDetails } = await import("@/actions/my-usage");
+    const result = await getMyIpGeoDetails({ ip: "198.51.100.88", lang: "en" });
+
+    expect(result).toEqual({ ok: false, error: "IP not found in current key usage logs" });
+    expect(mocks.lookupIp).not.toHaveBeenCalled();
+  });
+
+  it("系统关闭 IP 查询时返回禁用错误", async () => {
+    mocks.getSession.mockResolvedValueOnce({
+      user: { id: 1 },
+      key: { id: 10, key: "sk-test" },
+    });
+    mocks.dbLimit.mockResolvedValueOnce([{ id: 42 }]);
+    mocks.getSystemSettings.mockResolvedValueOnce({
+      ipGeoLookupEnabled: false,
+    });
+
+    const { getMyIpGeoDetails } = await import("@/actions/my-usage");
+    const result = await getMyIpGeoDetails({ ip: "203.0.113.9", lang: "en" });
+
+    expect(result).toEqual({ ok: false, error: "IP geolocation disabled" });
+    expect(mocks.lookupIp).not.toHaveBeenCalled();
+  });
+
+  it("readonly 会话只能查询自己日志里出现过的 IP", async () => {
+    mocks.getSession.mockResolvedValueOnce({
+      user: { id: 7 },
+      key: { id: 10, key: "sk-readonly" },
+    });
+    mocks.dbLimit.mockResolvedValueOnce([{ id: 42 }]);
+
+    const { getMyIpGeoDetails } = await import("@/actions/my-usage");
+    const result = await getMyIpGeoDetails({ ip: "203.0.113.9", lang: "ja" });
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        status: "ok",
+      },
+    });
+    expect(mocks.lookupIp).toHaveBeenCalledWith("203.0.113.9", { lang: "ja" });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a my-usage-specific IP geo action (`getMyIpGeoDetails`) gated by the current key's visible usage logs
- Keep `/api/ip-geo/[ip]` admin-only and route my-usage IP dialogs through the scoped action
- Cover the new behavior with unit and API integrity tests, plus my-usage component wiring

## Problem
PR #1027 introduced IP geolocation lookup via the admin-only `/api/ip-geo/[ip]` endpoint. PR #1029 then reused `VirtualizedLogsTable` in the my-usage page but left IP detail lookups disconnected (the detail dialog was disabled). Readonly/API-only key users had no way to view IP geo details for their own usage logs, while the admin endpoint was not suitable for non-admin access.

**Related PRs:**
- Follow-up to #1027 (IP geo feature) — creates a scoped action instead of exposing the admin endpoint
- Follow-up to #1029 (VirtualizedLogsTable in my-usage) — wires up IP geo lookups for the my-usage table
- Related to #965 (readonly key security) — same pattern of restricting sensitive data access for readonly sessions
- Related to #1031 (IP details dialog redesign) — extends `IpDetailsDialog` with a `lookupMode` prop

## Solution
Introduce a new server action `getMyIpGeoDetails` in the my-usage module that:
1. Authenticates the session with `allowReadOnlyAccess: true`
2. Verifies the requested IP actually appears in the current key's non-deleted usage logs (`message_request` table)
3. Checks that IP geo lookup is enabled in system settings
4. Performs the lookup via the existing `lookupIp` client

The `useIpGeo` hook gains a `mode` parameter (`"default"` | `"my-usage"`) that routes my-usage requests to the new scoped action instead of the admin endpoint. The `IpDetailsDialog` and `VirtualizedLogsTable` components propagate this mode through props.

## Changes

| File | Change |
|------|--------|
| `src/actions/my-usage.ts` | Add `getMyIpGeoDetails` action with key-scoped IP verification (+56) |
| `src/hooks/use-ip-geo.ts` | Add `IpGeoLookupMode` type; route `"my-usage"` mode through scoped action (+26/-2) |
| `src/app/[locale]/dashboard/_components/ip-details-dialog.tsx` | Accept and forward `lookupMode` prop (+11/-5) |
| `src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx` | Accept and forward `ipLookupMode` prop (+10/-1) |
| `src/app/[locale]/my-usage/_components/usage-logs-section.tsx` | Pass `ipLookupMode="my-usage"` to table (+1) |
| `src/app/api/actions/[...route]/route.ts` | Register `getMyIpGeoDetails` OpenAPI route with `allowReadOnlyAccess` (+24) |
| `tests/unit/actions/my-usage-ip-geo.test.ts` | New: 5 unit tests covering auth, validation, scope, and disabled scenarios (+138) |
| `tests/api/my-usage-readonly.test.ts` | New: integration test verifying key-scoped IP visibility (+71) |
| `tests/api/api-actions-integrity.test.ts` | Register new endpoint in integrity checks (+2/-1) |
| `src/app/[locale]/my-usage/_components/usage-logs-section.test.tsx` | Assert `ipLookupMode="my-usage"` is passed through (+3) |

## Security
The action enforces that only IPs appearing in the requesting key's own non-deleted `message_request` rows can be queried. A readonly key cannot probe arbitrary IPs or discover IPs from other keys' traffic.

## Verification
- `bun run build`
- `bun run lint`
- `bun run lint:fix`
- `bun run typecheck`
- `bun run test`
- `bunx vitest run tests/unit/actions/my-usage-ip-geo.test.ts 'src/app/[locale]/my-usage/_components/usage-logs-section.test.tsx' tests/api/api-actions-integrity.test.ts 'src/app/[locale]/dashboard/_components/ip-details-dialog.test.tsx'`
- `bunx vitest run --config tests/configs/integration.config.ts tests/api/my-usage-readonly.test.ts` *(fails locally in this environment because `DSN` is not set; existing DB-backed tests in that file cannot run without DB env)*

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes the access gap left by #1029 by introducing a key-scoped `getMyIpGeoDetails` server action that lets readonly/API-only users look up IP geo details for IPs that appear in their own usage logs, while keeping the admin `/api/ip-geo/[ip]` endpoint off-limits to non-admins. The scope check — verifying the requested IP appears in non-deleted, non-warmup `message_request` rows for the current key — is well-structured and the prop-threading through `VirtualizedLogsTable` → `IpDetailsDialog` → `useIpGeo` is clean.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all remaining findings are P2 style suggestions that do not affect correctness or security

The security model is sound: IP lookups are gated behind session auth, a key-scoped DB existence check, and the global feature flag. The usageLedger.requestId column is NOT NULL so the ledger-only fallback is correct. The disableDetailDialog + ipLookupMode combination is intentional (they gate different dialogs). Unit and integration test coverage is thorough. The two flagged items are a reversed check order (dead code) and a minor filter inconsistency in the ledger fallback — neither affects production behavior.

src/hooks/use-ip-geo.ts (check order) and src/actions/my-usage.ts (ledger fallback warmup filter) are worth a second look, but neither blocks merge
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/actions/my-usage.ts | Adds getMyIpGeoDetails server action with key-scoped IP verification; minor inconsistency in ledger-only fallback path (no warmup/deleted-at filter) |
| src/hooks/use-ip-geo.ts | Adds IpGeoLookupMode and routes my-usage requests through scoped action; response.ok guard is dead code in practice due to reversed check order |
| src/app/[locale]/dashboard/_components/ip-details-dialog.tsx | Cleanly threads lookupMode prop through to useIpGeo; no issues |
| src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx | Adds ipLookupMode prop forwarded to IpDetailsDialog independently of disableDetailDialog; wiring is correct |
| src/app/[locale]/my-usage/_components/usage-logs-section.tsx | Passes ipLookupMode="my-usage" alongside disableDetailDialog (which only gates the error/model dialog, not IP dialog); correct usage |
| tests/unit/actions/my-usage-ip-geo.test.ts | Well-structured unit tests covering auth, empty-IP, disabled-feature, scope, readonly, ledger-only, and privacy-preserving log output cases |
| tests/api/my-usage-readonly.test.ts | Integration test correctly asserts scope (not denied by scoping) vs. cross-key IP (denied), addressing the prior thread concern about feature-flag coupling |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/hooks/use-ip-geo.ts
Line: 36-38

Comment:
**Dead `response.ok` guard after `result.ok` check**

`response.ok` is checked on line 36 only after `result.ok` already returned on line 32. In practice this branch is unreachable: the server returns HTTP 4xx when `ok` is `false` and HTTP 200 when `ok` is `true`, so a combination of `result.ok === true` and `!response.ok` never occurs. A non-JSON 5xx response would throw at `response.json()` before either check runs.

The `default` mode guard (line 45) checks `response.ok` *before* parsing JSON, which is the more conventional order. Consider aligning the two paths:

```suggestion
        if (!response.ok) {
          return { status: "error", error: `my-ip-geo fetch failed: ${response.status}` };
        }

        const result = (await response.json()) as ActionResult<IpGeoLookupResponse>;
        if (!result.ok) {
          return { status: "error", error: result.error ?? "my-ip-geo fetch failed" };
        }

        return result.data;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/actions/my-usage.ts
Line: 735-742

Comment:
**Ledger-only fallback skips warmup and deleted-at filters**

The primary `messageRequest` query applies both `isNull(messageRequest.deletedAt)` and `EXCLUDE_WARMUP_CONDITION`, but the ledger-only fallback on these lines applies neither. In ledger-only mode an IP that appeared *only* in warmup or soft-deleted requests would still pass the scope check via the ledger, while it would be rejected in normal mode.

The impact is minor (the IP is still scoped to the key's own ledger rows), but the inconsistency could surprise future maintainers. Adding a warmup exclusion filter here keeps the two paths in sync with the user-visible "my-usage" log semantics.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: align my-usage ip visibility checks"](https://github.com/ding113/claude-code-hub/commit/c3dc50e296448276473bf0922b6c8087d0e38912) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28861693)</sub>

<!-- /greptile_comment -->