### PR TITLE
fix: sync live headers in request details

### DIFF
--- a/src/actions/my-usage.ts
+++ b/src/actions/my-usage.ts
@@ -48,12 +48,11 @@ function scrubProviderChainRequestForReadonly(
         return item;
       }
 
+      const { request: _request, ...errorDetailsWithoutRequest } = item.errorDetails;
+
       return {
         ...item,
-        errorDetails: {
-          ...item.errorDetails,
-          request: undefined,
-        },
+        errorDetails: errorDetailsWithoutRequest,
       };
     }) ?? null
   );
@@ -65,6 +64,12 @@ function scrubUsageLogsBatchForReadonly(result: UsageLogsBatchResult): UsageLogs
     logs: result.logs.map((log) => ({
       ...log,
       providerChain: scrubProviderChainRequestForReadonly(log.providerChain),
+      _liveChain: log._liveChain
+        ? {
+            ...log._liveChain,
+            chain: scrubProviderChainRequestForReadonly(log._liveChain.chain) ?? [],
+          }
+        : log._liveChain,
     })),
   };
 }

--- a/src/actions/my-usage.ts
+++ b/src/actions/my-usage.ts
@@ -31,11 +31,42 @@ import {
   type UsageLogsBatchResult,
 } from "@/repository/usage-logs";
 import type { IpGeoLookupResult, IpGeoPrivateMarker } from "@/types/ip-geo";
+import type { ProviderChainItem } from "@/types/message";
 import type { BillingModelSource } from "@/types/system-config";
 import type { ActionResult } from "./types";
 
 async function getErrorTranslator() {
   return getTranslations("errors");
+}
+
+function scrubProviderChainRequestForReadonly(
+  providerChain: ProviderChainItem[] | null
+): ProviderChainItem[] | null {
+  return (
+    providerChain?.map((item) => {
+      if (!item.errorDetails?.request) {
+        return item;
+      }
+
+      return {
+        ...item,
+        errorDetails: {
+          ...item.errorDetails,
+          request: undefined,
+        },
+      };
+    }) ?? null
+  );
+}
+
+function scrubUsageLogsBatchForReadonly(result: UsageLogsBatchResult): UsageLogsBatchResult {
+  return {
+    ...result,
+    logs: result.logs.map((log) => ({
+      ...log,
+      providerChain: scrubProviderChainRequestForReadonly(log.providerChain),
+    })),
+  };
 }
 
 /**
@@ -673,7 +704,7 @@ export async function getMyUsageLogsBatchFull(
       keyId: session.key.id,
     });
 
-    return { ok: true, data: result };
+    return { ok: true, data: scrubUsageLogsBatchForReadonly(result) };
   } catch (error) {
     logger.error("[my-usage] getMyUsageLogsBatchFull failed", error);
     return {

--- a/src/app/v1/_lib/proxy/errors.ts
+++ b/src/app/v1/_lib/proxy/errors.ts
@@ -1327,7 +1327,7 @@ export function buildRequestDetails(
   return {
     url: sanitizeUrl(session.requestUrl),
     method: session.method,
-    headers: sanitizeHeaders(session.headerLog),
+    headers: sanitizeHeaders(session.headers),
     body,
     bodyTruncated: truncated,
   };

--- a/tests/unit/actions/my-usage-readonly-provider-chain.test.ts
+++ b/tests/unit/actions/my-usage-readonly-provider-chain.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  findUsageLogsBatch: vi.fn(),
+  getTranslations: vi.fn(async () => (key: string) => key),
+  loggerError: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSession: mocks.getSession,
+}));
+
+vi.mock("@/repository/usage-logs", () => ({
+  findUsageLogsBatch: mocks.findUsageLogsBatch,
+  findUsageLogsForKeyBatch: vi.fn(),
+  findUsageLogsForKeySlim: vi.fn(),
+  getDistinctEndpointsForKey: vi.fn(),
+  getDistinctModelsForKey: vi.fn(),
+}));
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: mocks.getTranslations,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: mocks.loggerError,
+  },
+}));
+
+describe("getMyUsageLogsBatchFull", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("scrubs request details from providerChain for readonly my-usage responses", async () => {
+    mocks.getSession.mockResolvedValueOnce({
+      user: { id: 1 },
+      key: { id: 7, key: "sk-readonly" },
+    });
+
+    mocks.findUsageLogsBatch.mockResolvedValueOnce({
+      logs: [
+        {
+          id: 101,
+          providerChain: [
+            {
+              id: 1,
+              name: "provider-a",
+              errorDetails: {
+                request: {
+                  headers: "authorization: Bearer secret-token",
+                  body: "{}",
+                },
+                response: {
+                  statusCode: 500,
+                },
+              },
+            },
+            {
+              id: 2,
+              name: "provider-b",
+              errorDetails: null,
+            },
+          ],
+        },
+      ],
+      nextCursor: null,
+      hasMore: false,
+    });
+
+    const { getMyUsageLogsBatchFull } = await import("@/actions/my-usage");
+    const result = await getMyUsageLogsBatchFull({ limit: 20 });
+
+    expect(mocks.getSession).toHaveBeenCalledWith({ allowReadOnlyAccess: true });
+    expect(mocks.findUsageLogsBatch).toHaveBeenCalledWith({ keyId: 7, limit: 20 });
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        hasMore: false,
+      },
+    });
+    expect(
+      result.ok && result.data.logs[0]?.providerChain?.[0]?.errorDetails?.request
+    ).toBeUndefined();
+    expect(result.ok && result.data.logs[0]?.providerChain?.[0]?.errorDetails?.response).toEqual({
+      statusCode: 500,
+    });
+    expect(result.ok && result.data.logs[0]?.providerChain?.[1]).toEqual({
+      id: 2,
+      name: "provider-b",
+      errorDetails: null,
+    });
+  });
+});

--- a/tests/unit/actions/my-usage-readonly-provider-chain.test.ts
+++ b/tests/unit/actions/my-usage-readonly-provider-chain.test.ts
@@ -64,6 +64,21 @@ describe("getMyUsageLogsBatchFull", () => {
               errorDetails: null,
             },
           ],
+          _liveChain: {
+            chain: [
+              {
+                id: 3,
+                name: "live-provider",
+                errorDetails: {
+                  request: {
+                    headers: "x-api-key: live-secret",
+                  },
+                },
+              },
+            ],
+            phase: "provider",
+            updatedAt: 123,
+          },
         },
       ],
       nextCursor: null,
@@ -81,9 +96,9 @@ describe("getMyUsageLogsBatchFull", () => {
         hasMore: false,
       },
     });
-    expect(
-      result.ok && result.data.logs[0]?.providerChain?.[0]?.errorDetails?.request
-    ).toBeUndefined();
+    const scrubbedProviderErrorDetails =
+      result.ok && result.data.logs[0]?.providerChain?.[0]?.errorDetails;
+    expect(scrubbedProviderErrorDetails && "request" in scrubbedProviderErrorDetails).toBe(false);
     expect(result.ok && result.data.logs[0]?.providerChain?.[0]?.errorDetails?.response).toEqual({
       statusCode: 500,
     });
@@ -92,5 +107,8 @@ describe("getMyUsageLogsBatchFull", () => {
       name: "provider-b",
       errorDetails: null,
     });
+    const scrubbedLiveChainErrorDetails =
+      result.ok && result.data.logs[0]?._liveChain?.chain[0]?.errorDetails;
+    expect(scrubbedLiveChainErrorDetails && "request" in scrubbedLiveChainErrorDetails).toBe(false);
   });
 });

--- a/tests/unit/proxy/build-request-details-redaction.test.ts
+++ b/tests/unit/proxy/build-request-details-redaction.test.ts
@@ -42,15 +42,21 @@ const { buildRequestDetails, sanitizeUrl, truncateRequestBody } = await import(
 
 // Create a minimal mock session for testing
 function createMockSession(requestLog: string) {
-  const headerLog = "content-type: application/json\nauthorization: Bearer sk-1234";
-
-  return {
-    requestUrl: new URL("https://api.example.com/v1/messages"),
-    method: "POST",
-    headers: new Headers([
+  return createMockSessionWithHeaders(
+    requestLog,
+    new Headers([
       ["content-type", "application/json"],
       ["authorization", "Bearer sk-1234"],
     ]),
+    "content-type: application/json\nauthorization: Bearer sk-1234"
+  );
+}
+
+function createMockSessionWithHeaders(requestLog: string, headers: Headers, headerLog: string) {
+  return {
+    requestUrl: new URL("https://api.example.com/v1/messages"),
+    method: "POST",
+    headers,
     headerLog,
     request: {
       log: requestLog,
@@ -173,10 +179,9 @@ describe("buildRequestDetails - Redaction based on STORE_SESSION_MESSAGES", () =
     it("should reflect removed header from live session headers", () => {
       mockStoreMessages = false;
 
-      const session = createMockSession("{}");
-      session.headerLog = "x-removed: 1";
-      session.headers = new Headers([["x-removed", "1"]]);
-      session.headers.delete("x-removed");
+      const headers = new Headers([["x-removed", "1"]]);
+      headers.delete("x-removed");
+      const session = createMockSessionWithHeaders("{}", headers, "x-removed: 1");
       const result = buildRequestDetails(session);
 
       expect(result.headers).toBe("(empty)");
@@ -185,10 +190,9 @@ describe("buildRequestDetails - Redaction based on STORE_SESSION_MESSAGES", () =
     it("should reflect override header from live session headers", () => {
       mockStoreMessages = false;
 
-      const session = createMockSession("{}");
-      session.headerLog = "x-mode: old";
-      session.headers = new Headers([["x-mode", "old"]]);
-      session.headers.set("x-mode", "new");
+      const headers = new Headers([["x-mode", "old"]]);
+      headers.set("x-mode", "new");
+      const session = createMockSessionWithHeaders("{}", headers, "x-mode: old");
       const result = buildRequestDetails(session);
 
       expect(result.headers).toBe("x-mode: new");
@@ -198,10 +202,13 @@ describe("buildRequestDetails - Redaction based on STORE_SESSION_MESSAGES", () =
     it("should redact authorization live header after filters mutate session headers", () => {
       mockStoreMessages = false;
 
-      const session = createMockSession("{}");
-      session.headerLog = "authorization: Bearer stale-token";
-      session.headers = new Headers([["authorization", "Bearer stale-token"]]);
-      session.headers.set("authorization", "Bearer sk-1234");
+      const headers = new Headers([["authorization", "Bearer stale-token"]]);
+      headers.set("authorization", "Bearer sk-1234");
+      const session = createMockSessionWithHeaders(
+        "{}",
+        headers,
+        "authorization: Bearer stale-token"
+      );
       const result = buildRequestDetails(session);
 
       expect(result.headers).toBe("authorization: Bearer [REDACTED]");

--- a/tests/unit/proxy/build-request-details-redaction.test.ts
+++ b/tests/unit/proxy/build-request-details-redaction.test.ts
@@ -36,16 +36,22 @@ vi.mock("@/lib/error-rule-detector", () => ({
 }));
 
 // Import after mocks
-const { buildRequestDetails, sanitizeUrl, sanitizeHeaders, truncateRequestBody } = await import(
+const { buildRequestDetails, sanitizeUrl, truncateRequestBody } = await import(
   "@/app/v1/_lib/proxy/errors"
 );
 
 // Create a minimal mock session for testing
 function createMockSession(requestLog: string) {
+  const headerLog = "content-type: application/json\nauthorization: Bearer sk-1234";
+
   return {
     requestUrl: new URL("https://api.example.com/v1/messages"),
     method: "POST",
-    headerLog: "content-type: application/json\nauthorization: Bearer sk-1234",
+    headers: new Headers([
+      ["content-type", "application/json"],
+      ["authorization", "Bearer sk-1234"],
+    ]),
+    headerLog,
     request: {
       log: requestLog,
     },
@@ -162,6 +168,44 @@ describe("buildRequestDetails - Redaction based on STORE_SESSION_MESSAGES", () =
 
       expect(result.bodyTruncated).toBe(true);
       expect(result.body.length).toBe(2000);
+    });
+
+    it("should reflect removed header from live session headers", () => {
+      mockStoreMessages = false;
+
+      const session = createMockSession("{}");
+      session.headerLog = "x-removed: 1";
+      session.headers = new Headers([["x-removed", "1"]]);
+      session.headers.delete("x-removed");
+      const result = buildRequestDetails(session);
+
+      expect(result.headers).toBe("(empty)");
+    });
+
+    it("should reflect override header from live session headers", () => {
+      mockStoreMessages = false;
+
+      const session = createMockSession("{}");
+      session.headerLog = "x-mode: old";
+      session.headers = new Headers([["x-mode", "old"]]);
+      session.headers.set("x-mode", "new");
+      const result = buildRequestDetails(session);
+
+      expect(result.headers).toBe("x-mode: new");
+      expect(result.headers).not.toContain("x-mode: old");
+    });
+
+    it("should redact authorization live header after filters mutate session headers", () => {
+      mockStoreMessages = false;
+
+      const session = createMockSession("{}");
+      session.headerLog = "authorization: Bearer stale-token";
+      session.headers = new Headers([["authorization", "Bearer stale-token"]]);
+      session.headers.set("authorization", "Bearer sk-1234");
+      const result = buildRequestDetails(session);
+
+      expect(result.headers).toBe("authorization: Bearer [REDACTED]");
+      expect(result.headers).not.toContain("stale-token");
     });
   });
 });


### PR DESCRIPTION
## Summary
- switch `buildRequestDetails()` to log live `session.headers` instead of the frozen `headerLog` snapshot
- add focused regressions for removed / overridden / authorization live-header mutations
- scrub `providerChain.errorDetails.request` from readonly `my-usage` batch responses and cover it with a unit test

## Verification
- `bun run build`
- `bun run lint` (captured initial output), `bun run lint:fix`, `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bunx vitest run tests/unit/actions/my-usage-readonly-provider-chain.test.ts tests/unit/proxy/build-request-details-redaction.test.ts tests/unit/request-filter-binding.test.ts tests/unit/proxy/response-handler-gemini-stream-passthrough-timeouts.test.ts`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related issues: `buildRequestDetails()` now reads from the live `session.headers` (`Headers` object) rather than the frozen `headerLog` string snapshot, ensuring that header mutations made by proxy filters are captured correctly in error detail records. It also scrubs `errorDetails.request` from `ProviderChainItem` entries returned by the readonly `my-usage` batch endpoint (`getMyUsageLogsBatchFull`), preventing credential leakage to read-only users. Both changes are accompanied by focused regression tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both fixes are narrowly scoped, well-tested, and improve correctness/security without behavioral regressions.

All changes are P2 or below. The live-headers fix is mechanically correct (sanitizeHeaders already accepts Headers objects), the readonly scrub follows a straightforward destructure pattern, and regression tests cover all mutated header scenarios and the scrub of both providerChain and _liveChain. No data-loss or auth-boundary risks introduced.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/errors.ts | buildRequestDetails now passes live session.headers (Headers object) to sanitizeHeaders instead of the frozen headerLog string — sanitizeHeaders already handles both types, so the change is a clean drop-in fix. |
| src/actions/my-usage.ts | Adds scrubProviderChainRequestForReadonly and scrubUsageLogsBatchForReadonly helpers that strip errorDetails.request from both providerChain and _liveChain.chain before returning data to read-only callers. |
| tests/unit/proxy/build-request-details-redaction.test.ts | New regression tests for removed, overridden, and mutated authorization headers using the live-headers path; createMockSessionWithHeaders exposes both headers and headerLog so tests explicitly verify the live object wins. |
| tests/unit/actions/my-usage-readonly-provider-chain.test.ts | Unit test for the readonly scrub; validates request removal from both providerChain and _liveChain, and that items without errorDetails.request pass through unchanged. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getMyUsageLogsBatchFull] --> B[findUsageLogsBatch]
    B --> C[scrubUsageLogsBatchForReadonly]
    C --> D["for each log"]
    D --> E[scrubProviderChainRequestForReadonly\nproviderChain]
    D --> F{"_liveChain\nexists?"}
    F -- yes --> G[scrubProviderChainRequestForReadonly\n_liveChain.chain]
    F -- no --> H[pass through null/undefined]
    E --> I{"item.errorDetails\n.request exists?"}
    I -- no --> J[return item unchanged]
    I -- yes --> K["destructure out request\n{ request: _r, ...rest } = errorDetails"]
    K --> L[return item with errorDetails = rest]

    subgraph buildRequestDetails
        M[session.headers\nlive Headers object] --> N[sanitizeHeaders]
        N --> O[redacted header string\nin errorDetails.request]
    end

    style M fill:#d4edda,stroke:#28a745
    style O fill:#d4edda,stroke:#28a745
    style L fill:#d1ecf1,stroke:#17a2b8
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(my-usage): scrub readonly live chain..."](https://github.com/ding113/claude-code-hub/commit/a8fd597829c499a9dd13c2ce879fc6e3e9f5aba6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29166163)</sub>

<!-- /greptile_comment -->