### PR TITLE
feat(status): redesign /status page aligning to check-cx UI

### DIFF
--- a/messages/en/settings/statusPage.json
+++ b/messages/en/settings/statusPage.json
@@ -83,6 +83,7 @@
     "resetSort": "Reset order",
     "emptyByFilter": "No groups or models match your filter",
     "modelsLabel": "models",
-    "issuesLabel": "issues"
+    "issuesLabel": "issues",
+    "clearSearch": "Clear search"
   }
 }

--- a/messages/en/settings/statusPage.json
+++ b/messages/en/settings/statusPage.json
@@ -63,6 +63,26 @@
       "codex": "Codex",
       "anthropic": "Anthropic",
       "gemini": "Gemini"
-    }
+    },
+    "statusBadge": {
+      "operational": "Operational",
+      "degraded": "Degraded",
+      "failed": "Failed",
+      "noData": "No data"
+    },
+    "tooltip": {
+      "timeRange": "Time",
+      "availability": "Availability",
+      "ttfb": "TTFB",
+      "tps": "TPS",
+      "samples": "Samples",
+      "inferredFromNeighbors": "No requests in this window — inferred from neighbors"
+    },
+    "searchPlaceholder": "Search groups or models",
+    "customSort": "Custom sort",
+    "resetSort": "Reset order",
+    "emptyByFilter": "No groups or models match your filter",
+    "modelsLabel": "models",
+    "issuesLabel": "issues"
   }
 }

--- a/messages/en/settings/statusPage.json
+++ b/messages/en/settings/statusPage.json
@@ -71,12 +71,12 @@
       "noData": "No data"
     },
     "tooltip": {
-      "timeRange": "Time",
       "availability": "Availability",
       "ttfb": "TTFB",
       "tps": "TPS",
       "samples": "Samples",
-      "inferredFromNeighbors": "No requests in this window — inferred from neighbors"
+      "inferredFromNeighbors": "No requests in this window — inferred from neighbors",
+      "historyAriaLabel": "Status history timeline"
     },
     "searchPlaceholder": "Search groups or models",
     "customSort": "Custom sort",
@@ -84,6 +84,7 @@
     "emptyByFilter": "No groups or models match your filter",
     "modelsLabel": "models",
     "issuesLabel": "issues",
-    "clearSearch": "Clear search"
+    "clearSearch": "Clear search",
+    "dragHandle": "Drag to reorder"
   }
 }

--- a/messages/ja/settings/statusPage.json
+++ b/messages/ja/settings/statusPage.json
@@ -83,6 +83,7 @@
     "resetSort": "既定の順序に戻す",
     "emptyByFilter": "条件に一致するグループまたはモデルがありません",
     "modelsLabel": "モデル",
-    "issuesLabel": "異常"
+    "issuesLabel": "異常",
+    "clearSearch": "検索をクリア"
   }
 }

--- a/messages/ja/settings/statusPage.json
+++ b/messages/ja/settings/statusPage.json
@@ -71,12 +71,12 @@
       "noData": "データなし"
     },
     "tooltip": {
-      "timeRange": "期間",
       "availability": "可用率",
       "ttfb": "TTFB",
       "tps": "TPS",
       "samples": "サンプル数",
-      "inferredFromNeighbors": "この期間はリクエストがないため、隣接データから推定"
+      "inferredFromNeighbors": "この期間はリクエストがないため、隣接データから推定",
+      "historyAriaLabel": "状態履歴タイムライン"
     },
     "searchPlaceholder": "グループまたはモデルを検索",
     "customSort": "カスタム並び順",
@@ -84,6 +84,7 @@
     "emptyByFilter": "条件に一致するグループまたはモデルがありません",
     "modelsLabel": "モデル",
     "issuesLabel": "異常",
-    "clearSearch": "検索をクリア"
+    "clearSearch": "検索をクリア",
+    "dragHandle": "ドラッグして並べ替え"
   }
 }

--- a/messages/ja/settings/statusPage.json
+++ b/messages/ja/settings/statusPage.json
@@ -63,6 +63,26 @@
       "codex": "Codex",
       "anthropic": "Anthropic",
       "gemini": "Gemini"
-    }
+    },
+    "statusBadge": {
+      "operational": "正常",
+      "degraded": "低下",
+      "failed": "障害",
+      "noData": "データなし"
+    },
+    "tooltip": {
+      "timeRange": "期間",
+      "availability": "可用率",
+      "ttfb": "TTFB",
+      "tps": "TPS",
+      "samples": "サンプル数",
+      "inferredFromNeighbors": "この期間はリクエストがないため、隣接データから推定"
+    },
+    "searchPlaceholder": "グループまたはモデルを検索",
+    "customSort": "カスタム並び順",
+    "resetSort": "既定の順序に戻す",
+    "emptyByFilter": "条件に一致するグループまたはモデルがありません",
+    "modelsLabel": "モデル",
+    "issuesLabel": "異常"
   }
 }

--- a/messages/ru/settings/statusPage.json
+++ b/messages/ru/settings/statusPage.json
@@ -63,6 +63,26 @@
       "codex": "Codex",
       "anthropic": "Anthropic",
       "gemini": "Gemini"
-    }
+    },
+    "statusBadge": {
+      "operational": "Доступно",
+      "degraded": "Деградация",
+      "failed": "Ошибка",
+      "noData": "Нет данных"
+    },
+    "tooltip": {
+      "timeRange": "Период",
+      "availability": "Доступность",
+      "ttfb": "TTFB",
+      "tps": "TPS",
+      "samples": "Выборки",
+      "inferredFromNeighbors": "Запросов нет — состояние выведено из соседних интервалов"
+    },
+    "searchPlaceholder": "Поиск групп или моделей",
+    "customSort": "Произвольный порядок",
+    "resetSort": "Сбросить порядок",
+    "emptyByFilter": "Нет групп или моделей, соответствующих фильтру",
+    "modelsLabel": "моделей",
+    "issuesLabel": "проблем"
   }
 }

--- a/messages/ru/settings/statusPage.json
+++ b/messages/ru/settings/statusPage.json
@@ -71,12 +71,12 @@
       "noData": "Нет данных"
     },
     "tooltip": {
-      "timeRange": "Период",
       "availability": "Доступность",
       "ttfb": "TTFB",
       "tps": "TPS",
       "samples": "Выборки",
-      "inferredFromNeighbors": "Запросов нет — состояние выведено из соседних интервалов"
+      "inferredFromNeighbors": "Запросов нет — состояние выведено из соседних интервалов",
+      "historyAriaLabel": "История статуса"
     },
     "searchPlaceholder": "Поиск групп или моделей",
     "customSort": "Произвольный порядок",
@@ -84,6 +84,7 @@
     "emptyByFilter": "Нет групп или моделей, соответствующих фильтру",
     "modelsLabel": "моделей",
     "issuesLabel": "проблем",
-    "clearSearch": "Очистить поиск"
+    "clearSearch": "Очистить поиск",
+    "dragHandle": "Перетащить"
   }
 }

--- a/messages/ru/settings/statusPage.json
+++ b/messages/ru/settings/statusPage.json
@@ -83,6 +83,7 @@
     "resetSort": "Сбросить порядок",
     "emptyByFilter": "Нет групп или моделей, соответствующих фильтру",
     "modelsLabel": "моделей",
-    "issuesLabel": "проблем"
+    "issuesLabel": "проблем",
+    "clearSearch": "Очистить поиск"
   }
 }

--- a/messages/zh-CN/settings/statusPage.json
+++ b/messages/zh-CN/settings/statusPage.json
@@ -83,6 +83,7 @@
     "resetSort": "恢复默认顺序",
     "emptyByFilter": "未匹配到任何分组或模型",
     "modelsLabel": "模型",
-    "issuesLabel": "异常"
+    "issuesLabel": "异常",
+    "clearSearch": "清除搜索"
   }
 }

--- a/messages/zh-CN/settings/statusPage.json
+++ b/messages/zh-CN/settings/statusPage.json
@@ -63,6 +63,26 @@
       "codex": "Codex",
       "anthropic": "Anthropic",
       "gemini": "Gemini"
-    }
+    },
+    "statusBadge": {
+      "operational": "可用",
+      "degraded": "降级",
+      "failed": "错误",
+      "noData": "无数据"
+    },
+    "tooltip": {
+      "timeRange": "时段",
+      "availability": "可用率",
+      "ttfb": "TTFB",
+      "tps": "TPS",
+      "samples": "样本数",
+      "inferredFromNeighbors": "该时段无请求，根据相邻时段状态推断"
+    },
+    "searchPlaceholder": "搜索分组或模型",
+    "customSort": "自定义排序",
+    "resetSort": "恢复默认顺序",
+    "emptyByFilter": "未匹配到任何分组或模型",
+    "modelsLabel": "模型",
+    "issuesLabel": "异常"
   }
 }

--- a/messages/zh-CN/settings/statusPage.json
+++ b/messages/zh-CN/settings/statusPage.json
@@ -71,12 +71,12 @@
       "noData": "无数据"
     },
     "tooltip": {
-      "timeRange": "时段",
       "availability": "可用率",
       "ttfb": "TTFB",
       "tps": "TPS",
       "samples": "样本数",
-      "inferredFromNeighbors": "该时段无请求，根据相邻时段状态推断"
+      "inferredFromNeighbors": "该时段无请求，根据相邻时段状态推断",
+      "historyAriaLabel": "状态历史时间轴"
     },
     "searchPlaceholder": "搜索分组或模型",
     "customSort": "自定义排序",
@@ -84,6 +84,7 @@
     "emptyByFilter": "未匹配到任何分组或模型",
     "modelsLabel": "模型",
     "issuesLabel": "异常",
-    "clearSearch": "清除搜索"
+    "clearSearch": "清除搜索",
+    "dragHandle": "拖动重排"
   }
 }

--- a/messages/zh-TW/settings/statusPage.json
+++ b/messages/zh-TW/settings/statusPage.json
@@ -71,12 +71,12 @@
       "noData": "無資料"
     },
     "tooltip": {
-      "timeRange": "時段",
       "availability": "可用率",
       "ttfb": "TTFB",
       "tps": "TPS",
       "samples": "樣本數",
-      "inferredFromNeighbors": "該時段無請求，依相鄰時段狀態推斷"
+      "inferredFromNeighbors": "該時段無請求，依相鄰時段狀態推斷",
+      "historyAriaLabel": "狀態歷史時間軸"
     },
     "searchPlaceholder": "搜尋分組或模型",
     "customSort": "自訂排序",
@@ -84,6 +84,7 @@
     "emptyByFilter": "未匹配到任何分組或模型",
     "modelsLabel": "模型",
     "issuesLabel": "異常",
-    "clearSearch": "清除搜尋"
+    "clearSearch": "清除搜尋",
+    "dragHandle": "拖曳重排"
   }
 }

--- a/messages/zh-TW/settings/statusPage.json
+++ b/messages/zh-TW/settings/statusPage.json
@@ -63,6 +63,26 @@
       "codex": "Codex",
       "anthropic": "Anthropic",
       "gemini": "Gemini"
-    }
+    },
+    "statusBadge": {
+      "operational": "可用",
+      "degraded": "降級",
+      "failed": "錯誤",
+      "noData": "無資料"
+    },
+    "tooltip": {
+      "timeRange": "時段",
+      "availability": "可用率",
+      "ttfb": "TTFB",
+      "tps": "TPS",
+      "samples": "樣本數",
+      "inferredFromNeighbors": "該時段無請求，依相鄰時��狀態推斷"
+    },
+    "searchPlaceholder": "搜尋分組或模型",
+    "customSort": "自訂排序",
+    "resetSort": "恢復預設順序",
+    "emptyByFilter": "未匹配到任何分組或模型",
+    "modelsLabel": "模型",
+    "issuesLabel": "異常"
   }
 }

--- a/messages/zh-TW/settings/statusPage.json
+++ b/messages/zh-TW/settings/statusPage.json
@@ -76,13 +76,14 @@
       "ttfb": "TTFB",
       "tps": "TPS",
       "samples": "樣本數",
-      "inferredFromNeighbors": "該時段無請求，依相鄰時��狀態推斷"
+      "inferredFromNeighbors": "該時段無請求，依相鄰時段狀態推斷"
     },
     "searchPlaceholder": "搜尋分組或模型",
     "customSort": "自訂排序",
     "resetSort": "恢復預設順序",
     "emptyByFilter": "未匹配到任何分組或模型",
     "modelsLabel": "模型",
-    "issuesLabel": "異常"
+    "issuesLabel": "異常",
+    "clearSearch": "清除搜尋"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
   "dependencies": {
     "@bull-board/api": "^6",
     "@bull-board/express": "^6",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hono/swagger-ui": "^0.5",
     "@hono/zod-openapi": "^1",
     "@hookform/resolvers": "^5",

--- a/src/app/[locale]/status/_components/public-status-timeline.tsx
+++ b/src/app/[locale]/status/_components/public-status-timeline.tsx
@@ -107,7 +107,7 @@ export function PublicStatusTimeline({
                   <span className="text-muted-foreground">{labels.samples}</span>
                   <span className="text-right">{bucket.sampleCount}</span>
                 </div>
-                {bucket.sampleCount === 0 && !isPlaceholder ? (
+                {inferred && !isPlaceholder ? (
                   <p className="text-[10px] text-muted-foreground">
                     {labels.inferredFromNeighbors}
                   </p>

--- a/src/app/[locale]/status/_components/public-status-timeline.tsx
+++ b/src/app/[locale]/status/_components/public-status-timeline.tsx
@@ -1,55 +1,122 @@
 "use client";
 
-import type { PublicStatusTimelineBucket } from "@/lib/public-status/payload";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import type { FilledTimelineCell } from "../_lib/fill-display-timeline";
+
+export interface PublicStatusTimelineLabels {
+  availability: string;
+  ttfb: string;
+  tps: string;
+  samples: string;
+  inferredFromNeighbors: string;
+  noData: string;
+}
 
 interface PublicStatusTimelineProps {
-  items: PublicStatusTimelineBucket[];
+  cells: FilledTimelineCell[];
+  timeZone: string;
+  locale: string;
+  labels: PublicStatusTimelineLabels;
 }
 
-function normalizeItems(items: PublicStatusTimelineBucket[]): PublicStatusTimelineBucket[] {
-  if (items.length >= 60) {
-    return items.slice(-60);
+function cellColor(state: FilledTimelineCell["displayState"], inferred: boolean): string {
+  switch (state) {
+    case "operational":
+      return inferred ? "bg-emerald-500/60" : "bg-emerald-500";
+    case "degraded":
+      return inferred ? "bg-amber-500/60" : "bg-amber-500";
+    case "failed":
+      return inferred ? "bg-rose-500/60" : "bg-rose-500";
+    default:
+      return "bg-muted/40";
   }
-
-  const fillers = Array.from({ length: 60 - items.length }, (_, index) => ({
-    bucketStart: `filler-${index}`,
-    bucketEnd: `filler-${index}`,
-    state: "no_data" as const,
-    availabilityPct: null,
-    ttfbMs: null,
-    tps: null,
-    sampleCount: 0,
-  }));
-
-  return [...fillers, ...items];
 }
 
-function getBucketClassName(state: PublicStatusTimelineBucket["state"]): string {
-  if (state === "operational") {
-    return "bg-emerald-500/80";
+function formatRange(start: string, end: string, locale: string, timeZone: string): string {
+  try {
+    const fmt = new Intl.DateTimeFormat(locale, {
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone,
+      hour12: false,
+    });
+    const dateFmt = new Intl.DateTimeFormat(locale, {
+      month: "short",
+      day: "2-digit",
+      timeZone,
+    });
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    if (Number.isNaN(startDate.getTime())) return start;
+    return `${dateFmt.format(startDate)} ${fmt.format(startDate)} – ${fmt.format(endDate)}`;
+  } catch {
+    return `${start} – ${end}`;
   }
-  if (state === "failed") {
-    return "bg-rose-500/80";
-  }
-  return "bg-muted";
 }
 
-export function PublicStatusTimeline({ items }: PublicStatusTimelineProps) {
-  const normalized = normalizeItems(items);
-
+export function PublicStatusTimeline({
+  cells,
+  timeZone,
+  locale,
+  labels,
+}: PublicStatusTimelineProps) {
   return (
-    <div className="grid grid-cols-10 gap-1 sm:grid-cols-12 md:grid-cols-15 lg:grid-cols-20 xl:grid-cols-30">
-      {normalized.map((item, index) => (
-        <div
-          key={`${item.bucketStart}-${index}`}
-          className={cn(
-            "h-3 rounded-full border border-white/10 transition-colors",
-            getBucketClassName(item.state)
-          )}
-          title={item.bucketStart}
-        />
-      ))}
-    </div>
+    <TooltipProvider delayDuration={80}>
+      <div className="flex w-full items-center gap-[2px]" role="list" aria-label="status history">
+        {cells.map((cell, index) => {
+          const { bucket, displayState, inferred } = cell;
+          const isPlaceholder = bucket.bucketStart.startsWith("empty-");
+          return (
+            <Tooltip key={`${bucket.bucketStart}-${index}`}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  role="listitem"
+                  aria-label={`${labels.availability}: ${bucket.availabilityPct ?? "—"}`}
+                  className={cn(
+                    "h-6 flex-1 rounded-[2px] outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring",
+                    cellColor(displayState, inferred)
+                  )}
+                />
+              </TooltipTrigger>
+              <TooltipContent
+                side="top"
+                className="max-w-xs space-y-1 rounded-md bg-popover px-3 py-2 text-popover-foreground shadow-md"
+              >
+                {!isPlaceholder ? (
+                  <p className="font-medium tabular-nums">
+                    {formatRange(bucket.bucketStart, bucket.bucketEnd, locale, timeZone)}
+                  </p>
+                ) : null}
+                <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 font-mono">
+                  <span className="text-muted-foreground">{labels.availability}</span>
+                  <span className="text-right">
+                    {bucket.availabilityPct === null
+                      ? "—"
+                      : `${bucket.availabilityPct.toFixed(2)}%`}
+                  </span>
+                  <span className="text-muted-foreground">{labels.ttfb}</span>
+                  <span className="text-right">
+                    {bucket.ttfbMs === null ? "—" : `${bucket.ttfbMs} ms`}
+                  </span>
+                  <span className="text-muted-foreground">{labels.tps}</span>
+                  <span className="text-right">
+                    {bucket.tps === null ? "—" : bucket.tps.toFixed(1)}
+                  </span>
+                  <span className="text-muted-foreground">{labels.samples}</span>
+                  <span className="text-right">{bucket.sampleCount}</span>
+                </div>
+                {bucket.sampleCount === 0 && !isPlaceholder ? (
+                  <p className="text-[10px] text-muted-foreground">
+                    {labels.inferredFromNeighbors}
+                  </p>
+                ) : null}
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </TooltipProvider>
   );
 }

--- a/src/app/[locale]/status/_components/public-status-timeline.tsx
+++ b/src/app/[locale]/status/_components/public-status-timeline.tsx
@@ -11,6 +11,7 @@ export interface PublicStatusTimelineLabels {
   samples: string;
   inferredFromNeighbors: string;
   noData: string;
+  historyAriaLabel: string;
 }
 
 interface PublicStatusTimelineProps {
@@ -35,6 +36,11 @@ function cellColor(state: FilledTimelineCell["displayState"], inferred: boolean)
 
 function formatRange(start: string, end: string, locale: string, timeZone: string): string {
   try {
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+      return `${start} – ${end}`;
+    }
     const fmt = new Intl.DateTimeFormat(locale, {
       hour: "2-digit",
       minute: "2-digit",
@@ -46,9 +52,6 @@ function formatRange(start: string, end: string, locale: string, timeZone: strin
       day: "2-digit",
       timeZone,
     });
-    const startDate = new Date(start);
-    const endDate = new Date(end);
-    if (Number.isNaN(startDate.getTime())) return start;
     return `${dateFmt.format(startDate)} ${fmt.format(startDate)} – ${fmt.format(endDate)}`;
   } catch {
     return `${start} – ${end}`;
@@ -63,7 +66,11 @@ export function PublicStatusTimeline({
 }: PublicStatusTimelineProps) {
   return (
     <TooltipProvider delayDuration={80}>
-      <div className="flex w-full items-center gap-[2px]" role="list" aria-label="status history">
+      <div
+        className="flex w-full items-center gap-[2px]"
+        role="list"
+        aria-label={labels.historyAriaLabel}
+      >
         {cells.map((cell, index) => {
           const { bucket, displayState, inferred } = cell;
           const isPlaceholder = bucket.bucketStart.startsWith("empty-");

--- a/src/app/[locale]/status/_components/public-status-view.tsx
+++ b/src/app/[locale]/status/_components/public-status-view.tsx
@@ -86,6 +86,7 @@ interface PublicStatusViewProps {
     emptyByFilter: string;
     modelsLabel: string;
     issuesLabel: string;
+    clearSearch: string;
   };
 }
 
@@ -184,34 +185,55 @@ export function PublicStatusView({
     [payload.groups, labels.systemStatus, labels.emptyDescription]
   );
 
+  const derivedGroups = useMemo(() => {
+    return baseGroups.map((group) => {
+      const derivedModels = group.models.map((model) => {
+        const filled = fillDisplayTimeline(model.timeline);
+        const chartCells = sliceTimelineForChart(filled, CHART_BUCKETS);
+        const uptime24h = computeUptimePct(model.timeline);
+        const ttfb24h = computeAvgTtfb(model.timeline);
+        const latest = deriveLatestModelState(model);
+        return { model, chartCells, uptime24h, ttfb24h, latest };
+      });
+      const issueCount = derivedModels.filter(
+        (d) => d.latest === "failed" || d.latest === "degraded"
+      ).length;
+      return { group, derivedModels, issueCount };
+    });
+  }, [baseGroups]);
+
   const orderedGroups = useMemo(() => {
-    const slugs = baseGroups.map((g) => g.publicGroupSlug);
+    const slugs = derivedGroups.map((g) => g.group.publicGroupSlug);
     if (!orderHydrated || groupOrder.length === 0) {
-      return baseGroups;
+      return derivedGroups;
     }
     const ordered = reconcileOrder(groupOrder, slugs);
-    const map = new Map(baseGroups.map((g) => [g.publicGroupSlug, g]));
+    const map = new Map(derivedGroups.map((g) => [g.group.publicGroupSlug, g]));
     return ordered.map((slug) => map.get(slug)).filter((g) => g !== undefined);
-  }, [baseGroups, groupOrder, orderHydrated]);
+  }, [derivedGroups, groupOrder, orderHydrated]);
+
+  const isFiltering = searchQuery.trim().length > 0;
 
   const filteredGroups = useMemo(() => {
+    if (!isFiltering) return orderedGroups;
     const q = searchQuery.trim().toLowerCase();
-    if (!q) return orderedGroups;
     return orderedGroups
-      .map((group) => {
-        const groupMatches = group.displayName.toLowerCase().includes(q);
-        const matchedModels = group.models.filter((m) => m.label.toLowerCase().includes(q));
-        if (groupMatches) return group;
+      .map((entry) => {
+        const groupMatches = entry.group.displayName.toLowerCase().includes(q);
+        const matchedModels = entry.derivedModels.filter((d) =>
+          d.model.label.toLowerCase().includes(q)
+        );
+        if (groupMatches) return entry;
         if (matchedModels.length === 0) return null;
-        return { ...group, models: matchedModels };
+        return { ...entry, derivedModels: matchedModels };
       })
       .filter((g): g is (typeof orderedGroups)[number] => g !== null);
-  }, [orderedGroups, searchQuery]);
+  }, [orderedGroups, searchQuery, isFiltering]);
 
   const overallState: DisplayState = useMemo(() => {
-    const states = baseGroups.flatMap((g) => g.models.map((m) => deriveLatestModelState(m)));
+    const states = derivedGroups.flatMap((g) => g.derivedModels.map((d) => d.latest));
     return aggregateOverallState(states);
-  }, [baseGroups]);
+  }, [derivedGroups]);
 
   const overallLabel = badgeVariant(overallState).label(labels);
 
@@ -223,12 +245,12 @@ export function PublicStatusView({
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
-    const slugs = filteredGroups.map((g) => g.publicGroupSlug);
+    const slugs = orderedGroups.map((g) => g.group.publicGroupSlug);
     const oldIndex = slugs.indexOf(String(active.id));
     const newIndex = slugs.indexOf(String(over.id));
     if (oldIndex < 0 || newIndex < 0) return;
     const next = arrayMove(slugs, oldIndex, newIndex);
-    const baseSlugs = baseGroups.map((g) => g.publicGroupSlug);
+    const baseSlugs = derivedGroups.map((g) => g.group.publicGroupSlug);
     const reconciled = reconcileOrder(next, baseSlugs);
     setGroupOrder(reconciled);
     saveGroupOrder(reconciled);
@@ -289,6 +311,7 @@ export function PublicStatusView({
           searchPlaceholder={labels.searchPlaceholder}
           customSortLabel={labels.customSort}
           resetSortLabel={labels.resetSort}
+          clearSearchLabel={labels.clearSearch}
         />
 
         {filteredGroups.length === 0 ? (
@@ -302,102 +325,95 @@ export function PublicStatusView({
             onDragEnd={handleDragEnd}
           >
             <SortableContext
-              items={filteredGroups.map((g) => g.publicGroupSlug)}
+              items={filteredGroups.map((g) => g.group.publicGroupSlug)}
               strategy={verticalListSortingStrategy}
             >
               <div className="space-y-4">
-                {filteredGroups.map((group) => {
+                {filteredGroups.map((entry) => {
+                  const group = entry.group;
                   const open = !collapsedGroups.has(group.publicGroupSlug);
-                  const issueCount = group.models.filter((m) => {
-                    const s = deriveLatestModelState(m);
-                    return s === "failed" || s === "degraded";
-                  }).length;
-
                   return (
                     <SortableGroupPanel
                       key={group.publicGroupSlug}
                       slug={group.publicGroupSlug}
                       displayName={group.displayName}
-                      modelCount={group.models.length}
-                      issueCount={issueCount}
+                      modelCount={entry.derivedModels.length}
+                      issueCount={entry.issueCount}
                       open={open}
                       onOpenChange={(next) => handleGroupOpenChange(group.publicGroupSlug, next)}
-                      draggable={customSort}
+                      draggable={customSort && !isFiltering}
                       modelBadgeLabel={labels.modelsLabel}
                       issueBadgeLabel={labels.issuesLabel}
                     >
                       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-                        {group.models.map((model) => {
-                          const filled = fillDisplayTimeline(model.timeline);
-                          const chartCells = sliceTimelineForChart(filled, CHART_BUCKETS);
-                          const uptime24h = computeUptimePct(model.timeline);
-                          const ttfb24h = computeAvgTtfb(model.timeline);
-                          const latest = deriveLatestModelState(model);
-                          const variant = badgeVariant(latest);
-                          const { Icon } = getPublicStatusVendorIconComponent({
-                            modelName: model.publicModelKey,
-                            vendorIconKey: model.vendorIconKey,
-                          });
+                        {entry.derivedModels.map(
+                          ({ model, chartCells, uptime24h, ttfb24h, latest }) => {
+                            const variant = badgeVariant(latest);
+                            const { Icon } = getPublicStatusVendorIconComponent({
+                              modelName: model.publicModelKey,
+                              vendorIconKey: model.vendorIconKey,
+                            });
 
-                          return (
-                            <article
-                              key={model.publicModelKey}
-                              className="flex flex-col gap-3 rounded-xl border border-border/60 bg-background/50 p-4 backdrop-blur-sm"
-                            >
-                              <header className="flex items-start justify-between gap-2">
-                                <div className="flex min-w-0 items-center gap-2">
-                                  <span className="inline-flex size-8 items-center justify-center rounded-lg border border-border/60 bg-muted/30">
-                                    <Icon className="size-4" />
-                                  </span>
-                                  <div className="min-w-0">
-                                    <h3 className="truncate text-sm font-semibold">
-                                      {model.label}
-                                    </h3>
-                                    <p className="truncate font-mono text-[10px] text-muted-foreground">
-                                      {labels.requestTypes[model.requestTypeBadge] ??
-                                        model.requestTypeBadge}
-                                    </p>
+                            return (
+                              <article
+                                key={model.publicModelKey}
+                                className="flex flex-col gap-3 rounded-xl border border-border/60 bg-background/50 p-4 backdrop-blur-sm"
+                              >
+                                <header className="flex items-start justify-between gap-2">
+                                  <div className="flex min-w-0 items-center gap-2">
+                                    <span className="inline-flex size-8 items-center justify-center rounded-lg border border-border/60 bg-muted/30">
+                                      <Icon className="size-4" />
+                                    </span>
+                                    <div className="min-w-0">
+                                      <h3 className="truncate text-sm font-semibold">
+                                        {model.label}
+                                      </h3>
+                                      <p className="truncate font-mono text-[10px] text-muted-foreground">
+                                        {labels.requestTypes[model.requestTypeBadge] ??
+                                          model.requestTypeBadge}
+                                      </p>
+                                    </div>
+                                  </div>
+                                  <Badge
+                                    className={cn(
+                                      "border bg-transparent px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                                      variant.className
+                                    )}
+                                    variant="outline"
+                                  >
+                                    {variant.label(labels)}
+                                  </Badge>
+                                </header>
+
+                                <div className="grid grid-cols-2 gap-2 text-xs">
+                                  <div className="rounded-md border border-border/40 bg-muted/20 p-2">
+                                    <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                                      {labels.availability}
+                                    </div>
+                                    <div className="mt-1 font-mono text-base">
+                                      {uptime24h === null ? "—" : `${uptime24h.toFixed(2)}%`}
+                                    </div>
+                                  </div>
+                                  <div className="rounded-md border border-border/40 bg-muted/20 p-2">
+                                    <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                                      {labels.ttfb}
+                                    </div>
+                                    <div className="mt-1 font-mono text-base">
+                                      {ttfb24h === null ? "—" : `${ttfb24h} ms`}
+                                    </div>
                                   </div>
                                 </div>
-                                <Badge
-                                  className={cn(
-                                    "border bg-transparent px-2 py-0.5 text-[10px] uppercase tracking-wide",
-                                    variant.className
-                                  )}
-                                  variant="outline"
-                                >
-                                  {variant.label(labels)}
-                                </Badge>
-                              </header>
 
-                              <div className="grid grid-cols-2 gap-2 text-xs">
-                                <div className="rounded-md border border-border/40 bg-muted/20 p-2">
-                                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                                    {labels.availability}
-                                  </div>
-                                  <div className="mt-1 font-mono text-base">
-                                    {uptime24h === null ? "—" : `${uptime24h.toFixed(2)}%`}
-                                  </div>
-                                </div>
-                                <div className="rounded-md border border-border/40 bg-muted/20 p-2">
-                                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                                    {labels.ttfb}
-                                  </div>
-                                  <div className="mt-1 font-mono text-base">
-                                    {ttfb24h === null ? "—" : `${ttfb24h} ms`}
-                                  </div>
-                                </div>
-                              </div>
-
-                              <PublicStatusTimeline
-                                cells={chartCells}
-                                timeZone={timeZone}
-                                locale={locale}
-                                labels={timelineLabels}
-                              />
-                            </article>
-                          );
-                        })}
+                                <PublicStatusTimeline
+                                  cells={chartCells}
+                                  timeZone={timeZone}
+                                  locale={locale}
+                                  labels={timelineLabels}
+                                />
+                              </article>
+                            );
+                          }
+                        )}
                       </div>
                     </SortableGroupPanel>
                   );

--- a/src/app/[locale]/status/_components/public-status-view.tsx
+++ b/src/app/[locale]/status/_components/public-status-view.tsx
@@ -73,12 +73,12 @@ interface PublicStatusViewProps {
       noData: string;
     };
     tooltip: {
-      timeRange: string;
       availability: string;
       ttfb: string;
       tps: string;
       samples: string;
       inferredFromNeighbors: string;
+      historyAriaLabel: string;
     };
     searchPlaceholder: string;
     customSort: string;
@@ -87,6 +87,7 @@ interface PublicStatusViewProps {
     modelsLabel: string;
     issuesLabel: string;
     clearSearch: string;
+    dragHandle: string;
   };
 }
 
@@ -151,6 +152,7 @@ export function PublicStatusView({
             : `/api/public-status?interval=${intervalMinutes}&rangeHours=${rangeHours}`,
           { cache: "no-store" }
         );
+        if (!response.ok) return;
         const next = (await response.json()) as PublicStatusPayload;
         startTransition(() => setPayload(next));
       } catch {
@@ -209,7 +211,9 @@ export function PublicStatusView({
     }
     const ordered = reconcileOrder(groupOrder, slugs);
     const map = new Map(derivedGroups.map((g) => [g.group.publicGroupSlug, g]));
-    return ordered.map((slug) => map.get(slug)).filter((g) => g !== undefined);
+    return ordered
+      .map((slug) => map.get(slug))
+      .filter((g): g is (typeof derivedGroups)[number] => g !== undefined);
   }, [derivedGroups, groupOrder, orderHydrated]);
 
   const isFiltering = searchQuery.trim().length > 0;
@@ -286,6 +290,7 @@ export function PublicStatusView({
     samples: labels.tooltip.samples,
     inferredFromNeighbors: labels.tooltip.inferredFromNeighbors,
     noData: labels.noData,
+    historyAriaLabel: labels.tooltip.historyAriaLabel,
   };
 
   return (
@@ -344,6 +349,7 @@ export function PublicStatusView({
                       draggable={customSort && !isFiltering}
                       modelBadgeLabel={labels.modelsLabel}
                       issueBadgeLabel={labels.issuesLabel}
+                      dragHandleLabel={labels.dragHandle}
                     >
                       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                         {entry.derivedModels.map(

--- a/src/app/[locale]/status/_components/public-status-view.tsx
+++ b/src/app/[locale]/status/_components/public-status-view.tsx
@@ -1,10 +1,46 @@
 "use client";
 
-import { startTransition, useEffect, useState } from "react";
-import { ThemeSwitcher } from "@/components/ui/theme-switcher";
-import type { PublicStatusPayload, PublicStatusTimelineBucket } from "@/lib/public-status/payload";
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { startTransition, useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import type { PublicStatusPayload } from "@/lib/public-status/payload";
 import { getPublicStatusVendorIconComponent } from "@/lib/public-status/vendor-icon";
-import { PublicStatusTimeline } from "./public-status-timeline";
+import { cn } from "@/lib/utils";
+import { type DisplayState, deriveLatestModelState } from "../_lib/derive-display-state";
+import { fillDisplayTimeline } from "../_lib/fill-display-timeline";
+import {
+  clearGroupOrder,
+  loadCollapsedSet,
+  loadGroupOrder,
+  reconcileOrder,
+  saveCollapsedSet,
+  saveGroupOrder,
+} from "../_lib/group-order-store";
+import {
+  CHART_BUCKETS,
+  computeAvgTtfb,
+  computeUptimePct,
+  sliceTimelineForChart,
+} from "../_lib/timeline-windows";
+import "../status-page.css";
+import { PublicStatusTimeline, type PublicStatusTimelineLabels } from "./public-status-timeline";
+import { SortableGroupPanel } from "./sortable-group-panel";
+import { StatusHero } from "./status-hero";
+import { StatusToolbar } from "./status-toolbar";
 
 interface PublicStatusViewProps {
   initialPayload: PublicStatusPayload;
@@ -30,32 +66,62 @@ interface PublicStatusViewProps {
     noData: string;
     emptyDescription: string;
     requestTypes: Record<string, string>;
+    statusBadge: {
+      operational: string;
+      degraded: string;
+      failed: string;
+      noData: string;
+    };
+    tooltip: {
+      timeRange: string;
+      availability: string;
+      ttfb: string;
+      tps: string;
+      samples: string;
+      inferredFromNeighbors: string;
+    };
+    searchPlaceholder: string;
+    customSort: string;
+    resetSort: string;
+    emptyByFilter: string;
+    modelsLabel: string;
+    issuesLabel: string;
   };
 }
 
-function buildEmptyTimeline(): PublicStatusTimelineBucket[] {
-  return Array.from({ length: 60 }, (_, index) => ({
-    bucketStart: `empty-${index}`,
-    bucketEnd: `empty-${index}`,
-    state: "no_data",
-    availabilityPct: null,
-    ttfbMs: null,
-    tps: null,
-    sampleCount: 0,
-  }));
+function badgeVariant(state: DisplayState): {
+  className: string;
+  label: (labels: PublicStatusViewProps["labels"]) => string;
+} {
+  switch (state) {
+    case "operational":
+      return {
+        className: "border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+        label: (l) => l.statusBadge.operational,
+      };
+    case "degraded":
+      return {
+        className: "border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+        label: (l) => l.statusBadge.degraded,
+      };
+    case "failed":
+      return {
+        className: "border-rose-500/40 bg-rose-500/10 text-rose-600 dark:text-rose-400",
+        label: (l) => l.statusBadge.failed,
+      };
+    default:
+      return {
+        className: "border-border/60 bg-muted/40 text-muted-foreground",
+        label: (l) => l.statusBadge.noData,
+      };
+  }
 }
 
-function resolveStateLabel(
-  rebuildState: PublicStatusPayload["rebuildState"],
-  labels: PublicStatusViewProps["labels"]
-): string {
-  if (rebuildState === "rebuilding") {
-    return labels.rebuilding;
-  }
-  if (rebuildState === "no-data") {
-    return labels.noData;
-  }
-  return labels.fresh;
+function aggregateOverallState(states: DisplayState[]): DisplayState {
+  if (states.some((s) => s === "failed")) return "failed";
+  if (states.some((s) => s === "degraded")) return "degraded";
+  if (states.some((s) => s === "operational")) return "operational";
+  return "no_data";
 }
 
 export function PublicStatusView({
@@ -69,6 +135,11 @@ export function PublicStatusView({
   labels,
 }: PublicStatusViewProps) {
   const [payload, setPayload] = useState(initialPayload);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [customSort, setCustomSort] = useState(false);
+  const [orderHydrated, setOrderHydrated] = useState(false);
+  const [groupOrder, setGroupOrder] = useState<string[]>([]);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     const refresh = async () => {
@@ -77,183 +148,264 @@ export function PublicStatusView({
           followServerDefaults
             ? "/api/public-status"
             : `/api/public-status?interval=${intervalMinutes}&rangeHours=${rangeHours}`,
-          {
-            cache: "no-store",
-          }
+          { cache: "no-store" }
         );
-        const nextPayload = (await response.json()) as PublicStatusPayload;
-        startTransition(() => {
-          setPayload(nextPayload);
-        });
+        const next = (await response.json()) as PublicStatusPayload;
+        startTransition(() => setPayload(next));
       } catch {
-        // 保持最后一版 payload，等待下一个轮询周期。
+        // keep last payload until next tick
       }
     };
-
     if (followServerDefaults || initialPayload.rebuildState === "rebuilding") {
       void refresh();
     }
-
-    const pollId = window.setInterval(() => {
-      void refresh();
-    }, 30_000);
-
-    return () => {
-      window.clearInterval(pollId);
-    };
+    const pollId = window.setInterval(() => void refresh(), 30_000);
+    return () => window.clearInterval(pollId);
   }, [followServerDefaults, initialPayload.rebuildState, intervalMinutes, rangeHours]);
 
-  const groups =
-    payload.groups.length > 0
-      ? payload.groups
-      : [
-          {
-            publicGroupSlug: "bootstrap",
-            displayName: labels.systemStatus,
-            explanatoryCopy: labels.emptyDescription,
-            models: [
-              {
-                publicModelKey: "bootstrap",
-                label: labels.systemStatus,
-                vendorIconKey: "generic",
-                requestTypeBadge: "openaiCompatible",
-                latestState: "no_data" as const,
-                availabilityPct: null,
-                latestTtfbMs: null,
-                latestTps: null,
-                timeline: buildEmptyTimeline(),
-              },
-            ],
-          },
-        ];
+  useEffect(() => {
+    setGroupOrder(loadGroupOrder());
+    setCollapsedGroups(loadCollapsedSet());
+    setOrderHydrated(true);
+  }, []);
+
+  const baseGroups = useMemo(
+    () =>
+      payload.groups.length > 0
+        ? payload.groups
+        : [
+            {
+              publicGroupSlug: "bootstrap",
+              displayName: labels.systemStatus,
+              explanatoryCopy: labels.emptyDescription,
+              models: [],
+            },
+          ],
+    [payload.groups, labels.systemStatus, labels.emptyDescription]
+  );
+
+  const orderedGroups = useMemo(() => {
+    const slugs = baseGroups.map((g) => g.publicGroupSlug);
+    if (!orderHydrated || groupOrder.length === 0) {
+      return baseGroups;
+    }
+    const ordered = reconcileOrder(groupOrder, slugs);
+    const map = new Map(baseGroups.map((g) => [g.publicGroupSlug, g]));
+    return ordered.map((slug) => map.get(slug)).filter((g) => g !== undefined);
+  }, [baseGroups, groupOrder, orderHydrated]);
+
+  const filteredGroups = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return orderedGroups;
+    return orderedGroups
+      .map((group) => {
+        const groupMatches = group.displayName.toLowerCase().includes(q);
+        const matchedModels = group.models.filter((m) => m.label.toLowerCase().includes(q));
+        if (groupMatches) return group;
+        if (matchedModels.length === 0) return null;
+        return { ...group, models: matchedModels };
+      })
+      .filter((g): g is (typeof orderedGroups)[number] => g !== null);
+  }, [orderedGroups, searchQuery]);
+
+  const overallState: DisplayState = useMemo(() => {
+    const states = baseGroups.flatMap((g) => g.models.map((m) => deriveLatestModelState(m)));
+    return aggregateOverallState(states);
+  }, [baseGroups]);
+
+  const overallLabel = badgeVariant(overallState).label(labels);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const slugs = filteredGroups.map((g) => g.publicGroupSlug);
+    const oldIndex = slugs.indexOf(String(active.id));
+    const newIndex = slugs.indexOf(String(over.id));
+    if (oldIndex < 0 || newIndex < 0) return;
+    const next = arrayMove(slugs, oldIndex, newIndex);
+    const baseSlugs = baseGroups.map((g) => g.publicGroupSlug);
+    const reconciled = reconcileOrder(next, baseSlugs);
+    setGroupOrder(reconciled);
+    saveGroupOrder(reconciled);
+  };
+
+  const handleToggleCustomSort = () => {
+    if (customSort) {
+      setCustomSort(false);
+      setGroupOrder([]);
+      clearGroupOrder();
+    } else {
+      setCustomSort(true);
+    }
+  };
+
+  const handleGroupOpenChange = (slug: string, open: boolean) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (open) {
+        next.delete(slug);
+      } else {
+        next.add(slug);
+      }
+      saveCollapsedSet(next);
+      return next;
+    });
+  };
+
+  const timelineLabels: PublicStatusTimelineLabels = {
+    availability: labels.tooltip.availability,
+    ttfb: labels.tooltip.ttfb,
+    tps: labels.tooltip.tps,
+    samples: labels.tooltip.samples,
+    inferredFromNeighbors: labels.tooltip.inferredFromNeighbors,
+    noData: labels.noData,
+  };
 
   return (
-    <div className="relative min-h-[calc(100vh-4rem)] overflow-hidden bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.15),transparent_30%),linear-gradient(180deg,rgba(15,23,42,0.02),rgba(15,23,42,0.08))] text-foreground">
-      <div
-        className="pointer-events-none absolute inset-0 opacity-40"
-        style={{
-          backgroundImage:
-            "linear-gradient(to right, rgba(148,163,184,0.08) 1px, transparent 1px), linear-gradient(to bottom, rgba(148,163,184,0.08) 1px, transparent 1px)",
-          backgroundSize: "32px 32px",
-        }}
-      />
+    <div className="cch-status-bg relative min-h-screen text-foreground">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 sm:py-10">
+        <StatusHero
+          siteTitle={siteTitle}
+          heroPrimary={labels.heroPrimary}
+          heroSecondary={labels.heroSecondary}
+          generatedAtLabel={labels.generatedAt}
+          generatedAt={payload.generatedAt}
+          locale={locale}
+          timeZone={timeZone}
+          overallState={overallState}
+          statusLabel={overallLabel}
+        />
 
-      <div className="relative mx-auto flex w-full max-w-7xl flex-col gap-10 px-4 py-8 sm:px-6 lg:px-8">
-        <header className="rounded-[32px] border border-white/10 bg-card/72 p-6 shadow-2xl backdrop-blur-xl">
-          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-            <div className="space-y-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground">
-                {labels.heroPrimary}
-              </p>
-              <div className="space-y-3">
-                <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">{siteTitle}</h1>
-                <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
-                  {labels.heroSecondary}
-                </p>
-              </div>
-            </div>
+        <StatusToolbar
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          customSort={customSort}
+          onToggleCustomSort={handleToggleCustomSort}
+          searchPlaceholder={labels.searchPlaceholder}
+          customSortLabel={labels.customSort}
+          resetSortLabel={labels.resetSort}
+        />
 
-            <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
-              {payload.rebuildState !== "stale" ? (
-                <div className="rounded-full border border-white/10 bg-background/70 px-4 py-2 text-sm">
-                  {resolveStateLabel(payload.rebuildState, labels)}
-                </div>
-              ) : null}
-              <ThemeSwitcher />
-            </div>
+        {filteredGroups.length === 0 ? (
+          <div className="rounded-2xl border border-border/60 bg-card/40 p-8 text-center text-sm text-muted-foreground backdrop-blur-sm">
+            {labels.emptyByFilter}
           </div>
-
-          <div className="mt-6 space-y-2 text-sm text-muted-foreground">
-            <span>
-              {labels.generatedAt}:{" "}
-              {payload.generatedAt
-                ? new Intl.DateTimeFormat(locale, {
-                    dateStyle: "medium",
-                    timeStyle: "medium",
-                    timeZone,
-                  }).format(new Date(payload.generatedAt))
-                : labels.rebuilding}
-            </span>
-            {payload.rebuildState === "stale" ? (
-              <p className="text-xs">{labels.staleDetail}</p>
-            ) : null}
-          </div>
-        </header>
-
-        <div className="grid gap-6">
-          {groups.map((group) => (
-            <section
-              key={group.publicGroupSlug}
-              className="rounded-[28px] border border-white/10 bg-card/60 p-6 shadow-xl backdrop-blur-xl"
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={filteredGroups.map((g) => g.publicGroupSlug)}
+              strategy={verticalListSortingStrategy}
             >
-              <div className="mb-4 space-y-2">
-                <h2 className="text-2xl font-semibold tracking-tight">{group.displayName}</h2>
-                {group.explanatoryCopy ? (
-                  <p className="text-sm text-muted-foreground">{group.explanatoryCopy}</p>
-                ) : null}
-              </div>
-
-              <div className="grid gap-4 xl:grid-cols-2">
-                {group.models.map((model) => {
-                  const { iconKey, Icon: VendorIcon } = getPublicStatusVendorIconComponent({
-                    modelName: model.publicModelKey,
-                    vendorIconKey: model.vendorIconKey,
-                  });
+              <div className="space-y-4">
+                {filteredGroups.map((group) => {
+                  const open = !collapsedGroups.has(group.publicGroupSlug);
+                  const issueCount = group.models.filter((m) => {
+                    const s = deriveLatestModelState(m);
+                    return s === "failed" || s === "degraded";
+                  }).length;
 
                   return (
-                    <article
-                      key={model.publicModelKey}
-                      className="rounded-[24px] border border-white/10 bg-background/60 p-5"
+                    <SortableGroupPanel
+                      key={group.publicGroupSlug}
+                      slug={group.publicGroupSlug}
+                      displayName={group.displayName}
+                      modelCount={group.models.length}
+                      issueCount={issueCount}
+                      open={open}
+                      onOpenChange={(next) => handleGroupOpenChange(group.publicGroupSlug, next)}
+                      draggable={customSort}
+                      modelBadgeLabel={labels.modelsLabel}
+                      issueBadgeLabel={labels.issuesLabel}
                     >
-                      <div className="mb-4 flex items-start justify-between gap-4">
-                        <div className="space-y-2">
-                          <div className="flex items-center gap-2">
-                            <span
-                              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/10 bg-muted/40"
-                              data-vendor-icon-key={iconKey}
+                      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                        {group.models.map((model) => {
+                          const filled = fillDisplayTimeline(model.timeline);
+                          const chartCells = sliceTimelineForChart(filled, CHART_BUCKETS);
+                          const uptime24h = computeUptimePct(model.timeline);
+                          const ttfb24h = computeAvgTtfb(model.timeline);
+                          const latest = deriveLatestModelState(model);
+                          const variant = badgeVariant(latest);
+                          const { Icon } = getPublicStatusVendorIconComponent({
+                            modelName: model.publicModelKey,
+                            vendorIconKey: model.vendorIconKey,
+                          });
+
+                          return (
+                            <article
+                              key={model.publicModelKey}
+                              className="flex flex-col gap-3 rounded-xl border border-border/60 bg-background/50 p-4 backdrop-blur-sm"
                             >
-                              <VendorIcon className="h-4 w-4" />
-                            </span>
-                            <h3 className="text-lg font-semibold">{model.label}</h3>
-                          </div>
-                          <p className="font-mono text-xs text-muted-foreground">
-                            {model.publicModelKey}
-                          </p>
-                        </div>
-                        <div className="rounded-full border border-white/10 bg-muted/50 px-3 py-1 text-xs uppercase tracking-wide text-muted-foreground">
-                          {labels.requestTypes[model.requestTypeBadge] ?? model.requestTypeBadge}
-                        </div>
-                      </div>
+                              <header className="flex items-start justify-between gap-2">
+                                <div className="flex min-w-0 items-center gap-2">
+                                  <span className="inline-flex size-8 items-center justify-center rounded-lg border border-border/60 bg-muted/30">
+                                    <Icon className="size-4" />
+                                  </span>
+                                  <div className="min-w-0">
+                                    <h3 className="truncate text-sm font-semibold">
+                                      {model.label}
+                                    </h3>
+                                    <p className="truncate font-mono text-[10px] text-muted-foreground">
+                                      {labels.requestTypes[model.requestTypeBadge] ??
+                                        model.requestTypeBadge}
+                                    </p>
+                                  </div>
+                                </div>
+                                <Badge
+                                  className={cn(
+                                    "border bg-transparent px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                                    variant.className
+                                  )}
+                                  variant="outline"
+                                >
+                                  {variant.label(labels)}
+                                </Badge>
+                              </header>
 
-                      <div className="mb-4 grid gap-3 sm:grid-cols-2">
-                        <div className="rounded-2xl border border-white/10 bg-muted/30 p-3">
-                          <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-                            {labels.ttfb}
-                          </div>
-                          <div className="mt-2 font-mono text-xl">
-                            {model.latestTtfbMs === null ? "—" : `${model.latestTtfbMs} ms`}
-                          </div>
-                        </div>
-                        <div className="rounded-2xl border border-white/10 bg-muted/30 p-3">
-                          <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-                            {labels.availability}
-                          </div>
-                          <div className="mt-2 font-mono text-xl">
-                            {model.availabilityPct === null
-                              ? "—"
-                              : `${model.availabilityPct.toFixed(2)}%`}
-                          </div>
-                        </div>
-                      </div>
+                              <div className="grid grid-cols-2 gap-2 text-xs">
+                                <div className="rounded-md border border-border/40 bg-muted/20 p-2">
+                                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                                    {labels.availability}
+                                  </div>
+                                  <div className="mt-1 font-mono text-base">
+                                    {uptime24h === null ? "—" : `${uptime24h.toFixed(2)}%`}
+                                  </div>
+                                </div>
+                                <div className="rounded-md border border-border/40 bg-muted/20 p-2">
+                                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                                    {labels.ttfb}
+                                  </div>
+                                  <div className="mt-1 font-mono text-base">
+                                    {ttfb24h === null ? "—" : `${ttfb24h} ms`}
+                                  </div>
+                                </div>
+                              </div>
 
-                      <PublicStatusTimeline items={model.timeline} />
-                    </article>
+                              <PublicStatusTimeline
+                                cells={chartCells}
+                                timeZone={timeZone}
+                                locale={locale}
+                                labels={timelineLabels}
+                              />
+                            </article>
+                          );
+                        })}
+                      </div>
+                    </SortableGroupPanel>
                   );
                 })}
               </div>
-            </section>
-          ))}
-        </div>
+            </SortableContext>
+          </DndContext>
+        )}
       </div>
     </div>
   );

--- a/src/app/[locale]/status/_components/sortable-group-panel.tsx
+++ b/src/app/[locale]/status/_components/sortable-group-panel.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { ChevronDown, GripVertical } from "lucide-react";
+import type { ReactNode } from "react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+interface SortableGroupPanelProps {
+  slug: string;
+  displayName: string;
+  modelCount: number;
+  issueCount: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  draggable: boolean;
+  children: ReactNode;
+  issueBadgeLabel?: string;
+  modelBadgeLabel?: string;
+}
+
+export function SortableGroupPanel({
+  slug,
+  displayName,
+  modelCount,
+  issueCount,
+  open,
+  onOpenChange,
+  draggable,
+  children,
+  issueBadgeLabel,
+  modelBadgeLabel,
+}: SortableGroupPanelProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: slug,
+    disabled: !draggable,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.7 : 1,
+  };
+
+  return (
+    <section
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "rounded-2xl border border-border/60 bg-card/40 p-4 shadow-sm backdrop-blur-sm sm:p-6",
+        isDragging && "ring-2 ring-primary"
+      )}
+    >
+      <Collapsible open={open} onOpenChange={onOpenChange}>
+        <div className="flex items-center gap-2">
+          {draggable ? (
+            <button
+              type="button"
+              className="cursor-grab rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground active:cursor-grabbing"
+              aria-label="drag"
+              {...attributes}
+              {...listeners}
+            >
+              <GripVertical className="size-4" />
+            </button>
+          ) : null}
+          <CollapsibleTrigger className="flex min-w-0 flex-1 items-center gap-2 rounded-md py-1 text-left transition-colors hover:bg-accent/40">
+            <ChevronDown
+              className={cn(
+                "size-4 shrink-0 text-muted-foreground transition-transform duration-200",
+                open ? "rotate-0" : "-rotate-90"
+              )}
+            />
+            <h2 className="truncate text-lg font-semibold tracking-tight sm:text-xl">
+              {displayName}
+            </h2>
+            <span className="ml-auto flex flex-shrink-0 items-center gap-2 text-xs text-muted-foreground">
+              {modelBadgeLabel ? (
+                <span className="rounded-md border border-border/60 bg-background/60 px-2 py-0.5">
+                  {modelCount} {modelBadgeLabel}
+                </span>
+              ) : null}
+              {issueCount > 0 && issueBadgeLabel ? (
+                <span className="rounded-md border border-rose-500/40 bg-rose-500/10 px-2 py-0.5 text-rose-600 dark:text-rose-400">
+                  {issueCount} {issueBadgeLabel}
+                </span>
+              ) : null}
+            </span>
+          </CollapsibleTrigger>
+        </div>
+        <CollapsibleContent className="pt-4">{children}</CollapsibleContent>
+      </Collapsible>
+    </section>
+  );
+}

--- a/src/app/[locale]/status/_components/sortable-group-panel.tsx
+++ b/src/app/[locale]/status/_components/sortable-group-panel.tsx
@@ -18,6 +18,7 @@ interface SortableGroupPanelProps {
   children: ReactNode;
   issueBadgeLabel?: string;
   modelBadgeLabel?: string;
+  dragHandleLabel?: string;
 }
 
 export function SortableGroupPanel({
@@ -31,6 +32,7 @@ export function SortableGroupPanel({
   children,
   issueBadgeLabel,
   modelBadgeLabel,
+  dragHandleLabel,
 }: SortableGroupPanelProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: slug,
@@ -58,7 +60,7 @@ export function SortableGroupPanel({
             <button
               type="button"
               className="cursor-grab rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground active:cursor-grabbing"
-              aria-label="drag"
+              aria-label={dragHandleLabel ?? displayName}
               {...attributes}
               {...listeners}
             >

--- a/src/app/[locale]/status/_components/status-hero.tsx
+++ b/src/app/[locale]/status/_components/status-hero.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Activity } from "lucide-react";
+import { ThemeSwitcher } from "@/components/ui/theme-switcher";
+import { cn } from "@/lib/utils";
+import type { DisplayState } from "../_lib/derive-display-state";
+
+interface StatusHeroProps {
+  siteTitle: string;
+  heroPrimary: string;
+  heroSecondary: string;
+  generatedAtLabel: string;
+  generatedAt: string | null;
+  locale: string;
+  timeZone: string;
+  overallState: DisplayState;
+  statusLabel: string;
+}
+
+function pillColor(state: DisplayState): { dot: string; ring: string; text: string } {
+  switch (state) {
+    case "failed":
+      return { dot: "bg-rose-500", ring: "bg-rose-500", text: "text-rose-600 dark:text-rose-400" };
+    case "degraded":
+      return {
+        dot: "bg-amber-500",
+        ring: "bg-amber-500",
+        text: "text-amber-600 dark:text-amber-400",
+      };
+    case "operational":
+      return {
+        dot: "bg-emerald-500",
+        ring: "bg-emerald-500",
+        text: "text-emerald-600 dark:text-emerald-400",
+      };
+    default:
+      return {
+        dot: "bg-muted-foreground",
+        ring: "bg-muted-foreground",
+        text: "text-muted-foreground",
+      };
+  }
+}
+
+export function StatusHero({
+  siteTitle,
+  heroPrimary,
+  heroSecondary,
+  generatedAtLabel,
+  generatedAt,
+  locale,
+  timeZone,
+  overallState,
+  statusLabel,
+}: StatusHeroProps) {
+  const colors = pillColor(overallState);
+  const formattedGeneratedAt = generatedAt
+    ? new Intl.DateTimeFormat(locale, {
+        dateStyle: "medium",
+        timeStyle: "medium",
+        timeZone,
+      }).format(new Date(generatedAt))
+    : "—";
+
+  return (
+    <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-start gap-3">
+        <div className="mt-1 flex size-10 shrink-0 items-center justify-center rounded-xl border border-border/60 bg-background/60 backdrop-blur-sm">
+          <Activity className="size-5" />
+        </div>
+        <div className="min-w-0 space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+            {heroPrimary}
+          </p>
+          <h1 className="truncate text-2xl font-semibold tracking-tight sm:text-3xl">
+            {siteTitle}
+          </h1>
+          <p className="text-sm text-muted-foreground">{heroSecondary}</p>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <div
+          className={cn(
+            "flex items-center gap-2 rounded-full border border-border/60 bg-background/50 px-3 py-1.5 text-sm backdrop-blur-sm"
+          )}
+        >
+          <span className="relative flex size-2.5">
+            <span
+              className={cn(
+                "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
+                colors.ring
+              )}
+            />
+            <span className={cn("relative inline-flex size-2.5 rounded-full", colors.dot)} />
+          </span>
+          <span className={cn("font-medium", colors.text)}>{statusLabel}</span>
+          <span className="hidden text-muted-foreground sm:inline">·</span>
+          <span className="hidden font-mono text-xs text-muted-foreground sm:inline">
+            {generatedAtLabel} {formattedGeneratedAt}
+          </span>
+        </div>
+        <ThemeSwitcher />
+      </div>
+    </header>
+  );
+}

--- a/src/app/[locale]/status/_components/status-toolbar.tsx
+++ b/src/app/[locale]/status/_components/status-toolbar.tsx
@@ -13,6 +13,7 @@ interface StatusToolbarProps {
   searchPlaceholder: string;
   customSortLabel: string;
   resetSortLabel: string;
+  clearSearchLabel: string;
 }
 
 export function StatusToolbar({
@@ -23,6 +24,7 @@ export function StatusToolbar({
   searchPlaceholder,
   customSortLabel,
   resetSortLabel,
+  clearSearchLabel,
 }: StatusToolbarProps) {
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -41,7 +43,7 @@ export function StatusToolbar({
             type="button"
             onClick={() => onSearchChange("")}
             className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
-            aria-label="clear"
+            aria-label={clearSearchLabel}
           >
             <X className="size-3.5" />
           </button>

--- a/src/app/[locale]/status/_components/status-toolbar.tsx
+++ b/src/app/[locale]/status/_components/status-toolbar.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { ArrowDownAZ, Search, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface StatusToolbarProps {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  customSort: boolean;
+  onToggleCustomSort: () => void;
+  searchPlaceholder: string;
+  customSortLabel: string;
+  resetSortLabel: string;
+}
+
+export function StatusToolbar({
+  searchQuery,
+  onSearchChange,
+  customSort,
+  onToggleCustomSort,
+  searchPlaceholder,
+  customSortLabel,
+  resetSortLabel,
+}: StatusToolbarProps) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="relative w-full sm:max-w-sm">
+        <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          type="search"
+          value={searchQuery}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder={searchPlaceholder}
+          className="pl-9 pr-9"
+          aria-label={searchPlaceholder}
+        />
+        {searchQuery ? (
+          <button
+            type="button"
+            onClick={() => onSearchChange("")}
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground"
+            aria-label="clear"
+          >
+            <X className="size-3.5" />
+          </button>
+        ) : null}
+      </div>
+      <Button
+        type="button"
+        variant={customSort ? "default" : "outline"}
+        size="sm"
+        onClick={onToggleCustomSort}
+        className={cn("gap-1.5 self-start sm:self-auto")}
+      >
+        <ArrowDownAZ className="size-4" />
+        {customSort ? resetSortLabel : customSortLabel}
+      </Button>
+    </div>
+  );
+}

--- a/src/app/[locale]/status/_lib/derive-display-state.ts
+++ b/src/app/[locale]/status/_lib/derive-display-state.ts
@@ -16,7 +16,10 @@ export function deriveDisplayState(bucket: PublicStatusTimelineBucket): DisplayS
     return "no_data";
   }
   const pct = bucket.availabilityPct;
-  if (pct === null || pct >= 100) {
+  if (pct === null) {
+    return bucket.state === "degraded" ? "degraded" : "operational";
+  }
+  if (pct >= 100) {
     return "operational";
   }
   if (pct < DEGRADED_THRESHOLD) {

--- a/src/app/[locale]/status/_lib/derive-display-state.ts
+++ b/src/app/[locale]/status/_lib/derive-display-state.ts
@@ -1,0 +1,38 @@
+import type {
+  PublicStatusModelSnapshot,
+  PublicStatusTimelineBucket,
+  PublicStatusTimelineState,
+} from "@/lib/public-status/payload";
+
+export const DEGRADED_THRESHOLD = 50;
+
+export type DisplayState = PublicStatusTimelineState;
+
+export function deriveDisplayState(bucket: PublicStatusTimelineBucket): DisplayState {
+  if (bucket.state === "failed") {
+    return "failed";
+  }
+  if (bucket.state === "no_data") {
+    return "no_data";
+  }
+  const pct = bucket.availabilityPct;
+  if (pct === null || pct >= 100) {
+    return "operational";
+  }
+  if (pct < DEGRADED_THRESHOLD) {
+    return "failed";
+  }
+  return "degraded";
+}
+
+export function deriveLatestModelState(
+  model: Pick<PublicStatusModelSnapshot, "timeline" | "latestState">
+): DisplayState {
+  for (let index = model.timeline.length - 1; index >= 0; index--) {
+    const bucket = model.timeline[index];
+    if (bucket.state !== "no_data") {
+      return deriveDisplayState(bucket);
+    }
+  }
+  return model.latestState ?? "no_data";
+}

--- a/src/app/[locale]/status/_lib/fill-display-timeline.ts
+++ b/src/app/[locale]/status/_lib/fill-display-timeline.ts
@@ -1,0 +1,57 @@
+import type { PublicStatusTimelineBucket } from "@/lib/public-status/payload";
+import { type DisplayState, deriveDisplayState } from "./derive-display-state";
+
+export interface FilledTimelineCell {
+  bucket: PublicStatusTimelineBucket;
+  displayState: DisplayState;
+  inferred: boolean;
+}
+
+export function fillDisplayTimeline(timeline: PublicStatusTimelineBucket[]): FilledTimelineCell[] {
+  const derived: DisplayState[] = timeline.map((bucket) => deriveDisplayState(bucket));
+
+  const knownIndices: number[] = [];
+  derived.forEach((state, index) => {
+    if (state !== "no_data") {
+      knownIndices.push(index);
+    }
+  });
+
+  if (knownIndices.length === 0) {
+    return timeline.map((bucket) => ({ bucket, displayState: "no_data", inferred: false }));
+  }
+
+  const filled: DisplayState[] = derived.slice();
+  const firstKnown = knownIndices[0];
+  const lastKnown = knownIndices[knownIndices.length - 1];
+
+  for (let i = 0; i < firstKnown; i++) {
+    filled[i] = derived[firstKnown];
+  }
+  for (let i = lastKnown + 1; i < filled.length; i++) {
+    filled[i] = derived[lastKnown];
+  }
+
+  for (let cursor = 0; cursor < knownIndices.length - 1; cursor++) {
+    const leftIdx = knownIndices[cursor];
+    const rightIdx = knownIndices[cursor + 1];
+    const leftState = derived[leftIdx];
+    const rightState = derived[rightIdx];
+
+    for (let i = leftIdx + 1; i < rightIdx; i++) {
+      if (leftState === rightState) {
+        filled[i] = leftState;
+      } else {
+        const distLeft = i - leftIdx;
+        const distRight = rightIdx - i;
+        filled[i] = distLeft <= distRight ? leftState : rightState;
+      }
+    }
+  }
+
+  return timeline.map((bucket, index) => ({
+    bucket,
+    displayState: filled[index],
+    inferred: derived[index] === "no_data" && filled[index] !== "no_data",
+  }));
+}

--- a/src/app/[locale]/status/_lib/group-order-store.ts
+++ b/src/app/[locale]/status/_lib/group-order-store.ts
@@ -1,0 +1,66 @@
+const ORDER_KEY = "cch-status-group-order";
+const COLLAPSED_KEY = "cch-status-collapsed-groups";
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function loadGroupOrder(): string[] {
+  if (!isBrowser()) return [];
+  try {
+    const raw = window.localStorage.getItem(ORDER_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveGroupOrder(slugs: string[]): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(ORDER_KEY, JSON.stringify(slugs));
+  } catch {
+    // ignore quota/privacy errors
+  }
+}
+
+export function clearGroupOrder(): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.removeItem(ORDER_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function reconcileOrder(stored: string[], current: string[]): string[] {
+  const currentSet = new Set(current);
+  const kept = stored.filter((slug) => currentSet.has(slug));
+  const keptSet = new Set(kept);
+  const appended = current.filter((slug) => !keptSet.has(slug));
+  return [...kept, ...appended];
+}
+
+export function loadCollapsedSet(): Set<string> {
+  if (!isBrowser()) return new Set();
+  try {
+    const raw = window.localStorage.getItem(COLLAPSED_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((x): x is string => typeof x === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+export function saveCollapsedSet(slugs: Set<string>): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(COLLAPSED_KEY, JSON.stringify([...slugs]));
+  } catch {
+    // ignore
+  }
+}

--- a/src/app/[locale]/status/_lib/group-order-store.ts
+++ b/src/app/[locale]/status/_lib/group-order-store.ts
@@ -2,7 +2,12 @@ const ORDER_KEY = "cch-status-group-order";
 const COLLAPSED_KEY = "cch-status-collapsed-groups";
 
 function isBrowser(): boolean {
-  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+  if (typeof window === "undefined") return false;
+  try {
+    return typeof window.localStorage !== "undefined";
+  } catch {
+    return false;
+  }
 }
 
 export function loadGroupOrder(): string[] {
@@ -37,9 +42,14 @@ export function clearGroupOrder(): void {
 
 export function reconcileOrder(stored: string[], current: string[]): string[] {
   const currentSet = new Set(current);
-  const kept = stored.filter((slug) => currentSet.has(slug));
-  const keptSet = new Set(kept);
-  const appended = current.filter((slug) => !keptSet.has(slug));
+  const seen = new Set<string>();
+  const kept: string[] = [];
+  for (const slug of stored) {
+    if (!currentSet.has(slug) || seen.has(slug)) continue;
+    seen.add(slug);
+    kept.push(slug);
+  }
+  const appended = current.filter((slug) => !seen.has(slug));
   return [...kept, ...appended];
 }
 

--- a/src/app/[locale]/status/_lib/timeline-windows.ts
+++ b/src/app/[locale]/status/_lib/timeline-windows.ts
@@ -1,0 +1,40 @@
+import type { PublicStatusTimelineBucket } from "@/lib/public-status/payload";
+
+export const CHART_BUCKETS = 60;
+
+export function sliceTimelineForChart<T>(timeline: T[], chartBuckets: number = CHART_BUCKETS): T[] {
+  if (timeline.length <= chartBuckets) {
+    return timeline;
+  }
+  return timeline.slice(timeline.length - chartBuckets);
+}
+
+export function computeUptimePct(timeline: PublicStatusTimelineBucket[]): number | null {
+  let weightedSum = 0;
+  let sampleTotal = 0;
+  for (const bucket of timeline) {
+    if (bucket.sampleCount > 0 && bucket.availabilityPct !== null) {
+      weightedSum += bucket.availabilityPct * bucket.sampleCount;
+      sampleTotal += bucket.sampleCount;
+    }
+  }
+  if (sampleTotal === 0) {
+    return null;
+  }
+  return Number((weightedSum / sampleTotal).toFixed(2));
+}
+
+export function computeAvgTtfb(timeline: PublicStatusTimelineBucket[]): number | null {
+  let weightedSum = 0;
+  let sampleTotal = 0;
+  for (const bucket of timeline) {
+    if (bucket.sampleCount > 0 && bucket.ttfbMs !== null) {
+      weightedSum += bucket.ttfbMs * bucket.sampleCount;
+      sampleTotal += bucket.sampleCount;
+    }
+  }
+  if (sampleTotal === 0) {
+    return null;
+  }
+  return Math.round(weightedSum / sampleTotal);
+}

--- a/src/app/[locale]/status/page.tsx
+++ b/src/app/[locale]/status/page.tsx
@@ -87,6 +87,7 @@ export default async function PublicStatusPage({
         emptyByFilter: t("statusPage.public.emptyByFilter"),
         modelsLabel: t("statusPage.public.modelsLabel"),
         issuesLabel: t("statusPage.public.issuesLabel"),
+        clearSearch: t("statusPage.public.clearSearch"),
       }}
     />
   );

--- a/src/app/[locale]/status/page.tsx
+++ b/src/app/[locale]/status/page.tsx
@@ -74,12 +74,12 @@ export default async function PublicStatusPage({
           noData: t("statusPage.public.statusBadge.noData"),
         },
         tooltip: {
-          timeRange: t("statusPage.public.tooltip.timeRange"),
           availability: t("statusPage.public.tooltip.availability"),
           ttfb: t("statusPage.public.tooltip.ttfb"),
           tps: t("statusPage.public.tooltip.tps"),
           samples: t("statusPage.public.tooltip.samples"),
           inferredFromNeighbors: t("statusPage.public.tooltip.inferredFromNeighbors"),
+          historyAriaLabel: t("statusPage.public.tooltip.historyAriaLabel"),
         },
         searchPlaceholder: t("statusPage.public.searchPlaceholder"),
         customSort: t("statusPage.public.customSort"),
@@ -88,6 +88,7 @@ export default async function PublicStatusPage({
         modelsLabel: t("statusPage.public.modelsLabel"),
         issuesLabel: t("statusPage.public.issuesLabel"),
         clearSearch: t("statusPage.public.clearSearch"),
+        dragHandle: t("statusPage.public.dragHandle"),
       }}
     />
   );

--- a/src/app/[locale]/status/page.tsx
+++ b/src/app/[locale]/status/page.tsx
@@ -67,6 +67,26 @@ export default async function PublicStatusPage({
           anthropic: t("statusPage.public.requestTypes.anthropic"),
           gemini: t("statusPage.public.requestTypes.gemini"),
         },
+        statusBadge: {
+          operational: t("statusPage.public.statusBadge.operational"),
+          degraded: t("statusPage.public.statusBadge.degraded"),
+          failed: t("statusPage.public.statusBadge.failed"),
+          noData: t("statusPage.public.statusBadge.noData"),
+        },
+        tooltip: {
+          timeRange: t("statusPage.public.tooltip.timeRange"),
+          availability: t("statusPage.public.tooltip.availability"),
+          ttfb: t("statusPage.public.tooltip.ttfb"),
+          tps: t("statusPage.public.tooltip.tps"),
+          samples: t("statusPage.public.tooltip.samples"),
+          inferredFromNeighbors: t("statusPage.public.tooltip.inferredFromNeighbors"),
+        },
+        searchPlaceholder: t("statusPage.public.searchPlaceholder"),
+        customSort: t("statusPage.public.customSort"),
+        resetSort: t("statusPage.public.resetSort"),
+        emptyByFilter: t("statusPage.public.emptyByFilter"),
+        modelsLabel: t("statusPage.public.modelsLabel"),
+        issuesLabel: t("statusPage.public.issuesLabel"),
       }}
     />
   );

--- a/src/app/[locale]/status/status-page.css
+++ b/src/app/[locale]/status/status-page.css
@@ -1,0 +1,19 @@
+.cch-status-bg {
+  position: relative;
+}
+
+.cch-status-bg::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background-image:
+    linear-gradient(to right, var(--border) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--border) 1px, transparent 1px);
+  background-size: 40px 40px;
+  background-position: -1px -1px;
+  mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
+  opacity: 0.6;
+  pointer-events: none;
+}

--- a/src/app/[locale]/status/status-page.css
+++ b/src/app/[locale]/status/status-page.css
@@ -1,5 +1,6 @@
 .cch-status-bg {
   position: relative;
+  isolation: isolate;
 }
 
 .cch-status-bg::before {

--- a/src/lib/public-status/payload.ts
+++ b/src/lib/public-status/payload.ts
@@ -1,6 +1,6 @@
 import type { PublicStatusServeState } from "./redis-contract";
 
-export type PublicStatusTimelineState = "operational" | "failed" | "no_data";
+export type PublicStatusTimelineState = "operational" | "degraded" | "failed" | "no_data";
 
 export interface PublicStatusTimelineBucket {
   bucketStart: string;

--- a/tests/unit/app/status/derive-display-state.test.ts
+++ b/tests/unit/app/status/derive-display-state.test.ts
@@ -89,6 +89,14 @@ describe("deriveLatestModelState", () => {
     expect(result).toBe("no_data");
   });
 
+  it("returns degraded when last known bucket is degraded with null pct", () => {
+    const result = deriveLatestModelState({
+      latestState: "degraded",
+      timeline: [makeBucket({ state: "degraded", availabilityPct: null })],
+    });
+    expect(result).toBe("degraded");
+  });
+
   it("returns degraded when last known availability is partial", () => {
     const result = deriveLatestModelState({
       latestState: "operational",

--- a/tests/unit/app/status/derive-display-state.test.ts
+++ b/tests/unit/app/status/derive-display-state.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { PublicStatusTimelineBucket } from "@/lib/public-status/payload";
+import {
+  DEGRADED_THRESHOLD,
+  deriveDisplayState,
+  deriveLatestModelState,
+} from "@/app/[locale]/status/_lib/derive-display-state";
+
+function makeBucket(
+  overrides: Partial<PublicStatusTimelineBucket> = {}
+): PublicStatusTimelineBucket {
+  return {
+    bucketStart: "2026-04-22T00:00:00.000Z",
+    bucketEnd: "2026-04-22T00:05:00.000Z",
+    state: "operational",
+    availabilityPct: 100,
+    ttfbMs: 200,
+    tps: 50,
+    sampleCount: 10,
+    ...overrides,
+  };
+}
+
+describe("deriveDisplayState", () => {
+  it("returns failed when state is failed", () => {
+    expect(deriveDisplayState(makeBucket({ state: "failed" }))).toBe("failed");
+  });
+
+  it("returns no_data when state is no_data", () => {
+    expect(deriveDisplayState(makeBucket({ state: "no_data", availabilityPct: null }))).toBe(
+      "no_data"
+    );
+  });
+
+  it("returns operational when availabilityPct is null", () => {
+    expect(deriveDisplayState(makeBucket({ availabilityPct: null }))).toBe("operational");
+  });
+
+  it("returns operational when availabilityPct >= 100", () => {
+    expect(deriveDisplayState(makeBucket({ availabilityPct: 100 }))).toBe("operational");
+  });
+
+  it("returns degraded when availabilityPct between threshold and 100", () => {
+    expect(deriveDisplayState(makeBucket({ availabilityPct: 80 }))).toBe("degraded");
+    expect(deriveDisplayState(makeBucket({ availabilityPct: DEGRADED_THRESHOLD }))).toBe(
+      "degraded"
+    );
+  });
+
+  it("collapses to failed when availabilityPct below threshold", () => {
+    expect(deriveDisplayState(makeBucket({ availabilityPct: 30 }))).toBe("failed");
+    expect(deriveDisplayState(makeBucket({ availabilityPct: 0 }))).toBe("failed");
+  });
+});
+
+describe("deriveLatestModelState", () => {
+  it("returns the most recent non-no_data bucket state", () => {
+    const result = deriveLatestModelState({
+      latestState: "no_data",
+      timeline: [
+        makeBucket({ state: "operational", availabilityPct: 100 }),
+        makeBucket({ state: "no_data", availabilityPct: null }),
+        makeBucket({ state: "no_data", availabilityPct: null }),
+      ],
+    });
+    expect(result).toBe("operational");
+  });
+
+  it("returns failed when last known bucket is failed", () => {
+    const result = deriveLatestModelState({
+      latestState: "no_data",
+      timeline: [
+        makeBucket({ state: "operational" }),
+        makeBucket({ state: "failed", availabilityPct: 0 }),
+        makeBucket({ state: "no_data", availabilityPct: null }),
+      ],
+    });
+    expect(result).toBe("failed");
+  });
+
+  it("returns no_data when timeline has only no_data", () => {
+    const result = deriveLatestModelState({
+      latestState: "no_data",
+      timeline: [
+        makeBucket({ state: "no_data", availabilityPct: null }),
+        makeBucket({ state: "no_data", availabilityPct: null }),
+      ],
+    });
+    expect(result).toBe("no_data");
+  });
+
+  it("returns degraded when last known availability is partial", () => {
+    const result = deriveLatestModelState({
+      latestState: "operational",
+      timeline: [makeBucket({ state: "operational", availabilityPct: 75 })],
+    });
+    expect(result).toBe("degraded");
+  });
+});

--- a/tests/unit/app/status/fill-display-timeline.test.ts
+++ b/tests/unit/app/status/fill-display-timeline.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { PublicStatusTimelineBucket } from "@/lib/public-status/payload";
+import { fillDisplayTimeline } from "@/app/[locale]/status/_lib/fill-display-timeline";
+
+function bucket(
+  state: PublicStatusTimelineBucket["state"],
+  pct: number | null,
+  index: number
+): PublicStatusTimelineBucket {
+  return {
+    bucketStart: `2026-04-22T00:${String(index).padStart(2, "0")}:00.000Z`,
+    bucketEnd: `2026-04-22T00:${String(index + 1).padStart(2, "0")}:00.000Z`,
+    state,
+    availabilityPct: pct,
+    ttfbMs: state === "no_data" ? null : 200,
+    tps: state === "no_data" ? null : 50,
+    sampleCount: state === "no_data" ? 0 : 5,
+  };
+}
+
+describe("fillDisplayTimeline", () => {
+  it("fills middle no_data when both sides equal", () => {
+    const result = fillDisplayTimeline([
+      bucket("operational", 100, 0),
+      bucket("no_data", null, 1),
+      bucket("no_data", null, 2),
+      bucket("operational", 100, 3),
+    ]);
+    expect(result.map((c) => c.displayState)).toEqual([
+      "operational",
+      "operational",
+      "operational",
+      "operational",
+    ]);
+    expect(result[1].inferred).toBe(true);
+    expect(result[2].inferred).toBe(true);
+    expect(result[0].inferred).toBe(false);
+  });
+
+  it("uses nearest known state for middle gap with different sides", () => {
+    const result = fillDisplayTimeline([
+      bucket("operational", 100, 0),
+      bucket("no_data", null, 1),
+      bucket("no_data", null, 2),
+      bucket("no_data", null, 3),
+      bucket("failed", 0, 4),
+    ]);
+    expect(result.map((c) => c.displayState)).toEqual([
+      "operational",
+      "operational",
+      "operational",
+      "failed",
+      "failed",
+    ]);
+  });
+
+  it("breaks tie by preferring left side", () => {
+    const result = fillDisplayTimeline([
+      bucket("operational", 100, 0),
+      bucket("no_data", null, 1),
+      bucket("failed", 0, 2),
+    ]);
+    expect(result[1].displayState).toBe("operational");
+  });
+
+  it("extends head no_data using first known state", () => {
+    const result = fillDisplayTimeline([
+      bucket("no_data", null, 0),
+      bucket("no_data", null, 1),
+      bucket("failed", 0, 2),
+    ]);
+    expect(result.map((c) => c.displayState)).toEqual(["failed", "failed", "failed"]);
+  });
+
+  it("extends tail no_data using last known state", () => {
+    const result = fillDisplayTimeline([
+      bucket("operational", 100, 0),
+      bucket("no_data", null, 1),
+      bucket("no_data", null, 2),
+    ]);
+    expect(result.map((c) => c.displayState)).toEqual([
+      "operational",
+      "operational",
+      "operational",
+    ]);
+    expect(result[2].inferred).toBe(true);
+  });
+
+  it("keeps no_data when timeline has no known state", () => {
+    const result = fillDisplayTimeline([bucket("no_data", null, 0), bucket("no_data", null, 1)]);
+    expect(result.map((c) => c.displayState)).toEqual(["no_data", "no_data"]);
+    expect(result[0].inferred).toBe(false);
+  });
+
+  it("does not mutate the original bucket objects", () => {
+    const original = [bucket("operational", 100, 0), bucket("no_data", null, 1)];
+    const snapshot = JSON.stringify(original);
+    fillDisplayTimeline(original);
+    expect(JSON.stringify(original)).toBe(snapshot);
+  });
+
+  it("derives degraded for partial availability when filling", () => {
+    const result = fillDisplayTimeline([
+      bucket("operational", 80, 0),
+      bucket("no_data", null, 1),
+      bucket("operational", 80, 2),
+    ]);
+    expect(result.map((c) => c.displayState)).toEqual(["degraded", "degraded", "degraded"]);
+  });
+});

--- a/tests/unit/app/status/group-order-reconcile.test.ts
+++ b/tests/unit/app/status/group-order-reconcile.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { reconcileOrder } from "@/app/[locale]/status/_lib/group-order-store";
+
+describe("reconcileOrder", () => {
+  it("returns current order when stored is empty", () => {
+    expect(reconcileOrder([], ["a", "b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  it("preserves stored order for groups still present", () => {
+    expect(reconcileOrder(["c", "a", "b"], ["a", "b", "c"])).toEqual(["c", "a", "b"]);
+  });
+
+  it("drops slugs that are no longer present", () => {
+    expect(reconcileOrder(["a", "removed", "b"], ["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("appends newly added slugs at the tail", () => {
+    expect(reconcileOrder(["a", "b"], ["a", "b", "c", "d"])).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("handles add and remove together", () => {
+    expect(reconcileOrder(["b", "old", "a"], ["a", "b", "new"])).toEqual(["b", "a", "new"]);
+  });
+
+  it("returns empty when current is empty", () => {
+    expect(reconcileOrder(["a", "b"], [])).toEqual([]);
+  });
+});

--- a/tests/unit/app/status/timeline-windows.test.ts
+++ b/tests/unit/app/status/timeline-windows.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type { PublicStatusTimelineBucket } from "@/lib/public-status/payload";
+import {
+  CHART_BUCKETS,
+  computeAvgTtfb,
+  computeUptimePct,
+  sliceTimelineForChart,
+} from "@/app/[locale]/status/_lib/timeline-windows";
+
+function makeBucket(
+  index: number,
+  overrides: Partial<PublicStatusTimelineBucket> = {}
+): PublicStatusTimelineBucket {
+  return {
+    bucketStart: `2026-04-22T${String(Math.floor(index / 12)).padStart(2, "0")}:${String((index % 12) * 5).padStart(2, "0")}:00.000Z`,
+    bucketEnd: "",
+    state: "operational",
+    availabilityPct: 100,
+    ttfbMs: 200,
+    tps: 50,
+    sampleCount: 10,
+    ...overrides,
+  };
+}
+
+describe("sliceTimelineForChart", () => {
+  it("returns the full array when shorter than chart buckets", () => {
+    const t = Array.from({ length: 10 }, (_, i) => makeBucket(i));
+    expect(sliceTimelineForChart(t)).toHaveLength(10);
+  });
+
+  it("slices the last N buckets when longer than chart buckets", () => {
+    const t = Array.from({ length: 288 }, (_, i) => makeBucket(i));
+    const result = sliceTimelineForChart(t);
+    expect(result).toHaveLength(CHART_BUCKETS);
+    expect(result[0]).toBe(t[t.length - CHART_BUCKETS]);
+    expect(result[result.length - 1]).toBe(t[t.length - 1]);
+  });
+
+  it("respects custom chart buckets size", () => {
+    const t = Array.from({ length: 100 }, (_, i) => makeBucket(i));
+    expect(sliceTimelineForChart(t, 30)).toHaveLength(30);
+  });
+});
+
+describe("computeUptimePct", () => {
+  it("returns null when no samples", () => {
+    expect(computeUptimePct([])).toBeNull();
+    expect(
+      computeUptimePct([makeBucket(0, { sampleCount: 0, availabilityPct: null, state: "no_data" })])
+    ).toBeNull();
+  });
+
+  it("computes weighted average across buckets", () => {
+    const result = computeUptimePct([
+      makeBucket(0, { availabilityPct: 100, sampleCount: 8 }),
+      makeBucket(1, { availabilityPct: 50, sampleCount: 2 }),
+    ]);
+    expect(result).toBe(90);
+  });
+
+  it("ignores buckets with no samples", () => {
+    const result = computeUptimePct([
+      makeBucket(0, { availabilityPct: 100, sampleCount: 5 }),
+      makeBucket(1, { availabilityPct: null, sampleCount: 0, state: "no_data" }),
+    ]);
+    expect(result).toBe(100);
+  });
+});
+
+describe("computeAvgTtfb", () => {
+  it("returns null when no samples", () => {
+    expect(computeAvgTtfb([])).toBeNull();
+  });
+
+  it("computes weighted integer average", () => {
+    const result = computeAvgTtfb([
+      makeBucket(0, { ttfbMs: 100, sampleCount: 4 }),
+      makeBucket(1, { ttfbMs: 300, sampleCount: 4 }),
+    ]);
+    expect(result).toBe(200);
+  });
+
+  it("skips buckets with null ttfb", () => {
+    const result = computeAvgTtfb([
+      makeBucket(0, { ttfbMs: 200, sampleCount: 5 }),
+      makeBucket(1, { ttfbMs: null, sampleCount: 5 }),
+    ]);
+    expect(result).toBe(200);
+  });
+});


### PR DESCRIPTION
## Related

- Follow-up to #1062 — continues status page UI optimization and public branding
- Follow-up to #1056 — redesigns the public-facing UI layer introduced by the Redis-projected public status page
- Related to #1072 — builds on the model-type picker fix for the status page

Visual alignment target: [BingZi-233/check-cx](https://github.com/BingZi-233/check-cx)

## Summary

- Model card top-right adds Operational / Degraded / Failed / No Data status badge, derived from the latest non-empty time bucket using availability thresholds (>=100=operational, [50,100)=degraded, <50 or failed=error)
- History status bar redesigned to compact single-line + shadcn `<Tooltip>`, showing time range / availability / TTFB / TPS / sample count on hover; zero-sample buckets show "inferred from neighbors" hint
- No-request time bucket cells use bidirectional unbounded fill from adjacent states (mid-range nearest, edges extend), eliminating grey gaps
- Statistics window aligned to check-cx: online rate / TTFB use 24h weighted average, timeline 5h x 60 points
- Hero (Activity icon + overall status capsule + animate-ping + ThemeSwitcher) / toolbar (search + custom sort) / grid background 1:1 replicate check-cx visuals
- Groups default to collapsed, support `@dnd-kit` drag reorder (only when custom sort enabled); collapsed state and custom order persist to localStorage with backend add/delete reconciliation
- 5 locales synced with new keys: `statusBadge / tooltip / searchPlaceholder / customSort / resetSort / emptyByFilter / modelsLabel / issuesLabel`
- Mobile: hero and toolbar `flex-col sm:flex-row`, card grid `md:grid-cols-2 xl:grid-cols-3`, timeline always single-row full-width

## Files

- Modified: `src/lib/public-status/payload.ts` (`PublicStatusTimelineState` gains `degraded`)
- Modified: `src/app/[locale]/status/page.tsx` (rangeHours=24, labels passthrough)
- Rewritten: `src/app/[locale]/status/_components/public-status-view.tsx` (assembles hero + toolbar + DnD + collapsible groups + cards)
- Rewritten: `src/app/[locale]/status/_components/public-status-timeline.tsx` (single-row + Tooltip)
- Added: `status-hero.tsx` / `status-toolbar.tsx` / `sortable-group-panel.tsx`
- Added libs: `derive-display-state.ts` / `fill-display-timeline.ts` / `timeline-windows.ts` / `group-order-store.ts`
- Added styles: `status-page.css` (scoped `.cch-status-bg` grid background)
- Added 4 unit test files, 33 tests total
- Added deps: `@dnd-kit/core` `@dnd-kit/sortable` `@dnd-kit/utilities`
- 5 locale `statusPage.json` files expanded with new i18n keys

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (only pre-existing 8 warnings, no new errors)
- [x] `bun run build` passes
- [x] `bunx vitest run tests/unit/app/status/` -> 4 files / 33 tests all pass
- [ ] `cd dev && make dev` then visit `/zh-CN/status` for manual testing
  - [ ] Create no-request time windows -> timeline fills with adjacent colors
  - [ ] Trigger 4xx/5xx -> red cell + tooltip data
  - [ ] Partial success rate 60-99% -> amber degraded
  - [ ] Card top-right badge tracks latest non-empty bucket
  - [ ] Refresh preserves group collapsed state
  - [ ] Custom sort drag -> order persists after refresh
  - [ ] Search model/group name filters in real-time
  - [ ] 5 locale labels render correctly
  - [ ] 375px mobile viewport responsive

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR substantially redesigns the public `/status` page to align with the check-cx UI, introducing a new hero/toolbar/collapsible-group layout, DnD-based group reordering (persisted to localStorage), a compact single-row timeline with Tooltip, a new `"degraded"` state, and bidirectional neighbour-fill for zero-request timeline cells. Five locales are updated and 33 unit tests cover the new utility functions. The overall implementation is clean and well-tested, with two minor UX correctness notes below.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after addressing the customSort persistence gap and verifying the empty-state experience.

All P0/P1 concerns from previous reviews are addressed (inferred-flag fix, drag-while-filtering guard). Two P2 findings remain: the customSort toggle not being initialized from the stored order causes a UX inconsistency on reload, and the bootstrap placeholder group no longer renders a visible model card.

src/app/[locale]/status/_components/public-status-view.tsx — customSort hydration logic and bootstrap placeholder group
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/status/_components/public-status-view.tsx | Major rewrite adding DnD, collapsible groups, search/filter, and derived-state badges; customSort toggle not persisted (UX inconsistency after reload) and bootstrap placeholder group loses its model card |
| src/app/[locale]/status/_lib/derive-display-state.ts | New utility cleanly derives display state from backend bucket; threshold logic (≥100 operational, [50,100) degraded, <50 failed) is well-tested |
| src/app/[locale]/status/_lib/fill-display-timeline.ts | Bidirectional neighbour-fill algorithm is correct; uses cell.inferred flag properly; well-covered by unit tests |
| src/app/[locale]/status/_lib/group-order-store.ts | Robust localStorage wrapper with SSR guard, quota-error handling, and correct reconcileOrder logic verified by tests |
| src/app/[locale]/status/_components/public-status-timeline.tsx | Compact single-row timeline with Tooltip; correctly uses cell.inferred (not sampleCount === 0) for the inferred from neighbours hint |
| src/app/[locale]/status/_components/sortable-group-panel.tsx | Clean DnD-sortable collapsible panel; disables useSortable when !draggable, preventing drag during search filtering |
| src/lib/public-status/payload.ts | Added degraded to PublicStatusTimelineState union; backward-compatible addition |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[page.tsx\nServer Component] -->|initialPayload + labels| B[PublicStatusView]
    B --> C[StatusHero\noverallState + animate-ping]
    B --> D[StatusToolbar\nsearch + customSort toggle]
    B --> E{filteredGroups\nempty?}
    E -->|yes| F[emptyByFilter message]
    E -->|no| G[DndContext + SortableContext]
    G --> H[SortableGroupPanel x N\ncollapsible + drag handle]
    H --> I[model cards x M]
    I --> J[PublicStatusTimeline\nFilledTimelineCell x 60]
    J --> K[Tooltip per cell]

    B --> L[(localStorage)]
    L -->|loadGroupOrder| M[groupOrder state]
    L -->|loadCollapsedSet| N[collapsedGroups state]
    M --> O[orderedGroups memo]
    O --> P[filteredGroups memo]
    P --> G

    subgraph Derive pipeline
        Q[model.timeline] --> R[fillDisplayTimeline\ninferred fill]
        R --> S[sliceTimelineForChart\nlast 60 cells]
        Q --> T[computeUptimePct\nweighted avg]
        Q --> U[computeAvgTtfb\nweighted avg]
        Q --> V[deriveLatestModelState\nbadge state]
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/app/[locale]/status/_components/public-status-view.tsx`, line 668-680 ([link](https://github.com/ding113/claude-code-hub/blob/ae6f1d84fbd1322ae5feb386a3a6e4ac3d6a4196/src/app/[locale]/status/_components/public-status-view.tsx#L668-L680)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Drag-while-filtering silently relocates hidden groups**

   `handleDragEnd` builds `slugs` from `filteredGroups`, then calls `reconcileOrder(next, baseSlugs)` which appends every base slug not present in `next` to the tail. When search is active, all non-matching groups are absent from `next`, so they all end up at the end of the persisted order after a single drag — the user sees a reordered list only after clearing the filter.

   Consider either disabling drag (`draggable={customSort && !searchQuery}`) while a filter is active, or applying the drag delta to `groupOrder` in-place rather than rebuilding from `filteredGroups`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/status/_components/public-status-view.tsx
   Line: 668-680

   Comment:
   **Drag-while-filtering silently relocates hidden groups**

   `handleDragEnd` builds `slugs` from `filteredGroups`, then calls `reconcileOrder(next, baseSlugs)` which appends every base slug not present in `next` to the tail. When search is active, all non-matching groups are absent from `next`, so they all end up at the end of the persisted order after a single drag — the user sees a reordered list only after clearing the filter.

   Consider either disabling drag (`draggable={customSort && !searchQuery}`) while a filter is active, or applying the drag delta to `groupOrder` in-place rather than rebuilding from `filteredGroups`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/app/[locale]/status/page.tsx`, line 1430-1432 ([link](https://github.com/ding113/claude-code-hub/blob/ae6f1d84fbd1322ae5feb386a3a6e4ac3d6a4196/src/app/[locale]/status/page.tsx#L1430-L1432)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead locale key `tooltip.timeRange`**

   `tooltip.timeRange` is defined in all five locale files and plumbed through `page.tsx` into `labels.tooltip.timeRange`, but `PublicStatusTimelineLabels` does not include this field and `PublicStatusTimeline` never reads it — the time range is formatted inline via `formatRange`. Consider removing the key from all locale files and from the `tooltip` object in `page.tsx` to avoid confusion.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/status/page.tsx
   Line: 1430-1432

   Comment:
   **Dead locale key `tooltip.timeRange`**

   `tooltip.timeRange` is defined in all five locale files and plumbed through `page.tsx` into `labels.tooltip.timeRange`, but `PublicStatusTimelineLabels` does not include this field and `PublicStatusTimeline` never reads it — the time range is formatted inline via `formatRange`. Consider removing the key from all locale files and from the `tooltip` object in `page.tsx` to avoid confusion.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/[locale]/status/_components/public-status-view.tsx
Line: 543-547

Comment:
**`customSort` toggle not initialized from persisted order**

`customSort` is always initialized to `false`, so after a page reload the saved group order is silently applied (via `groupOrder` from localStorage) but the button still reads "Custom Sort" instead of "Reset Order" and drag handles are hidden. Users who previously arranged groups have no visible indication that their order is active, and must re-click "Custom Sort" to get drag handles back.

Fix: sync `customSort` to `true` inside the hydration `useEffect` when a saved order exists:
```ts
useEffect(() => {
  const savedOrder = loadGroupOrder();
  setGroupOrder(savedOrder);
  if (savedOrder.length > 0) setCustomSort(true);
  setCollapsedGroups(loadCollapsedSet());
  setOrderHydrated(true);
}, []);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/[locale]/status/_components/public-status-view.tsx
Line: 553-566

Comment:
**Bootstrap placeholder group silently loses its model card**

The original empty-state group had a single placeholder model so the UI rendered a visible card. The new `baseGroups` memo sets `models: []`, so when `payload.groups` is empty the rendered panel has a header (showing "0 models") but no cards — a noticeably degraded empty-state compared to the prior behaviour.

If a visible placeholder is intentional UX, the bootstrap entry should include at least one model snapshot. If an empty panel is intended, a dedicated zero-state illustration inside the panel body would communicate the state more clearly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(status): address second-round bugbot..."](https://github.com/ding113/claude-code-hub/commit/bc51b595e7becbd199671499db119bdea9119d30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29302047)</sub>

<!-- /greptile_comment -->