### PR TITLE
fix: enforce OpenAI image endpoint constraints

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -65,6 +65,13 @@ import {
   sanitizeUrl,
 } from "./errors";
 import { ModelRedirector } from "./model-redirector";
+import {
+  cloneOpenAIImageRequestMetadata,
+  sanitizeGenerationsRequestForProvider,
+  serializeOpenAIImageMultipartRequest,
+  syncOpenAIImageMultipartFromLogicalBody,
+  validateOpenAIImageRequest,
+} from "./openai-image-compat";
 import { ProxyProviderResolver } from "./provider-selector";
 import type { ProxySession } from "./session";
 import { setDeferredStreamingFinalization } from "./stream-finalization";
@@ -2308,6 +2315,55 @@ export class ProxyForwarder {
           } catch {
             isStreaming = false;
           }
+        } else if (session.isOpenAIImageMultipartRequest()) {
+          const imageRequestMetadata = session.getOpenAIImageRequestMetadata();
+          if (!imageRequestMetadata) {
+            throw new ProxyError("Invalid request: image multipart metadata is missing.", 400);
+          }
+
+          const logicalBody = filterPrivateParameters(
+            structuredClone(session.request.message)
+          ) as Record<string, unknown>;
+
+          if (!session.getEndpointPolicy().bypassRequestFilters) {
+            const { requestFilterEngine } = await import("@/lib/request-filter-engine");
+            await requestFilterEngine.applyFinal(session, logicalBody, processedHeaders);
+          }
+
+          syncOpenAIImageMultipartFromLogicalBody(imageRequestMetadata, logicalBody);
+
+          const validation = await validateOpenAIImageRequest({
+            pathname: requestPath,
+            body: logicalBody,
+            imageRequestMetadata,
+          });
+          if (!validation.ok) {
+            throw new ProxyError(validation.message ?? "Invalid request.", 400);
+          }
+
+          const serializedMultipart =
+            await serializeOpenAIImageMultipartRequest(imageRequestMetadata);
+          requestBody = serializedMultipart.body;
+          session.forwardedRequestBody = serializedMultipart.summary;
+          isStreaming = serializedMultipart.isStreaming;
+
+          if (serializedMultipart.contentType) {
+            processedHeaders.set("content-type", serializedMultipart.contentType);
+          } else {
+            processedHeaders.delete("content-type");
+          }
+
+          if (process.env.NODE_ENV === "development") {
+            logger.trace("ProxyForwarder: Forwarding multipart image request", {
+              provider: provider.name,
+              providerId: provider.id,
+              proxyUrl: proxyUrl,
+              format: session.originalFormat,
+              method: session.method,
+              bodyLength: serializedMultipart.body.byteLength,
+              isStreaming,
+            });
+          }
         } else {
           const filteredMessage = filterPrivateParameters(session.request.message) as Record<
             string,
@@ -2336,6 +2392,19 @@ export class ProxyForwarder {
           if (!session.getEndpointPolicy().bypassRequestFilters) {
             const { requestFilterEngine } = await import("@/lib/request-filter-engine");
             await requestFilterEngine.applyFinal(session, messageToSend, processedHeaders);
+          }
+
+          if (requestPath === "/v1/images/generations") {
+            sanitizeGenerationsRequestForProvider(messageToSend, provider);
+          }
+
+          const validation = await validateOpenAIImageRequest({
+            pathname: requestPath,
+            body: messageToSend,
+            imageRequestMetadata: session.getOpenAIImageRequestMetadata(),
+          });
+          if (!validation.ok) {
+            throw new ProxyError(validation.message ?? "Invalid request.", 400);
           }
 
           const bodyString = JSON.stringify(messageToSend);
@@ -3847,6 +3916,7 @@ export class ProxyForwarder {
       ...session.request,
       message: structuredClone(session.request.message),
       buffer: session.request.buffer ? session.request.buffer.slice(0) : undefined,
+      imageRequestMetadata: cloneOpenAIImageRequestMetadata(session.request.imageRequestMetadata),
     };
     shadow.requestUrl = new URL(session.requestUrl.toString());
     shadowState.headers = new Headers(session.headers);
@@ -3878,6 +3948,9 @@ export class ProxyForwarder {
     target.request.log = source.request.log;
     target.request.note = source.request.note;
     target.request.model = source.request.model;
+    target.request.imageRequestMetadata = cloneOpenAIImageRequestMetadata(
+      source.request.imageRequestMetadata
+    );
     target.requestUrl = new URL(source.requestUrl.toString());
     target.forwardedRequestBody = source.forwardedRequestBody;
     target.setCacheTtlResolved(source.getCacheTtlResolved());

--- a/src/app/v1/_lib/proxy/model-redirector.ts
+++ b/src/app/v1/_lib/proxy/model-redirector.ts
@@ -5,6 +5,7 @@ import {
   hasProviderModelRedirectRules,
 } from "@/lib/provider-model-redirects";
 import type { Provider } from "@/types/provider";
+import { isOpenAIImageMultipartRequest, setOpenAIImageMultipartModel } from "./openai-image-compat";
 import type { ProxySession } from "./session";
 
 /**
@@ -109,16 +110,24 @@ export class ModelRedirector {
       }
     }
 
-    // 修改 message 对象中的模型（对 Claude/OpenAI 有效，对 Gemini 无效但不影响）
-    session.request.message.model = redirectedModel;
+    // multipart 图片请求不能伪装成 JSON；模型改写写回 sidecar metadata。
+    const imageRequestMetadata = session.getOpenAIImageRequestMetadata();
+    if (isOpenAIImageMultipartRequest(imageRequestMetadata) && imageRequestMetadata) {
+      setOpenAIImageMultipartModel(imageRequestMetadata, redirectedModel);
+      session.request.message.model = redirectedModel;
+      session.request.model = redirectedModel;
+    } else {
+      // 修改 message 对象中的模型（对 Claude/OpenAI 有效，对 Gemini 无效但不影响）
+      session.request.message.model = redirectedModel;
 
-    // 更新缓存的 model 字段
-    session.request.model = redirectedModel;
+      // 更新缓存的 model 字段
+      session.request.model = redirectedModel;
 
-    // 重新生成请求 buffer（使用 TextEncoder）
-    const updatedBody = JSON.stringify(session.request.message);
-    const encoder = new TextEncoder();
-    session.request.buffer = encoder.encode(updatedBody).buffer;
+      // 重新生成请求 buffer（使用 TextEncoder）
+      const updatedBody = JSON.stringify(session.request.message);
+      const encoder = new TextEncoder();
+      session.request.buffer = encoder.encode(updatedBody).buffer;
+    }
 
     // 更新日志（记录重定向）
     session.request.note = `[Model Redirected: ${originalModel} → ${redirectedModel}] ${session.request.note || ""}`;
@@ -186,9 +195,15 @@ export class ModelRedirector {
     originalModel: string,
     provider: Provider
   ): void {
-    // 重置 request.model 和 request.message.model
+    // 重置 request.model 和 request.message.model / multipart sidecar
     session.request.model = originalModel;
-    session.request.message.model = originalModel;
+    const imageRequestMetadata = session.getOpenAIImageRequestMetadata();
+    if (isOpenAIImageMultipartRequest(imageRequestMetadata) && imageRequestMetadata) {
+      setOpenAIImageMultipartModel(imageRequestMetadata, originalModel);
+      session.request.message.model = originalModel;
+    } else {
+      session.request.message.model = originalModel;
+    }
 
     // 重置 Gemini URL 路径（如果适用）
     if (provider.providerType === "gemini" || provider.providerType === "gemini-cli") {
@@ -207,8 +222,10 @@ export class ModelRedirector {
     }
 
     // 重新生成请求 buffer
-    const updatedBody = JSON.stringify(session.request.message);
-    session.request.buffer = new TextEncoder().encode(updatedBody).buffer;
+    if (!isOpenAIImageMultipartRequest(imageRequestMetadata)) {
+      const updatedBody = JSON.stringify(session.request.message);
+      session.request.buffer = new TextEncoder().encode(updatedBody).buffer;
+    }
 
     logger.info("[ModelRedirector] Reset model to original (provider switch)", {
       originalModel,

--- a/src/app/v1/_lib/proxy/openai-image-compat.ts
+++ b/src/app/v1/_lib/proxy/openai-image-compat.ts
@@ -1,0 +1,1032 @@
+import type { Provider } from "@/types/provider";
+
+export type OpenAIImageEndpoint = "generations" | "edits" | "variations";
+
+type OpenAIImageModelFamily = "gpt" | "dall-e-2" | "dall-e-3" | "unknown";
+
+type MultipartTextPart = {
+  name: string;
+  kind: "text";
+  value: string;
+};
+
+type MultipartFilePart = {
+  name: string;
+  kind: "file";
+  value: File;
+};
+
+export type OpenAIImageMultipartPart = MultipartTextPart | MultipartFilePart;
+
+export interface OpenAIImageRequestMetadata {
+  endpoint: OpenAIImageEndpoint;
+  bodyKind: "json" | "multipart";
+  contentType: string | null;
+  model: string | null;
+  parts: OpenAIImageMultipartPart[];
+}
+
+export interface OpenAIImageValidationResult {
+  ok: boolean;
+  message?: string;
+}
+
+const GENERATION_GPT_MODELS = new Set([
+  "gpt-image-1",
+  "gpt-image-1-mini",
+  "gpt-image-1.5",
+  "chatgpt-image-latest",
+]);
+const EDIT_GPT_MODELS = new Set([
+  "gpt-image-1",
+  "gpt-image-1-mini",
+  "gpt-image-1.5",
+  "chatgpt-image-latest",
+]);
+const VARIATION_MODEL = "dall-e-2";
+
+const GPT_ONLY_GENERATION_PARAMS = new Set([
+  "background",
+  "moderation",
+  "output_compression",
+  "output_format",
+  "partial_images",
+  "stream",
+]);
+
+const GPT_ONLY_EDIT_PARAMS = new Set([
+  "moderation",
+  "output_compression",
+  "output_format",
+  "partial_images",
+  "quality",
+  "size",
+  "stream",
+]);
+
+const BOOLEAN_MULTIPART_FIELDS = new Set(["stream"]);
+const INTEGER_MULTIPART_FIELDS = new Set(["n", "output_compression", "partial_images"]);
+const PRIMARY_IMAGE_FILE_FIELDS = new Set(["image", "image[]"]);
+const SINGLE_VALUE_MULTIPART_FIELDS = new Set([
+  "prompt",
+  "model",
+  "background",
+  "input_fidelity",
+  "mask",
+  "moderation",
+  "n",
+  "output_compression",
+  "output_format",
+  "partial_images",
+  "quality",
+  "size",
+  "stream",
+  "user",
+  "response_format",
+  "style",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isOpenAIImageUrl(value: string): boolean {
+  if (value.startsWith("data:")) {
+    return true;
+  }
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function firstTextPart(
+  metadata: OpenAIImageRequestMetadata | null | undefined,
+  name: string
+): string | null {
+  if (!metadata) return null;
+  const part = metadata.parts.find((entry) => entry.kind === "text" && entry.name === name);
+  return part?.kind === "text" ? part.value : null;
+}
+
+function allTextParts(
+  metadata: OpenAIImageRequestMetadata | null | undefined,
+  name: string
+): string[] {
+  if (!metadata) return [];
+  return metadata.parts
+    .filter((entry): entry is MultipartTextPart => entry.kind === "text" && entry.name === name)
+    .map((entry) => entry.value);
+}
+
+function countFileParts(
+  metadata: OpenAIImageRequestMetadata | null | undefined,
+  names: string[]
+): number {
+  if (!metadata) return 0;
+  const nameSet = new Set(names);
+  return metadata.parts.filter((entry) => entry.kind === "file" && nameSet.has(entry.name)).length;
+}
+
+function parseInteger(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value !== "string" || value.trim() === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return null;
+}
+
+function parseString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function fail(message: string): OpenAIImageValidationResult {
+  return { ok: false, message };
+}
+
+function success(): OpenAIImageValidationResult {
+  return { ok: true };
+}
+
+function isGptImageModel(model: string): boolean {
+  return GENERATION_GPT_MODELS.has(model) || EDIT_GPT_MODELS.has(model);
+}
+
+function getKnownModelFamily(
+  endpoint: OpenAIImageEndpoint,
+  model: string | null
+): OpenAIImageModelFamily | null {
+  if (!model) return null;
+  if (model === "dall-e-2") return "dall-e-2";
+  if (model === "dall-e-3") return "dall-e-3";
+  if (
+    (endpoint === "generations" && isGptImageModel(model)) ||
+    (endpoint === "edits" && isGptImageModel(model))
+  ) {
+    return "gpt";
+  }
+  return null;
+}
+
+function inferGenerationModelFamily(body: Record<string, unknown>, model: string | null) {
+  const knownFamily = getKnownModelFamily("generations", model);
+  if (knownFamily) return knownFamily;
+  if (model) return "unknown" as const;
+
+  const size = parseString(body.size);
+  const quality = parseString(body.quality);
+  const style = parseString(body.style);
+  const hasGptOnlyParam = Array.from(GPT_ONLY_GENERATION_PARAMS).some(
+    (key) => body[key] !== undefined
+  );
+
+  if (style === "vivid" || style === "natural") return "dall-e-3";
+  if (size === "1792x1024" || size === "1024x1792") return "dall-e-3";
+  if (quality === "hd") return "dall-e-3";
+
+  if (hasGptOnlyParam) return "gpt";
+  if (size === "auto" || size === "1536x1024" || size === "1024x1536") return "gpt";
+  if (quality === "low" || quality === "medium" || quality === "high") return "gpt";
+
+  return "dall-e-2";
+}
+
+function inferEditModelFamily(
+  body: Record<string, unknown>,
+  model: string | null
+): OpenAIImageModelFamily | null {
+  const knownFamily = getKnownModelFamily("edits", model);
+  if (knownFamily) return knownFamily;
+  if (model) return "unknown";
+
+  const hasGptOnlyParam = Array.from(GPT_ONLY_EDIT_PARAMS).some((key) => body[key] !== undefined);
+  return hasGptOnlyParam ? "gpt" : null;
+}
+
+function inferMultipartEditModelFamily(
+  metadata: OpenAIImageRequestMetadata,
+  model: string | null
+): OpenAIImageModelFamily | null {
+  const knownFamily = getKnownModelFamily("edits", model);
+  if (knownFamily) return knownFamily;
+  if (model) return "unknown";
+
+  const hasGptOnlyParam = Array.from(GPT_ONLY_EDIT_PARAMS).some(
+    (key) => firstTextPart(metadata, key) !== null
+  );
+  return hasGptOnlyParam ? "gpt" : null;
+}
+
+function validatePromptLength(
+  prompt: string,
+  family: OpenAIImageModelFamily | null
+): OpenAIImageValidationResult {
+  if (family === "gpt") {
+    return prompt.length <= 32000
+      ? success()
+      : fail("Invalid request: prompt exceeds the 32000 character limit for GPT image models.");
+  }
+
+  if (family === "dall-e-2") {
+    return prompt.length <= 1000
+      ? success()
+      : fail("Invalid request: prompt exceeds the 1000 character limit for dall-e-2.");
+  }
+
+  if (family === "dall-e-3") {
+    return prompt.length <= 4000
+      ? success()
+      : fail("Invalid request: prompt exceeds the 4000 character limit for dall-e-3.");
+  }
+
+  return success();
+}
+
+function validateDallEUrlField(name: string, value: string): OpenAIImageValidationResult {
+  if (value.length > 20 * 1024 * 1024) {
+    return fail(`Invalid request: ${name} exceeds the documented maxLength of 20971520.`);
+  }
+
+  return isOpenAIImageUrl(value)
+    ? success()
+    : fail(`Invalid request: ${name} must be a fully qualified URL or a data URL.`);
+}
+
+function validateGenerationsRequest(body: Record<string, unknown>): OpenAIImageValidationResult {
+  const prompt = parseString(body.prompt);
+  if (!prompt) {
+    return fail("Missing required parameter: prompt");
+  }
+
+  const model = parseString(body.model);
+  if (model === "gpt-image-2") {
+    return success();
+  }
+
+  const family = inferGenerationModelFamily(body, model);
+  const promptLengthResult = validatePromptLength(prompt, family);
+  if (!promptLengthResult.ok) return promptLengthResult;
+
+  const background = parseString(body.background);
+  if (
+    background &&
+    background !== "transparent" &&
+    background !== "opaque" &&
+    background !== "auto"
+  ) {
+    return fail('Invalid request: background must be one of "transparent", "opaque", or "auto".');
+  }
+  if (background && family !== "gpt") {
+    return fail("Invalid request: background is only supported for GPT image models.");
+  }
+
+  const outputFormat = parseString(body.output_format);
+  if (outputFormat && !["png", "jpeg", "webp"].includes(outputFormat)) {
+    return fail('Invalid request: output_format must be one of "png", "jpeg", or "webp".');
+  }
+  if (outputFormat && family !== "gpt") {
+    return fail("Invalid request: output_format is only supported for GPT image models.");
+  }
+  if (background === "transparent" && outputFormat && !["png", "webp"].includes(outputFormat)) {
+    return fail('Invalid request: transparent background requires output_format "png" or "webp".');
+  }
+
+  const moderation = parseString(body.moderation);
+  if (moderation && moderation !== "low" && moderation !== "auto") {
+    return fail('Invalid request: moderation must be either "low" or "auto".');
+  }
+  if (moderation && family !== "gpt") {
+    return fail("Invalid request: moderation is only supported for GPT image models.");
+  }
+
+  const n = parseInteger(body.n);
+  if (body.n !== undefined) {
+    if (n === null || !Number.isInteger(n) || n < 1 || n > 10) {
+      return fail("Invalid request: n must be an integer between 1 and 10.");
+    }
+    if (family === "dall-e-3" && n !== 1) {
+      return fail("Invalid request: dall-e-3 only supports n=1.");
+    }
+  }
+
+  const outputCompression = parseInteger(body.output_compression);
+  if (body.output_compression !== undefined) {
+    if (outputCompression === null || outputCompression < 0 || outputCompression > 100) {
+      return fail("Invalid request: output_compression must be between 0 and 100.");
+    }
+    if (family !== "gpt") {
+      return fail("Invalid request: output_compression is only supported for GPT image models.");
+    }
+    if (outputFormat && !["jpeg", "webp"].includes(outputFormat)) {
+      return fail('Invalid request: output_compression requires output_format "jpeg" or "webp".');
+    }
+  }
+
+  const partialImages = parseInteger(body.partial_images);
+  if (body.partial_images !== undefined) {
+    if (partialImages === null || !Number.isInteger(partialImages) || partialImages < 0) {
+      return fail("Invalid request: partial_images must be an integer between 0 and 3.");
+    }
+    if (partialImages > 3) {
+      return fail("Invalid request: partial_images must be an integer between 0 and 3.");
+    }
+  }
+
+  const quality = parseString(body.quality);
+  if (quality && !["standard", "hd", "low", "medium", "high", "auto"].includes(quality)) {
+    return fail(
+      'Invalid request: quality must be one of "standard", "hd", "low", "medium", "high", or "auto".'
+    );
+  }
+  if (quality && family === "gpt" && !["low", "medium", "high", "auto"].includes(quality)) {
+    return fail(
+      'Invalid request: GPT image models only support quality "low", "medium", "high", or "auto".'
+    );
+  }
+  if (quality && family === "dall-e-3" && !["standard", "hd", "auto"].includes(quality)) {
+    return fail('Invalid request: dall-e-3 only supports quality "standard" or "hd".');
+  }
+  if (quality && family === "dall-e-2" && !["standard", "auto"].includes(quality)) {
+    return fail('Invalid request: dall-e-2 only supports quality "standard".');
+  }
+
+  const responseFormat = parseString(body.response_format);
+  if (responseFormat && !["url", "b64_json"].includes(responseFormat)) {
+    return fail('Invalid request: response_format must be either "url" or "b64_json".');
+  }
+  if (responseFormat && family === "gpt") {
+    return fail("Invalid request: response_format is not supported for GPT image models.");
+  }
+
+  const size = parseString(body.size);
+  if (
+    size &&
+    ![
+      "auto",
+      "1024x1024",
+      "1536x1024",
+      "1024x1536",
+      "256x256",
+      "512x512",
+      "1792x1024",
+      "1024x1792",
+    ].includes(size)
+  ) {
+    return fail("Invalid request: size is not a supported value for the Images API.");
+  }
+  if (size && family === "gpt" && !["auto", "1024x1024", "1536x1024", "1024x1536"].includes(size)) {
+    return fail(
+      "Invalid request: GPT image models only support size auto, 1024x1024, 1536x1024, or 1024x1536."
+    );
+  }
+  if (size && family === "dall-e-2" && !["256x256", "512x512", "1024x1024"].includes(size)) {
+    return fail("Invalid request: dall-e-2 only supports size 256x256, 512x512, or 1024x1024.");
+  }
+  if (size && family === "dall-e-3" && !["1024x1024", "1792x1024", "1024x1792"].includes(size)) {
+    return fail("Invalid request: dall-e-3 only supports size 1024x1024, 1792x1024, or 1024x1792.");
+  }
+
+  const stream = parseBoolean(body.stream);
+  if (body.stream !== undefined && stream === null) {
+    return fail("Invalid request: stream must be a boolean.");
+  }
+  if (stream !== null && stream && family !== "gpt") {
+    return fail("Invalid request: stream is only supported for GPT image models.");
+  }
+
+  const style = parseString(body.style);
+  if (style && style !== "vivid" && style !== "natural") {
+    return fail('Invalid request: style must be either "vivid" or "natural".');
+  }
+  if (style && family !== "dall-e-3") {
+    return fail("Invalid request: style is only supported for dall-e-3.");
+  }
+
+  return success();
+}
+
+function validateEditMask(mask: unknown): OpenAIImageValidationResult {
+  if (!isRecord(mask)) {
+    return fail("Invalid request: mask must be an object.");
+  }
+
+  const fileId = parseString(mask.file_id);
+  const imageUrl = parseString(mask.image_url);
+  if ((fileId ? 1 : 0) + (imageUrl ? 1 : 0) !== 1) {
+    return fail("Invalid request: mask must provide exactly one of image_url or file_id.");
+  }
+
+  if (imageUrl) {
+    return validateDallEUrlField("mask.image_url", imageUrl);
+  }
+
+  return success();
+}
+
+function validateEditImages(images: unknown, family: OpenAIImageModelFamily | null) {
+  if (!Array.isArray(images) || images.length === 0) {
+    return fail("Missing required parameter: images");
+  }
+  if (family === "gpt" && images.length > 16) {
+    return fail("Invalid request: GPT image edit requests support up to 16 images.");
+  }
+
+  for (const [index, image] of images.entries()) {
+    if (!isRecord(image)) {
+      return fail(`Invalid request: images[${index}] must be an object.`);
+    }
+    const fileId = parseString(image.file_id);
+    const imageUrl = parseString(image.image_url);
+    if (!fileId && !imageUrl) {
+      return fail(`Invalid request: images[${index}] must provide file_id or image_url.`);
+    }
+    if (imageUrl) {
+      const result = validateDallEUrlField(`images[${index}].image_url`, imageUrl);
+      if (!result.ok) return result;
+    }
+  }
+
+  return success();
+}
+
+function validateEditsJsonRequest(body: Record<string, unknown>): OpenAIImageValidationResult {
+  const prompt = parseString(body.prompt);
+  if (!prompt) {
+    return fail("Missing required parameter: prompt");
+  }
+  if (prompt.length < 1 || prompt.length > 32000) {
+    return fail("Invalid request: prompt must be between 1 and 32000 characters.");
+  }
+
+  const model = parseString(body.model);
+  if (model === "dall-e-3") {
+    return fail("Invalid request: /images/edits does not support dall-e-3.");
+  }
+
+  const family = inferEditModelFamily(body, model);
+  const imagesResult = validateEditImages(body.images, family);
+  if (!imagesResult.ok) return imagesResult;
+
+  const background = parseString(body.background);
+  if (
+    background &&
+    background !== "transparent" &&
+    background !== "opaque" &&
+    background !== "auto"
+  ) {
+    return fail('Invalid request: background must be one of "transparent", "opaque", or "auto".');
+  }
+
+  const inputFidelity = parseString(body.input_fidelity);
+  if (inputFidelity && inputFidelity !== "high" && inputFidelity !== "low") {
+    return fail('Invalid request: input_fidelity must be "high" or "low".');
+  }
+
+  if (body.mask !== undefined) {
+    const maskResult = validateEditMask(body.mask);
+    if (!maskResult.ok) return maskResult;
+  }
+
+  if (model === "gpt-image-2") {
+    return success();
+  }
+
+  const moderation = parseString(body.moderation);
+  if (moderation && moderation !== "low" && moderation !== "auto") {
+    return fail('Invalid request: moderation must be either "low" or "auto".');
+  }
+  if (moderation && family !== "gpt") {
+    return fail("Invalid request: moderation is only supported for GPT image models.");
+  }
+
+  const n = parseInteger(body.n);
+  if (body.n !== undefined && (n === null || !Number.isInteger(n) || n < 1 || n > 10)) {
+    return fail("Invalid request: n must be an integer between 1 and 10.");
+  }
+
+  const outputCompression = parseInteger(body.output_compression);
+  if (body.output_compression !== undefined) {
+    if (outputCompression === null || outputCompression < 0 || outputCompression > 100) {
+      return fail("Invalid request: output_compression must be between 0 and 100.");
+    }
+    const outputFormat = parseString(body.output_format);
+    if (outputFormat && !["jpeg", "webp"].includes(outputFormat)) {
+      return fail('Invalid request: output_compression requires output_format "jpeg" or "webp".');
+    }
+  }
+
+  const outputFormat = parseString(body.output_format);
+  if (outputFormat && !["png", "jpeg", "webp"].includes(outputFormat)) {
+    return fail('Invalid request: output_format must be one of "png", "jpeg", or "webp".');
+  }
+  if (outputFormat && family !== "gpt") {
+    return fail("Invalid request: output_format is only supported for GPT image models.");
+  }
+
+  const partialImages = parseInteger(body.partial_images);
+  if (body.partial_images !== undefined) {
+    if (partialImages === null || !Number.isInteger(partialImages) || partialImages < 0) {
+      return fail("Invalid request: partial_images must be an integer between 0 and 3.");
+    }
+    if (partialImages > 3) {
+      return fail("Invalid request: partial_images must be an integer between 0 and 3.");
+    }
+  }
+
+  const quality = parseString(body.quality);
+  if (quality && !["low", "medium", "high", "auto"].includes(quality)) {
+    return fail('Invalid request: quality must be one of "low", "medium", "high", or "auto".');
+  }
+  if (quality && family !== "gpt") {
+    return fail("Invalid request: quality is only supported for GPT image models.");
+  }
+
+  const size = parseString(body.size);
+  if (size && !["auto", "1024x1024", "1536x1024", "1024x1536"].includes(size)) {
+    return fail(
+      "Invalid request: /images/edits only supports size auto, 1024x1024, 1536x1024, or 1024x1536."
+    );
+  }
+
+  const stream = parseBoolean(body.stream);
+  if (body.stream !== undefined && stream === null) {
+    return fail("Invalid request: stream must be a boolean.");
+  }
+
+  return success();
+}
+
+function getPngSize(bytes: Uint8Array): { width: number; height: number } | null {
+  if (bytes.length < 24) return null;
+  const signature = [137, 80, 78, 71, 13, 10, 26, 10];
+  for (let index = 0; index < signature.length; index += 1) {
+    if (bytes[index] !== signature[index]) return null;
+  }
+  const width = (bytes[16] << 24) | (bytes[17] << 16) | (bytes[18] << 8) | (bytes[19] & 0xff);
+  const height = (bytes[20] << 24) | (bytes[21] << 16) | (bytes[22] << 8) | (bytes[23] & 0xff);
+  return { width: width >>> 0, height: height >>> 0 };
+}
+
+async function validateVariationImageFile(file: File): Promise<OpenAIImageValidationResult> {
+  const fileName = file.name.toLowerCase();
+  const isPng = file.type === "image/png" || fileName.endsWith(".png");
+  if (!isPng) {
+    return fail("Invalid request: /images/variations requires a valid PNG file.");
+  }
+
+  if (file.size >= 4 * 1024 * 1024) {
+    return fail("Invalid request: /images/variations requires the image file to be less than 4MB.");
+  }
+
+  const buffer = await file.arrayBuffer();
+  const pngSize = getPngSize(new Uint8Array(buffer));
+  if (!pngSize) {
+    return fail("Invalid request: /images/variations requires a valid PNG file.");
+  }
+
+  if (pngSize.width !== pngSize.height) {
+    return fail("Invalid request: /images/variations requires a square PNG image.");
+  }
+
+  return success();
+}
+
+async function validateVariationsMultipartRequest(
+  metadata: OpenAIImageRequestMetadata
+): Promise<OpenAIImageValidationResult> {
+  const imageFiles = metadata.parts.filter(
+    (entry): entry is MultipartFilePart => entry.kind === "file" && entry.name === "image"
+  );
+
+  if (imageFiles.length !== 1) {
+    return fail("Missing required parameter: image");
+  }
+
+  const imageResult = await validateVariationImageFile(imageFiles[0].value);
+  if (!imageResult.ok) return imageResult;
+
+  const model = firstTextPart(metadata, "model");
+  if (model && model !== VARIATION_MODEL) {
+    return fail("Invalid request: /images/variations only supports model dall-e-2.");
+  }
+
+  const n = parseInteger(firstTextPart(metadata, "n"));
+  if (n !== null && (!Number.isInteger(n) || n < 1 || n > 10)) {
+    return fail("Invalid request: n must be an integer between 1 and 10.");
+  }
+
+  const responseFormat = firstTextPart(metadata, "response_format");
+  if (responseFormat && responseFormat !== "url" && responseFormat !== "b64_json") {
+    return fail('Invalid request: response_format must be either "url" or "b64_json".');
+  }
+
+  const size = firstTextPart(metadata, "size");
+  if (size && !["256x256", "512x512", "1024x1024"].includes(size)) {
+    return fail(
+      "Invalid request: /images/variations only supports size 256x256, 512x512, or 1024x1024."
+    );
+  }
+
+  return success();
+}
+
+async function validateEditsMultipartRequest(
+  metadata: OpenAIImageRequestMetadata
+): Promise<OpenAIImageValidationResult> {
+  for (const field of SINGLE_VALUE_MULTIPART_FIELDS) {
+    if (allTextParts(metadata, field).length > 1) {
+      return fail(`Invalid request: multipart field "${field}" must not be repeated.`);
+    }
+  }
+
+  const prompt = firstTextPart(metadata, "prompt");
+  if (!prompt) {
+    return fail("Missing required parameter: prompt");
+  }
+  if (prompt.length < 1 || prompt.length > 32000) {
+    return fail("Invalid request: prompt must be between 1 and 32000 characters.");
+  }
+
+  const model = firstTextPart(metadata, "model");
+  if (model === "dall-e-3") {
+    return fail("Invalid request: /images/edits does not support dall-e-3.");
+  }
+
+  const family = inferMultipartEditModelFamily(metadata, model);
+  const imageCount = countFileParts(metadata, ["image", "image[]"]);
+  if (imageCount < 1) {
+    return fail("Missing required parameter: image");
+  }
+  if (family === "gpt" && imageCount > 16) {
+    return fail("Invalid request: GPT image edit requests support up to 16 images.");
+  }
+
+  const background = firstTextPart(metadata, "background");
+  if (
+    background &&
+    background !== "transparent" &&
+    background !== "opaque" &&
+    background !== "auto"
+  ) {
+    return fail('Invalid request: background must be one of "transparent", "opaque", or "auto".');
+  }
+
+  const inputFidelity = firstTextPart(metadata, "input_fidelity");
+  if (inputFidelity && inputFidelity !== "high" && inputFidelity !== "low") {
+    return fail('Invalid request: input_fidelity must be "high" or "low".');
+  }
+
+  const maskTextCount = allTextParts(metadata, "mask").length;
+  const maskFileCount = countFileParts(metadata, ["mask"]);
+  if (maskTextCount + maskFileCount > 1) {
+    return fail("Invalid request: multipart /images/edits accepts at most one mask field.");
+  }
+
+  if (model === "gpt-image-2") {
+    return success();
+  }
+
+  const moderation = firstTextPart(metadata, "moderation");
+  if (moderation && moderation !== "low" && moderation !== "auto") {
+    return fail('Invalid request: moderation must be either "low" or "auto".');
+  }
+  if (moderation && family !== "gpt") {
+    return fail("Invalid request: moderation is only supported for GPT image models.");
+  }
+
+  const n = parseInteger(firstTextPart(metadata, "n"));
+  if (n !== null && (!Number.isInteger(n) || n < 1 || n > 10)) {
+    return fail("Invalid request: n must be an integer between 1 and 10.");
+  }
+
+  const outputCompression = parseInteger(firstTextPart(metadata, "output_compression"));
+  const outputFormat = firstTextPart(metadata, "output_format");
+  if (outputCompression !== null) {
+    if (outputCompression < 0 || outputCompression > 100) {
+      return fail("Invalid request: output_compression must be between 0 and 100.");
+    }
+    if (outputFormat && !["jpeg", "webp"].includes(outputFormat)) {
+      return fail('Invalid request: output_compression requires output_format "jpeg" or "webp".');
+    }
+  }
+
+  if (outputFormat && !["png", "jpeg", "webp"].includes(outputFormat)) {
+    return fail('Invalid request: output_format must be one of "png", "jpeg", or "webp".');
+  }
+  if (outputFormat && family !== "gpt") {
+    return fail("Invalid request: output_format is only supported for GPT image models.");
+  }
+
+  const partialImages = parseInteger(firstTextPart(metadata, "partial_images"));
+  if (partialImages !== null && (!Number.isInteger(partialImages) || partialImages < 0)) {
+    return fail("Invalid request: partial_images must be an integer between 0 and 3.");
+  }
+  if (partialImages !== null && partialImages > 3) {
+    return fail("Invalid request: partial_images must be an integer between 0 and 3.");
+  }
+
+  const quality = firstTextPart(metadata, "quality");
+  if (quality && !["low", "medium", "high", "auto"].includes(quality)) {
+    return fail('Invalid request: quality must be one of "low", "medium", "high", or "auto".');
+  }
+  if (quality && family !== "gpt") {
+    return fail("Invalid request: quality is only supported for GPT image models.");
+  }
+
+  const size = firstTextPart(metadata, "size");
+  if (size && !["auto", "1024x1024", "1536x1024", "1024x1536"].includes(size)) {
+    return fail(
+      "Invalid request: /images/edits only supports size auto, 1024x1024, 1536x1024, or 1024x1536."
+    );
+  }
+
+  const stream = firstTextPart(metadata, "stream");
+  if (stream !== null && parseBoolean(stream) === null) {
+    return fail("Invalid request: stream must be a boolean.");
+  }
+
+  return success();
+}
+
+export function getOpenAIImageEndpoint(pathname: string): OpenAIImageEndpoint | null {
+  if (pathname === "/v1/images/generations") return "generations";
+  if (pathname === "/v1/images/edits") return "edits";
+  if (pathname === "/v1/images/variations") return "variations";
+  return null;
+}
+
+export function isOpenAIImageMultipartContentType(contentType: string | null): boolean {
+  return (
+    typeof contentType === "string" && contentType.toLowerCase().includes("multipart/form-data")
+  );
+}
+
+export async function parseOpenAIImageMultipartMetadata(
+  request: Request,
+  pathname: string,
+  contentType: string | null
+): Promise<OpenAIImageRequestMetadata | null> {
+  const endpoint = getOpenAIImageEndpoint(pathname);
+  if (!endpoint || !isOpenAIImageMultipartContentType(contentType)) {
+    return null;
+  }
+
+  const formData = await request.clone().formData();
+  const parts: OpenAIImageMultipartPart[] = [];
+  let model: string | null = null;
+
+  for (const [name, value] of formData.entries()) {
+    if (typeof value === "string") {
+      parts.push({ name, kind: "text", value });
+      if (name === "model" && model === null) {
+        model = value;
+      }
+      continue;
+    }
+
+    parts.push({ name, kind: "file", value });
+  }
+
+  return {
+    endpoint,
+    bodyKind: "multipart",
+    contentType,
+    model,
+    parts,
+  };
+}
+
+export function getOpenAIImageMultipartSummary(metadata: OpenAIImageRequestMetadata): string {
+  const fileCount = metadata.parts.filter((entry) => entry.kind === "file").length;
+  const fieldCount = metadata.parts.filter((entry) => entry.kind === "text").length;
+  const promptLength = firstTextPart(metadata, "prompt")?.length ?? 0;
+  return JSON.stringify(
+    {
+      type: "openai_image_multipart",
+      endpoint: metadata.endpoint,
+      model: metadata.model,
+      fieldCount,
+      fileCount,
+      promptLength,
+    },
+    null,
+    2
+  );
+}
+
+export function isOpenAIImageMultipartRequest(
+  metadata: OpenAIImageRequestMetadata | null | undefined
+): boolean {
+  return metadata?.bodyKind === "multipart";
+}
+
+export function setOpenAIImageMultipartModel(
+  metadata: OpenAIImageRequestMetadata,
+  model: string
+): void {
+  let rewritten = false;
+  metadata.model = model;
+
+  metadata.parts = metadata.parts.map((entry) => {
+    if (entry.kind === "text" && entry.name === "model") {
+      if (!rewritten) {
+        rewritten = true;
+        return { ...entry, value: model };
+      }
+      return entry;
+    }
+
+    return entry;
+  });
+
+  if (!rewritten) {
+    metadata.parts.push({ name: "model", kind: "text", value: model });
+  }
+}
+
+export function buildOpenAIImageLogicalBody(
+  metadata: OpenAIImageRequestMetadata | null | undefined
+): Record<string, unknown> {
+  if (!metadata) {
+    return {};
+  }
+
+  const grouped = new Map<string, string[]>();
+  for (const part of metadata.parts) {
+    if (part.kind !== "text") continue;
+    const existing = grouped.get(part.name) ?? [];
+    existing.push(part.value);
+    grouped.set(part.name, existing);
+  }
+
+  const logicalBody: Record<string, unknown> = {};
+  for (const [name, values] of grouped.entries()) {
+    logicalBody[name] = values.length === 1 ? coerceMultipartLogicalValue(name, values[0]) : values;
+  }
+
+  for (const part of metadata.parts) {
+    if (part.kind !== "file" || PRIMARY_IMAGE_FILE_FIELDS.has(part.name)) continue;
+    if (!(part.name in logicalBody)) {
+      logicalBody[part.name] = "[file]";
+    }
+  }
+
+  return logicalBody;
+}
+
+function coerceMultipartLogicalValue(name: string, value: string): unknown {
+  if (BOOLEAN_MULTIPART_FIELDS.has(name)) {
+    return parseBoolean(value) ?? value;
+  }
+  if (INTEGER_MULTIPART_FIELDS.has(name)) {
+    return parseInteger(value) ?? value;
+  }
+  return value;
+}
+
+export function syncOpenAIImageMultipartFromLogicalBody(
+  metadata: OpenAIImageRequestMetadata,
+  logicalBody: Record<string, unknown>
+): void {
+  const fileParts = metadata.parts.filter((part): part is MultipartFilePart => {
+    if (part.kind !== "file") return false;
+    if (part.name.startsWith("_")) return false;
+    if (PRIMARY_IMAGE_FILE_FIELDS.has(part.name)) return true;
+    return Object.prototype.hasOwnProperty.call(logicalBody, part.name);
+  });
+  const nextTextParts: MultipartTextPart[] = [];
+
+  for (const [key, value] of Object.entries(logicalBody)) {
+    if (value === undefined || value === null) continue;
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === "string" || typeof item === "number" || typeof item === "boolean") {
+          nextTextParts.push({ name: key, kind: "text", value: String(item) });
+        }
+      }
+      continue;
+    }
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      nextTextParts.push({ name: key, kind: "text", value: String(value) });
+    }
+  }
+
+  metadata.parts = [...nextTextParts, ...fileParts];
+  metadata.model = parseString(logicalBody.model) ?? null;
+}
+
+export function cloneOpenAIImageRequestMetadata(
+  metadata: OpenAIImageRequestMetadata | null | undefined
+): OpenAIImageRequestMetadata | null {
+  if (!metadata) return null;
+
+  return {
+    endpoint: metadata.endpoint,
+    bodyKind: metadata.bodyKind,
+    contentType: metadata.contentType,
+    model: metadata.model,
+    parts: metadata.parts.map((part) =>
+      part.kind === "text" ? { ...part } : { ...part, value: part.value }
+    ),
+  };
+}
+
+export async function serializeOpenAIImageMultipartRequest(metadata: OpenAIImageRequestMetadata) {
+  const formData = new FormData();
+  for (const part of metadata.parts) {
+    if (part.kind === "text") {
+      formData.append(part.name, part.value);
+      continue;
+    }
+
+    formData.append(part.name, part.value, part.value.name);
+  }
+
+  const request = new Request("https://proxy.invalid/upload", {
+    method: "POST",
+    body: formData,
+  });
+
+  return {
+    body: await request.arrayBuffer(),
+    contentType: request.headers.get("content-type"),
+    summary: getOpenAIImageMultipartSummary(metadata),
+    isStreaming: parseBoolean(firstTextPart(metadata, "stream")) === true,
+  };
+}
+
+export function sanitizeGenerationsRequestForProvider(
+  body: Record<string, unknown>,
+  provider: Provider | null | undefined
+): boolean {
+  if (!provider || body.response_format === undefined) {
+    return false;
+  }
+
+  const providerName = provider.name.toLowerCase();
+  const providerUrl = provider.url.toLowerCase();
+  const looksLikeYunAiAzure =
+    (providerName.includes("yunai") && providerName.includes("azure")) ||
+    (providerUrl.includes("yunai") && providerUrl.includes("azure"));
+
+  if (!looksLikeYunAiAzure) {
+    return false;
+  }
+
+  delete body.response_format;
+  return true;
+}
+
+export async function validateOpenAIImageRequest(options: {
+  pathname: string;
+  body: Record<string, unknown>;
+  imageRequestMetadata?: OpenAIImageRequestMetadata | null;
+}): Promise<OpenAIImageValidationResult> {
+  const endpoint = getOpenAIImageEndpoint(options.pathname);
+  if (!endpoint) {
+    return success();
+  }
+
+  if (endpoint === "generations") {
+    if (options.imageRequestMetadata?.bodyKind === "multipart") {
+      return fail("Invalid request: /images/generations requires a JSON request body.");
+    }
+    return validateGenerationsRequest(options.body);
+  }
+
+  if (endpoint === "edits") {
+    if (options.imageRequestMetadata?.bodyKind === "multipart") {
+      return validateEditsMultipartRequest(options.imageRequestMetadata);
+    }
+    return validateEditsJsonRequest(options.body);
+  }
+
+  if (endpoint === "variations") {
+    if (!options.imageRequestMetadata || options.imageRequestMetadata.bodyKind !== "multipart") {
+      return fail("Invalid request: /images/variations requires multipart/form-data.");
+    }
+    return validateVariationsMultipartRequest(options.imageRequestMetadata);
+  }
+
+  return success();
+}

--- a/src/app/v1/_lib/proxy/session.ts
+++ b/src/app/v1/_lib/proxy/session.ts
@@ -20,6 +20,15 @@ import { isCountTokensEndpointPath } from "./endpoint-paths";
 import { type EndpointPolicy, resolveEndpointPolicy } from "./endpoint-policy";
 import { ProxyError } from "./errors";
 import type { ClientFormat } from "./format-mapper";
+import {
+  buildOpenAIImageLogicalBody,
+  getOpenAIImageEndpoint,
+  getOpenAIImageMultipartSummary,
+  isOpenAIImageMultipartContentType,
+  isOpenAIImageMultipartRequest,
+  type OpenAIImageRequestMetadata,
+  parseOpenAIImageMultipartMetadata,
+} from "./openai-image-compat";
 
 export interface AuthState {
   user: User | null;
@@ -43,6 +52,7 @@ export interface ProxyRequestPayload {
   log: string;
   note?: string;
   model: string | null;
+  imageRequestMetadata?: OpenAIImageRequestMetadata | null;
 }
 
 interface RequestBodyResult {
@@ -52,6 +62,7 @@ interface RequestBodyResult {
   requestBodyBuffer?: ArrayBuffer;
   contentLength?: number | null;
   actualBodyBytes?: number;
+  imageRequestMetadata?: OpenAIImageRequestMetadata | null;
 }
 
 export class ProxySession {
@@ -207,6 +218,7 @@ export class ProxySession {
 
     const modelFromBody =
       typeof bodyResult.requestMessage.model === "string" ? bodyResult.requestMessage.model : null;
+    const modelFromImageRequest = bodyResult.imageRequestMetadata?.model ?? null;
 
     // 针对官方 Gemini 路径（/v1beta/models/{model}:generateContent）
     // 请求体中通常没有 model 字段，需从 URL 路径提取用于调度器匹配
@@ -219,7 +231,10 @@ export class ProxySession {
       modelFromPath !== null;
 
     const resolvedModel =
-      modelFromBody ?? modelFromPath ?? (isLikelyGeminiRequest ? "gemini-2.5-flash" : null);
+      modelFromBody ??
+      modelFromImageRequest ??
+      modelFromPath ??
+      (isLikelyGeminiRequest ? "gemini-2.5-flash" : null);
 
     const isLargeRequestBody =
       (bodyResult.contentLength !== null &&
@@ -247,6 +262,7 @@ export class ProxySession {
       log: bodyResult.requestBodyLog,
       note: bodyResult.requestBodyLogNote,
       model: resolvedModel,
+      imageRequestMetadata: bodyResult.imageRequestMetadata,
     };
 
     return new ProxySession({
@@ -645,6 +661,14 @@ export class ProxySession {
    */
   getCurrentModel(): string | null {
     return this.request.model;
+  }
+
+  getOpenAIImageRequestMetadata(): OpenAIImageRequestMetadata | null {
+    return this.request.imageRequestMetadata ?? null;
+  }
+
+  isOpenAIImageMultipartRequest(): boolean {
+    return isOpenAIImageMultipartRequest(this.getOpenAIImageRequestMetadata());
   }
 
   getEndpointPolicy(): EndpointPolicy {
@@ -1064,6 +1088,8 @@ async function parseRequestBody(c: Context): Promise<RequestBodyResult> {
   }
 
   const contentLength = parseContentLengthHeader(c.req.header("content-length"));
+  const contentType = c.req.header("content-type") ?? null;
+  const pathname = new URL(c.req.url).pathname;
   const requestBodyBuffer = await c.req.raw.clone().arrayBuffer();
   const actualBodyBytes = requestBodyBuffer.byteLength;
   const requestBodyText = new TextDecoder().decode(requestBodyBuffer);
@@ -1090,6 +1116,31 @@ async function parseRequestBody(c: Context): Promise<RequestBodyResult> {
   let requestMessage: Record<string, unknown> = {};
   let requestBodyLog: string;
   let requestBodyLogNote: string | undefined;
+  let imageRequestMetadata: OpenAIImageRequestMetadata | null = null;
+
+  if (getOpenAIImageEndpoint(pathname) && isOpenAIImageMultipartContentType(contentType)) {
+    // 图片 multipart 请求保留 sidecar metadata，并为过滤/敏感词提供文本字段视图。
+    imageRequestMetadata = await parseOpenAIImageMultipartMetadata(
+      c.req.raw,
+      pathname,
+      contentType
+    );
+    requestMessage = buildOpenAIImageLogicalBody(imageRequestMetadata);
+    requestBodyLog = imageRequestMetadata
+      ? getOpenAIImageMultipartSummary(imageRequestMetadata)
+      : "(multipart image request)";
+    requestBodyLogNote = "图片 multipart 请求已记录结构化摘要。";
+
+    return {
+      requestMessage,
+      requestBodyLog,
+      requestBodyLogNote,
+      requestBodyBuffer,
+      contentLength,
+      actualBodyBytes,
+      imageRequestMetadata,
+    };
+  }
 
   try {
     const parsedMessage = JSON.parse(requestBodyText) as Record<string, unknown>;
@@ -1108,5 +1159,6 @@ async function parseRequestBody(c: Context): Promise<RequestBodyResult> {
     requestBodyBuffer,
     contentLength,
     actualBodyBytes,
+    imageRequestMetadata,
   };
 }

--- a/src/app/v1/_lib/url.ts
+++ b/src/app/v1/_lib/url.ts
@@ -9,6 +9,10 @@ const targetEndpoints = [
   "/messages", // Claude Messages API
   "/chat/completions", // OpenAI Compatible
   "/embeddings", // OpenAI Compatible Embeddings
+  "/images", // OpenAI Compatible Images API
+  "/audio/transcriptions", // OpenAI Compatible Audio API
+  "/audio/translations", // OpenAI Compatible Audio API
+  "/files", // OpenAI Compatible Files API
   "/models", // Gemini & OpenAI models
 ] as const;
 

--- a/src/lib/message-extractor.ts
+++ b/src/lib/message-extractor.ts
@@ -149,6 +149,17 @@ function extractInputText(input: unknown): string[] {
 export function extractTextFromMessages(message: Record<string, unknown>): string[] {
   const texts: string[] = [];
 
+  // 0. 提取图片接口等顶层 prompt 文本
+  if (typeof message.prompt === "string") {
+    texts.push(message.prompt);
+  } else if (Array.isArray(message.prompt)) {
+    for (const item of message.prompt) {
+      if (typeof item === "string") {
+        texts.push(item);
+      }
+    }
+  }
+
   // 1. 提取 system
   if ("system" in message) {
     const systemTexts = extractSystemText(message.system);

--- a/tests/unit/app/v1/url.test.ts
+++ b/tests/unit/app/v1/url.test.ts
@@ -160,6 +160,30 @@ describe("buildProxyUrl", () => {
     );
   });
 
+  test("版本根路径 + Images 端点：不应重复追加 /v1", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/v1",
+      "/v1/images/generations?x=1",
+      "https://relay.example.com/openai/v1/images/generations?x=1"
+    );
+  });
+
+  test("完整 Images path：baseUrl 已包含 /openai/v1/images 时保持原路径", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/v1/images",
+      "/v1/images/edits?x=1",
+      "https://relay.example.com/openai/v1/images/edits?x=1"
+    );
+  });
+
+  test("版本根路径 + Audio 端点：不应重复追加 /v1", () => {
+    expectBuiltUrl(
+      "https://relay.example.com/openai/v1",
+      "/v1/audio/transcriptions?x=1",
+      "https://relay.example.com/openai/v1/audio/transcriptions?x=1"
+    );
+  });
+
   test("完整子端点：baseUrl 已包含 /v1/messages/count_tokens 时不应重复拼接", () => {
     expectBuiltUrl(
       "https://proxy.example.com/anthropic/v1/messages/count_tokens",

--- a/tests/unit/proxy/endpoint-family-catalog.test.ts
+++ b/tests/unit/proxy/endpoint-family-catalog.test.ts
@@ -106,6 +106,20 @@ const FAMILY_SAMPLES = [
     modelRequired: false,
   },
   {
+    id: "openai-images",
+    path: "/v1/images/edits",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
+    id: "openai-images",
+    path: "/v1/images/variations",
+    format: "openai",
+    accountingTier: "none",
+    modelRequired: false,
+  },
+  {
     id: "openai-files",
     path: "/v1/files/file_123/content",
     format: "openai",

--- a/tests/unit/proxy/endpoint-family-provider-routing.test.ts
+++ b/tests/unit/proxy/endpoint-family-provider-routing.test.ts
@@ -96,6 +96,18 @@ const ENDPOINT_PROVIDER_CASES = [
     expectedProviderType: "openai-compatible",
   },
   {
+    id: "openai-images",
+    path: "/v1/images/edits",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
+    id: "openai-images",
+    path: "/v1/images/variations",
+    requestedModel: "",
+    expectedProviderType: "openai-compatible",
+  },
+  {
     id: "openai-files",
     path: "/v1/files/file_123/content",
     requestedModel: "",

--- a/tests/unit/proxy/openai-image-compat.test.ts
+++ b/tests/unit/proxy/openai-image-compat.test.ts
@@ -1,0 +1,428 @@
+import { describe, expect, it } from "vitest";
+import type { Provider } from "@/types/provider";
+import {
+  parseOpenAIImageMultipartMetadata,
+  sanitizeGenerationsRequestForProvider,
+  serializeOpenAIImageMultipartRequest,
+  setOpenAIImageMultipartModel,
+  validateOpenAIImageRequest,
+  type OpenAIImageRequestMetadata,
+} from "@/app/v1/_lib/proxy/openai-image-compat";
+
+function createProvider(name: string, url: string): Provider {
+  return {
+    id: 1,
+    name,
+    url,
+    key: "test-key",
+    providerType: "openai-compatible",
+  } as unknown as Provider;
+}
+
+function buildPngBytes(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(33);
+  bytes.set([137, 80, 78, 71, 13, 10, 26, 10], 0);
+  bytes.set([0, 0, 0, 13], 8);
+  bytes.set([73, 72, 68, 82], 12);
+  bytes[16] = (width >>> 24) & 0xff;
+  bytes[17] = (width >>> 16) & 0xff;
+  bytes[18] = (width >>> 8) & 0xff;
+  bytes[19] = width & 0xff;
+  bytes[20] = (height >>> 24) & 0xff;
+  bytes[21] = (height >>> 16) & 0xff;
+  bytes[22] = (height >>> 8) & 0xff;
+  bytes[23] = height & 0xff;
+  bytes.set([8, 6, 0, 0, 0], 24);
+  return bytes;
+}
+
+function createPngFile(name: string, width: number, height: number): File {
+  return new File([buildPngBytes(width, height)], name, { type: "image/png" });
+}
+
+async function createMultipartMetadata(parts: {
+  pathname: string;
+  fields?: Array<[string, string]>;
+  files?: Array<[string, File]>;
+}): Promise<OpenAIImageRequestMetadata> {
+  const formData = new FormData();
+  for (const [name, value] of parts.fields ?? []) {
+    formData.append(name, value);
+  }
+  for (const [name, file] of parts.files ?? []) {
+    formData.append(name, file, file.name);
+  }
+
+  const request = new Request(`https://proxy.example.com${parts.pathname}`, {
+    method: "POST",
+    body: formData,
+  });
+
+  const metadata = await parseOpenAIImageMultipartMetadata(
+    request,
+    parts.pathname,
+    request.headers.get("content-type")
+  );
+
+  if (!metadata) {
+    throw new Error("Expected multipart metadata to be parsed");
+  }
+
+  return metadata;
+}
+
+describe("openai-image-compat - generations constraints", () => {
+  it("rejects GPT models with response_format", async () => {
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/generations",
+      body: {
+        model: "gpt-image-1.5",
+        prompt: "otter",
+        response_format: "url",
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("response_format");
+  });
+
+  it("rejects transparent background with jpeg output", async () => {
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/generations",
+      body: {
+        model: "gpt-image-1",
+        prompt: "otter",
+        background: "transparent",
+        output_format: "jpeg",
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("transparent background");
+  });
+
+  it("rejects dall-e-3 n values other than 1", async () => {
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/generations",
+      body: {
+        model: "dall-e-3",
+        prompt: "otter",
+        n: 2,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("n=1");
+  });
+
+  it("rejects invalid prompt length for dall-e-2", async () => {
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/generations",
+      body: {
+        model: "dall-e-2",
+        prompt: "x".repeat(1001),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("1000");
+  });
+
+  it("accepts valid implicit dall-e-2 generations requests", async () => {
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/generations",
+      body: {
+        prompt: "otter",
+        response_format: "url",
+        size: "1024x1024",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("treats chatgpt-image-latest as a GPT image model on generations", async () => {
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/generations",
+      body: {
+        model: "chatgpt-image-latest",
+        prompt: "otter",
+        output_format: "png",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("fails open for gpt-image-2 until the API reference documents its matrix", async () => {
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/generations",
+      body: {
+        model: "gpt-image-2",
+        prompt: "otter",
+        background: "transparent",
+        output_format: "png",
+        size: "2048x2048",
+        response_format: "url",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("openai-image-compat - edits constraints", () => {
+  it("rejects edit requests without images", async () => {
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/edits",
+      body: {
+        model: "gpt-image-1.5",
+        prompt: "edit this",
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("images");
+  });
+
+  it("rejects masks that provide both file_id and image_url", async () => {
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/edits",
+      body: {
+        model: "gpt-image-1.5",
+        prompt: "edit this",
+        images: [{ file_id: "file-1" }],
+        mask: {
+          file_id: "mask-file",
+          image_url: "https://example.com/mask.png",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("mask");
+  });
+
+  it("rejects dall-e-3 on /images/edits", async () => {
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/edits",
+      body: {
+        model: "dall-e-3",
+        prompt: "edit this",
+        images: [{ file_id: "file-1" }],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("dall-e-3");
+  });
+
+  it("rejects GPT edits with more than 16 input images", async () => {
+    const images = Array.from({ length: 17 }, (_, index) => ({
+      image_url: `https://example.com/${index}.png`,
+    }));
+
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/edits",
+      body: {
+        model: "gpt-image-1.5",
+        prompt: "edit this",
+        images,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("16");
+  });
+
+  it("rejects multipart edits without input images", async () => {
+    const metadata = await createMultipartMetadata({
+      pathname: "/v1/images/edits",
+      fields: [
+        ["model", "gpt-image-1.5"],
+        ["prompt", "edit this"],
+      ],
+    });
+
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/edits",
+      body: {},
+      imageRequestMetadata: metadata,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("image");
+  });
+
+  it("rejects repeated multipart prompt fields", async () => {
+    const metadata = await createMultipartMetadata({
+      pathname: "/v1/images/edits",
+      fields: [
+        ["model", "gpt-image-1.5"],
+        ["prompt", "safe text"],
+        ["prompt", "blocked text"],
+      ],
+      files: [["image[]", createPngFile("source.png", 32, 32)]],
+    });
+
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/edits",
+      body: {},
+      imageRequestMetadata: metadata,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('multipart field "prompt"');
+  });
+
+  it("accepts valid multipart GPT edits requests", async () => {
+    const metadata = await createMultipartMetadata({
+      pathname: "/v1/images/edits",
+      fields: [
+        ["model", "gpt-image-1.5"],
+        ["prompt", "edit this"],
+        ["output_format", "png"],
+        ["size", "1024x1024"],
+        ["stream", "true"],
+      ],
+      files: [["image[]", createPngFile("source.png", 32, 32)]],
+    });
+
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/edits",
+      body: {},
+      imageRequestMetadata: metadata,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("openai-image-compat - variations constraints", () => {
+  it("rejects non-multipart variation requests", async () => {
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/variations",
+      body: { image: "x" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("multipart/form-data");
+  });
+
+  it("rejects variation models other than dall-e-2", async () => {
+    const metadata = await createMultipartMetadata({
+      pathname: "/v1/images/variations",
+      fields: [["model", "gpt-image-1.5"]],
+      files: [["image", createPngFile("square.png", 32, 32)]],
+    });
+
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/variations",
+      body: {},
+      imageRequestMetadata: metadata,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("dall-e-2");
+  });
+
+  it("rejects non-PNG variation files", async () => {
+    const metadata = await createMultipartMetadata({
+      pathname: "/v1/images/variations",
+      files: [["image", new File(["gif"], "image.gif", { type: "image/gif" })]],
+    });
+
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/variations",
+      body: {},
+      imageRequestMetadata: metadata,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("PNG");
+  });
+
+  it("rejects non-square PNG variation files", async () => {
+    const metadata = await createMultipartMetadata({
+      pathname: "/v1/images/variations",
+      files: [["image", createPngFile("wide.png", 64, 32)]],
+    });
+
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/variations",
+      body: {},
+      imageRequestMetadata: metadata,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("square");
+  });
+
+  it("accepts valid square PNG variation files", async () => {
+    const metadata = await createMultipartMetadata({
+      pathname: "/v1/images/variations",
+      files: [["image", createPngFile("square.png", 64, 64)]],
+    });
+
+    const result = await validateOpenAIImageRequest({
+      pathname: "/v1/images/variations",
+      body: {},
+      imageRequestMetadata: metadata,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("openai-image-compat - multipart helpers", () => {
+  it("parses multipart model fields and serializes rewritten models", async () => {
+    const metadata = await createMultipartMetadata({
+      pathname: "/v1/images/edits",
+      fields: [
+        ["model", "gpt-image-1.5"],
+        ["prompt", "edit this"],
+      ],
+      files: [["image[]", createPngFile("source.png", 32, 32)]],
+    });
+
+    setOpenAIImageMultipartModel(metadata, "redirected-model");
+    const serialized = await serializeOpenAIImageMultipartRequest(metadata);
+    const bodyText = new TextDecoder().decode(serialized.body);
+
+    expect(serialized.contentType).toContain("multipart/form-data");
+    expect(bodyText).toContain('name="model"');
+    expect(bodyText).toContain("redirected-model");
+  });
+});
+
+describe("openai-image-compat - provider sanitizer", () => {
+  it("strips response_format for YunAI Azure generations requests", () => {
+    const body: Record<string, unknown> = {
+      prompt: "otter",
+      response_format: "url",
+    };
+
+    const stripped = sanitizeGenerationsRequestForProvider(
+      body,
+      createProvider("YunAI Azure", "https://yunai.azure.example.com/openai")
+    );
+
+    expect(stripped).toBe(true);
+    expect(body.response_format).toBeUndefined();
+  });
+
+  it("keeps response_format for other providers", () => {
+    const body: Record<string, unknown> = {
+      prompt: "otter",
+      response_format: "url",
+    };
+
+    const stripped = sanitizeGenerationsRequestForProvider(
+      body,
+      createProvider("Regular OpenAI", "https://api.example.com/openai")
+    );
+
+    expect(stripped).toBe(false);
+    expect(body.response_format).toBe("url");
+  });
+});

--- a/tests/unit/proxy/openai-image-forwarder-constraints.test.ts
+++ b/tests/unit/proxy/openai-image-forwarder-constraints.test.ts
@@ -1,0 +1,470 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
+import {
+  buildOpenAIImageLogicalBody,
+  parseOpenAIImageMultipartMetadata,
+  serializeOpenAIImageMultipartRequest,
+  syncOpenAIImageMultipartFromLogicalBody,
+  type OpenAIImageRequestMetadata,
+} from "@/app/v1/_lib/proxy/openai-image-compat";
+import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
+import type { ProxyError } from "@/app/v1/_lib/proxy/errors";
+import { ProxySession } from "@/app/v1/_lib/proxy/session";
+import type { Provider } from "@/types/provider";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+    warn: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/request-filter-engine", () => ({
+  requestFilterEngine: {
+    applyFinal: vi.fn(async () => {}),
+  },
+}));
+
+function createProvider({
+  name,
+  url,
+  modelRedirects,
+}: {
+  name: string;
+  url: string;
+  modelRedirects?: Array<{ matchType: "exact"; source: string; target: string }>;
+}): Provider {
+  return {
+    id: 1,
+    name,
+    providerType: "openai-compatible",
+    url,
+    key: "upstream-key",
+    preserveClientIp: false,
+    priority: 0,
+    costMultiplier: 1,
+    maxRetryAttempts: 1,
+    mcpPassthroughType: "minimax",
+    mcpPassthroughUrl: "https://mcp.example.com",
+    modelRedirects,
+  } as unknown as Provider;
+}
+
+async function createImageMetadata(): Promise<OpenAIImageRequestMetadata> {
+  const formData = new FormData();
+  formData.append("model", "source-model");
+  formData.append("prompt", "edit this");
+  formData.append(
+    "image[]",
+    new File([new Uint8Array([1, 2, 3])], "image.png", {
+      type: "image/png",
+    })
+  );
+
+  const request = new Request("https://proxy.example.com/v1/images/edits", {
+    method: "POST",
+    body: formData,
+  });
+
+  const metadata = await parseOpenAIImageMultipartMetadata(
+    request,
+    "/v1/images/edits",
+    request.headers.get("content-type")
+  );
+
+  if (!metadata) {
+    throw new Error("Expected multipart metadata");
+  }
+
+  return metadata;
+}
+
+function createSession({
+  pathname,
+  body,
+  model,
+  imageRequestMetadata,
+}: {
+  pathname: string;
+  body: Record<string, unknown>;
+  model: string | null;
+  imageRequestMetadata?: OpenAIImageRequestMetadata | null;
+}): ProxySession {
+  const headers = new Headers({
+    "content-type": "application/json",
+    authorization: "Bearer proxy-user-key",
+  });
+  const session = Object.create(ProxySession.prototype);
+
+  Object.assign(session, {
+    startTime: Date.now(),
+    method: "POST",
+    requestUrl: new URL(`https://proxy.example.com${pathname}`),
+    headers,
+    originalHeaders: new Headers(headers),
+    headerLog: JSON.stringify(Object.fromEntries(headers.entries())),
+    request: {
+      model,
+      log: JSON.stringify(body),
+      message: body,
+      imageRequestMetadata: imageRequestMetadata ?? null,
+    },
+    userAgent: "OpenAITest/1.0",
+    context: null,
+    clientAbortSignal: null,
+    userName: "test-user",
+    authState: { success: true, user: null, key: null, apiKey: null },
+    provider: null,
+    messageContext: null,
+    sessionId: null,
+    requestSequence: 1,
+    originalFormat: "openai",
+    providerType: null,
+    originalModelName: null,
+    originalUrlPathname: null,
+    providerChain: [],
+    specialSettings: [],
+    cacheTtlResolved: null,
+    context1mApplied: false,
+    cachedPriceData: undefined,
+    cachedBillingModelSource: undefined,
+    forwardedRequestBody: null,
+    endpointPolicy: resolveEndpointPolicy(pathname),
+    setCacheTtlResolved: vi.fn(),
+    getCacheTtlResolved: vi.fn(() => null),
+    getCurrentModel: vi.fn(() => model),
+    clientRequestsContext1m: vi.fn(() => false),
+    setContext1mApplied: vi.fn(),
+    getContext1mApplied: vi.fn(() => false),
+    getGroupCostMultiplier: vi.fn(() => 1),
+    getEndpointPolicy: vi.fn(() => resolveEndpointPolicy(pathname)),
+    isHeaderModified: vi.fn(() => false),
+    shouldPersistSessionDebugArtifacts: vi.fn(() => false),
+    addSpecialSetting: vi.fn(),
+    getSpecialSettings: vi.fn(() => []),
+  });
+
+  return session as ProxySession;
+}
+
+describe("ProxyForwarder - openai image constraints", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("blocks invalid GPT generations requests before any upstream fetch", async () => {
+    const provider = createProvider({
+      name: "Regular OpenAI",
+      url: "https://openai.example.com/openai",
+    });
+    const session = createSession({
+      pathname: "/v1/images/generations",
+      model: "gpt-image-1.5",
+      body: {
+        model: "gpt-image-1.5",
+        prompt: "otter",
+        response_format: "url",
+      },
+    });
+
+    const fetchWithoutAutoDecode = vi.spyOn(ProxyForwarder as never, "fetchWithoutAutoDecode");
+
+    const { doForward } = ProxyForwarder as unknown as {
+      doForward: (session: ProxySession, provider: Provider, baseUrl: string) => Promise<Response>;
+    };
+
+    await expect(doForward(session, provider, provider.url)).rejects.toMatchObject<
+      Partial<ProxyError>
+    >({
+      message: expect.stringContaining("response_format"),
+      statusCode: 400,
+    });
+    expect(fetchWithoutAutoDecode).not.toHaveBeenCalled();
+  });
+
+  it("rewrites multipart edits model redirects and rebuilds multipart content-type", async () => {
+    const provider = createProvider({
+      name: "Regular OpenAI",
+      url: "https://openai.example.com/openai",
+      modelRedirects: [{ matchType: "exact", source: "source-model", target: "target-model" }],
+    });
+    const session = createSession({
+      pathname: "/v1/images/edits",
+      model: "source-model",
+      body: {
+        model: "source-model",
+        prompt: "edit this",
+      },
+      imageRequestMetadata: await createImageMetadata(),
+    });
+
+    let capturedHeaders: Headers | null = null;
+    let capturedBody: BodyInit | null = null;
+
+    vi.spyOn(ProxyForwarder as never, "fetchWithoutAutoDecode").mockImplementationOnce(
+      async (_url: string, init: RequestInit) => {
+        capturedHeaders = init.headers as Headers;
+        capturedBody = init.body ?? null;
+        return new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        });
+      }
+    );
+
+    const { doForward } = ProxyForwarder as unknown as {
+      doForward: (session: ProxySession, provider: Provider, baseUrl: string) => Promise<Response>;
+    };
+
+    await doForward(session, provider, provider.url);
+
+    expect(capturedHeaders?.get("content-type")).toContain("multipart/form-data");
+    const bodyText = new TextDecoder().decode(new Uint8Array(capturedBody as ArrayBuffer));
+    expect(bodyText).toContain('name="model"');
+    expect(bodyText).toContain("target-model");
+  });
+
+  it("strips response_format for YunAI Azure generations compatibility", async () => {
+    const provider = createProvider({
+      name: "YunAI Azure",
+      url: "https://yunai.azure.example.com/openai",
+    });
+    const session = createSession({
+      pathname: "/v1/images/generations",
+      model: null,
+      body: {
+        prompt: "otter",
+        response_format: "url",
+      },
+    });
+
+    let capturedBody = "";
+
+    vi.spyOn(ProxyForwarder as never, "fetchWithoutAutoDecode").mockImplementationOnce(
+      async (_url: string, init: RequestInit) => {
+        capturedBody = String(init.body ?? "");
+        return new Response("ok", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+    );
+
+    const { doForward } = ProxyForwarder as unknown as {
+      doForward: (session: ProxySession, provider: Provider, baseUrl: string) => Promise<Response>;
+    };
+
+    await doForward(session, provider, provider.url);
+
+    expect(capturedBody).toContain('"prompt":"otter"');
+    expect(capturedBody).not.toContain("response_format");
+  });
+
+  it("strips response_format for YunAI Azure even when GPT model is explicit", async () => {
+    const provider = createProvider({
+      name: "YunAI Azure",
+      url: "https://yunai.azure.example.com/openai",
+    });
+    const session = createSession({
+      pathname: "/v1/images/generations",
+      model: "gpt-image-1.5",
+      body: {
+        model: "gpt-image-1.5",
+        prompt: "otter",
+        response_format: "url",
+      },
+    });
+
+    let capturedBody = "";
+
+    vi.spyOn(ProxyForwarder as never, "fetchWithoutAutoDecode").mockImplementationOnce(
+      async (_url: string, init: RequestInit) => {
+        capturedBody = String(init.body ?? "");
+        return new Response("ok", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+    );
+
+    const { doForward } = ProxyForwarder as unknown as {
+      doForward: (session: ProxySession, provider: Provider, baseUrl: string) => Promise<Response>;
+    };
+
+    await doForward(session, provider, provider.url);
+
+    expect(capturedBody).toContain('"model":"gpt-image-1.5"');
+    expect(capturedBody).not.toContain("response_format");
+  });
+
+  it("creates isolated multipart sidecars for hedge shadow sessions", async () => {
+    const provider = createProvider({
+      name: "Regular OpenAI",
+      url: "https://openai.example.com/openai",
+    });
+    const session = createSession({
+      pathname: "/v1/images/edits",
+      model: "source-model",
+      body: {
+        model: "source-model",
+        prompt: "edit this",
+      },
+      imageRequestMetadata: await createImageMetadata(),
+    });
+
+    const { createStreamingShadowSession } = ProxyForwarder as unknown as {
+      createStreamingShadowSession: (session: ProxySession, provider: Provider) => ProxySession;
+    };
+
+    const shadow = createStreamingShadowSession(session, provider);
+    shadow.request.message.prompt = "shadow prompt";
+    shadow.getOpenAIImageRequestMetadata()!.parts[0] = {
+      name: "model",
+      kind: "text",
+      value: "shadow-model",
+    };
+    shadow.getOpenAIImageRequestMetadata()!.model = "shadow-model";
+
+    expect(session.request.message.prompt).toBe("edit this");
+    expect(session.getOpenAIImageRequestMetadata()!.model).toBe("source-model");
+  });
+
+  it("treats multipart stream=true as a real streaming hedge candidate", async () => {
+    const metadata = await createImageMetadata();
+    metadata.parts.splice(2, 0, { name: "stream", kind: "text", value: "true" });
+    const session = createSession({
+      pathname: "/v1/images/edits",
+      model: "source-model",
+      body: {
+        model: "source-model",
+        prompt: "edit this",
+        stream: true,
+      },
+      imageRequestMetadata: metadata,
+    });
+    session.provider = {
+      ...(createProvider({
+        name: "Regular OpenAI",
+        url: "https://openai.example.com/openai",
+      }) as Provider),
+      firstByteTimeoutStreamingMs: 100,
+    };
+
+    const { shouldUseStreamingHedge } = ProxyForwarder as unknown as {
+      shouldUseStreamingHedge: (session: ProxySession) => boolean;
+    };
+
+    expect(shouldUseStreamingHedge(session)).toBe(true);
+  });
+
+  it("strips underscore-prefixed multipart text fields before upstream forwarding", async () => {
+    const metadata = await createImageMetadata();
+    metadata.parts.splice(2, 0, {
+      name: "_internal",
+      kind: "text",
+      value: "should-not-leak",
+    });
+    const provider = createProvider({
+      name: "Regular OpenAI",
+      url: "https://openai.example.com/openai",
+    });
+    const session = createSession({
+      pathname: "/v1/images/edits",
+      model: "source-model",
+      body: {
+        model: "source-model",
+        prompt: "edit this",
+        _internal: "should-not-leak",
+      },
+      imageRequestMetadata: metadata,
+    });
+
+    let capturedBody = "";
+
+    vi.spyOn(ProxyForwarder as never, "fetchWithoutAutoDecode").mockImplementationOnce(
+      async (_url: string, init: RequestInit) => {
+        capturedBody = new TextDecoder().decode(new Uint8Array(init.body as ArrayBuffer));
+        return new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        });
+      }
+    );
+
+    const { doForward } = ProxyForwarder as unknown as {
+      doForward: (session: ProxySession, provider: Provider, baseUrl: string) => Promise<Response>;
+    };
+
+    await doForward(session, provider, provider.url);
+
+    expect(capturedBody).toContain('name="prompt"');
+    expect(capturedBody).not.toContain("_internal");
+    expect(capturedBody).not.toContain("should-not-leak");
+  });
+
+  it("drops private multipart file parts before upstream forwarding", async () => {
+    const metadata = await createImageMetadata();
+    metadata.parts.push({
+      name: "_internal",
+      kind: "file",
+      value: new File([new Uint8Array([9, 9, 9])], "secret.bin", {
+        type: "application/octet-stream",
+      }),
+    });
+    const provider = createProvider({
+      name: "Regular OpenAI",
+      url: "https://openai.example.com/openai",
+    });
+    const session = createSession({
+      pathname: "/v1/images/edits",
+      model: "source-model",
+      body: {
+        model: "source-model",
+        prompt: "edit this",
+        _internal: "[file]",
+      },
+      imageRequestMetadata: metadata,
+    });
+
+    let capturedBody = "";
+
+    vi.spyOn(ProxyForwarder as never, "fetchWithoutAutoDecode").mockImplementationOnce(
+      async (_url: string, init: RequestInit) => {
+        capturedBody = new TextDecoder().decode(new Uint8Array(init.body as ArrayBuffer));
+        return new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        });
+      }
+    );
+
+    const { doForward } = ProxyForwarder as unknown as {
+      doForward: (session: ProxySession, provider: Provider, baseUrl: string) => Promise<Response>;
+    };
+
+    await doForward(session, provider, provider.url);
+
+    expect(capturedBody).not.toContain('name="_internal"');
+    expect(capturedBody).not.toContain("secret.bin");
+  });
+
+  it("drops mask file parts when filters remove the logical mask field", async () => {
+    const metadata = await createImageMetadata();
+    metadata.parts.push({
+      name: "mask",
+      kind: "file",
+      value: new File([new Uint8Array([7, 7, 7])], "mask.png", { type: "image/png" }),
+    });
+    const logicalBody = buildOpenAIImageLogicalBody(metadata);
+    delete logicalBody.mask;
+
+    syncOpenAIImageMultipartFromLogicalBody(metadata, logicalBody);
+    const serialized = await serializeOpenAIImageMultipartRequest(metadata);
+    const bodyText = new TextDecoder().decode(new Uint8Array(serialized.body));
+    expect(bodyText).not.toContain('name="mask"');
+  });
+});

--- a/tests/unit/proxy/openai-image-session-multipart.test.ts
+++ b/tests/unit/proxy/openai-image-session-multipart.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { ProxySession } from "@/app/v1/_lib/proxy/session";
+
+function createContext(request: Request) {
+  return {
+    req: {
+      method: request.method,
+      url: request.url,
+      raw: request,
+      header(name?: string) {
+        if (name) {
+          return request.headers.get(name) ?? undefined;
+        }
+        return Object.fromEntries(request.headers.entries());
+      },
+    },
+  } as any;
+}
+
+function createMultipartRequest({
+  pathname,
+  fields,
+  fileSize,
+}: {
+  pathname: string;
+  fields: Array<[string, string]>;
+  fileSize: number;
+}) {
+  const formData = new FormData();
+  for (const [name, value] of fields) {
+    formData.append(name, value);
+  }
+  formData.append(
+    pathname.endsWith("/variations") ? "image" : "image[]",
+    new File([new Uint8Array(fileSize)], "image.png", { type: "image/png" }),
+    "image.png"
+  );
+
+  return new Request(`https://proxy.example.com${pathname}`, {
+    method: "POST",
+    body: formData,
+  });
+}
+
+describe("ProxySession - openai image multipart parsing", () => {
+  it("extracts model from /images/edits multipart requests", async () => {
+    const request = createMultipartRequest({
+      pathname: "/v1/images/edits",
+      fields: [
+        ["model", "gpt-image-1.5"],
+        ["prompt", "edit this"],
+      ],
+      fileSize: 32,
+    });
+
+    const session = await ProxySession.fromContext(createContext(request));
+
+    expect(session.request.model).toBe("gpt-image-1.5");
+    expect(session.isOpenAIImageMultipartRequest()).toBe(true);
+    expect(session.request.message).toEqual({
+      model: "gpt-image-1.5",
+      prompt: "edit this",
+    });
+    expect(session.getOpenAIImageRequestMetadata()?.endpoint).toBe("edits");
+  });
+
+  it("does not trip the large-body missing-model guard when multipart model is present", async () => {
+    const request = createMultipartRequest({
+      pathname: "/v1/images/edits",
+      fields: [
+        ["model", "gpt-image-1.5"],
+        ["prompt", "edit this"],
+      ],
+      fileSize: 10 * 1024 * 1024 + 1,
+    });
+
+    await expect(ProxySession.fromContext(createContext(request))).resolves.toBeInstanceOf(
+      ProxySession
+    );
+  });
+});

--- a/tests/unit/proxy/sensitive-word-guard-multipart.test.ts
+++ b/tests/unit/proxy/sensitive-word-guard-multipart.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/drizzle/db", () => ({
+  db: {
+    insert: vi.fn(() => ({
+      values: vi.fn(async () => undefined),
+    })),
+  },
+}));
+
+vi.mock("@/drizzle/schema", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/drizzle/schema")>();
+  return {
+    ...actual,
+    messageRequest: {},
+  };
+});
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/sensitive-word-detector", () => ({
+  sensitiveWordDetector: {
+    isEmpty: vi.fn(() => false),
+    detect: vi.fn((text: string) =>
+      text.includes("blocked")
+        ? {
+            matched: true,
+            word: "blocked",
+            matchType: "contains",
+            matchedText: "blocked",
+          }
+        : { matched: false }
+    ),
+  },
+}));
+
+import { ProxySensitiveWordGuard } from "@/app/v1/_lib/proxy/sensitive-word-guard";
+import { ProxySession } from "@/app/v1/_lib/proxy/session";
+
+function createContext(request: Request) {
+  return {
+    req: {
+      method: request.method,
+      url: request.url,
+      raw: request,
+      header(name?: string) {
+        if (name) {
+          return request.headers.get(name) ?? undefined;
+        }
+        return Object.fromEntries(request.headers.entries());
+      },
+    },
+  } as any;
+}
+
+describe("ProxySensitiveWordGuard - multipart image logical body", () => {
+  it("inspects multipart image prompt text via the logical body view", async () => {
+    const formData = new FormData();
+    formData.append("model", "gpt-image-1.5");
+    formData.append("prompt", "this is blocked content");
+    formData.append(
+      "image[]",
+      new File([new Uint8Array([1, 2, 3])], "image.png", { type: "image/png" }),
+      "image.png"
+    );
+
+    const request = new Request("https://proxy.example.com/v1/images/edits", {
+      method: "POST",
+      body: formData,
+    });
+    const session = await ProxySession.fromContext(createContext(request));
+    session.authState = {
+      success: true,
+      user: { id: 1, name: "tester" } as any,
+      key: { id: 2 } as any,
+      apiKey: "sk-test",
+    };
+
+    const response = await ProxySensitiveWordGuard.ensure(session);
+
+    expect(response?.status).toBe(400);
+    expect(await response?.text()).toContain("敏感词");
+  });
+
+  it("inspects repeated multipart prompt fields via the logical body array view", async () => {
+    const formData = new FormData();
+    formData.append("model", "gpt-image-1.5");
+    formData.append("prompt", "safe content");
+    formData.append("prompt", "blocked content");
+    formData.append(
+      "image[]",
+      new File([new Uint8Array([1, 2, 3])], "image.png", { type: "image/png" }),
+      "image.png"
+    );
+
+    const request = new Request("https://proxy.example.com/v1/images/edits", {
+      method: "POST",
+      body: formData,
+    });
+    const session = await ProxySession.fromContext(createContext(request));
+    session.authState = {
+      success: true,
+      user: { id: 1, name: "tester" } as any,
+      key: { id: 2 } as any,
+      apiKey: "sk-test",
+    };
+
+    const response = await ProxySensitiveWordGuard.ensure(session);
+
+    expect(response?.status).toBe(400);
+  });
+});

--- a/tests/unit/request-filter-engine-image-multipart.test.ts
+++ b/tests/unit/request-filter-engine-image-multipart.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "vitest";
+import { requestFilterEngine } from "@/lib/request-filter-engine";
+import type { RequestFilter } from "@/repository/request-filters";
+
+function createMultipartSession() {
+  return {
+    headers: new Headers({
+      "user-agent": "UA",
+      "x-remove": "foo",
+    }),
+    request: {
+      message: {
+        prompt: "hello secret",
+        model: "gpt-image-1.5",
+        _private: "strip-me",
+      },
+      log: "",
+      model: "gpt-image-1.5",
+      imageRequestMetadata: {
+        endpoint: "edits",
+        bodyKind: "multipart",
+        contentType: "multipart/form-data; boundary=test",
+        model: "gpt-image-1.5",
+        parts: [],
+      },
+    },
+    provider: {
+      id: 1,
+      groupTag: null,
+    },
+  } as any;
+}
+
+describe("请求过滤引擎 - image multipart logical body contract", () => {
+  test("guard phase 仍应允许 body filters 作用到逻辑文本字段", async () => {
+    const filters: RequestFilter[] = [
+      {
+        id: 1,
+        name: "remove-header",
+        description: null,
+        scope: "header",
+        action: "remove",
+        matchType: null,
+        target: "x-remove",
+        replacement: null,
+        priority: 0,
+        isEnabled: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 2,
+        name: "redact-prompt",
+        description: null,
+        scope: "body",
+        action: "text_replace",
+        matchType: "contains",
+        target: "secret",
+        replacement: "[redacted]",
+        priority: 1,
+        isEnabled: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    requestFilterEngine.setFiltersForTest(filters);
+    const session = createMultipartSession();
+
+    await requestFilterEngine.applyGlobal(session);
+
+    expect(session.headers.has("x-remove")).toBe(false);
+    expect(session.request.message.prompt).toContain("[redacted]");
+  });
+
+  test("final phase 仍应允许 body filters 修改 multipart 逻辑文本字段", async () => {
+    const filters: RequestFilter[] = [
+      {
+        id: 3,
+        name: "final-redact-prompt",
+        description: null,
+        scope: "body",
+        action: "json_path",
+        matchType: null,
+        target: "prompt",
+        replacement: "sanitized prompt",
+        priority: 0,
+        isEnabled: true,
+        executionPhase: "final",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as RequestFilter,
+    ];
+
+    requestFilterEngine.setFiltersForTest(filters);
+    const headers = new Headers();
+    const logicalBody = { prompt: "hello secret" };
+    const session = createMultipartSession();
+
+    await requestFilterEngine.applyFinal(session, logicalBody, headers);
+
+    expect(logicalBody.prompt).toBe("sanitized prompt");
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds comprehensive OpenAI Images API compatibility to the proxy layer, enabling full support for `/v1/images/generations`, `/v1/images/edits`, and `/v1/images/variations` endpoints with proper request validation and multipart/form-data handling.

## Problem

The proxy previously lacked proper handling for OpenAI image endpoints, which:
- Use multipart/form-data for file uploads (edits/variations)
- Have strict model-specific constraints (prompt lengths, sizes, formats)
- Require special handling for model redirects with multipart payloads
- Need integration with sensitive word detection and request filtering

## Solution

### Core Changes
- **New `openai-image-compat.ts` module** (+1032 lines): Complete compatibility layer with:
  - Request validation for all 3 image endpoints
  - Model family detection (dall-e-2, dall-e-3, GPT image models)
  - Multipart request parsing and serialization
  - Provider-specific sanitization (YunAI Azure compatibility)

- **Forwarder integration** (`forwarder.ts`): Added multipart request handling path with validation, filtering, and proper body serialization

- **Model redirect support** (`model-redirector.ts`): Handles model rewrites for multipart requests via sidecar metadata instead of JSON buffer manipulation

- **Session parsing** (`session.ts`): Parses multipart image requests and builds logical body views for filtering/sensitive word detection

- **URL routing** (`url.ts`): Added `/images`, `/audio/*`, and `/files` to recognized proxy endpoints

### Validation Coverage

Enforces OpenAI API constraints including:

| Endpoint | Key Constraints |
|----------|----------------|
| `/images/generations` | dall-e-3 only supports n=1, GPT models don't support response_format, transparent background requires png/webp |
| `/images/edits` | No dall-e-3 support, GPT models max 16 images, prompt 1-32000 chars |
| `/images/variations` | dall-e-2 only, PNG only, square images required, max 4MB |

### Testing

#### Automated Tests (7 new test files, 1490+ lines)
- `openai-image-compat.test.ts` - Core validation logic (428 lines)
- `openai-image-forwarder-constraints.test.ts` - Forwarder integration (470 lines)
- `openai-image-session-multipart.test.ts` - Session parsing (81 lines)
- `sensitive-word-guard-multipart.test.ts` - Sensitive word detection (121 lines)
- `request-filter-engine-image-multipart.test.ts` - Request filtering (104 lines)
- Plus updates to existing URL, endpoint catalog, and routing tests

#### Manual Testing
1. Send multipart image edit request with file upload
2. Verify model redirects work with multipart payloads
3. Test sensitive word detection on image prompts
4. Verify request filters apply to multipart fields

## Validation Completed

- [x] `bun run lint` - Biome formatting/linting passes
- [x] `bun run typecheck` - TypeScript check passes
- [x] `bun run build` - Production build succeeds
- [x] Directly affected test suites pass:
  - `openai-image-compat.test.ts`
  - `openai-image-forwarder-constraints.test.ts`
  - `openai-image-session-multipart.test.ts`
  - `sensitive-word-guard-multipart.test.ts`
  - `request-filter-engine-image-multipart.test.ts`
  - `endpoint-family-catalog.test.ts`
  - `endpoint-family-provider-routing.test.ts`
  - `app/v1/url.test.ts`

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a comprehensive OpenAI image compatibility layer (`openai-image-compat.ts`) that validates `/images/generations`, `/images/edits`, and `/images/variations` requests — including model-family inference, multipart form-data parsing, provider-specific sanitization, and proper metadata propagation through redirect/shadow-session flows.

- **P1 — Validation bypass for `gpt-image-2`**: All three validators return early success for `model === \"gpt-image-2\"` after only the most basic prompt/image checks, skipping all enum and range constraints — contrary to the PR's stated goal of enforcing image endpoint constraints.
- **P2 — Misleading dall-e-3 quality error message**: The guard accepts `[\"standard\", \"hd\", \"auto\"]` but the error text only mentions `\"standard\"` and `\"hd\"`.
- **P2 — Dead-code length check** in `validateEditsJsonRequest` and minor redundant branch in `model-redirector.ts`.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the gpt-image-2 validation bypass, which contradicts the PR's core purpose.

One clear P1 defect: gpt-image-2 completely bypasses the parameter validation this PR is meant to enforce, meaning invalid parameter combinations pass through undetected for that model. The rest of the implementation is solid and well-tested.

src/app/v1/_lib/proxy/openai-image-compat.ts — the gpt-image-2 early-return in all three validators needs review.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/openai-image-compat.ts | New 1032-line validation module for OpenAI image endpoints; contains a complete bypass for gpt-image-2, a misleading dall-e-3 quality error message, and unreachable code in the edits JSON validator. |
| src/app/v1/_lib/proxy/model-redirector.ts | Correctly skips JSON buffer re-serialization for multipart requests; minor duplication where both branches of the if/else set the same session.request.message.model field. |
| src/app/v1/_lib/proxy/forwarder.ts | Adds multipart image request handling branch and JSON-path validation; clones metadata correctly for shadow sessions; looks correct. |
| src/app/v1/_lib/proxy/session.ts | Adds imageRequestMetadata to ProxyRequestPayload and resolves the model from it; multipart body parsed via parseOpenAIImageMultipartMetadata; logic appears correct. |
| src/app/v1/_lib/url.ts | Adds /images to targetEndpoints list to support URL routing; no logic issues found. |
| src/lib/message-extractor.ts | Adds top-level prompt field extraction for image API requests; straightforward and correct. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Session
    participant Forwarder
    participant ImageCompat as openai-image-compat
    participant Upstream

    Client->>Session: POST /v1/images/edits (multipart/form-data)
    Session->>ImageCompat: parseOpenAIImageMultipartMetadata()
    ImageCompat-->>Session: OpenAIImageRequestMetadata {parts, model, endpoint}
    Session->>Session: buildOpenAIImageLogicalBody() → session.request.message

    Session->>Forwarder: forward(session)
    alt isOpenAIImageMultipartRequest
        Forwarder->>Forwarder: filterPrivateParameters(logicalBody)
        Forwarder->>ImageCompat: syncOpenAIImageMultipartFromLogicalBody()
        Forwarder->>ImageCompat: validateOpenAIImageRequest()
        ImageCompat-->>Forwarder: {ok: true/false}
        Forwarder->>ImageCompat: serializeOpenAIImageMultipartRequest()
        ImageCompat-->>Forwarder: {body: ArrayBuffer, contentType, summary}
        Forwarder->>Upstream: POST (multipart/form-data)
    else JSON body (generations)
        Forwarder->>ImageCompat: sanitizeGenerationsRequestForProvider()
        Forwarder->>ImageCompat: validateOpenAIImageRequest()
        Forwarder->>Upstream: POST (application/json)
    end
    Upstream-->>Client: Response
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/v1/_lib/proxy/model-redirector.ts`, line 168-174 ([link](https://github.com/ding113/claude-code-hub/blob/61773d6c37754fa0d754d0c7ba561fd81df3d9e4/src/app/v1/_lib/proxy/model-redirector.ts#L168-L174)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Both branches of `restoreOriginalModel` duplicate `session.request.message.model = originalModel`**

   The `if` and `else` arms both assign the same value to `session.request.message.model`. The only real difference is the `setOpenAIImageMultipartModel` call inside the `if` arm. The duplication can be removed by hoisting the assignment out of the conditional.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/v1/_lib/proxy/model-redirector.ts
   Line: 168-174

   Comment:
   **Both branches of `restoreOriginalModel` duplicate `session.request.message.model = originalModel`**

   The `if` and `else` arms both assign the same value to `session.request.message.model`. The only real difference is the `setOpenAIImageMultipartModel` call inside the `if` arm. The duplication can be removed by hoisting the assignment out of the conditional.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/openai-image-compat.ts
Line: 280-282

Comment:
**`gpt-image-2` silently bypasses all parameter validation**

After the `prompt` check, an early `return success()` for `model === "gpt-image-2"` skips every downstream constraint (background, output_format, n, size, stream, style, output_compression, etc.). This means a request with `background: "invalid-value"` or `n: 99` would pass validation and be forwarded upstream — which defeats the stated purpose of the PR. The same bypass pattern also exists in `validateEditsJsonRequest` (line 508) and `validateEditsMultipartRequest` (line 703).

If `gpt-image-2` constraints are intentionally unknown, consider at minimum validating the parameters that are shared across all models (e.g., `n` range, boolean `stream`, enum enumerations) rather than skipping validation entirely.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/openai-image-compat.ts
Line: 364-365

Comment:
**Error message omits "auto" as a valid dall-e-3 quality value**

The validation at line 364 accepts `["standard", "hd", "auto"]` for dall-e-3, but the error message tells the user only `"standard"` or `"hd"` are valid. A client that receives this error and tries `"auto"` next would silently succeed, making the message misleading.

```suggestion
return fail('Invalid request: dall-e-3 only supports quality "standard", "hd", or "auto".');
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/openai-image-compat.ts
Line: 475-477

Comment:
**Dead code: `prompt.length < 1` is unreachable**

`parseString` returns `null` for non-strings and the raw string otherwise. The `!prompt` guard above (line 471) already returns early for both `null` and `""` (empty string is falsy). Therefore `prompt` reaching line 475 is always a non-empty string, making `prompt.length < 1` permanently false.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/model-redirector.ts
Line: 168-174

Comment:
**Both branches of `restoreOriginalModel` duplicate `session.request.message.model = originalModel`**

The `if` and `else` arms both assign the same value to `session.request.message.model`. The only real difference is the `setOpenAIImageMultipartModel` call inside the `if` arm. The duplication can be removed by hoisting the assignment out of the conditional.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: enforce openai image endpoint const..."](https://github.com/ding113/claude-code-hub/commit/61773d6c37754fa0d754d0c7ba561fd81df3d9e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29250867)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->