### PR TITLE
fix: repair audit log action i18n labels

### DIFF
--- a/messages/en/auditLogs.json
+++ b/messages/en/auditLogs.json
@@ -30,30 +30,48 @@
     "status": "Status"
   },
   "actions": {
-    "login.success": "Login succeeded",
-    "login.failure": "Login failed",
-    "login.rate_limited": "Login rate limited",
-    "user.create": "Create user",
-    "user.update": "Update user",
-    "user.delete": "Delete user",
-    "provider.create": "Create provider",
-    "provider.update": "Update provider",
-    "provider.delete": "Delete provider",
-    "provider_group.create": "Create provider group",
-    "provider_group.update": "Update provider group",
-    "provider_group.delete": "Delete provider group",
-    "system_settings.update": "Update system settings",
-    "key.create": "Create key",
-    "key.update": "Update key",
-    "key.delete": "Delete key",
-    "notification.update": "Update notification",
-    "sensitive_word.create": "Create sensitive word",
-    "sensitive_word.update": "Update sensitive word",
-    "sensitive_word.delete": "Delete sensitive word",
-    "model_price.bulk_upload": "Bulk upload model prices",
-    "model_price.sync_litellm": "Sync LiteLLM model prices",
-    "model_price.upsert": "Upsert model price",
-    "model_price.delete": "Delete model price"
+    "login": {
+      "success": "Login succeeded",
+      "failure": "Login failed",
+      "rate_limited": "Login rate limited"
+    },
+    "user": {
+      "create": "Create user",
+      "update": "Update user",
+      "delete": "Delete user"
+    },
+    "provider": {
+      "create": "Create provider",
+      "update": "Update provider",
+      "delete": "Delete provider"
+    },
+    "provider_group": {
+      "create": "Create provider group",
+      "update": "Update provider group",
+      "delete": "Delete provider group"
+    },
+    "system_settings": {
+      "update": "Update system settings"
+    },
+    "key": {
+      "create": "Create key",
+      "update": "Update key",
+      "delete": "Delete key"
+    },
+    "notification": {
+      "update": "Update notification"
+    },
+    "sensitive_word": {
+      "create": "Create sensitive word",
+      "update": "Update sensitive word",
+      "delete": "Delete sensitive word"
+    },
+    "model_price": {
+      "bulk_upload": "Bulk upload model prices",
+      "sync_litellm": "Sync LiteLLM model prices",
+      "upsert": "Upsert model price",
+      "delete": "Delete model price"
+    }
   },
   "detail": {
     "title": "Audit entry",

--- a/messages/ja/auditLogs.json
+++ b/messages/ja/auditLogs.json
@@ -30,30 +30,48 @@
     "status": "ステータス"
   },
   "actions": {
-    "login.success": "ログイン成功",
-    "login.failure": "ログイン失敗",
-    "login.rate_limited": "ログインのレート制限",
-    "user.create": "ユーザー作成",
-    "user.update": "ユーザー更新",
-    "user.delete": "ユーザー削除",
-    "provider.create": "プロバイダー作成",
-    "provider.update": "プロバイダー更新",
-    "provider.delete": "プロバイダー削除",
-    "provider_group.create": "プロバイダーグループ作成",
-    "provider_group.update": "プロバイダーグループ更新",
-    "provider_group.delete": "プロバイダーグループ削除",
-    "system_settings.update": "システム設定更新",
-    "key.create": "キー作成",
-    "key.update": "キー更新",
-    "key.delete": "キー削除",
-    "notification.update": "通知更新",
-    "sensitive_word.create": "機密ワード作成",
-    "sensitive_word.update": "機密ワード更新",
-    "sensitive_word.delete": "機密ワード削除",
-    "model_price.bulk_upload": "モデル価格の一括アップロード",
-    "model_price.sync_litellm": "LiteLLM モデル価格の同期",
-    "model_price.upsert": "モデル価格更新",
-    "model_price.delete": "モデル価格削除"
+    "login": {
+      "success": "ログイン成功",
+      "failure": "ログイン失敗",
+      "rate_limited": "ログインのレート制限"
+    },
+    "user": {
+      "create": "ユーザー作成",
+      "update": "ユーザー更新",
+      "delete": "ユーザー削除"
+    },
+    "provider": {
+      "create": "プロバイダー作成",
+      "update": "プロバイダー更新",
+      "delete": "プロバイダー削除"
+    },
+    "provider_group": {
+      "create": "プロバイダーグループ作成",
+      "update": "プロバイダーグループ更新",
+      "delete": "プロバイダーグループ削除"
+    },
+    "system_settings": {
+      "update": "システム設定更新"
+    },
+    "key": {
+      "create": "キー作成",
+      "update": "キー更新",
+      "delete": "キー削除"
+    },
+    "notification": {
+      "update": "通知更新"
+    },
+    "sensitive_word": {
+      "create": "機密ワード作成",
+      "update": "機密ワード更新",
+      "delete": "機密ワード削除"
+    },
+    "model_price": {
+      "bulk_upload": "モデル価格の一括アップロード",
+      "sync_litellm": "LiteLLM モデル価格の同期",
+      "upsert": "モデル価格更新",
+      "delete": "モデル価格削除"
+    }
   },
   "detail": {
     "title": "監査エントリー",

--- a/messages/ru/auditLogs.json
+++ b/messages/ru/auditLogs.json
@@ -30,30 +30,48 @@
     "status": "Статус"
   },
   "actions": {
-    "login.success": "Успешный вход",
-    "login.failure": "Ошибка входа",
-    "login.rate_limited": "Ограничение частоты входа",
-    "user.create": "Создание пользователя",
-    "user.update": "Обновление пользователя",
-    "user.delete": "Удаление пользователя",
-    "provider.create": "Создание провайдера",
-    "provider.update": "Обновление провайдера",
-    "provider.delete": "Удаление провайдера",
-    "provider_group.create": "Создание группы провайдеров",
-    "provider_group.update": "Обновление группы провайдеров",
-    "provider_group.delete": "Удаление группы провайдеров",
-    "system_settings.update": "Обновление системных настроек",
-    "key.create": "Создание ключа",
-    "key.update": "Обновление ключа",
-    "key.delete": "Удаление ключа",
-    "notification.update": "Обновление уведомления",
-    "sensitive_word.create": "Создание запрещённого слова",
-    "sensitive_word.update": "Обновление запрещённого слова",
-    "sensitive_word.delete": "Удаление запрещённого слова",
-    "model_price.bulk_upload": "Массовая загрузка цен моделей",
-    "model_price.sync_litellm": "Синхронизация цен моделей LiteLLM",
-    "model_price.upsert": "Обновление цены модели",
-    "model_price.delete": "Удаление цены модели"
+    "login": {
+      "success": "Успешный вход",
+      "failure": "Ошибка входа",
+      "rate_limited": "Ограничение частоты входа"
+    },
+    "user": {
+      "create": "Создание пользователя",
+      "update": "Обновление пользователя",
+      "delete": "Удаление пользователя"
+    },
+    "provider": {
+      "create": "Создание провайдера",
+      "update": "Обновление провайдера",
+      "delete": "Удаление провайдера"
+    },
+    "provider_group": {
+      "create": "Создание группы провайдеров",
+      "update": "Обновление группы провайдеров",
+      "delete": "Удаление группы провайдеров"
+    },
+    "system_settings": {
+      "update": "Обновление системных настроек"
+    },
+    "key": {
+      "create": "Создание ключа",
+      "update": "Обновление ключа",
+      "delete": "Удаление ключа"
+    },
+    "notification": {
+      "update": "Обновление уведомления"
+    },
+    "sensitive_word": {
+      "create": "Создание запрещённого слова",
+      "update": "Обновление запрещённого слова",
+      "delete": "Удаление запрещённого слова"
+    },
+    "model_price": {
+      "bulk_upload": "Массовая загрузка цен моделей",
+      "sync_litellm": "Синхронизация цен моделей LiteLLM",
+      "upsert": "Обновление цены модели",
+      "delete": "Удаление цены модели"
+    }
   },
   "detail": {
     "title": "Запись аудита",

--- a/messages/zh-CN/auditLogs.json
+++ b/messages/zh-CN/auditLogs.json
@@ -30,30 +30,48 @@
     "status": "状态"
   },
   "actions": {
-    "login.success": "登录成功",
-    "login.failure": "登录失败",
-    "login.rate_limited": "登录限流",
-    "user.create": "创建用户",
-    "user.update": "更新用户",
-    "user.delete": "删除用户",
-    "provider.create": "创建供应商",
-    "provider.update": "更新供应商",
-    "provider.delete": "删除供应商",
-    "provider_group.create": "创建供应商分组",
-    "provider_group.update": "更新供应商分组",
-    "provider_group.delete": "删除供应商分组",
-    "system_settings.update": "更新系统设置",
-    "key.create": "创建密钥",
-    "key.update": "更新密钥",
-    "key.delete": "删除密钥",
-    "notification.update": "更新通知",
-    "sensitive_word.create": "创建敏感词",
-    "sensitive_word.update": "更新敏感词",
-    "sensitive_word.delete": "删除敏感词",
-    "model_price.bulk_upload": "批量上传模型价格",
-    "model_price.sync_litellm": "同步 LiteLLM 模型价格",
-    "model_price.upsert": "更新模型价格",
-    "model_price.delete": "删除模型价格"
+    "login": {
+      "success": "登录成功",
+      "failure": "登录失败",
+      "rate_limited": "登录限流"
+    },
+    "user": {
+      "create": "创建用户",
+      "update": "更新用户",
+      "delete": "删除用户"
+    },
+    "provider": {
+      "create": "创建供应商",
+      "update": "更新供应商",
+      "delete": "删除供应商"
+    },
+    "provider_group": {
+      "create": "创建供应商分组",
+      "update": "更新供应商分组",
+      "delete": "删除供应商分组"
+    },
+    "system_settings": {
+      "update": "更新系统设置"
+    },
+    "key": {
+      "create": "创建密钥",
+      "update": "更新密钥",
+      "delete": "删除密钥"
+    },
+    "notification": {
+      "update": "更新通知"
+    },
+    "sensitive_word": {
+      "create": "创建敏感词",
+      "update": "更新敏感词",
+      "delete": "删除敏感词"
+    },
+    "model_price": {
+      "bulk_upload": "批量上传模型价格",
+      "sync_litellm": "同步 LiteLLM 模型价格",
+      "upsert": "更新模型价格",
+      "delete": "删除模型价格"
+    }
   },
   "detail": {
     "title": "审计详情",

--- a/messages/zh-TW/auditLogs.json
+++ b/messages/zh-TW/auditLogs.json
@@ -30,30 +30,48 @@
     "status": "狀態"
   },
   "actions": {
-    "login.success": "登入成功",
-    "login.failure": "登入失敗",
-    "login.rate_limited": "登入限流",
-    "user.create": "建立使用者",
-    "user.update": "更新使用者",
-    "user.delete": "刪除使用者",
-    "provider.create": "建立供應商",
-    "provider.update": "更新供應商",
-    "provider.delete": "刪除供應商",
-    "provider_group.create": "建立供應商分組",
-    "provider_group.update": "更新供應商分組",
-    "provider_group.delete": "刪除供應商分組",
-    "system_settings.update": "更新系統設定",
-    "key.create": "建立金鑰",
-    "key.update": "更新金鑰",
-    "key.delete": "刪除金鑰",
-    "notification.update": "更新通知",
-    "sensitive_word.create": "建立敏感詞",
-    "sensitive_word.update": "更新敏感詞",
-    "sensitive_word.delete": "刪除敏感詞",
-    "model_price.bulk_upload": "批次上傳模型價格",
-    "model_price.sync_litellm": "同步 LiteLLM 模型價格",
-    "model_price.upsert": "更新模型價格",
-    "model_price.delete": "刪除模型價格"
+    "login": {
+      "success": "登入成功",
+      "failure": "登入失敗",
+      "rate_limited": "登入限流"
+    },
+    "user": {
+      "create": "建立使用者",
+      "update": "更新使用者",
+      "delete": "刪除使用者"
+    },
+    "provider": {
+      "create": "建立供應商",
+      "update": "更新供應商",
+      "delete": "刪除供應商"
+    },
+    "provider_group": {
+      "create": "建立供應商分組",
+      "update": "更新供應商分組",
+      "delete": "刪除供應商分組"
+    },
+    "system_settings": {
+      "update": "更新系統設定"
+    },
+    "key": {
+      "create": "建立金鑰",
+      "update": "更新金鑰",
+      "delete": "刪除金鑰"
+    },
+    "notification": {
+      "update": "更新通知"
+    },
+    "sensitive_word": {
+      "create": "建立敏感詞",
+      "update": "更新敏感詞",
+      "delete": "刪除敏感詞"
+    },
+    "model_price": {
+      "bulk_upload": "批次上傳模型價格",
+      "sync_litellm": "同步 LiteLLM 模型價格",
+      "upsert": "更新模型價格",
+      "delete": "刪除模型價格"
+    }
   },
   "detail": {
     "title": "稽核詳情",

--- a/src/app/[locale]/dashboard/audit-logs/_components/audit-log-detail-sheet.test.tsx
+++ b/src/app/[locale]/dashboard/audit-logs/_components/audit-log-detail-sheet.test.tsx
@@ -7,6 +7,7 @@ import type { ReactNode } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { describe, expect, test, vi } from "vitest";
+import { AuditLogDetailSheet } from "@/app/[locale]/dashboard/audit-logs/_components/audit-log-detail-sheet";
 import type { AuditLogRow } from "@/types/audit-log";
 import auditLogsMessages from "../../../../../../messages/en/auditLogs.json";
 
@@ -59,8 +60,6 @@ vi.mock("@/app/[locale]/dashboard/_components/ip-display-trigger", () => ({
 vi.mock("@/app/[locale]/dashboard/_components/ip-details-dialog", () => ({
   IpDetailsDialog: () => null,
 }));
-
-import { AuditLogDetailSheet } from "./audit-log-detail-sheet";
 
 const messages = { auditLogs: auditLogsMessages };
 

--- a/src/app/[locale]/dashboard/audit-logs/_components/audit-log-detail-sheet.test.tsx
+++ b/src/app/[locale]/dashboard/audit-logs/_components/audit-log-detail-sheet.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { NextIntlClientProvider } from "next-intl";
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, test, vi } from "vitest";
+import type { AuditLogRow } from "@/types/audit-log";
+import auditLogsMessages from "../../../../../../messages/en/auditLogs.json";
+
+vi.mock("@/components/ui/sheet", () => {
+  type PropsWithChildren = { children?: ReactNode };
+
+  function Sheet({
+    children,
+    open,
+  }: PropsWithChildren & { open?: boolean; onOpenChange?: (open: boolean) => void }) {
+    return open ? <div data-slot="sheet-root">{children}</div> : null;
+  }
+
+  function SheetContent({ children }: PropsWithChildren) {
+    return <div data-slot="sheet-content">{children}</div>;
+  }
+
+  function SheetHeader({ children }: PropsWithChildren) {
+    return <div data-slot="sheet-header">{children}</div>;
+  }
+
+  function SheetTitle({ children }: PropsWithChildren) {
+    return <div data-slot="sheet-title">{children}</div>;
+  }
+
+  return {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+  };
+});
+
+vi.mock("@/components/ui/separator", () => ({
+  Separator: () => <div data-slot="separator" />,
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/relative-time", () => ({
+  RelativeTime: ({ date }: { date: Date }) => <span>{date.toISOString()}</span>,
+}));
+
+vi.mock("@/app/[locale]/dashboard/_components/ip-display-trigger", () => ({
+  IpDisplayTrigger: ({ ip }: { ip?: string | null }) => <span>{ip ?? "—"}</span>,
+}));
+
+vi.mock("@/app/[locale]/dashboard/_components/ip-details-dialog", () => ({
+  IpDetailsDialog: () => null,
+}));
+
+import { AuditLogDetailSheet } from "./audit-log-detail-sheet";
+
+const messages = { auditLogs: auditLogsMessages };
+
+const SAMPLE_LOG: AuditLogRow = {
+  id: 1,
+  actionCategory: "auth",
+  actionType: "login.success",
+  targetType: "session",
+  targetId: "sess_123",
+  targetName: "Admin sign in",
+  beforeValue: null,
+  afterValue: { login: true },
+  operatorUserId: 7,
+  operatorUserName: "Alice",
+  operatorKeyId: null,
+  operatorKeyName: null,
+  operatorIp: "127.0.0.1",
+  userAgent: "Vitest",
+  success: true,
+  errorMessage: null,
+  createdAt: new Date("2026-04-20T00:00:00.000Z"),
+};
+
+function render(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("AuditLogDetailSheet", () => {
+  test("translates dotted audit action types instead of showing the raw key", () => {
+    const { unmount } = render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <AuditLogDetailSheet log={SAMPLE_LOG} open onOpenChange={() => {}} />
+      </NextIntlClientProvider>
+    );
+
+    const text = document.body.textContent ?? "";
+
+    expect(text).toContain("Login succeeded");
+    expect(text).not.toContain("login.success");
+
+    unmount();
+  });
+
+  test("falls back to the raw action type when no translation exists", () => {
+    const { unmount } = render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <AuditLogDetailSheet
+          log={{ ...SAMPLE_LOG, actionType: "totally.unknown" }}
+          open
+          onOpenChange={() => {}}
+        />
+      </NextIntlClientProvider>
+    );
+
+    const text = document.body.textContent ?? "";
+
+    expect(text).toContain("totally.unknown");
+    expect(text).not.toContain("auditLogs.actions.totally.unknown");
+
+    unmount();
+  });
+});

--- a/src/app/[locale]/dashboard/audit-logs/_components/audit-log-detail-sheet.tsx
+++ b/src/app/[locale]/dashboard/audit-logs/_components/audit-log-detail-sheet.tsx
@@ -9,6 +9,7 @@ import { RelativeTime } from "@/components/ui/relative-time";
 import { Separator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import type { AuditLogRow } from "@/types/audit-log";
+import { getAuditActionLabel, getAuditCategoryLabel } from "./audit-log-labels";
 
 interface AuditLogDetailSheetProps {
   log: AuditLogRow | null;
@@ -59,23 +60,8 @@ export function AuditLogDetailSheet({ log, open, onOpenChange }: AuditLogDetailS
 
   const operatorName = log.operatorUserName ?? t("adminTokenOperator");
 
-  const categoryLabel = (() => {
-    const key = `categories.${log.actionCategory}` as const;
-    try {
-      return t(key);
-    } catch {
-      return log.actionCategory;
-    }
-  })();
-
-  const actionLabel = (() => {
-    const key = `actions.${log.actionType}` as const;
-    try {
-      return t(key);
-    } catch {
-      return log.actionType;
-    }
-  })();
+  const categoryLabel = getAuditCategoryLabel(t, log.actionCategory);
+  const actionLabel = getAuditActionLabel(t, log.actionType);
 
   const openIpDialog = (ip: string) => {
     setIpDialogValue(ip);

--- a/src/app/[locale]/dashboard/audit-logs/_components/audit-log-detail-sheet.tsx
+++ b/src/app/[locale]/dashboard/audit-logs/_components/audit-log-detail-sheet.tsx
@@ -4,12 +4,15 @@ import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { IpDetailsDialog } from "@/app/[locale]/dashboard/_components/ip-details-dialog";
 import { IpDisplayTrigger } from "@/app/[locale]/dashboard/_components/ip-display-trigger";
+import {
+  getAuditActionLabel,
+  getAuditCategoryLabel,
+} from "@/app/[locale]/dashboard/audit-logs/_components/audit-log-labels";
 import { Badge } from "@/components/ui/badge";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { Separator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import type { AuditLogRow } from "@/types/audit-log";
-import { getAuditActionLabel, getAuditCategoryLabel } from "./audit-log-labels";
 
 interface AuditLogDetailSheetProps {
   log: AuditLogRow | null;

--- a/src/app/[locale]/dashboard/audit-logs/_components/audit-log-labels.ts
+++ b/src/app/[locale]/dashboard/audit-logs/_components/audit-log-labels.ts
@@ -1,0 +1,15 @@
+interface AuditLogTranslator {
+  (key: string): string;
+  has: (key: string) => boolean;
+}
+
+export function getAuditCategoryLabel(t: AuditLogTranslator, category: string): string {
+  const key = `categories.${category}`;
+  return t.has(key) ? t(key) : category;
+}
+
+export function getAuditActionLabel(t: AuditLogTranslator, actionType: string): string {
+  // next-intl 缺失文案时会返回完整 key 字符串，因此这里必须先用 has() 判断。
+  const key = `actions.${actionType}`;
+  return t.has(key) ? t(key) : actionType;
+}

--- a/src/app/[locale]/dashboard/audit-logs/_components/audit-logs-view.tsx
+++ b/src/app/[locale]/dashboard/audit-logs/_components/audit-logs-view.tsx
@@ -21,6 +21,7 @@ import { useVirtualizedInfiniteList } from "@/hooks/use-virtualized-infinite-lis
 import { cn } from "@/lib/utils";
 import type { AuditCategory, AuditLogRow } from "@/types/audit-log";
 import { AuditLogDetailSheet } from "./audit-log-detail-sheet";
+import { getAuditActionLabel, getAuditCategoryLabel } from "./audit-log-labels";
 
 const BATCH_SIZE = 50;
 const ROW_HEIGHT = 56;
@@ -109,21 +110,11 @@ export function AuditLogsView() {
   };
 
   const categoryLabel = (cat: string) => {
-    const key = `categories.${cat}` as const;
-    try {
-      return t(key);
-    } catch {
-      return cat;
-    }
+    return getAuditCategoryLabel(t, cat);
   };
 
   const actionLabel = (actionType: string) => {
-    const key = `actions.${actionType}` as const;
-    try {
-      return t(key);
-    } catch {
-      return actionType;
-    }
+    return getAuditActionLabel(t, actionType);
   };
 
   return (

--- a/src/app/[locale]/dashboard/audit-logs/_components/audit-logs-view.tsx
+++ b/src/app/[locale]/dashboard/audit-logs/_components/audit-logs-view.tsx
@@ -7,6 +7,10 @@ import { useCallback, useMemo, useState } from "react";
 import { getAuditLogsBatch } from "@/actions/audit-logs";
 import { IpDetailsDialog } from "@/app/[locale]/dashboard/_components/ip-details-dialog";
 import { IpDisplayTrigger } from "@/app/[locale]/dashboard/_components/ip-display-trigger";
+import {
+  getAuditActionLabel,
+  getAuditCategoryLabel,
+} from "@/app/[locale]/dashboard/audit-logs/_components/audit-log-labels";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { RelativeTime } from "@/components/ui/relative-time";
@@ -21,7 +25,6 @@ import { useVirtualizedInfiniteList } from "@/hooks/use-virtualized-infinite-lis
 import { cn } from "@/lib/utils";
 import type { AuditCategory, AuditLogRow } from "@/types/audit-log";
 import { AuditLogDetailSheet } from "./audit-log-detail-sheet";
-import { getAuditActionLabel, getAuditCategoryLabel } from "./audit-log-labels";
 
 const BATCH_SIZE = 50;
 const ROW_HEIGHT = 56;

--- a/tests/unit/i18n/audit-log-actions-messages.test.ts
+++ b/tests/unit/i18n/audit-log-actions-messages.test.ts
@@ -1,0 +1,101 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+const REPO_ROOT = process.cwd();
+const LOCALES = ["en", "zh-CN", "zh-TW", "ja", "ru"] as const;
+
+function walkFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = path.join(dir, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      results.push(...walkFiles(fullPath));
+    } else {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function getDirectDottedKeys(record: Record<string, unknown>): string[] {
+  const dotted: string[] = [];
+  for (const [key, value] of Object.entries(record)) {
+    if (key.includes(".")) {
+      dotted.push(key);
+    }
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      dotted.push(...getDirectDottedKeys(value as Record<string, unknown>));
+    }
+  }
+  return dotted;
+}
+
+function flattenLeafKeys(record: Record<string, unknown>, prefix = ""): string[] {
+  const keys: string[] = [];
+  for (const [key, value] of Object.entries(record)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      keys.push(...flattenLeafKeys(value as Record<string, unknown>, fullKey));
+    } else {
+      keys.push(fullKey);
+    }
+  }
+  return keys;
+}
+
+function collectEmittedAuditActionTypes(): string[] {
+  const srcRoot = path.join(REPO_ROOT, "src");
+  const files = walkFiles(srcRoot).filter((file) => file.endsWith(".ts") || file.endsWith(".tsx"));
+  const actions = new Set<string>();
+
+  const patterns = [
+    /emitActionAudit\(\s*\{[\s\S]*?action:\s*"([^"]+)"/g,
+    /createAuditLogAsync\(\s*\{[\s\S]*?actionType:\s*"([^"]+)"/g,
+  ];
+
+  for (const file of files) {
+    const content = readFileSync(file, "utf8");
+    for (const pattern of patterns) {
+      let match: RegExpExecArray | null;
+      pattern.lastIndex = 0;
+      while ((match = pattern.exec(content)) !== null) {
+        actions.add(match[1]);
+      }
+    }
+  }
+
+  return [...actions].sort();
+}
+
+function readLocaleActionTree(locale: (typeof LOCALES)[number]): Record<string, unknown> {
+  const file = path.join(REPO_ROOT, "messages", locale, "auditLogs.json");
+  const parsed = JSON.parse(readFileSync(file, "utf8")) as { actions: Record<string, unknown> };
+  return parsed.actions;
+}
+
+describe("audit log action messages", () => {
+  test("store actions in nested objects instead of dotted leaf keys", () => {
+    for (const locale of LOCALES) {
+      const dottedKeys = getDirectDottedKeys(readLocaleActionTree(locale));
+      expect(dottedKeys, `${locale} should not contain dotted direct keys under actions`).toEqual(
+        []
+      );
+    }
+  });
+
+  test("stay in sync across locales and cover every emitted audit action type", () => {
+    const canonicalKeys = flattenLeafKeys(readLocaleActionTree("en")).sort();
+    const emittedKeys = collectEmittedAuditActionTypes();
+
+    expect(canonicalKeys).toEqual(emittedKeys);
+
+    for (const locale of LOCALES) {
+      expect(
+        flattenLeafKeys(readLocaleActionTree(locale)).sort(),
+        `${locale} action keys drifted`
+      ).toEqual(canonicalKeys);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- fix audit log action i18n lookups by moving `auditLogs.actions` to nested locale objects that `next-intl` can resolve
- route both audit log UI surfaces through a shared action/category label helper that uses `t.has(...)` before translating
- add regression tests for translated action rendering, raw-action fallback, and locale/action coverage drift

## Verification
- `bun run build`
- `bun run lint`
- `bun run lint:fix`
- `bun run typecheck`
- `bun run test`
- `bunx vitest run 'src/app/[locale]/dashboard/audit-logs/_components/audit-log-detail-sheet.test.tsx' 'tests/unit/i18n/audit-log-actions-messages.test.ts'`

## UI Verification
- Component-level browser verification of the real `AuditLogDetailSheet` rendering with `login.success` sample data and production locale messages.
- Local full-page runtime screenshot was not used because this checkout has no local `DSN` / `REDIS_URL` runtime configured.

![Audit log i18n verification](https://i.111666.best/image/9PrrbUMUtLUsKtBPrLQOOf.png)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `next-intl` could not resolve audit-log action labels stored as flat dotted keys (e.g. `"login.success": "..."`) by restructuring all five locale files into proper nested objects and routing both UI surfaces through a new shared `getAuditActionLabel` / `getAuditCategoryLabel` helper that guards with `t.has()` before translating. New tests cover correct translation, raw-action fallback, and cross-locale key sync.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — the fix is correct, well-tested, and all five locales are consistent.

The root cause (flat dotted keys unresolvable by next-intl) is addressed correctly by nesting the messages and using t.has() guards. All five locale files are updated consistently, both UI surfaces route through the shared helper, and new tests cover translation, fallback, and cross-locale drift. No P0 or P1 findings were identified.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/audit-logs/_components/audit-log-labels.ts | New shared helper; correctly uses t.has() guard before resolving dotted action paths into next-intl's nested message tree. |
| messages/en/auditLogs.json | Restructured actions from flat dotted keys to properly nested objects; all leaf keys present and consistent with other locales. |
| src/app/[locale]/dashboard/audit-logs/_components/audit-log-detail-sheet.tsx | Updated to use shared label helpers; category and action labels now resolved through t.has() guard, removing direct inline t() calls for dynamic keys. |
| src/app/[locale]/dashboard/audit-logs/_components/audit-logs-view.tsx | Updated to use shared label helpers for both category and action columns; logic is clean and consistent with the detail sheet. |
| tests/unit/i18n/audit-log-actions-messages.test.ts | Drift-guard test: verifies no dotted-key regressions, bidirectional sync across all five locales, and coverage of every emitted action type found via static regex scan. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[actionType from DB] --> B[getAuditActionLabel]
    B --> C[Build key with actions prefix]
    C --> D{t.has check}
    D -- found --> E[Return translated string]
    D -- missing --> F[Return raw actionType]
    E --> G[UI renders label]
    F --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: align audit log imports with alias ..."](https://github.com/ding113/claude-code-hub/commit/d236ce5b3acb08896caf427292acb76b775c7bef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28943124)</sub>

<!-- /greptile_comment -->