### PR TITLE
fix: trim nonessential proxy headers

### DIFF
--- a/docs/error-session-id-guide.md
+++ b/docs/error-session-id-guide.md
@@ -4,10 +4,11 @@ When reporting an API error, include the CCH session id so maintainers can locat
 
 ## Where to find it
 
-1. **Preferred**: response header `x-cch-session-id`
-2. **Fallback**: `error.message` suffix `cch_session_id: <id>`
+1. **Primary**: JSON `error.message` suffix `cch_session_id: <id>`
+2. **Note**: proxy 不再返回 `x-cch-session-id` response header
 
-If the response does not include a session id, the server could not determine it for that request.
+If the response does not include a session id suffix, the server either could not determine it for that
+request, or the error response did not normalize into a JSON `error.message` envelope.
 
 ## Example (curl)
 
@@ -21,6 +22,5 @@ curl -i -sS \\
 
 In the response:
 
-- Check header: `x-cch-session-id: ...`
-- If missing, check JSON: `{"error":{"message":"... (cch_session_id: ...)"} }`
-
+- Check JSON: `{"error":{"message":"... (cch_session_id: ...)"} }`
+- Do not expect `x-cch-session-id` header from the proxy anymore

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -4182,11 +4182,15 @@ async function executeProviderApiTest(
   }
 }
 
-function resolveAnthropicAuthHeaders(apiKey: string, providerUrl: string): Record<string, string> {
+function resolveAnthropicAuthHeaders(
+  apiKey: string,
+  providerUrl: string,
+  options?: { forceBearerOnly?: boolean }
+): Record<string, string> {
   return {
     "Content-Type": "application/json",
     "anthropic-version": "2023-06-01",
-    ...resolveAnthropicAuthHeaderSet(apiKey, providerUrl),
+    ...resolveAnthropicAuthHeaderSet(apiKey, providerUrl, options),
   };
 }
 
@@ -5007,7 +5011,9 @@ async function fetchAnthropicModels(
   const url = `${normalizedUrl}/v1/models`;
 
   // 复用认证逻辑：官方 API 用 x-api-key，代理用 Bearer token
-  const authHeaders = resolveAnthropicAuthHeaders(data.apiKey, normalizedUrl);
+  const authHeaders = resolveAnthropicAuthHeaders(data.apiKey, normalizedUrl, {
+    forceBearerOnly: data.providerType === "claude-auth",
+  });
 
   try {
     const response = await executeProxiedFetch(

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -3,6 +3,7 @@
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { GeminiAuth } from "@/app/v1/_lib/gemini/auth";
+import { resolveAnthropicAuthHeaders as resolveAnthropicAuthHeaderSet } from "@/app/v1/_lib/headers";
 import { isClientAbortError } from "@/app/v1/_lib/proxy/errors";
 import { buildProxyUrl } from "@/app/v1/_lib/url";
 import { db } from "@/drizzle/db";
@@ -4181,44 +4182,12 @@ async function executeProviderApiTest(
   }
 }
 
-/**
- * 测试 Anthropic Messages API 连通性
- */
-function getHostnameFromUrl(url: string): string | null {
-  try {
-    return new URL(url).hostname.toLowerCase();
-  } catch {
-    return null;
-  }
-}
-
 function resolveAnthropicAuthHeaders(apiKey: string, providerUrl: string): Record<string, string> {
-  const headers: Record<string, string> = {
+  return {
     "Content-Type": "application/json",
     "anthropic-version": "2023-06-01",
+    ...resolveAnthropicAuthHeaderSet(apiKey, providerUrl),
   };
-
-  const hostname = getHostnameFromUrl(providerUrl);
-  const isOfficialAnthropic = hostname
-    ? hostname.endsWith("anthropic.com") || hostname.endsWith("claude.ai")
-    : false;
-  const looksLikeProxy = hostname
-    ? /proxy|relay|gateway|router|openai|api2d|openrouter|worker|gpt/i.test(hostname)
-    : false;
-
-  if (isOfficialAnthropic) {
-    headers["x-api-key"] = apiKey;
-    return headers;
-  }
-
-  if (looksLikeProxy) {
-    headers.Authorization = `Bearer ${apiKey}`;
-    return headers;
-  }
-
-  headers["x-api-key"] = apiKey;
-  headers.Authorization = `Bearer ${apiKey}`;
-  return headers;
 }
 
 export async function testProviderAnthropicMessages(

--- a/src/app/v1/_lib/headers.ts
+++ b/src/app/v1/_lib/headers.ts
@@ -14,6 +14,43 @@ export interface HeaderProcessorConfig {
   preserveClientIpHeaders?: boolean;
 }
 
+export function looksLikeAnthropicProxyUrl(providerUrl?: string | null): boolean {
+  if (!providerUrl) {
+    return false;
+  }
+
+  try {
+    const hostname = new URL(providerUrl).hostname.toLowerCase();
+    if (hostname.endsWith("anthropic.com") || hostname.endsWith("claude.ai")) {
+      return false;
+    }
+
+    // 只匹配常见 relay/proxy 标识，避免把普通业务域名误识别成代理层。
+    return /(?:^|[.-])(proxy|relay|gateway|router|worker|openrouter|api2d|oaipro)(?:[.-]|$)/i.test(
+      hostname
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function resolveAnthropicAuthHeaders(
+  apiKey: string,
+  providerUrl?: string | null,
+  options?: { forceBearerOnly?: boolean }
+): Record<string, string> {
+  if (options?.forceBearerOnly || looksLikeAnthropicProxyUrl(providerUrl)) {
+    return {
+      Authorization: `Bearer ${apiKey}`,
+    };
+  }
+
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "x-api-key": apiKey,
+  };
+}
+
 /**
  * 代理请求 Header 处理器
  */

--- a/src/app/v1/_lib/headers.ts
+++ b/src/app/v1/_lib/headers.ts
@@ -21,7 +21,12 @@ export function looksLikeAnthropicProxyUrl(providerUrl?: string | null): boolean
 
   try {
     const hostname = new URL(providerUrl).hostname.toLowerCase();
-    if (hostname.endsWith("anthropic.com") || hostname.endsWith("claude.ai")) {
+    if (
+      hostname === "anthropic.com" ||
+      hostname.endsWith(".anthropic.com") ||
+      hostname === "claude.ai" ||
+      hostname.endsWith(".claude.ai")
+    ) {
       return false;
     }
 

--- a/src/app/v1/_lib/proxy/error-handler.ts
+++ b/src/app/v1/_lib/proxy/error-handler.ts
@@ -321,7 +321,7 @@ export class ProxyErrorHandler {
    * - error.limit: 限制值
    * - error.reset_time: 重置时间（ISO-8601格式，滚动窗口为 null）
    *
-   * 响应头（3个标准 rate limit 头）：
+   * 响应头（标准 rate limit 头）：
    * - X-RateLimit-Limit: 限制值
    * - X-RateLimit-Remaining: 剩余配额（max(0, limit - current)）
    * - X-RateLimit-Reset: Unix 时间戳（秒），滚动窗口不设置此头
@@ -338,8 +338,6 @@ export class ProxyErrorHandler {
       // 标准 rate limit 响应头
       "X-RateLimit-Limit": error.limitValue.toString(),
       "X-RateLimit-Remaining": remaining.toString(),
-      // 额外的自定义头（便于客户端快速识别限流类型）
-      "X-RateLimit-Type": error.limitType,
     });
 
     // 只有固定窗口才设置重置时间相关头（滚动窗口 resetTime 为 null）

--- a/src/app/v1/_lib/proxy/error-session-id.ts
+++ b/src/app/v1/_lib/proxy/error-session-id.ts
@@ -14,23 +14,16 @@ export async function attachSessionIdToErrorResponse(
   if (!sessionId) return response;
   if (response.status < 400) return response;
 
-  const headers = new Headers(response.headers);
-  headers.set("x-cch-session-id", sessionId);
-
-  const contentType = headers.get("content-type") || "";
-  if (contentType.includes("text/event-stream")) {
-    return new Response(response.body, { status: response.status, headers });
-  }
-
+  const contentType = response.headers.get("content-type") || "";
   if (!contentType.includes("application/json")) {
-    return new Response(response.body, { status: response.status, headers });
+    return response;
   }
 
   let text: string;
   try {
     text = await response.clone().text();
   } catch {
-    return new Response(response.body, { status: response.status, headers });
+    return response;
   }
 
   try {
@@ -46,11 +39,15 @@ export async function attachSessionIdToErrorResponse(
     ) {
       const p = parsed as { error: { message: string } } & Record<string, unknown>;
       p.error.message = attachSessionIdToErrorMessage(sessionId, p.error.message);
-      return new Response(JSON.stringify(p), { status: response.status, headers });
+      return new Response(JSON.stringify(p), {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
     }
   } catch {
     // best-effort: keep original response body
   }
 
-  return new Response(text, { status: response.status, headers });
+  return response;
 }

--- a/src/app/v1/_lib/proxy/error-session-id.ts
+++ b/src/app/v1/_lib/proxy/error-session-id.ts
@@ -14,7 +14,7 @@ export async function attachSessionIdToErrorResponse(
   if (!sessionId) return response;
   if (response.status < 400) return response;
 
-  const contentType = response.headers.get("content-type") || "";
+  const contentType = response.headers.get("content-type")?.toLowerCase() || "";
   if (!contentType.includes("application/json")) {
     return response;
   }
@@ -39,10 +39,18 @@ export async function attachSessionIdToErrorResponse(
     ) {
       const p = parsed as { error: { message: string } } & Record<string, unknown>;
       p.error.message = attachSessionIdToErrorMessage(sessionId, p.error.message);
+      const headers = new Headers(response.headers);
+      headers.delete("content-length");
+      headers.delete("transfer-encoding");
+      headers.delete("content-encoding");
+      headers.delete("content-range");
+      headers.delete("content-md5");
+      headers.delete("digest");
+      headers.delete("content-digest");
       return new Response(JSON.stringify(p), {
         status: response.status,
         statusText: response.statusText,
-        headers: response.headers,
+        headers,
       });
     }
   } catch {

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -2266,24 +2266,6 @@ export class ProxyForwarder {
         }
       } // end bypassForwarderPreprocessing gate
 
-      processedHeaders = ProxyForwarder.buildHeaders(session, provider);
-
-      if (session.sessionId && session.shouldPersistSessionDebugArtifacts()) {
-        void SessionManager.storeSessionRequestHeaders(
-          session.sessionId,
-          processedHeaders,
-          session.requestSequence
-        ).catch((err) => logger.error("Failed to store request headers:", err));
-      }
-
-      if (process.env.NODE_ENV === "development") {
-        logger.trace("ProxyForwarder: Final request headers", {
-          provider: provider.name,
-          providerType: provider.providerType,
-          headers: Object.fromEntries(processedHeaders.entries()),
-        });
-      }
-
       // ⭐ MCP 透传处理：检测是否为 MCP 请求，并使用相应的 URL
       let effectiveBaseUrl = baseUrl || provider.url;
 
@@ -2341,6 +2323,24 @@ export class ProxyForwarder {
             requestPath,
           }
         );
+      }
+
+      processedHeaders = ProxyForwarder.buildHeaders(session, provider, effectiveBaseUrl);
+
+      if (session.sessionId && session.shouldPersistSessionDebugArtifacts()) {
+        void SessionManager.storeSessionRequestHeaders(
+          session.sessionId,
+          processedHeaders,
+          session.requestSequence
+        ).catch((err) => logger.error("Failed to store request headers:", err));
+      }
+
+      if (process.env.NODE_ENV === "development") {
+        logger.trace("ProxyForwarder: Final request headers", {
+          provider: provider.name,
+          providerType: provider.providerType,
+          headers: Object.fromEntries(processedHeaders.entries()),
+        });
       }
 
       // ⭐ 直接使用原始请求路径，让 buildProxyUrl() 智能处理路径拼接
@@ -4164,7 +4164,8 @@ export class ProxyForwarder {
 
   private static buildHeaders(
     session: ProxySession,
-    provider: NonNullable<typeof session.provider>
+    provider: NonNullable<typeof session.provider>,
+    upstreamBaseUrl: string = provider.url
   ): Headers {
     const outboundKey = provider.key;
     const preserveClientIp = provider.preserveClientIp ?? false;
@@ -4180,7 +4181,7 @@ export class ProxyForwarder {
     if (provider.providerType === "claude-auth" || provider.providerType === "claude") {
       Object.assign(
         overrides,
-        resolveAnthropicAuthHeaders(outboundKey, provider.url, {
+        resolveAnthropicAuthHeaders(outboundKey, upstreamBaseUrl, {
           forceBearerOnly: provider.providerType === "claude-auth",
         })
       );

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -46,7 +46,7 @@ import type {
 
 import { GeminiAuth } from "../gemini/auth";
 import { GEMINI_PROTOCOL } from "../gemini/protocol";
-import { HeaderProcessor } from "../headers";
+import { HeaderProcessor, resolveAnthropicAuthHeaders } from "../headers";
 import { buildProxyUrl } from "../url";
 import { rectifyBillingHeader } from "./billing-header-rectifier";
 import { isStandardProxyEndpointPath } from "./endpoint-family-catalog";
@@ -4173,15 +4173,21 @@ export class ProxyForwarder {
     // 构建请求头覆盖规则
     const overrides: Record<string, string> = {
       host: HeaderProcessor.extractHost(provider.url),
-      authorization: `Bearer ${outboundKey}`,
-      "x-api-key": outboundKey,
       "content-type": "application/json", // 确保 Content-Type
       "accept-encoding": "identity", // 禁用压缩：避免 undici ZlibError（代理应透传原始数据）
     };
 
-    // claude-auth: 移除 x-api-key（避免中转服务冲突）
-    if (provider.providerType === "claude-auth") {
-      delete overrides["x-api-key"];
+    if (provider.providerType === "claude-auth" || provider.providerType === "claude") {
+      Object.assign(
+        overrides,
+        resolveAnthropicAuthHeaders(outboundKey, provider.url, {
+          forceBearerOnly: provider.providerType === "claude-auth",
+        })
+      );
+    }
+
+    if (provider.providerType === "codex" || provider.providerType === "openai-compatible") {
+      overrides.authorization = `Bearer ${outboundKey}`;
     }
 
     // Codex 特殊处理：优先使用过滤器修改的 User-Agent
@@ -4238,14 +4244,13 @@ export class ProxyForwarder {
     }
 
     const headerProcessor = HeaderProcessor.createForProxy({
-      blacklist: OUTBOUND_TRANSPORT_HEADER_BLACKLIST,
+      blacklist: [...OUTBOUND_TRANSPORT_HEADER_BLACKLIST, "x-api-key"],
       preserveClientIpHeaders: preserveClientIp,
       overrides,
     });
 
     return headerProcessor.process(session.headers);
   }
-
   private static buildGeminiHeaders(
     session: ProxySession,
     provider: NonNullable<typeof session.provider>,

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -2327,10 +2327,20 @@ export class ProxyForwarder {
 
       processedHeaders = ProxyForwarder.buildHeaders(session, provider, effectiveBaseUrl);
 
+      // ⭐ 直接使用原始请求路径，让 buildProxyUrl() 智能处理路径拼接
+      // 移除了强制 /v1/responses 路径重写，解决 Issue #139
+      // buildProxyUrl() 会检测 base_url 是否已包含完整路径，避免重复拼接
+      proxyUrl = buildProxyUrl(effectiveBaseUrl, session.requestUrl);
+
+      // Host header must match actual request target for undici TLS cert validation
+      // When provider has multiple endpoints, provider.url and proxyUrl hosts may differ
+      const actualHost = HeaderProcessor.extractHost(proxyUrl);
+      processedHeaders.set("host", actualHost);
+
       if (session.sessionId && session.shouldPersistSessionDebugArtifacts()) {
         void SessionManager.storeSessionRequestHeaders(
           session.sessionId,
-          processedHeaders,
+          new Headers(processedHeaders),
           session.requestSequence
         ).catch((err) => logger.error("Failed to store request headers:", err));
       }
@@ -2342,16 +2352,6 @@ export class ProxyForwarder {
           headers: Object.fromEntries(processedHeaders.entries()),
         });
       }
-
-      // ⭐ 直接使用原始请求路径，让 buildProxyUrl() 智能处理路径拼接
-      // 移除了强制 /v1/responses 路径重写，解决 Issue #139
-      // buildProxyUrl() 会检测 base_url 是否已包含完整路径，避免重复拼接
-      proxyUrl = buildProxyUrl(effectiveBaseUrl, session.requestUrl);
-
-      // Host header must match actual request target for undici TLS cert validation
-      // When provider has multiple endpoints, provider.url and proxyUrl hosts may differ
-      const actualHost = HeaderProcessor.extractHost(proxyUrl);
-      processedHeaders.set("host", actualHost);
 
       logger.debug("ProxyForwarder: Final proxy URL", {
         url: proxyUrl,
@@ -4165,7 +4165,7 @@ export class ProxyForwarder {
   private static buildHeaders(
     session: ProxySession,
     provider: NonNullable<typeof session.provider>,
-    upstreamBaseUrl: string = provider.url
+    upstreamBaseUrl: string
   ): Headers {
     const outboundKey = provider.key;
     const preserveClientIp = provider.preserveClientIp ?? false;
@@ -4173,7 +4173,7 @@ export class ProxyForwarder {
 
     // 构建请求头覆盖规则
     const overrides: Record<string, string> = {
-      host: HeaderProcessor.extractHost(provider.url),
+      host: HeaderProcessor.extractHost(upstreamBaseUrl),
       "content-type": "application/json", // 确保 Content-Type
       "accept-encoding": "identity", // 禁用压缩：避免 undici ZlibError（代理应透传原始数据）
     };

--- a/src/app/v1/_lib/proxy/openai-image-compat.ts
+++ b/src/app/v1/_lib/proxy/openai-image-compat.ts
@@ -910,7 +910,7 @@ export function syncOpenAIImageMultipartFromLogicalBody(
     if (part.kind !== "file") return false;
     if (part.name.startsWith("_")) return false;
     if (PRIMARY_IMAGE_FILE_FIELDS.has(part.name)) return true;
-    return Object.prototype.hasOwnProperty.call(logicalBody, part.name);
+    return Object.hasOwn(logicalBody, part.name);
   });
   const nextTextParts: MultipartTextPart[] = [];
 

--- a/src/app/v1/_lib/proxy/response-fixer/index.ts
+++ b/src/app/v1/_lib/proxy/response-fixer/index.ts
@@ -285,7 +285,6 @@ export class ResponseFixer {
     }
 
     const headers = cleanResponseHeaders(response.headers);
-    headers.set("x-cch-response-fixer", audit.hit ? "applied" : "not-applied");
 
     return new Response(toArrayBufferUint8Array(data), {
       status: response.status,
@@ -326,9 +325,6 @@ export class ResponseFixer {
     const maxBufferBytes = config.maxFixSize;
 
     const headers = cleanResponseHeaders(response.headers);
-    // 流式响应无法在返回 Response 时准确判断是否发生了“实际修复”（需要读完整流）。
-    // 这里使用“processed”表示已启用并参与处理；真实命中情况以 specialSettings 审计为准。
-    headers.set("x-cch-response-fixer", "processed");
 
     const transform = new TransformStream<Uint8Array, Uint8Array>({
       transform(chunk, controller) {

--- a/src/app/v1/_lib/proxy/response-fixer/index.ts
+++ b/src/app/v1/_lib/proxy/response-fixer/index.ts
@@ -42,6 +42,7 @@ function cleanResponseHeaders(headers: Headers): Headers {
   const cleaned = new Headers(headers);
   cleaned.delete("transfer-encoding");
   cleaned.delete("content-length");
+  cleaned.delete("x-cch-response-fixer");
   return cleaned;
 }
 

--- a/src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts
+++ b/src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts
@@ -92,7 +92,10 @@ describe("ResponseFixer", () => {
     const session = createSession();
     const bomJson = new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode('{"a":1}')]);
     const response = new Response(bomJson, {
-      headers: { "content-type": "application/json; charset=utf-8" },
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "x-cch-response-fixer": "applied",
+      },
     });
 
     const fixed = await ResponseFixer.process(session, response);
@@ -122,7 +125,10 @@ describe("ResponseFixer", () => {
     session.shouldPersistSessionDebugArtifacts = () => false;
     const bomJson = new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode('{"a":1}')]);
     const response = new Response(bomJson, {
-      headers: { "content-type": "application/json; charset=utf-8" },
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "x-cch-response-fixer": "applied",
+      },
     });
 
     const fixed = await ResponseFixer.process(session, response);
@@ -148,7 +154,10 @@ describe("ResponseFixer", () => {
     });
 
     const response = new Response(stream, {
-      headers: { "content-type": "text/event-stream" },
+      headers: {
+        "content-type": "text/event-stream",
+        "x-cch-response-fixer": "processed",
+      },
     });
 
     const fixed = await ResponseFixer.process(session, response);

--- a/src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts
+++ b/src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts
@@ -97,7 +97,7 @@ describe("ResponseFixer", () => {
 
     const fixed = await ResponseFixer.process(session, response);
     expect(await fixed.text()).toBe('{"a":1}');
-    expect(fixed.headers.get("x-cch-response-fixer")).toBe("applied");
+    expect(fixed.headers.get("x-cch-response-fixer")).toBeNull();
     expect(session.getSpecialSettings()).not.toBeNull();
     expect(mocks.storeSessionSpecialSettings).toHaveBeenCalledTimes(1);
     expect(mocks.updateMessageRequestDetails).toHaveBeenCalledTimes(1);
@@ -127,7 +127,7 @@ describe("ResponseFixer", () => {
 
     const fixed = await ResponseFixer.process(session, response);
     expect(await fixed.text()).toBe('{"a":1}');
-    expect(fixed.headers.get("x-cch-response-fixer")).toBe("applied");
+    expect(fixed.headers.get("x-cch-response-fixer")).toBeNull();
     expect(session.getSpecialSettings()).not.toBeNull();
     expect(mocks.storeSessionSpecialSettings).not.toHaveBeenCalled();
     expect(mocks.updateMessageRequestDetails).toHaveBeenCalledTimes(1);
@@ -154,7 +154,7 @@ describe("ResponseFixer", () => {
     const fixed = await ResponseFixer.process(session, response);
     const text = await fixed.text();
 
-    expect(fixed.headers.get("x-cch-response-fixer")).toBe("processed");
+    expect(fixed.headers.get("x-cch-response-fixer")).toBeNull();
     expect(text).toBe('data: {"key":null}\n\n');
     expect(session.getSpecialSettings()).not.toBeNull();
   });

--- a/src/app/v1/_lib/proxy/warmup-guard.ts
+++ b/src/app/v1/_lib/proxy/warmup-guard.ts
@@ -42,9 +42,6 @@ export class ProxyWarmupGuard {
 
     const responseHeaders = new Headers({
       "content-type": "application/json; charset=utf-8",
-      // 标注：这是 CCH 抢答的响应（便于客户端/排查）
-      "x-cch-intercepted": "warmup",
-      "x-cch-intercepted-by": "claude-code-hub",
     });
 
     // 尽量把“本地抢答”的响应写入 Session 详情（用于排查/审计）

--- a/tests/unit/proxy/anthropic-auth-headers.test.ts
+++ b/tests/unit/proxy/anthropic-auth-headers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { looksLikeAnthropicProxyUrl, resolveAnthropicAuthHeaders } from "@/app/v1/_lib/headers";
+
+describe("Anthropic auth header helpers", () => {
+  it("treats official Anthropic domains as direct endpoints", () => {
+    expect(looksLikeAnthropicProxyUrl("https://api.anthropic.com/v1/messages")).toBe(false);
+    expect(looksLikeAnthropicProxyUrl("https://console.claude.ai/v1/messages")).toBe(false);
+  });
+
+  it("does not misclassify lookalike domains as official Anthropic", () => {
+    expect(looksLikeAnthropicProxyUrl("https://proxyanthropic.com/v1/messages")).toBe(false);
+    expect(
+      resolveAnthropicAuthHeaders("sk-test", "https://proxyanthropic.com/v1/messages")
+    ).toEqual({
+      Authorization: "Bearer sk-test",
+      "x-api-key": "sk-test",
+    });
+  });
+
+  it("returns bearer-only auth for proxy-like Anthropic endpoints", () => {
+    expect(
+      resolveAnthropicAuthHeaders("sk-test", "https://openrouter.example.com/v1/messages")
+    ).toEqual({
+      Authorization: "Bearer sk-test",
+    });
+  });
+
+  it("honors forceBearerOnly for claude-auth style callsites", () => {
+    expect(
+      resolveAnthropicAuthHeaders("sk-test", "https://api.anthropic.com/v1/messages", {
+        forceBearerOnly: true,
+      })
+    ).toEqual({
+      Authorization: "Bearer sk-test",
+    });
+  });
+});

--- a/tests/unit/proxy/anthropic-auth-headers.test.ts
+++ b/tests/unit/proxy/anthropic-auth-headers.test.ts
@@ -7,7 +7,7 @@ describe("Anthropic auth header helpers", () => {
     expect(looksLikeAnthropicProxyUrl("https://console.claude.ai/v1/messages")).toBe(false);
   });
 
-  it("does not misclassify lookalike domains as official Anthropic", () => {
+  it("treats non-proxy lookalike domains as direct-compatible endpoints", () => {
     expect(looksLikeAnthropicProxyUrl("https://proxyanthropic.com/v1/messages")).toBe(false);
     expect(
       resolveAnthropicAuthHeaders("sk-test", "https://proxyanthropic.com/v1/messages")

--- a/tests/unit/proxy/error-handler-session-id-error.test.ts
+++ b/tests/unit/proxy/error-handler-session-id-error.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "vitest";
 import { ProxyErrorHandler } from "@/app/v1/_lib/proxy/error-handler";
+import { RateLimitError } from "@/app/v1/_lib/proxy/errors";
 
 describe("ProxyErrorHandler.handle - session id on errors", () => {
-  test("decorates error response with x-cch-session-id and message suffix", async () => {
+  test("decorates error response with message suffix only", async () => {
     const session = {
       sessionId: "s_123",
       messageContext: null,
@@ -17,9 +18,74 @@ describe("ProxyErrorHandler.handle - session id on errors", () => {
     const res = await ProxyErrorHandler.handle(session, new Error("boom"));
 
     expect(res.status).toBe(500);
-    expect(res.headers.get("x-cch-session-id")).toBe("s_123");
+    expect(res.headers.get("x-cch-session-id")).toBeNull();
 
     const body = await res.json();
     expect(body.error.message).toBe("boom (cch_session_id: s_123)");
+  });
+
+  test("keeps fixed-window rate-limit headers while removing X-RateLimit-Type", async () => {
+    const session = {
+      sessionId: "s_123",
+      messageContext: null,
+      startTime: Date.now(),
+      getProviderChain: () => [],
+      getCurrentModel: () => null,
+      getContext1mApplied: () => false,
+      getGroupCostMultiplier: () => 1,
+      provider: null,
+    } as any;
+
+    const res = await ProxyErrorHandler.handle(
+      session,
+      new RateLimitError(
+        "rate_limit_error",
+        "limit exceeded",
+        "daily_quota",
+        12,
+        20,
+        "2026-04-22T13:30:00.000Z"
+      )
+    );
+
+    expect(res.status).toBe(402);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("20");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("8");
+    expect(res.headers.get("X-RateLimit-Reset")).toBe("1776864600");
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Type")).toBeNull();
+
+    const body = await res.json();
+    expect(body.error.message).toBe("limit exceeded (cch_session_id: s_123)");
+    expect(body.error.limit_type).toBe("daily_quota");
+  });
+
+  test("keeps rolling-window rate-limit headers while removing X-RateLimit-Type", async () => {
+    const session = {
+      sessionId: "s_123",
+      messageContext: null,
+      startTime: Date.now(),
+      getProviderChain: () => [],
+      getCurrentModel: () => null,
+      getContext1mApplied: () => false,
+      getGroupCostMultiplier: () => 1,
+      provider: null,
+    } as any;
+
+    const res = await ProxyErrorHandler.handle(
+      session,
+      new RateLimitError("rate_limit_error", "too many requests", "rpm", 21, 25, null)
+    );
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("25");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("4");
+    expect(res.headers.get("X-RateLimit-Reset")).toBeNull();
+    expect(res.headers.get("Retry-After")).toBeNull();
+    expect(res.headers.get("X-RateLimit-Type")).toBeNull();
+
+    const body = await res.json();
+    expect(body.error.message).toBe("too many requests (cch_session_id: s_123)");
+    expect(body.error.limit_type).toBe("rpm");
   });
 });

--- a/tests/unit/proxy/hedge-error-pipeline.test.ts
+++ b/tests/unit/proxy/hedge-error-pipeline.test.ts
@@ -121,7 +121,7 @@ describe("handleProxyRequest - hedge terminal error pipeline", async () => {
     const res = await handleProxyRequest({} as any);
 
     expect(res.status).toBe(503);
-    expect(res.headers.get("x-cch-session-id")).toBe("s_hedge");
+    expect(res.headers.get("x-cch-session-id")).toBeNull();
 
     const body = await res.json();
     expect(body.error.message).toBe("所有供应商暂时不可用，请稍后重试 (cch_session_id: s_hedge)");
@@ -129,7 +129,7 @@ describe("handleProxyRequest - hedge terminal error pipeline", async () => {
     expect(body.error.details).toBeUndefined();
   });
 
-  test("命中 error override 时，应返回 override body/status，且保留 session id header", async () => {
+  test("命中 error override 时，应返回 override body/status，并仅保留消息后缀", async () => {
     h.verboseProviderError = true;
     h.override = {
       statusCode: 451,
@@ -145,7 +145,7 @@ describe("handleProxyRequest - hedge terminal error pipeline", async () => {
     const res = await handleProxyRequest({} as any);
 
     expect(res.status).toBe(451);
-    expect(res.headers.get("x-cch-session-id")).toBe("s_hedge");
+    expect(res.headers.get("x-cch-session-id")).toBeNull();
 
     const body = await res.json();
     expect(body).toEqual({

--- a/tests/unit/proxy/proxy-forwarder-host-header-fix.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-host-header-fix.test.ts
@@ -49,6 +49,17 @@ function createSession({
   return session as any;
 }
 
+function buildHeaders(session: ProxySession, provider: Provider): Headers {
+  const forwarder = ProxyForwarder as unknown as {
+    buildHeaders: (session: ProxySession, provider: Provider, upstreamBaseUrl: string) => Headers;
+  };
+  return forwarder.buildHeaders(
+    session,
+    provider,
+    ((provider as { url?: string }).url ?? "https://example.com").toString()
+  );
+}
+
 describe("ProxyForwarder - Host header correction for multi-endpoint providers", () => {
   it("buildHeaders sets Host from provider.url, which may differ from actual target", () => {
     const session = createSession({
@@ -63,9 +74,6 @@ describe("ProxyForwarder - Host header correction for multi-endpoint providers",
       preserveClientIp: false,
     } as unknown as Provider;
 
-    const { buildHeaders } = ProxyForwarder as unknown as {
-      buildHeaders: (session: ProxySession, provider: Provider) => Headers;
-    };
     const resultHeaders = buildHeaders(session, provider);
 
     // buildHeaders uses provider.url for Host
@@ -85,9 +93,6 @@ describe("ProxyForwarder - Host header correction for multi-endpoint providers",
       preserveClientIp: false,
     } as unknown as Provider;
 
-    const { buildHeaders } = ProxyForwarder as unknown as {
-      buildHeaders: (session: ProxySession, provider: Provider) => Headers;
-    };
     const processedHeaders = buildHeaders(session, provider);
 
     // Initial Host from provider.url
@@ -115,9 +120,6 @@ describe("ProxyForwarder - Host header correction for multi-endpoint providers",
       preserveClientIp: false,
     } as unknown as Provider;
 
-    const { buildHeaders } = ProxyForwarder as unknown as {
-      buildHeaders: (session: ProxySession, provider: Provider) => Headers;
-    };
     const processedHeaders = buildHeaders(session, provider);
 
     // Initial Host from provider.url (includes /anthropic path)
@@ -145,9 +147,6 @@ describe("ProxyForwarder - Host header correction for multi-endpoint providers",
       preserveClientIp: false,
     } as unknown as Provider;
 
-    const { buildHeaders } = ProxyForwarder as unknown as {
-      buildHeaders: (session: ProxySession, provider: Provider) => Headers;
-    };
     const processedHeaders = buildHeaders(session, provider);
 
     // Same host, correction is a no-op

--- a/tests/unit/proxy/proxy-forwarder.test.ts
+++ b/tests/unit/proxy/proxy-forwarder.test.ts
@@ -95,9 +95,13 @@ function createGeminiProvider(providerType: "gemini" | "gemini-cli"): Provider {
 
 function buildHeaders(session: ProxySession, provider: Provider): Headers {
   const forwarder = ProxyForwarder as unknown as {
-    buildHeaders: (session: ProxySession, provider: Provider) => Headers;
+    buildHeaders: (session: ProxySession, provider: Provider, upstreamBaseUrl: string) => Headers;
   };
-  return forwarder.buildHeaders(session, provider);
+  return forwarder.buildHeaders(
+    session,
+    provider,
+    ((provider as { url?: string }).url ?? "https://example.com").toString()
+  );
 }
 
 function createAuthLeakSession(): ProxySession {
@@ -120,9 +124,6 @@ describe("ProxyForwarder - buildHeaders User-Agent resolution", () => {
     (session as any).originalHeaders = new Headers([["user-agent", "Original-UA/1.0"]]);
 
     const provider = createCodexProvider();
-    const { buildHeaders } = ProxyForwarder as unknown as {
-      buildHeaders: (session: ProxySession, provider: Provider) => Headers;
-    };
     const resultHeaders = buildHeaders(session, provider);
 
     expect(resultHeaders.get("user-agent")).toBe("Filtered-UA/2.0");
@@ -137,9 +138,6 @@ describe("ProxyForwarder - buildHeaders User-Agent resolution", () => {
     (session as any).originalHeaders = new Headers([["user-agent", "Original-UA/1.0"]]);
 
     const provider = createCodexProvider();
-    const { buildHeaders } = ProxyForwarder as unknown as {
-      buildHeaders: (session: ProxySession, provider: Provider) => Headers;
-    };
     const resultHeaders = buildHeaders(session, provider);
 
     expect(resultHeaders.get("user-agent")).toBe("Original-UA/1.0");
@@ -154,9 +152,6 @@ describe("ProxyForwarder - buildHeaders User-Agent resolution", () => {
     (session as any).originalHeaders = new Headers([["user-agent", "Original-UA/1.0"]]);
 
     const provider = createCodexProvider();
-    const { buildHeaders } = ProxyForwarder as unknown as {
-      buildHeaders: (session: ProxySession, provider: Provider) => Headers;
-    };
     const resultHeaders = buildHeaders(session, provider);
 
     expect(resultHeaders.get("user-agent")).toBe("Original-UA/1.0");
@@ -170,9 +165,6 @@ describe("ProxyForwarder - buildHeaders User-Agent resolution", () => {
     (session as any).originalHeaders = new Headers();
 
     const provider = createCodexProvider();
-    const { buildHeaders } = ProxyForwarder as unknown as {
-      buildHeaders: (session: ProxySession, provider: Provider) => Headers;
-    };
     const resultHeaders = buildHeaders(session, provider);
 
     expect(resultHeaders.get("user-agent")).toBe(DEFAULT_CODEX_USER_AGENT);
@@ -187,9 +179,6 @@ describe("ProxyForwarder - buildHeaders User-Agent resolution", () => {
     (session as any).originalHeaders = new Headers([["user-agent", "Original-UA/1.0"]]);
 
     const provider = createCodexProvider();
-    const { buildHeaders } = ProxyForwarder as unknown as {
-      buildHeaders: (session: ProxySession, provider: Provider) => Headers;
-    };
     const resultHeaders = buildHeaders(session, provider);
 
     // 空字符串应该被保留（使用 ?? 而非 ||）
@@ -208,9 +197,6 @@ describe("ProxyForwarder - buildHeaders User-Agent resolution", () => {
     });
 
     const provider = createCodexProvider();
-    const { buildHeaders } = ProxyForwarder as unknown as {
-      buildHeaders: (session: ProxySession, provider: Provider) => Headers;
-    };
     const resultHeaders = buildHeaders(session, provider);
 
     expect(resultHeaders.get("connection")).toBeNull();

--- a/tests/unit/proxy/proxy-forwarder.test.ts
+++ b/tests/unit/proxy/proxy-forwarder.test.ts
@@ -10,7 +10,6 @@ function createSession({
   userAgent: string | null;
   headers: Headers;
 }): ProxySession {
-  // 使用 ProxySession 的内部构造方法创建测试实例
   const session = Object.create(ProxySession.prototype);
 
   Object.assign(session, {
@@ -18,7 +17,7 @@ function createSession({
     method: "POST",
     requestUrl: new URL("https://example.com/v1/messages"),
     headers,
-    originalHeaders: new Headers(headers), // 同步更新 originalHeaders
+    originalHeaders: new Headers(headers),
     headerLog: JSON.stringify(Object.fromEntries(headers.entries())),
     request: { message: {}, log: "" },
     userAgent,
@@ -40,7 +39,6 @@ function createSession({
     cachedPriceData: undefined,
     cachedBillingModelSource: undefined,
     isHeaderModified: (key: string) => {
-      // 简化的 isHeaderModified 实现
       const original = session.originalHeaders?.get(key);
       const current = session.headers.get(key);
       return original !== current;
@@ -59,6 +57,33 @@ function createCodexProvider(): Provider {
   } as unknown as Provider;
 }
 
+function createOpenAIProvider(): Provider {
+  return {
+    providerType: "openai-compatible",
+    url: "https://openai.example.com/v1/chat/completions",
+    key: "test-outbound-key",
+    preserveClientIp: false,
+  } as unknown as Provider;
+}
+
+function createClaudeProvider(url = "https://api.anthropic.com/v1/messages"): Provider {
+  return {
+    providerType: "claude",
+    url,
+    key: "test-outbound-key",
+    preserveClientIp: false,
+  } as unknown as Provider;
+}
+
+function createClaudeAuthProvider(): Provider {
+  return {
+    providerType: "claude-auth",
+    url: "https://relay.example.com/v1/messages",
+    key: "test-outbound-key",
+    preserveClientIp: false,
+  } as unknown as Provider;
+}
+
 function createGeminiProvider(providerType: "gemini" | "gemini-cli"): Provider {
   return {
     providerType,
@@ -66,6 +91,23 @@ function createGeminiProvider(providerType: "gemini" | "gemini-cli"): Provider {
     key: "test-outbound-key",
     preserveClientIp: false,
   } as unknown as Provider;
+}
+
+function buildHeaders(session: ProxySession, provider: Provider): Headers {
+  const forwarder = ProxyForwarder as unknown as {
+    buildHeaders: (session: ProxySession, provider: Provider) => Headers;
+  };
+  return forwarder.buildHeaders(session, provider);
+}
+
+function createAuthLeakSession(): ProxySession {
+  return createSession({
+    userAgent: "Original-UA/1.0",
+    headers: new Headers([
+      ["authorization", "Bearer proxy-user-bearer-should-not-leak"],
+      ["x-api-key", "proxy-user-key-should-not-leak"],
+    ]),
+  });
 }
 
 describe("ProxyForwarder - buildHeaders User-Agent resolution", () => {
@@ -174,6 +216,66 @@ describe("ProxyForwarder - buildHeaders User-Agent resolution", () => {
     expect(resultHeaders.get("connection")).toBeNull();
     expect(resultHeaders.get("transfer-encoding")).toBeNull();
     expect(resultHeaders.get("content-length")).toBeNull();
+  });
+});
+
+describe("ProxyForwarder - buildHeaders auth minimization", () => {
+  it("codex 应只发送 Authorization，不再默认双发 x-api-key", () => {
+    const resultHeaders = buildHeaders(createAuthLeakSession(), createCodexProvider());
+
+    expect(resultHeaders.get("authorization")).toBe("Bearer test-outbound-key");
+    expect(resultHeaders.get("x-api-key")).toBeNull();
+  });
+
+  it("openai-compatible 应只发送 Authorization，不再默认双发 x-api-key", () => {
+    const resultHeaders = buildHeaders(createAuthLeakSession(), createOpenAIProvider());
+
+    expect(resultHeaders.get("authorization")).toBe("Bearer test-outbound-key");
+    expect(resultHeaders.get("x-api-key")).toBeNull();
+  });
+
+  it("claude-auth 应只发送 Authorization", () => {
+    const resultHeaders = buildHeaders(createAuthLeakSession(), createClaudeAuthProvider());
+
+    expect(resultHeaders.get("authorization")).toBe("Bearer test-outbound-key");
+    expect(resultHeaders.get("x-api-key")).toBeNull();
+  });
+
+  it("claude proxy host 应只发送 Authorization", () => {
+    const resultHeaders = buildHeaders(
+      createAuthLeakSession(),
+      createClaudeProvider("https://proxy.openrouter.example.com/v1/messages")
+    );
+
+    expect(resultHeaders.get("authorization")).toBe("Bearer test-outbound-key");
+    expect(resultHeaders.get("x-api-key")).toBeNull();
+  });
+
+  it("openrouter 风格 host 应被识别为 proxy 并只发送 Authorization", () => {
+    const resultHeaders = buildHeaders(
+      createAuthLeakSession(),
+      createClaudeProvider("https://openrouter.example.com/v1/messages")
+    );
+
+    expect(resultHeaders.get("authorization")).toBe("Bearer test-outbound-key");
+    expect(resultHeaders.get("x-api-key")).toBeNull();
+  });
+
+  it("非代理 claude 直连仍保留双头兼容性", () => {
+    const resultHeaders = buildHeaders(createAuthLeakSession(), createClaudeProvider());
+
+    expect(resultHeaders.get("authorization")).toBe("Bearer test-outbound-key");
+    expect(resultHeaders.get("x-api-key")).toBe("test-outbound-key");
+  });
+
+  it("普通自定义域名的 claude endpoint 仍保留双头兼容性", () => {
+    const resultHeaders = buildHeaders(
+      createAuthLeakSession(),
+      createClaudeProvider("https://models.partner.example.com/v1/messages")
+    );
+
+    expect(resultHeaders.get("authorization")).toBe("Bearer test-outbound-key");
+    expect(resultHeaders.get("x-api-key")).toBe("test-outbound-key");
   });
 });
 

--- a/tests/unit/proxy/proxy-handler-session-id-error.test.ts
+++ b/tests/unit/proxy/proxy-handler-session-id-error.test.ts
@@ -105,10 +105,22 @@ vi.mock("@/lib/proxy-status-tracker", () => ({
   },
 }));
 
+async function expectMessageSuffixOnly(
+  response: Response,
+  expectedStatus: number,
+  expectedMessage: string
+) {
+  expect(response.status).toBe(expectedStatus);
+  expect(response.headers.get("x-cch-session-id")).toBeNull();
+
+  const body = await response.json();
+  expect(body.error.message).toBe(`${expectedMessage} (cch_session_id: s_123)`);
+}
+
 describe("handleProxyRequest - session id on errors", async () => {
   const { handleProxyRequest } = await import("@/app/v1/_lib/proxy-handler");
 
-  test("decorates early error response with x-cch-session-id and message suffix", async () => {
+  test("decorates early error response with message suffix only", async () => {
     h.fromContextError = null;
     h.session.originalFormat = "openai";
     h.endpointFormat = null;
@@ -117,14 +129,10 @@ describe("handleProxyRequest - session id on errors", async () => {
     h.earlyResponse = ProxyResponses.buildError(400, "bad request");
     const res = await handleProxyRequest({} as any);
 
-    expect(res.status).toBe(400);
-    expect(res.headers.get("x-cch-session-id")).toBe("s_123");
-
-    const body = await res.json();
-    expect(body.error.message).toBe("bad request (cch_session_id: s_123)");
+    await expectMessageSuffixOnly(res, 400, "bad request");
   });
 
-  test("decorates dispatch error response with x-cch-session-id and message suffix", async () => {
+  test("decorates dispatch error response with message suffix only", async () => {
     h.fromContextError = null;
     h.session.originalFormat = "openai";
     h.endpointFormat = null;
@@ -136,11 +144,7 @@ describe("handleProxyRequest - session id on errors", async () => {
 
     const res = await handleProxyRequest({} as any);
 
-    expect(res.status).toBe(502);
-    expect(res.headers.get("x-cch-session-id")).toBe("s_123");
-
-    const body = await res.json();
-    expect(body.error.message).toBe("bad gateway (cch_session_id: s_123)");
+    await expectMessageSuffixOnly(res, 502, "bad gateway");
   });
 
   test("covers claude format detection branch without breaking behavior", async () => {
@@ -154,8 +158,7 @@ describe("handleProxyRequest - session id on errors", async () => {
     h.session.request = { model: "gpt", message: { contents: [] } };
 
     const res = await handleProxyRequest({} as any);
-    expect(res.status).toBe(400);
-    expect(res.headers.get("x-cch-session-id")).toBe("s_123");
+    await expectMessageSuffixOnly(res, 400, "bad request");
   });
 
   test("covers endpoint format detection + tracking + finally decrement", async () => {
@@ -187,10 +190,7 @@ describe("handleProxyRequest - session id on errors", async () => {
       pathname: V1_ENDPOINT_PATHS.RESPONSES_COMPACT,
       isCountTokensRequest: false,
     },
-  ])("RED: raw endpoint $pathname 应统一跳过并发计数（Wave2 未实现前会失败）", async ({
-    pathname,
-    isCountTokensRequest,
-  }) => {
+  ])("raw endpoint $pathname 应统一跳过并发计数", async ({ pathname, isCountTokensRequest }) => {
     h.fromContextError = null;
     h.session.originalFormat = "claude";
     h.endpointFormat = "openai";

--- a/tests/unit/proxy/responses-session-id.test.ts
+++ b/tests/unit/proxy/responses-session-id.test.ts
@@ -3,12 +3,12 @@ import { ProxyResponses } from "@/app/v1/_lib/proxy/responses";
 import { attachSessionIdToErrorResponse } from "@/app/v1/_lib/proxy/error-session-id";
 
 describe("ProxyResponses.attachSessionIdToErrorResponse", () => {
-  test("adds x-cch-session-id and appends to error.message for JSON error responses", async () => {
+  test("appends to error.message for JSON error responses without exposing header", async () => {
     const response = ProxyResponses.buildError(400, "bad request");
     const decorated = await attachSessionIdToErrorResponse("s_123", response);
 
     expect(decorated.status).toBe(400);
-    expect(decorated.headers.get("x-cch-session-id")).toBe("s_123");
+    expect(decorated.headers.get("x-cch-session-id")).toBeNull();
 
     const body = await decorated.json();
     expect(body.error.message).toBe("bad request (cch_session_id: s_123)");
@@ -39,37 +39,36 @@ describe("ProxyResponses.attachSessionIdToErrorResponse", () => {
     expect(body.error.message).toBe("bad request (cch_session_id: s_123)");
   });
 
-  test("adds header for non-json error responses (body unchanged)", async () => {
+  test("does not rewrite non-json error responses", async () => {
     const response = new Response("oops", {
       status: 500,
       headers: { "Content-Type": "text/plain" },
     });
     const decorated = await attachSessionIdToErrorResponse("s_123", response);
 
-    expect(decorated.status).toBe(500);
-    expect(decorated.headers.get("x-cch-session-id")).toBe("s_123");
+    expect(decorated).toBe(response);
     expect(await decorated.text()).toBe("oops");
   });
 
-  test("adds header for json without error.message (body unchanged)", async () => {
+  test("does not rewrite json without error.message", async () => {
     const response = new Response(JSON.stringify({ foo: "bar" }), {
       status: 500,
       headers: { "Content-Type": "application/json" },
     });
     const decorated = await attachSessionIdToErrorResponse("s_123", response);
 
-    expect(decorated.headers.get("x-cch-session-id")).toBe("s_123");
+    expect(decorated).toBe(response);
     expect(await decorated.json()).toEqual({ foo: "bar" });
   });
 
-  test("adds header for SSE error responses (no body rewrite)", async () => {
+  test("does not rewrite SSE error responses", async () => {
     const response = new Response("data: hi\n\n", {
       status: 500,
       headers: { "Content-Type": "text/event-stream" },
     });
     const decorated = await attachSessionIdToErrorResponse("s_123", response);
 
-    expect(decorated.headers.get("x-cch-session-id")).toBe("s_123");
+    expect(decorated).toBe(response);
     expect(await decorated.text()).toBe("data: hi\n\n");
   });
 });

--- a/tests/unit/proxy/warmup-guard.test.ts
+++ b/tests/unit/proxy/warmup-guard.test.ts
@@ -129,8 +129,8 @@ describe("ProxyWarmupGuard.ensure", () => {
     expect(result).not.toBeNull();
     expect(result?.status).toBe(200);
     expect(result?.headers.get("content-type")).toContain("application/json");
-    expect(result?.headers.get("x-cch-intercepted")).toBe("warmup");
-    expect(result?.headers.get("x-cch-intercepted-by")).toBe("claude-code-hub");
+    expect(result?.headers.get("x-cch-intercepted")).toBeNull();
+    expect(result?.headers.get("x-cch-intercepted-by")).toBeNull();
 
     const body = await result!.json();
     expect(body).toEqual(


### PR DESCRIPTION
## Summary
Remove client-visible nonessential proxy debug headers and optimize Anthropic authentication header logic to reduce header fan-out and improve compatibility with various proxy configurations.

### Key Changes

#### Removed Response Headers
The following internal debug headers are no longer returned to clients:

| Header | Location | Reason |
|--------|----------|--------|
| `x-cch-response-fixer` | `response-fixer/index.ts` | Internal debug signal not needed by clients |
| `x-cch-intercepted` | `warmup-guard.ts` | Marked CCH-generated warmup responses |
| `x-cch-intercepted-by` | `warmup-guard.ts` | Redundant debug attribution |
| `X-RateLimit-Type` | `error-handler.ts` | Non-standard header; type info available in error body |
| `x-cch-session-id` | `error-session-id.ts` | Moved to message suffix only (see below) |

#### Session ID Handling
- **Changed**: Session ID (`cch_session_id`) is now attached **only** to the `error.message` suffix
- **Before**: Both `x-cch-session-id` response header AND message suffix
- **After**: Message suffix `(cch_session_id: <id>)` only
- **Impact**: Reduces response header footprint while maintaining debuggability via error messages

#### Anthropic Auth Header Optimization (`src/app/v1/_lib/headers.ts`)
New intelligent auth header resolution for Anthropic providers:

- **Proxy detection**: Added `looksLikeAnthropicProxyUrl()` to identify relay/proxy/gateway endpoints
- **Smart header selection**:
  - Proxy endpoints (OpenRouter, API2D, custom relays): Send only `Authorization: Bearer <key>`
  - Official Anthropic endpoints (`anthropic.com`, `claude.ai`): Send both `Authorization` and `x-api-key` for compatibility
- **Benefit**: Reduces header fan-out that can cause issues with some proxy services

#### Provider API Test Alignment (`src/actions/providers.ts`)
- Refactored Anthropic provider testing to use shared `resolveAnthropicAuthHeaders` from `headers.ts`
- Ensures consistent auth logic between runtime proxy and provider health checks

#### Minor Improvements
- Modernized `Object.prototype.hasOwnProperty.call()` → `Object.hasOwn()` in `openai-image-compat.ts`

## Validation
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bunx vitest run tests/unit/proxy/proxy-forwarder.test.ts tests/unit/proxy/responses-session-id.test.ts tests/unit/proxy/proxy-handler-session-id-error.test.ts tests/unit/proxy/error-handler-session-id-error.test.ts tests/unit/proxy/hedge-error-pipeline.test.ts tests/unit/proxy/warmup-guard.test.ts src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts tests/unit/proxy/openai-image-forwarder-constraints.test.ts`

## Files Changed
- `src/app/v1/_lib/headers.ts` (+37 lines) - New Anthropic auth utilities
- `src/app/v1/_lib/proxy/forwarder.ts` (+13/-8) - Use new auth header resolution
- `src/app/v1/_lib/proxy/error-handler.ts` (+1/-3) - Remove X-RateLimit-Type header
- `src/app/v1/_lib/proxy/error-session-id.ts` (+9/-12) - Remove x-cch-session-id header
- `src/app/v1/_lib/proxy/response-fixer/index.ts` (-4 lines) - Remove debug header
- `src/app/v1/_lib/proxy/warmup-guard.ts` (-3 lines) - Remove debug headers
- `src/actions/providers.ts` (+3/-34) - Use shared auth logic
- `src/app/v1/_lib/proxy/openai-image-compat.ts` (+1/-1) - Modernize hasOwn check
- `docs/error-session-id-guide.md` (+6/-6) - Update documentation
- Various test files - Update assertions for removed headers

## Caveat
- `bun run test` is still blocked by the pre-existing `src/components/ui/__tests__/map.test.tsx` OOM. I reproduced the same failure on the untouched `dev` checkout with `NODE_OPTIONS='--max-old-space-size=8192' bunx vitest run src/components/ui/__tests__/map.test.tsx --pool=forks --maxWorkers=1`, so this PR does not introduce that blocker.

---
*Description enhanced with additional technical details*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR trims several internal debug response headers (`x-cch-response-fixer`, `x-cch-intercepted`, `x-cch-intercepted-by`, `X-RateLimit-Type`, `x-cch-session-id`) and refactors Anthropic auth-header resolution into a shared utility (`resolveAnthropicAuthHeaders`) that selects between bearer-only and dual-header modes based on URL heuristics. All changes are backed by updated or new unit tests, and the documentation is kept in sync.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all current provider types are handled correctly and the test suite validates the new behaviour end-to-end.

No P0/P1 issues found. The only finding is a P2 style suggestion about adding a defensive fallback for future provider types in `buildHeaders`. All logic changes are unit-tested, the header-minimisation approach is sound, and the `HeaderProcessor` correctly lowercases override keys so the `Authorization`/`authorization` casing difference is harmless.

No files require special attention, though the `buildHeaders` auth-dispatch block in `forwarder.ts` would benefit from a defensive fallback as noted.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/headers.ts | Adds `looksLikeAnthropicProxyUrl()` (regex-based proxy detection) and `resolveAnthropicAuthHeaders()` (smart bearer-vs-dual-header selection); both are exported and tested. |
| src/app/v1/_lib/proxy/forwarder.ts | `buildHeaders` now takes `upstreamBaseUrl`, gates auth-header injection per provider type, and moves header storage/logging after the effective URL is resolved; auth logic for unrecognised provider types falls through silently with no auth set. |
| src/app/v1/_lib/proxy/error-session-id.ts | Drops `x-cch-session-id` header; now only rewrites JSON error bodies, returns original response unchanged for SSE/non-JSON. Correctly strips stale content headers (length, encoding, digest) when body is re-serialised. |
| src/actions/providers.ts | Removes ~30-line local `resolveAnthropicAuthHeaders` wrapper and delegates to the shared one from `headers.ts`; behaviour is equivalent for all current call-sites. |
| src/app/v1/_lib/proxy/error-handler.ts | Removes non-standard `X-RateLimit-Type` response header; type info still surfaced in JSON body as `error.limit_type`. |
| tests/unit/proxy/anthropic-auth-headers.test.ts | New unit tests covering proxy-URL detection and auth-header resolution logic; includes edge cases for `forceBearerOnly` and boundary hostnames. |
| tests/unit/proxy/proxy-forwarder.test.ts | Adds provider factories and a `buildHeaders` helper reflecting new three-arg signature; new suite verifies auth minimisation for codex, openai-compatible, claude, and claude-auth provider types. |
| src/app/v1/_lib/proxy/warmup-guard.ts | Removes `x-cch-intercepted` and `x-cch-intercepted-by` debug response headers from warmup intercept responses. |
| src/app/v1/_lib/proxy/response-fixer/index.ts | Removes `x-cch-response-fixer` debug header from both buffered and streaming responses; `cleanResponseHeaders` also deletes it if present on the incoming response. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildHeaders called\nwith upstreamBaseUrl] --> B{providerType?}
    B -->|claude| C[resolveAnthropicAuthHeaders]
    B -->|claude-auth| C
    C --> D{looksLikeAnthropicProxyUrl?}
    D -->|yes| E[Authorization: Bearer only]
    D -->|no| F[Authorization + x-api-key]
    B -->|codex| G[Authorization: Bearer only]
    B -->|openai-compatible| G
    B -->|gemini / gemini-cli| H[buildGeminiHeaders — separate path]
    B -->|other / future type| I[⚠️ No auth header set]
    E --> J[HeaderProcessor\nx-api-key blacklisted]
    F --> J
    G --> J
    J --> K[Final outbound Headers]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/forwarder.ts
Line: 4181-4192

Comment:
**Silent auth drop for unlisted provider types**

The previous code defaulted to `authorization: Bearer ${outboundKey}` for every provider that passed through `buildHeaders`. The new code only injects auth headers for the four explicitly named types (`claude`, `claude-auth`, `codex`, `openai-compatible`). Any future provider type routed here — without a corresponding branch — will reach the upstream with **no** auth header at all, and the failure will be a silent 401 from the upstream rather than a local error.

Adding a fallback `else` that at minimum warns (or sends the bearer token) would make the invariant explicit:

```ts
} else if (
  provider.providerType !== "gemini" &&
  provider.providerType !== "gemini-cli"
) {
  // Fallback: send bearer token for any unrecognised non-Gemini type
  overrides.authorization = `Bearer ${outboundKey}`;
  logger.warn("buildHeaders: unrecognised providerType, falling back to Bearer auth", {
    providerType: provider.providerType,
  });
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["test: fix forwarder host header helpers"](https://github.com/ding113/claude-code-hub/commit/3ba5eeb6dada46c302e0f66f2bafe6ad9af15ca3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29274951)</sub>

<!-- /greptile_comment -->