### PR TITLE
fix: improve IP extraction config editor

### DIFF
--- a/messages/en/settings/config.json
+++ b/messages/en/settings/config.json
@@ -126,6 +126,7 @@
     "geoLookupHint": "When enabled, the dashboard will resolve IP addresses to country / city / ASN via the configured IP geolocation service.",
     "extractionConfigLabel": "Header extraction chain (JSON)",
     "extractionConfigHint": "Leave empty to use the safe built-in default: x-real-ip → x-forwarded-for (rightmost). If fronted by Cloudflare or a CDN that strips client-supplied headers, add its header explicitly (example: `{\"headers\":[{\"name\":\"cf-connecting-ip\"},{\"name\":\"x-real-ip\"},{\"name\":\"x-forwarded-for\",\"pick\":\"rightmost\"}]}`). Each entry has `name` and optional `pick` (\"leftmost\" | \"rightmost\" | {\"kind\":\"index\",\"index\":N}).",
+    "extractionConfigHelpLabel": "Show header extraction JSON help",
     "resetToDefault": "Reset to default"
   },
   "section": {

--- a/messages/ja/settings/config.json
+++ b/messages/ja/settings/config.json
@@ -126,6 +126,7 @@
     "geoLookupHint": "有効にすると、ダッシュボードは設定済みの IP 地理情報サービスを用いて IP を国・都市・ASN に解決します。",
     "extractionConfigLabel": "ヘッダー抽出チェーン（JSON）",
     "extractionConfigHint": "空の場合は安全な組み込み既定（x-real-ip → x-forwarded-for の最右値）を使用します。Cloudflare や同等の CDN 経由の場合は、そのヘッダーを明示的に追加してください（例：`{\"headers\":[{\"name\":\"cf-connecting-ip\"},{\"name\":\"x-real-ip\"},{\"name\":\"x-forwarded-for\",\"pick\":\"rightmost\"}]}`）。各項目には `name` と任意の `pick`（\"leftmost\" | \"rightmost\" | {\"kind\":\"index\",\"index\":N}）を含められます。",
+    "extractionConfigHelpLabel": "ヘッダー抽出 JSON のヘルプを表示",
     "resetToDefault": "既定に戻す"
   },
   "section": {

--- a/messages/ru/settings/config.json
+++ b/messages/ru/settings/config.json
@@ -126,6 +126,7 @@
     "geoLookupHint": "Если включено, панель будет определять страну, город и ASN по IP через настроенный сервис геолокации.",
     "extractionConfigLabel": "Цепочка извлечения из заголовков (JSON)",
     "extractionConfigHint": "Оставьте пустым для безопасной встроенной цепочки по умолчанию: x-real-ip → x-forwarded-for (самое правое значение). Если перед приложением работает Cloudflare или аналогичный CDN, добавьте соответствующий заголовок явно (пример: `{\"headers\":[{\"name\":\"cf-connecting-ip\"},{\"name\":\"x-real-ip\"},{\"name\":\"x-forwarded-for\",\"pick\":\"rightmost\"}]}`). Каждый элемент содержит `name` и необязательное `pick` (\"leftmost\" | \"rightmost\" | {\"kind\":\"index\",\"index\":N}).",
+    "extractionConfigHelpLabel": "Показать справку по JSON цепочки заголовков",
     "resetToDefault": "Сбросить к умолчанию"
   },
   "section": {

--- a/messages/zh-CN/settings/config.json
+++ b/messages/zh-CN/settings/config.json
@@ -139,6 +139,7 @@
     "geoLookupHint": "开启后，仪表盘会通过配置的 IP 归属地服务解析出国家/城市/ASN 等信息。",
     "extractionConfigLabel": "请求头提取链（JSON）",
     "extractionConfigHint": "留空则使用安全的内置默认链：x-real-ip → x-forwarded-for（取最右）。如果应用前面有 Cloudflare 等剥离客户端伪造头的 CDN，请显式把其专有头加到链的最前面（示例：`{\"headers\":[{\"name\":\"cf-connecting-ip\"},{\"name\":\"x-real-ip\"},{\"name\":\"x-forwarded-for\",\"pick\":\"rightmost\"}]}`）。数组每项包含 `name` 以及可选的 `pick`（\"leftmost\" | \"rightmost\" | {\"kind\":\"index\",\"index\":N}）。",
+    "extractionConfigHelpLabel": "显示请求头提取 JSON 帮助",
     "resetToDefault": "恢复默认"
   }
 }

--- a/messages/zh-TW/settings/config.json
+++ b/messages/zh-TW/settings/config.json
@@ -126,6 +126,7 @@
     "geoLookupHint": "啟用後，儀表板會透過設定的 IP 歸屬地服務解析出國家/城市/ASN 等資訊。",
     "extractionConfigLabel": "請求標頭提取鏈（JSON）",
     "extractionConfigHint": "留空則使用安全的內建預設鏈：x-real-ip → x-forwarded-for（取最右）。若應用前方有 Cloudflare 等會剝除客戶端偽造標頭的 CDN，請顯式將其專用標頭加到鏈的最前面（範例：`{\"headers\":[{\"name\":\"cf-connecting-ip\"},{\"name\":\"x-real-ip\"},{\"name\":\"x-forwarded-for\",\"pick\":\"rightmost\"}]}`）。陣列每一項皆含 `name` 以及可選的 `pick`（\"leftmost\" | \"rightmost\" | {\"kind\":\"index\",\"index\":N}）。",
+    "extractionConfigHelpLabel": "顯示請求標頭提取 JSON 說明",
     "resetToDefault": "恢復預設"
   },
   "section": {

--- a/src/app/[locale]/settings/config/_components/system-settings-form.tsx
+++ b/src/app/[locale]/settings/config/_components/system-settings-form.tsx
@@ -3,6 +3,7 @@
 import {
   AlertTriangle,
   ChevronDown,
+  CircleHelp,
   Clock,
   Eye,
   FileCode,
@@ -34,6 +35,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { CurrencyCode } from "@/lib/utils";
 import { CURRENCY_CONFIG } from "@/lib/utils";
 import { COMMON_TIMEZONES, getTimezoneLabel } from "@/lib/utils/timezone";
@@ -43,7 +45,7 @@ import {
   shouldWarnQuotaLeaseCapZero,
   shouldWarnQuotaLeasePercentZero,
 } from "@/lib/utils/validation/quota-lease-warnings";
-import type { IpExtractionConfig } from "@/types/ip-extraction";
+import { DEFAULT_IP_EXTRACTION_CONFIG, type IpExtractionConfig } from "@/types/ip-extraction";
 import type {
   BillingModelSource,
   CodexPriorityBillingSource,
@@ -88,6 +90,12 @@ function clampQuotaDbRefreshIntervalSeconds(raw: string): number {
   const rounded = Math.round(parsed);
   return Math.min(300, Math.max(1, rounded));
 }
+
+function formatIpExtractionConfig(config: IpExtractionConfig): string {
+  return JSON.stringify(config, null, 2);
+}
+
+const DEFAULT_IP_EXTRACTION_CONFIG_TEXT = formatIpExtractionConfig(DEFAULT_IP_EXTRACTION_CONFIG);
 
 export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps) {
   const router = useRouter();
@@ -169,9 +177,7 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
     initialSettings.ipGeoLookupEnabled ?? true
   );
   const [ipExtractionConfigText, setIpExtractionConfigText] = useState<string>(
-    initialSettings.ipExtractionConfig
-      ? JSON.stringify(initialSettings.ipExtractionConfig, null, 2)
-      : ""
+    formatIpExtractionConfig(initialSettings.ipExtractionConfig ?? DEFAULT_IP_EXTRACTION_CONFIG)
   );
   const [isPending, startTransition] = useTransition();
   const [responseFixerOpen, setResponseFixerOpen] = useState(false);
@@ -283,9 +289,7 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
         );
         setIpGeoLookupEnabled(result.data.ipGeoLookupEnabled ?? true);
         setIpExtractionConfigText(
-          result.data.ipExtractionConfig
-            ? JSON.stringify(result.data.ipExtractionConfig, null, 2)
-            : ""
+          formatIpExtractionConfig(result.data.ipExtractionConfig ?? DEFAULT_IP_EXTRACTION_CONFIG)
         );
       }
 
@@ -653,7 +657,7 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
                 {t("enableClaudeMetadataUserIdInjection")}
               </p>
               <p className="text-xs text-muted-foreground mt-0.5">
-                {t("enableClaudeMetadataUserIdInjectionDesc")}
+                {t.raw("enableClaudeMetadataUserIdInjectionDesc")}
               </p>
             </div>
           </div>
@@ -1013,25 +1017,41 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
 
           {/* Extraction config JSON */}
           <div className="space-y-2 pl-11">
-            <Label htmlFor="ip-extraction-config" className="text-sm font-medium text-foreground">
-              {tIpLogging("extractionConfigLabel")}
-            </Label>
+            <div className="flex items-center gap-1.5">
+              <Label htmlFor="ip-extraction-config" className="text-sm font-medium text-foreground">
+                {tIpLogging("extractionConfigLabel")}
+              </Label>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={tIpLogging("extractionConfigHelpLabel")}
+                    className="inline-flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  >
+                    <CircleHelp className="size-3.5" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={6} className="max-w-sm leading-relaxed">
+                  {tIpLogging.raw("extractionConfigHint")}
+                </TooltipContent>
+              </Tooltip>
+            </div>
             <Textarea
               id="ip-extraction-config"
               value={ipExtractionConfigText}
               onChange={(event) => setIpExtractionConfigText(event.target.value)}
+              placeholder={DEFAULT_IP_EXTRACTION_CONFIG_TEXT}
               disabled={isPending}
               rows={5}
               spellCheck={false}
               className={`${inputClassName} font-mono text-xs`}
             />
-            <p className="text-xs text-muted-foreground">{tIpLogging("extractionConfigHint")}</p>
             <div>
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={() => setIpExtractionConfigText("")}
+                onClick={() => setIpExtractionConfigText(DEFAULT_IP_EXTRACTION_CONFIG_TEXT)}
                 disabled={isPending}
               >
                 {tIpLogging("resetToDefault")}

--- a/tests/unit/settings/system-settings-form-ip-extraction.test.tsx
+++ b/tests/unit/settings/system-settings-form-ip-extraction.test.tsx
@@ -38,15 +38,6 @@ function loadMessages() {
   };
 }
 
-function buildSettings(
-  overrides: Partial<Pick<SystemSettings, keyof typeof baseSettings>> = {}
-): Pick<SystemSettings, keyof typeof baseSettings> {
-  return {
-    ...baseSettings,
-    ...overrides,
-  };
-}
-
 const baseSettings = {
   siteTitle: "Claude Code Hub",
   allowGlobalUsageView: true,
@@ -107,6 +98,15 @@ const baseSettings = {
   | "ipGeoLookupEnabled"
   | "ipExtractionConfig"
 >;
+
+function buildSettings(
+  overrides: Partial<Pick<SystemSettings, keyof typeof baseSettings>> = {}
+): Pick<SystemSettings, keyof typeof baseSettings> {
+  return {
+    ...baseSettings,
+    ...overrides,
+  };
+}
 
 function render(node: ReactNode) {
   const container = document.createElement("div");

--- a/tests/unit/settings/system-settings-form-ip-extraction.test.tsx
+++ b/tests/unit/settings/system-settings-form-ip-extraction.test.tsx
@@ -1,0 +1,241 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { SystemSettingsForm } from "@/app/[locale]/settings/config/_components/system-settings-form";
+import { DEFAULT_IP_EXTRACTION_CONFIG } from "@/types/ip-extraction";
+import type { SystemSettings } from "@/types/system-config";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+const systemConfigActionMocks = vi.hoisted(() => ({
+  saveSystemSettings: vi.fn(async () => ({ ok: true })),
+}));
+vi.mock("@/actions/system-config", () => systemConfigActionMocks);
+
+const sonnerMocks = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+vi.mock("sonner", () => sonnerMocks);
+
+function loadMessages() {
+  const base = path.join(process.cwd(), "messages/en/settings");
+  const read = (name: string) => JSON.parse(fs.readFileSync(path.join(base, name), "utf8"));
+
+  return {
+    settings: {
+      common: read("common.json"),
+      config: read("config.json"),
+    },
+  };
+}
+
+function buildSettings(
+  overrides: Partial<Pick<SystemSettings, keyof typeof baseSettings>> = {}
+): Pick<SystemSettings, keyof typeof baseSettings> {
+  return {
+    ...baseSettings,
+    ...overrides,
+  };
+}
+
+const baseSettings = {
+  siteTitle: "Claude Code Hub",
+  allowGlobalUsageView: true,
+  currencyDisplay: "USD",
+  billingModelSource: "redirected",
+  codexPriorityBillingSource: "requested",
+  timezone: "UTC",
+  verboseProviderError: false,
+  enableHttp2: true,
+  enableHighConcurrencyMode: false,
+  interceptAnthropicWarmupRequests: true,
+  enableThinkingSignatureRectifier: true,
+  enableBillingHeaderRectifier: true,
+  enableResponseInputRectifier: true,
+  enableThinkingBudgetRectifier: true,
+  enableCodexSessionIdCompletion: true,
+  enableClaudeMetadataUserIdInjection: true,
+  enableResponseFixer: true,
+  responseFixerConfig: {
+    fixEncoding: true,
+    fixSseFormat: true,
+    fixTruncatedJson: true,
+  },
+  quotaDbRefreshIntervalSeconds: 10,
+  quotaLeasePercent5h: 0.05,
+  quotaLeasePercentDaily: 0.05,
+  quotaLeasePercentWeekly: 0.05,
+  quotaLeasePercentMonthly: 0.05,
+  quotaLeaseCapUsd: null,
+  ipGeoLookupEnabled: true,
+  ipExtractionConfig: null,
+} satisfies Pick<
+  SystemSettings,
+  | "siteTitle"
+  | "allowGlobalUsageView"
+  | "currencyDisplay"
+  | "billingModelSource"
+  | "codexPriorityBillingSource"
+  | "timezone"
+  | "verboseProviderError"
+  | "enableHttp2"
+  | "enableHighConcurrencyMode"
+  | "interceptAnthropicWarmupRequests"
+  | "enableThinkingSignatureRectifier"
+  | "enableBillingHeaderRectifier"
+  | "enableResponseInputRectifier"
+  | "enableThinkingBudgetRectifier"
+  | "enableCodexSessionIdCompletion"
+  | "enableClaudeMetadataUserIdInjection"
+  | "enableResponseFixer"
+  | "responseFixerConfig"
+  | "quotaDbRefreshIntervalSeconds"
+  | "quotaLeasePercent5h"
+  | "quotaLeasePercentDaily"
+  | "quotaLeasePercentWeekly"
+  | "quotaLeasePercentMonthly"
+  | "quotaLeaseCapUsd"
+  | "ipGeoLookupEnabled"
+  | "ipExtractionConfig"
+>;
+
+function render(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <NextIntlClientProvider locale="en" messages={loadMessages()} timeZone="UTC">
+        {node}
+      </NextIntlClientProvider>
+    );
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function renderForm(settings: Pick<SystemSettings, keyof typeof baseSettings> = baseSettings) {
+  return render(<SystemSettingsForm initialSettings={settings} />);
+}
+
+function getIpExtractionTextarea() {
+  const textarea = document.getElementById("ip-extraction-config") as HTMLTextAreaElement | null;
+  if (!textarea) throw new Error("未找到 IP 提取配置输入框");
+  return textarea;
+}
+
+function setTextareaValue(textarea: HTMLTextAreaElement, value: string) {
+  act(() => {
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value"
+    )?.set;
+    valueSetter?.call(textarea, value);
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function clickButtonByText(text: string) {
+  const button = Array.from(document.body.querySelectorAll("button")).find((element) =>
+    (element.textContent || "").includes(text)
+  );
+  if (!button) throw new Error(`未找到按钮: ${text}`);
+
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+async function submitForm() {
+  const form = document.body.querySelector("form");
+  if (!form) throw new Error("未找到系统设置表单");
+
+  await act(async () => {
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe("SystemSettingsForm IP 提取配置 JSON 输入框", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  test("未配置自定义链时直接显示格式化后的内置默认 JSON", () => {
+    const { unmount } = renderForm(buildSettings({ ipExtractionConfig: null }));
+
+    const textarea = getIpExtractionTextarea();
+    const formattedDefault = JSON.stringify(DEFAULT_IP_EXTRACTION_CONFIG, null, 2);
+
+    expect(textarea.value).toBe(formattedDefault);
+    expect(textarea.placeholder).toBe(formattedDefault);
+
+    unmount();
+  });
+
+  test("恢复默认只把默认 JSON 插入输入框，不会立即保存", () => {
+    const { unmount } = renderForm(
+      buildSettings({
+        ipExtractionConfig: {
+          headers: [{ name: "cf-connecting-ip" }],
+        },
+      })
+    );
+
+    const textarea = getIpExtractionTextarea();
+    setTextareaValue(textarea, '{"headers":[]}');
+    clickButtonByText("Reset to default");
+
+    expect(textarea.value).toBe(JSON.stringify(DEFAULT_IP_EXTRACTION_CONFIG, null, 2));
+    expect(systemConfigActionMocks.saveSystemSettings).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  test("直接保存默认 JSON 时提交默认对象", async () => {
+    const { unmount } = renderForm(buildSettings({ ipExtractionConfig: null }));
+
+    await submitForm();
+
+    expect(systemConfigActionMocks.saveSystemSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipExtractionConfig: DEFAULT_IP_EXTRACTION_CONFIG,
+      })
+    );
+
+    unmount();
+  });
+
+  test("用户显式清空输入框后保存仍提交 null", async () => {
+    const { unmount } = renderForm(buildSettings({ ipExtractionConfig: null }));
+
+    setTextareaValue(getIpExtractionTextarea(), "");
+    await submitForm();
+
+    expect(systemConfigActionMocks.saveSystemSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipExtractionConfig: null,
+      })
+    );
+
+    unmount();
+  });
+});


### PR DESCRIPTION
## Summary
Improves the IP extraction config editor in system settings to always display the effective configuration (either custom or default) and enhances the UX with a tooltip-based help system.

## Problem
The IP header extraction configuration editor had several usability issues:
- When no custom value was stored, the textarea appeared empty, making it unclear what the actual default configuration was
- The long help text for the extraction chain was always visible, cluttering the UI
- The "Reset to default" behavior wasn't clear about whether it would immediately save or just populate the field

## Solution
- Always show the effective IP header extraction JSON (custom if set, otherwise the built-in default) in the textarea
- Move the lengthy extraction-chain guidance into an accessible tooltip (CircleHelp icon) next to the label
- Add localized tooltip label strings for all 5 supported languages
- Change "Reset to default" to only insert the default JSON into the textarea without saving, giving users a chance to review before explicitly saving
- Add the default configuration as a textarea placeholder for additional clarity

## Changes

### Core Changes (src/app/[locale]/settings/config/_components/system-settings-form.tsx)
- Added `formatIpExtractionConfig()` helper to consistently format JSON with indentation
- Added `DEFAULT_IP_EXTRACTION_CONFIG_TEXT` constant for reuse
- Changed initial state to always show formatted default config when no custom value exists
- Added Tooltip component wrapping a help button with CircleHelp icon
- Changed Reset button behavior to populate textarea with default JSON instead of clearing it
- Added `placeholder` attribute showing the default config

### i18n Updates (messages/*/settings/config.json)
- Added `extractionConfigHelpLabel` translation key for tooltip button accessibility in all 5 languages (en, ja, ru, zh-CN, zh-TW)

### Tests (tests/unit/settings/system-settings-form-ip-extraction.test.tsx)
- **New test file** (241 lines) covering:
  - Default config display when no custom value is stored
  - Reset to default button behavior (only populates, doesn't auto-save)
  - Form submission with default JSON when no changes made
  - Form submission with `null` when user explicitly clears the textarea

## Testing

### Automated Tests
- [x] Unit tests added (`system-settings-form-ip-extraction.test.tsx`)
- [x] Existing IP extraction tests verified (`extract-client-ip.test.ts`)

### Manual Testing Performed
1. Open System Settings → Config page
2. Verify IP extraction config textarea shows formatted default JSON
3. Hover over help icon to verify tooltip displays correctly
4. Click "Reset to default" and verify textarea populates with default JSON
5. Modify the JSON and save, verify custom config persists
6. Clear textarea and save, verify it saves as null (reverts to system default)

## Checklist
- [x] Code follows project conventions (Biome formatting)
- [x] Self-review completed
- [x] Tests pass locally (Vitest)
- [x] TypeScript checks pass (tsgo)
- [x] Build passes (Next.js production build)
- [x] i18n strings added for all 5 languages
- [x] No breaking changes (UI enhancement only)

---
*Original description preserved - enhanced for reviewer clarity*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the IP extraction config editor by pre-filling the textarea with the effective configuration (custom or built-in default), replacing the always-visible help text with a tooltip (`CircleHelp` icon), changing "Reset to default" to populate without auto-saving, and adding the `extractionConfigHelpLabel` i18n key to all five locales. The UX improvements are clear and well-tested, though two concerns raised in prior review rounds remain open: (1) pre-filling the textarea when `ipExtractionConfig` is `null` means the very first save on an unconfigured instance will write the current hardcoded default to the DB, blocking future upgrades from changing that default; (2) the shape validator does not verify that each header entry has the required `name: string` field.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge until the implicit-null-to-explicit-default write issue is resolved.

The two P1 findings from prior review threads — implicit promotion of null to the hardcoded default on any save, and incomplete per-item shape validation — are still present and unaddressed. The new test at line 213 actually asserts the implicit-write behavior as expected, confirming it has not been fixed.

src/app/[locale]/settings/config/_components/system-settings-form.tsx lines 179-181 (initial state) and 215-223 (shape validator) need attention before merging.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/settings/config/_components/system-settings-form.tsx | Core form component: adds helper/constant, pre-fills textarea with default when config is null, tooltip help button, and updated reset logic — but pre-filling means any save while config is null writes the hardcoded default to the DB (prior P1 thread), and the shape validator doesn't check that each header item has the required `name` field (prior P1 thread). |
| tests/unit/settings/system-settings-form-ip-extraction.test.tsx | New 241-line unit test covering default display, reset-to-default, and save behavior; test 3 explicitly asserts that saving when config is null submits DEFAULT_IP_EXTRACTION_CONFIG (confirming the implicit-write behavior). Error messages and describe/test labels are in Chinese only. |
| messages/en/settings/config.json | Adds `extractionConfigHelpLabel` key to the `ipLogging` namespace; all 5 locales updated consistently. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant DB as Database
    participant Form as SystemSettingsForm
    participant UI as Textarea

    Note over Form: Mount / initialSettings loaded
    DB-->>Form: ipExtractionConfig = null
    Form->>UI: value = DEFAULT_IP_EXTRACTION_CONFIG_TEXT

    Note over UI: User makes no changes and saves
    UI->>Form: ipExtractionConfigText = default JSON
    Form->>DB: saveSystemSettings({ ipExtractionConfig: DEFAULT_IP_EXTRACTION_CONFIG })
    Note over DB: null → hardcoded default written permanently

    Note over UI: User explicitly clears textarea and saves
    UI->>Form: ipExtractionConfigText = empty
    Form->>DB: saveSystemSettings({ ipExtractionConfig: null })
    DB-->>Form: result.data.ipExtractionConfig = null
    Form->>UI: value = DEFAULT_IP_EXTRACTION_CONFIG_TEXT (re-filled)
    Note over UI: UI shows default even though null was saved
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/[locale]/settings/config/_components/system-settings-form.tsx`, line 215-223 ([link](https://github.com/ding113/claude-code-hub/blob/8d588b5b2e76fac34fdd46e878c635475351feb4/src/app/[locale]/settings/config/_components/system-settings-form.tsx#L215-L223)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Incomplete header-item validation**

   The shape check only confirms `headers` is an array — it does not verify that each element contains the required `name: string` field from `IpHeaderRule`. Input like `{"headers":[{"pick":"leftmost"}]}` (missing `name`) would pass this guard, be persisted to the DB, and silently break IP extraction at runtime.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/settings/config/_components/system-settings-form.tsx
   Line: 215-223

   Comment:
   **Incomplete header-item validation**

   The shape check only confirms `headers` is an array — it does not verify that each element contains the required `name: string` field from `IpHeaderRule`. Input like `{"headers":[{"pick":"leftmost"}]}` (missing `name`) would pass this guard, be persisted to the DB, and silently break IP extraction at runtime.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/unit/settings/system-settings-form-ip-extraction.test.tsx
Line: 139-167

Comment:
**Test error messages and names in Chinese only**

All `describe`/`test` labels and every internal `throw new Error(...)` in this file are written in Chinese. For an open-source project with international contributors, Chinese-only test output makes failures hard to triage without translation. Consider using English (matching the rest of the codebase's test files) or at least providing bilingual messages.

```suggestion
function getIpExtractionTextarea() {
  const textarea = document.getElementById("ip-extraction-config") as HTMLTextAreaElement | null;
  if (!textarea) throw new Error("IP extraction config textarea not found");
  return textarea;
}
```

The same applies to the helper that looks up a button by text (`"Button not found: ${text}"`) and the one that locates the form element (`"System settings form not found"`).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: clarify IP extraction form fixture..."](https://github.com/ding113/claude-code-hub/commit/2d9de44ace9cc790e5e650a493beecf83ac449b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28898036)</sub>

<!-- /greptile_comment -->