### PR TITLE
fix: stop stale long-context surcharge behavior

### DIFF
--- a/src/lib/special-attributes/index.ts
+++ b/src/lib/special-attributes/index.ts
@@ -15,9 +15,10 @@
 export const CONTEXT_1M_TOKEN_THRESHOLD = 200000;
 
 /**
- * Pricing multipliers for tokens exceeding the threshold
- * - Input: 2x ($3/MTok -> $6/MTok for tokens >200k)
- * - Output: 1.5x ($15/MTok -> $22.50/MTok for tokens >200k)
+ * Legacy 1M context premium multipliers.
+ *
+ * 保留这些常量仅用于兼容旧数据/旧文档引用；当前成本计算已不再直接
+ * 依赖本地硬编码倍数，而是以云端价格表中的显式长上下文字段为准。
  */
 export const CONTEXT_1M_INPUT_PREMIUM_MULTIPLIER = 2.0;
 export const CONTEXT_1M_OUTPUT_PREMIUM_MULTIPLIER = 1.5;

--- a/src/lib/utils/cost-calculation.ts
+++ b/src/lib/utils/cost-calculation.ts
@@ -797,7 +797,7 @@ export function calculateRequestCost(
   // 检查是否有 200K 分层的缓存价格
   // 注意：只有当价格表中的原始基础价格存在时才启用分层计费，避免派生价格与分层价格混用导致误计费
 
-  // 缓存创建费用（5分钟 TTL）：优先级 explicit long-context > context1m fallback > 普通
+  // 缓存创建费用（5分钟 TTL）：优先级 explicit long-context > 显式分层价格 > 普通
   if (
     longContextPricing &&
     longContextPricing.cacheCreationInputTokenCost != null &&
@@ -815,7 +815,7 @@ export function calculateRequestCost(
     segments.push(multiplyCost(cache5mTokens, cacheCreation5mCost));
   }
 
-  // 缓存创建费用（1小时 TTL）：优先级 explicit long-context > context1m fallback > 普通
+  // 缓存创建费用（1小时 TTL）：优先级 explicit long-context > 显式分层价格 > 普通
   if (
     longContextPricing &&
     longContextPricing.cacheCreationInputTokenCostAbove1hr != null &&

--- a/src/lib/utils/cost-calculation.ts
+++ b/src/lib/utils/cost-calculation.ts
@@ -1,8 +1,4 @@
-import {
-  CONTEXT_1M_INPUT_PREMIUM_MULTIPLIER,
-  CONTEXT_1M_OUTPUT_PREMIUM_MULTIPLIER,
-  CONTEXT_1M_TOKEN_THRESHOLD,
-} from "@/lib/special-attributes";
+import { CONTEXT_1M_TOKEN_THRESHOLD } from "@/lib/special-attributes";
 import type { ModelPriceData } from "@/types/model-price";
 import { COST_SCALE, Decimal, toDecimal } from "./currency";
 
@@ -113,62 +109,6 @@ function multiplyCost(quantity: number | undefined, unitCost: number | undefined
   }
 
   return qtyDecimal.mul(costDecimal);
-}
-
-/**
- * 计算阶梯定价费用（用于1M上下文窗口）
- * 超过阈值的token使用溢价费率
- * @param tokens - token数量
- * @param baseCostPerToken - 基础单价
- * @param premiumMultiplier - 溢价倍数
- * @param threshold - 阈值（默认200k）
- * @returns 费用
- */
-function _calculateTieredCost(
-  tokens: number,
-  baseCostPerToken: number,
-  premiumMultiplier: number,
-  threshold: number = CONTEXT_1M_TOKEN_THRESHOLD
-): Decimal {
-  if (tokens <= 0) {
-    return new Decimal(0);
-  }
-
-  const baseCostDecimal = new Decimal(baseCostPerToken);
-
-  if (tokens <= threshold) {
-    return new Decimal(tokens).mul(baseCostDecimal);
-  }
-
-  return new Decimal(tokens).mul(baseCostDecimal).mul(premiumMultiplier);
-}
-
-/**
- * 使用独立价格字段计算分层费用（适用于 Gemini 等模型）
- * @param tokens - token 数量
- * @param baseCostPerToken - 基础单价（<=200K 部分）
- * @param premiumCostPerToken - 溢价单价（>200K 部分）
- * @param threshold - 阈值（默认 200K）
- * @returns 费用
- */
-function __calculateTieredCostWithSeparatePrices(
-  tokens: number,
-  baseCostPerToken: number,
-  premiumCostPerToken: number,
-  threshold: number = CONTEXT_1M_TOKEN_THRESHOLD
-): Decimal {
-  if (tokens <= 0) {
-    return new Decimal(0);
-  }
-
-  const baseCostDecimal = new Decimal(baseCostPerToken);
-  const premiumCostDecimal = new Decimal(premiumCostPerToken);
-
-  if (tokens <= threshold) {
-    return new Decimal(tokens).mul(baseCostDecimal);
-  }
-
-  return new Decimal(tokens).mul(premiumCostDecimal);
 }
 
 function resolveLongContextThreshold(priceData: ModelPriceData): number {
@@ -567,16 +507,6 @@ export function calculateRequestCostBreakdown(
     usage.input_tokens != null
   ) {
     inputBucket = inputBucket.add(multiplyCost(usage.input_tokens, inputAboveThreshold));
-  } else if (
-    longContextThresholdExceeded &&
-    options.context1mApplied &&
-    !options.priorityServiceTierApplied &&
-    inputCostPerToken != null &&
-    usage.input_tokens != null
-  ) {
-    inputBucket = inputBucket.add(
-      multiplyCost(usage.input_tokens, inputCostPerToken * CONTEXT_1M_INPUT_PREMIUM_MULTIPLIER)
-    );
   } else {
     inputBucket = inputBucket.add(multiplyCost(usage.input_tokens, inputCostPerToken));
   }
@@ -597,16 +527,6 @@ export function calculateRequestCostBreakdown(
     usage.output_tokens != null
   ) {
     outputBucket = outputBucket.add(multiplyCost(usage.output_tokens, outputAboveThreshold));
-  } else if (
-    longContextThresholdExceeded &&
-    options.context1mApplied &&
-    !options.priorityServiceTierApplied &&
-    outputCostPerToken != null &&
-    usage.output_tokens != null
-  ) {
-    outputBucket = outputBucket.add(
-      multiplyCost(usage.output_tokens, outputCostPerToken * CONTEXT_1M_OUTPUT_PREMIUM_MULTIPLIER)
-    );
   } else {
     outputBucket = outputBucket.add(multiplyCost(usage.output_tokens, outputCostPerToken));
   }
@@ -631,16 +551,6 @@ export function calculateRequestCostBreakdown(
     cacheCreation5mBucket = cacheCreation5mBucket.add(
       multiplyCost(cache5mTokens, cacheCreationAboveThreshold)
     );
-  } else if (
-    longContextThresholdExceeded &&
-    options.context1mApplied &&
-    !options.priorityServiceTierApplied &&
-    cacheCreation5mCost != null &&
-    cache5mTokens != null
-  ) {
-    cacheCreation5mBucket = cacheCreation5mBucket.add(
-      multiplyCost(cache5mTokens, cacheCreation5mCost * CONTEXT_1M_INPUT_PREMIUM_MULTIPLIER)
-    );
   } else {
     cacheCreation5mBucket = cacheCreation5mBucket.add(
       multiplyCost(cache5mTokens, cacheCreation5mCost)
@@ -664,16 +574,6 @@ export function calculateRequestCostBreakdown(
   ) {
     cacheCreation1hBucket = cacheCreation1hBucket.add(
       multiplyCost(cache1hTokens, cacheCreation1hAboveThreshold)
-    );
-  } else if (
-    longContextThresholdExceeded &&
-    options.context1mApplied &&
-    !options.priorityServiceTierApplied &&
-    cacheCreation1hCost != null &&
-    cache1hTokens != null
-  ) {
-    cacheCreation1hBucket = cacheCreation1hBucket.add(
-      multiplyCost(cache1hTokens, cacheCreation1hCost * CONTEXT_1M_INPUT_PREMIUM_MULTIPLIER)
     );
   } else {
     cacheCreation1hBucket = cacheCreation1hBucket.add(
@@ -737,7 +637,7 @@ export function calculateRequestCostBreakdown(
  * @param usage - token使用量
  * @param priceData - 模型价格数据
  * @param multiplier - 成本倍率（默认 1.0，表示官方价格）
- * @param context1mApplied - 是否应用了1M上下文窗口（启用阶梯定价）
+ * @param context1mApplied - 是否应用了1M上下文窗口（保留兼容；不再单独触发本地硬编码加价）
  * @returns 费用（美元），保留 15 位小数
  */
 export function calculateRequestCost(
@@ -872,16 +772,6 @@ export function calculateRequestCost(
     usage.input_tokens != null
   ) {
     segments.push(multiplyCost(usage.input_tokens, inputAboveThreshold));
-  } else if (
-    longContextThresholdExceeded &&
-    options.context1mApplied &&
-    !options.priorityServiceTierApplied &&
-    inputCostPerToken != null &&
-    usage.input_tokens != null
-  ) {
-    segments.push(
-      multiplyCost(usage.input_tokens, inputCostPerToken * CONTEXT_1M_INPUT_PREMIUM_MULTIPLIER)
-    );
   } else {
     segments.push(multiplyCost(usage.input_tokens, inputCostPerToken));
   }
@@ -899,16 +789,6 @@ export function calculateRequestCost(
     usage.output_tokens != null
   ) {
     segments.push(multiplyCost(usage.output_tokens, outputAboveThreshold));
-  } else if (
-    longContextThresholdExceeded &&
-    options.context1mApplied &&
-    !options.priorityServiceTierApplied &&
-    outputCostPerToken != null &&
-    usage.output_tokens != null
-  ) {
-    segments.push(
-      multiplyCost(usage.output_tokens, outputCostPerToken * CONTEXT_1M_OUTPUT_PREMIUM_MULTIPLIER)
-    );
   } else {
     segments.push(multiplyCost(usage.output_tokens, outputCostPerToken));
   }
@@ -931,16 +811,6 @@ export function calculateRequestCost(
     cache5mTokens != null
   ) {
     segments.push(multiplyCost(cache5mTokens, cacheCreationAboveThreshold));
-  } else if (
-    longContextThresholdExceeded &&
-    options.context1mApplied &&
-    !options.priorityServiceTierApplied &&
-    cacheCreation5mCost != null &&
-    cache5mTokens != null
-  ) {
-    segments.push(
-      multiplyCost(cache5mTokens, cacheCreation5mCost * CONTEXT_1M_INPUT_PREMIUM_MULTIPLIER)
-    );
   } else {
     segments.push(multiplyCost(cache5mTokens, cacheCreation5mCost));
   }
@@ -961,16 +831,6 @@ export function calculateRequestCost(
     cache1hTokens != null
   ) {
     segments.push(multiplyCost(cache1hTokens, cacheCreation1hAboveThreshold));
-  } else if (
-    longContextThresholdExceeded &&
-    options.context1mApplied &&
-    !options.priorityServiceTierApplied &&
-    cacheCreation1hCost != null &&
-    cache1hTokens != null
-  ) {
-    segments.push(
-      multiplyCost(cache1hTokens, cacheCreation1hCost * CONTEXT_1M_INPUT_PREMIUM_MULTIPLIER)
-    );
   } else {
     segments.push(multiplyCost(cache1hTokens, cacheCreation1hCost));
   }

--- a/src/lib/utils/pricing-resolution.ts
+++ b/src/lib/utils/pricing-resolution.ts
@@ -37,10 +37,9 @@ export interface ResolvePricingForModelRecordsInput {
   fallbackRecord: ModelPrice | null;
 }
 
-const DETAIL_FIELDS = [
+const PROVIDER_DETAIL_FIELDS = [
   "input_cost_per_token",
   "output_cost_per_token",
-  "input_cost_per_request",
   "cache_creation_input_token_cost",
   "cache_creation_input_token_cost_above_1hr",
   "cache_read_input_token_cost",
@@ -67,8 +66,9 @@ const DETAIL_FIELDS = [
   "input_cost_per_image",
   "output_cost_per_image_token",
   "input_cost_per_image_token",
-  "long_context_pricing",
 ] as const;
+
+const DETAIL_SCORE_OBJECT_FIELDS = ["long_context_pricing"] as const;
 
 const DETAIL_TIE_BREAK_ORDER = [
   "openrouter",
@@ -205,7 +205,7 @@ function mergePriceData(
   // 再叠加当前 provider 的 pricing 节点，避免把别家 above_200k/272k
   // 等字段残留到当前解析结果里。
   const clearedBase: ModelPriceData = { ...base };
-  for (const field of DETAIL_FIELDS) {
+  for (const field of PROVIDER_DETAIL_FIELDS) {
     delete clearedBase[field];
   }
 
@@ -218,10 +218,20 @@ function mergePriceData(
 }
 
 function getDetailScore(pricingNode: Record<string, unknown>): number {
-  return DETAIL_FIELDS.reduce((score, field) => {
+  const numericScore = PROVIDER_DETAIL_FIELDS.reduce((score, field) => {
     const value = pricingNode[field];
     return typeof value === "number" && Number.isFinite(value) ? score + 1 : score;
   }, 0);
+
+  const objectScore = DETAIL_SCORE_OBJECT_FIELDS.reduce((score, field) => {
+    const value = pricingNode[field];
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return score;
+    }
+    return Object.keys(value).length > 0 ? score + 1 : score;
+  }, 0);
+
+  return numericScore + objectScore;
 }
 
 function compareDetailKeys(

--- a/src/lib/utils/pricing-resolution.ts
+++ b/src/lib/utils/pricing-resolution.ts
@@ -65,6 +65,9 @@ const DETAIL_FIELDS = [
   "cache_read_input_token_cost_priority",
   "output_cost_per_image",
   "input_cost_per_image",
+  "output_cost_per_image_token",
+  "input_cost_per_image_token",
+  "long_context_pricing",
 ] as const;
 
 const DETAIL_TIE_BREAK_ORDER = [
@@ -198,8 +201,16 @@ function mergePriceData(
       : { ...base };
   }
 
+  // 价格节点切换时，先清空上一 provider 遗留的明细价格字段，
+  // 再叠加当前 provider 的 pricing 节点，避免把别家 above_200k/272k
+  // 等字段残留到当前解析结果里。
+  const clearedBase: ModelPriceData = { ...base };
+  for (const field of DETAIL_FIELDS) {
+    delete clearedBase[field];
+  }
+
   return {
-    ...base,
+    ...clearedBase,
     ...pricingNode,
     pricing: base.pricing,
     selected_pricing_provider: pricingProviderKey,

--- a/tests/unit/lib/cost-calculation-breakdown.test.ts
+++ b/tests/unit/lib/cost-calculation-breakdown.test.ts
@@ -75,7 +75,7 @@ describe("calculateRequestCostBreakdown", () => {
     expect(result.output).toBeCloseTo(0.01075, 6);
   });
 
-  test("tiered pricing with context1mApplied", () => {
+  test("context1mApplied alone does not change breakdown without explicit long-context price fields", () => {
     const result = calculateRequestCostBreakdown(
       {
         input_tokens: 300000, // crosses 200k threshold
@@ -85,10 +85,8 @@ describe("calculateRequestCostBreakdown", () => {
       true // context1mApplied
     );
 
-    // input: 300000 * 0.000003 * 2.0 = 1.8 (all tokens at premium when context > 200K)
-    expect(result.input).toBeCloseTo(1.8, 4);
-    // output: 100 * 0.000015 * 1.5 = 0.00225 (output also at premium when context > 200K)
-    expect(result.output).toBeCloseTo(0.00225, 6);
+    expect(result.input).toBeCloseTo(0.9, 6);
+    expect(result.output).toBeCloseTo(0.0015, 6);
   });
 
   test("200k tier pricing (Gemini style)", () => {

--- a/tests/unit/lib/cost-calculation-long-context.test.ts
+++ b/tests/unit/lib/cost-calculation-long-context.test.ts
@@ -43,4 +43,23 @@ describe("calculateRequestCost long-context", () => {
 
     expect(Number(cost.toString())).toBe(0.63);
   });
+
+  test("context1mApplied alone does not trigger legacy anthropic premium without explicit long-context price fields", () => {
+    const cost = calculateRequestCost(
+      {
+        input_tokens: 250001,
+        output_tokens: 100,
+      },
+      {
+        mode: "chat",
+        model_family: "claude-sonnet",
+        input_cost_per_token: 0.000003,
+        output_cost_per_token: 0.000015,
+      },
+      1,
+      true
+    );
+
+    expect(Number(cost.toString())).toBeCloseTo(0.751503, 9);
+  });
 });

--- a/tests/unit/lib/utils/pricing-resolution.test.ts
+++ b/tests/unit/lib/utils/pricing-resolution.test.ts
@@ -143,4 +143,46 @@ describe("resolvePricingForModelRecords", () => {
     expect(resolved?.priceData.input_cost_per_token).toBe(0.0000099);
     expect(resolved?.resolvedPricingProviderKey).toBe("manual-custom");
   });
+
+  test("official anthropic fallback clears stale long-context fields from unrelated provider top-level data", () => {
+    const cloudRecord = makeRecord("claude-sonnet-4-6", {
+      mode: "chat",
+      model_family: "claude-sonnet",
+      litellm_provider: "bedrock_converse",
+      input_cost_per_token: 0.000003,
+      output_cost_per_token: 0.000015,
+      input_cost_per_token_above_200k_tokens: 0.000006,
+      output_cost_per_token_above_200k_tokens: 0.0000225,
+      pricing: {
+        anthropic: {
+          input_cost_per_token: 0.000003,
+          output_cost_per_token: 0.000015,
+        },
+        openrouter: {
+          input_cost_per_token: 0.000003,
+          output_cost_per_token: 0.000015,
+          input_cost_per_token_above_200k_tokens: 0.000006,
+          output_cost_per_token_above_200k_tokens: 0.0000225,
+        },
+      },
+    });
+
+    const resolved = resolvePricingForModelRecords({
+      provider: {
+        id: 3,
+        name: "Anthropic",
+        url: "https://api.anthropic.com/v1/messages",
+      } as never,
+      primaryModelName: "claude-sonnet-4-6",
+      fallbackModelName: null,
+      primaryRecord: cloudRecord,
+      fallbackRecord: null,
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.resolvedPricingProviderKey).toBe("anthropic");
+    expect(resolved?.priceData.input_cost_per_token).toBe(0.000003);
+    expect(resolved?.priceData.input_cost_per_token_above_200k_tokens).toBeUndefined();
+    expect(resolved?.priceData.output_cost_per_token_above_200k_tokens).toBeUndefined();
+  });
 });

--- a/tests/unit/lib/utils/pricing-resolution.test.ts
+++ b/tests/unit/lib/utils/pricing-resolution.test.ts
@@ -168,11 +168,7 @@ describe("resolvePricingForModelRecords", () => {
     });
 
     const resolved = resolvePricingForModelRecords({
-      provider: {
-        id: 3,
-        name: "Anthropic",
-        url: "https://api.anthropic.com/v1/messages",
-      } as never,
+      provider: null,
       primaryModelName: "claude-sonnet-4-6",
       fallbackModelName: null,
       primaryRecord: cloudRecord,
@@ -180,9 +176,53 @@ describe("resolvePricingForModelRecords", () => {
     });
 
     expect(resolved).not.toBeNull();
+    expect(resolved?.source).toBe("official_fallback");
     expect(resolved?.resolvedPricingProviderKey).toBe("anthropic");
     expect(resolved?.priceData.input_cost_per_token).toBe(0.000003);
     expect(resolved?.priceData.input_cost_per_token_above_200k_tokens).toBeUndefined();
     expect(resolved?.priceData.output_cost_per_token_above_200k_tokens).toBeUndefined();
+  });
+
+  test("provider merge keeps shared top-level request fees and long_context_pricing", () => {
+    const cloudRecord = makeRecord("gpt-5.4", {
+      mode: "responses",
+      model_family: "gpt",
+      litellm_provider: "azure",
+      input_cost_per_request: 0.123,
+      long_context_pricing: {
+        threshold_tokens: 272000,
+        input_cost_per_token: 0.000005,
+      },
+      pricing: {
+        openai: {
+          input_cost_per_token: 0.0000025,
+          output_cost_per_token: 0.000015,
+        },
+        azure: {
+          input_cost_per_token: 0.0000027,
+          output_cost_per_token: 0.000016,
+        },
+      },
+    });
+
+    const resolved = resolvePricingForModelRecords({
+      provider: {
+        id: 4,
+        name: "OpenAI",
+        url: "https://api.openai.com/v1/responses",
+      } as never,
+      primaryModelName: "gpt-5.4",
+      fallbackModelName: null,
+      primaryRecord: cloudRecord,
+      fallbackRecord: null,
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.resolvedPricingProviderKey).toBe("openai");
+    expect(resolved?.priceData.input_cost_per_request).toBe(0.123);
+    expect(resolved?.priceData.long_context_pricing).toEqual({
+      threshold_tokens: 272000,
+      input_cost_per_token: 0.000005,
+    });
   });
 });


### PR DESCRIPTION
## Summary
This PR eliminates stale long-context surcharge behaviors that were causing incorrect cost calculations for Claude models. It removes the legacy local 1M fallback multiplier, prevents provider-specific long-context fields from leaking across pricing nodes during resolution, and adds regression tests to ensure accurate billing.

## Problem

**Related Issues:**
- **Fixes #955** - Nested pricing.anthropic above_200k fields and legacy context1mApplied fallback caused 2x overcharge for Claude models with >200K context

### Root Cause Analysis

Modern Claude models (opus-4-6, sonnet-4-6, sonnet-4-5, etc.) have **flat pricing regardless of context length**, but the cost calculation had two stale behaviors causing overcharges:

1. **Legacy context1mApplied fallback (P3 path)**: When `context1mApplied=true` and tokens exceeded 200K threshold, hardcoded multipliers (2x input, 1.5x output) were applied even when explicit long-context price fields didn't exist. This was designed for legacy Claude 3 models but incorrectly applied to modern flat-pricing models.

2. **Stale provider field leakage**: When resolving pricing nodes in multi-provider models, provider-specific long-context fields (e.g., `input_cost_per_token_above_200k_tokens` from OpenRouter) could persist into resolved price data even when switching to a different provider (e.g., Anthropic) that shouldn't have those fields.

The cost calculation priority chain was:
- P1: `longContextPricing` - explicit config (rarely used)
- P2: `inputAboveThreshold` - above_200k/272k fields (could be stale)
- P3: `context1mApplied` - hardcoded 2x/1.5x fallback (**REMOVED in this PR**)
- P4: Standard rate

**Impact:**
- Affected models: All Claude models when using 1M context window (>200K tokens)
- Overcharge rate: Up to 100% (2x cost) for input/cache tokens, ~50% for output tokens
- Trigger: Any request with `context1mApplied=true` exceeding 200K total input context

## Solution

### Core Changes

1. **Removed legacy P3 fallback** (`src/lib/utils/cost-calculation.ts`)
   - Eliminated all `context1mApplied && longContextThresholdExceeded` fallback branches
   - Removed 140+ lines of dead code for `_calculateTieredCost` and `__calculateTieredCostWithSeparatePrices` helper functions
   - Now only explicit long-context price fields (P1/P2 paths) trigger premium pricing
   - Constants `CONTEXT_1M_INPUT_PREMIUM_MULTIPLIER` and `CONTEXT_1M_OUTPUT_PREMIUM_MULTIPLIER` retained for backward compatibility with existing data/documentation only

2. **Fixed provider field leakage** (`src/lib/utils/pricing-resolution.ts`)
   - Added field clearing logic before merging pricing nodes
   - `DETAIL_FIELDS` array now includes all provider-specific fields (`above_200k`, `above_272k`, `long_context_pricing`, image costs, etc.)
   - When switching pricing providers, stale long-context fields are explicitly cleared before applying the new provider's pricing node
   - Prevents cross-provider contamination in multi-provider model resolution

### Supporting Changes

- **Test updates** (`tests/unit/lib/cost-calculation-breakdown.test.ts`, `cost-calculation-long-context.test.ts`)
  - Updated tiered pricing test expectations to reflect corrected behavior
  - Added regression test: "context1mApplied alone does not trigger legacy anthropic premium without explicit long-context price fields"
  - Verified cost for 250K input tokens now calculates at base rate (~$0.75) instead of inflated premium (~$1.50)

- **Pricing resolution tests** (`tests/unit/lib/utils/pricing-resolution.test.ts`)
  - Added test: "official anthropic fallback clears stale long-context fields from unrelated provider top-level data"
  - Validates that Bedrock/OpenRouter `above_200k` fields don't persist when resolving to Anthropic pricing

## Changes

| File | Change |
|------|--------|
| `src/lib/utils/cost-calculation.ts` | Removed legacy context1mApplied fallback paths (142 lines deleted); updated comments |
| `src/lib/utils/pricing-resolution.ts` | Added field clearing for DETAIL_FIELDS during merge (12 lines added) |
| `src/lib/special-attributes/index.ts` | Updated comments to mark premium multipliers as legacy-only |
| `tests/unit/lib/cost-calculation-breakdown.test.ts` | Updated test expectations for corrected tiered pricing |
| `tests/unit/lib/cost-calculation-long-context.test.ts` | Added regression test for context1mApplied behavior |
| `tests/unit/lib/utils/pricing-resolution.test.ts` | Added regression test for stale field clearing |

## Breaking Changes

**Cost calculation behavior change** - This is an intentional fix that reduces costs:

| Scenario | Before (Bug) | After (Correct) | Change |
|----------|--------------|-----------------|--------|
| 250K input tokens, no explicit above_200k fields, context1mApplied=true | ~$1.50 (2x premium) | ~$0.75 (base rate) | **-50%** |
| 300K output tokens, no explicit above_200k fields, context1mApplied=true | ~$6.75 (1.5x premium) | ~$4.50 (base rate) | **-33%** |

**Administrators should verify:**
- Manual price records with explicit `above_200k` fields are unaffected (P2 path still works)
- Cloud price records relying on `context1mApplied` behavior will now correctly use base rates
- Any billing alerts/dashboards that assumed the old 2x/1.5x multipliers need updating

## Testing

### Automated Tests
- [x] Unit test: context1mApplied alone does not trigger premium without explicit long-context fields
- [x] Unit test: Stale provider fields cleared when resolving pricing nodes
- [x] Updated test: Tiered pricing expectations corrected

### Verification Commands (Pre-commit Checklist)
```bash
bun run build      # Production build
bun run lint       # Biome linting
bun run lint:fix   # Biome auto-fix
bun run typecheck  # TypeScript checking
bun run test       # Run all tests
```

### Manual Testing
For deployments with custom manual pricing:
1. Create a test request with >200K tokens and context1mApplied
2. Verify cost calculates at base rate (not 2x)
3. Check logs show correct pricing without "premium" annotations

## Checklist
- [x] Code follows project conventions (Biome formatting)
- [x] Self-review completed
- [x] Tests pass locally (Vitest)
- [x] TypeScript type checking passes (tsgo)
- [x] Breaking changes assessed and documented
- [x] Pre-commit verification commands executed

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the legacy `context1mApplied` hardcoded 2×/1.5× premium fallback from cost calculation and adds field-clearing logic to `mergePriceData` to prevent stale provider-specific long-context fields from leaking across pricing nodes. The fix is well-scoped, covered by regression tests, and correctly resolves a real billing overcharge for flat-rate Claude models using 1M context windows.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is correct, well-tested, and intentionally reduces billing overcharges; no blocking issues remain.

All prior P2 concerns (context1mApplied as a no-op in the interface; resolveTopLevel not clearing fields) were raised in previous reviews and are pre-existing non-blocking notes. No new P0/P1 issues found. The implementation is clean, the regression tests are thorough, and the field-clearing logic is correctly scoped to non-null pricingNode merges only.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/utils/cost-calculation.ts | Removed 140+ lines of legacy P3 context1mApplied fallback; pricing now relies exclusively on explicit P1 (longContextPricing) or P2 (above_200k/272k fields) paths. context1mApplied is preserved in the interface for backward compatibility but is no longer read during cost calculation. |
| src/lib/utils/pricing-resolution.ts | Added PROVIDER_DETAIL_FIELDS constant and clearing loop in mergePriceData for non-null pricingNodes; base/shared fields (input_cost_per_request, long_context_pricing) are intentionally excluded from clearing and preserved during merge. resolveTopLevel/resolveManualPricing still pass null and do not clear fields — a known pre-existing edge case. |
| src/lib/special-attributes/index.ts | CONTEXT_1M_INPUT_PREMIUM_MULTIPLIER and CONTEXT_1M_OUTPUT_PREMIUM_MULTIPLIER are now documented as legacy-only; comment correctly reflects that cost calculation no longer uses them directly. |
| tests/unit/lib/cost-calculation-long-context.test.ts | New regression test confirms context1mApplied alone (no above_200k fields) results in base-rate billing instead of 2× premium; existing tests for explicit tiered pricing remain valid. |
| tests/unit/lib/utils/pricing-resolution.test.ts | New tests verify that stale Bedrock/OpenRouter above_200k fields are cleared when resolving to Anthropic pricing, and that shared fields (input_cost_per_request, long_context_pricing) are preserved during provider merge. |
| tests/unit/lib/cost-calculation-breakdown.test.ts | Updated tiered pricing test expectations to reflect corrected behavior; added regression test confirming context1mApplied alone does not change breakdown when no explicit long-context fields are present. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/utils/pricing-resolution.ts`, line 341-367 ([link](https://github.com/ding113/claude-code-hub/blob/c71db4cabfced0c7becfd93c858297aa6cc95fe0/src/lib/utils/pricing-resolution.ts#L341-L367)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`resolveTopLevel` does not clear stale detail fields**

   `mergePriceData` only clears `DETAIL_FIELDS` when `pricingNode` is non-null. Both `resolveTopLevel` and `resolveManualPricing` pass `null`, so stale provider-specific fields (e.g., `input_cost_per_token_above_200k_tokens` seeded from Bedrock or OpenRouter top-level data) are preserved in the returned `priceData` even after resolving to a different provider label.

   This matters for models whose LiteLLM top-level row carries long-context fields but whose correct provider's pricing node either doesn't exist or can't be matched — `resolveTopLevel` is the last-resort path, and in that case the stale surcharge fields survive. The same clearing logic applied in the `pricingNode != null` branch could be applied here too for correctness, though this is a pre-existing edge case not newly introduced by this PR.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/utils/pricing-resolution.ts
   Line: 341-367

   Comment:
   **`resolveTopLevel` does not clear stale detail fields**

   `mergePriceData` only clears `DETAIL_FIELDS` when `pricingNode` is non-null. Both `resolveTopLevel` and `resolveManualPricing` pass `null`, so stale provider-specific fields (e.g., `input_cost_per_token_above_200k_tokens` seeded from Bedrock or OpenRouter top-level data) are preserved in the returned `priceData` even after resolving to a different provider label.

   This matters for models whose LiteLLM top-level row carries long-context fields but whose correct provider's pricing node either doesn't exist or can't be matched — `resolveTopLevel` is the last-resort path, and in that case the stale surcharge fields survive. The same clearing logic applied in the `pricingNode != null` branch could be applied here too for correctness, though this is a pre-existing edge case not newly introduced by this PR.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/lib/utils/cost-calculation.ts`, line 30-41 ([link](https://github.com/ding113/claude-code-hub/blob/c71db4cabfced0c7becfd93c858297aa6cc95fe0/src/lib/utils/cost-calculation.ts#L30-L41)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`context1mApplied` retained in the public interface but is now a no-op**

   `context1mApplied` is still part of `RequestCostCalculationOptions` and is faithfully passed through `normalizeRequestCostOptions` / `normalizeRequestCostBreakdownOptions`, but `options.context1mApplied` is never read anywhere in `calculateRequestCost` or `calculateRequestCostBreakdown`. Callers who set this flag expecting it to influence cost calculation will silently get no effect. The JSDoc on `calculateRequestCost` mentions "kept for compatibility; no longer triggers local hardcoded premium", which is accurate, but the field on the options interface carries no such warning. Adding a `@deprecated` annotation to the field in the interface (and the JSDoc param) would make the intent clear to future callers.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/utils/cost-calculation.ts
   Line: 30-41

   Comment:
   **`context1mApplied` retained in the public interface but is now a no-op**

   `context1mApplied` is still part of `RequestCostCalculationOptions` and is faithfully passed through `normalizeRequestCostOptions` / `normalizeRequestCostBreakdownOptions`, but `options.context1mApplied` is never read anywhere in `calculateRequestCost` or `calculateRequestCostBreakdown`. Callers who set this flag expecting it to influence cost calculation will silently get no effect. The JSDoc on `calculateRequestCost` mentions "kept for compatibility; no longer triggers local hardcoded premium", which is accurate, but the field on the options interface carries no such warning. Adding a `@deprecated` annotation to the field in the interface (and the JSDoc param) would make the intent clear to future callers.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: preserve shared pricing fields duri..."](https://github.com/ding113/claude-code-hub/commit/b03bf96b2c9e7750b37b4cb0e887bba9861afb0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28962127)</sub>

<!-- /greptile_comment -->