### PR TITLE
fix: align base_url full-path compatibility

### DIFF
--- a/messages/en/settings/providers/form/url.json
+++ b/messages/en/settings/providers/form/url.json
@@ -1,4 +1,6 @@
 {
   "label": "API Address",
-  "placeholder": "e.g. https://open.bigmodel.cn/api/anthropic"
+  "placeholder": "e.g. https://open.bigmodel.cn/api/anthropic",
+  "description": "Use your provider's base address. For request forwarding, preview, and provider testing, you can also paste a version path or exact endpoint here.",
+  "tooltip": "Examples: https://relay.example.com/openai, https://relay.example.com/openai/v1, https://relay.example.com/openai/v1/responses. Claude Code Hub reuses the path you provide instead of appending the same endpoint twice."
 }

--- a/messages/ja/settings/providers/form/url.json
+++ b/messages/ja/settings/providers/form/url.json
@@ -1,4 +1,6 @@
 {
   "label": "API アドレス",
-  "placeholder": "例: https://open.bigmodel.cn/api/anthropic"
+  "placeholder": "例: https://open.bigmodel.cn/api/anthropic",
+  "description": "通常はプロバイダーの基本アドレスを入力してください。リクエスト転送、プレビュー、provider testing では、バージョン付きのパスや完全なエンドポイントもそのまま使えます。",
+  "tooltip": "例: https://relay.example.com/openai、https://relay.example.com/openai/v1、https://relay.example.com/openai/v1/responses。Claude Code Hub は入力されたパスを再利用し、同じ endpoint を二重に付けません。"
 }

--- a/messages/ru/settings/providers/form/url.json
+++ b/messages/ru/settings/providers/form/url.json
@@ -1,4 +1,6 @@
 {
   "label": "Адрес API",
-  "placeholder": "например: https://open.bigmodel.cn/api/anthropic"
+  "placeholder": "например: https://open.bigmodel.cn/api/anthropic",
+  "description": "Обычно сюда вводят базовый адрес провайдера. Для маршрутизации запросов, предпросмотра и provider testing поле также принимает путь с версией или полный URL конечной точки.",
+  "tooltip": "Примеры: https://relay.example.com/openai, https://relay.example.com/openai/v1, https://relay.example.com/openai/v1/responses. Claude Code Hub переиспользует указанный путь и не дописывает тот же endpoint повторно."
 }

--- a/messages/zh-CN/settings/providers/form/url.json
+++ b/messages/zh-CN/settings/providers/form/url.json
@@ -1,4 +1,6 @@
 {
   "label": "API 地址",
-  "placeholder": "例如: https://open.bigmodel.cn/api/anthropic"
+  "placeholder": "例如: https://open.bigmodel.cn/api/anthropic",
+  "description": "填写供应商的基础地址即可。在请求转发、预览和 provider testing 中，这里也支持版本路径或完整接口地址。",
+  "tooltip": "例如：https://relay.example.com/openai、https://relay.example.com/openai/v1、https://relay.example.com/openai/v1/responses。Claude Code Hub 会复用你提供的路径，不会把同一个 endpoint 再追加一次。"
 }

--- a/messages/zh-TW/settings/providers/form/url.json
+++ b/messages/zh-TW/settings/providers/form/url.json
@@ -1,4 +1,6 @@
 {
   "label": "API 位址",
-  "placeholder": "例如：https://open.bigmodel.cn/api/anthropic"
+  "placeholder": "例如：https://open.bigmodel.cn/api/anthropic",
+  "description": "填入供應商的基礎位址即可。在請求轉發、預覽與 provider testing 中，這裡也支援版本路徑或完整介面位址。",
+  "tooltip": "例如：https://relay.example.com/openai、https://relay.example.com/openai/v1、https://relay.example.com/openai/v1/responses。Claude Code Hub 會重用你提供的路徑，不會把同一個 endpoint 再追加一次。"
 }

--- a/src/app/[locale]/settings/providers/_components/forms/provider-form/components/section-card.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/provider-form/components/section-card.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { motion } from "framer-motion";
-import type { LucideIcon } from "lucide-react";
+import { Info, type LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 interface SectionCardProps {
@@ -140,6 +141,7 @@ export function SmartInputWrapper({
   description,
   error,
   required,
+  tooltip,
   children,
   className,
 }: SmartInputWrapperProps) {
@@ -150,6 +152,27 @@ export function SmartInputWrapper({
           {label}
           {required && <span className="text-destructive ml-0.5">*</span>}
         </label>
+        {tooltip ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={tooltip}
+                data-smart-input-tooltip
+                className={cn(
+                  "inline-flex items-center justify-center rounded-sm text-muted-foreground",
+                  "transition-colors hover:text-foreground focus:outline-none focus:ring-2",
+                  "focus:ring-ring focus:ring-offset-2"
+                )}
+              >
+                <Info className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs">
+              <p className="text-sm">{tooltip}</p>
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
       </div>
       {children}
       {error ? (

--- a/src/app/[locale]/settings/providers/_components/forms/provider-form/components/section-card.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/provider-form/components/section-card.tsx
@@ -3,7 +3,7 @@
 import { motion } from "framer-motion";
 import { Info, type LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
 interface SectionCardProps {
@@ -153,8 +153,8 @@ export function SmartInputWrapper({
           {required && <span className="text-destructive ml-0.5">*</span>}
         </label>
         {tooltip ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
+          <Popover>
+            <PopoverTrigger asChild>
               <button
                 type="button"
                 aria-label={tooltip}
@@ -167,11 +167,11 @@ export function SmartInputWrapper({
               >
                 <Info className="h-4 w-4" />
               </button>
-            </TooltipTrigger>
-            <TooltipContent side="top" className="max-w-xs">
+            </PopoverTrigger>
+            <PopoverContent side="top" className="max-w-xs">
               <p className="text-sm">{tooltip}</p>
-            </TooltipContent>
-          </Tooltip>
+            </PopoverContent>
+          </Popover>
         ) : null}
       </div>
       {children}

--- a/src/app/[locale]/settings/providers/_components/forms/provider-form/sections/basic-info-section.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/provider-form/sections/basic-info-section.tsx
@@ -208,7 +208,12 @@ export function BasicInfoSection({ autoUrlPending, endpointPool }: BasicInfoSect
           icon={Link2}
         >
           <div className="space-y-4">
-            <SmartInputWrapper label={t("url.label")} required>
+            <SmartInputWrapper
+              label={t("url.label")}
+              description={t("url.description")}
+              tooltip={t("url.tooltip")}
+              required
+            >
               <div className="relative">
                 <Input
                   id={isEdit ? "edit-url" : "url"}

--- a/src/app/[locale]/settings/providers/_components/forms/url-preview.tsx
+++ b/src/app/[locale]/settings/providers/_components/forms/url-preview.tsx
@@ -3,7 +3,11 @@ import { AlertCircle, Check, CheckCircle2, Copy } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import { previewProxyUrls } from "@/app/v1/_lib/url";
+import {
+  getPreviewEndpoints,
+  hasDuplicatedEndpointPath,
+  previewProxyUrls,
+} from "@/app/v1/_lib/url";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -33,34 +37,36 @@ export function UrlPreview({ baseUrl, providerType }: UrlPreviewProps) {
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
 
   // 实时生成预览结果
-  const previews = useMemo(() => {
+  const previewItems = useMemo(() => {
     if (!baseUrl || baseUrl.trim() === "") {
       return null;
     }
 
     try {
-      const result = previewProxyUrls(baseUrl, providerType);
-      return Object.keys(result).length > 0 ? result : null;
+      const previewUrls = previewProxyUrls(baseUrl, providerType);
+      const items = getPreviewEndpoints(providerType, baseUrl)
+        .map(({ key, path }) => {
+          const url = previewUrls[key];
+          if (!url) {
+            return null;
+          }
+
+          return {
+            endpointKey: key,
+            hasDuplicate: hasDuplicatedEndpointPath(baseUrl, path),
+            url,
+          };
+        })
+        .filter(
+          (item): item is { endpointKey: string; hasDuplicate: boolean; url: string } =>
+            item !== null
+        );
+
+      return items.length > 0 ? items : null;
     } catch {
       return null;
     }
   }, [baseUrl, providerType]);
-
-  // 检测 URL 是否包含重复路径（基础启发式检测）
-  const detectDuplicatePath = (url: string): boolean => {
-    try {
-      const urlObj = new URL(url);
-      const path = urlObj.pathname;
-
-      // 检测重复的路径段（如 /responses/v1/responses）
-      const segments = path.split("/").filter(Boolean);
-      const duplicates = segments.filter((seg, idx) => segments.indexOf(seg) !== idx);
-
-      return duplicates.length > 0;
-    } catch {
-      return false;
-    }
-  };
 
   // 复制 URL 到剪贴板
   const copyToClipboard = async (url: string, name: string) => {
@@ -82,7 +88,7 @@ export function UrlPreview({ baseUrl, providerType }: UrlPreviewProps) {
   }
 
   // 如果 URL 解析失败
-  if (!previews) {
+  if (!previewItems) {
     return (
       <Card className="p-4 border-orange-200 bg-orange-50">
         <div className="flex items-start gap-3">
@@ -109,8 +115,7 @@ export function UrlPreview({ baseUrl, providerType }: UrlPreviewProps) {
 
         {/* 预览列表 */}
         <div className="space-y-2">
-          {Object.entries(previews).map(([endpointKey, url]) => {
-            const hasDuplicate = detectDuplicatePath(url);
+          {previewItems.map(({ endpointKey, hasDuplicate, url }) => {
             const isCopied = copiedUrl === url;
             const label = t(`endpoints.${endpointKey}`);
 

--- a/src/app/v1/_lib/url.ts
+++ b/src/app/v1/_lib/url.ts
@@ -24,7 +24,7 @@ function isVersionRootPath(basePath: string): boolean {
   }
 
   // 仅接受常见版本 token，避免把 /v1api、/v10models 之类的普通路径误判成版本根。
-  return /^(v\d+(?:(?:alpha|beta|preview|internal)\d*)?)$/.test(tail);
+  return /^(v\d+(?:(?:alpha|beta|preview|internal|rc|ga|stable|dev|canary)\d*)?)$/.test(tail);
 }
 
 type PreviewEndpoint = {
@@ -168,6 +168,7 @@ export function buildProxyUrl(baseUrl: string, requestUrl: URL): string {
 }
 
 function matchesEndpointRoot(basePath: string, requestPath: string): boolean {
+  // `targetEndpoints` 需要保持前缀互不歧义；否则 preview 过滤会无法判断该保留哪一行。
   for (const { endpoint, regex } of endpointRegexes) {
     const match = requestPath.match(regex);
     if (!match) {

--- a/src/app/v1/_lib/url.ts
+++ b/src/app/v1/_lib/url.ts
@@ -1,6 +1,8 @@
 import { logger } from "@/lib/logger";
 
-const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 const targetEndpoints = [
   "/responses", // Codex Response API
@@ -15,25 +17,87 @@ const endpointRegexes = targetEndpoints.map((endpoint) => ({
   regex: new RegExp(`^/(v\\d+[a-z0-9]*)${escapeRegExp(endpoint)}(?<suffix>/.*)?$`),
 }));
 
+function isVersionRootPath(basePath: string): boolean {
+  const tail = basePath.split("/").filter(Boolean).at(-1)?.toLowerCase();
+  if (!tail) {
+    return false;
+  }
+
+  // 仅接受常见版本 token，避免把 /v1api、/v10models 之类的普通路径误判成版本根。
+  return /^(v\d+(?:(?:alpha|beta|preview|internal)\d*)?)$/.test(tail);
+}
+
+type PreviewEndpoint = {
+  key: string;
+  path: string;
+};
+
+const previewEndpointsByType: Record<string, PreviewEndpoint[]> = {
+  claude: [
+    { key: "claudeMessages", path: "/v1/messages" },
+    { key: "claudeCountTokens", path: "/v1/messages/count_tokens" },
+  ],
+  "claude-auth": [
+    { key: "claudeMessages", path: "/v1/messages" },
+    { key: "claudeCountTokens", path: "/v1/messages/count_tokens" },
+  ],
+  codex: [{ key: "codexResponses", path: "/v1/responses" }],
+  "openai-compatible": [
+    { key: "openaiChatCompletions", path: "/v1/chat/completions" },
+    { key: "openaiModels", path: "/v1/models" },
+  ],
+  gemini: [
+    {
+      key: "geminiGenerateContent",
+      path: "/v1beta/models/gemini-1.5-pro:generateContent",
+    },
+    {
+      key: "geminiStreamContent",
+      path: "/v1beta/models/gemini-1.5-pro:streamGenerateContent",
+    },
+  ],
+  "gemini-cli": [
+    {
+      key: "geminiCliGenerate",
+      path: "/v1internal/models/gemini-2.5-flash:generateContent",
+    },
+    {
+      key: "geminiCliStream",
+      path: "/v1internal/models/gemini-2.5-flash:streamGenerateContent",
+    },
+  ],
+};
+
+const fallbackPreviewEndpoints: PreviewEndpoint[] = [
+  { key: "claudeMessages", path: "/v1/messages" },
+  { key: "codexResponses", path: "/v1/responses" },
+  { key: "openaiChatCompletions", path: "/v1/chat/completions" },
+];
+
+function splitPathSegments(pathname: string): string[] {
+  return pathname.split("/").filter(Boolean);
+}
+
+function endsWithSegments(haystack: string[], needle: string[]): boolean {
+  if (needle.length === 0 || needle.length > haystack.length) {
+    return false;
+  }
+
+  const offset = haystack.length - needle.length;
+  return needle.every((segment, index) => haystack[offset + index] === segment);
+}
+
 /**
- * 构建代理目标URL（智能检测版本）
+ * 构建代理目标 URL，并在以下场景下避免重复拼接：
  *
- * 核心改进：智能检测 base_url 是否已包含完整路径
- *
- * **问题场景（Issue #139）**：
- * - 用户填写：`https://xxx.com/openai/responses`（已包含完整路径）
- * - 请求路径：`/v1/responses`
- * - 旧逻辑结果：`https://xxx.com/openai/responses/v1/responses` ❌
- * - 新逻辑结果：`https://xxx.com/openai/responses` ✅
- *
- * **智能检测规则**：
- * 1. 检查 base_url 末尾是否已包含完整目标路径（如 `/responses`, `/messages`）
- * 2. 如果已包含，直接使用 base_url（不再拼接）
- * 3. 如果未包含，执行标准拼接
+ * 1. `baseUrl` 已经是完整 endpoint 或 endpoint 根路径
+ * 2. `baseUrl` 只停在版本根路径，例如 `/v1`、`/v4`、`/v1beta`
+ * 3. `requestUrl` 命中的是 endpoint 子路径，例如 `/v1/messages/count_tokens`
  *
  * @param baseUrl - 基础URL（用户配置的供应商URL）
- *   - 示例 1：`https://api.openai.com` → 需要拼接
- *   - 示例 2：`https://xxx.com/openai/responses` → 已包含，不拼接
+ *   - 示例 1：`https://api.openai.com` -> 需要拼接
+ *   - 示例 2：`https://xxx.com/openai/responses` -> 已包含完整 endpoint
+ *   - 示例 3：`https://xxx.com/openai/v1` -> 只包含版本根路径
  * @param requestUrl - 原始请求URL对象（包含路径和查询参数）
  * @returns 拼接后的完整URL字符串
  */
@@ -55,12 +119,12 @@ export function buildProxyUrl(baseUrl: string, requestUrl: URL): string {
     // Case 2: baseUrl 已包含“端点根路径”（可能带有额外前缀），仅追加 requestPath 的子路径部分。
 
     for (const { endpoint, regex } of endpointRegexes) {
-      const m = requestPath.match(regex);
-      if (!m) continue;
+      const endpointMatch = requestPath.match(regex);
+      if (!endpointMatch) continue;
 
-      const version = m[1];
-      const requestRoot = `/${version}${endpoint}`;
-      const suffix = m.groups?.suffix ?? "";
+      const versionPrefix = endpointMatch[1];
+      const requestRoot = `/${versionPrefix}${endpoint}`;
+      const suffix = endpointMatch.groups?.suffix ?? "";
 
       if (basePath.endsWith(endpoint) || basePath.endsWith(requestRoot)) {
         baseUrlObj.pathname = basePath + suffix;
@@ -71,6 +135,20 @@ export function buildProxyUrl(baseUrl: string, requestUrl: URL): string {
           requestPath,
           endpoint,
           action: "append_suffix",
+        });
+
+        return baseUrlObj.toString();
+      }
+
+      if (isVersionRootPath(basePath)) {
+        baseUrlObj.pathname = `${basePath}${endpoint}${suffix}`;
+        baseUrlObj.search = requestUrl.search;
+
+        logger.debug("[buildProxyUrl] Detected version root in baseUrl", {
+          basePath,
+          requestPath,
+          endpoint,
+          action: "append_endpoint",
         });
 
         return baseUrlObj.toString();
@@ -86,6 +164,80 @@ export function buildProxyUrl(baseUrl: string, requestUrl: URL): string {
     // 降级到字符串拼接
     const normalizedBaseUrl = baseUrl.replace(/\/$/, "");
     return `${normalizedBaseUrl}${requestUrl.pathname}${requestUrl.search}`;
+  }
+}
+
+function matchesEndpointRoot(basePath: string, requestPath: string): boolean {
+  for (const { endpoint, regex } of endpointRegexes) {
+    const match = requestPath.match(regex);
+    if (!match) {
+      continue;
+    }
+
+    const requestRoot = `/${match[1]}${endpoint}`;
+    return basePath.endsWith(endpoint) || basePath.endsWith(requestRoot);
+  }
+
+  return false;
+}
+
+export function getPreviewEndpoints(providerType?: string, baseUrl?: string): PreviewEndpoint[] {
+  const endpoints = providerType
+    ? previewEndpointsByType[providerType] || []
+    : previewEndpointsByType.claude;
+  const effectiveEndpoints = endpoints.length > 0 ? endpoints : fallbackPreviewEndpoints;
+
+  if (!baseUrl) {
+    return effectiveEndpoints;
+  }
+
+  try {
+    const basePath = new URL(baseUrl).pathname.replace(/\/$/, "");
+    const matchedEndpoints = effectiveEndpoints.filter(({ path }) =>
+      matchesEndpointRoot(basePath, path)
+    );
+    return matchedEndpoints.length > 0 ? matchedEndpoints : effectiveEndpoints;
+  } catch {
+    return effectiveEndpoints;
+  }
+}
+
+export function hasDuplicatedEndpointPath(baseUrl: string, requestPath: string): boolean {
+  try {
+    const basePathSegments = splitPathSegments(new URL(baseUrl).pathname.replace(/\/$/, ""));
+    if (basePathSegments.length === 0) {
+      return false;
+    }
+
+    for (const { endpoint, regex } of endpointRegexes) {
+      const match = requestPath.match(regex);
+      if (!match) {
+        continue;
+      }
+
+      const endpointSegments = splitPathSegments(endpoint);
+      const requestRootSegments = [match[1], ...endpointSegments];
+
+      if (endsWithSegments(basePathSegments, requestRootSegments)) {
+        const prefixSegments = basePathSegments.slice(0, -requestRootSegments.length);
+        return (
+          endsWithSegments(prefixSegments, requestRootSegments) ||
+          endsWithSegments(prefixSegments, endpointSegments)
+        );
+      }
+
+      if (endsWithSegments(basePathSegments, endpointSegments)) {
+        const prefixSegments = basePathSegments.slice(0, -endpointSegments.length);
+        return (
+          endsWithSegments(prefixSegments, requestRootSegments) ||
+          endsWithSegments(prefixSegments, endpointSegments)
+        );
+      }
+    }
+
+    return false;
+  } catch {
+    return false;
   }
 }
 
@@ -109,58 +261,8 @@ export function previewProxyUrls(baseUrl: string, providerType?: string): Record
     return previews;
   }
 
-  // 根据供应商类型定义端点映射（key 由 UI 负责 i18n）
-  const endpointsByType: Record<string, Array<{ key: string; path: string }>> = {
-    claude: [
-      { key: "claudeMessages", path: "/v1/messages" },
-      { key: "claudeCountTokens", path: "/v1/messages/count_tokens" },
-    ],
-    "claude-auth": [
-      { key: "claudeMessages", path: "/v1/messages" },
-      { key: "claudeCountTokens", path: "/v1/messages/count_tokens" },
-    ],
-    codex: [{ key: "codexResponses", path: "/v1/responses" }],
-    "openai-compatible": [
-      { key: "openaiChatCompletions", path: "/v1/chat/completions" },
-      { key: "openaiModels", path: "/v1/models" },
-    ],
-    gemini: [
-      {
-        key: "geminiGenerateContent",
-        path: "/v1beta/models/gemini-1.5-pro:generateContent",
-      },
-      {
-        key: "geminiStreamContent",
-        path: "/v1beta/models/gemini-1.5-pro:streamGenerateContent",
-      },
-    ],
-    "gemini-cli": [
-      {
-        key: "geminiCliGenerate",
-        path: "/v1internal/models/gemini-2.5-flash:generateContent",
-      },
-      {
-        key: "geminiCliStream",
-        path: "/v1internal/models/gemini-2.5-flash:streamGenerateContent",
-      },
-    ],
-  };
-
-  // 获取当前供应商类型对应的端点列表（默认显示 Claude）
-  const endpoints = providerType ? endpointsByType[providerType] || [] : endpointsByType.claude;
-
-  // 如果没有匹配的端点，显示常见端点
-  const effectiveEndpoints =
-    endpoints.length > 0
-      ? endpoints
-      : [
-          { key: "claudeMessages", path: "/v1/messages" },
-          { key: "codexResponses", path: "/v1/responses" },
-          { key: "openaiChatCompletions", path: "/v1/chat/completions" },
-        ];
-
   // 生成当前供应商类型的端点预览
-  for (const { key, path } of effectiveEndpoints) {
+  for (const { key, path } of getPreviewEndpoints(providerType, baseUrl)) {
     const fakeRequestUrl = new URL(`https://dummy.com${path}`);
     previews[key] = buildProxyUrl(baseUrl, fakeRequestUrl);
   }

--- a/src/app/v1/_lib/url.ts
+++ b/src/app/v1/_lib/url.ts
@@ -125,16 +125,21 @@ export function buildProxyUrl(baseUrl: string, requestUrl: URL): string {
       const versionPrefix = endpointMatch[1];
       const requestRoot = `/${versionPrefix}${endpoint}`;
       const suffix = endpointMatch.groups?.suffix ?? "";
+      const requestEndpoint = `${requestRoot}${suffix}`;
+      const endpointWithSuffix = `${endpoint}${suffix}`;
+      const hasFullEndpoint =
+        suffix.length > 0 &&
+        (basePath.endsWith(requestEndpoint) || basePath.endsWith(endpointWithSuffix));
 
-      if (basePath.endsWith(endpoint) || basePath.endsWith(requestRoot)) {
-        baseUrlObj.pathname = basePath + suffix;
+      if (hasFullEndpoint || basePath.endsWith(endpoint) || basePath.endsWith(requestRoot)) {
+        baseUrlObj.pathname = hasFullEndpoint ? basePath : basePath + suffix;
         baseUrlObj.search = requestUrl.search;
 
         logger.debug("[buildProxyUrl] Detected endpoint root in baseUrl", {
           basePath,
           requestPath,
           endpoint,
-          action: "append_suffix",
+          action: hasFullEndpoint ? "reuse_full_endpoint" : "append_suffix",
         });
 
         return baseUrlObj.toString();
@@ -176,7 +181,15 @@ function matchesEndpointRoot(basePath: string, requestPath: string): boolean {
     }
 
     const requestRoot = `/${match[1]}${endpoint}`;
-    return basePath.endsWith(endpoint) || basePath.endsWith(requestRoot);
+    const suffix = match.groups?.suffix ?? "";
+    const requestEndpoint = `${requestRoot}${suffix}`;
+    const endpointWithSuffix = `${endpoint}${suffix}`;
+    return (
+      basePath.endsWith(endpoint) ||
+      basePath.endsWith(requestRoot) ||
+      (suffix.length > 0 &&
+        (basePath.endsWith(requestEndpoint) || basePath.endsWith(endpointWithSuffix)))
+    );
   }
 
   return false;
@@ -217,22 +230,24 @@ export function hasDuplicatedEndpointPath(baseUrl: string, requestPath: string):
       }
 
       const endpointSegments = splitPathSegments(endpoint);
+      const suffixSegments = splitPathSegments(match.groups?.suffix ?? "");
+      const endpointWithSuffixSegments = [...endpointSegments, ...suffixSegments];
       const requestRootSegments = [match[1], ...endpointSegments];
+      const requestPathSegments = [match[1], ...endpointWithSuffixSegments];
+      const duplicateCandidates = [
+        requestPathSegments,
+        endpointWithSuffixSegments,
+        requestRootSegments,
+        endpointSegments,
+      ];
 
-      if (endsWithSegments(basePathSegments, requestRootSegments)) {
-        const prefixSegments = basePathSegments.slice(0, -requestRootSegments.length);
-        return (
-          endsWithSegments(prefixSegments, requestRootSegments) ||
-          endsWithSegments(prefixSegments, endpointSegments)
-        );
-      }
-
-      if (endsWithSegments(basePathSegments, endpointSegments)) {
-        const prefixSegments = basePathSegments.slice(0, -endpointSegments.length);
-        return (
-          endsWithSegments(prefixSegments, requestRootSegments) ||
-          endsWithSegments(prefixSegments, endpointSegments)
-        );
+      for (const candidateSegments of duplicateCandidates) {
+        if (endsWithSegments(basePathSegments, candidateSegments)) {
+          const prefixSegments = basePathSegments.slice(0, -candidateSegments.length);
+          return duplicateCandidates.some((prefixCandidate) =>
+            endsWithSegments(prefixSegments, prefixCandidate)
+          );
+        }
       }
     }
 

--- a/src/app/v1/_lib/url.ts
+++ b/src/app/v1/_lib/url.ts
@@ -232,6 +232,7 @@ export function hasDuplicatedEndpointPath(baseUrl: string, requestPath: string):
       const endpointSegments = splitPathSegments(endpoint);
       const suffixSegments = splitPathSegments(match.groups?.suffix ?? "");
       const endpointWithSuffixSegments = [...endpointSegments, ...suffixSegments];
+      const versionSegments = [match[1]];
       const requestRootSegments = [match[1], ...endpointSegments];
       const requestPathSegments = [match[1], ...endpointWithSuffixSegments];
       const duplicateCandidates = [
@@ -239,6 +240,7 @@ export function hasDuplicatedEndpointPath(baseUrl: string, requestPath: string):
         endpointWithSuffixSegments,
         requestRootSegments,
         endpointSegments,
+        versionSegments,
       ];
 
       for (const candidateSegments of duplicateCandidates) {

--- a/src/lib/provider-testing/test-service.test.ts
+++ b/src/lib/provider-testing/test-service.test.ts
@@ -250,6 +250,33 @@ describe("executeProviderTest", () => {
     expectRequestUrl("https://relay.example.com/openai/v1beta1/chat/completions");
   });
 
+  test("带 rc 后缀的版本根路径在 provider testing 中也应生效", async () => {
+    mockJsonResponse({
+      id: "chatcmpl_test",
+      model: "gpt-4.1-mini",
+      choices: [
+        {
+          index: 0,
+          finish_reason: "stop",
+          message: {
+            role: "assistant",
+            content: "pong",
+          },
+        },
+      ],
+    });
+
+    const result = await executeProviderTest({
+      providerUrl: "https://relay.example.com/openai/v1rc1",
+      apiKey: "sk-test-openai-compatible",
+      providerType: "openai-compatible",
+      model: "gpt-4.1-mini",
+    });
+
+    expect(result.success).toBe(true);
+    expectRequestUrl("https://relay.example.com/openai/v1rc1/chat/completions");
+  });
+
   test("带 query 的 preset URL 应保留 preset 自带查询参数", async () => {
     mockJsonResponse({
       id: "msg_123",

--- a/src/lib/provider-testing/test-service.test.ts
+++ b/src/lib/provider-testing/test-service.test.ts
@@ -8,6 +8,46 @@ import { executeProviderTest } from "./test-service";
 
 const fetchMock = vi.fn<typeof fetch>();
 
+function createMockResponse(
+  responseBody: string,
+  options?: {
+    contentType?: string;
+    ok?: boolean;
+    status?: number;
+    statusText?: string;
+  }
+): Response {
+  const ok = options?.ok ?? true;
+
+  return {
+    ok,
+    status: options?.status ?? (ok ? 200 : 400),
+    statusText: options?.statusText ?? (ok ? "OK" : "Bad Request"),
+    headers: new Headers({
+      "content-type": options?.contentType ?? "application/json",
+    }),
+    text: async () => responseBody,
+  } as Response;
+}
+
+function mockJsonResponse(body: unknown): string {
+  const responseBody = JSON.stringify(body);
+  fetchMock.mockResolvedValue(createMockResponse(responseBody));
+  return responseBody;
+}
+
+function mockSseResponse(responseBody: string): void {
+  fetchMock.mockResolvedValue(
+    createMockResponse(responseBody, {
+      contentType: "text/event-stream",
+    })
+  );
+}
+
+function expectRequestUrl(url: string): void {
+  expect(fetchMock).toHaveBeenCalledWith(url, expect.any(Object));
+}
+
 describe("executeProviderTest", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -19,7 +59,7 @@ describe("executeProviderTest", () => {
   });
 
   test("openai-compatible 应该把聊天内容解析为纯文本预览，而不是直接回显整段 JSON", async () => {
-    const responseBody = JSON.stringify({
+    mockJsonResponse({
       id: "chatcmpl_test",
       model: "gpt-4.1-mini",
       choices: [
@@ -39,16 +79,6 @@ describe("executeProviderTest", () => {
       },
     });
 
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: new Headers({
-        "content-type": "application/json",
-      }),
-      text: async () => responseBody,
-    } as Response);
-
     const result = await executeProviderTest({
       providerUrl: "https://api.example.com",
       apiKey: "sk-test-openai-compatible",
@@ -63,7 +93,7 @@ describe("executeProviderTest", () => {
 
   test("rawResponse 应该保留完整响应体，不能在服务层被截断", async () => {
     const assistantText = `pong-${"x".repeat(7000)}`;
-    const responseBody = JSON.stringify({
+    const responseBody = mockJsonResponse({
       id: "resp_test",
       model: "gpt-5-codex",
       output: [
@@ -80,16 +110,6 @@ describe("executeProviderTest", () => {
       ],
     });
 
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: new Headers({
-        "content-type": "application/json",
-      }),
-      text: async () => responseBody,
-    } as Response);
-
     const result = await executeProviderTest({
       providerUrl: "https://api.example.com",
       apiKey: "sk-test-codex",
@@ -103,25 +123,16 @@ describe("executeProviderTest", () => {
   });
 
   test("指定 preset 但未显式传 model 时，应使用 preset 的默认模型构造 Gemini URL", async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: new Headers({
-        "content-type": "application/json",
-      }),
-      text: async () =>
-        JSON.stringify({
-          modelVersion: "gemini-2.5-pro",
-          candidates: [
-            {
-              content: {
-                parts: [{ text: "pong" }],
-              },
-            },
-          ],
-        }),
-    } as Response);
+    mockJsonResponse({
+      modelVersion: "gemini-2.5-pro",
+      candidates: [
+        {
+          content: {
+            parts: [{ text: "pong" }],
+          },
+        },
+      ],
+    });
 
     const result = await executeProviderTest({
       providerUrl: "https://gemini.example.com",
@@ -131,10 +142,180 @@ describe("executeProviderTest", () => {
     });
 
     expect(result.success).toBe(true);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://gemini.example.com/v1beta/models/gemini-2.5-pro:generateContent",
-      expect.any(Object)
-    );
+    expectRequestUrl("https://gemini.example.com/v1beta/models/gemini-2.5-pro:generateContent");
+  });
+
+  test("codex full-path baseUrl 不应重复拼接 /v1/responses", async () => {
+    mockJsonResponse({
+      id: "resp_test",
+      model: "gpt-5.3-codex",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "pong" }],
+        },
+      ],
+    });
+
+    const result = await executeProviderTest({
+      providerUrl: "https://relay.example.com/openai/v1/responses",
+      apiKey: "sk-test-codex",
+      providerType: "codex",
+      model: "gpt-5.3-codex",
+    });
+
+    expect(result.success).toBe(true);
+    expectRequestUrl("https://relay.example.com/openai/v1/responses");
+  });
+
+  test("openai-compatible 版本根路径应只追加 endpoint，不重复拼接 /v1", async () => {
+    mockJsonResponse({
+      id: "chatcmpl_test",
+      model: "gpt-4.1-mini",
+      choices: [
+        {
+          index: 0,
+          finish_reason: "stop",
+          message: {
+            role: "assistant",
+            content: "pong",
+          },
+        },
+      ],
+    });
+
+    const result = await executeProviderTest({
+      providerUrl: "https://relay.example.com/openai/v1",
+      apiKey: "sk-test-openai-compatible",
+      providerType: "openai-compatible",
+      model: "gpt-4.1-mini",
+    });
+
+    expect(result.success).toBe(true);
+    expectRequestUrl("https://relay.example.com/openai/v1/chat/completions");
+  });
+
+  test("任意版本根路径在 provider testing 中也应只追加 endpoint", async () => {
+    mockJsonResponse({
+      id: "chatcmpl_test",
+      model: "glm-4.6",
+      choices: [
+        {
+          index: 0,
+          finish_reason: "stop",
+          message: {
+            role: "assistant",
+            content: "pong",
+          },
+        },
+      ],
+    });
+
+    const result = await executeProviderTest({
+      providerUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+      apiKey: "sk-test-openai-compatible",
+      providerType: "openai-compatible",
+      model: "glm-4.6",
+    });
+
+    expect(result.success).toBe(true);
+    expectRequestUrl("https://open.bigmodel.cn/api/coding/paas/v4/chat/completions");
+  });
+
+  test("带 alpha/beta 数字后缀的版本根路径在 provider testing 中也应生效", async () => {
+    mockJsonResponse({
+      id: "chatcmpl_test",
+      model: "gpt-4.1-mini",
+      choices: [
+        {
+          index: 0,
+          finish_reason: "stop",
+          message: {
+            role: "assistant",
+            content: "pong",
+          },
+        },
+      ],
+    });
+
+    const result = await executeProviderTest({
+      providerUrl: "https://relay.example.com/openai/v1beta1",
+      apiKey: "sk-test-openai-compatible",
+      providerType: "openai-compatible",
+      model: "gpt-4.1-mini",
+    });
+
+    expect(result.success).toBe(true);
+    expectRequestUrl("https://relay.example.com/openai/v1beta1/chat/completions");
+  });
+
+  test("带 query 的 preset URL 应保留 preset 自带查询参数", async () => {
+    mockJsonResponse({
+      id: "msg_123",
+      type: "message",
+      role: "assistant",
+      model: "claude-haiku-4-5-20251001",
+      content: [{ type: "text", text: "pong" }],
+    });
+
+    const result = await executeProviderTest({
+      providerUrl: "https://relay.example.com/anthropic/v1?from=base",
+      apiKey: "sk-ant-test",
+      providerType: "claude",
+      preset: "cc_beta_cli",
+    });
+
+    expect(result.success).toBe(true);
+    expectRequestUrl("https://relay.example.com/anthropic/v1/messages?beta=true");
+  });
+
+  test("无版本 endpoint 根路径在 provider testing 中应与 runtime URL 语义一致", async () => {
+    mockJsonResponse({
+      id: "resp_test",
+      model: "gpt-5.3-codex",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "pong" }],
+        },
+      ],
+    });
+
+    const result = await executeProviderTest({
+      providerUrl: "https://relay.example.com/openai/responses",
+      apiKey: "sk-test-codex",
+      providerType: "codex",
+      model: "gpt-5.3-codex",
+    });
+
+    expect(result.success).toBe(true);
+    expectRequestUrl("https://relay.example.com/openai/responses");
+  });
+
+  test("非标准相似路径在 provider testing 中不应被错误折叠", async () => {
+    mockJsonResponse({
+      id: "resp_test",
+      model: "gpt-5.3-codex",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "pong" }],
+        },
+      ],
+    });
+
+    const result = await executeProviderTest({
+      providerUrl: "https://relay.example.com/openai/responses-archive",
+      apiKey: "sk-test-codex",
+      providerType: "codex",
+      model: "gpt-5.3-codex",
+    });
+
+    expect(result.success).toBe(true);
+    expectRequestUrl("https://relay.example.com/openai/responses-archive/v1/responses");
   });
 
   test("传入未知 preset 时，应直接报错而不是悄悄回退到默认模板", async () => {
@@ -167,24 +348,14 @@ describe("executeProviderTest", () => {
     });
 
     fetchMock
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        statusText: "Bad Request",
-        headers: new Headers({
-          "content-type": "application/json",
-        }),
-        text: async () => errorBody,
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        headers: new Headers({
-          "content-type": "application/json",
-        }),
-        text: async () => okBody,
-      } as Response);
+      .mockResolvedValueOnce(
+        createMockResponse(errorBody, {
+          ok: false,
+          status: 400,
+          statusText: "Bad Request",
+        })
+      )
+      .mockResolvedValueOnce(createMockResponse(okBody));
 
     const result = await executeProviderTest({
       providerUrl: "https://api.example.com",
@@ -214,15 +385,7 @@ event: response.completed
 data: {"type":"response.completed","response":{"model":"gpt-5.3-codex","usage":{"input_tokens":39,"output_tokens":5,"total_tokens":44}},"sequence_number":2}
 `;
 
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: new Headers({
-        "content-type": "text/event-stream",
-      }),
-      text: async () => responseBody,
-    } as Response);
+    mockSseResponse(responseBody);
 
     const result = await executeProviderTest({
       providerUrl: "https://sub.fkcodex.com",
@@ -249,15 +412,7 @@ event: response.completed
 data: {"type":"response.completed","response":{"model":"gpt-5.3-codex","usage":{"input_tokens":39,"output_tokens":5,"total_tokens":44},"output":[{"type":"message","content":[{"type":"output_text","text":"pong"}]}]},"sequence_number":2}
 `;
 
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: new Headers({
-        "content-type": "text/event-stream",
-      }),
-      text: async () => responseBody,
-    } as Response);
+    mockSseResponse(responseBody);
 
     const result = await executeProviderTest({
       providerUrl: "https://sub.fkcodex.com",
@@ -272,26 +427,17 @@ data: {"type":"response.completed","response":{"model":"gpt-5.3-codex","usage":{
   });
 
   test("内容校验应优先使用解析后的文本，不能被原始 JSON 字段名误判为成功", async () => {
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: new Headers({
-        "content-type": "application/json",
-      }),
-      text: async () =>
-        JSON.stringify({
-          model: "gpt-4.1-mini",
-          choices: [
-            {
-              message: {
-                role: "assistant",
-                content: "no match here",
-              },
-            },
-          ],
-        }),
-    } as Response);
+    mockJsonResponse({
+      model: "gpt-4.1-mini",
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "no match here",
+          },
+        },
+      ],
+    });
 
     const result = await executeProviderTest({
       providerUrl: "https://api.example.com",

--- a/src/lib/provider-testing/utils/test-prompts.ts
+++ b/src/lib/provider-testing/utils/test-prompts.ts
@@ -4,6 +4,7 @@
  * 这里保留协议级兜底默认值；真正执行时会优先使用 presets.ts 里的模板定义。
  */
 
+import { buildProxyUrl } from "@/app/v1/_lib/url";
 import type { ProviderType } from "@/types/provider";
 import type { ClaudeTestBody, CodexTestBody, GeminiTestBody, OpenAITestBody } from "../types";
 
@@ -251,14 +252,10 @@ export function getTestUrl(
   model?: string,
   pathOverride?: string
 ): string {
-  const cleanBaseUrl = baseUrl.replace(/\/$/, "");
-  const endpoint = pathOverride || API_ENDPOINTS[providerType];
   const targetModel = model || DEFAULT_MODELS[providerType];
-  let url = `${cleanBaseUrl}${endpoint}`;
+  const requestPath = (pathOverride || API_ENDPOINTS[providerType]).replace("{model}", targetModel);
+  const requestUrl = new URL(`https://provider-test.local${requestPath}`);
 
-  if (providerType === "gemini" || providerType === "gemini-cli") {
-    url = url.replace("{model}", targetModel);
-  }
-
-  return url;
+  // 与真实代理转发共用同一 URL 语义，避免 provider testing 再次分叉出一套拼接规则。
+  return buildProxyUrl(baseUrl, requestUrl);
 }

--- a/tests/unit/app/v1/url.test.ts
+++ b/tests/unit/app/v1/url.test.ts
@@ -160,6 +160,14 @@ describe("buildProxyUrl", () => {
     );
   });
 
+  test("完整子端点：baseUrl 已包含 /v1/messages/count_tokens 时不应重复拼接", () => {
+    expectBuiltUrl(
+      "https://proxy.example.com/anthropic/v1/messages/count_tokens",
+      "/v1/messages/count_tokens?x=1",
+      "https://proxy.example.com/anthropic/v1/messages/count_tokens?x=1"
+    );
+  });
+
   test("无版本 endpoint 根路径：baseUrl=/openai/responses + /v1/responses/abc 应只追加 suffix", () => {
     expectBuiltUrl(
       "https://relay.example.com/openai/responses",

--- a/tests/unit/app/v1/url.test.ts
+++ b/tests/unit/app/v1/url.test.ts
@@ -128,6 +128,14 @@ describe("buildProxyUrl", () => {
     );
   });
 
+  test("带 rc 后缀的版本根路径也应被识别", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/v1rc1",
+      "/v1/chat/completions?x=1",
+      "https://relay.example.com/openai/v1rc1/chat/completions?x=1"
+    );
+  });
+
   test("版本根路径 + Chat 资源后缀：应保留 suffix", () => {
     expectBuiltUrl(
       "https://relay.example.com/openai/v1",

--- a/tests/unit/app/v1/url.test.ts
+++ b/tests/unit/app/v1/url.test.ts
@@ -11,85 +11,168 @@ vi.mock("@/lib/logger", () => ({
 
 import { buildProxyUrl } from "@/app/v1/_lib/url";
 
+function expectBuiltUrl(baseUrl: string, requestPath: string, expectedUrl: string): void {
+  expect(buildProxyUrl(baseUrl, new URL(`https://dummy.com${requestPath}`))).toBe(expectedUrl);
+}
+
 describe("buildProxyUrl", () => {
   test("标准拼接：baseUrl 无路径时使用 requestPath + search", () => {
-    const out = buildProxyUrl(
+    expectBuiltUrl(
       "https://api.example.com",
-      new URL("https://dummy.com/v1/messages?x=1")
+      "/v1/messages?x=1",
+      "https://api.example.com/v1/messages?x=1"
     );
-
-    expect(out).toBe("https://api.example.com/v1/messages?x=1");
   });
 
   test("避免重复拼接：baseUrl 已包含 /responses 时不追加 /v1/responses", () => {
-    const out = buildProxyUrl(
+    expectBuiltUrl(
       "https://example.com/openai/responses",
-      new URL("https://dummy.com/v1/responses?x=1")
+      "/v1/responses?x=1",
+      "https://example.com/openai/responses?x=1"
     );
-
-    expect(out).toBe("https://example.com/openai/responses?x=1");
   });
 
   test("避免重复拼接：baseUrl 已包含 /embeddings 时不追加 /v1/embeddings", () => {
-    const out = buildProxyUrl(
+    expectBuiltUrl(
       "https://example.com/openai/embeddings",
-      new URL("https://dummy.com/v1/embeddings?x=1")
+      "/v1/embeddings?x=1",
+      "https://example.com/openai/embeddings?x=1"
     );
-
-    expect(out).toBe("https://example.com/openai/embeddings?x=1");
   });
 
   test("子路径不丢失：baseUrl=/v1/messages + request=/v1/messages/count_tokens", () => {
-    const out = buildProxyUrl(
+    expectBuiltUrl(
       "https://api.example.com/v1/messages",
-      new URL("https://dummy.com/v1/messages/count_tokens")
+      "/v1/messages/count_tokens",
+      "https://api.example.com/v1/messages/count_tokens"
     );
-
-    expect(out).toBe("https://api.example.com/v1/messages/count_tokens");
   });
 
   test("带前缀路径的 baseUrl：/openai/messages + /v1/messages/count_tokens", () => {
-    const out = buildProxyUrl(
+    expectBuiltUrl(
       "https://example.com/openai/messages",
-      new URL("https://dummy.com/v1/messages/count_tokens")
+      "/v1/messages/count_tokens",
+      "https://example.com/openai/messages/count_tokens"
     );
-
-    expect(out).toBe("https://example.com/openai/messages/count_tokens");
   });
 
   test("query 以 requestUrl 为准（覆盖 baseUrl 自带 query）", () => {
-    const out = buildProxyUrl(
+    expectBuiltUrl(
       "https://api.example.com/v1/messages?from=base",
-      new URL("https://dummy.com/v1/messages?from=request")
+      "/v1/messages?from=request",
+      "https://api.example.com/v1/messages?from=request"
     );
-
-    expect(out).toBe("https://api.example.com/v1/messages?from=request");
   });
 
   test("baseUrl 以 /models 结尾时去除请求中的版本前缀", () => {
-    const out = buildProxyUrl(
+    expectBuiltUrl(
       "https://api.example.com/gemini/models",
-      new URL("https://dummy.com/v1beta/models/gemini-1.5-pro:streamGenerateContent")
+      "/v1beta/models/gemini-1.5-pro:streamGenerateContent",
+      "https://api.example.com/gemini/models/gemini-1.5-pro:streamGenerateContent"
     );
-
-    expect(out).toBe("https://api.example.com/gemini/models/gemini-1.5-pro:streamGenerateContent");
   });
 
   test("支持 v1internal 版本前缀", () => {
-    const out = buildProxyUrl(
+    expectBuiltUrl(
       "https://example.com/gemini/models",
-      new URL("https://dummy.com/v1internal/models/gemini-2.5-flash:generateContent")
+      "/v1internal/models/gemini-2.5-flash:generateContent",
+      "https://example.com/gemini/models/gemini-2.5-flash:generateContent"
     );
-
-    expect(out).toBe("https://example.com/gemini/models/gemini-2.5-flash:generateContent");
   });
 
   test("支持未来的版本前缀如 v2", () => {
-    const out = buildProxyUrl(
+    expectBuiltUrl(
       "https://example.com/api/models",
-      new URL("https://dummy.com/v2/models/some-model:action")
+      "/v2/models/some-model:action",
+      "https://example.com/api/models/some-model:action"
     );
+  });
 
-    expect(out).toBe("https://example.com/api/models/some-model:action");
+  test("完整 Codex path：baseUrl 已包含 /openai/v1/responses 时保持原路径", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/v1/responses",
+      "/v1/responses?x=1",
+      "https://relay.example.com/openai/v1/responses?x=1"
+    );
+  });
+
+  test("完整 OpenAI Chat path：baseUrl 已包含 /openai/v1/chat/completions 时保持原路径", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/v1/chat/completions",
+      "/v1/chat/completions?x=1",
+      "https://relay.example.com/openai/v1/chat/completions?x=1"
+    );
+  });
+
+  test("版本根路径：baseUrl=/openai/v1 时只追加 endpoint，不重复追加 /v1", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/v1",
+      "/v1/chat/completions?x=1",
+      "https://relay.example.com/openai/v1/chat/completions?x=1"
+    );
+  });
+
+  test("任意版本根路径：baseUrl=/api/coding/paas/v4 时只追加 endpoint", () => {
+    expectBuiltUrl(
+      "https://open.bigmodel.cn/api/coding/paas/v4",
+      "/v1/chat/completions?x=1",
+      "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions?x=1"
+    );
+  });
+
+  test("带 alpha/beta 数字后缀的版本根路径也应被识别", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/v1beta1",
+      "/v1/chat/completions?x=1",
+      "https://relay.example.com/openai/v1beta1/chat/completions?x=1"
+    );
+  });
+
+  test("版本根路径 + Chat 资源后缀：应保留 suffix", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/v1",
+      "/v1/chat/completions/cmpl_123/messages?x=1",
+      "https://relay.example.com/openai/v1/chat/completions/cmpl_123/messages?x=1"
+    );
+  });
+
+  test("版本根路径 + Responses 资源后缀：应保留 suffix", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/v1",
+      "/v1/responses/resp_123/input_items?x=1",
+      "https://relay.example.com/openai/v1/responses/resp_123/input_items?x=1"
+    );
+  });
+
+  test("版本根路径 + Models 资源后缀：应保留 suffix", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/v1",
+      "/v1/models/gpt-4o?x=1",
+      "https://relay.example.com/openai/v1/models/gpt-4o?x=1"
+    );
+  });
+
+  test("无版本 endpoint 根路径：baseUrl=/openai/responses + /v1/responses/abc 应只追加 suffix", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/responses",
+      "/v1/responses/abc?x=1",
+      "https://relay.example.com/openai/responses/abc?x=1"
+    );
+  });
+
+  test("相似但非标准 endpoint：responses-archive 不应被折叠成标准 /responses", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/responses-archive",
+      "/v1/responses?x=1",
+      "https://relay.example.com/openai/responses-archive/v1/responses?x=1"
+    );
+  });
+
+  test("version root 识别不应误伤普通路径尾巴，如 /v1api", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/proxy/v1api",
+      "/v1/chat/completions?x=1",
+      "https://relay.example.com/proxy/v1api/v1/chat/completions?x=1"
+    );
   });
 });

--- a/tests/unit/i18n/ja-providers-form-strings-quality.test.ts
+++ b/tests/unit/i18n/ja-providers-form-strings-quality.test.ts
@@ -44,3 +44,27 @@ describe("messages/ja/settings/providers/form/strings.json", () => {
     expect(sameAsEn).toEqual(allowedSameAsEn);
   });
 });
+
+describe("messages/ja/settings/providers/form/url.json", () => {
+  test("does not contain placeholder markers and uses halfwidth parentheses", () => {
+    const ja = readJson("messages/ja/settings/providers/form/url.json");
+
+    for (const value of Object.values(ja)) {
+      expect(value).not.toContain("[JA]");
+      expect(value).not.toContain("（");
+      expect(value).not.toContain("）");
+      expect(value).not.toContain("（繁）");
+      expect(value).not.toContain("(TW)");
+      expect(value).not.toContain("（TW）");
+    }
+  });
+
+  test("does not keep raw English strings", () => {
+    const ja = readJson("messages/ja/settings/providers/form/url.json");
+    const en = readJson("messages/en/settings/providers/form/url.json");
+
+    for (const [key, value] of Object.entries(ja)) {
+      expect(value).not.toBe(en[key]);
+    }
+  });
+});

--- a/tests/unit/i18n/zh-tw-providers-form-strings-quality.test.ts
+++ b/tests/unit/i18n/zh-tw-providers-form-strings-quality.test.ts
@@ -25,3 +25,20 @@ describe("messages/zh-TW/settings/providers/form/strings.json", () => {
     }
   });
 });
+
+describe("messages/zh-TW/settings/providers/form/url.json", () => {
+  test("does not contain placeholder markers and uses fullwidth parentheses", () => {
+    const zhTW = readJson("messages/zh-TW/settings/providers/form/url.json");
+
+    for (const value of Object.values(zhTW)) {
+      expect(value).not.toContain("（繁）");
+      expect(value).not.toContain("[JA]");
+      expect(value).not.toContain("(TW)");
+      expect(value).not.toContain("(繁)");
+      expect(value).not.toContain("（TW）");
+
+      expect(value).not.toContain("(");
+      expect(value).not.toContain(")");
+    }
+  });
+});

--- a/tests/unit/i18n/zh-tw-providers-form-strings-quality.test.ts
+++ b/tests/unit/i18n/zh-tw-providers-form-strings-quality.test.ts
@@ -29,13 +29,15 @@ describe("messages/zh-TW/settings/providers/form/strings.json", () => {
 describe("messages/zh-TW/settings/providers/form/url.json", () => {
   test("does not contain placeholder markers and uses fullwidth parentheses", () => {
     const zhTW = readJson("messages/zh-TW/settings/providers/form/url.json");
+    const en = readJson("messages/en/settings/providers/form/url.json");
 
-    for (const value of Object.values(zhTW)) {
+    for (const [key, value] of Object.entries(zhTW)) {
       expect(value).not.toContain("（繁）");
       expect(value).not.toContain("[JA]");
       expect(value).not.toContain("(TW)");
       expect(value).not.toContain("(繁)");
       expect(value).not.toContain("（TW）");
+      expect(zhTW[key]).not.toBe(en[key]);
 
       expect(value).not.toContain("(");
       expect(value).not.toContain(")");

--- a/tests/unit/settings/providers/provider-form-base-url-guidance.test.tsx
+++ b/tests/unit/settings/providers/provider-form-base-url-guidance.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import enMessages from "../../../../messages/en";
+import { BasicInfoSection } from "../../../../src/app/[locale]/settings/providers/_components/forms/provider-form/sections/basic-info-section";
+
+const providerFormContextMock = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  state: {
+    basic: {
+      name: "",
+      url: "",
+      key: "",
+      websiteUrl: "",
+    },
+    routing: {
+      providerType: "openai-compatible",
+    },
+    ui: {
+      isPending: false,
+    },
+  },
+}));
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...props }: { children?: ReactNode } & Record<string, unknown>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+vi.mock(
+  "@/app/[locale]/settings/providers/_components/forms/provider-form/components/quick-paste-dialog",
+  () => ({
+    QuickPasteDialog: () => <button type="button">Quick Paste</button>,
+  })
+);
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="tooltip-content">{children}</div>
+  ),
+}));
+
+vi.mock(
+  "@/app/[locale]/settings/providers/_components/forms/provider-form/provider-form-context",
+  () => ({
+    useProviderForm: () => ({
+      state: providerFormContextMock.state,
+      dispatch: providerFormContextMock.dispatch,
+      mode: "create",
+      provider: null,
+      hideUrl: false,
+      hideWebsiteUrl: false,
+      batchProviders: null,
+    }),
+  })
+);
+
+function renderWithIntl(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        {node}
+      </NextIntlClientProvider>
+    );
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("BasicInfoSection base URL guidance", () => {
+  beforeEach(() => {
+    providerFormContextMock.dispatch.mockClear();
+    document.body.innerHTML = "";
+  });
+
+  test("renders inline guidance text and tooltip help for the API address field", () => {
+    const { container, unmount } = renderWithIntl(<BasicInfoSection />);
+
+    expect(document.getElementById("url")).not.toBeNull();
+    expect(container.textContent).toContain(
+      "Use your provider's base address. For request forwarding, preview, and provider testing, you can also paste a version path or exact endpoint here."
+    );
+    expect(container.textContent).toContain(
+      "Examples: https://relay.example.com/openai, https://relay.example.com/openai/v1, https://relay.example.com/openai/v1/responses. Claude Code Hub reuses the path you provide instead of appending the same endpoint twice."
+    );
+
+    const helpTrigger = container.querySelector("button[data-smart-input-tooltip]");
+    expect(helpTrigger).not.toBeNull();
+    expect(helpTrigger?.getAttribute("aria-label")).toBe(
+      "Examples: https://relay.example.com/openai, https://relay.example.com/openai/v1, https://relay.example.com/openai/v1/responses. Claude Code Hub reuses the path you provide instead of appending the same endpoint twice."
+    );
+
+    unmount();
+  });
+});

--- a/tests/unit/settings/providers/provider-form-base-url-guidance.test.tsx
+++ b/tests/unit/settings/providers/provider-form-base-url-guidance.test.tsx
@@ -36,21 +36,20 @@ vi.mock("framer-motion", () => ({
   },
 }));
 
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="popover-content">{children}</div>
+  ),
+}));
+
 vi.mock(
   "@/app/[locale]/settings/providers/_components/forms/provider-form/components/quick-paste-dialog",
   () => ({
     QuickPasteDialog: () => <button type="button">Quick Paste</button>,
   })
 );
-
-vi.mock("@/components/ui/tooltip", () => ({
-  TooltipProvider: ({ children }: { children?: ReactNode }) => <>{children}</>,
-  Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
-  TooltipTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
-  TooltipContent: ({ children }: { children?: ReactNode }) => (
-    <div data-testid="tooltip-content">{children}</div>
-  ),
-}));
 
 vi.mock(
   "@/app/[locale]/settings/providers/_components/forms/provider-form/provider-form-context",
@@ -96,21 +95,19 @@ describe("BasicInfoSection base URL guidance", () => {
   });
 
   test("renders inline guidance text and tooltip help for the API address field", () => {
+    const urlMessages = enMessages.settings.providers.form.url as {
+      description: string;
+      tooltip: string;
+    };
     const { container, unmount } = renderWithIntl(<BasicInfoSection />);
 
     expect(document.getElementById("url")).not.toBeNull();
-    expect(container.textContent).toContain(
-      "Use your provider's base address. For request forwarding, preview, and provider testing, you can also paste a version path or exact endpoint here."
-    );
-    expect(container.textContent).toContain(
-      "Examples: https://relay.example.com/openai, https://relay.example.com/openai/v1, https://relay.example.com/openai/v1/responses. Claude Code Hub reuses the path you provide instead of appending the same endpoint twice."
-    );
+    expect(container.textContent).toContain(urlMessages.description);
+    expect(container.textContent).toContain(urlMessages.tooltip);
 
     const helpTrigger = container.querySelector("button[data-smart-input-tooltip]");
     expect(helpTrigger).not.toBeNull();
-    expect(helpTrigger?.getAttribute("aria-label")).toBe(
-      "Examples: https://relay.example.com/openai, https://relay.example.com/openai/v1, https://relay.example.com/openai/v1/responses. Claude Code Hub reuses the path you provide instead of appending the same endpoint twice."
-    );
+    expect(helpTrigger?.getAttribute("aria-label")).toBe(urlMessages.tooltip);
 
     unmount();
   });

--- a/tests/unit/settings/providers/url-preview-full-path.test.tsx
+++ b/tests/unit/settings/providers/url-preview-full-path.test.tsx
@@ -95,6 +95,25 @@ describe("UrlPreview full-path compatibility", () => {
     unmount();
   });
 
+  test("完整子端点 base URL 只应预览当前子端点，不应重复追加 suffix", () => {
+    const { container, unmount } = renderWithIntl(
+      <UrlPreview
+        baseUrl="https://proxy.example.com/anthropic/v1/messages/count_tokens"
+        providerType="claude"
+      />
+    );
+
+    expect(container.textContent).toContain(
+      "https://proxy.example.com/anthropic/v1/messages/count_tokens"
+    );
+    expect(container.textContent).not.toContain("Claude Messages");
+    expect(container.textContent).not.toContain(
+      "https://proxy.example.com/anthropic/v1/messages/count_tokens/v1/messages/count_tokens"
+    );
+
+    unmount();
+  });
+
   test("版本根路径预览应只追加 endpoint，不重复拼接 /v1", () => {
     const { container, unmount } = renderWithIntl(
       <UrlPreview baseUrl="https://relay.example.com/openai/v1" providerType="openai-compatible" />

--- a/tests/unit/settings/providers/url-preview-full-path.test.tsx
+++ b/tests/unit/settings/providers/url-preview-full-path.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import enMessages from "../../../../messages/en";
+import { UrlPreview } from "../../../../src/app/[locale]/settings/providers/_components/forms/url-preview";
+
+const sonnerMocks = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => sonnerMocks);
+
+function renderWithIntl(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        {node}
+      </NextIntlClientProvider>
+    );
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("UrlPreview full-path compatibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("合法 full-path base URL 应原样预览且不显示 duplicate warning", () => {
+    const { container, unmount } = renderWithIntl(
+      <UrlPreview baseUrl="https://relay.example.com/openai/v1/responses" providerType="codex" />
+    );
+
+    expect(container.textContent).toContain("https://relay.example.com/openai/v1/responses");
+    expect(container.textContent).not.toContain("Duplicate path detected");
+
+    unmount();
+  });
+
+  test("合法重复业务片段不应触发 duplicate warning", () => {
+    const { container, unmount } = renderWithIntl(
+      <UrlPreview
+        baseUrl="https://relay.example.com/team/team/openai/v1/responses"
+        providerType="codex"
+      />
+    );
+
+    expect(container.textContent).toContain(
+      "https://relay.example.com/team/team/openai/v1/responses"
+    );
+    expect(container.textContent).not.toContain("Duplicate path detected");
+
+    unmount();
+  });
+
+  test("完整 Chat endpoint base URL 只应预览当前 endpoint，不应再拼出 /v1/models", () => {
+    const { container, unmount } = renderWithIntl(
+      <UrlPreview
+        baseUrl="https://relay.example.com/openai/v1/chat/completions"
+        providerType="openai-compatible"
+      />
+    );
+
+    expect(container.textContent).toContain("https://relay.example.com/openai/v1/chat/completions");
+    expect(container.textContent).not.toContain("OpenAI Models");
+    expect(container.textContent).not.toContain(
+      "https://relay.example.com/openai/v1/chat/completions/v1/models"
+    );
+
+    unmount();
+  });
+
+  test("版本根路径预览应只追加 endpoint，不重复拼接 /v1", () => {
+    const { container, unmount } = renderWithIntl(
+      <UrlPreview baseUrl="https://relay.example.com/openai/v1" providerType="openai-compatible" />
+    );
+
+    expect(container.textContent).toContain("https://relay.example.com/openai/v1/chat/completions");
+    expect(container.textContent).not.toContain(
+      "https://relay.example.com/openai/v1/v1/chat/completions"
+    );
+
+    unmount();
+  });
+
+  test("真实重复路径仍应显示 duplicate warning", () => {
+    const { container, unmount } = renderWithIntl(
+      <UrlPreview
+        baseUrl="https://relay.example.com/openai/v1/responses/v1/responses"
+        providerType="codex"
+      />
+    );
+
+    expect(container.textContent).toContain("Duplicate path detected");
+
+    unmount();
+  });
+});

--- a/tests/unit/settings/providers/url-preview-full-path.test.tsx
+++ b/tests/unit/settings/providers/url-preview-full-path.test.tsx
@@ -139,4 +139,17 @@ describe("UrlPreview full-path compatibility", () => {
 
     unmount();
   });
+
+  test("双版本前缀也应触发 duplicate warning", () => {
+    const { container, unmount } = renderWithIntl(
+      <UrlPreview
+        baseUrl="https://relay.example.com/openai/v1/v1/chat/completions"
+        providerType="openai-compatible"
+      />
+    );
+
+    expect(container.textContent).toContain("Duplicate path detected");
+
+    unmount();
+  });
 });


### PR DESCRIPTION
## Summary
- align `buildProxyUrl()` across full endpoint URLs, version roots, unversioned endpoint roots, and endpoint-aware duplicate preview detection
- reuse the runtime URL builder inside provider testing, including query-bearing presets
- add clearer base URL guidance + tooltip copy with 5-locale coverage
- add regression tests for runtime URL matrix, provider-testing parity, preview filtering, tooltip guidance, and ja/zh-TW locale quality

## Verification
- `bunx vitest run tests/unit/app/v1/url.test.ts`
- `bunx vitest run src/lib/provider-testing/test-service.test.ts src/lib/provider-testing/presets.test.ts`
- `bunx vitest run tests/unit/settings/providers/url-preview-full-path.test.tsx tests/unit/settings/providers/provider-form-base-url-guidance.test.tsx`
- `bunx vitest run tests/unit/i18n/settings-split-guards.test.ts tests/unit/i18n/ja-providers-form-strings-quality.test.ts tests/unit/i18n/zh-tw-providers-form-strings-quality.test.ts`
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends `buildProxyUrl()` to correctly handle four URL shapes — full endpoint paths, version-root paths, unversioned endpoint roots, and sub-endpoint paths — preventing double-appending. It also unifies the URL-building logic between the runtime proxy and provider testing, adds a live URL preview component with duplicate-path detection, and ships 5-locale i18n copy for the new guidance text. The `isVersionRootPath` regex has been expanded to include `rc`, `ga`, `stable`, `dev`, and `canary` suffixes, addressing the previous review feedback.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — no P0/P1 findings; all edge cases are well-covered by the new test suite.

All findings from the previous review round have been addressed (expanded isVersionRootPath regex, unified URL builder across provider testing and runtime). The core logic has been traced through every documented edge case and is correct. The new test suite covers full-path, version-root, unversioned-endpoint, sub-endpoint, suffix-preservation, duplicate-detection, and i18n quality scenarios.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/url.ts | Core URL-building logic; expanded version-root regex, added endpoint-root detection, preview helpers, and duplicate-path detection — all well-tested with no apparent logic errors. |
| src/lib/provider-testing/utils/test-prompts.ts | Added getTestUrl() that reuses buildProxyUrl() to unify URL semantics between provider testing and the runtime proxy; API_ENDPOINTS["gemini-cli"] still mirrors gemini (/v1beta/…) while the preview uses /v1internal/… — a pre-existing inconsistency, not introduced here. |
| src/app/[locale]/settings/providers/_components/forms/url-preview.tsx | New live URL preview component; correctly calls previewProxyUrls and hasDuplicatedEndpointPath from the shared url.ts module. |
| tests/unit/app/v1/url.test.ts | Comprehensive matrix of URL-building edge cases including full-path, version-root, unversioned-endpoint, sub-endpoint, and non-standard similar paths — good regression coverage. |
| src/lib/provider-testing/test-service.test.ts | New provider-testing parity tests including full-path base URLs, version roots, rc/beta suffixes, query-bearing presets, and unversioned endpoint roots. |
| tests/unit/settings/providers/url-preview-full-path.test.tsx | Integration tests for the UrlPreview component covering duplicate-path detection, endpoint filtering, and version-root display. |
| messages/en/settings/providers/form/url.json | New English i18n strings for base URL guidance with clear examples covering all three supported URL shapes. |
| messages/ja/settings/providers/form/url.json | Japanese translation uses halfwidth parentheses and proper localization; passes all quality-gate tests. |
| messages/zh-TW/settings/providers/form/url.json | Traditional Chinese translation; uses fullwidth parentheses as required and avoids placeholder markers. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildProxyUrl
baseUrl + requestUrl] --> B{Case 1:
requestPath === basePath
or starts with basePath+/}
    B -- Yes --> C[Use requestPath directly
+ requestUrl.search]
    B -- No --> D{Case 2:
for each endpointRegex
match requestPath?}
    D -- No match --> E[Fallback:
basePath + requestPath]
    D -- Matched endpoint --> F{basePath ends with
full/partial endpoint?}
    F -- Yes hasFullEndpoint --> G[Reuse basePath as-is
+ suffix if needed]
    F -- Yes endpoint or requestRoot --> H[Append suffix to basePath]
    F -- No --> I{isVersionRootPath
basePath tail?}
    I -- Yes --> J[basePath + endpoint + suffix]
    I -- No --> E

    style C fill:#90EE90
    style G fill:#90EE90
    style H fill:#90EE90
    style J fill:#90EE90
    style E fill:#87CEEB
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/v1/_lib/url.ts`, line 104-117 ([link](https://github.com/ding113/claude-code-hub/blob/0c2838c7813893e19572e024aa5624e0b44f5854/src/app/v1/_lib/url.ts#L104-L117)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Query string in `baseUrl` silently discarded**

   `baseUrlObj.search` is unconditionally overwritten with `requestUrl.search` in every branch (Cases 1, 2, and the fallback). If a user configures a base URL that includes a query parameter their relay requires (e.g. `?channel=foo` or an auth token), that parameter is dropped silently. The existing test at line 59 documents this as intentional, but there is no log line to alert operators. A `logger.debug` when a non-empty `baseUrlObj.search` is discarded would make debugging misconfigured relay URLs easier.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/v1/_lib/url.ts
   Line: 104-117

   Comment:
   **Query string in `baseUrl` silently discarded**

   `baseUrlObj.search` is unconditionally overwritten with `requestUrl.search` in every branch (Cases 1, 2, and the fallback). If a user configures a base URL that includes a query parameter their relay requires (e.g. `?channel=foo` or an auth token), that parameter is dropped silently. The existing test at line 59 documents this as intentional, but there is no log line to alert operators. A `logger.debug` when a non-empty `baseUrlObj.search` is discarded would make debugging misconfigured relay URLs easier.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix: flag duplicated version prefixes in..."](https://github.com/ding113/claude-code-hub/commit/a3700acf0387e28257437e5f334db05a73d9a593) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29156716)</sub>

<!-- /greptile_comment -->