### PR TITLE
fix: refine usage logs cost tooltip breakdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,4 +89,5 @@ tmp/
 .ace-tool/
 .worktrees/
 .omx/
+.opencode/
 bunx-*/

--- a/messages/en/dashboard.json
+++ b/messages/en/dashboard.json
@@ -306,6 +306,7 @@
         "providerMultiplier": "Provider Multiplier",
         "groupMultiplier": "Group Multiplier",
         "baseTotal": "Base Total",
+        "unitPricePer1M": "@ {price} / 1M",
         "unit": {
           "tokens": "tokens"
         }

--- a/messages/ja/dashboard.json
+++ b/messages/ja/dashboard.json
@@ -306,6 +306,7 @@
         "providerMultiplier": "プロバイダー倍率",
         "groupMultiplier": "グループ倍率",
         "baseTotal": "基本合計",
+        "unitPricePer1M": "@ {price} / 1M",
         "unit": {
           "tokens": "トークン"
         }

--- a/messages/ru/dashboard.json
+++ b/messages/ru/dashboard.json
@@ -306,6 +306,7 @@
         "providerMultiplier": "Множитель поставщика",
         "groupMultiplier": "Множитель группы",
         "baseTotal": "Базовый итог",
+        "unitPricePer1M": "@ {price} / 1M",
         "unit": {
           "tokens": "токенов"
         }

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -306,6 +306,7 @@
         "providerMultiplier": "供应商倍率",
         "groupMultiplier": "分组倍率",
         "baseTotal": "基础合计",
+        "unitPricePer1M": "@ {price} / 1M",
         "unit": {
           "tokens": "tokens"
         }

--- a/messages/zh-TW/dashboard.json
+++ b/messages/zh-TW/dashboard.json
@@ -306,6 +306,7 @@
         "providerMultiplier": "供應商倍率",
         "groupMultiplier": "分組倍率",
         "baseTotal": "基礎合計",
+        "unitPricePer1M": "@ {price} / 1M",
         "unit": {
           "tokens": "tokens"
         }

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import { act } from "react";
 import { describe, expect, test, vi } from "vitest";
@@ -15,7 +15,8 @@ let mockIsFetchingNextPage = false;
 const useInfiniteQuerySpy = vi.hoisted(() => vi.fn());
 
 vi.mock("next-intl", () => ({
-  useTranslations: () => (key: string) => key,
+  useTranslations: () => (key: string, values?: Record<string, string>) =>
+    key === "logs.billingDetails.unitPricePer1M" && values?.price ? `@ ${values.price} / 1M` : key,
 }));
 
 vi.mock("@tanstack/react-query", () => ({
@@ -71,7 +72,7 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipProvider: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   Tooltip: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   TooltipTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-  TooltipContent: ({ children, className }: React.ComponentProps<"div">) => (
+  TooltipContent: ({ children, className }: ComponentProps<"div">) => (
     <div data-slot="tooltip-content" className={className}>
       {children}
     </div>
@@ -79,7 +80,7 @@ vi.mock("@/components/ui/tooltip", () => ({
 }));
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children, className, ...props }: React.ComponentProps<"button">) => (
+  Button: ({ children, className, ...props }: ComponentProps<"button">) => (
     <button className={className} {...props}>
       {children}
     </button>
@@ -480,7 +481,7 @@ describe("virtualized-logs-table multiplier badge", () => {
     expect(tooltip.textContent).not.toContain("logs.billingDetails.pricingSourceLabel");
   });
 
-  test("collapses to a single total row when no multiplier is active", () => {
+  test("keeps cost rows but collapses the summary to a single total row when no multiplier is active", () => {
     const tooltip = renderCostTooltipWithLog({
       costUsd: "0.005125",
       inputTokens: 2000,

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
@@ -71,7 +71,11 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipProvider: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   Tooltip: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   TooltipTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-  TooltipContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children, className }: React.ComponentProps<"div">) => (
+    <div data-slot="tooltip-content" className={className}>
+      {children}
+    </div>
+  ),
 }));
 
 vi.mock("@/components/ui/button", () => ({
@@ -148,6 +152,33 @@ function makeLog(overrides: Partial<UsageLogRow>): UsageLogRow {
     specialSettings: null,
     ...overrides,
   };
+}
+
+function renderTableWithLog(overrides: Partial<UsageLogRow>) {
+  mockIsLoading = false;
+  mockIsError = false;
+  mockError = null;
+  mockHasNextPage = false;
+  mockIsFetchingNextPage = false;
+  mockLogs = [makeLog({ id: 1, ...overrides })];
+
+  return renderToStaticMarkup(<VirtualizedLogsTable filters={{}} autoRefreshEnabled={false} />);
+}
+
+function renderCostTooltipWithLog(overrides: Partial<UsageLogRow>) {
+  const html = renderTableWithLog(overrides);
+  const container = document.createElement("div");
+  container.innerHTML = html;
+
+  const tooltip = [...container.querySelectorAll('[data-slot="tooltip-content"]')].find((node) =>
+    node.textContent?.includes("logs.details.billingDetails.title")
+  );
+
+  if (!(tooltip instanceof HTMLDivElement)) {
+    throw new Error("Cost tooltip content not found");
+  }
+
+  return tooltip;
 }
 
 describe("virtualized-logs-table multiplier badge", () => {
@@ -405,6 +436,191 @@ describe("virtualized-logs-table multiplier badge", () => {
     expect(html).toContain("5m");
     expect(html).not.toContain("5m ~");
     expect(html).not.toContain("bg-amber-50");
+  });
+
+  test("renders redesigned cost tooltip with positive rows and active multiplier rules only", () => {
+    const tooltip = renderCostTooltipWithLog({
+      costUsd: "0.009000",
+      inputTokens: 2000,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheCreation5mInputTokens: 0,
+      cacheCreation1hInputTokens: 0,
+      cacheReadInputTokens: 500,
+      context1mApplied: true,
+      costBreakdown: {
+        input: "0.005",
+        output: "0",
+        cache_creation: "0",
+        cache_creation_5m: "0",
+        cache_creation_1h: "0",
+        cache_read: "0.000125",
+        base_total: "0.005125",
+        provider_multiplier: 1.5,
+        group_multiplier: 1.2,
+        total: "0.009225",
+      },
+    });
+
+    expect(tooltip.textContent).toContain("logs.details.billingDetails.title");
+    expect(tooltip.textContent).toContain("logs.billingDetails.context1m");
+    expect(tooltip.textContent).toContain("logs.billingDetails.input");
+    expect(tooltip.textContent).toContain("logs.billingDetails.cacheRead");
+    expect(tooltip.textContent).toContain("@ $2.50 / 1M");
+    expect(tooltip.textContent).toContain("$0.005000");
+    expect(tooltip.textContent).toContain("@ $0.25 / 1M");
+    expect(tooltip.textContent).toContain("$0.000125");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.output");
+    expect(tooltip.textContent).not.toContain("@ $0.00 / 1M");
+    expect(tooltip.textContent).toContain("logs.billingDetails.baseTotal");
+    expect(tooltip.textContent).toContain("logs.billingDetails.providerMultiplier");
+    expect(tooltip.textContent).toContain("logs.billingDetails.groupMultiplier");
+    expect(tooltip.innerHTML).toContain("line-through");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.pricingProvider");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.pricingSourceLabel");
+  });
+
+  test("collapses to a single total row when no multiplier is active", () => {
+    const tooltip = renderCostTooltipWithLog({
+      costUsd: "0.005125",
+      inputTokens: 2000,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheCreation5mInputTokens: 0,
+      cacheCreation1hInputTokens: 0,
+      cacheReadInputTokens: 500,
+      costBreakdown: {
+        input: "0.005",
+        output: "0",
+        cache_creation: "0",
+        cache_creation_5m: "0",
+        cache_creation_1h: "0",
+        cache_read: "0.000125",
+        base_total: "0.005125",
+        provider_multiplier: 1,
+        group_multiplier: 1,
+        total: "0.005125",
+      },
+    });
+
+    expect(tooltip.textContent).toContain("logs.billingDetails.input");
+    expect(tooltip.textContent).toContain("logs.billingDetails.cacheRead");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.baseTotal");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.providerMultiplier");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.groupMultiplier");
+    expect(tooltip.innerHTML).not.toContain("line-through");
+  });
+
+  test("ignores zero or negative multipliers in the rules block", () => {
+    const tooltip = renderCostTooltipWithLog({
+      costUsd: "0.005125",
+      inputTokens: 2000,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheCreation5mInputTokens: 0,
+      cacheCreation1hInputTokens: 0,
+      cacheReadInputTokens: 500,
+      costBreakdown: {
+        input: "0.005",
+        output: "0",
+        cache_creation: "0",
+        cache_creation_5m: "0",
+        cache_creation_1h: "0",
+        cache_read: "0.000125",
+        base_total: "0.005125",
+        provider_multiplier: 0,
+        group_multiplier: -2,
+        total: "0.005125",
+      },
+    });
+
+    expect(tooltip.textContent).toContain("logs.billingDetails.input");
+    expect(tooltip.textContent).toContain("logs.billingDetails.cacheRead");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.baseTotal");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.providerMultiplier");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.groupMultiplier");
+    expect(tooltip.textContent).not.toContain("0.00x");
+    expect(tooltip.textContent).not.toContain("-2.00x");
+    expect(tooltip.innerHTML).not.toContain("line-through");
+  });
+
+  test("renders legacy aggregate cache creation as a generic cache-write row when ttl is unknown", () => {
+    const tooltip = renderCostTooltipWithLog({
+      costUsd: "0.003000",
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 1000,
+      cacheCreation5mInputTokens: 0,
+      cacheCreation1hInputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheTtlApplied: null,
+      costBreakdown: {
+        input: "0",
+        output: "0",
+        cache_creation: "0.003",
+        cache_read: "0",
+        base_total: "0.003",
+        provider_multiplier: 1,
+        group_multiplier: 1,
+        total: "0.003",
+      },
+    });
+
+    expect(tooltip.textContent).toContain("logs.columns.cacheWrite");
+    expect(tooltip.textContent).toContain("@ $3.00 / 1M");
+    expect(tooltip.textContent).toContain("$0.003000");
+    expect(tooltip.innerHTML).not.toContain(">5m<");
+    expect(tooltip.innerHTML).not.toContain(">1h<");
+  });
+
+  test("keeps a ttl chip for aggregate cache creation when ttl is explicitly known", () => {
+    const tooltip = renderCostTooltipWithLog({
+      costUsd: "0.003000",
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 1000,
+      cacheCreation5mInputTokens: 0,
+      cacheCreation1hInputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheTtlApplied: "1h",
+      costBreakdown: {
+        input: "0",
+        output: "0",
+        cache_creation: "0.003",
+        cache_read: "0",
+        base_total: "0.003",
+        provider_multiplier: 1,
+        group_multiplier: 1,
+        total: "0.003",
+      },
+    });
+
+    expect(tooltip.textContent).toContain("logs.columns.cacheWrite");
+    expect(tooltip.textContent).toContain("@ $3.00 / 1M");
+    expect(tooltip.innerHTML).toContain(">1h<");
+    expect(tooltip.innerHTML).not.toContain(">5m<");
+  });
+
+  test("falls back to total-only tooltip when cost breakdown is missing", () => {
+    const tooltip = renderCostTooltipWithLog({
+      costUsd: "0.010000",
+      inputTokens: 1234,
+      outputTokens: 5678,
+      cacheCreationInputTokens: 999,
+      cacheReadInputTokens: 111,
+      context1mApplied: true,
+      costBreakdown: null,
+    });
+
+    expect(tooltip.textContent).toContain("logs.details.billingDetails.title");
+    expect(tooltip.textContent).toContain("logs.billingDetails.context1m");
+    expect(tooltip.textContent).toContain("logs.billingDetails.totalCost");
+    expect(tooltip.textContent).toContain("$0.010000");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.input");
+    expect(tooltip.textContent).not.toContain("@ $");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.baseTotal");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.providerMultiplier");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.pricingProvider");
   });
 });
 

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -368,7 +368,11 @@ export function VirtualizedLogsTable({
         key: `${label}-${ttl ?? "default"}`,
         label,
         ttl,
-        unitPrice: unitPrice ? `@ ${formatCurrency(unitPrice, currencyCode, 2)} / 1M` : null,
+        unitPrice: unitPrice
+          ? t("logs.billingDetails.unitPricePer1M", {
+              price: formatCurrency(unitPrice, currencyCode, 2),
+            })
+          : null,
         amount: formatCurrency(parsedAmount, currencyCode, 6),
       };
     };

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -291,14 +291,12 @@ export function VirtualizedLogsTable({
         return [
           {
             amount: breakdown.cache_creation_5m ?? "0",
-            tokens:
-              tokens5m > 0 ? tokens5m : log.cacheTtlApplied !== "1h" ? totalCacheTokens : 0,
+            tokens: tokens5m > 0 ? tokens5m : log.cacheTtlApplied !== "1h" ? totalCacheTokens : 0,
             ttl: "5m" as const,
           },
           {
             amount: breakdown.cache_creation_1h ?? "0",
-            tokens:
-              tokens1h > 0 ? tokens1h : log.cacheTtlApplied === "1h" ? totalCacheTokens : 0,
+            tokens: tokens1h > 0 ? tokens1h : log.cacheTtlApplied === "1h" ? totalCacheTokens : 0,
             ttl: "1h" as const,
           },
         ];
@@ -398,7 +396,9 @@ export function VirtualizedLogsTable({
             {secondary}
           </span>
         ) : null}
-        <span className={cn(emphasize ? "text-sm font-semibold text-emerald-600" : "")}>{primary}</span>
+        <span className={cn(emphasize ? "text-sm font-semibold text-emerald-600" : "")}>
+          {primary}
+        </span>
       </div>
     );
 
@@ -423,7 +423,8 @@ export function VirtualizedLogsTable({
       </div>
     );
 
-    const isActiveMultiplier = (value: number) => Number.isFinite(value) && value > 0 && value !== 1;
+    const isActiveMultiplier = (value: number) =>
+      Number.isFinite(value) && value > 0 && value !== 1;
 
     if (!log.costBreakdown) {
       return (
@@ -452,7 +453,11 @@ export function VirtualizedLogsTable({
       ...cacheCreationRows.map((row) =>
         createCostRow(t("logs.columns.cacheWrite"), row.amount, row.tokens, row.ttl)
       ),
-      createCostRow(t("logs.billingDetails.cacheRead"), log.costBreakdown.cache_read, log.cacheReadInputTokens),
+      createCostRow(
+        t("logs.billingDetails.cacheRead"),
+        log.costBreakdown.cache_read,
+        log.cacheReadInputTokens
+      ),
     ].filter((row): row is NonNullable<typeof row> => row !== null);
 
     const activeMultiplierRows = [

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -5,6 +5,7 @@ import { ArrowUp, GitBranch, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
   type MouseEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useEffectEvent,
@@ -27,7 +28,7 @@ import type { LogsTableColumn } from "@/lib/column-visibility";
 import { cn, formatTokenAmount } from "@/lib/utils";
 import { copyTextToClipboard } from "@/lib/utils/clipboard";
 import type { CurrencyCode } from "@/lib/utils/currency";
-import { formatCurrency } from "@/lib/utils/currency";
+import { Decimal, formatCurrency, toDecimal } from "@/lib/utils/currency";
 import {
   calculateOutputRate,
   formatDuration,
@@ -37,11 +38,8 @@ import {
 import { shouldShowCostBadgeInCell } from "@/lib/utils/provider-chain-display";
 import { getFinalProviderName } from "@/lib/utils/provider-chain-formatter";
 import { isProviderFinalized } from "@/lib/utils/provider-display";
-import {
-  getPricingResolutionSpecialSetting,
-  hasPriorityServiceTierSpecialSetting,
-} from "@/lib/utils/special-settings";
-import type { UsageLogsBatchResult } from "@/repository/usage-logs";
+import { hasPriorityServiceTierSpecialSetting } from "@/lib/utils/special-settings";
+import type { UsageLogRow, UsageLogsBatchResult } from "@/repository/usage-logs";
 import type { BillingModelSource } from "@/types/system-config";
 import { ErrorDetailsDialog } from "./error-details-dialog";
 import { ModelDisplayWithRedirect } from "./model-display-with-redirect";
@@ -133,8 +131,6 @@ export function VirtualizedLogsTable({
   ipLookupMode = "default",
 }: VirtualizedLogsTableProps) {
   const t = useTranslations("dashboard");
-  const getPricingSourceLabel = (source: string) =>
-    t(`logs.billingDetails.pricingSource.${source}`);
   const tChain = useTranslations("provider-chain");
   const [isHistoryBrowsing, setIsHistoryBrowsing] = useState(false);
   const shouldPoll = autoRefreshEnabled && !isHistoryBrowsing;
@@ -262,6 +258,284 @@ export function VirtualizedLogsTable({
   if (allLogs.length === 0) {
     return <div className="text-center py-8 text-muted-foreground">{t("logs.table.noData")}</div>;
   }
+
+  const renderCostTooltip = (log: UsageLogRow) => {
+    const title = t("logs.details.billingDetails.title");
+    const totalCostLabel = t("logs.billingDetails.totalCost");
+    const amountClassName = "font-mono tabular-nums text-right";
+    const headerChip = log.context1mApplied ? (
+      <Badge
+        variant="outline"
+        className="shrink-0 text-[10px] leading-tight px-1 bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-950/30 dark:text-purple-300 dark:border-purple-800"
+      >
+        {t("logs.billingDetails.context1m")}
+      </Badge>
+    ) : null;
+
+    const resolveCacheCreationRows = () => {
+      const breakdown = log.costBreakdown;
+      if (!breakdown) {
+        return [] as Array<{
+          amount: string;
+          tokens: number | null | undefined;
+          ttl?: "5m" | "1h";
+        }>;
+      }
+
+      const tokens5m = log.cacheCreation5mInputTokens ?? 0;
+      const tokens1h = log.cacheCreation1hInputTokens ?? 0;
+      const totalCacheTokens = log.cacheCreationInputTokens;
+      const has5m = breakdown.cache_creation_5m !== undefined;
+      const has1h = breakdown.cache_creation_1h !== undefined;
+      if (has5m || has1h) {
+        return [
+          {
+            amount: breakdown.cache_creation_5m ?? "0",
+            tokens:
+              tokens5m > 0 ? tokens5m : log.cacheTtlApplied !== "1h" ? totalCacheTokens : 0,
+            ttl: "5m" as const,
+          },
+          {
+            amount: breakdown.cache_creation_1h ?? "0",
+            tokens:
+              tokens1h > 0 ? tokens1h : log.cacheTtlApplied === "1h" ? totalCacheTokens : 0,
+            ttl: "1h" as const,
+          },
+        ];
+      }
+
+      const aggregate = toDecimal(breakdown.cache_creation);
+      if (!aggregate || aggregate.lte(0)) {
+        return [];
+      }
+
+      if (log.cacheTtlApplied === "mixed" && tokens5m + tokens1h > 0) {
+        const totalTokens = new Decimal(tokens5m + tokens1h);
+        const fiveMShare = aggregate.mul(tokens5m).div(totalTokens);
+        return [
+          {
+            amount: fiveMShare.toString(),
+            tokens: tokens5m,
+            ttl: "5m" as const,
+          },
+          {
+            amount: aggregate.minus(fiveMShare).toString(),
+            tokens: tokens1h,
+            ttl: "1h" as const,
+          },
+        ];
+      }
+
+      if (log.cacheTtlApplied === "1h") {
+        return [
+          {
+            amount: aggregate.toString(),
+            tokens: tokens1h > 0 ? tokens1h : totalCacheTokens,
+            ttl: "1h" as const,
+          },
+        ];
+      }
+
+      if (log.cacheTtlApplied === "5m") {
+        return [
+          {
+            amount: aggregate.toString(),
+            tokens: tokens5m > 0 ? tokens5m : totalCacheTokens,
+            ttl: "5m" as const,
+          },
+        ];
+      }
+
+      return [
+        {
+          amount: aggregate.toString(),
+          tokens: totalCacheTokens,
+        },
+      ];
+    };
+
+    const createCostRow = (
+      label: string,
+      amount: string | null | undefined,
+      tokens: number | null | undefined,
+      ttl?: "5m" | "1h"
+    ) => {
+      const parsedAmount = toDecimal(amount);
+      if (!parsedAmount || parsedAmount.lte(0)) return null;
+
+      const tokenCount = tokens ?? 0;
+      const unitPrice = tokenCount > 0 ? parsedAmount.mul(1_000_000).div(tokenCount) : null;
+
+      return {
+        key: `${label}-${ttl ?? "default"}`,
+        label,
+        ttl,
+        unitPrice: unitPrice ? `@ ${formatCurrency(unitPrice, currencyCode, 2)} / 1M` : null,
+        amount: formatCurrency(parsedAmount, currencyCode, 6),
+      };
+    };
+
+    const renderTtlChip = (ttl: "5m" | "1h") => (
+      <Badge variant="outline" className="px-1 text-[10px] leading-tight text-muted-foreground">
+        {ttl}
+      </Badge>
+    );
+
+    const renderValueBlock = ({
+      primary,
+      secondary,
+      emphasize = false,
+      secondaryClassName,
+    }: {
+      primary: string;
+      secondary?: ReactNode;
+      emphasize?: boolean;
+      secondaryClassName?: string;
+    }) => (
+      <div className={cn("flex flex-col items-end", amountClassName)}>
+        {secondary ? (
+          <span className={cn("text-[11px] text-muted-foreground", secondaryClassName)}>
+            {secondary}
+          </span>
+        ) : null}
+        <span className={cn(emphasize ? "text-sm font-semibold text-emerald-600" : "")}>{primary}</span>
+      </div>
+    );
+
+    const renderSummaryRow = ({
+      label,
+      primary,
+      secondary,
+      emphasize = false,
+      className,
+      secondaryClassName,
+    }: {
+      label: string;
+      primary: string;
+      secondary?: ReactNode;
+      emphasize?: boolean;
+      className?: string;
+      secondaryClassName?: string;
+    }) => (
+      <div className={cn("flex items-start justify-between gap-3", className)}>
+        <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
+        {renderValueBlock({ primary, secondary, emphasize, secondaryClassName })}
+      </div>
+    );
+
+    const isActiveMultiplier = (value: number) => Number.isFinite(value) && value > 0 && value !== 1;
+
+    if (!log.costBreakdown) {
+      return (
+        <TooltipContent align="end" className="max-w-[320px] p-3">
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs font-semibold text-foreground">{title}</span>
+              {headerChip}
+            </div>
+            <div className="border-t border-border/60 pt-2">
+              {renderSummaryRow({
+                label: totalCostLabel,
+                primary: formatCurrency(log.costUsd, currencyCode, 6),
+                emphasize: true,
+              })}
+            </div>
+          </div>
+        </TooltipContent>
+      );
+    }
+
+    const cacheCreationRows = resolveCacheCreationRows();
+    const costRows = [
+      createCostRow(t("logs.billingDetails.input"), log.costBreakdown.input, log.inputTokens),
+      createCostRow(t("logs.billingDetails.output"), log.costBreakdown.output, log.outputTokens),
+      ...cacheCreationRows.map((row) =>
+        createCostRow(t("logs.columns.cacheWrite"), row.amount, row.tokens, row.ttl)
+      ),
+      createCostRow(t("logs.billingDetails.cacheRead"), log.costBreakdown.cache_read, log.cacheReadInputTokens),
+    ].filter((row): row is NonNullable<typeof row> => row !== null);
+
+    const activeMultiplierRows = [
+      isActiveMultiplier(log.costBreakdown.provider_multiplier)
+        ? {
+            key: "provider",
+            label: t("logs.billingDetails.providerMultiplier"),
+            value: `${log.costBreakdown.provider_multiplier.toFixed(2)}x`,
+          }
+        : null,
+      isActiveMultiplier(log.costBreakdown.group_multiplier)
+        ? {
+            key: "group",
+            label: t("logs.billingDetails.groupMultiplier"),
+            value: `${log.costBreakdown.group_multiplier.toFixed(2)}x`,
+          }
+        : null,
+    ].filter((row): row is NonNullable<typeof row> => row !== null);
+
+    const hasActiveMultipliers = activeMultiplierRows.length > 0;
+    const baseTotal = formatCurrency(log.costBreakdown.base_total, currencyCode, 6);
+    const finalTotal = formatCurrency(log.costBreakdown.total, currencyCode, 6);
+
+    return (
+      <TooltipContent align="end" className="max-w-[320px] p-3">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-semibold text-foreground">{title}</span>
+            {headerChip}
+          </div>
+
+          {costRows.length > 0 ? (
+            <div className="space-y-2">
+              {costRows.map((row) => (
+                <div key={row.key} className="flex items-start justify-between gap-3">
+                  <div className="flex items-center gap-1.5 min-w-0 text-[11px] text-muted-foreground">
+                    <span>{row.label}</span>
+                    {row.ttl ? renderTtlChip(row.ttl) : null}
+                  </div>
+                  {renderValueBlock({ primary: row.amount, secondary: row.unitPrice })}
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {hasActiveMultipliers ? (
+            <>
+              {renderSummaryRow({
+                label: t("logs.billingDetails.baseTotal"),
+                primary: baseTotal,
+                className: costRows.length > 0 ? "border-t border-border/60 pt-2" : undefined,
+              })}
+
+              <div className="space-y-2 rounded-md border border-border/60 bg-muted/30 p-2">
+                {activeMultiplierRows.map((row) => (
+                  <div key={row.key} className="flex items-center justify-between gap-3">
+                    <span className="text-[11px] text-muted-foreground">{row.label}</span>
+                    <span className={cn(amountClassName, "text-[11px]")}>{row.value}</span>
+                  </div>
+                ))}
+              </div>
+
+              {renderSummaryRow({
+                label: totalCostLabel,
+                primary: finalTotal,
+                secondary: baseTotal,
+                secondaryClassName: "line-through",
+                emphasize: true,
+                className: "border-t border-border/60 pt-2",
+              })}
+            </>
+          ) : (
+            renderSummaryRow({
+              label: totalCostLabel,
+              primary: finalTotal,
+              emphasize: true,
+              className: costRows.length > 0 ? "border-t border-border/60 pt-2" : undefined,
+            })
+          )}
+        </div>
+      </TooltipContent>
+    );
+  };
 
   return (
     <div className="space-y-4">
@@ -413,8 +687,6 @@ export function VirtualizedLogsTable({
 
                 const isNonBilling = log.endpoint === NON_BILLING_ENDPOINT;
                 const _isWarmupSkipped = log.blockedBy === "warmup";
-                const pricingResolution = getPricingResolutionSpecialSetting(log.specialSettings);
-
                 return (
                   <div
                     key={log.id}
@@ -760,40 +1032,7 @@ export function VirtualizedLogsTable({
                                   )}
                                 </span>
                               </TooltipTrigger>
-                              <TooltipContent
-                                align="end"
-                                className="text-xs space-y-1 max-w-[300px]"
-                              >
-                                {hasPriorityServiceTierSpecialSetting(log.specialSettings) && (
-                                  <div className="text-orange-600 dark:text-orange-400 font-medium">
-                                    {t("logs.billingDetails.fastPriority")}
-                                  </div>
-                                )}
-                                {log.context1mApplied && (
-                                  <div className="text-purple-600 dark:text-purple-400 font-medium">
-                                    {t("logs.billingDetails.context1m")}
-                                  </div>
-                                )}
-                                {pricingResolution && (
-                                  <>
-                                    <div>
-                                      {t("logs.billingDetails.pricingProvider")}:{" "}
-                                      <span className="font-mono">
-                                        {pricingResolution.resolvedPricingProviderKey}
-                                      </span>
-                                    </div>
-                                    <div>{getPricingSourceLabel(pricingResolution.source)}</div>
-                                  </>
-                                )}
-                                <div>
-                                  {t("logs.billingDetails.input")}:{" "}
-                                  {formatTokenAmount(log.inputTokens)} tokens
-                                </div>
-                                <div>
-                                  {t("logs.billingDetails.output")}:{" "}
-                                  {formatTokenAmount(log.outputTokens)} tokens
-                                </div>
-                              </TooltipContent>
+                              {renderCostTooltip(log)}
                             </Tooltip>
                           </TooltipProvider>
                         ) : (


### PR DESCRIPTION
## Summary
- Refine the dashboard usage logs cost tooltip into a compact row-based cost breakdown with derived unit prices and conditional multiplier rules.
- Stop inventing a `5m` cache TTL when legacy aggregate cache creation data does not carry trustworthy TTL metadata.
- Ignore the local `.opencode/` workspace so it stays out of future commits.

## Problem
The previous tooltip mixed token counts, pricing metadata, and badges in a way that made the cost column hard to scan. It also treated legacy aggregate cache creation data as if it were definitively `5m`, which could misrepresent old rows.

**Related PRs:**
- Follow-up to #1025 — that PR introduced the `costBreakdown` jsonb field and compound multiplier logic; this PR redesigns the live-dashboard tooltip to properly consume that data.
- Related to #873 — that PR's review flagged a broken `getPricingSourceLabel` translation key and stale tiered-pricing annotations in the tooltip; this PR replaces the entire tooltip, removing those bugs.

## Root cause
The cost tooltip was assembled as a loose collection of sections instead of a cost-first breakdown, and the cache fallback path inferred a TTL even when the stored data could not justify one.

## Fix
Rewrote the live dashboard cost tooltip in `VirtualizedLogsTable` so it only renders positive-cost rows, shows `@ $X.XX / 1M` unit prices, collapses to a single total row when there are no active multipliers, and falls back to a generic cache-write row when legacy aggregate cache data has unknown TTL. Also added focused regression coverage for the redesigned tooltip and added `.opencode/` to `.gitignore`.

## Changes

### Core Changes
- `virtualized-logs-table.tsx` — New `renderCostTooltip()` function (~280 lines) replaces the old inline tooltip, with `resolveCacheCreationRows()`, `createCostRow()`, and multiplier rendering helpers.
- `virtualized-logs-table.tsx` — Removed unused `getPricingSourceLabel` and `getPricingResolutionSpecialSetting` imports.

### Supporting Changes
- `.gitignore` — Added `.opencode/` entry.
- `virtualized-logs-table.test.tsx` — Updated `TooltipContent` mock to forward `className`, added `renderTableWithLog` and `renderCostTooltipWithLog` test helpers, added 6 new test cases.

## Testing

### Automated Tests
- [x] Renders redesigned cost tooltip with positive rows and active multiplier rules only
- [x] Collapses to a single total row when no multiplier is active
- [x] Ignores zero or negative multipliers in the rules block
- [x] Renders legacy aggregate cache creation as a generic cache-write row when TTL is unknown
- [x] Keeps a TTL chip for aggregate cache creation when TTL is explicitly known
- [x] Falls back to total-only tooltip when cost breakdown is missing

### Validation
- `bun run lint`
- `bun run lint:fix`
- `bun run typecheck`
- `bun run test`
- `bun run build`

## UI verification
Rendered preview of the updated tooltip states:

\![Cost tooltip preview](https://github.com/ding113/claude-code-hub/releases/download/untagged-c5fcb48f4b3c1243daaa/cost-tooltip-preview.png)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the inline cost tooltip in `VirtualizedLogsTable` with a structured `renderCostTooltip()` helper that renders per-token-type rows with derived unit prices, collapses multiplier blocks when none are active, and falls back to a TTL-agnostic cache-write row for legacy aggregate data.

- **P1 — Missing `unitPricePer1M` in `logs.billingDetails`**: `createCostRow` calls `t(\"logs.billingDetails.unitPricePer1M\")` but the key only exists at `logs.details.billingDetails.unitPricePer1M`. All five locale files are affected. The test mock hard-codes a match for this key, so the gap is not caught by the test suite — in production every unit-price cell will render the raw key string instead of `\"@ $X.XX / 1M\"`.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge: the unitPricePer1M i18n key used by the new tooltip is missing from the logs.billingDetails namespace in all locale files, so unit prices will display as raw key strings in production.

One confirmed P1 defect (broken i18n key path masked by the test mock) affects the primary user-facing output of this PR — the unit price line in every cost tooltip row. The rest of the logic (TTL fallback, multiplier rows, zero-row filtering) is correct and well-tested.

All five messages/*/dashboard.json files need "unitPricePer1M": "@ {price} / 1M" added to the logs.billingDetails block.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx | New renderCostTooltip() with resolveCacheCreationRows/createCostRow helpers; correctly handles legacy aggregate TTL fallback, multiplier rows, and zero-cost filtering — but references the wrong i18n key path for unitPricePer1M (P1) and has a token-count fallback issue in the per-TTL branch (P2). |
| src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx | Six new cost-tooltip test cases covering TTL fallback, multiplier visibility, and zero-row suppression; test helper renderCostTooltipWithLog works correctly; the useTranslations mock hard-codes the missing unitPricePer1M key, masking the production i18n bug. |
| messages/en/dashboard.json | Adds providerMultiplier, groupMultiplier, baseTotal, and unitPricePer1M to logs.details.billingDetails, plus the first three to logs.billingDetails — but unitPricePer1M is absent from logs.billingDetails, which is the path the component actually uses. |
| messages/zh-CN/dashboard.json | Same pattern as en/dashboard.json — unitPricePer1M present only in logs.details.billingDetails, missing from logs.billingDetails. |
| messages/zh-TW/dashboard.json | Same unitPricePer1M gap as the zh-CN file. |
| messages/ja/dashboard.json | Same unitPricePer1M gap as the other locale files. |
| messages/ru/dashboard.json | Same unitPricePer1M gap as the other locale files. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[renderCostTooltip] --> B{costBreakdown present?}
    B -- No --> C[Total-only fallback tooltip]
    B -- Yes --> D[resolveCacheCreationRows]
    D --> E{has cache_creation_5m OR _1h?}
    E -- Yes --> F[Return per-TTL rows with hardcoded 5m/1h labels]
    E -- No --> G{aggregate cache_creation > 0?}
    G -- No --> H[Return empty array]
    G -- Yes --> I{cacheTtlApplied?}
    I -- mixed + tokens > 0 --> J[Prorate by token share]
    I -- 1h --> K[Return single 1h row]
    I -- 5m --> L[Return single 5m row]
    I -- null/unknown --> M[Return TTL-agnostic row — no chip]
    F & J & K & L & M --> N[createCostRow: filter zero-cost rows, derive unit price]
    N --> O[Assemble activeMultiplierRows]
    O --> P{Any active multipliers?}
    P -- Yes --> Q[Show baseTotal + multiplier block + struck-through total]
    P -- No --> R[Show single total row]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx`, line 982-998 ([link](https://github.com/ding113/claude-code-hub/blob/a6ada3b51d4aa628e6e04aaa431ab60a5098efd7/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx#L982-L998)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Cache column tooltip still infers 5m TTL for legacy rows**

   The cost tooltip was deliberately fixed to return a TTL-less row when `cacheTtlApplied` is `null`, but the token-count breakdown rendered in the cache column tooltip still uses the old inference:

   ```tsx
   5m:{" "}
   {formatTokenAmount(
     (log.cacheCreation5mInputTokens ?? 0) > 0
       ? log.cacheCreation5mInputTokens
       : log.cacheTtlApplied !== "1h"   // ← shows totalCacheTokens as "5m" when TTL is null
         ? log.cacheCreationInputTokens
         : 0
   )}
   ```

   For a legacy aggregate row where `cacheTtlApplied` is `null`, the cache column tooltip will display the total write-token count as "5m: N" — exactly the misleading presentation the PR aims to avoid. Consider applying the same fallback guard here (show "5m: 0" when TTL is unknown) for consistency.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
   Line: 982-998

   Comment:
   **Cache column tooltip still infers 5m TTL for legacy rows**

   The cost tooltip was deliberately fixed to return a TTL-less row when `cacheTtlApplied` is `null`, but the token-count breakdown rendered in the cache column tooltip still uses the old inference:

   ```tsx
   5m:{" "}
   {formatTokenAmount(
     (log.cacheCreation5mInputTokens ?? 0) > 0
       ? log.cacheCreation5mInputTokens
       : log.cacheTtlApplied !== "1h"   // ← shows totalCacheTokens as "5m" when TTL is null
         ? log.cacheCreationInputTokens
         : 0
   )}
   ```

   For a legacy aggregate row where `cacheTtlApplied` is `null`, the cache column tooltip will display the total write-token count as "5m: N" — exactly the misleading presentation the PR aims to avoid. Consider applying the same fallback guard here (show "5m: 0" when TTL is unknown) for consistency.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `messages/en/dashboard.json`, line 423-424 ([link](https://github.com/ding113/claude-code-hub/blob/d334316871b780ffbf19324a6935b171b82adf6f/messages/en/dashboard.json#L423-L424)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing `unitPricePer1M` key in `logs.billingDetails`**

   The component calls `t("logs.billingDetails.unitPricePer1M", { price })` (virtualized-logs-table.tsx, `createCostRow`), but the key only exists at `logs.details.billingDetails.unitPricePer1M` (line 309) — it is absent from the top-level `logs.billingDetails` block (lines 396-427). In production `next-intl` will fall back to the raw key string, so every unit-price cell in the cost tooltip will display `"logs.billingDetails.unitPricePer1M"` instead of `"@ $X.XX / 1M"`. The test suite masks this because the `useTranslations` mock hard-codes a match on that exact key.

   The fix is to add the missing entry to `logs.billingDetails` in every locale file (the `"@ {price} / 1M"` format string is locale-neutral so all five files need the same change):

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: messages/en/dashboard.json
   Line: 423-424

   Comment:
   **Missing `unitPricePer1M` key in `logs.billingDetails`**

   The component calls `t("logs.billingDetails.unitPricePer1M", { price })` (virtualized-logs-table.tsx, `createCostRow`), but the key only exists at `logs.details.billingDetails.unitPricePer1M` (line 309) — it is absent from the top-level `logs.billingDetails` block (lines 396-427). In production `next-intl` will fall back to the raw key string, so every unit-price cell in the cost tooltip will display `"logs.billingDetails.unitPricePer1M"` instead of `"@ $X.XX / 1M"`. The test suite masks this because the `useTranslations` mock hard-codes a match on that exact key.

   The fix is to add the missing entry to `logs.billingDetails` in every locale file (the `"@ {price} / 1M"` format string is locale-neutral so all five files need the same change):

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: messages/en/dashboard.json
Line: 423-424

Comment:
**Missing `unitPricePer1M` key in `logs.billingDetails`**

The component calls `t("logs.billingDetails.unitPricePer1M", { price })` (virtualized-logs-table.tsx, `createCostRow`), but the key only exists at `logs.details.billingDetails.unitPricePer1M` (line 309) — it is absent from the top-level `logs.billingDetails` block (lines 396-427). In production `next-intl` will fall back to the raw key string, so every unit-price cell in the cost tooltip will display `"logs.billingDetails.unitPricePer1M"` instead of `"@ $X.XX / 1M"`. The test suite masks this because the `useTranslations` mock hard-codes a match on that exact key.

The fix is to add the missing entry to `logs.billingDetails` in every locale file (the `"@ {price} / 1M"` format string is locale-neutral so all five files need the same change):

```suggestion
      "baseTotal": "Base Total",
      "unitPricePer1M": "@ {price} / 1M",
      "unit": {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
Line: 290-302

Comment:
**Unit-price denominator falls back to aggregate token count in per-TTL branch**

When the breakdown has explicit `cache_creation_5m`/`cache_creation_1h` entries (`has5m || has1h` is true), but `cacheCreation5mInputTokens` is `0` and `cacheTtlApplied` is neither `"1h"` nor explicitly `"5m"` (e.g. it is `null`), the 5m row's `tokens` field is set to `totalCacheTokens`. This total may include both 5m and 1h tokens, so the derived unit price passed to `createCostRow` would be understated relative to the actual 5m-bucket rate. The aggregate `resolveCacheCreationRows` path (reached when neither key is present) correctly returns a TTL-agnostic row in this case, but the per-TTL path does not apply the same guard.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test: align cost tooltip review follow-u..."](https://github.com/ding113/claude-code-hub/commit/d334316871b780ffbf19324a6935b171b82adf6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28903084)</sub>

<!-- /greptile_comment -->