### PR TITLE
fix: support all model types in public status picker

### DIFF
--- a/src/actions/model-prices.ts
+++ b/src/actions/model-prices.ts
@@ -316,21 +316,26 @@ export interface AvailableModelCatalogItem {
   updatedAt: string;
 }
 
+export type AvailableModelCatalogScope = "chat" | "all";
+
 /**
- * 获取本地价格表中的聊天模型目录。
- * 供供应商白名单模型选择器回退使用，按更新时间倒序返回。
+ * 获取本地价格表中的模型目录。
+ * 默认只返回聊天模型；调用方可显式放宽到任意类型。
  */
-export async function getAvailableModelCatalog(): Promise<AvailableModelCatalogItem[]> {
+export async function getAvailableModelCatalog(options?: {
+  scope?: AvailableModelCatalogScope;
+}): Promise<AvailableModelCatalogItem[]> {
   try {
     const session = await getSession();
     if (!session || session.user.role !== "admin") {
       return [];
     }
 
+    const scope = options?.scope ?? "chat";
     const allPrices = await findAllLatestPrices();
 
     return allPrices
-      .filter((price) => price.priceData.mode === "chat")
+      .filter((price) => scope === "all" || price.priceData.mode === "chat")
       .sort((left, right) => {
         const timeDelta = right.updatedAt.getTime() - left.updatedAt.getTime();
         if (timeDelta !== 0) {
@@ -407,7 +412,7 @@ export async function hasPriceTable(): Promise<boolean> {
  */
 export async function getAvailableModelsByProviderType(): Promise<string[]> {
   try {
-    const catalog = await getAvailableModelCatalog();
+    const catalog = await getAvailableModelCatalog({ scope: "chat" });
     return catalog.map((item) => item.modelName);
   } catch (error) {
     logger.error("获取可用模型列表失败:", error);

--- a/src/app/[locale]/settings/providers/_components/model-multi-select.tsx
+++ b/src/app/[locale]/settings/providers/_components/model-multi-select.tsx
@@ -11,7 +11,11 @@ import {
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
-import { type AvailableModelCatalogItem, getAvailableModelCatalog } from "@/actions/model-prices";
+import {
+  type AvailableModelCatalogItem,
+  type AvailableModelCatalogScope,
+  getAvailableModelCatalog,
+} from "@/actions/model-prices";
 import { fetchUpstreamModels, getUnmaskedProviderKey } from "@/actions/providers";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -55,6 +59,7 @@ interface ModelMultiSelectProps {
   proxyUrl?: string | null;
   proxyFallbackToDirect?: boolean;
   providerId?: number;
+  catalogScope?: AvailableModelCatalogScope;
 }
 
 function normalizeModelName(model: string): string {
@@ -105,6 +110,7 @@ export function ModelMultiSelect({
   proxyUrl,
   proxyFallbackToDirect,
   providerId,
+  catalogScope = "chat",
 }: ModelMultiSelectProps) {
   const t = useTranslations("settings.providers.form.modelSelect");
   const tPrices = useTranslations("settings.prices");
@@ -258,7 +264,7 @@ export function ModelMultiSelect({
         }
       }
 
-      const localCatalog = await getAvailableModelCatalog();
+      const localCatalog = await getAvailableModelCatalog({ scope: catalogScope });
       if (requestId !== requestIdRef.current) {
         return;
       }
@@ -270,7 +276,16 @@ export function ModelMultiSelect({
         setLoading(false);
       }
     }
-  }, [apiKey, providerId, providerType, providerUrl, proxyFallbackToDirect, proxyUrl, t]);
+  }, [
+    apiKey,
+    catalogScope,
+    providerId,
+    providerType,
+    providerUrl,
+    proxyFallbackToDirect,
+    proxyUrl,
+    t,
+  ]);
 
   const handleOpenLoad = useEffectEvent(() => {
     void loadModels();

--- a/src/app/[locale]/settings/status-page/_components/public-status-settings-form.tsx
+++ b/src/app/[locale]/settings/status-page/_components/public-status-settings-form.tsx
@@ -324,6 +324,7 @@ export function PublicStatusSettingsForm({
                       <Label>{t("statusPage.form.models")}</Label>
                       <ModelMultiSelect
                         providerType="openai-compatible"
+                        catalogScope="all"
                         selectedModels={selectedModelKeys}
                         emptyLabel={t("statusPage.form.modelsEmpty")}
                         onChange={(nextModelKeys) =>

--- a/src/app/[locale]/status/_components/public-status-view.tsx
+++ b/src/app/[locale]/status/_components/public-status-view.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Azure, Bedrock, Claude, Gemini, OpenAI } from "@lobehub/icons";
-import { Bot } from "lucide-react";
 import { startTransition, useEffect, useState } from "react";
 import { ThemeSwitcher } from "@/components/ui/theme-switcher";
 import type { PublicStatusPayload, PublicStatusTimelineBucket } from "@/lib/public-status/payload";
+import { getPublicStatusVendorIconComponent } from "@/lib/public-status/vendor-icon";
 import { PublicStatusTimeline } from "./public-status-timeline";
 
 interface PublicStatusViewProps {
@@ -57,23 +56,6 @@ function resolveStateLabel(
     return labels.noData;
   }
   return labels.fresh;
-}
-
-function resolveVendorIcon(vendorIconKey: string) {
-  switch (vendorIconKey) {
-    case "openai":
-      return OpenAI;
-    case "anthropic":
-      return Claude.Color;
-    case "gemini":
-      return Gemini.Color;
-    case "azure":
-      return Azure;
-    case "bedrock":
-      return Bedrock;
-    default:
-      return Bot;
-  }
 }
 
 export function PublicStatusView({
@@ -213,7 +195,10 @@ export function PublicStatusView({
 
               <div className="grid gap-4 xl:grid-cols-2">
                 {group.models.map((model) => {
-                  const VendorIcon = resolveVendorIcon(model.vendorIconKey);
+                  const { iconKey, Icon: VendorIcon } = getPublicStatusVendorIconComponent({
+                    modelName: model.publicModelKey,
+                    vendorIconKey: model.vendorIconKey,
+                  });
 
                   return (
                     <article
@@ -223,7 +208,10 @@ export function PublicStatusView({
                       <div className="mb-4 flex items-start justify-between gap-4">
                         <div className="space-y-2">
                           <div className="flex items-center gap-2">
-                            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-muted/40">
+                            <span
+                              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-muted/40"
+                              data-vendor-icon-key={iconKey}
+                            >
                               <VendorIcon className="h-4 w-4" />
                             </span>
                             <h3 className="text-lg font-semibold">{model.label}</h3>

--- a/src/lib/public-status/config-publisher.ts
+++ b/src/lib/public-status/config-publisher.ts
@@ -17,42 +17,7 @@ import {
   resolvePublicStatusSiteDescription,
 } from "./config-snapshot";
 import { MAX_PUBLIC_STATUS_RANGE_HOURS, PUBLIC_STATUS_INTERVAL_SET } from "./constants";
-
-const PUBLIC_VENDOR_ICON_KEYS = new Set([
-  "openai",
-  "anthropic",
-  "gemini",
-  "azure",
-  "bedrock",
-  "generic",
-]);
-
-function resolvePublicVendorIconKey(
-  modelName: string,
-  raw?: string,
-  providerTypeOverride?: ProviderType
-): string {
-  if (providerTypeOverride === "claude" || providerTypeOverride === "claude-auth") {
-    return "anthropic";
-  }
-  if (providerTypeOverride === "codex" || providerTypeOverride === "openai-compatible") {
-    return "openai";
-  }
-  if (providerTypeOverride === "gemini" || providerTypeOverride === "gemini-cli") {
-    return "gemini";
-  }
-
-  const normalized = raw?.trim().toLowerCase();
-  if (normalized && PUBLIC_VENDOR_ICON_KEYS.has(normalized)) {
-    return normalized;
-  }
-
-  const lowerModelName = modelName.toLowerCase();
-  if (lowerModelName.includes("codex")) return "openai";
-  if (lowerModelName.includes("claude")) return "anthropic";
-  if (lowerModelName.includes("gemini")) return "gemini";
-  return "generic";
-}
+import { resolvePublicStatusVendorIconKey } from "./vendor-icon";
 
 function resolveRequestTypeBadge(modelName: string, providerTypeOverride?: ProviderType): string {
   if (providerTypeOverride === "claude" || providerTypeOverride === "claude-auth") {
@@ -132,13 +97,14 @@ export async function publishCurrentPublicStatusConfigProjection(input: {
         return {
           publicModelKey: modelName,
           label: price?.priceData.display_name?.trim() || modelName,
-          vendorIconKey: resolvePublicVendorIconKey(
+          vendorIconKey: resolvePublicStatusVendorIconKey({
             modelName,
-            typeof price?.priceData.litellm_provider === "string"
-              ? price.priceData.litellm_provider
-              : undefined,
-            model.providerTypeOverride
-          ),
+            vendorIconKey:
+              typeof price?.priceData.litellm_provider === "string"
+                ? price.priceData.litellm_provider
+                : undefined,
+            providerTypeOverride: model.providerTypeOverride,
+          }),
           requestTypeBadge: resolveRequestTypeBadge(modelName, model.providerTypeOverride),
         };
       }),
@@ -163,13 +129,14 @@ export async function publishCurrentPublicStatusConfigProjection(input: {
         return {
           publicModelKey: modelName,
           label: price?.priceData.display_name?.trim() || modelName,
-          vendorIconKey: resolvePublicVendorIconKey(
+          vendorIconKey: resolvePublicStatusVendorIconKey({
             modelName,
-            typeof price?.priceData.litellm_provider === "string"
-              ? price.priceData.litellm_provider
-              : undefined,
-            model.providerTypeOverride
-          ),
+            vendorIconKey:
+              typeof price?.priceData.litellm_provider === "string"
+                ? price.priceData.litellm_provider
+                : undefined,
+            providerTypeOverride: model.providerTypeOverride,
+          }),
           requestTypeBadge: resolveRequestTypeBadge(modelName, model.providerTypeOverride),
         };
       }),

--- a/src/lib/public-status/config-publisher.ts
+++ b/src/lib/public-status/config-publisher.ts
@@ -17,7 +17,7 @@ import {
   resolvePublicStatusSiteDescription,
 } from "./config-snapshot";
 import { MAX_PUBLIC_STATUS_RANGE_HOURS, PUBLIC_STATUS_INTERVAL_SET } from "./constants";
-import { resolvePublicStatusVendorIconKey } from "./vendor-icon";
+import { resolvePublicStatusVendorIconKey } from "./vendor-icon-key";
 
 function resolveRequestTypeBadge(modelName: string, providerTypeOverride?: ProviderType): string {
   if (providerTypeOverride === "claude" || providerTypeOverride === "claude-auth") {

--- a/src/lib/public-status/vendor-icon-key.ts
+++ b/src/lib/public-status/vendor-icon-key.ts
@@ -1,0 +1,156 @@
+import { getModelVendor } from "@/lib/model-vendor-icons";
+import type { ProviderType } from "@/types/provider";
+
+export const PUBLIC_STATUS_VENDOR_ICON_KEYS = [
+  "anthropic",
+  "azure",
+  "baichuan",
+  "bedrock",
+  "cohere",
+  "deepseek",
+  "fireworks",
+  "gemini",
+  "gemma",
+  "generic",
+  "groq",
+  "hunyuan",
+  "internlm",
+  "kimi",
+  "meta",
+  "minimax",
+  "mistral",
+  "moonshot",
+  "nvidia",
+  "ollama",
+  "openai",
+  "openrouter",
+  "perplexity",
+  "qwen",
+  "sensenova",
+  "spark",
+  "stepfun",
+  "together",
+  "volcengine",
+  "wenxin",
+  "xai",
+  "yi",
+  "zhipuai",
+] as const;
+
+export type PublicStatusVendorIconKey = (typeof PUBLIC_STATUS_VENDOR_ICON_KEYS)[number];
+
+const PUBLIC_STATUS_VENDOR_ICON_KEY_SET = new Set<string>(PUBLIC_STATUS_VENDOR_ICON_KEYS);
+
+const PROVIDER_TYPE_ICON_KEYS: Partial<Record<ProviderType, PublicStatusVendorIconKey>> = {
+  "claude-auth": "anthropic",
+  claude: "anthropic",
+  codex: "openai",
+  gemini: "gemini",
+  "gemini-cli": "gemini",
+};
+
+const RAW_PROVIDER_TO_PUBLIC_STATUS_ICON_KEY: Record<string, PublicStatusVendorIconKey> = {
+  anthropic: "anthropic",
+  azure: "azure",
+  bedrock: "bedrock",
+  cohere_chat: "cohere",
+  deepseek: "deepseek",
+  fireworks_ai: "fireworks",
+  groq: "groq",
+  meta: "meta",
+  minimax: "minimax",
+  mistral: "mistral",
+  nvidia_nim: "nvidia",
+  ollama: "ollama",
+  openai: "openai",
+  openrouter: "openrouter",
+  qwen: "qwen",
+  together_ai: "together",
+  "vertex_ai-language-models": "gemini",
+  volcengine: "volcengine",
+  xai: "xai",
+  zhipuai: "zhipuai",
+};
+
+const MODEL_VENDOR_TO_PUBLIC_STATUS_ICON_KEY: Record<string, PublicStatusVendorIconKey> = {
+  anthropic: "anthropic",
+  azure: "azure",
+  baichuan: "baichuan",
+  bedrock: "bedrock",
+  cohere: "cohere",
+  deepseek: "deepseek",
+  gemma: "gemma",
+  groq: "groq",
+  hunyuan: "hunyuan",
+  internlm: "internlm",
+  kimi: "kimi",
+  meta: "meta",
+  minimax: "minimax",
+  mistral: "mistral",
+  moonshot: "moonshot",
+  nvidia: "nvidia",
+  ollama: "ollama",
+  openai: "openai",
+  openrouter: "openrouter",
+  perplexity: "perplexity",
+  qwen: "qwen",
+  sensenova: "sensenova",
+  spark: "spark",
+  stepfun: "stepfun",
+  together: "together",
+  vertex: "gemini",
+  volcengine: "volcengine",
+  wenxin: "wenxin",
+  xai: "xai",
+  yi: "yi",
+  zhipuai: "zhipuai",
+};
+
+function normalizePublicStatusVendorIconKey(
+  vendorIconKey?: string | null
+): PublicStatusVendorIconKey | null {
+  if (!vendorIconKey) {
+    return null;
+  }
+
+  const normalized = vendorIconKey.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  if (Object.hasOwn(RAW_PROVIDER_TO_PUBLIC_STATUS_ICON_KEY, normalized)) {
+    return RAW_PROVIDER_TO_PUBLIC_STATUS_ICON_KEY[normalized];
+  }
+
+  return PUBLIC_STATUS_VENDOR_ICON_KEY_SET.has(normalized)
+    ? (normalized as PublicStatusVendorIconKey)
+    : null;
+}
+
+export function resolvePublicStatusVendorIconKey(input: {
+  modelName: string;
+  vendorIconKey?: string | null;
+  providerTypeOverride?: ProviderType;
+}): PublicStatusVendorIconKey {
+  const overrideKey = input.providerTypeOverride
+    ? PROVIDER_TYPE_ICON_KEYS[input.providerTypeOverride]
+    : undefined;
+  if (overrideKey) {
+    return overrideKey;
+  }
+
+  const explicitKey = normalizePublicStatusVendorIconKey(input.vendorIconKey);
+  if (explicitKey && explicitKey !== "generic") {
+    return explicitKey;
+  }
+
+  const matchedVendor = getModelVendor(input.modelName);
+  if (matchedVendor) {
+    const normalizedKey = MODEL_VENDOR_TO_PUBLIC_STATUS_ICON_KEY[matchedVendor.i18nKey];
+    if (normalizedKey) {
+      return normalizedKey;
+    }
+  }
+
+  return explicitKey ?? "generic";
+}

--- a/src/lib/public-status/vendor-icon.ts
+++ b/src/lib/public-status/vendor-icon.ts
@@ -1,3 +1,4 @@
+import type { ComponentType } from "react";
 import {
   Azure,
   Baichuan,
@@ -6,6 +7,7 @@ import {
   Cohere,
   DeepSeek,
   Doubao,
+  Fireworks,
   Gemini,
   Gemma,
   Grok,
@@ -32,17 +34,22 @@ import {
   Zhipu,
 } from "@lobehub/icons";
 import { Bot } from "lucide-react";
-import type { ComponentType } from "react";
-import { getModelVendor } from "@/lib/model-vendor-icons";
-import type { ProviderType } from "@/types/provider";
+import {
+  type PublicStatusVendorIconKey,
+  resolvePublicStatusVendorIconKey,
+} from "./vendor-icon-key";
 
-const PUBLIC_STATUS_VENDOR_ICON_REGISTRY = {
+const PUBLIC_STATUS_VENDOR_ICON_REGISTRY: Record<
+  PublicStatusVendorIconKey,
+  ComponentType<{ className?: string }>
+> = {
   anthropic: Claude.Color,
   azure: Azure,
   baichuan: Baichuan.Color,
   bedrock: Bedrock,
   cohere: Cohere.Color,
   deepseek: DeepSeek.Color,
+  fireworks: Fireworks.Color,
   gemini: Gemini.Color,
   gemma: Gemma.Color,
   generic: Bot,
@@ -69,101 +76,12 @@ const PUBLIC_STATUS_VENDOR_ICON_REGISTRY = {
   xai: Grok,
   yi: Yi.Color,
   zhipuai: Zhipu.Color,
-} satisfies Record<string, ComponentType<{ className?: string }>>;
-
-export type PublicStatusVendorIconKey = keyof typeof PUBLIC_STATUS_VENDOR_ICON_REGISTRY;
-
-const PROVIDER_TYPE_ICON_KEYS: Partial<Record<ProviderType, PublicStatusVendorIconKey>> = {
-  "claude-auth": "anthropic",
-  claude: "anthropic",
-  codex: "openai",
-  gemini: "gemini",
-  "gemini-cli": "gemini",
-  "openai-compatible": "openai",
 };
-
-const MODEL_VENDOR_TO_PUBLIC_STATUS_ICON_KEY: Record<string, PublicStatusVendorIconKey> = {
-  anthropic: "anthropic",
-  azure: "azure",
-  baichuan: "baichuan",
-  bedrock: "bedrock",
-  cohere: "cohere",
-  deepseek: "deepseek",
-  gemma: "gemma",
-  groq: "groq",
-  hunyuan: "hunyuan",
-  internlm: "internlm",
-  kimi: "kimi",
-  meta: "meta",
-  minimax: "minimax",
-  mistral: "mistral",
-  moonshot: "moonshot",
-  nvidia: "nvidia",
-  ollama: "ollama",
-  openai: "openai",
-  openrouter: "openrouter",
-  perplexity: "perplexity",
-  qwen: "qwen",
-  sensenova: "sensenova",
-  spark: "spark",
-  stepfun: "stepfun",
-  vertex: "gemini",
-  volcengine: "volcengine",
-  wenxin: "wenxin",
-  xai: "xai",
-  yi: "yi",
-  zhipuai: "zhipuai",
-};
-
-function normalizePublicStatusVendorIconKey(
-  vendorIconKey?: string | null
-): PublicStatusVendorIconKey | null {
-  if (!vendorIconKey) {
-    return null;
-  }
-
-  const normalized = vendorIconKey.trim().toLowerCase();
-  if (!normalized) {
-    return null;
-  }
-
-  return normalized in PUBLIC_STATUS_VENDOR_ICON_REGISTRY
-    ? (normalized as PublicStatusVendorIconKey)
-    : null;
-}
-
-export function resolvePublicStatusVendorIconKey(input: {
-  modelName: string;
-  vendorIconKey?: string | null;
-  providerTypeOverride?: ProviderType;
-}): PublicStatusVendorIconKey {
-  const overrideKey = input.providerTypeOverride
-    ? PROVIDER_TYPE_ICON_KEYS[input.providerTypeOverride]
-    : undefined;
-  if (overrideKey) {
-    return overrideKey;
-  }
-
-  const explicitKey = normalizePublicStatusVendorIconKey(input.vendorIconKey);
-  if (explicitKey && explicitKey !== "generic") {
-    return explicitKey;
-  }
-
-  const matchedVendor = getModelVendor(input.modelName);
-  if (matchedVendor) {
-    const normalizedKey = MODEL_VENDOR_TO_PUBLIC_STATUS_ICON_KEY[matchedVendor.i18nKey];
-    if (normalizedKey) {
-      return normalizedKey;
-    }
-  }
-
-  return explicitKey ?? "generic";
-}
 
 export function getPublicStatusVendorIconComponent(input: {
   modelName: string;
   vendorIconKey?: string | null;
-  providerTypeOverride?: ProviderType;
+  providerTypeOverride?: import("@/types/provider").ProviderType;
 }): {
   iconKey: PublicStatusVendorIconKey;
   Icon: ComponentType<{ className?: string }>;
@@ -171,6 +89,6 @@ export function getPublicStatusVendorIconComponent(input: {
   const iconKey = resolvePublicStatusVendorIconKey(input);
   return {
     iconKey,
-    Icon: PUBLIC_STATUS_VENDOR_ICON_REGISTRY[iconKey] ?? Bot,
+    Icon: PUBLIC_STATUS_VENDOR_ICON_REGISTRY[iconKey],
   };
 }

--- a/src/lib/public-status/vendor-icon.ts
+++ b/src/lib/public-status/vendor-icon.ts
@@ -1,0 +1,176 @@
+import {
+  Azure,
+  Baichuan,
+  Bedrock,
+  Claude,
+  Cohere,
+  DeepSeek,
+  Doubao,
+  Gemini,
+  Gemma,
+  Grok,
+  Groq,
+  Hunyuan,
+  InternLM,
+  Kimi,
+  Meta,
+  Minimax,
+  Mistral,
+  Moonshot,
+  Nvidia,
+  Ollama,
+  OpenAI,
+  OpenRouter,
+  Perplexity,
+  Qwen,
+  SenseNova,
+  Spark,
+  Stepfun,
+  Together,
+  Wenxin,
+  Yi,
+  Zhipu,
+} from "@lobehub/icons";
+import { Bot } from "lucide-react";
+import type { ComponentType } from "react";
+import { getModelVendor } from "@/lib/model-vendor-icons";
+import type { ProviderType } from "@/types/provider";
+
+const PUBLIC_STATUS_VENDOR_ICON_REGISTRY = {
+  anthropic: Claude.Color,
+  azure: Azure,
+  baichuan: Baichuan.Color,
+  bedrock: Bedrock,
+  cohere: Cohere.Color,
+  deepseek: DeepSeek.Color,
+  gemini: Gemini.Color,
+  gemma: Gemma.Color,
+  generic: Bot,
+  groq: Groq,
+  hunyuan: Hunyuan.Color,
+  internlm: InternLM.Color,
+  kimi: Kimi.Color,
+  meta: Meta.Color,
+  minimax: Minimax.Color,
+  mistral: Mistral.Color,
+  moonshot: Moonshot,
+  nvidia: Nvidia.Color,
+  ollama: Ollama,
+  openai: OpenAI,
+  openrouter: OpenRouter,
+  perplexity: Perplexity.Color,
+  qwen: Qwen.Color,
+  sensenova: SenseNova.Color,
+  spark: Spark.Color,
+  stepfun: Stepfun.Color,
+  together: Together.Color,
+  volcengine: Doubao.Color,
+  wenxin: Wenxin.Color,
+  xai: Grok,
+  yi: Yi.Color,
+  zhipuai: Zhipu.Color,
+} satisfies Record<string, ComponentType<{ className?: string }>>;
+
+export type PublicStatusVendorIconKey = keyof typeof PUBLIC_STATUS_VENDOR_ICON_REGISTRY;
+
+const PROVIDER_TYPE_ICON_KEYS: Partial<Record<ProviderType, PublicStatusVendorIconKey>> = {
+  "claude-auth": "anthropic",
+  claude: "anthropic",
+  codex: "openai",
+  gemini: "gemini",
+  "gemini-cli": "gemini",
+  "openai-compatible": "openai",
+};
+
+const MODEL_VENDOR_TO_PUBLIC_STATUS_ICON_KEY: Record<string, PublicStatusVendorIconKey> = {
+  anthropic: "anthropic",
+  azure: "azure",
+  baichuan: "baichuan",
+  bedrock: "bedrock",
+  cohere: "cohere",
+  deepseek: "deepseek",
+  gemma: "gemma",
+  groq: "groq",
+  hunyuan: "hunyuan",
+  internlm: "internlm",
+  kimi: "kimi",
+  meta: "meta",
+  minimax: "minimax",
+  mistral: "mistral",
+  moonshot: "moonshot",
+  nvidia: "nvidia",
+  ollama: "ollama",
+  openai: "openai",
+  openrouter: "openrouter",
+  perplexity: "perplexity",
+  qwen: "qwen",
+  sensenova: "sensenova",
+  spark: "spark",
+  stepfun: "stepfun",
+  vertex: "gemini",
+  volcengine: "volcengine",
+  wenxin: "wenxin",
+  xai: "xai",
+  yi: "yi",
+  zhipuai: "zhipuai",
+};
+
+function normalizePublicStatusVendorIconKey(
+  vendorIconKey?: string | null
+): PublicStatusVendorIconKey | null {
+  if (!vendorIconKey) {
+    return null;
+  }
+
+  const normalized = vendorIconKey.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized in PUBLIC_STATUS_VENDOR_ICON_REGISTRY
+    ? (normalized as PublicStatusVendorIconKey)
+    : null;
+}
+
+export function resolvePublicStatusVendorIconKey(input: {
+  modelName: string;
+  vendorIconKey?: string | null;
+  providerTypeOverride?: ProviderType;
+}): PublicStatusVendorIconKey {
+  const overrideKey = input.providerTypeOverride
+    ? PROVIDER_TYPE_ICON_KEYS[input.providerTypeOverride]
+    : undefined;
+  if (overrideKey) {
+    return overrideKey;
+  }
+
+  const explicitKey = normalizePublicStatusVendorIconKey(input.vendorIconKey);
+  if (explicitKey && explicitKey !== "generic") {
+    return explicitKey;
+  }
+
+  const matchedVendor = getModelVendor(input.modelName);
+  if (matchedVendor) {
+    const normalizedKey = MODEL_VENDOR_TO_PUBLIC_STATUS_ICON_KEY[matchedVendor.i18nKey];
+    if (normalizedKey) {
+      return normalizedKey;
+    }
+  }
+
+  return explicitKey ?? "generic";
+}
+
+export function getPublicStatusVendorIconComponent(input: {
+  modelName: string;
+  vendorIconKey?: string | null;
+  providerTypeOverride?: ProviderType;
+}): {
+  iconKey: PublicStatusVendorIconKey;
+  Icon: ComponentType<{ className?: string }>;
+} {
+  const iconKey = resolvePublicStatusVendorIconKey(input);
+  return {
+    iconKey,
+    Icon: PUBLIC_STATUS_VENDOR_ICON_REGISTRY[iconKey] ?? Bot,
+  };
+}

--- a/src/lib/public-status/vendor-icon.ts
+++ b/src/lib/public-status/vendor-icon.ts
@@ -1,4 +1,3 @@
-import type { ComponentType } from "react";
 import {
   Azure,
   Baichuan,
@@ -34,6 +33,7 @@ import {
   Zhipu,
 } from "@lobehub/icons";
 import { Bot } from "lucide-react";
+import type { ComponentType } from "react";
 import {
   type PublicStatusVendorIconKey,
   resolvePublicStatusVendorIconKey,

--- a/tests/unit/actions/model-prices.test.ts
+++ b/tests/unit/actions/model-prices.test.ts
@@ -92,6 +92,48 @@ describe("Model Price Actions", () => {
     findAllLatestPricesMock.mockResolvedValue([]);
   });
 
+  describe("getAvailableModelCatalog", () => {
+    it("returns chat models only by default", async () => {
+      findAllLatestPricesMock.mockResolvedValue([
+        makeMockPrice("gpt-4.1", { mode: "chat" }),
+        makeMockPrice("gpt-image-2", { mode: "image_generation" }),
+      ]);
+
+      const { getAvailableModelCatalog } = await import("@/actions/model-prices");
+      const result = await getAvailableModelCatalog();
+
+      expect(result.map((item) => item.modelName)).toEqual(["gpt-4.1"]);
+    });
+
+    it("returns all model types when scope is all", async () => {
+      findAllLatestPricesMock.mockResolvedValue([
+        makeMockPrice("gpt-image-2", { mode: "image_generation" }),
+        makeMockPrice("gpt-4.1", { mode: "chat" }),
+      ]);
+
+      const { getAvailableModelCatalog } = await import("@/actions/model-prices");
+      const result = await getAvailableModelCatalog({ scope: "all" });
+
+      expect(result.map((item) => item.modelName)).toEqual(
+        expect.arrayContaining(["gpt-image-2", "gpt-4.1"])
+      );
+    });
+  });
+
+  describe("getAvailableModelsByProviderType", () => {
+    it("keeps using the chat-only catalog", async () => {
+      findAllLatestPricesMock.mockResolvedValue([
+        makeMockPrice("gpt-4.1", { mode: "chat" }),
+        makeMockPrice("gpt-image-2", { mode: "image_generation" }),
+      ]);
+
+      const { getAvailableModelsByProviderType } = await import("@/actions/model-prices");
+      const result = await getAvailableModelsByProviderType();
+
+      expect(result).toEqual(["gpt-4.1"]);
+    });
+  });
+
   describe("upsertSingleModelPrice", () => {
     it("should create a new model price for admin", async () => {
       const mockResult = makeMockPrice("gpt-5.2-codex", {

--- a/tests/unit/public-status/config-publisher.test.ts
+++ b/tests/unit/public-status/config-publisher.test.ts
@@ -116,5 +116,50 @@ describe("public-status config publisher", () => {
         }),
       })
     );
+  }, 20_000);
+
+  it("uses shared model-prefix matching for vendor icons without changing request type badges", async () => {
+    mockFindAllProviderGroups.mockResolvedValue([
+      {
+        id: 1,
+        name: "mixed",
+        description: JSON.stringify({
+          version: 2,
+          publicStatus: {
+            displayName: "Mixed",
+            publicModels: [{ modelKey: "qwen-max" }, { modelKey: "deepseek-chat" }],
+          },
+        }),
+      },
+    ]);
+
+    const mod = await import("@/lib/public-status/config-publisher");
+    await mod.publishCurrentPublicStatusConfigProjection({
+      reason: "test",
+      configVersion: "cfg-test",
+    });
+
+    expect(mockPublishPublicStatusConfigSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          groups: [
+            expect.objectContaining({
+              models: [
+                expect.objectContaining({
+                  publicModelKey: "qwen-max",
+                  vendorIconKey: "qwen",
+                  requestTypeBadge: "openaiCompatible",
+                }),
+                expect.objectContaining({
+                  publicModelKey: "deepseek-chat",
+                  vendorIconKey: "deepseek",
+                  requestTypeBadge: "openaiCompatible",
+                }),
+              ],
+            }),
+          ],
+        }),
+      })
+    );
   });
 });

--- a/tests/unit/public-status/config-publisher.test.ts
+++ b/tests/unit/public-status/config-publisher.test.ts
@@ -127,7 +127,11 @@ describe("public-status config publisher", () => {
           version: 2,
           publicStatus: {
             displayName: "Mixed",
-            publicModels: [{ modelKey: "qwen-max" }, { modelKey: "deepseek-chat" }],
+            publicModels: [
+              { modelKey: "qwen-max" },
+              { modelKey: "deepseek-chat" },
+              { modelKey: "qwen-plus", providerTypeOverride: "openai-compatible" },
+            ],
           },
         }),
       },
@@ -153,6 +157,11 @@ describe("public-status config publisher", () => {
                 expect.objectContaining({
                   publicModelKey: "deepseek-chat",
                   vendorIconKey: "deepseek",
+                  requestTypeBadge: "openaiCompatible",
+                }),
+                expect.objectContaining({
+                  publicModelKey: "qwen-plus",
+                  vendorIconKey: "qwen",
                   requestTypeBadge: "openaiCompatible",
                 }),
               ],

--- a/tests/unit/public-status/public-status-view.test.tsx
+++ b/tests/unit/public-status/public-status-view.test.tsx
@@ -234,4 +234,124 @@ describe("public-status view", () => {
     vi.useRealTimers();
     unmount();
   });
+
+  it("falls back to shared model-prefix vendor icons when payload vendorIconKey is generic", () => {
+    const { container, unmount } = render(
+      <PublicStatusView
+        initialPayload={buildPayload({
+          groups: [
+            {
+              publicGroupSlug: "mixed",
+              displayName: "Mixed",
+              explanatoryCopy: "Prefix-matched icons",
+              models: [
+                {
+                  publicModelKey: "qwen-max",
+                  label: "Qwen Max",
+                  vendorIconKey: "generic",
+                  requestTypeBadge: "openaiCompatible",
+                  latestState: "operational",
+                  availabilityPct: 99.9,
+                  latestTtfbMs: 420,
+                  latestTps: null,
+                  timeline: [],
+                },
+              ],
+            },
+          ],
+        })}
+        intervalMinutes={5}
+        rangeHours={24}
+        locale="en"
+        timeZone="UTC"
+        labels={{
+          systemStatus: "System Status",
+          heroPrimary: "AI SERVICES",
+          heroSecondary: "INTELLIGENCE MONITOR",
+          generatedAt: "Updated",
+          history: "History",
+          availability: "Availability",
+          ttfb: "TTFB",
+          freshnessWindow: "Snapshot freshness",
+          fresh: "Fresh",
+          stale: "Stale",
+          staleDetail: "Refresh delayed",
+          rebuilding: "Rebuilding",
+          noData: "No data",
+          emptyDescription: "Preparing first snapshot",
+          requestTypes: {
+            openaiCompatible: "OpenAI Compatible",
+            codex: "Codex",
+            anthropic: "Anthropic",
+            gemini: "Gemini",
+          },
+        }}
+        siteTitle="Acme AI Hub"
+      />
+    );
+
+    expect(container.querySelector('[data-vendor-icon-key="qwen"]')).not.toBeNull();
+
+    unmount();
+  });
+
+  it("keeps explicit vendorIconKey when the model prefix itself is ambiguous", () => {
+    const { container, unmount } = render(
+      <PublicStatusView
+        initialPayload={buildPayload({
+          groups: [
+            {
+              publicGroupSlug: "mixed",
+              displayName: "Mixed",
+              explanatoryCopy: "Override icon",
+              models: [
+                {
+                  publicModelKey: "reasoner-pro",
+                  label: "Reasoner Pro",
+                  vendorIconKey: "gemini",
+                  requestTypeBadge: "gemini",
+                  latestState: "operational",
+                  availabilityPct: 99.9,
+                  latestTtfbMs: 420,
+                  latestTps: null,
+                  timeline: [],
+                },
+              ],
+            },
+          ],
+        })}
+        intervalMinutes={5}
+        rangeHours={24}
+        locale="en"
+        timeZone="UTC"
+        labels={{
+          systemStatus: "System Status",
+          heroPrimary: "AI SERVICES",
+          heroSecondary: "INTELLIGENCE MONITOR",
+          generatedAt: "Updated",
+          history: "History",
+          availability: "Availability",
+          ttfb: "TTFB",
+          freshnessWindow: "Snapshot freshness",
+          fresh: "Fresh",
+          stale: "Stale",
+          staleDetail: "Refresh delayed",
+          rebuilding: "Rebuilding",
+          noData: "No data",
+          emptyDescription: "Preparing first snapshot",
+          requestTypes: {
+            openaiCompatible: "OpenAI Compatible",
+            codex: "Codex",
+            anthropic: "Anthropic",
+            gemini: "Gemini",
+          },
+        }}
+        siteTitle="Acme AI Hub"
+      />
+    );
+
+    expect(container.querySelector('[data-vendor-icon-key="gemini"]')).not.toBeNull();
+
+    unmount();
+  });
 });

--- a/tests/unit/settings/providers/model-multi-select.test.tsx
+++ b/tests/unit/settings/providers/model-multi-select.test.tsx
@@ -194,13 +194,19 @@ describe("ModelMultiSelect", () => {
     expect(modelPricesActionMocks.getAvailableModelCatalog).not.toHaveBeenCalled();
     await openPicker();
     expect(modelPricesActionMocks.getAvailableModelCatalog).toHaveBeenCalledTimes(1);
+    expect(modelPricesActionMocks.getAvailableModelCatalog).toHaveBeenCalledWith({
+      scope: "chat",
+    });
 
     const initialItems = Array.from(
       document.querySelectorAll('[data-model-group="available"] [data-slot="command-item"]')
     ).map((element) => element.textContent?.trim() || "");
-    expect(initialItems[0]).toContain("openai-new");
-    expect(initialItems[1]).toContain("anthropic-mid");
-    expect(initialItems[2]).toContain("openai-old");
+    expect(initialItems.some((text) => text.includes("openai-new"))).toBe(true);
+    expect(initialItems.some((text) => text.includes("anthropic-mid"))).toBe(true);
+    expect(initialItems.some((text) => text.includes("openai-old"))).toBe(true);
+    expect(
+      initialItems.findIndex((text) => text.includes("openai-new"))
+    ).toBeLessThan(initialItems.findIndex((text) => text.includes("openai-old")));
 
     const providerFilter = document.querySelector(
       '[data-testid="provider-filter-select"]'
@@ -221,6 +227,52 @@ describe("ModelMultiSelect", () => {
     expect(filteredItems.some((text) => text.includes("anthropic-mid"))).toBe(false);
     expect(filteredItems.some((text) => text.includes("openai-new"))).toBe(true);
     expect(filteredItems.some((text) => text.includes("openai-old"))).toBe(true);
+
+    unmount();
+  });
+
+  test("supports all model types when the caller opts into all-type catalog scope", async () => {
+    const messages = loadMessages();
+
+    modelPricesActionMocks.getAvailableModelCatalog.mockResolvedValueOnce([
+      {
+        modelName: "gpt-image-2",
+        litellmProvider: "openai",
+        updatedAt: "2026-04-06T12:00:00.000Z",
+      },
+      {
+        modelName: "openai-new",
+        litellmProvider: "openai",
+        updatedAt: "2026-04-05T12:00:00.000Z",
+      },
+      {
+        modelName: "anthropic-mid",
+        litellmProvider: "anthropic",
+        updatedAt: "2026-04-04T12:00:00.000Z",
+      },
+    ]);
+
+    const { unmount } = render(
+      <NextIntlClientProvider locale="en" messages={messages} timeZone="UTC">
+        <ModelMultiSelect
+          providerType="openai-compatible"
+          catalogScope="all"
+          selectedModels={[]}
+          onChange={vi.fn()}
+        />
+      </NextIntlClientProvider>
+    );
+
+    await openPicker();
+
+    expect(modelPricesActionMocks.getAvailableModelCatalog).toHaveBeenCalledWith({
+      scope: "all",
+    });
+
+    const items = Array.from(
+      document.querySelectorAll('[data-model-group="available"] [data-slot="command-item"]')
+    ).map((element) => element.textContent?.trim() || "");
+    expect(items.some((text) => text.includes("gpt-image-2"))).toBe(true);
 
     unmount();
   });

--- a/tests/unit/settings/providers/model-multi-select.test.tsx
+++ b/tests/unit/settings/providers/model-multi-select.test.tsx
@@ -204,9 +204,9 @@ describe("ModelMultiSelect", () => {
     expect(initialItems.some((text) => text.includes("openai-new"))).toBe(true);
     expect(initialItems.some((text) => text.includes("anthropic-mid"))).toBe(true);
     expect(initialItems.some((text) => text.includes("openai-old"))).toBe(true);
-    expect(
-      initialItems.findIndex((text) => text.includes("openai-new"))
-    ).toBeLessThan(initialItems.findIndex((text) => text.includes("openai-old")));
+    expect(initialItems.findIndex((text) => text.includes("openai-new"))).toBeLessThan(
+      initialItems.findIndex((text) => text.includes("openai-old"))
+    );
 
     const providerFilter = document.querySelector(
       '[data-testid="provider-filter-select"]'

--- a/tests/unit/settings/status-page/public-status-settings-form.test.tsx
+++ b/tests/unit/settings/status-page/public-status-settings-form.test.tsx
@@ -10,6 +10,7 @@ import { PublicStatusSettingsForm } from "@/app/[locale]/settings/status-page/_c
 
 const mockRefresh = vi.hoisted(() => vi.fn());
 const mockSavePublicStatusSettings = vi.hoisted(() => vi.fn());
+const modelMultiSelectPropsSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -31,20 +32,28 @@ vi.mock("@/i18n/routing", () => ({
 
 vi.mock("@/app/[locale]/settings/providers/_components/model-multi-select", () => ({
   ModelMultiSelect: ({
+    catalogScope,
+    providerType,
     selectedModels,
     onChange,
   }: {
+    catalogScope?: string;
+    providerType?: string;
     selectedModels: string[];
     onChange: (models: string[]) => void;
-  }) => (
-    <button
-      type="button"
-      data-testid="public-status-model-picker"
-      onClick={() => onChange([...selectedModels, "gpt-4.1"])}
-    >
-      picker
-    </button>
-  ),
+  }) => {
+    modelMultiSelectPropsSpy({ catalogScope, providerType, selectedModels });
+
+    return (
+      <button
+        type="button"
+        data-testid="public-status-model-picker"
+        onClick={() => onChange([...selectedModels, "gpt-4.1"])}
+      >
+        picker
+      </button>
+    );
+  },
 }));
 
 vi.mock("@/components/section", () => ({
@@ -194,6 +203,12 @@ describe("public-status settings form", () => {
 
     expect(container.querySelector('[data-testid="public-status-model-picker"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="public-status-preview-link"]')).not.toBeNull();
+    expect(modelMultiSelectPropsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        catalogScope: "all",
+        providerType: "openai-compatible",
+      })
+    );
 
     unmount();
   });


### PR DESCRIPTION
## Summary
This PR extends the public status page model picker to support **all model types** (not just chat models) and introduces a **shared vendor icon resolution system** for consistent provider branding across the public status page.

## Problem
The public status page added in PR #1056 had two limitations:
1. **Chat-only model catalog**: The model picker in the public status settings only showed chat models, preventing users from adding non-chat models (image generation, embedding, etc.) to their public status page.
2. **Limited vendor icons**: The public status view only supported 5 hardcoded vendor icons (OpenAI, Anthropic, Gemini, Azure, Bedrock) with a generic fallback, causing most models to display the same default icon regardless of their actual provider.

## Solution

### 1. Extensible Model Catalog Scope
Added an optional `scope` parameter to `getAvailableModelCatalog()` that accepts `"chat" | "all"`:
- `"chat"` (default): Maintains backward compatibility - returns only chat models
- `"all"`: Returns all model types including image generation, embedding, STT, TTS, etc.

The public status settings form now uses `catalogScope="all"` to allow selecting any model type for status monitoring.

### 2. Shared Vendor Icon Resolution
Extracted vendor icon logic into a new shared module (`src/lib/public-status/vendor-icon.ts`) that:
- Supports 27+ provider icons (DeepSeek, Qwen, Moonshot, Grok, Mistral, etc.)
- Uses model name prefix matching for automatic vendor detection
- Falls back to explicit vendor keys, then provider type overrides
- Provides both icon key resolution and React component lookup

This ensures the public status page shows the correct vendor icon for any model, not just the major providers.

## Changes

### Core Changes
| File | Change |
|------|--------|
| `src/actions/model-prices.ts` | Add `AvailableModelCatalogScope` type and optional `scope` parameter to `getAvailableModelCatalog()` |
| `src/lib/public-status/vendor-icon.ts` | **New file**: Shared vendor icon registry with 27+ provider icons and model-prefix matching |
| `src/lib/public-status/config-publisher.ts` | Refactor to use shared `resolvePublicStatusVendorIconKey()` |
| `src/app/[locale]/status/_components/public-status-view.tsx` | Replace hardcoded `resolveVendorIcon()` with shared `getPublicStatusVendorIconComponent()` |

### UI Changes
| File | Change |
|------|--------|
| `src/app/[locale]/settings/providers/_components/model-multi-select.tsx` | Add `catalogScope` prop, pass to `getAvailableModelCatalog()` |
| `src/app/[locale]/settings/status-page/_components/public-status-settings-form.tsx` | Set `catalogScope="all"` on model picker |

### Test Coverage
| File | Change |
|------|--------|
| `tests/unit/actions/model-prices.test.ts` | Add tests for `scope` parameter (default "chat" and "all") |
| `tests/unit/settings/providers/model-multi-select.test.tsx` | Add test for `catalogScope="all"` behavior |
| `tests/unit/public-status/config-publisher.test.ts` | Add test for vendor icon resolution with prefix matching |
| `tests/unit/public-status/public-status-view.test.tsx` | Add tests for vendor icon fallback and explicit key preservation |
| `tests/unit/settings/status-page/public-status-settings-form.test.tsx` | Verify `catalogScope="all"` is passed to picker |

## Related Work
- **Follow-up to #1056** — Extends the Redis-projected public status page with better model support
- **Related to #974** — While not adding status URLs to providers, improves the public status page UX

## Breaking Changes
None. All changes are backward compatible:
- `getAvailableModelCatalog()` defaults to `scope: "chat"` (existing behavior)
- `ModelMultiSelect` defaults to `catalogScope="chat"` (existing behavior)
- All existing consumers continue to work without modification

## Testing

### Automated Tests
```bash
# Unit tests for catalog scope
bunx vitest run tests/unit/actions/model-prices.test.ts

# Unit tests for model picker with catalogScope
bunx vitest run tests/unit/settings/providers/model-multi-select.test.tsx

# Unit tests for vendor icon resolution
bunx vitest run tests/unit/public-status/config-publisher.test.ts
bunx vitest run tests/unit/public-status/public-status-view.test.tsx

# Unit tests for settings form integration
bunx vitest run tests/unit/settings/status-page/public-status-settings-form.test.tsx
```

### Manual Verification
1. Navigate to **Settings → Status Page**
2. Open the model picker
3. Verify non-chat models (e.g., image generation models) appear in the list
4. Add a non-chat model to the public status configuration
5. Save and view the public status page
6. Verify the correct vendor icon displays for the model

## Screenshots
\![Public status preview](https://i.111666.best/image/MlQv9sXlRq7IWzPiqPOWIV.png)

## Verification
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] Unit tests pass for affected modules

## Known Baseline Blockers
- `bun run lint` still reports unrelated pre-existing Biome issues in `src/components/ui/map.tsx`, `src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx`, and existing test mocks outside this change set.
- `bun run test` still aborts on the pre-existing `src/components/ui/__tests__/map.test.tsx` worker OOM. Re-run with `VITEST_MAX_WORKERS=2` and `--pool forks` to work around.

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the public status page model picker to show all model types (not just chat) and refactors vendor icon resolution into two separate modules: a server-safe `vendor-icon-key.ts` (string resolution only) and a client-only `vendor-icon.ts` (React component registry). All three concerns raised in the previous review round have been addressed: server/client bundle separation, removal of the `openai-compatible` override that was swallowing prefix matching, and the unreachable `?? Bot` fallback.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all previous review concerns are addressed and no new issues introduced.

All three concerns from the previous review round (server bundle, openai-compatible override, unreachable Bot fallback) have been resolved. The scope parameter is backward-compatible, all 27 registry keys are covered, test coverage is thorough, and no P0/P1 issues were found.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/public-status/vendor-icon-key.ts | New server-safe key-resolution module: cleanly separates string-only logic from UI imports. Covers 27+ providers via RAW_PROVIDER, MODEL_VENDOR, and prefix-matching layers. No issues found. |
| src/lib/public-status/vendor-icon.ts | New client-only React component registry; delegates key resolution to vendor-icon-key.ts. All 27 keys in PUBLIC_STATUS_VENDOR_ICON_KEYS are covered in the registry, making the index lookup safe. |
| src/actions/model-prices.ts | Adds optional scope param to getAvailableModelCatalog() with 'chat' default; getAvailableModelsByProviderType() now passes scope explicitly to preserve existing behavior. Backward compatible. |
| src/lib/public-status/config-publisher.ts | Replaced inline resolvePublicVendorIconKey() with shared resolvePublicStatusVendorIconKey() from vendor-icon-key.ts. Removes openai-compatible override so qwen/deepseek models served via openai-compatible API now correctly get their own icons. |
| src/app/[locale]/status/_components/public-status-view.tsx | Replaced 5-case switch with getPublicStatusVendorIconComponent(); adds data-vendor-icon-key attribute for testing. Re-resolution at render time correctly handles legacy 'generic' snapshots. |
| src/app/[locale]/settings/providers/_components/model-multi-select.tsx | Adds catalogScope prop (defaults to 'chat') and correctly includes it in the useCallback dependency array. No issues. |
| src/app/[locale]/settings/status-page/_components/public-status-settings-form.tsx | Single-line change: passes catalogScope='all' to ModelMultiSelect for the status page model picker. |
| tests/unit/public-status/config-publisher.test.ts | New test verifies prefix matching for qwen-max, deepseek-chat, and qwen-plus (with openai-compatible override removed). Covers the key behavior change well. |
| tests/unit/public-status/public-status-view.test.tsx | New tests cover generic-to-qwen fallback and explicit key preservation at render time via data-vendor-icon-key assertions. Good coverage. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Config Publisher\n(server)"] -->|"resolvePublicStatusVendorIconKey()"| B["vendor-icon-key.ts\n(server-safe, no UI imports)"]
    B --> C{providerType\noverride?}
    C -- yes --> D["Return mapped key\ne.g. claude→anthropic"]
    C -- no --> E{Explicit\nvendorIconKey?}
    E -- yes, not generic --> F["Return explicit key\nvia RAW_PROVIDER map\nor key set"]
    E -- no / generic --> G["getModelVendor(modelName)\nprefix matching"]
    G --> H{Match\nfound?}
    H -- yes --> I["Return MODEL_VENDOR\nmapped key"]
    H -- no --> J["Return explicitKey ?? 'generic'"]

    K["PublicStatusView\n(client)"] -->|"getPublicStatusVendorIconComponent()"| L["vendor-icon.ts\n(client-only, React components)"]
    L --> B
    L --> M["PUBLIC_STATUS_VENDOR_ICON_REGISTRY\n27+ icon components"]
    M --> N["Icon Component"]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: tighten public status vendor icon r..."](https://github.com/ding113/claude-code-hub/commit/78eac03e1e763768ee6cc7cbae1607e1a6cf33a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29266219)</sub>

<!-- /greptile_comment -->