### PR TITLE
fix: harden k8s deploy scripts against pipefail early exits

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -27,6 +27,18 @@ deploy/k8s/
     └── traefik-ingressroute.yaml      # Traefik IngressRoute 备选 (k3s 默认)
 ```
 
+## 客户端 IP 透传
+
+- `ingress/ingress.yaml` 不默认依赖 `configuration-snippet`; 标准 Ingress 路径要求你在
+  controller 级别打开 forwarded-header / real-ip 配置,避免被
+  `allow-snippet-annotations=false` 的默认安装直接拒绝。
+- 若你还希望应用优先信任 `X-Real-IP`,请先在 ingress controller / 上游 LB 上正确配置
+  trusted proxies / real-ip(`use-forwarded-headers`、`proxy-real-ip-cidr` 等)。
+- `ingress/traefik-ingressroute.yaml` 依赖 Traefik 默认透传 `X-Forwarded-For`;
+  `X-Real-Ip` 是否可信取决于 `forwardedHeaders.trustedIPs` 等 entrypoint 配置。
+- 应用侧的默认提取链仍等价于
+  `{ headers: [{ name: "x-real-ip" }, { name: "x-forwarded-for", pick: "rightmost" }] }`。
+
 ## 占位符参考
 
 | 占位符 | 含义 | 默认值 |
@@ -59,6 +71,7 @@ deploy/k8s/
 
 ```bash
 # 集群侧一键部署 (推荐)
+# 默认等价 main 分支发布镜像 -> ghcr.io/ding113/claude-code-hub:latest
 bash scripts/deploy-k8s.sh -y
 
 # 自定义 namespace / 镜像 / 域名

--- a/deploy/k8s/ingress/ingress.yaml
+++ b/deploy/k8s/ingress/ingress.yaml
@@ -9,6 +9,10 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+    # 客户端 IP 透传依赖 ingress controller 级 forwarded-header / real-ip 配置。
+    # 不默认使用 configuration-snippet:
+    # - ingress-nginx 常见安装默认 allow-snippet-annotations=false
+    # - X-Real-IP 只有在 trusted proxies / real-ip 正确配置后才可靠
     # Traefik 注解(安装为 Ingress Controller 时生效)
     traefik.ingress.kubernetes.io/router.middlewares: "{{NAMESPACE}}-streaming-headers@kubernetescrd"
 spec:

--- a/deploy/k8s/ingress/traefik-ingressroute.yaml
+++ b/deploy/k8s/ingress/traefik-ingressroute.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{NAMESPACE}}
 spec:
   headers:
+    # Traefik 默认会继续透传 X-Forwarded-For;
+    # 若要让 X-Real-Ip 可信,还需要在 entrypoint 上配置 forwardedHeaders.trustedIPs。
+    # 这里仅补充流式响应所需的响应头,不覆盖源 IP 链。
     customResponseHeaders:
       X-Accel-Buffering: "no"
 ---
@@ -22,6 +25,8 @@ spec:
       middlewares:
         - name: streaming-headers
       services:
+        # 依赖 Traefik 默认透传 X-Forwarded-For;
+        # X-Real-Ip 是否可信取决于 forwardedHeaders.trustedIPs / 等效 trusted proxy 配置。
         - name: claude-code-hub
           port: 80
           passHostHeader: true

--- a/docs/k8s-deployment.md
+++ b/docs/k8s-deployment.md
@@ -213,6 +213,23 @@ bash scripts/deploy-k8s.sh --replicas 3 --hpa-min 3 --hpa-max 10 -y
 默认模板保留 `replicas=2`,但 `AUTO_MIGRATE` 入口 `src/instrumentation.ts` 会先获取 PostgreSQL advisory lock,
 因此首次多副本启动时迁移会串行执行。如果你更关心首启速度,也可以先用 `--replicas 1` 部署,确认健康后再扩容。
 
+### 客户端 IP 透传
+
+- 默认 k8s 部署保持 `main -> ghcr.io/ding113/claude-code-hub:latest`；只有显式传
+  `-b dev` 才会切到 `:dev`。
+- `deploy/k8s/ingress/ingress.yaml` 不默认依赖 `configuration-snippet`;
+  标准 Ingress 路径要求你在 controller 级别配置 forwarded headers / real-ip。
+- 若你希望应用优先信任 `X-Real-IP`,必须先在 ingress-nginx / 上游 LB 上配置
+  `use-forwarded-headers`、`proxy-real-ip-cidr` 等 trusted proxy / real-ip 选项。
+- 若你显式打算使用 `configuration-snippet`,还要确认 ingress-nginx 已打开
+  `allow-snippet-annotations=true`。
+- `deploy/k8s/ingress/traefik-ingressroute.yaml` 依赖 Traefik 默认透传
+  `X-Forwarded-For`; `X-Real-Ip` 是否可信取决于 `forwardedHeaders.trustedIPs`
+  (或等效 trusted proxy / proxy protocol 配置)。
+- 应用侧的默认 IP 提取链仍等价于
+  `{ headers: [{ name: "x-real-ip" }, { name: "x-forwarded-for", pick: "rightmost" }] }`,
+  不需要通过 SQL 或初始化脚本额外落库。
+
 ### NetworkPolicy 自定义
 
 默认 `deploy/k8s/app/networkpolicy.yaml` 只在 **Ingress 模式** 下应用,并放行以下三个 Ingress Controller namespace:
@@ -246,11 +263,18 @@ bash scripts/deploy-k8s.sh --replicas 3 --hpa-min 3 --hpa-max 10 -y
 ### 生命周期
 
 ```bash
-cch update            # 拉新镜像 + 自动迁移 + 滚动更新,失败自动回滚
+cch update            # 拉新镜像 + 自动迁移 + 滚动更新
 cch restart           # 滚动重启 (不换镜像)
 cch rollback          # 回滚到上一个 revision
 cch scale 3           # 调整副本数
 ```
+
+> 说明:
+> - `cch update` 在 rollout / 健康检查失败时会自动执行 `rollout undo` 并恢复副本数。
+> - 若 k3s digest 解析失败,会先回落到同 tag 的 `set image + rollout restart`;
+>   只有后续 rollout / 健康检查失败时才会执行 `rollout undo`。
+> - 在这种同 tag fallback 场景里,`rollout undo` 回退的是 Deployment 模板,
+>   不保证严格回到上一份镜像 digest。
 
 ### 观测
 

--- a/scripts/cch
+++ b/scripts/cch
@@ -126,7 +126,9 @@ detect_runtime() {
             fi
         fi
     elif command -v kubectl &>/dev/null && kubectl cluster-info &>/dev/null; then
-        if kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.kubeletVersion}' 2>/dev/null | grep -q 'k3s'; then
+        local kubelet_versions
+        kubelet_versions="$(kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.kubeletVersion}' 2>/dev/null || echo "")"
+        if [[ "$kubelet_versions" == *"k3s"* ]]; then
             RUNTIME="k3s"
         else
             RUNTIME="kubectl"
@@ -212,6 +214,58 @@ restore_update_scaling() {
     $KUBECTL -n "$NAMESPACE" scale deployment/claude-code-hub --replicas="$target_replicas" >/dev/null || true
 }
 
+resolve_k3s_image_digest() {
+    local image="$1"
+    sudo k3s ctr images ls 2>/dev/null | awk -v img="$image" 'found==0 && $1==img { print $3; found=1 }'
+}
+
+restart_k3s_rollout_with_image() {
+    local reason="$1"
+    local image="$2"
+    warn "$reason"
+    if ! $KUBECTL -n "$NAMESPACE" set image deployment/claude-code-hub app="$image" >/dev/null; then
+        err "set image 失败，未能应用目标镜像: $image"
+        return 1
+    fi
+    $KUBECTL -n "$NAMESPACE" rollout restart deployment/claude-code-hub >/dev/null
+}
+
+build_image_ref_with_digest() {
+    local image="$1"
+    local image_digest="$2"
+    local image_without_digest="${image%@*}"
+    local last_segment
+
+    if [[ "$image_without_digest" == "$image" ]]; then
+        last_segment="${image##*/}"
+        if [[ "$last_segment" == *:* ]]; then
+            image_without_digest="${image%:*}"
+        fi
+    fi
+
+    printf '%s@%s' "$image_without_digest" "$image_digest"
+}
+
+update_k3s_image_by_digest_or_restart() {
+    local image="$1"
+    local image_digest="" image_by_digest
+
+    # 这里不能在 awk 命中第一条后直接 exit:
+    # 在 set -euo pipefail 下,上游 ctr 仍继续写 pipe 时会收到 SIGPIPE(141),
+    # 进而让整个命令替换失败并静默退出升级流程。
+    if image_digest=$(resolve_k3s_image_digest "$image"); then
+        if [[ -n "$image_digest" ]] && [[ "${image_digest#sha256:}" != "$image_digest" ]]; then
+            image_by_digest="$(build_image_ref_with_digest "$image" "$image_digest")"
+            info "  digest: $image_digest"
+            $KUBECTL -n "$NAMESPACE" set image deployment/claude-code-hub app="$image_by_digest" >/dev/null
+        else
+            restart_k3s_rollout_with_image "未解析到可用 digest,回落到 rollout restart" "$image"
+        fi
+    else
+        restart_k3s_rollout_with_image "k3s ctr images ls 失败,回落到 rollout restart" "$image"
+    fi
+}
+
 ###############################################################################
 # Commands
 ###############################################################################
@@ -283,16 +337,9 @@ cmd_update() {
     info "Step 4/6: Updating image on single instance (auto-migration)..."
     if [[ "$RUNTIME" == "k3s" ]]; then
         # k3s: 用 digest 固定,避免 tag 相同导致 no-op rollout
-        local IMAGE_DIGEST IMAGE_BY_DIGEST
-        IMAGE_DIGEST=$(sudo k3s ctr images ls 2>/dev/null | awk -v img="$IMAGE" '$1==img {print $3; exit}')
-        if [[ -n "$IMAGE_DIGEST" ]] && [[ "${IMAGE_DIGEST#sha256:}" != "$IMAGE_DIGEST" ]]; then
-            IMAGE_BY_DIGEST="${IMAGE%:*}@${IMAGE_DIGEST}"
-            info "  digest: $IMAGE_DIGEST"
-            $KUBECTL -n "$NAMESPACE" set image deployment/claude-code-hub app="$IMAGE_BY_DIGEST" >/dev/null
-        else
-            warn "无法解析 digest,回落到 rollout restart"
-            $KUBECTL -n "$NAMESPACE" set image deployment/claude-code-hub app="$IMAGE" >/dev/null || true
-            $KUBECTL -n "$NAMESPACE" rollout restart deployment/claude-code-hub >/dev/null
+        if ! update_k3s_image_by_digest_or_restart "$IMAGE"; then
+            restore_update_scaling "$CURRENT_REPLICAS" "$MIN_REPLICAS"
+            exit 1
         fi
     else
         # 标准 k8s: set image 到目标 tag,触发 rollout;相同 tag 时强制 restart 拿最新 digest
@@ -530,7 +577,7 @@ cmd_doctor() {
 
     # kubectl
     if command -v kubectl &>/dev/null; then
-        check_pass "kubectl installed: $(kubectl version --client -o yaml 2>/dev/null | awk '/gitVersion/{print $2; exit}')"
+        check_pass "kubectl installed: $(kubectl version --client -o jsonpath='{.clientVersion.gitVersion}' 2>/dev/null)"
     elif [[ "$RUNTIME" == "k3s" ]] && command -v k3s &>/dev/null; then
         check_warn "kubectl 未安装,将使用 sudo k3s kubectl"
     else
@@ -703,23 +750,25 @@ EOF
 ###############################################################################
 # Dispatch
 ###############################################################################
-case "${1:-help}" in
-    update)    shift; cmd_update "$@" ;;
-    status)    shift; cmd_status "$@" ;;
-    logs)      shift; cmd_logs "$@" ;;
-    follow)    cmd_follow ;;
-    restart)   cmd_restart ;;
-    rollback)  cmd_rollback ;;
-    backup)    cmd_backup ;;
-    scale)     shift; cmd_scale "$@" ;;
-    env)       cmd_env ;;
-    secret)    shift; cmd_secret "$@" ;;
-    shell)     cmd_shell ;;
-    dbshell)   cmd_dbshell ;;
-    info)      cmd_info ;;
-    version|--version|-v) cmd_version ;;
-    doctor)    cmd_doctor ;;
-    install)   shift; cmd_install "$@" ;;
-    uninstall) cmd_uninstall ;;
-    help|--help|-h|*) cmd_help ;;
-esac
+if [[ "${CCH_SOURCE_ONLY:-0}" != "1" ]]; then
+    case "${1:-help}" in
+        update)    shift; cmd_update "$@" ;;
+        status)    shift; cmd_status "$@" ;;
+        logs)      shift; cmd_logs "$@" ;;
+        follow)    cmd_follow ;;
+        restart)   cmd_restart ;;
+        rollback)  cmd_rollback ;;
+        backup)    cmd_backup ;;
+        scale)     shift; cmd_scale "$@" ;;
+        env)       cmd_env ;;
+        secret)    shift; cmd_secret "$@" ;;
+        shell)     cmd_shell ;;
+        dbshell)   cmd_dbshell ;;
+        info)      cmd_info ;;
+        version|--version|-v) cmd_version ;;
+        doctor)    cmd_doctor ;;
+        install)   shift; cmd_install "$@" ;;
+        uninstall) cmd_uninstall ;;
+        help|--help|-h|*) cmd_help ;;
+    esac
+fi

--- a/scripts/deploy-k8s.sh
+++ b/scripts/deploy-k8s.sh
@@ -39,6 +39,10 @@ log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
 log_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
 log_error()   { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 
+has_command() {
+    command -v "$1" >/dev/null 2>&1
+}
+
 # 跨平台 base64 decode (macOS BSD 旧版只认 -D)
 b64d() {
     if base64 -d </dev/null >/dev/null 2>&1; then
@@ -54,6 +58,7 @@ b64d() {
 # Defaults
 ###############################################################################
 DEFAULT_NAMESPACE="claude-code-hub"
+# k8s 部署默认跟随 main 分支发布镜像;仅显式传 -b dev 时才切到 :dev。
 DEFAULT_IMAGE="ghcr.io/ding113/claude-code-hub:latest"
 DEFAULT_REPLICAS=2
 DEFAULT_HPA_MIN=2
@@ -129,7 +134,7 @@ Cluster:
 
 Application:
   -i, --image <ref>             应用镜像 (default: ${DEFAULT_IMAGE})
-  -b, --branch <name>           分支捷径 main→:latest / dev→:dev
+  -b, --branch <name>           分支捷径 默认 main→:latest / dev→:dev
   -t, --admin-token <token>     自定义 ADMIN_TOKEN (default: auto-generated)
       --replicas <n>            Deployment 基线副本数 (default: ${DEFAULT_REPLICAS})
       --hpa-min <n>             HPA 最小副本 (default: ${DEFAULT_HPA_MIN})
@@ -281,7 +286,9 @@ detect_runtime() {
             RUNTIME="kubectl"
             KUBECTL="kubectl"
             # 探测当前集群是否是 k3s (观察节点 kubelet version 或 rancher 标识)
-            if kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.kubeletVersion}' 2>/dev/null | grep -q 'k3s'; then
+            local kubelet_versions
+            kubelet_versions="$(kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.kubeletVersion}' 2>/dev/null || echo "")"
+            if [[ "$kubelet_versions" == *"k3s"* ]]; then
                 RUNTIME="k3s"
                 log_info "Runtime: k3s (via kubectl)"
             else
@@ -369,7 +376,7 @@ preflight_checks() {
 resolve_config() {
     NAMESPACE="${NAMESPACE_ARG:-$DEFAULT_NAMESPACE}"
 
-    # 分支捷径
+    # 分支捷径：不传时保持 main/latest 为默认语义
     if [[ -n "$BRANCH_ARG" ]]; then
         case "$BRANCH_ARG" in
             main|master) APP_IMAGE="ghcr.io/ding113/claude-code-hub:latest" ;;
@@ -426,9 +433,17 @@ detect_storage_class() {
     fi
     # 尝试找默认 StorageClass
     local default_sc
-    default_sc=$($KUBECTL get sc -o jsonpath='{range .items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")]}{.metadata.name}{"\n"}{end}' 2>/dev/null | head -1)
+    if default_sc=$($KUBECTL get sc -o jsonpath='{range .items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")]}{.metadata.name}{"\n"}{end}' 2>/dev/null); then
+        default_sc="${default_sc%%$'\n'*}"
+    else
+        default_sc=""
+    fi
     if [[ -z "$default_sc" ]]; then
-        default_sc=$($KUBECTL get sc -o jsonpath='{range .items[?(@.metadata.annotations.storageclass\.beta\.kubernetes\.io/is-default-class=="true")]}{.metadata.name}{"\n"}{end}' 2>/dev/null | head -1)
+        if default_sc=$($KUBECTL get sc -o jsonpath='{range .items[?(@.metadata.annotations.storageclass\.beta\.kubernetes\.io/is-default-class=="true")]}{.metadata.name}{"\n"}{end}' 2>/dev/null); then
+            default_sc="${default_sc%%$'\n'*}"
+        else
+            default_sc=""
+        fi
     fi
     if [[ -n "$default_sc" ]]; then
         STORAGE_CLASS="$default_sc"
@@ -464,7 +479,9 @@ detect_ingress_variant() {
     fi
 
     # 标准 Ingress
-    if $KUBECTL api-resources 2>/dev/null | grep -q '^ingresses.*networking.k8s.io'; then
+    local api_resources
+    api_resources="$($KUBECTL api-resources --api-group=networking.k8s.io -o name 2>/dev/null || echo "")"
+    if [[ "$api_resources" == *"ingresses.networking.k8s.io"* ]]; then
         INGRESS_CLASS="${INGRESS_CLASS_ARG:-}"
         if [[ -z "$INGRESS_CLASS" ]]; then
             # 查找 IngressClass
@@ -546,11 +563,26 @@ detect_existing_deployment() {
 ###############################################################################
 generate_random() {
     local length="${1:-32}"
-    if command -v openssl &>/dev/null; then
-        openssl rand -base64 48 | tr -d '=/+' | head -c "$length"
+    local random=""
+    local chunk=""
+    if has_command openssl; then
+        while [[ "${#random}" -lt "$length" ]]; do
+            if ! chunk=$(openssl rand -base64 48 | tr -d '=/+'); then
+                log_error "使用 openssl 生成随机串失败"
+                return 1
+            fi
+            random+="$chunk"
+        done
     else
-        tr -dc 'A-Za-z0-9' < /dev/urandom | head -c "$length"
+        while [[ "${#random}" -lt "$length" ]]; do
+            if ! chunk=$(LC_ALL=C dd if=/dev/urandom bs=256 count=1 status=none | tr -dc 'A-Za-z0-9'); then
+                log_error "从 /dev/urandom 生成随机串失败"
+                return 1
+            fi
+            random+="$chunk"
+        done
     fi
+    printf '%s' "${random:0:length}"
 }
 
 prepare_secret_values() {
@@ -911,4 +943,6 @@ main() {
     print_success_message
 }
 
-main "$@"
+if [[ "${DEPLOY_K8S_SOURCE_ONLY:-0}" != "1" ]]; then
+    main "$@"
+fi

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -815,7 +815,7 @@ export const systemSettings = pgTable('system_settings', {
   quotaLeasePercentMonthly: numeric('quota_lease_percent_monthly', { precision: 5, scale: 4 }).default('0.05'),
   quotaLeaseCapUsd: numeric('quota_lease_cap_usd', { precision: 10, scale: 2 }),
 
-  // 客户端 IP 提取配置（null 表示使用内置默认链：cf-connecting-ip → x-real-ip → x-forwarded-for rightmost）
+  // 客户端 IP 提取配置（null 表示使用内置默认链：x-real-ip → x-forwarded-for rightmost）
   ipExtractionConfig: jsonb('ip_extraction_config').$type<IpExtractionConfig>(),
   // 是否启用 IP 归属地查询（默认开启）
   ipGeoLookupEnabled: boolean('ip_geo_lookup_enabled').notNull().default(true),

--- a/tests/unit/k8s-cch-update-flow.test.ts
+++ b/tests/unit/k8s-cch-update-flow.test.ts
@@ -1,0 +1,169 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+function runCchHelper(scriptBody: string) {
+  return execFileSync(
+    "bash",
+    [
+      "-lc",
+      `
+set -euo pipefail
+export CCH_SOURCE_ONLY=1
+source scripts/cch
+${scriptBody}
+      `,
+    ],
+    {
+      encoding: "utf8",
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        NO_COLOR: "1",
+      },
+    }
+  ).trim();
+}
+
+function runK3sUpdateHarness(options: { k3sBody: string; kubectlBody?: string; tail?: string }) {
+  const kubectlBody =
+    options.kubectlBody ??
+    `
+  printf '%s\\n' "$*" >> "$LOG_FILE"
+`;
+  const tail =
+    options.tail ??
+    `
+update_k3s_image_by_digest_or_restart "$IMAGE"
+cat "$LOG_FILE"
+`;
+
+  return runCchHelper(`
+LOG_FILE=$(mktemp)
+KUBECTL=kubectl_stub
+NAMESPACE=test-ns
+IMAGE=ghcr.io/ding113/claude-code-hub:latest
+
+kubectl_stub() {
+${kubectlBody}
+}
+
+sudo() {
+  "$@"
+}
+
+k3s() {
+${options.k3sBody}
+}
+
+${tail}
+  `);
+}
+
+describe("scripts/cch k3s update flow", () => {
+  it("pins the deployment image by digest when ctr returns a sha256 digest", () => {
+    const output = runK3sUpdateHarness({
+      k3sBody: `
+  cat <<'EOF'
+ghcr.io/ding113/claude-code-hub:latest READY sha256:abc123
+EOF
+`,
+    });
+
+    expect(output).toContain(
+      "-n test-ns set image deployment/claude-code-hub app=ghcr.io/ding113/claude-code-hub@sha256:abc123"
+    );
+    expect(output).not.toContain("rollout restart deployment/claude-code-hub");
+  });
+
+  it("replaces an existing digest ref instead of appending a second @sha256 segment", () => {
+    const output = runCchHelper(`
+printf '%s' "$(build_image_ref_with_digest 'ghcr.io/ding113/claude-code-hub@sha256:old' 'sha256:new')"
+    `);
+
+    expect(output).toBe("ghcr.io/ding113/claude-code-hub@sha256:new");
+  });
+
+  it("keeps registry ports intact when converting a tagged ref to digest form", () => {
+    const output = runCchHelper(`
+printf '%s' "$(build_image_ref_with_digest 'registry.example.com:5000/team/cch:latest' 'sha256:new')"
+    `);
+
+    expect(output).toBe("registry.example.com:5000/team/cch@sha256:new");
+  });
+
+  it("falls back to rollout restart when ctr succeeds but no matching digest is found", () => {
+    const output = runK3sUpdateHarness({
+      k3sBody: `
+  cat <<'EOF'
+ghcr.io/ding113/claude-code-hub:dev READY sha256:def456
+EOF
+`,
+    });
+
+    expect(output).toContain(
+      "-n test-ns set image deployment/claude-code-hub app=ghcr.io/ding113/claude-code-hub:latest"
+    );
+    expect(output).toContain("-n test-ns rollout restart deployment/claude-code-hub");
+  });
+
+  it("falls back to rollout restart when ctr exits non-zero", () => {
+    const output = runK3sUpdateHarness({
+      k3sBody: "  return 1",
+    });
+
+    expect(output).toContain(
+      "-n test-ns set image deployment/claude-code-hub app=ghcr.io/ding113/claude-code-hub:latest"
+    );
+    expect(output).toContain("-n test-ns rollout restart deployment/claude-code-hub");
+  });
+
+  it("fails fast when fallback set image itself fails", () => {
+    expect(() =>
+      runK3sUpdateHarness({
+        kubectlBody: `
+  if [[ "$3" == "set" && "$4" == "image" ]]; then
+    return 1
+  fi
+  printf '%s\\n' "$*" >> "$LOG_FILE"
+`,
+        k3sBody: "  return 1",
+        tail: 'update_k3s_image_by_digest_or_restart "$IMAGE"',
+      })
+    ).toThrow(/set image 失败，未能应用目标镜像/);
+  });
+
+  it("reads kubectl client version without an awk early-exit pipeline", () => {
+    const output = runCchHelper(`
+command() {
+  if [[ "$1" == "-v" && "$2" == "kubectl" ]]; then
+    return 0
+  fi
+  if [[ "$1" == "-v" && "$2" == "k3s" ]]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+
+kubectl() {
+  if [[ "$1" == "cluster-info" ]]; then
+    return 0
+  fi
+  if [[ "$1" == "get" && "$2" == "nodes" ]]; then
+    printf 'v1.31.0+k3s1'
+    return 0
+  fi
+  if [[ "$1" == "version" ]]; then
+    printf 'v1.31.0'
+    return 0
+  fi
+  return 1
+}
+
+detect_runtime
+cmd_doctor
+    `);
+
+    expect(output).toContain("kubectl installed: v1.31.0");
+    expect(output).toContain("Runtime detected (runtime=k3s, kubectl=kubectl)");
+  });
+});

--- a/tests/unit/k8s-deploy-assets-review-fixes.test.ts
+++ b/tests/unit/k8s-deploy-assets-review-fixes.test.ts
@@ -31,23 +31,42 @@ describe("k8s deploy review regressions", () => {
   it("uses replica-safe disruption settings and lint-safe ingress placeholders", () => {
     const pdb = readRepoFile("deploy/k8s/app/pdb.yaml");
     const ingress = readRepoFile("deploy/k8s/ingress/ingress.yaml");
+    const traefikIngressRoute = readRepoFile("deploy/k8s/ingress/traefik-ingressroute.yaml");
 
     expect(pdb).toContain("maxUnavailable: 1");
     expect(pdb).not.toContain("minAvailable: 1");
     expect(ingress).toContain(
       'traefik.ingress.kubernetes.io/router.middlewares: "{{NAMESPACE}}-streaming-headers@kubernetescrd"'
     );
+    expect(ingress).not.toContain("nginx.ingress.kubernetes.io/configuration-snippet: |");
+    expect(ingress).toContain("allow-snippet-annotations=false");
+    expect(ingress).toContain("trusted proxies / real-ip");
     expect(ingress).toContain('ingressClassName: "{{INGRESS_CLASS}}"');
     expect(ingress).toContain('- host: "{{INGRESS_HOST}}"');
+    expect(traefikIngressRoute).toContain("Traefik 默认会继续透传 X-Forwarded-For");
+    expect(traefikIngressRoute).toContain("forwardedHeaders.trustedIPs");
   });
 
   it("documents and enforces the NodePort-safe deployment path", () => {
     const deployScript = readRepoFile("scripts/deploy-k8s.sh");
 
+    expect(deployScript).toContain('DEFAULT_IMAGE="ghcr.io/ding113/claude-code-hub:latest"');
+    expect(deployScript).toContain("默认跟随 main 分支发布镜像");
+    expect(deployScript).toContain("分支捷径 默认 main→:latest / dev→:dev");
     expect(deployScript).toContain("NodePort 模式下跳过 app NetworkPolicy");
     expect(deployScript).toContain("删除 namespace=$NAMESPACE 并重建所有资源");
     expect(deployScript).toContain("storageclass\\.beta\\.kubernetes\\.io/is-default-class");
     expect(deployScript).toContain("reclaimPolicy");
+    expect(deployScript).not.toContain("| head -1");
+    expect(deployScript).not.toContain('| head -c "$length"');
+    expect(deployScript).not.toContain("dd if=/dev/urandom bs=256 count=1 status=none 2>/dev/null");
+    expect(deployScript).not.toContain("| grep -q 'k3s'");
+    expect(deployScript).not.toContain("| grep -q '^ingresses.*networking.k8s.io'");
+    expect(deployScript).toContain("default_sc=\"${default_sc%%$'\\n'*}\"");
+    expect(deployScript).toContain("api-resources --api-group=networking.k8s.io -o name");
+    expect(deployScript).toContain("ingresses.networking.k8s.io");
+    expect(deployScript).toContain('while [[ "${#random}" -lt "$length" ]]');
+    expect(deployScript).toContain('if [[ "${DEPLOY_K8S_SOURCE_ONLY:-0}" != "1" ]]; then');
     expect(deployScript).toContain('if ! [[ "$APP_HPA_MIN" =~ ^[0-9]+$ ]]');
     expect(deployScript).toContain("node_ip=$($KUBECTL get nodes");
   });
@@ -56,9 +75,23 @@ describe("k8s deploy review regressions", () => {
     const cchScript = readRepoFile("scripts/cch");
 
     expect(cchScript).not.toContain('source "$CCH_CONFIG_FILE"');
+    expect(cchScript).not.toContain(
+      "IMAGE_DIGEST=$(sudo k3s ctr images ls 2>/dev/null | awk -v img=\"$IMAGE\" '$1==img {print $3; exit}')"
+    );
+    expect(cchScript).not.toContain("| grep -q 'k3s'");
     expect(cchScript).toContain("load_config_file()");
+    expect(cchScript).toContain("resolve_k3s_image_digest()");
+    expect(cchScript).toContain("build_image_ref_with_digest()");
+    expect(cchScript).toContain("update_k3s_image_by_digest_or_restart");
+    expect(cchScript).toContain(
+      "kubectl version --client -o jsonpath='{.clientVersion.gitVersion}'"
+    );
     expect(cchScript).toContain('if [[ -z "${!key:-}" ]]; then');
     expect(cchScript).toContain('if [[ "${1:-}" =~ ^[0-9]+$ ]]; then');
+    expect(cchScript).toContain("if image_digest=$(resolve_k3s_image_digest");
+    expect(cchScript).toContain("found==0 && $1==img { print $3; found=1 }");
+    expect(cchScript).toContain("k3s ctr images ls 失败,回落到 rollout restart");
+    expect(cchScript).toContain('if [[ "${CCH_SOURCE_ONLY:-0}" != "1" ]]; then');
     expect(cchScript).toContain("wait_for_deployment_rollout()");
     expect(cchScript).toContain('if ! wait_for_deployment_rollout 180s "缩容到 1 副本"; then');
     expect(cchScript).toContain('local desired_replicas="$CURRENT_REPLICAS"');
@@ -70,12 +103,28 @@ describe("k8s deploy review regressions", () => {
 
   it("keeps the restore playbook compatible with CPU/memory HPA", () => {
     const docs = readRepoFile("docs/k8s-deployment.md");
+    const k8sReadme = readRepoFile("deploy/k8s/README.md");
 
+    expect(docs).toContain("默认 k8s 部署保持 `main -> ghcr.io/ding113/claude-code-hub:latest`");
+    expect(docs).toContain("controller 级别配置 forwarded headers / real-ip");
+    expect(docs).toContain("allow-snippet-annotations=true");
+    expect(docs).toContain("proxy-real-ip-cidr");
+    expect(docs).toContain("forwardedHeaders.trustedIPs");
+    expect(docs).toContain("不保证严格回到上一份镜像 digest");
+    expect(docs).toContain(
+      '{ headers: [{ name: "x-real-ip" }, { name: "x-forwarded-for", pick: "rightmost" }] }'
+    );
     expect(docs).toContain("kubectl -n claude-code-hub delete hpa claude-code-hub");
     expect(docs).toContain("恢复到 max(升级前实际副本数, HPA minReplicas)");
     expect(docs).toContain("<repeat-your-original-cli-args>");
     expect(docs).not.toContain('minReplicas":0');
     expect(docs).toContain("```text");
     expect(docs).toContain("```console");
+    expect(k8sReadme).toContain(
+      "默认等价 main 分支发布镜像 -> ghcr.io/ding113/claude-code-hub:latest"
+    );
+    expect(k8sReadme).toContain("X-Forwarded-For");
+    expect(k8sReadme).toContain("allow-snippet-annotations=false");
+    expect(k8sReadme).toContain("proxy-real-ip");
   });
 });

--- a/tests/unit/k8s-deploy-shell-helpers.test.ts
+++ b/tests/unit/k8s-deploy-shell-helpers.test.ts
@@ -1,0 +1,150 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+function runDeployHelper(scriptBody: string) {
+  return execFileSync(
+    "bash",
+    [
+      "-lc",
+      `
+set -euo pipefail
+export DEPLOY_K8S_SOURCE_ONLY=1
+source scripts/deploy-k8s.sh
+${scriptBody}
+      `,
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NO_COLOR: "1",
+      },
+    }
+  ).trim();
+}
+
+describe("scripts/deploy-k8s.sh shell helpers", () => {
+  it("generate_random fallback returns exact-length alnum output without openssl", () => {
+    const output = runDeployHelper(`
+has_command() {
+  if [[ "$1" == "openssl" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+value=$(generate_random 40)
+printf '%s\\n%s' "$value" "\${#value}"
+    `);
+
+    const [value, length] = output.split("\n");
+    expect(length).toBe("40");
+    expect(value).toMatch(/^[A-Za-z0-9]{40}$/);
+  });
+
+  it("detect_storage_class picks the first discovered default class without head pipelines", () => {
+    const output = runDeployHelper(`
+KUBECTL=kubectl_stub
+RUNTIME=kubectl
+STORAGE_CLASS=""
+STORAGE_CLASS_ARG=""
+
+log_info() { :; }
+head() {
+  printf 'unexpected head invocation\\n' >&2
+  return 99
+}
+
+kubectl_stub() {
+  if [[ "$1" == "get" && "$2" == "sc" ]]; then
+    printf 'fast\\nslow\\n'
+    return 0
+  fi
+  return 1
+}
+
+detect_storage_class
+printf '%s' "$STORAGE_CLASS"
+    `);
+
+    expect(output).toBe("fast");
+  });
+
+  it("detect_runtime and detect_ingress_variant use full output matching instead of grep pipes", () => {
+    const output = runDeployHelper(`
+command() {
+  if [[ "$1" == "-v" && "$2" == "kubectl" ]]; then
+    return 0
+  fi
+  if [[ "$1" == "-v" && "$2" == "k3s" ]]; then
+    return 1
+  fi
+  builtin command "$@"
+}
+
+kubectl() {
+  if [[ "$1" == "cluster-info" ]]; then
+    return 0
+  fi
+  if [[ "$1" == "get" && "$2" == "nodes" ]]; then
+    printf 'v1.31.0+k3s1'
+    return 0
+  fi
+  if [[ "$1" == "get" && "$2" == "crd" ]]; then
+    return 1
+  fi
+  if [[ "$1" == "api-resources" && "$2" == "--api-group=networking.k8s.io" && "$3" == "-o" && "$4" == "name" ]]; then
+    printf 'ingresses.networking.k8s.io\\n'
+    return 0
+  fi
+  if [[ "$1" == "get" && "$2" == "ingressclass" ]]; then
+    printf 'nginx'
+    return 0
+  fi
+  return 1
+}
+
+log_info() { :; }
+log_warning() { :; }
+
+INGRESS_HOST=hub.example.com
+INGRESS_CLASS_ARG=""
+DISABLE_INGRESS=false
+
+detect_runtime
+detect_ingress_variant
+printf '%s\\n%s\\n%s' "$RUNTIME" "$INGRESS_VARIANT" "$INGRESS_CLASS"
+    `);
+
+    expect(output).toBe("k3s\nstandard\nnginx");
+  });
+
+  it("detect_ingress_variant ignores unrelated networking.k8s.io resource names", () => {
+    const output = runDeployHelper(`
+KUBECTL=kubectl_stub
+INGRESS_HOST=hub.example.com
+INGRESS_CLASS_ARG=""
+DISABLE_INGRESS=false
+
+log_info() { :; }
+log_warning() { :; }
+
+kubectl_stub() {
+  if [[ "$1" == "get" && "$2" == "crd" ]]; then
+    return 1
+  fi
+  if [[ "$1" == "api-resources" && "$2" == "--api-group=networking.k8s.io" && "$3" == "-o" && "$4" == "name" ]]; then
+    printf 'gateways.gateway.networking.k8s.io\\ningresses.extensions\\n'
+    return 0
+  fi
+  return 1
+}
+
+detect_ingress_variant
+printf '%s\\n%s' "$INGRESS_VARIANT" "$APP_SERVICE_TYPE"
+    `);
+
+    expect(output).toBe("nodeport\nNodePort");
+  });
+});


### PR DESCRIPTION
## Summary
- Harden `scripts/cch` against pipefail early-exit cases in k3s digest resolution, doctor version probing, and fallback `set image` handling
- Harden `scripts/deploy-k8s.sh` against the same class of early-exit issues in default StorageClass detection and random secret generation
- Align k8s ingress / docs / schema comments around IP extraction expectations and add shell behavior tests for the deploy scripts

**Related PRs:**
- Follow-up to #1048 — fixes pipefail-related early-exit bugs in the k8s deploy scripts and `cch` CLI introduced by that PR
- Related to #1027 — updates the `ipExtractionConfig` schema comment to reflect the actual default IP extraction chain (removes stale `cf-connecting-ip` reference)

## Problem

Both `scripts/cch` and `scripts/deploy-k8s.sh` run under `set -euo pipefail`, but several pipelines used `awk … {print …; exit}` or `head -1`/`head -c` patterns that cause the upstream process to receive `SIGPIPE` (exit code 141) when it continues writing after the downstream consumer exits early. This silently kills the entire command substitution under `pipefail`, aborting upgrade or deployment flows without error reporting.

Additionally, ingress manifests and documentation did not clearly document the assumptions around client IP passthrough in k8s environments.

## Changes

### Core Fixes (`scripts/cch`)
- Extract k3s digest resolution into `resolve_k3s_image_digest()` and `update_k3s_image_by_digest_or_restart()`, replacing the inline `awk … exit` pipeline with a `found` flag pattern that avoids SIGPIPE
- Replace `kubectl version … | awk '/gitVersion/{print $2; exit}'` with `jsonpath` extraction in `cmd_doctor`
- Wrap fallback `set image` in proper error handling — failure now exits with explicit error message instead of silently continuing
- Add `CCH_SOURCE_ONLY` guard to enable unit-testing by sourcing the script without triggering the dispatch block

### Core Fixes (`scripts/deploy-k8s.sh`)
- Replace `| head -1` in StorageClass detection with bash-native `${default_sc%%$'\n'*}` parameter expansion
- Replace `openssl rand … | head -c` and `tr … | head -c` in `generate_random()` with a loop-based accumulator that guarantees exact-length output without broken pipes
- Add `DEPLOY_K8S_SOURCE_ONLY` guard for test sourcing
- Add `has_command()` helper to eliminate scattered `command -v` invocations

### Docs & Schema Alignment
- `deploy/k8s/ingress/ingress.yaml`: Document that `configuration-snippet` is not used by default because `allow-snippet-annotations=false` is the ingress-nginx default
- `deploy/k8s/ingress/traefik-ingressroute.yaml`: Document `X-Forwarded-For` passthrough and `forwardedHeaders.trustedIPs` requirements
- `docs/k8s-deployment.md`: Add client IP passthrough section; clarify `cch update` rollback behavior with digest fallback
- `deploy/k8s/README.md`: Add IP passthrough section; clarify default image source
- `src/drizzle/schema.ts`: Update `ipExtractionConfig` comment to match actual default chain (`x-real-ip -> x-forwarded-for rightmost`)

### Tests
- `tests/unit/k8s-cch-update-flow.test.ts` (new): Tests k3s digest pinning, fallback to rollout restart, fallback failure propagation, and doctor version probing
- `tests/unit/k8s-deploy-shell-helpers.test.ts` (new): Tests `generate_random()` exact-length output and StorageClass detection without pipe-based `head`
- `tests/unit/k8s-deploy-assets-review-fixes.test.ts` (updated): Expanded assertions covering all new patterns

## Verification
- `bash -n scripts/cch scripts/deploy-k8s.sh`
- `bunx vitest run tests/unit/k8s-cch-update-flow.test.ts tests/unit/k8s-deploy-shell-helpers.test.ts tests/unit/k8s-deploy-assets-review-fixes.test.ts`
- `bunx vitest run tests/unit/k8s-cch-update-flow.test.ts tests/unit/k8s-deploy-assets-review-fixes.test.ts src/lib/ip/extract-client-ip.test.ts src/lib/ip/index.test.ts tests/unit/settings/system-settings-form-ip-extraction.test.tsx`
- `bun run typecheck`
- `bun run build`

## Notes
- `bun run lint` / `bun run lint:fix` are still blocked locally by pre-existing repo baseline issues outside this diff (`biome.json` schema-version mismatch and existing Biome findings in unrelated files)
- `bun run test` still hits pre-existing local baseline issues outside this diff (existing public-status test failures / worker OOM), so targeted regressions were used as the binding proof for this change set

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens `scripts/cch` and `scripts/deploy-k8s.sh` against `pipefail`/SIGPIPE early exits by refactoring the k3s digest resolution (`found`-flag awk pattern), StorageClass detection (parameter expansion instead of `| head -1`), ingress detection (`--api-group` filter), and random secret generation (loop-based accumulator instead of `| head -c`). Documentation and schema comments are updated to accurately reflect the IP extraction chain. New unit tests cover the k3s update fallback paths and the shell helpers.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all SIGPIPE/pipefail fixes are logically correct and covered by new unit tests; no P0/P1 issues found.

All core changes correctly address the stated pipefail/SIGPIPE problem. The awk `found`-flag avoids early exit without introducing new failure modes, parameter expansion replaces `| head -1` cleanly, and the loop-based `generate_random` produces exact-length output. Previously flagged concerns (`${random:0:length}` style, `bash -lc` in tests) remain P2-only and do not affect correctness. No new P1 issues were identified.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/cch | Key SIGPIPE fix: k3s digest resolution refactored into `found`-flag awk helper; `kubectl version` switched to jsonpath; dispatch block guarded by `CCH_SOURCE_ONLY`; fallback `set image` now surfaces explicit errors. |
| scripts/deploy-k8s.sh | Replaces all `| head -1` / `| head -c` patterns with bash-native expansions and a loop accumulator; adds `has_command` helper; guards main dispatch with `DEPLOY_K8S_SOURCE_ONLY`; fixes ingress detection to use `--api-group` filter. |
| tests/unit/k8s-cch-update-flow.test.ts | New test file covering k3s digest pinning, fallback-to-restart paths, double-`@sha256` avoidance, fallback set-image failure propagation, and doctor version probing via jsonpath. |
| tests/unit/k8s-deploy-shell-helpers.test.ts | New test file verifying exact-length output from `generate_random` fallback, first-class detection without `head` pipes, and runtime/ingress detection without grep pipes. |
| src/drizzle/schema.ts | Comment-only change removing stale `cf-connecting-ip` from the documented default IP extraction chain; no schema or runtime change. |
| deploy/k8s/ingress/ingress.yaml | Adds comments clarifying that `configuration-snippet` is not used by default due to `allow-snippet-annotations=false` and that IP passthrough requires controller-level configuration. |
| deploy/k8s/ingress/traefik-ingressroute.yaml | Adds comments documenting Traefik X-Forwarded-For passthrough behaviour and `forwardedHeaders.trustedIPs` requirement for X-Real-Ip trust. |
| docs/k8s-deployment.md | Adds client IP passthrough section, clarifies `cch update` rollout-undo semantics and digest-fallback limitations, removes stale 'automatic rollback' phrasing. |
| deploy/k8s/README.md | Adds IP passthrough section and clarifies default image source (`main` → `:latest`); purely documentation. |
| tests/unit/k8s-deploy-assets-review-fixes.test.ts | Expanded assertions confirm absence of old pipe patterns, presence of new parameter-expansion forms, and documentation correctness for IP passthrough and default image reference. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[cmd_update: k3s path] --> B[update_k3s_image_by_digest_or_restart]
    B --> C[resolve_k3s_image_digest\nk3s ctr images ls - awk found-flag]
    C -->|non-zero exit| D[restart_k3s_rollout_with_image\nreason: ctr images ls failed]
    C -->|exit 0, empty or non-sha256| E[restart_k3s_rollout_with_image\nreason: no usable digest]
    C -->|exit 0, sha256 digest| F[build_image_ref_with_digest\nimage at sha256-xxx]
    F --> G[kubectl set image by digest]
    D --> H{set image ok?}
    E --> H
    H -->|yes| I[kubectl rollout restart]
    H -->|no| J[err: set image failed\nreturn 1]
    J --> K[restore_update_scaling + exit 1]
    G --> L[continue rollout and health-check]
    I --> L
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(k8s): harden deploy script pipefail ..."](https://github.com/ding113/claude-code-hub/commit/9d74e5608f8e1443102695ffb3e73845a92caa17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29378101)</sub>

<!-- /greptile_comment -->