### PR TITLE
fix: preserve extra pricing fields and expose semantic pricing details

### DIFF
--- a/messages/en/settings/prices.json
+++ b/messages/en/settings/prices.json
@@ -214,7 +214,25 @@
     "kindUnsupported": "Review",
     "kindDisplay": "Display",
     "booleanTrue": "Yes",
-    "booleanFalse": "No"
+    "booleanFalse": "No",
+    "fields": {
+      "mode": "Mode",
+      "displayName": "Display name",
+      "litellmProvider": "LiteLLM provider",
+      "selectedPricingProvider": "Selected pricing provider",
+      "selectedPricingSourceModel": "Selected source model",
+      "selectedPricingResolution": "Selected resolution",
+      "maxInputTokens": "Max input tokens",
+      "maxOutputTokens": "Max output tokens",
+      "maxTokens": "Max tokens",
+      "outputVectorSize": "Output vector size",
+      "inputCostPerToken": "Input Cost Per Token",
+      "outputCostPerToken": "Output Cost Per Token",
+      "inputCostPerRequest": "Input Cost Per Request",
+      "outputCostPerImage": "Output Cost Per Image",
+      "inputCostPerSecond": "Input Cost Per Second",
+      "fileSearchCostPer1kCalls": "File Search Cost Per 1k Calls"
+    }
   },
   "toast": {
     "createSuccess": "Model added",

--- a/messages/en/settings/prices.json
+++ b/messages/en/settings/prices.json
@@ -195,7 +195,7 @@
     "cachePricingTitle": "Cache Pricing",
     "advancedFieldsTitle": "Advanced fields",
     "advancedFieldsJson": "Additional price fields JSON",
-    "advancedFieldsPlaceholder": "Example: input_cost_per_second = 0.5",
+    "advancedFieldsPlaceholder": "Example: '{\"input_cost_per_second\": 0.5}'",
     "advancedFieldsHint": "Use a JSON object to store extra cloud or local fields not covered by the basic form."
   },
   "actions": {

--- a/messages/en/settings/prices.json
+++ b/messages/en/settings/prices.json
@@ -192,13 +192,29 @@
     "prefillEmpty": "No matching models found",
     "prefillFailed": "Search failed",
     "promptCachingHint": "Enable if the model supports prompt caching",
-    "cachePricingTitle": "Cache Pricing"
+    "cachePricingTitle": "Cache Pricing",
+    "advancedFieldsTitle": "Advanced fields",
+    "advancedFieldsJson": "Additional price fields JSON",
+    "advancedFieldsPlaceholder": "Example: input_cost_per_second = 0.5",
+    "advancedFieldsHint": "Use a JSON object to store extra cloud or local fields not covered by the basic form."
   },
   "actions": {
     "edit": "Edit",
     "more": "More actions",
     "delete": "Delete",
-    "comparePricing": "Compare pricing"
+    "comparePricing": "Compare pricing",
+    "viewDetails": "View details"
+  },
+  "details": {
+    "coreFieldsTitle": "Core fields",
+    "additionalBillableTitle": "Additional billable fields",
+    "additionalMetadataTitle": "Additional metadata",
+    "providerPricingTitle": "Provider pricing nodes",
+    "kindSupported": "Chargeable",
+    "kindUnsupported": "Review",
+    "kindDisplay": "Display",
+    "booleanTrue": "Yes",
+    "booleanFalse": "No"
   },
   "toast": {
     "createSuccess": "Model added",

--- a/messages/ja/settings/prices.json
+++ b/messages/ja/settings/prices.json
@@ -214,7 +214,25 @@
     "kindUnsupported": "要確認",
     "kindDisplay": "表示のみ",
     "booleanTrue": "はい",
-    "booleanFalse": "いいえ"
+    "booleanFalse": "いいえ",
+    "fields": {
+      "mode": "モード",
+      "displayName": "表示名",
+      "litellmProvider": "LiteLLM プロバイダー",
+      "selectedPricingProvider": "選択中の価格プロバイダー",
+      "selectedPricingSourceModel": "選択元モデル",
+      "selectedPricingResolution": "選択解決方式",
+      "maxInputTokens": "最大入力 Tokens",
+      "maxOutputTokens": "最大出力 Tokens",
+      "maxTokens": "最大 Tokens",
+      "outputVectorSize": "出力ベクトル次元",
+      "inputCostPerToken": "入力 Token 単価",
+      "outputCostPerToken": "出力 Token 単価",
+      "inputCostPerRequest": "リクエスト単価",
+      "outputCostPerImage": "画像出力単価",
+      "inputCostPerSecond": "秒単位入力価格",
+      "fileSearchCostPer1kCalls": "ファイル検索 1k 回あたりの価格"
+    }
   },
   "toast": {
     "createSuccess": "モデルを追加しました",

--- a/messages/ja/settings/prices.json
+++ b/messages/ja/settings/prices.json
@@ -192,13 +192,29 @@
     "prefillEmpty": "一致するモデルが見つかりません",
     "prefillFailed": "検索に失敗しました",
     "promptCachingHint": "モデルがキャッシュに対応している場合のみ有効化し、下のキャッシュ価格を設定してください",
-    "cachePricingTitle": "キャッシュ価格"
+    "cachePricingTitle": "キャッシュ価格",
+    "advancedFieldsTitle": "高度なフィールド",
+    "advancedFieldsJson": "追加価格フィールド JSON",
+    "advancedFieldsPlaceholder": "例: input_cost_per_second = 0.5",
+    "advancedFieldsHint": "基本フォームで扱わないクラウド/ローカル拡張フィールドを JSON オブジェクトで保存します。"
   },
   "actions": {
     "edit": "編集",
     "more": "その他の操作",
     "delete": "削除",
-    "comparePricing": "価格を比較"
+    "comparePricing": "価格を比較",
+    "viewDetails": "詳細を見る"
+  },
+  "details": {
+    "coreFieldsTitle": "主要フィールド",
+    "additionalBillableTitle": "追加の課金フィールド",
+    "additionalMetadataTitle": "追加メタデータ",
+    "providerPricingTitle": "プロバイダー価格ノード",
+    "kindSupported": "課金可能",
+    "kindUnsupported": "要確認",
+    "kindDisplay": "表示のみ",
+    "booleanTrue": "はい",
+    "booleanFalse": "いいえ"
   },
   "toast": {
     "createSuccess": "モデルを追加しました",

--- a/messages/ja/settings/prices.json
+++ b/messages/ja/settings/prices.json
@@ -195,7 +195,7 @@
     "cachePricingTitle": "キャッシュ価格",
     "advancedFieldsTitle": "高度なフィールド",
     "advancedFieldsJson": "追加価格フィールド JSON",
-    "advancedFieldsPlaceholder": "例: input_cost_per_second = 0.5",
+    "advancedFieldsPlaceholder": "例: '{\"input_cost_per_second\": 0.5}'",
     "advancedFieldsHint": "基本フォームで扱わないクラウド/ローカル拡張フィールドを JSON オブジェクトで保存します。"
   },
   "actions": {

--- a/messages/ru/settings/prices.json
+++ b/messages/ru/settings/prices.json
@@ -192,13 +192,29 @@
     "prefillEmpty": "Модели не найдены",
     "prefillFailed": "Ошибка поиска",
     "promptCachingHint": "Включайте только если модель поддерживает кэширование, и задайте цены кэша ниже",
-    "cachePricingTitle": "Цены кэша"
+    "cachePricingTitle": "Цены кэша",
+    "advancedFieldsTitle": "Расширенные поля",
+    "advancedFieldsJson": "JSON дополнительных ценовых полей",
+    "advancedFieldsPlaceholder": "Пример: input_cost_per_second = 0.5",
+    "advancedFieldsHint": "Используйте JSON-объект для сохранения облачных или локальных полей, которых нет в базовой форме."
   },
   "actions": {
     "edit": "Редактировать",
     "more": "Больше действий",
     "delete": "Удалить",
-    "comparePricing": "Сравнить цены"
+    "comparePricing": "Сравнить цены",
+    "viewDetails": "Показать детали"
+  },
+  "details": {
+    "coreFieldsTitle": "Основные поля",
+    "additionalBillableTitle": "Дополнительные тарифицируемые поля",
+    "additionalMetadataTitle": "Дополнительные метаданные",
+    "providerPricingTitle": "Узлы цен провайдеров",
+    "kindSupported": "Тарифицируется",
+    "kindUnsupported": "Требует поддержки",
+    "kindDisplay": "Только показ",
+    "booleanTrue": "Да",
+    "booleanFalse": "Нет"
   },
   "toast": {
     "createSuccess": "Модель добавлена",

--- a/messages/ru/settings/prices.json
+++ b/messages/ru/settings/prices.json
@@ -195,7 +195,7 @@
     "cachePricingTitle": "Цены кэша",
     "advancedFieldsTitle": "Расширенные поля",
     "advancedFieldsJson": "JSON дополнительных ценовых полей",
-    "advancedFieldsPlaceholder": "Пример: input_cost_per_second = 0.5",
+    "advancedFieldsPlaceholder": "Пример: '{\"input_cost_per_second\": 0.5}'",
     "advancedFieldsHint": "Используйте JSON-объект для сохранения облачных или локальных полей, которых нет в базовой форме."
   },
   "actions": {

--- a/messages/ru/settings/prices.json
+++ b/messages/ru/settings/prices.json
@@ -214,7 +214,25 @@
     "kindUnsupported": "Требует поддержки",
     "kindDisplay": "Только показ",
     "booleanTrue": "Да",
-    "booleanFalse": "Нет"
+    "booleanFalse": "Нет",
+    "fields": {
+      "mode": "Режим",
+      "displayName": "Отображаемое имя",
+      "litellmProvider": "Провайдер LiteLLM",
+      "selectedPricingProvider": "Выбранный провайдер цены",
+      "selectedPricingSourceModel": "Выбранная исходная модель",
+      "selectedPricingResolution": "Способ разрешения",
+      "maxInputTokens": "Макс. входные Tokens",
+      "maxOutputTokens": "Макс. выходные Tokens",
+      "maxTokens": "Макс. Tokens",
+      "outputVectorSize": "Размер выходного вектора",
+      "inputCostPerToken": "Цена входного Token",
+      "outputCostPerToken": "Цена выходного Token",
+      "inputCostPerRequest": "Цена за запрос",
+      "outputCostPerImage": "Цена за изображение",
+      "inputCostPerSecond": "Цена за секунду ввода",
+      "fileSearchCostPer1kCalls": "Цена файлового поиска за 1k вызовов"
+    }
   },
   "toast": {
     "createSuccess": "Модель добавлена",

--- a/messages/zh-CN/settings/prices.json
+++ b/messages/zh-CN/settings/prices.json
@@ -192,13 +192,29 @@
     "prefillEmpty": "未找到匹配的模型",
     "prefillFailed": "搜索失败",
     "promptCachingHint": "仅当模型支持缓存时开启，并配置下方缓存价格",
-    "cachePricingTitle": "缓存价格"
+    "cachePricingTitle": "缓存价格",
+    "advancedFieldsTitle": "高级字段",
+    "advancedFieldsJson": "额外价格字段 JSON",
+    "advancedFieldsPlaceholder": "示例：input_cost_per_second = 0.5",
+    "advancedFieldsHint": "使用 JSON 对象保存基础表单未覆盖的云端或本地扩展字段。"
   },
   "actions": {
     "edit": "编辑",
     "more": "更多操作",
     "delete": "删除",
-    "comparePricing": "对比价格"
+    "comparePricing": "对比价格",
+    "viewDetails": "查看详情"
+  },
+  "details": {
+    "coreFieldsTitle": "核心字段",
+    "additionalBillableTitle": "额外计费字段",
+    "additionalMetadataTitle": "额外元数据",
+    "providerPricingTitle": "供应商价格节点",
+    "kindSupported": "可计费",
+    "kindUnsupported": "待支持",
+    "kindDisplay": "仅展示",
+    "booleanTrue": "是",
+    "booleanFalse": "否"
   },
   "toast": {
     "createSuccess": "模型已添加",

--- a/messages/zh-CN/settings/prices.json
+++ b/messages/zh-CN/settings/prices.json
@@ -195,7 +195,7 @@
     "cachePricingTitle": "缓存价格",
     "advancedFieldsTitle": "高级字段",
     "advancedFieldsJson": "额外价格字段 JSON",
-    "advancedFieldsPlaceholder": "示例：input_cost_per_second = 0.5",
+    "advancedFieldsPlaceholder": "示例：'{\"input_cost_per_second\": 0.5}'",
     "advancedFieldsHint": "使用 JSON 对象保存基础表单未覆盖的云端或本地扩展字段。"
   },
   "actions": {

--- a/messages/zh-CN/settings/prices.json
+++ b/messages/zh-CN/settings/prices.json
@@ -214,7 +214,25 @@
     "kindUnsupported": "待支持",
     "kindDisplay": "仅展示",
     "booleanTrue": "是",
-    "booleanFalse": "否"
+    "booleanFalse": "否",
+    "fields": {
+      "mode": "模式",
+      "displayName": "展示名称",
+      "litellmProvider": "LiteLLM 供应商",
+      "selectedPricingProvider": "选中价格提供方",
+      "selectedPricingSourceModel": "选中源模型",
+      "selectedPricingResolution": "选中解析方式",
+      "maxInputTokens": "最大输入 Tokens",
+      "maxOutputTokens": "最大输出 Tokens",
+      "maxTokens": "最大 Tokens",
+      "outputVectorSize": "输出向量维度",
+      "inputCostPerToken": "输入单 Token 价格",
+      "outputCostPerToken": "输出单 Token 价格",
+      "inputCostPerRequest": "按次输入价格",
+      "outputCostPerImage": "按图输出价格",
+      "inputCostPerSecond": "按秒输入价格",
+      "fileSearchCostPer1kCalls": "每千次文件检索价格"
+    }
   },
   "toast": {
     "createSuccess": "模型已添加",

--- a/messages/zh-TW/settings/prices.json
+++ b/messages/zh-TW/settings/prices.json
@@ -192,13 +192,29 @@
     "prefillEmpty": "找不到符合的模型",
     "prefillFailed": "搜尋失敗",
     "promptCachingHint": "僅當模型支援快取時開啟，並配置下方快取價格",
-    "cachePricingTitle": "快取價格"
+    "cachePricingTitle": "快取價格",
+    "advancedFieldsTitle": "進階欄位",
+    "advancedFieldsJson": "額外價格欄位 JSON",
+    "advancedFieldsPlaceholder": "範例：input_cost_per_second = 0.5",
+    "advancedFieldsHint": "使用 JSON 物件保存基礎表單未覆蓋的雲端或本地擴充欄位。"
   },
   "actions": {
     "edit": "編輯",
     "more": "更多動作",
     "delete": "刪除",
-    "comparePricing": "比較價格"
+    "comparePricing": "比較價格",
+    "viewDetails": "查看詳情"
+  },
+  "details": {
+    "coreFieldsTitle": "核心欄位",
+    "additionalBillableTitle": "額外計費欄位",
+    "additionalMetadataTitle": "額外中繼資料",
+    "providerPricingTitle": "供應商價格節點",
+    "kindSupported": "可計費",
+    "kindUnsupported": "待支援",
+    "kindDisplay": "僅展示",
+    "booleanTrue": "是",
+    "booleanFalse": "否"
   },
   "toast": {
     "createSuccess": "模型已新增",

--- a/messages/zh-TW/settings/prices.json
+++ b/messages/zh-TW/settings/prices.json
@@ -195,7 +195,7 @@
     "cachePricingTitle": "快取價格",
     "advancedFieldsTitle": "進階欄位",
     "advancedFieldsJson": "額外價格欄位 JSON",
-    "advancedFieldsPlaceholder": "範例：input_cost_per_second = 0.5",
+    "advancedFieldsPlaceholder": "範例：'{\"input_cost_per_second\": 0.5}'",
     "advancedFieldsHint": "使用 JSON 物件保存基礎表單未覆蓋的雲端或本地擴充欄位。"
   },
   "actions": {

--- a/messages/zh-TW/settings/prices.json
+++ b/messages/zh-TW/settings/prices.json
@@ -214,7 +214,25 @@
     "kindUnsupported": "待支援",
     "kindDisplay": "僅展示",
     "booleanTrue": "是",
-    "booleanFalse": "否"
+    "booleanFalse": "否",
+    "fields": {
+      "mode": "模式",
+      "displayName": "顯示名稱",
+      "litellmProvider": "LiteLLM 供應商",
+      "selectedPricingProvider": "選定價格提供方",
+      "selectedPricingSourceModel": "選定來源模型",
+      "selectedPricingResolution": "選定解析方式",
+      "maxInputTokens": "最大輸入 Tokens",
+      "maxOutputTokens": "最大輸出 Tokens",
+      "maxTokens": "最大 Tokens",
+      "outputVectorSize": "輸出向量維度",
+      "inputCostPerToken": "輸入單 Token 價格",
+      "outputCostPerToken": "輸出單 Token 價格",
+      "inputCostPerRequest": "按次輸入價格",
+      "outputCostPerImage": "按圖輸出價格",
+      "inputCostPerSecond": "按秒輸入價格",
+      "fileSearchCostPer1kCalls": "每千次檔案檢索價格"
+    }
   },
   "toast": {
     "createSuccess": "模型已新增",

--- a/src/actions/model-prices.ts
+++ b/src/actions/model-prices.ts
@@ -8,6 +8,7 @@ import {
   fetchCloudPriceTableToml,
   parseCloudPriceTableToml,
 } from "@/lib/price-sync/cloud-price-table";
+import { isPriceLikeFieldPath } from "@/lib/utils/model-price-fields";
 import {
   createModelPrice,
   deleteModelPriceByName,
@@ -605,10 +606,7 @@ function sanitizeExtraPriceData(value: unknown, path = ""): unknown {
   }
 
   if (!isPlainObject(value)) {
-    if (
-      path &&
-      /(cost|price|per_|rate|multiplier|session|query|page|pixel|character|dbu)/i.test(path)
-    ) {
+    if (path && isPriceLikeFieldPath(path)) {
       if (typeof value === "string" && value.trim()) {
         const parsed = Number(value);
         if (Number.isFinite(parsed) && parsed >= 0) {
@@ -625,10 +623,12 @@ function sanitizeExtraPriceData(value: unknown, path = ""): unknown {
   }
 
   return Object.fromEntries(
-    Object.entries(value).map(([key, nestedValue]) => [
-      key,
-      sanitizeExtraPriceData(nestedValue, path ? `${path}.${key}` : key),
-    ])
+    Object.entries(value)
+      .filter(([key]) => key !== "__proto__" && key !== "constructor" && key !== "prototype")
+      .map(([key, nestedValue]) => [
+        key,
+        sanitizeExtraPriceData(nestedValue, path ? `${path}.${key}` : key),
+      ])
   );
 }
 
@@ -715,19 +715,37 @@ export async function upsertSingleModelPrice(
     }
 
     // 构建价格数据
+    const displayName = input.displayName?.trim();
+    const litellmProvider = input.litellmProvider?.trim();
     const priceData: ModelPriceData = {
       ...extraPriceData,
       mode: input.mode,
-      display_name: input.displayName?.trim() || undefined,
-      litellm_provider: input.litellmProvider || undefined,
-      supports_prompt_caching: input.supportsPromptCaching,
-      input_cost_per_token: input.inputCostPerToken,
-      output_cost_per_token: input.outputCostPerToken,
-      output_cost_per_image: input.outputCostPerImage,
-      input_cost_per_request: input.inputCostPerRequest,
-      cache_read_input_token_cost: input.cacheReadInputTokenCost,
-      cache_creation_input_token_cost: input.cacheCreationInputTokenCost,
-      cache_creation_input_token_cost_above_1hr: input.cacheCreationInputTokenCostAbove1hr,
+      ...(displayName ? { display_name: displayName } : {}),
+      ...(litellmProvider ? { litellm_provider: litellmProvider } : {}),
+      ...(input.supportsPromptCaching !== undefined
+        ? { supports_prompt_caching: input.supportsPromptCaching }
+        : {}),
+      ...(input.inputCostPerToken !== undefined
+        ? { input_cost_per_token: input.inputCostPerToken }
+        : {}),
+      ...(input.outputCostPerToken !== undefined
+        ? { output_cost_per_token: input.outputCostPerToken }
+        : {}),
+      ...(input.outputCostPerImage !== undefined
+        ? { output_cost_per_image: input.outputCostPerImage }
+        : {}),
+      ...(input.inputCostPerRequest !== undefined
+        ? { input_cost_per_request: input.inputCostPerRequest }
+        : {}),
+      ...(input.cacheReadInputTokenCost !== undefined
+        ? { cache_read_input_token_cost: input.cacheReadInputTokenCost }
+        : {}),
+      ...(input.cacheCreationInputTokenCost !== undefined
+        ? { cache_creation_input_token_cost: input.cacheCreationInputTokenCost }
+        : {}),
+      ...(input.cacheCreationInputTokenCostAbove1hr !== undefined
+        ? { cache_creation_input_token_cost_above_1hr: input.cacheCreationInputTokenCostAbove1hr }
+        : {}),
     };
 
     // 捕获 before 快照

--- a/src/actions/model-prices.ts
+++ b/src/actions/model-prices.ts
@@ -595,6 +595,43 @@ export interface SingleModelPriceInput {
   extraFieldsJson?: string;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitizeExtraPriceData(value: unknown, path = ""): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item, index) => sanitizeExtraPriceData(item, `${path}[${index}]`));
+  }
+
+  if (!isPlainObject(value)) {
+    if (
+      path &&
+      /(cost|price|per_|rate|multiplier|session|query|page|pixel|character|dbu)/i.test(path)
+    ) {
+      if (typeof value === "string" && value.trim()) {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed) && parsed >= 0) {
+          return parsed;
+        }
+      }
+
+      if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+        throw new Error(`${path} 必须是非负数`);
+      }
+    }
+
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nestedValue]) => [
+      key,
+      sanitizeExtraPriceData(nestedValue, path ? `${path}.${key}` : key),
+    ])
+  );
+}
+
 /**
  * 创建或更新单个模型价格（手动维护）
  */
@@ -665,7 +702,7 @@ export async function upsertSingleModelPrice(
         if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
           return { ok: false, error: "高级字段必须是 JSON 对象" };
         }
-        extraPriceData = parsed as Record<string, unknown>;
+        extraPriceData = sanitizeExtraPriceData(parsed) as Record<string, unknown>;
       } catch (error) {
         return {
           ok: false,

--- a/src/actions/model-prices.ts
+++ b/src/actions/model-prices.ts
@@ -592,6 +592,7 @@ export interface SingleModelPriceInput {
   cacheReadInputTokenCost?: number;
   cacheCreationInputTokenCost?: number;
   cacheCreationInputTokenCostAbove1hr?: number;
+  extraFieldsJson?: string;
 }
 
 /**
@@ -657,8 +658,28 @@ export async function upsertSingleModelPrice(
       return { ok: false, error: "缓存创建(1h)价格必须为非负数" };
     }
 
+    let extraPriceData: Record<string, unknown> = {};
+    if (input.extraFieldsJson?.trim()) {
+      try {
+        const parsed = JSON.parse(input.extraFieldsJson);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+          return { ok: false, error: "高级字段必须是 JSON 对象" };
+        }
+        extraPriceData = parsed as Record<string, unknown>;
+      } catch (error) {
+        return {
+          ok: false,
+          error:
+            error instanceof Error
+              ? `高级字段 JSON 解析失败: ${error.message}`
+              : "高级字段 JSON 解析失败",
+        };
+      }
+    }
+
     // 构建价格数据
     const priceData: ModelPriceData = {
+      ...extraPriceData,
       mode: input.mode,
       display_name: input.displayName?.trim() || undefined,
       litellm_provider: input.litellmProvider || undefined,

--- a/src/app/[locale]/settings/prices/_components/model-price-details-dialog.tsx
+++ b/src/app/[locale]/settings/prices/_components/model-price-details-dialog.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { Info } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  collectModelPriceFieldEntries,
+  type ModelPriceFieldEntry,
+} from "@/lib/utils/model-price-fields";
+import type { ModelPrice } from "@/types/model-price";
+
+interface ModelPriceDetailsDialogProps {
+  price: ModelPrice;
+  trigger?: React.ReactNode;
+}
+
+function formatValue(
+  value: unknown,
+  t: ReturnType<typeof useTranslations<"settings.prices">>
+): string {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : "-";
+  }
+  if (typeof value === "boolean") {
+    return value ? t("details.booleanTrue") : t("details.booleanFalse");
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (value === undefined) {
+    return "-";
+  }
+  return JSON.stringify(value);
+}
+
+function kindLabel(
+  kind: ModelPriceFieldEntry["kind"],
+  t: ReturnType<typeof useTranslations<"settings.prices">>
+): string {
+  switch (kind) {
+    case "supported":
+      return t("details.kindSupported");
+    case "unsupported":
+      return t("details.kindUnsupported");
+    default:
+      return t("details.kindDisplay");
+  }
+}
+
+function FieldRow({
+  entry,
+  t,
+}: {
+  entry: ModelPriceFieldEntry;
+  t: ReturnType<typeof useTranslations<"settings.prices">>;
+}) {
+  return (
+    <div className="rounded-md border border-white/10 bg-white/[0.02] p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-foreground">{entry.label}</div>
+          <div className="mt-1 font-mono text-[11px] text-muted-foreground">{entry.path}</div>
+        </div>
+        <Badge variant="outline" className="shrink-0">
+          {kindLabel(entry.kind, t)}
+        </Badge>
+      </div>
+      <div className="mt-2 break-all font-mono text-xs text-foreground">
+        {formatValue(entry.value, t)}
+      </div>
+    </div>
+  );
+}
+
+export function ModelPriceDetailsDialog({ price, trigger }: ModelPriceDetailsDialogProps) {
+  const t = useTranslations("settings.prices");
+
+  const entries = useMemo(() => collectModelPriceFieldEntries(price.priceData), [price.priceData]);
+  const coreEntries = entries.filter((entry) => entry.isCore && entry.source === "top_level");
+  const additionalBillableEntries = entries.filter(
+    (entry) => !entry.isCore && entry.kind !== "display" && entry.source === "top_level"
+  );
+  const additionalMetadataEntries = entries.filter(
+    (entry) => !entry.isCore && entry.kind === "display" && entry.source === "top_level"
+  );
+  const providerEntries = entries.filter((entry) => entry.source === "provider_pricing");
+  const providerGroups = useMemo(() => {
+    const groups = new Map<string, ModelPriceFieldEntry[]>();
+    for (const entry of providerEntries) {
+      const key = entry.providerKey ?? "unknown";
+      const bucket = groups.get(key) ?? [];
+      bucket.push(entry);
+      groups.set(key, bucket);
+    }
+    return Array.from(groups.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  }, [providerEntries]);
+
+  const defaultTrigger = (
+    <Button variant="ghost" size="sm">
+      <Info className="mr-2 h-4 w-4" />
+      {t("actions.viewDetails")}
+    </Button>
+  );
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{trigger || defaultTrigger}</DialogTrigger>
+      <DialogContent className="max-w-4xl overflow-y-auto max-h-[85vh]">
+        <DialogHeader>
+          <DialogTitle>{price.priceData.display_name?.trim() || price.modelName}</DialogTitle>
+          <DialogDescription>
+            <span className="font-mono">{price.modelName}</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <section className="space-y-3">
+            <div className="text-sm font-medium">{t("details.coreFieldsTitle")}</div>
+            <div className="grid gap-3 md:grid-cols-2">
+              {coreEntries.map((entry) => (
+                <FieldRow key={entry.path} entry={entry} t={t} />
+              ))}
+            </div>
+          </section>
+
+          {additionalBillableEntries.length > 0 ? (
+            <details className="rounded-md border border-white/10 bg-white/[0.02] p-3">
+              <summary className="cursor-pointer text-sm font-medium">
+                {t("details.additionalBillableTitle")}
+              </summary>
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                {additionalBillableEntries.map((entry) => (
+                  <FieldRow key={entry.path} entry={entry} t={t} />
+                ))}
+              </div>
+            </details>
+          ) : null}
+
+          {additionalMetadataEntries.length > 0 ? (
+            <details className="rounded-md border border-white/10 bg-white/[0.02] p-3">
+              <summary className="cursor-pointer text-sm font-medium">
+                {t("details.additionalMetadataTitle")}
+              </summary>
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                {additionalMetadataEntries.map((entry) => (
+                  <FieldRow key={entry.path} entry={entry} t={t} />
+                ))}
+              </div>
+            </details>
+          ) : null}
+
+          {providerGroups.length > 0 ? (
+            <section className="space-y-3">
+              <div className="text-sm font-medium">{t("details.providerPricingTitle")}</div>
+              {providerGroups.map(([providerKey, groupEntries]) => (
+                <details
+                  key={providerKey}
+                  className="rounded-md border border-white/10 bg-white/[0.02] p-3"
+                >
+                  <summary className="cursor-pointer text-sm font-medium">{providerKey}</summary>
+                  <div className="mt-3 grid gap-3 md:grid-cols-2">
+                    {groupEntries.map((entry) => (
+                      <FieldRow key={entry.path} entry={entry} t={t} />
+                    ))}
+                  </div>
+                </details>
+              ))}
+            </section>
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/[locale]/settings/prices/_components/model-price-details-dialog.tsx
+++ b/src/app/[locale]/settings/prices/_components/model-price-details-dialog.tsx
@@ -24,12 +24,33 @@ interface ModelPriceDetailsDialogProps {
   trigger?: React.ReactNode;
 }
 
+const FIELD_LABEL_KEYS: Record<string, string> = {
+  mode: "mode",
+  display_name: "displayName",
+  litellm_provider: "litellmProvider",
+  selected_pricing_provider: "selectedPricingProvider",
+  selected_pricing_source_model: "selectedPricingSourceModel",
+  selected_pricing_resolution: "selectedPricingResolution",
+  max_input_tokens: "maxInputTokens",
+  max_output_tokens: "maxOutputTokens",
+  max_tokens: "maxTokens",
+  output_vector_size: "outputVectorSize",
+  input_cost_per_token: "inputCostPerToken",
+  output_cost_per_token: "outputCostPerToken",
+  input_cost_per_request: "inputCostPerRequest",
+  output_cost_per_image: "outputCostPerImage",
+  input_cost_per_second: "inputCostPerSecond",
+  file_search_cost_per_1k_calls: "fileSearchCostPer1kCalls",
+};
+
 function formatValue(
   value: unknown,
   t: ReturnType<typeof useTranslations<"settings.prices">>
 ): string {
   if (typeof value === "number") {
-    return Number.isFinite(value) ? String(value) : "-";
+    return Number.isFinite(value)
+      ? value.toLocaleString("en-US", { maximumFractionDigits: 10 })
+      : "-";
   }
   if (typeof value === "boolean") {
     return value ? t("details.booleanTrue") : t("details.booleanFalse");
@@ -44,6 +65,18 @@ function formatValue(
     return "-";
   }
   return JSON.stringify(value);
+}
+
+function resolveEntryLabel(
+  entry: ModelPriceFieldEntry,
+  t: ReturnType<typeof useTranslations<"settings.prices">>
+): string {
+  const fieldLabelKey = FIELD_LABEL_KEYS[entry.key];
+  if (fieldLabelKey) {
+    return t(`details.fields.${fieldLabelKey}`);
+  }
+
+  return entry.label;
 }
 
 function kindLabel(
@@ -71,7 +104,7 @@ function FieldRow({
     <div className="rounded-md border border-white/10 bg-white/[0.02] p-3">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-sm font-medium text-foreground">{entry.label}</div>
+          <div className="text-sm font-medium text-foreground">{resolveEntryLabel(entry, t)}</div>
           <div className="mt-1 font-mono text-[11px] text-muted-foreground">{entry.path}</div>
         </div>
         <Badge variant="outline" className="shrink-0">
@@ -88,25 +121,42 @@ function FieldRow({
 export function ModelPriceDetailsDialog({ price, trigger }: ModelPriceDetailsDialogProps) {
   const t = useTranslations("settings.prices");
 
-  const entries = useMemo(() => collectModelPriceFieldEntries(price.priceData), [price.priceData]);
-  const coreEntries = entries.filter((entry) => entry.isCore && entry.source === "top_level");
-  const additionalBillableEntries = entries.filter(
-    (entry) => !entry.isCore && entry.kind !== "display" && entry.source === "top_level"
-  );
-  const additionalMetadataEntries = entries.filter(
-    (entry) => !entry.isCore && entry.kind === "display" && entry.source === "top_level"
-  );
-  const providerEntries = entries.filter((entry) => entry.source === "provider_pricing");
-  const providerGroups = useMemo(() => {
-    const groups = new Map<string, ModelPriceFieldEntry[]>();
-    for (const entry of providerEntries) {
-      const key = entry.providerKey ?? "unknown";
-      const bucket = groups.get(key) ?? [];
-      bucket.push(entry);
-      groups.set(key, bucket);
-    }
-    return Array.from(groups.entries()).sort((a, b) => a[0].localeCompare(b[0]));
-  }, [providerEntries]);
+  const { coreEntries, additionalBillableEntries, additionalMetadataEntries, providerGroups } =
+    useMemo(() => {
+      const entries = collectModelPriceFieldEntries(price.priceData);
+      const groups = new Map<string, ModelPriceFieldEntry[]>();
+      const core: ModelPriceFieldEntry[] = [];
+      const extraBillable: ModelPriceFieldEntry[] = [];
+      const extraMetadata: ModelPriceFieldEntry[] = [];
+
+      for (const entry of entries) {
+        if (entry.source === "provider_pricing") {
+          const key = entry.providerKey ?? "unknown";
+          const bucket = groups.get(key) ?? [];
+          bucket.push(entry);
+          groups.set(key, bucket);
+          continue;
+        }
+
+        if (entry.isCore) {
+          core.push(entry);
+          continue;
+        }
+
+        if (entry.kind === "display") {
+          extraMetadata.push(entry);
+        } else {
+          extraBillable.push(entry);
+        }
+      }
+
+      return {
+        coreEntries: core,
+        additionalBillableEntries: extraBillable,
+        additionalMetadataEntries: extraMetadata,
+        providerGroups: Array.from(groups.entries()).sort((a, b) => a[0].localeCompare(b[0])),
+      };
+    }, [price.priceData]);
 
   const defaultTrigger = (
     <Button variant="ghost" size="sm">
@@ -117,7 +167,7 @@ export function ModelPriceDetailsDialog({ price, trigger }: ModelPriceDetailsDia
 
   return (
     <Dialog>
-      <DialogTrigger asChild>{trigger || defaultTrigger}</DialogTrigger>
+      <DialogTrigger asChild>{trigger ?? defaultTrigger}</DialogTrigger>
       <DialogContent className="max-w-4xl overflow-y-auto max-h-[85vh]">
         <DialogHeader>
           <DialogTitle>{price.priceData.display_name?.trim() || price.modelName}</DialogTitle>

--- a/src/app/[locale]/settings/prices/_components/model-price-drawer.tsx
+++ b/src/app/[locale]/settings/prices/_components/model-price-drawer.tsx
@@ -33,7 +33,9 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 import { useDebounce } from "@/lib/hooks/use-debounce";
+import { getEditableExtraPriceData } from "@/lib/utils/model-price-fields";
 import type { ModelPrice } from "@/types/model-price";
 
 interface ModelPriceDrawerProps {
@@ -99,6 +101,7 @@ export function ModelPriceDrawer({
   const [cacheReadPrice, setCacheReadPrice] = useState("");
   const [cacheCreation5mPrice, setCacheCreation5mPrice] = useState("");
   const [cacheCreation1hPrice, setCacheCreation1hPrice] = useState("");
+  const [extraFieldsJson, setExtraFieldsJson] = useState("");
 
   // 预填充搜索（仅 create 模式显示）
   const [prefillQuery, setPrefillQuery] = useState("");
@@ -118,6 +121,7 @@ export function ModelPriceDrawer({
     setCacheReadPrice("");
     setCacheCreation5mPrice("");
     setCacheCreation1hPrice("");
+    setExtraFieldsJson("");
     setPrefillQuery("");
     setPrefillStatus("idle");
     setPrefillResults([]);
@@ -155,6 +159,10 @@ export function ModelPriceDrawer({
     );
     setCacheCreation1hPrice(
       formatPerTokenPriceToPerMillion(selected.priceData.cache_creation_input_token_cost_above_1hr)
+    );
+    const extraPriceData = getEditableExtraPriceData(selected.priceData);
+    setExtraFieldsJson(
+      Object.keys(extraPriceData).length > 0 ? JSON.stringify(extraPriceData, null, 2) : ""
     );
   }, []);
 
@@ -270,6 +278,7 @@ export function ModelPriceDrawer({
         cacheReadInputTokenCost: cacheReadCostPerToken,
         cacheCreationInputTokenCost: cacheCreation5mCostPerToken,
         cacheCreationInputTokenCostAbove1hr: cacheCreation1hCostPerToken,
+        extraFieldsJson,
       });
 
       if (!result.ok) {
@@ -606,6 +615,24 @@ export function ModelPriceDrawer({
                 </div>
               </div>
             </div>
+
+            <details className="rounded-md border border-white/10 bg-white/[0.02] p-3">
+              <summary className="cursor-pointer text-sm font-medium">
+                {t("drawer.advancedFieldsTitle")}
+              </summary>
+              <div className="mt-3 space-y-2">
+                <Label htmlFor="extraFieldsJson">{t("drawer.advancedFieldsJson")}</Label>
+                <Textarea
+                  id="extraFieldsJson"
+                  value={extraFieldsJson}
+                  onChange={(event) => setExtraFieldsJson(event.target.value)}
+                  placeholder={t("drawer.advancedFieldsPlaceholder")}
+                  className="min-h-32 bg-white/[0.02] border-white/10 focus:border-[#E25706]/50 font-mono text-xs"
+                  disabled={loading}
+                />
+                <p className="text-xs text-muted-foreground">{t("drawer.advancedFieldsHint")}</p>
+              </div>
+            </details>
           </div>
         </div>
 

--- a/src/app/[locale]/settings/prices/_components/model-price-drawer.tsx
+++ b/src/app/[locale]/settings/prices/_components/model-price-drawer.tsx
@@ -50,6 +50,8 @@ type ModelMode = "chat" | "image_generation" | "completion";
 
 type PrefillStatus = "idle" | "loading" | "loaded" | "error";
 
+const EXTRA_FIELDS_JSON_PLACEHOLDER = JSON.stringify({ input_cost_per_second: 0.5 }, null, 2);
+
 function parsePricePerMillionToPerToken(value: string): number | undefined {
   const trimmed = value.trim();
   if (!trimmed) return undefined;
@@ -626,7 +628,7 @@ export function ModelPriceDrawer({
                   id="extraFieldsJson"
                   value={extraFieldsJson}
                   onChange={(event) => setExtraFieldsJson(event.target.value)}
-                  placeholder={t("drawer.advancedFieldsPlaceholder")}
+                  placeholder={EXTRA_FIELDS_JSON_PLACEHOLDER}
                   className="min-h-32 bg-white/[0.02] border-white/10 focus:border-[#E25706]/50 font-mono text-xs"
                   disabled={loading}
                 />

--- a/src/app/[locale]/settings/prices/_components/price-list.tsx
+++ b/src/app/[locale]/settings/prices/_components/price-list.tsx
@@ -11,6 +11,7 @@ import {
   DollarSign,
   Eye,
   FileText,
+  Info,
   Monitor,
   MoreHorizontal,
   Package,
@@ -46,6 +47,7 @@ import { copyToClipboard } from "@/lib/utils/clipboard";
 import { resolvePricingForModelRecords } from "@/lib/utils/pricing-resolution";
 import type { ModelPrice, ModelPriceSource } from "@/types/model-price";
 import { DeleteModelDialog } from "./delete-model-dialog";
+import { ModelPriceDetailsDialog } from "./model-price-details-dialog";
 import { ModelPriceDrawer } from "./model-price-drawer";
 import { ProviderPricingDialog } from "./provider-pricing-dialog";
 
@@ -633,6 +635,15 @@ export function PriceList({
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
+                          <ModelPriceDetailsDialog
+                            price={price}
+                            trigger={
+                              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                                <Info className="h-4 w-4 mr-2" />
+                                {t("actions.viewDetails")}
+                              </DropdownMenuItem>
+                            }
+                          />
                           {price.priceData.pricing &&
                           Object.keys(price.priceData.pricing).length > 0 ? (
                             <ProviderPricingDialog

--- a/src/lib/utils/model-price-fields.ts
+++ b/src/lib/utils/model-price-fields.ts
@@ -85,7 +85,6 @@ const NON_EDITABLE_MANAGED_FIELDS = new Set([
   "cache_read_input_token_cost",
   "cache_creation_input_token_cost",
   "cache_creation_input_token_cost_above_1hr",
-  "pricing",
 ]);
 
 const LABEL_OVERRIDES: Record<string, string> = {
@@ -118,6 +117,10 @@ export function isPriceLikeFieldKey(key: string): boolean {
   );
 }
 
+export function isPriceLikeFieldPath(path: string): boolean {
+  return path.split(".").some((segment) => isPriceLikeFieldKey(segment));
+}
+
 function classifyField(path: string, key: string): ModelPriceFieldKind {
   if (
     SUPPORTED_TOP_LEVEL_BILLING_KEYS.has(key) ||
@@ -126,7 +129,7 @@ function classifyField(path: string, key: string): ModelPriceFieldKind {
     return "supported";
   }
 
-  if (isPriceLikeFieldKey(key)) {
+  if (isPriceLikeFieldPath(path) || isPriceLikeFieldKey(key)) {
     return "unsupported";
   }
 
@@ -207,8 +210,7 @@ export function collectModelPriceFieldEntries(priceData: ModelPriceData): ModelP
 
 function collectDynamicPriceLikeNumbers(node: unknown, path = ""): number[] {
   if (typeof node === "number") {
-    const leafKey = path.split(".").pop();
-    if (leafKey && isPriceLikeFieldKey(leafKey) && Number.isFinite(node) && node >= 0) {
+    if (path && isPriceLikeFieldPath(path) && Number.isFinite(node) && node >= 0) {
       return [node];
     }
     return [];

--- a/src/lib/utils/model-price-fields.ts
+++ b/src/lib/utils/model-price-fields.ts
@@ -1,0 +1,244 @@
+import type { ModelPriceData } from "@/types/model-price";
+
+export type ModelPriceFieldKind = "supported" | "unsupported" | "display";
+export type ModelPriceFieldSource = "top_level" | "provider_pricing";
+
+export interface ModelPriceFieldEntry {
+  key: string;
+  label: string;
+  path: string;
+  value: unknown;
+  kind: ModelPriceFieldKind;
+  source: ModelPriceFieldSource;
+  providerKey?: string;
+  isCore: boolean;
+}
+
+const SUPPORTED_TOP_LEVEL_BILLING_KEYS = new Set([
+  "input_cost_per_token",
+  "output_cost_per_token",
+  "input_cost_per_request",
+  "cache_creation_input_token_cost",
+  "cache_creation_input_token_cost_above_1hr",
+  "cache_read_input_token_cost",
+  "input_cost_per_token_above_200k_tokens",
+  "output_cost_per_token_above_200k_tokens",
+  "cache_creation_input_token_cost_above_200k_tokens",
+  "cache_read_input_token_cost_above_200k_tokens",
+  "cache_creation_input_token_cost_above_1hr_above_200k_tokens",
+  "input_cost_per_token_above_200k_tokens_priority",
+  "output_cost_per_token_above_200k_tokens_priority",
+  "cache_read_input_token_cost_above_200k_tokens_priority",
+  "input_cost_per_token_above_272k_tokens",
+  "output_cost_per_token_above_272k_tokens",
+  "cache_creation_input_token_cost_above_272k_tokens",
+  "cache_read_input_token_cost_above_272k_tokens",
+  "cache_creation_input_token_cost_above_1hr_above_272k_tokens",
+  "input_cost_per_token_above_272k_tokens_priority",
+  "output_cost_per_token_above_272k_tokens_priority",
+  "cache_read_input_token_cost_above_272k_tokens_priority",
+  "input_cost_per_token_priority",
+  "output_cost_per_token_priority",
+  "cache_read_input_token_cost_priority",
+  "output_cost_per_image",
+  "input_cost_per_image",
+  "output_cost_per_image_token",
+  "input_cost_per_image_token",
+]);
+
+const SUPPORTED_LONG_CONTEXT_KEYS = new Set([
+  "input_multiplier",
+  "output_multiplier",
+  "cache_creation_input_multiplier",
+  "cache_creation_input_multiplier_above_1hr",
+  "cache_read_input_multiplier",
+  "input_cost_per_token",
+  "output_cost_per_token",
+  "cache_creation_input_token_cost",
+  "cache_creation_input_token_cost_above_1hr",
+  "cache_read_input_token_cost",
+]);
+
+const CORE_TOP_LEVEL_FIELDS = new Set([
+  "mode",
+  "display_name",
+  "litellm_provider",
+  "selected_pricing_provider",
+  "selected_pricing_source_model",
+  "selected_pricing_resolution",
+  "max_input_tokens",
+  "max_output_tokens",
+  "max_tokens",
+  "output_vector_size",
+  ...SUPPORTED_TOP_LEVEL_BILLING_KEYS,
+]);
+
+const NON_EDITABLE_MANAGED_FIELDS = new Set([
+  "mode",
+  "display_name",
+  "litellm_provider",
+  "supports_prompt_caching",
+  "input_cost_per_token",
+  "output_cost_per_token",
+  "output_cost_per_image",
+  "input_cost_per_request",
+  "cache_read_input_token_cost",
+  "cache_creation_input_token_cost",
+  "cache_creation_input_token_cost_above_1hr",
+  "pricing",
+]);
+
+const LABEL_OVERRIDES: Record<string, string> = {
+  display_name: "Display name",
+  litellm_provider: "LiteLLM provider",
+  selected_pricing_provider: "Selected pricing provider",
+  selected_pricing_source_model: "Selected source model",
+  selected_pricing_resolution: "Selected resolution",
+  max_input_tokens: "Max input tokens",
+  max_output_tokens: "Max output tokens",
+  max_tokens: "Max tokens",
+  output_vector_size: "Output vector size",
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function humanizeKey(key: string): string {
+  if (LABEL_OVERRIDES[key]) {
+    return LABEL_OVERRIDES[key];
+  }
+
+  return key.replace(/_/g, " ").replace(/\b([a-z])/g, (match) => match.toUpperCase());
+}
+
+export function isPriceLikeFieldKey(key: string): boolean {
+  return /(cost|price|rate|multiplier|per_|second|session|query|page|pixel|character|dbu)/i.test(
+    key
+  );
+}
+
+function classifyField(path: string, key: string): ModelPriceFieldKind {
+  if (
+    SUPPORTED_TOP_LEVEL_BILLING_KEYS.has(key) ||
+    (path.startsWith("long_context_pricing.") && SUPPORTED_LONG_CONTEXT_KEYS.has(key))
+  ) {
+    return "supported";
+  }
+
+  if (isPriceLikeFieldKey(key)) {
+    return "unsupported";
+  }
+
+  return "display";
+}
+
+function isCoreField(
+  path: string,
+  key: string,
+  kind: ModelPriceFieldKind,
+  source: ModelPriceFieldSource
+) {
+  if (source === "provider_pricing") {
+    return false;
+  }
+
+  if (kind === "supported") {
+    return true;
+  }
+
+  return CORE_TOP_LEVEL_FIELDS.has(key) || path.startsWith("long_context_pricing.");
+}
+
+function pushEntries(
+  entries: ModelPriceFieldEntry[],
+  node: Record<string, unknown>,
+  pathPrefix: string,
+  source: ModelPriceFieldSource,
+  providerKey?: string
+) {
+  for (const [key, value] of Object.entries(node)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    const path = pathPrefix ? `${pathPrefix}.${key}` : key;
+    if (isPlainObject(value)) {
+      pushEntries(entries, value, path, source, providerKey);
+      continue;
+    }
+
+    entries.push({
+      key,
+      label: humanizeKey(key),
+      path,
+      value,
+      kind: classifyField(path, key),
+      source,
+      providerKey,
+      isCore: isCoreField(path, key, classifyField(path, key), source),
+    });
+  }
+}
+
+export function collectModelPriceFieldEntries(priceData: ModelPriceData): ModelPriceFieldEntry[] {
+  const entries: ModelPriceFieldEntry[] = [];
+  const { pricing, ...topLevel } = priceData;
+
+  pushEntries(entries, topLevel, "", "top_level");
+
+  if (isPlainObject(pricing)) {
+    for (const [providerKey, providerPricing] of Object.entries(pricing)) {
+      if (!isPlainObject(providerPricing)) {
+        continue;
+      }
+      pushEntries(
+        entries,
+        providerPricing,
+        `pricing.${providerKey}`,
+        "provider_pricing",
+        providerKey
+      );
+    }
+  }
+
+  return entries;
+}
+
+function collectDynamicPriceLikeNumbers(node: unknown, path = ""): number[] {
+  if (typeof node === "number") {
+    const leafKey = path.split(".").pop();
+    if (leafKey && isPriceLikeFieldKey(leafKey) && Number.isFinite(node) && node >= 0) {
+      return [node];
+    }
+    return [];
+  }
+
+  if (Array.isArray(node) || !isPlainObject(node)) {
+    return [];
+  }
+
+  const result: number[] = [];
+  for (const [key, value] of Object.entries(node)) {
+    const nextPath = path ? `${path}.${key}` : key;
+    result.push(...collectDynamicPriceLikeNumbers(value, nextPath));
+  }
+  return result;
+}
+
+export function collectAdditionalPriceLikeNumbers(priceData: ModelPriceData): number[] {
+  return collectDynamicPriceLikeNumbers(priceData);
+}
+
+export function getEditableExtraPriceData(priceData: ModelPriceData): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(priceData)) {
+    if (NON_EDITABLE_MANAGED_FIELDS.has(key) || value === undefined) {
+      continue;
+    }
+    result[key] = value;
+  }
+
+  return result;
+}

--- a/src/lib/utils/price-data.ts
+++ b/src/lib/utils/price-data.ts
@@ -1,4 +1,5 @@
 import type { ModelPriceData } from "@/types/model-price";
+import { collectAdditionalPriceLikeNumbers } from "./model-price-fields";
 
 function hasValidNumericPrice(values: unknown[]): boolean {
   return values.some((value) => typeof value === "number" && Number.isFinite(value) && value >= 0);
@@ -51,7 +52,12 @@ function collectNumericCosts(priceData: ModelPriceData): unknown[] {
  * 避免把数据库中的 `{}` 或仅包含元信息的记录当成有效价格。
  */
 export function hasValidPriceData(priceData: ModelPriceData): boolean {
-  if (hasValidNumericPrice(collectNumericCosts(priceData))) {
+  if (
+    hasValidNumericPrice([
+      ...collectNumericCosts(priceData),
+      ...collectAdditionalPriceLikeNumbers(priceData),
+    ])
+  ) {
     return true;
   }
 

--- a/tests/integration/billing-model-source.test.ts
+++ b/tests/integration/billing-model-source.test.ts
@@ -41,7 +41,7 @@ vi.mock("@/repository/system-config", () => ({
 }));
 
 vi.mock("@/repository/message", () => ({
-  updateMessageRequestCost: vi.fn(),
+  updateMessageRequestCostWithBreakdown: vi.fn(),
   updateMessageRequestDetails: vi.fn(),
   updateMessageRequestDuration: vi.fn(),
 }));
@@ -84,7 +84,7 @@ import { SessionManager } from "@/lib/session-manager";
 import { RateLimitService } from "@/lib/rate-limit";
 import { SessionTracker } from "@/lib/session-tracker";
 import {
-  updateMessageRequestCost,
+  updateMessageRequestCostWithBreakdown,
   updateMessageRequestDetails,
   updateMessageRequestDuration,
 } from "@/repository/message";
@@ -328,9 +328,11 @@ async function runScenario({
   vi.mocked(SessionTracker.refreshSession).mockResolvedValue(undefined);
 
   const dbCosts: string[] = [];
-  vi.mocked(updateMessageRequestCost).mockImplementation(async (_id: number, costUsd: unknown) => {
-    dbCosts.push(String(costUsd));
-  });
+  vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
+    async (_id: number, costUsd: unknown) => {
+      dbCosts.push(String(costUsd));
+    }
+  );
 
   const sessionCosts: string[] = [];
   vi.mocked(SessionManager.updateSessionUsage).mockImplementation(
@@ -467,7 +469,7 @@ describe("Billing model source - Redis session cost vs DB cost", () => {
     });
 
     const dbCosts: string[] = [];
-    vi.mocked(updateMessageRequestCost).mockImplementation(
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
       async (_id: number, costUsd: unknown) => {
         dbCosts.push(String(costUsd));
       }
@@ -531,7 +533,7 @@ describe("Billing model source - Redis session cost vs DB cost", () => {
     });
 
     const dbCosts: string[] = [];
-    vi.mocked(updateMessageRequestCost).mockImplementation(
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
       async (_id: number, costUsd: unknown) => {
         dbCosts.push(String(costUsd));
       }
@@ -600,7 +602,7 @@ describe("Billing model source - Redis session cost vs DB cost", () => {
     });
 
     const dbCosts: string[] = [];
-    vi.mocked(updateMessageRequestCost).mockImplementation(
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
       async (_id: number, costUsd: unknown) => {
         dbCosts.push(String(costUsd));
       }
@@ -660,7 +662,7 @@ describe("Billing model source - Redis session cost vs DB cost", () => {
     });
 
     const dbCosts: string[] = [];
-    vi.mocked(updateMessageRequestCost).mockImplementation(
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
       async (_id: number, costUsd: unknown) => {
         dbCosts.push(String(costUsd));
       }
@@ -726,7 +728,7 @@ describe("Billing model source - Redis session cost vs DB cost", () => {
     });
 
     const dbCosts: string[] = [];
-    vi.mocked(updateMessageRequestCost).mockImplementation(
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
       async (_id: number, costUsd: unknown) => {
         dbCosts.push(String(costUsd));
       }
@@ -785,7 +787,7 @@ describe("Billing model source - Redis session cost vs DB cost", () => {
     });
 
     const dbCosts: string[] = [];
-    vi.mocked(updateMessageRequestCost).mockImplementation(
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
       async (_id: number, costUsd: unknown) => {
         dbCosts.push(String(costUsd));
       }
@@ -844,7 +846,7 @@ describe("Billing model source - Redis session cost vs DB cost", () => {
     });
 
     const dbCosts: string[] = [];
-    vi.mocked(updateMessageRequestCost).mockImplementation(
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
       async (_id: number, costUsd: unknown) => {
         dbCosts.push(String(costUsd));
       }
@@ -903,7 +905,7 @@ describe("Billing model source - Redis session cost vs DB cost", () => {
     });
 
     const dbCosts: string[] = [];
-    vi.mocked(updateMessageRequestCost).mockImplementation(
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
       async (_id: number, costUsd: unknown) => {
         dbCosts.push(String(costUsd));
       }
@@ -962,7 +964,7 @@ describe("Billing model source - Redis session cost vs DB cost", () => {
     });
 
     const dbCosts: string[] = [];
-    vi.mocked(updateMessageRequestCost).mockImplementation(
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
       async (_id: number, costUsd: unknown) => {
         dbCosts.push(String(costUsd));
       }
@@ -1019,7 +1021,7 @@ describe("价格表缺失/查询失败：不计费放行", () => {
     vi.mocked(RateLimitService.trackUserDailyCost).mockResolvedValue(undefined);
     vi.mocked(SessionTracker.refreshSession).mockResolvedValue(undefined);
 
-    vi.mocked(updateMessageRequestCost).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockResolvedValue(undefined);
     vi.mocked(RateLimitService.trackCost).mockResolvedValue(undefined);
     vi.mocked(SessionManager.updateSessionUsage).mockResolvedValue(undefined);
 
@@ -1039,7 +1041,7 @@ describe("价格表缺失/查询失败：不计费放行", () => {
     await drainAsyncTasks();
 
     return {
-      dbCostCalls: vi.mocked(updateMessageRequestCost).mock.calls.length,
+      dbCostCalls: vi.mocked(updateMessageRequestCostWithBreakdown).mock.calls.length,
       rateLimitCalls: vi.mocked(RateLimitService.trackCost).mock.calls.length,
     };
   }

--- a/tests/unit/actions/model-prices.test.ts
+++ b/tests/unit/actions/model-prices.test.ts
@@ -205,6 +205,49 @@ describe("Model Price Actions", () => {
       );
     });
 
+    it("should reject invalid extra JSON", async () => {
+      const { upsertSingleModelPrice } = await import("@/actions/model-prices");
+      const result = await upsertSingleModelPrice({
+        modelName: "broken-model",
+        mode: "chat",
+        extraFieldsJson: "{invalid",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("JSON");
+      expect(upsertModelPriceMock).not.toHaveBeenCalled();
+    });
+
+    it("should let managed form fields override conflicting extra JSON fields", async () => {
+      const mockResult = makeMockPrice("conflict-model", {
+        mode: "chat",
+        input_cost_per_token: 0.000015,
+      });
+      upsertModelPriceMock.mockResolvedValue(mockResult);
+
+      const { upsertSingleModelPrice } = await import("@/actions/model-prices");
+      const result = await upsertSingleModelPrice({
+        modelName: "conflict-model",
+        mode: "chat",
+        inputCostPerToken: 0.000015,
+        extraFieldsJson: JSON.stringify({
+          mode: "image_generation",
+          input_cost_per_token: 999,
+          input_cost_per_second: 0.25,
+        }),
+      });
+
+      expect(result.ok).toBe(true);
+      expect(upsertModelPriceMock).toHaveBeenCalledWith(
+        "conflict-model",
+        expect.objectContaining({
+          mode: "chat",
+          input_cost_per_token: 0.000015,
+          input_cost_per_second: 0.25,
+        })
+      );
+    });
+
     it("should handle repository errors gracefully", async () => {
       upsertModelPriceMock.mockRejectedValue(new Error("Database error"));
 

--- a/tests/unit/actions/model-prices.test.ts
+++ b/tests/unit/actions/model-prices.test.ts
@@ -174,6 +174,37 @@ describe("Model Price Actions", () => {
       );
     });
 
+    it("should merge extra JSON fields into price data", async () => {
+      const mockResult = makeMockPrice("omni-model", {
+        mode: "chat",
+        input_cost_per_second: 0.5,
+        file_search_cost_per_1k_calls: 2,
+      });
+      upsertModelPriceMock.mockResolvedValue(mockResult);
+
+      const { upsertSingleModelPrice } = await import("@/actions/model-prices");
+      const result = await upsertSingleModelPrice({
+        modelName: "omni-model",
+        mode: "chat",
+        inputCostPerToken: 0.000015,
+        extraFieldsJson: JSON.stringify({
+          input_cost_per_second: 0.5,
+          file_search_cost_per_1k_calls: 2,
+        }),
+      });
+
+      expect(result.ok).toBe(true);
+      expect(upsertModelPriceMock).toHaveBeenCalledWith(
+        "omni-model",
+        expect.objectContaining({
+          mode: "chat",
+          input_cost_per_token: 0.000015,
+          input_cost_per_second: 0.5,
+          file_search_cost_per_1k_calls: 2,
+        })
+      );
+    });
+
     it("should handle repository errors gracefully", async () => {
       upsertModelPriceMock.mockRejectedValue(new Error("Database error"));
 

--- a/tests/unit/lib/model-price-fields.test.ts
+++ b/tests/unit/lib/model-price-fields.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+import {
+  collectModelPriceFieldEntries,
+  getEditableExtraPriceData,
+  isPriceLikeFieldKey,
+} from "@/lib/utils/model-price-fields";
+
+describe("model-price-fields", () => {
+  test("detects generic price-like keys", () => {
+    expect(isPriceLikeFieldKey("input_cost_per_second")).toBe(true);
+    expect(isPriceLikeFieldKey("file_search_cost_per_1k_calls")).toBe(true);
+    expect(isPriceLikeFieldKey("display_name")).toBe(false);
+  });
+
+  test("collects supported, unsupported, and provider pricing entries", () => {
+    const entries = collectModelPriceFieldEntries({
+      mode: "chat",
+      display_name: "Demo",
+      input_cost_per_request: 0.25,
+      input_cost_per_second: 0.5,
+      supports_reasoning: true,
+      long_context_pricing: {
+        threshold_tokens: 128000,
+        input_cost_per_token: 0.000005,
+      },
+      pricing: {
+        openai: {
+          input_cost_per_token: 0.0000025,
+          output_cost_per_token: 0.000015,
+          file_search_cost_per_1k_calls: 2,
+        },
+      },
+    });
+
+    expect(entries.find((entry) => entry.path === "input_cost_per_request")?.kind).toBe(
+      "supported"
+    );
+    expect(entries.find((entry) => entry.path === "input_cost_per_second")?.kind).toBe(
+      "unsupported"
+    );
+    expect(entries.find((entry) => entry.path === "supports_reasoning")?.kind).toBe("display");
+    expect(
+      entries.find((entry) => entry.path === "pricing.openai.file_search_cost_per_1k_calls")?.kind
+    ).toBe("unsupported");
+    expect(
+      entries.find((entry) => entry.path === "long_context_pricing.input_cost_per_token")?.kind
+    ).toBe("supported");
+  });
+
+  test("extracts editable extra price data by excluding managed fields", () => {
+    const extra = getEditableExtraPriceData({
+      mode: "chat",
+      display_name: "Demo",
+      input_cost_per_token: 0.000001,
+      input_cost_per_request: 0.1,
+      supports_reasoning: true,
+      input_cost_per_second: 0.5,
+      output_vector_size: 1024,
+    });
+
+    expect(extra).toEqual({
+      supports_reasoning: true,
+      input_cost_per_second: 0.5,
+      output_vector_size: 1024,
+    });
+  });
+});

--- a/tests/unit/lib/price-data-price-like-fields.test.ts
+++ b/tests/unit/lib/price-data-price-like-fields.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { hasValidPriceData } from "@/lib/utils/price-data";
+
+describe("hasValidPriceData: generic price-like fields", () => {
+  test("treats per-second pricing as valid price data", () => {
+    expect(
+      hasValidPriceData({
+        input_cost_per_second: 0.5,
+      })
+    ).toBe(true);
+  });
+
+  test("treats provider pricing nodes with session/page prices as valid", () => {
+    expect(
+      hasValidPriceData({
+        pricing: {
+          openai: {
+            code_interpreter_cost_per_session: 3,
+            annotation_cost_per_page: 0.2,
+          },
+        },
+      })
+    ).toBe(true);
+  });
+
+  test("ignores non price-like numeric metadata", () => {
+    expect(
+      hasValidPriceData({
+        max_tokens: 4096,
+        output_vector_size: 1024,
+      })
+    ).toBe(false);
+  });
+});

--- a/tests/unit/price-sync/cloud-price-table.test.ts
+++ b/tests/unit/price-sync/cloud-price-table.test.ts
@@ -46,6 +46,37 @@ describe("parseCloudPriceTableToml", () => {
     expect(pricing.anthropic?.input_cost_per_token).toBe(0.000001);
   });
 
+  it("preserves newer generic pricing fields from cloud table", () => {
+    const toml = [
+      '[models."m3"]',
+      'mode = "chat"',
+      'litellm_provider = "openai"',
+      "input_cost_per_second = 0.5",
+      "file_search_cost_per_1k_calls = 2",
+      "",
+      '[models."m3".pricing."openai"]',
+      "input_cost_per_second = 0.75",
+      "code_interpreter_cost_per_session = 3",
+    ].join("\n");
+
+    const result = parseCloudPriceTableToml(toml);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.data.models.m3.input_cost_per_second).toBe(0.5);
+    expect(result.data.models.m3.file_search_cost_per_1k_calls).toBe(2);
+
+    const pricing = result.data.models.m3.pricing as {
+      openai?: {
+        input_cost_per_second?: number;
+        code_interpreter_cost_per_session?: number;
+      };
+    };
+    expect(pricing.openai?.input_cost_per_second).toBe(0.75);
+    expect(pricing.openai?.code_interpreter_cost_per_session).toBe(3);
+  });
+
   it("returns an error when models table is missing", () => {
     const toml = ["[metadata]", 'version = "test"'].join("\n");
     const result = parseCloudPriceTableToml(toml);

--- a/tests/unit/settings/prices/model-price-details-dialog.test.tsx
+++ b/tests/unit/settings/prices/model-price-details-dialog.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, test } from "vitest";
+import { ModelPriceDetailsDialog } from "@/app/[locale]/settings/prices/_components/model-price-details-dialog";
+import type { ModelPrice } from "@/types/model-price";
+import { loadMessages } from "./test-messages";
+
+function render(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(node);
+  });
+
+  return {
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+async function flushPromises() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("ModelPriceDetailsDialog", () => {
+  test("renders core fields and additional billable/provider fields", async () => {
+    const messages = loadMessages();
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const price: ModelPrice = {
+      id: 1,
+      modelName: "demo-model",
+      priceData: {
+        mode: "chat",
+        display_name: "Demo Model",
+        input_cost_per_request: 0.25,
+        input_cost_per_second: 0.5,
+        supports_reasoning: true,
+        pricing: {
+          openai: {
+            input_cost_per_token: 0.0000025,
+            file_search_cost_per_1k_calls: 2,
+          },
+        },
+      },
+      source: "manual",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const { unmount } = render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <ModelPriceDetailsDialog price={price} />
+      </NextIntlClientProvider>
+    );
+
+    const trigger = Array.from(document.querySelectorAll("button")).find((element) =>
+      element.textContent?.includes("View details")
+    );
+    expect(trigger).toBeTruthy();
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flushPromises();
+      await flushPromises();
+    });
+
+    expect(document.body.textContent).toContain("Core fields");
+    expect(document.body.textContent).toContain("input_cost_per_request");
+    expect(document.body.textContent).toContain("Additional billable fields");
+    expect(document.body.textContent).toContain("pricing.openai.file_search_cost_per_1k_calls");
+
+    unmount();
+  });
+});

--- a/tests/unit/settings/prices/model-price-details-dialog.test.tsx
+++ b/tests/unit/settings/prices/model-price-details-dialog.test.tsx
@@ -35,6 +35,9 @@ async function flushPromises() {
 describe("ModelPriceDetailsDialog", () => {
   test("renders core fields and additional billable/provider fields", async () => {
     const messages = loadMessages();
+    const pricingMessages = messages.settings.prices as Record<string, unknown>;
+    const actionMessages = pricingMessages.actions as Record<string, string>;
+    const detailsMessages = pricingMessages.details as Record<string, string>;
     const now = new Date("2026-01-01T00:00:00.000Z");
     const price: ModelPrice = {
       id: 1,
@@ -64,7 +67,7 @@ describe("ModelPriceDetailsDialog", () => {
     );
 
     const trigger = Array.from(document.querySelectorAll("button")).find((element) =>
-      element.textContent?.includes("View details")
+      element.textContent?.includes(actionMessages.viewDetails)
     );
     expect(trigger).toBeTruthy();
 
@@ -74,9 +77,9 @@ describe("ModelPriceDetailsDialog", () => {
       await flushPromises();
     });
 
-    expect(document.body.textContent).toContain("Core fields");
+    expect(document.body.textContent).toContain(detailsMessages.coreFieldsTitle);
     expect(document.body.textContent).toContain("input_cost_per_request");
-    expect(document.body.textContent).toContain("Additional billable fields");
+    expect(document.body.textContent).toContain(detailsMessages.additionalBillableTitle);
     expect(document.body.textContent).toContain("pricing.openai.file_search_cost_per_1k_calls");
 
     unmount();

--- a/tests/unit/settings/prices/model-price-drawer-prefill-and-submit-ui.test.tsx
+++ b/tests/unit/settings/prices/model-price-drawer-prefill-and-submit-ui.test.tsx
@@ -50,8 +50,8 @@ async function flushMicrotasks() {
   await Promise.resolve();
 }
 
-function setReactInputValue(input: HTMLInputElement, value: string) {
-  const prototype = Object.getPrototypeOf(input) as HTMLInputElement;
+function setReactInputValue(input: HTMLInputElement | HTMLTextAreaElement, value: string) {
+  const prototype = Object.getPrototypeOf(input) as HTMLInputElement | HTMLTextAreaElement;
   const descriptor = Object.getOwnPropertyDescriptor(prototype, "value");
   descriptor?.set?.call(input, value);
   input.dispatchEvent(new Event("input", { bubbles: true }));
@@ -296,6 +296,75 @@ describe("ModelPriceDrawer: 预填充与提交", () => {
     expect(payload.cacheReadInputTokenCost).toBeCloseTo(0.0000002);
     expect(payload.cacheCreationInputTokenCost).toBeCloseTo(0.0000025);
     expect(payload.cacheCreationInputTokenCostAbove1hr).toBeCloseTo(0.000004);
+
+    unmount();
+  });
+
+  test("编辑时应预填额外 JSON 字段，并在提交时透传", async () => {
+    const messages = loadMessages();
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const initialData: ModelPrice = {
+      id: 2,
+      modelName: "advanced-model",
+      priceData: {
+        mode: "chat",
+        display_name: "Advanced Model",
+        litellm_provider: "openai",
+        input_cost_per_token: 0.000001,
+        output_cost_per_token: 0.000002,
+        input_cost_per_second: 0.5,
+        file_search_cost_per_1k_calls: 2,
+      },
+      source: "manual",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const { unmount } = render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <ModelPriceDrawer mode="edit" initialData={initialData} defaultOpen />
+      </NextIntlClientProvider>
+    );
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    const extraFieldsInput = document.getElementById(
+      "extraFieldsJson"
+    ) as HTMLTextAreaElement | null;
+    expect(extraFieldsInput).toBeTruthy();
+    expect(extraFieldsInput?.value).toContain('"input_cost_per_second": 0.5');
+    expect(extraFieldsInput?.value).toContain('"file_search_cost_per_1k_calls": 2');
+
+    await act(async () => {
+      setReactInputValue(
+        extraFieldsInput!,
+        JSON.stringify({
+          input_cost_per_second: 0.75,
+          file_search_cost_per_1k_calls: 3,
+        })
+      );
+    });
+
+    const submit = Array.from(document.querySelectorAll("button")).find(
+      (el) => el.textContent?.trim() === "Confirm"
+    );
+    expect(submit).toBeTruthy();
+
+    await act(async () => {
+      submit?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await flushPromises();
+      await flushPromises();
+    });
+
+    expect(modelPricesActionMocks.upsertSingleModelPrice).toHaveBeenCalled();
+    const payload = modelPricesActionMocks.upsertSingleModelPrice.mock.calls.at(-1)?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload.extraFieldsJson).toContain('"input_cost_per_second":0.75');
+    expect(payload.extraFieldsJson).toContain('"file_search_cost_per_1k_calls":3');
 
     unmount();
   });


### PR DESCRIPTION
## Summary
Preserve extra price-like fields during manual price edits instead of dropping them to the drawer-managed subset, align billing-model-source integration tests with breakdown-backed DB cost writes, add a semantic pricing details dialog and advanced extra-fields JSON editing for local model prices, and recognize generic price-like fields as valid pricing data.

## Problem
When editing model prices through the drawer UI, only the explicitly managed fields (input/output/cache costs) were preserved. Any extra pricing fields from cloud price tables (e.g. `input_cost_per_second`, `file_search_cost_per_1k_calls`, `code_interpreter_cost_per_session`) were silently dropped on save. Additionally, there was no way to inspect the full pricing record to see what fields exist, and the integration test suite still referenced the old `updateMessageRequestCost` function that was renamed to `updateMessageRequestCostWithBreakdown` in PR #1025.

**Related PRs:**
- Related to #1025 — This PR extends the pricing infrastructure introduced by the cost breakdown feature. The billing-model-source test alignment renames `updateMessageRequestCost` mocks to `updateMessageRequestCostWithBreakdown` to match the repository function renamed in that PR.
- Related to #1038 — Same pricing/cost display area.
- Related to #1047 — Same pricing resolution subsystem.

## Solution
1. **New `model-price-fields` utility** (`src/lib/utils/model-price-fields.ts`) — Classifies every field in a price record as "supported" (billing keys the app knows), "unsupported" (generic price-like keys by regex), or "display" (metadata). Provides `getEditableExtraPriceData()` to extract non-managed fields for round-tripping, and `collectAdditionalPriceLikeNumbers()` for price validity checks.
2. **Extra fields JSON in drawer** — The model price drawer now pre-fills and submits an `extraFieldsJson` textarea so users can view/edit arbitrary extra pricing fields that aren't covered by the basic form. These are spread into the `priceData` object on upsert.
3. **Pricing details dialog** (`model-price-details-dialog.tsx`) — A new "View details" action in the price list dropdown opens a dialog showing all fields organized into Core fields, Additional billable fields, Additional metadata, and Provider pricing nodes (grouped by provider key).
4. **Price validity enhancement** (`price-data.ts`) — `hasValidPriceData` now also considers generic price-like numeric fields (matching `cost|price|rate|multiplier|per_|second|session|query|page|pixel|character|dbu`) as valid pricing data, so models priced by non-token metrics are recognized as having valid prices.
5. **Integration test alignment** — Renamed all `updateMessageRequestCost` mock references to `updateMessageRequestCostWithBreakdown` in `billing-model-source.test.ts` to match the current repository API.

## Changes

### Core Changes
- `src/lib/utils/model-price-fields.ts` (new) — Field classification, editable extras extraction, and price-like key detection utilities
- `src/actions/model-prices.ts` — Accept `extraFieldsJson`, parse and spread into `priceData` on upsert
- `src/lib/utils/price-data.ts` — Include generic price-like numbers in `hasValidPriceData` check
- `src/app/[locale]/settings/prices/_components/model-price-details-dialog.tsx` (new) — Semantic details dialog with field categories
- `src/app/[locale]/settings/prices/_components/model-price-drawer.tsx` — Extra fields JSON textarea with pre-fill on edit
- `src/app/[locale]/settings/prices/_components/price-list.tsx` — "View details" menu item

### Supporting Changes
- `messages/*/settings/prices.json` (all 5 locales) — i18n strings for advanced fields and details dialog
- `tests/unit/lib/model-price-fields.test.ts` (new) — Tests for field classification, editable extras, and price-like detection
- `tests/unit/lib/price-data-price-like-fields.test.ts` (new) — Tests for generic price-like field recognition in `hasValidPriceData`
- `tests/unit/settings/prices/model-price-details-dialog.test.tsx` (new) — Dialog rendering tests
- `tests/unit/settings/prices/model-price-drawer-prefill-and-submit-ui.test.tsx` — Tests for extra fields pre-fill and submit round-trip
- `tests/unit/actions/model-prices.test.ts` — Test for extra JSON fields merge on upsert
- `tests/unit/price-sync/cloud-price-table.test.ts` — Test for preserving generic pricing fields from TOML
- `tests/integration/billing-model-source.test.ts` — Align mocks with renamed `updateMessageRequestCostWithBreakdown`

## Breaking Changes
None. All changes are additive — existing price records and workflows continue to work unchanged.

## Verification
```bash
bunx vitest run tests/unit/price-sync/cloud-price-table.test.ts tests/unit/actions/model-prices.test.ts tests/unit/settings/prices/model-price-drawer-prefill-and-submit-ui.test.tsx tests/unit/settings/prices/model-price-details-dialog.test.tsx tests/unit/lib/model-price-fields.test.ts tests/unit/lib/price-data-price-like-fields.test.ts tests/integration/billing-model-source.test.ts --reporter=dot
bun run typecheck
bun run build
bun run test
bun run lint -- --max-diagnostics 200
```

## Screenshot
- Pricing preview: https://i.111666.best/image/pD2J7xhqf2VFxWxwIif3yX.png

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves extra pricing fields during manual edits by introducing a `model-price-fields` utility for field classification, adds an `extraFieldsJson` textarea to the price drawer for round-tripping non-managed fields, exposes a semantic "View details" dialog for inspecting all price record fields, broadens `hasValidPriceData` to recognise generic price-like numerics, and aligns integration test mocks with the `updateMessageRequestCostWithBreakdown` rename from PR #1025.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all remaining findings are minor style/consistency P2s that do not affect correctness or data integrity.

Prior P0/P1 concerns (negative-value bypass, server-side managed-field stripping, regex false positives) were surfaced in earlier review rounds and the current state either addresses them or intentionally defers them. The two new findings — duplicate `classifyField` call and unconditional core-section rendering — are cosmetic and do not impact runtime behaviour or data correctness.

No files require special attention; `src/lib/utils/model-price-fields.ts` has the minor duplicate-call nit and `model-price-details-dialog.tsx` has the inconsistent section guard.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/utils/model-price-fields.ts | New utility providing field classification, editable-extra extraction, and price-like key detection; minor duplicate `classifyField` call per entry in `pushEntries` |
| src/actions/model-prices.ts | Accepts `extraFieldsJson`, sanitizes via `sanitizeExtraPriceData` (prototype-pollution-safe, validates price-like leaf values), spreads before managed fields; server-side does not strip `NON_EDITABLE_MANAGED_FIELDS` keys such as `pricing` (noted in prior review) |
| src/lib/utils/price-data.ts | Extends `hasValidPriceData` to delegate to `collectAdditionalPriceLikeNumbers`; known cost fields are double-counted with `collectNumericCosts` but harmlessly so due to `.some()` semantics |
| src/app/[locale]/settings/prices/_components/model-price-details-dialog.tsx | New dialog displaying price fields organised into core/billable/metadata/provider sections; core section renders unconditionally unlike the other three guarded sections |
| src/app/[locale]/settings/prices/_components/model-price-drawer.tsx | Adds `extraFieldsJson` textarea with pre-fill via `getEditableExtraPriceData` on edit/prefill; correctly round-trips extra fields through the action |
| src/app/[locale]/settings/prices/_components/price-list.tsx | Adds "View details" dropdown item wired to `ModelPriceDetailsDialog` via standard `onSelect`-prevents-close + `asChild` pattern |
| tests/integration/billing-model-source.test.ts | Aligns mock references from renamed `updateMessageRequestCost` → `updateMessageRequestCostWithBreakdown`; straightforward rename alignment |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/actions/model-prices.ts`, line 661-694 ([link](https://github.com/ding113/claude-code-hub/blob/128c0c3b5e618b44cb185c51ae0f5d457cea522b/src/actions/model-prices.ts#L661-L694)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Server-side does not strip `NON_EDITABLE_MANAGED_FIELDS` from `extraPriceData` before the spread**

   `getEditableExtraPriceData` filters out `NON_EDITABLE_MANAGED_FIELDS` (including `pricing`) only on the client to pre-populate the textarea. The server never applies the same filter. A user who manually types `{"pricing": {"openai": {...}}}` in the advanced JSON textarea will persist a `pricing` node even though the form treats `pricing` as a managed field it doesn't control. The `pricing` key is not set explicitly later in the spread, so it won't be overridden. Consider stripping managed fields server-side before the merge, or reusing `getEditableExtraPriceData` on the server path.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/actions/model-prices.ts
   Line: 661-694

   Comment:
   **Server-side does not strip `NON_EDITABLE_MANAGED_FIELDS` from `extraPriceData` before the spread**

   `getEditableExtraPriceData` filters out `NON_EDITABLE_MANAGED_FIELDS` (including `pricing`) only on the client to pre-populate the textarea. The server never applies the same filter. A user who manually types `{"pricing": {"openai": {...}}}` in the advanced JSON textarea will persist a `pricing` node even though the form treats `pricing` as a managed field it doesn't control. The `pricing` key is not set explicitly later in the spread, so it won't be overridden. Consider stripping managed fields server-side before the merge, or reusing `getEditableExtraPriceData` on the server path.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/utils/model-price-fields.ts
Line: 163-184

Comment:
**`classifyField` computed twice per entry**

`classifyField(path, key)` is called once to populate `kind` and again inside the `isCoreField` call. Since it's a pure function, extracting it to a local variable avoids the duplicate computation on every iteration.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/[locale]/settings/prices/_components/model-price-details-dialog.tsx
Line: 180-187

Comment:
**Core fields section renders unconditionally**

The "Core fields" `<section>` is always rendered even when `coreEntries` is empty, producing an orphaned heading. The other three sections (`additionalBillable`, `additionalMetadata`, `providerGroups`) all guard with a length check — wrapping this section in a `{coreEntries.length > 0 && (...)}` guard would make the rendering logic consistent.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(pricing): address second-round revie..."](https://github.com/ding113/claude-code-hub/commit/19aa55e3e49ef8bbbb74c5b533b29583be3613bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29009167)</sub>

<!-- /greptile_comment -->