### PR TITLE
fix(metrics): align success-rate outcome semantics

### DIFF
--- a/drizzle/0095_young_lily_hollister.sql
+++ b/drizzle/0095_young_lily_hollister.sql
@@ -1,3 +1,5 @@
+ALTER TABLE "usage_ledger" ADD COLUMN "success_rate_outcome" varchar(16);
+--> statement-breakpoint
 CREATE OR REPLACE FUNCTION fn_is_message_request_finalized(
   blocked_by varchar,
   status_code integer,
@@ -54,7 +56,7 @@ BEGIN
   RETURN FALSE;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-
+--> statement-breakpoint
 CREATE OR REPLACE FUNCTION fn_compute_message_request_success_rate_outcome(
   blocked_by varchar,
   blocked_reason text,
@@ -146,7 +148,7 @@ BEGIN
   RETURN 'failure';
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
-
+--> statement-breakpoint
 CREATE OR REPLACE FUNCTION fn_upsert_usage_ledger()
 RETURNS TRIGGER AS $$
 DECLARE
@@ -163,7 +165,6 @@ BEGIN
   );
 
   IF NEW.blocked_by = 'warmup' THEN
-    -- If a ledger row already exists (row was originally non-warmup), mark it as warmup
     UPDATE usage_ledger
     SET blocked_by = 'warmup',
         success_rate_outcome = 'excluded'
@@ -234,8 +235,6 @@ BEGIN
     duration_ms = EXCLUDED.duration_ms,
     ttfb_ms = EXCLUDED.ttfb_ms,
     client_ip = EXCLUDED.client_ip;
-    -- created_at deliberately NOT updated on conflict: it represents the
-    -- original insert time of the ledger row, which is immutable by design.
 
   RETURN NEW;
 EXCEPTION WHEN OTHERS THEN
@@ -243,10 +242,3 @@ EXCEPTION WHEN OTHERS THEN
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
-
-DROP TRIGGER IF EXISTS trg_upsert_usage_ledger ON message_request;
-
-CREATE TRIGGER trg_upsert_usage_ledger
-AFTER INSERT OR UPDATE ON message_request
-FOR EACH ROW
-EXECUTE FUNCTION fn_upsert_usage_ledger();

--- a/drizzle/0095_young_lily_hollister.sql
+++ b/drizzle/0095_young_lily_hollister.sql
@@ -59,7 +59,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 --> statement-breakpoint
 CREATE OR REPLACE FUNCTION fn_compute_message_request_success_rate_outcome(
   blocked_by varchar,
-  blocked_reason text,
   status_code integer,
   error_message text,
   provider_chain jsonb
@@ -158,7 +157,6 @@ DECLARE
 BEGIN
   v_success_rate_outcome := fn_compute_message_request_success_rate_outcome(
     NEW.blocked_by,
-    NEW.blocked_reason,
     NEW.status_code,
     NEW.error_message,
     NEW.provider_chain
@@ -167,7 +165,7 @@ BEGIN
   IF NEW.blocked_by = 'warmup' THEN
     UPDATE usage_ledger
     SET blocked_by = 'warmup',
-        success_rate_outcome = 'excluded'
+        success_rate_outcome = v_success_rate_outcome
     WHERE request_id = NEW.id;
     RETURN NEW;
   END IF;

--- a/drizzle/meta/0095_snapshot.json
+++ b/drizzle/meta/0095_snapshot.json
@@ -1,0 +1,4445 @@
+{
+  "id": "d2129730-c1c7-45d5-9a70-01e2b872a197",
+  "prevId": "a09fc08d-607f-4be2-8cb3-0c8f9cc7926e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action_category": {
+          "name": "action_category",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_value": {
+          "name": "before_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_value": {
+          "name": "after_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_user_id": {
+          "name": "operator_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_user_name": {
+          "name": "operator_user_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_key_id": {
+          "name": "operator_key_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_key_name": {
+          "name": "operator_key_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_ip": {
+          "name": "operator_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_category_created_at": {
+          "name": "idx_audit_log_category_created_at",
+          "columns": [
+            {
+              "expression": "action_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_operator_user_created_at": {
+          "name": "idx_audit_log_operator_user_created_at",
+          "columns": [
+            {
+              "expression": "operator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"operator_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_operator_ip_created_at": {
+          "name": "idx_audit_log_operator_ip_created_at",
+          "columns": [
+            {
+              "expression": "operator_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"operator_ip\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_target": {
+          "name": "idx_audit_log_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"target_type\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_created_at_id": {
+          "name": "idx_audit_log_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_rules": {
+      "name": "error_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regex'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_response": {
+          "name": "override_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_status_code": {
+          "name": "override_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_rules_enabled": {
+          "name": "idx_error_rules_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_pattern": {
+          "name": "unique_pattern",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_category": {
+          "name": "idx_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_match_type": {
+          "name": "idx_match_type",
+          "columns": [
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_login_web_ui": {
+          "name": "can_login_web_ui",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_reset_mode": {
+          "name": "limit_5h_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rolling'"
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_reset_at": {
+          "name": "cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_keys_user_id": {
+          "name": "idx_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_key": {
+          "name": "idx_keys_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_created_at": {
+          "name": "idx_keys_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_deleted_at": {
+          "name": "idx_keys_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_request": {
+      "name": "message_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_cost_multiplier": {
+          "name": "group_cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_breakdown": {
+          "name": "cost_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "provider_chain": {
+          "name": "provider_chain",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "swap_cache_ttl_applied": {
+          "name": "swap_cache_ttl_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "special_settings": {
+          "name": "special_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_cause": {
+          "name": "error_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages_count": {
+          "name": "messages_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_message_request_user_date_cost": {
+          "name": "idx_message_request_user_date_cost",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_created_at_cost_stats": {
+          "name": "idx_message_request_user_created_at_cost_stats",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_query": {
+          "name": "idx_message_request_user_query",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_created_at_active": {
+          "name": "idx_message_request_provider_created_at_active",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_created_at_finalized_active": {
+          "name": "idx_message_request_provider_created_at_finalized_active",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"status_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_id": {
+          "name": "idx_message_request_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_id_prefix": {
+          "name": "idx_message_request_session_id_prefix",
+          "columns": [
+            {
+              "expression": "\"session_id\" varchar_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_seq": {
+          "name": "idx_message_request_session_seq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_endpoint": {
+          "name": "idx_message_request_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_blocked_by": {
+          "name": "idx_message_request_blocked_by",
+          "columns": [
+            {
+              "expression": "blocked_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_id": {
+          "name": "idx_message_request_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_id": {
+          "name": "idx_message_request_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key": {
+          "name": "idx_message_request_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_created_at_id": {
+          "name": "idx_message_request_key_created_at_id",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_model_active": {
+          "name": "idx_message_request_key_model_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"model\" IS NOT NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_endpoint_active": {
+          "name": "idx_message_request_key_endpoint_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"endpoint\" IS NOT NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_created_at_id_active": {
+          "name": "idx_message_request_created_at_id_active",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_model_active": {
+          "name": "idx_message_request_model_active",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"model\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_status_code_active": {
+          "name": "idx_message_request_status_code_active",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"status_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_created_at": {
+          "name": "idx_message_request_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_deleted_at": {
+          "name": "idx_message_request_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_last_active": {
+          "name": "idx_message_request_key_last_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_cost_active": {
+          "name": "idx_message_request_key_cost_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_user_info": {
+          "name": "idx_message_request_session_user_info",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_client_ip_created_at": {
+          "name": "idx_message_request_client_ip_created_at",
+          "columns": [
+            {
+              "expression": "client_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"client_ip\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_prices": {
+      "name": "model_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_data": {
+          "name": "price_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'litellm'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_prices_latest": {
+          "name": "idx_model_prices_latest",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_model_name": {
+          "name": "idx_model_prices_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_created_at": {
+          "name": "idx_model_prices_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_source": {
+          "name": "idx_model_prices_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_legacy_mode": {
+          "name": "use_legacy_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_enabled": {
+          "name": "circuit_breaker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_webhook": {
+          "name": "circuit_breaker_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_enabled": {
+          "name": "daily_leaderboard_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "daily_leaderboard_webhook": {
+          "name": "daily_leaderboard_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_time": {
+          "name": "daily_leaderboard_time",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'09:00'"
+        },
+        "daily_leaderboard_top_n": {
+          "name": "daily_leaderboard_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cost_alert_enabled": {
+          "name": "cost_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cost_alert_webhook": {
+          "name": "cost_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_alert_threshold": {
+          "name": "cost_alert_threshold",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.80'"
+        },
+        "cost_alert_check_interval": {
+          "name": "cost_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "cache_hit_rate_alert_enabled": {
+          "name": "cache_hit_rate_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_hit_rate_alert_webhook": {
+          "name": "cache_hit_rate_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit_rate_alert_window_mode": {
+          "name": "cache_hit_rate_alert_window_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "cache_hit_rate_alert_check_interval": {
+          "name": "cache_hit_rate_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cache_hit_rate_alert_historical_lookback_days": {
+          "name": "cache_hit_rate_alert_historical_lookback_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 7
+        },
+        "cache_hit_rate_alert_min_eligible_requests": {
+          "name": "cache_hit_rate_alert_min_eligible_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 20
+        },
+        "cache_hit_rate_alert_min_eligible_tokens": {
+          "name": "cache_hit_rate_alert_min_eligible_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cache_hit_rate_alert_abs_min": {
+          "name": "cache_hit_rate_alert_abs_min",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "cache_hit_rate_alert_drop_rel": {
+          "name": "cache_hit_rate_alert_drop_rel",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.3'"
+        },
+        "cache_hit_rate_alert_drop_abs": {
+          "name": "cache_hit_rate_alert_drop_abs",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.1'"
+        },
+        "cache_hit_rate_alert_cooldown_minutes": {
+          "name": "cache_hit_rate_alert_cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cache_hit_rate_alert_top_n": {
+          "name": "cache_hit_rate_alert_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_target_bindings": {
+      "name": "notification_target_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule_cron": {
+          "name": "schedule_cron",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_timezone": {
+          "name": "schedule_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_override": {
+          "name": "template_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_notification_target_binding": {
+          "name": "unique_notification_target_binding",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_type": {
+          "name": "idx_notification_bindings_type",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_target": {
+          "name": "idx_notification_bindings_target",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_target_bindings_target_id_webhook_targets_id_fk": {
+          "name": "notification_target_bindings_target_id_webhook_targets_id_fk",
+          "tableFrom": "notification_target_bindings",
+          "tableTo": "webhook_targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoint_probe_logs": {
+      "name": "provider_endpoint_probe_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_endpoint_probe_logs_endpoint_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_endpoint_created_at",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoint_probe_logs_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk": {
+          "name": "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk",
+          "tableFrom": "provider_endpoint_probe_logs",
+          "tableTo": "provider_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoints": {
+      "name": "provider_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_probed_at": {
+          "name": "last_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_ok": {
+          "name": "last_probe_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_status_code": {
+          "name": "last_probe_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_latency_ms": {
+          "name": "last_probe_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_type": {
+          "name": "last_probe_error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_message": {
+          "name": "last_probe_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uniq_provider_endpoints_vendor_type_url": {
+          "name": "uniq_provider_endpoints_vendor_type_url",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_vendor_type": {
+          "name": "idx_provider_endpoints_vendor_type",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_enabled": {
+          "name": "idx_provider_endpoints_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_pick_enabled": {
+          "name": "idx_provider_endpoints_pick_enabled",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_created_at": {
+          "name": "idx_provider_endpoints_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_deleted_at": {
+          "name": "idx_provider_endpoints_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoints_vendor_id_provider_vendors_id_fk": {
+          "name": "provider_endpoints_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "provider_endpoints",
+          "tableTo": "provider_vendors",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_groups": {
+      "name": "provider_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_groups_name_unique": {
+          "name": "provider_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_vendors": {
+      "name": "provider_vendors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "website_domain": {
+          "name": "website_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_provider_vendors_website_domain": {
+          "name": "uniq_provider_vendors_website_domain",
+          "columns": [
+            {
+              "expression": "website_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_vendors_created_at": {
+          "name": "idx_provider_vendors_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_vendor_id": {
+          "name": "provider_vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "group_priorities": {
+          "name": "group_priorities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.0'"
+        },
+        "group_tag": {
+          "name": "group_tag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "preserve_client_ip": {
+          "name": "preserve_client_ip",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disable_session_reuse": {
+          "name": "disable_session_reuse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_redirects": {
+          "name": "model_redirects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_clients": {
+          "name": "blocked_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active_time_start": {
+          "name": "active_time_start",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_end": {
+          "name": "active_time_end",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_instructions_strategy": {
+          "name": "codex_instructions_strategy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "mcp_passthrough_type": {
+          "name": "mcp_passthrough_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "mcp_passthrough_url": {
+          "name": "mcp_passthrough_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_reset_mode": {
+          "name": "limit_5h_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rolling'"
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost_reset_at": {
+          "name": "total_cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_retry_attempts": {
+          "name": "max_retry_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circuit_breaker_failure_threshold": {
+          "name": "circuit_breaker_failure_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "circuit_breaker_open_duration": {
+          "name": "circuit_breaker_open_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1800000
+        },
+        "circuit_breaker_half_open_success_threshold": {
+          "name": "circuit_breaker_half_open_success_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "first_byte_timeout_streaming_ms": {
+          "name": "first_byte_timeout_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "streaming_idle_timeout_ms": {
+          "name": "streaming_idle_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_timeout_non_streaming_ms": {
+          "name": "request_timeout_non_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swap_cache_ttl_billing": {
+          "name": "swap_cache_ttl_billing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "context_1m_preference": {
+          "name": "context_1m_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_effort_preference": {
+          "name": "codex_reasoning_effort_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_summary_preference": {
+          "name": "codex_reasoning_summary_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_text_verbosity_preference": {
+          "name": "codex_text_verbosity_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_parallel_tool_calls_preference": {
+          "name": "codex_parallel_tool_calls_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_service_tier_preference": {
+          "name": "codex_service_tier_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_max_tokens_preference": {
+          "name": "anthropic_max_tokens_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_thinking_budget_preference": {
+          "name": "anthropic_thinking_budget_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_adaptive_thinking": {
+          "name": "anthropic_adaptive_thinking",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "gemini_google_search_preference": {
+          "name": "gemini_google_search_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tpm": {
+          "name": "tpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpm": {
+          "name": "rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpd": {
+          "name": "rpd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cc": {
+          "name": "cc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_providers_enabled_priority": {
+          "name": "idx_providers_enabled_priority",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_group": {
+          "name": "idx_providers_group",
+          "columns": [
+            {
+              "expression": "group_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_vendor_type_url_active": {
+          "name": "idx_providers_vendor_type_url_active",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_created_at": {
+          "name": "idx_providers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_deleted_at": {
+          "name": "idx_providers_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_vendor_type": {
+          "name": "idx_providers_vendor_type",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_enabled_vendor_type": {
+          "name": "idx_providers_enabled_vendor_type",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL AND \"providers\".\"is_enabled\" = true AND \"providers\".\"provider_vendor_id\" IS NOT NULL AND \"providers\".\"provider_vendor_id\" > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "providers_provider_vendor_id_provider_vendors_id_fk": {
+          "name": "providers_provider_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "provider_vendors",
+          "columnsFrom": [
+            "provider_vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_filters": {
+      "name": "request_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement": {
+          "name": "replacement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "provider_ids": {
+          "name": "provider_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_tags": {
+          "name": "group_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_mode": {
+          "name": "rule_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simple'"
+        },
+        "execution_phase": {
+          "name": "execution_phase",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guard'"
+        },
+        "operations": {
+          "name": "operations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_request_filters_enabled": {
+          "name": "idx_request_filters_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_scope": {
+          "name": "idx_request_filters_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_action": {
+          "name": "idx_request_filters_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_binding": {
+          "name": "idx_request_filters_binding",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_phase": {
+          "name": "idx_request_filters_phase",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "execution_phase",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sensitive_words": {
+      "name": "sensitive_words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contains'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sensitive_words_enabled": {
+          "name": "idx_sensitive_words_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sensitive_words_created_at": {
+          "name": "idx_sensitive_words_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_title": {
+          "name": "site_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Claude Code Hub'"
+        },
+        "allow_global_usage_view": {
+          "name": "allow_global_usage_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "currency_display": {
+          "name": "currency_display",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "billing_model_source": {
+          "name": "billing_model_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'original'"
+        },
+        "codex_priority_billing_source": {
+          "name": "codex_priority_billing_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_auto_cleanup": {
+          "name": "enable_auto_cleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cleanup_retention_days": {
+          "name": "cleanup_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cleanup_schedule": {
+          "name": "cleanup_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 2 * * *'"
+        },
+        "cleanup_batch_size": {
+          "name": "cleanup_batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10000
+        },
+        "enable_client_version_check": {
+          "name": "enable_client_version_check",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verbose_provider_error": {
+          "name": "verbose_provider_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_http2": {
+          "name": "enable_http2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_high_concurrency_mode": {
+          "name": "enable_high_concurrency_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "intercept_anthropic_warmup_requests": {
+          "name": "intercept_anthropic_warmup_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_thinking_signature_rectifier": {
+          "name": "enable_thinking_signature_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_thinking_budget_rectifier": {
+          "name": "enable_thinking_budget_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_billing_header_rectifier": {
+          "name": "enable_billing_header_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_response_input_rectifier": {
+          "name": "enable_response_input_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_codex_session_id_completion": {
+          "name": "enable_codex_session_id_completion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_claude_metadata_user_id_injection": {
+          "name": "enable_claude_metadata_user_id_injection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_response_fixer": {
+          "name": "enable_response_fixer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "response_fixer_config": {
+          "name": "response_fixer_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"fixTruncatedJson\":true,\"fixSseFormat\":true,\"fixEncoding\":true,\"maxJsonDepth\":200,\"maxFixSize\":1048576}'::jsonb"
+        },
+        "quota_db_refresh_interval_seconds": {
+          "name": "quota_db_refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "quota_lease_percent_5h": {
+          "name": "quota_lease_percent_5h",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_daily": {
+          "name": "quota_lease_percent_daily",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_weekly": {
+          "name": "quota_lease_percent_weekly",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_monthly": {
+          "name": "quota_lease_percent_monthly",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_cap_usd": {
+          "name": "quota_lease_cap_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_extraction_config": {
+          "name": "ip_extraction_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_geo_lookup_enabled": {
+          "name": "ip_geo_lookup_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_status_window_hours": {
+          "name": "public_status_window_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "public_status_aggregation_interval_minutes": {
+          "name": "public_status_aggregation_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_ledger": {
+      "name": "usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_provider_id": {
+          "name": "final_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_success": {
+          "name": "is_success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "success_rate_outcome": {
+          "name": "success_rate_outcome",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_cost_multiplier": {
+          "name": "group_cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "swap_cache_ttl_applied": {
+          "name": "swap_cache_ttl_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_ledger_request_id": {
+          "name": "idx_usage_ledger_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_user_created_at": {
+          "name": "idx_usage_ledger_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_key_created_at": {
+          "name": "idx_usage_ledger_key_created_at",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_provider_created_at": {
+          "name": "idx_usage_ledger_provider_created_at",
+          "columns": [
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_created_at_minute": {
+          "name": "idx_usage_ledger_created_at_minute",
+          "columns": [
+            {
+              "expression": "date_trunc('minute', \"created_at\" AT TIME ZONE 'UTC')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_created_at_desc_id": {
+          "name": "idx_usage_ledger_created_at_desc_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_session_id": {
+          "name": "idx_usage_ledger_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"session_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_model": {
+          "name": "idx_usage_ledger_model",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"model\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_key_cost": {
+          "name": "idx_usage_ledger_key_cost",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_user_cost_cover": {
+          "name": "idx_usage_ledger_user_cost_cover",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_provider_cost_cover": {
+          "name": "idx_usage_ledger_provider_cost_cover",
+          "columns": [
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_key_created_at_desc_cover": {
+          "name": "idx_usage_ledger_key_created_at_desc_cover",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC NULLS LAST",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "rpm_limit": {
+          "name": "rpm_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_limit_usd": {
+          "name": "daily_limit_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_reset_mode": {
+          "name": "limit_5h_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rolling'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_reset_at": {
+          "name": "cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_cost_reset_at": {
+          "name": "limit_5h_cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_clients": {
+          "name": "blocked_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_active_role_sort": {
+          "name": "idx_users_active_role_sort",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_enabled_expires_at": {
+          "name": "idx_users_enabled_expires_at",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_tags_gin": {
+          "name": "idx_users_tags_gin",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_deleted_at": {
+          "name": "idx_users_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_targets": {
+      "name": "webhook_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "webhook_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_bot_token": {
+          "name": "telegram_bot_token",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dingtalk_secret": {
+          "name": "dingtalk_secret",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_template": {
+          "name": "custom_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_test_at": {
+          "name": "last_test_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_result": {
+          "name": "last_test_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.daily_reset_mode": {
+      "name": "daily_reset_mode",
+      "schema": "public",
+      "values": [
+        "fixed",
+        "rolling"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "circuit_breaker",
+        "daily_leaderboard",
+        "cost_alert",
+        "cache_hit_rate_alert"
+      ]
+    },
+    "public.webhook_provider_type": {
+      "name": "webhook_provider_type",
+      "schema": "public",
+      "values": [
+        "wechat",
+        "feishu",
+        "dingtalk",
+        "telegram",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -666,6 +666,13 @@
       "when": 1776831143074,
       "tag": "0094_third_spacker_dave",
       "breakpoints": true
+    },
+    {
+      "idx": 95,
+      "version": "7",
+      "when": 1776916341782,
+      "tag": "0095_young_lily_hollister",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/en/dashboard.json
+++ b/messages/en/dashboard.json
@@ -492,7 +492,9 @@
       "avgTokensPerSecond": "Avg tok/s",
       "avgCostPerRequest": "Avg Cost/Req",
       "avgCostPerMillionTokens": "Avg Cost/1M Tokens",
-      "unknownModel": "Unknown"
+      "unknownModel": "Unknown",
+      "successRateUnavailable": "N/A",
+      "successRateBasisDisclosure": "Success rate is unavailable here because redirected billing mode can merge multiple original models into one row."
     },
     "expandModelStats": "Expand model details",
     "collapseModelStats": "Collapse model details",

--- a/messages/ja/dashboard.json
+++ b/messages/ja/dashboard.json
@@ -492,7 +492,9 @@
       "avgTokensPerSecond": "平均トークン/秒",
       "avgCostPerRequest": "平均リクエスト単価",
       "avgCostPerMillionTokens": "100万トークンあたりコスト",
-      "unknownModel": "不明"
+      "unknownModel": "不明",
+      "successRateUnavailable": "利用不可",
+      "successRateBasisDisclosure": "redirected 課金モデルでは 1 行に複数の元モデルが混在しうるため、誤解を避けるためここでは成功率を表示しません。"
     },
     "expandModelStats": "モデル詳細を展開",
     "collapseModelStats": "モデル詳細を折りたたむ",

--- a/messages/ru/dashboard.json
+++ b/messages/ru/dashboard.json
@@ -492,7 +492,9 @@
       "avgTokensPerSecond": "Средн. ток/с",
       "avgCostPerRequest": "Ср. стоимость/запрос",
       "avgCostPerMillionTokens": "Ср. стоимость/1М токенов",
-      "unknownModel": "Неизвестно"
+      "unknownModel": "Неизвестно",
+      "successRateUnavailable": "Н/Д",
+      "successRateBasisDisclosure": "В режиме redirected billing одна строка может объединять несколько исходных моделей, поэтому здесь успешность скрыта, чтобы не вводить в заблуждение."
     },
     "expandModelStats": "Развернуть модели",
     "collapseModelStats": "Свернуть модели",

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -492,7 +492,9 @@
       "avgTokensPerSecond": "平均输出速率",
       "avgCostPerRequest": "平均单次请求成本",
       "avgCostPerMillionTokens": "平均百万 Token 成本",
-      "unknownModel": "未知"
+      "unknownModel": "未知",
+      "successRateUnavailable": "不适用",
+      "successRateBasisDisclosure": "在 redirected 计费模型模式下，一行可能合并多个原始模型，因此这里不展示成功率以避免口径误导。"
     },
     "expandModelStats": "展开模型详情",
     "collapseModelStats": "收起模型详情",

--- a/messages/zh-TW/dashboard.json
+++ b/messages/zh-TW/dashboard.json
@@ -492,7 +492,9 @@
       "avgTokensPerSecond": "平均輸出速率",
       "avgCostPerRequest": "平均每次請求成本",
       "avgCostPerMillionTokens": "平均每百萬 Token 成本",
-      "unknownModel": "未知"
+      "unknownModel": "未知",
+      "successRateUnavailable": "不適用",
+      "successRateBasisDisclosure": "在 redirected 計費模型模式下，一列可能合併多個原始模型，因此這裡不顯示成功率以避免口徑誤導。"
     },
     "expandModelStats": "展開模型詳情",
     "collapseModelStats": "收起模型詳情",

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
@@ -35,7 +35,7 @@ export interface ColumnDef<T> {
    */
   cell: (row: T, index: number, isSubRow?: boolean) => React.ReactNode;
   sortKey?: string; // 用于排序的字段名
-  getValue?: (row: T) => number | string; // 获取排序值的函数
+  getValue?: (row: T) => number | string | null; // 获取排序值的函数
   defaultBold?: boolean; // 默认加粗（无排序时显示加粗）
 }
 
@@ -128,6 +128,11 @@ export function LeaderboardTable<TParent, TSub = TParent>({
     return [...data].sort((a, b) => {
       const valueA = column.getValue!(a);
       const valueB = column.getValue!(b);
+
+      // N/A/null values should always sort after real values.
+      if (valueA == null && valueB == null) return 0;
+      if (valueA == null) return 1;
+      if (valueB == null) return -1;
 
       if (typeof valueA === "number" && typeof valueB === "number") {
         return sortDirection === "asc" ? valueA - valueB : valueB - valueA;

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
@@ -337,7 +337,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
       className: "text-right",
       cell: (row) => renderSuccessRateCell(row, t),
       sortKey: "successRate",
-      getValue: (row) => row.successRate ?? -1,
+      getValue: (row) => row.successRate,
     },
     {
       header: t("columns.avgTtfbMs"),
@@ -538,7 +538,7 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
       className: "text-right",
       cell: (row) => renderSuccessRateCell(row, t),
       sortKey: "successRate",
-      getValue: (row) => row.successRate ?? -1,
+      getValue: (row) => row.successRate,
     },
   ];
 

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
@@ -40,6 +40,7 @@ import type {
 import type { ProviderType } from "@/types/provider";
 import { DateRangePicker } from "./date-range-picker";
 import { type ColumnDef, LeaderboardTable } from "./leaderboard-table";
+import { getSuccessRateCellDisplay } from "./success-rate-display";
 
 interface LeaderboardViewProps {
   isAdmin: boolean;
@@ -78,6 +79,21 @@ type AnyEntry =
   | ProviderEntry
   | ProviderCacheHitRateEntry
   | ModelEntry;
+
+function renderSuccessRateCell(
+  row: { successRate: number | null; basisDisclosureRequired?: boolean },
+  t: ReturnType<typeof useTranslations>
+) {
+  const display = getSuccessRateCellDisplay(row, t);
+  return (
+    <span
+      className={typeof row.successRate === "number" ? undefined : "text-muted-foreground"}
+      title={display.title}
+    >
+      {display.label}
+    </span>
+  );
+}
 
 const VALID_PERIODS: LeaderboardPeriod[] = ["daily", "weekly", "monthly", "allTime", "custom"];
 
@@ -319,9 +335,9 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     {
       header: t("columns.successRate"),
       className: "text-right",
-      cell: (row) => `${(Number(row.successRate || 0) * 100).toFixed(1)}%`,
+      cell: (row) => renderSuccessRateCell(row, t),
       sortKey: "successRate",
-      getValue: (row) => row.successRate,
+      getValue: (row) => row.successRate ?? -1,
     },
     {
       header: t("columns.avgTtfbMs"),
@@ -520,9 +536,9 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     {
       header: t("columns.successRate"),
       className: "text-right",
-      cell: (row) => `${(Number(row.successRate || 0) * 100).toFixed(1)}%`,
+      cell: (row) => renderSuccessRateCell(row, t),
       sortKey: "successRate",
-      getValue: (row) => row.successRate,
+      getValue: (row) => row.successRate ?? -1,
     },
   ];
 

--- a/src/app/[locale]/dashboard/leaderboard/_components/success-rate-display.ts
+++ b/src/app/[locale]/dashboard/leaderboard/_components/success-rate-display.ts
@@ -1,0 +1,26 @@
+export interface SuccessRateDisplayRow {
+  successRate: number | null;
+  basisDisclosureRequired?: boolean;
+}
+
+export interface SuccessRateDisplayValue {
+  label: string;
+  title?: string;
+}
+
+export function getSuccessRateCellDisplay(
+  row: SuccessRateDisplayRow,
+  t: (key: string) => string
+): SuccessRateDisplayValue {
+  if (typeof row.successRate === "number") {
+    return {
+      label: `${(Number(row.successRate) * 100).toFixed(1)}%`,
+      title: undefined,
+    };
+  }
+
+  return {
+    label: t("columns.successRateUnavailable"),
+    title: row.basisDisclosureRequired ? t("columns.successRateBasisDisclosure") : undefined,
+  };
+}

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -955,6 +955,7 @@ export const usageLedger = pgTable('usage_ledger', {
   sessionId: varchar('session_id', { length: 64 }),
   statusCode: integer('status_code'),
   isSuccess: boolean('is_success').notNull().default(false),
+  successRateOutcome: varchar('success_rate_outcome', { length: 16 }),
   blockedBy: varchar('blocked_by', { length: 50 }),
   costUsd: numeric('cost_usd', { precision: 21, scale: 15 }).default('0'),
   costMultiplier: numeric('cost_multiplier', { precision: 10, scale: 4 }),

--- a/src/lib/availability/availability-service.ts
+++ b/src/lib/availability/availability-service.ts
@@ -163,14 +163,12 @@ function isAvailabilitySuccessStatusCode(statusCode: number): boolean {
 
 function buildRequestOutcomeSql(
   blockedByExpression: SQLWrapper,
-  blockedReasonExpression: SQLWrapper,
   statusCodeExpression: SQLWrapper,
   errorMessageExpression: SQLWrapper,
   providerChainExpression: SQLWrapper
 ) {
   return sql`fn_compute_message_request_success_rate_outcome(
     ${blockedByExpression},
-    ${blockedReasonExpression},
     ${statusCodeExpression},
     ${errorMessageExpression},
     ${providerChainExpression}
@@ -374,7 +372,6 @@ export async function queryProviderAvailability(
         ${messageRequest.createdAt} AS "createdAt",
         ${buildRequestOutcomeSql(
           messageRequest.blockedBy,
-          messageRequest.blockedReason,
           messageRequest.statusCode,
           messageRequest.errorMessage,
           messageRequest.providerChain
@@ -601,7 +598,6 @@ export async function getCurrentProviderStatus(): Promise<
       COUNT(*) FILTER (WHERE ${buildAvailabilitySuccessOutcomeCondition(
         buildRequestOutcomeSql(
           messageRequest.blockedBy,
-          messageRequest.blockedReason,
           messageRequest.statusCode,
           messageRequest.errorMessage,
           messageRequest.providerChain
@@ -610,7 +606,6 @@ export async function getCurrentProviderStatus(): Promise<
       COUNT(*) FILTER (WHERE ${buildAvailabilityFailureOutcomeCondition(
         buildRequestOutcomeSql(
           messageRequest.blockedBy,
-          messageRequest.blockedReason,
           messageRequest.statusCode,
           messageRequest.errorMessage,
           messageRequest.providerChain

--- a/src/lib/availability/availability-service.ts
+++ b/src/lib/availability/availability-service.ts
@@ -4,7 +4,7 @@
  * Simple two-tier status: success (green) or failure (red)
  */
 
-import { and, eq, inArray, isNotNull, isNull, type SQLWrapper, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, type SQLWrapper, sql } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { messageRequest, providers } from "@/drizzle/schema";
 import type {
@@ -42,14 +42,9 @@ export const MAX_BUCKET_SIZE_MINUTES = 1440;
 const DEFAULT_MAX_BUCKETS = 100;
 const AVAILABILITY_SUCCESS_STATUS_CODE_MIN = 200;
 const AVAILABILITY_SUCCESS_STATUS_CODE_MAX_EXCLUSIVE = 400;
-const FINALIZED_REQUEST_STATUS_CODE_ALIAS = "statusCode" as const;
-const AVAILABILITY_SUCCESS_STATUS_CODE_MIN_SQL = sql.raw(
-  String(AVAILABILITY_SUCCESS_STATUS_CODE_MIN)
-);
-const AVAILABILITY_SUCCESS_STATUS_CODE_MAX_EXCLUSIVE_SQL = sql.raw(
-  String(AVAILABILITY_SUCCESS_STATUS_CODE_MAX_EXCLUSIVE)
-);
-const FINALIZED_REQUEST_STATUS_CODE_SQL = sql.raw(`"${FINALIZED_REQUEST_STATUS_CODE_ALIAS}"`);
+const FINALIZED_REQUEST_OUTCOME_ALIAS = "successRateOutcome" as const;
+const FINALIZED_REQUEST_OUTCOME_SQL = sql.raw(`"${FINALIZED_REQUEST_OUTCOME_ALIAS}"`);
+const COUNTABLE_REQUEST_OUTCOME_SQL = sql`${FINALIZED_REQUEST_OUTCOME_SQL} IN ('success', 'failure')`;
 // Keep the hard cap independent from the UI/API default so future default tuning does not silently relax/tighten the guardrail.
 // It intentionally equals the default today; the separation preserves distinct semantic roles for future tuning.
 export const MAX_BUCKETS_HARD_LIMIT = 100;
@@ -74,7 +69,12 @@ export class AvailabilityQueryValidationError extends Error {
  * 届时应引入独立的 finalized 谓词，而不是直接放宽为 `durationMs IS NOT NULL`。
  */
 function buildAvailabilityFinalizedCondition() {
-  return isNotNull(messageRequest.statusCode);
+  return sql`fn_is_message_request_finalized(
+    ${messageRequest.blockedBy},
+    ${messageRequest.statusCode},
+    ${messageRequest.providerChain},
+    ${messageRequest.errorMessage}
+  )`;
 }
 
 function assertValidDate(date: Date, fieldName: string): Date {
@@ -161,14 +161,28 @@ function isAvailabilitySuccessStatusCode(statusCode: number): boolean {
   );
 }
 
-function buildAvailabilitySuccessStatusCondition(statusCodeExpression: SQLWrapper) {
-  return sql`${statusCodeExpression} >= ${AVAILABILITY_SUCCESS_STATUS_CODE_MIN_SQL}
-    AND ${statusCodeExpression} < ${AVAILABILITY_SUCCESS_STATUS_CODE_MAX_EXCLUSIVE_SQL}`;
+function buildRequestOutcomeSql(
+  blockedByExpression: SQLWrapper,
+  blockedReasonExpression: SQLWrapper,
+  statusCodeExpression: SQLWrapper,
+  errorMessageExpression: SQLWrapper,
+  providerChainExpression: SQLWrapper
+) {
+  return sql`fn_compute_message_request_success_rate_outcome(
+    ${blockedByExpression},
+    ${blockedReasonExpression},
+    ${statusCodeExpression},
+    ${errorMessageExpression},
+    ${providerChainExpression}
+  )`;
 }
 
-function buildAvailabilityFailureStatusCondition(statusCodeExpression: SQLWrapper) {
-  return sql`(${statusCodeExpression} < ${AVAILABILITY_SUCCESS_STATUS_CODE_MIN_SQL}
-    OR ${statusCodeExpression} >= ${AVAILABILITY_SUCCESS_STATUS_CODE_MAX_EXCLUSIVE_SQL})`;
+function buildAvailabilitySuccessOutcomeCondition(outcomeExpression: SQLWrapper) {
+  return sql`${outcomeExpression} = 'success'`;
+}
+
+function buildAvailabilityFailureOutcomeCondition(outcomeExpression: SQLWrapper) {
+  return sql`${outcomeExpression} = 'failure'`;
 }
 
 /**
@@ -358,7 +372,13 @@ export async function queryProviderAvailability(
       SELECT
         ${messageRequest.providerId} AS "providerId",
         ${messageRequest.createdAt} AS "createdAt",
-        ${messageRequest.statusCode} AS ${FINALIZED_REQUEST_STATUS_CODE_SQL},
+        ${buildRequestOutcomeSql(
+          messageRequest.blockedBy,
+          messageRequest.blockedReason,
+          messageRequest.statusCode,
+          messageRequest.errorMessage,
+          messageRequest.providerChain
+        )} AS ${FINALIZED_REQUEST_OUTCOME_SQL},
         ${messageRequest.durationMs} AS "durationMs",
         to_timestamp(
           floor(extract(epoch from ${messageRequest.createdAt}) / ${bucketSizeSeconds}) * ${bucketSizeSeconds}
@@ -370,24 +390,30 @@ export async function queryProviderAvailability(
       SELECT
         "providerId",
         "bucketStart",
-        COUNT(*) FILTER (WHERE ${buildAvailabilitySuccessStatusCondition(FINALIZED_REQUEST_STATUS_CODE_SQL)})::int AS "greenCount",
-        COUNT(*) FILTER (WHERE ${buildAvailabilityFailureStatusCondition(FINALIZED_REQUEST_STATUS_CODE_SQL)})::int AS "redCount",
-        COUNT("durationMs")::int AS "latencyCount",
-        COALESCE(SUM("durationMs")::double precision, 0) AS "latencySumMs",
-        COALESCE(AVG("durationMs")::double precision, 0) AS "avgLatencyMs",
+        COUNT(*) FILTER (WHERE ${buildAvailabilitySuccessOutcomeCondition(FINALIZED_REQUEST_OUTCOME_SQL)})::int AS "greenCount",
+        COUNT(*) FILTER (WHERE ${buildAvailabilityFailureOutcomeCondition(FINALIZED_REQUEST_OUTCOME_SQL)})::int AS "redCount",
+        COUNT("durationMs") FILTER (WHERE ${COUNTABLE_REQUEST_OUTCOME_SQL})::int AS "latencyCount",
+        COALESCE(
+          SUM("durationMs") FILTER (WHERE ${COUNTABLE_REQUEST_OUTCOME_SQL})::double precision,
+          0
+        ) AS "latencySumMs",
+        COALESCE(
+          AVG("durationMs") FILTER (WHERE ${COUNTABLE_REQUEST_OUTCOME_SQL})::double precision,
+          0
+        ) AS "avgLatencyMs",
         COALESCE(
           percentile_cont(0.5) WITHIN GROUP (ORDER BY "durationMs"::double precision)
-            FILTER (WHERE "durationMs" IS NOT NULL),
+            FILTER (WHERE "durationMs" IS NOT NULL AND ${COUNTABLE_REQUEST_OUTCOME_SQL}),
           0
         )::double precision AS "p50LatencyMs",
         COALESCE(
           percentile_cont(0.95) WITHIN GROUP (ORDER BY "durationMs"::double precision)
-            FILTER (WHERE "durationMs" IS NOT NULL),
+            FILTER (WHERE "durationMs" IS NOT NULL AND ${COUNTABLE_REQUEST_OUTCOME_SQL}),
           0
         )::double precision AS "p95LatencyMs",
         COALESCE(
           percentile_cont(0.99) WITHIN GROUP (ORDER BY "durationMs"::double precision)
-            FILTER (WHERE "durationMs" IS NOT NULL),
+            FILTER (WHERE "durationMs" IS NOT NULL AND ${COUNTABLE_REQUEST_OUTCOME_SQL}),
           0
         )::double precision AS "p99LatencyMs",
         MAX("createdAt") AS "lastRequestAt"
@@ -488,10 +514,11 @@ export async function queryProviderAvailability(
       const recentBuckets = timeBuckets.slice(-3); // Last 3 buckets
       const recentGreen = recentBuckets.reduce((sum, bucket) => sum + bucket.greenCount, 0);
       const recentRed = recentBuckets.reduce((sum, bucket) => sum + bucket.redCount, 0);
+      const recentTotal = recentGreen + recentRed;
       const recentScore = calculateAvailabilityScore(recentGreen, recentRed);
 
       // Simple: >= 50% success = green, otherwise red
-      currentStatus = recentScore >= 0.5 ? "green" : "red";
+      currentStatus = recentTotal === 0 ? "unknown" : recentScore >= 0.5 ? "green" : "red";
     }
 
     providerSummaries.push({
@@ -571,8 +598,24 @@ export async function getCurrentProviderStatus(): Promise<
   const aggregateQuery = sql<AggregatedCurrentProviderStatusRow>`
     SELECT
       ${messageRequest.providerId} AS "providerId",
-      COUNT(*) FILTER (WHERE ${buildAvailabilitySuccessStatusCondition(messageRequest.statusCode)})::int AS "greenCount",
-      COUNT(*) FILTER (WHERE ${buildAvailabilityFailureStatusCondition(messageRequest.statusCode)})::int AS "redCount",
+      COUNT(*) FILTER (WHERE ${buildAvailabilitySuccessOutcomeCondition(
+        buildRequestOutcomeSql(
+          messageRequest.blockedBy,
+          messageRequest.blockedReason,
+          messageRequest.statusCode,
+          messageRequest.errorMessage,
+          messageRequest.providerChain
+        )
+      )})::int AS "greenCount",
+      COUNT(*) FILTER (WHERE ${buildAvailabilityFailureOutcomeCondition(
+        buildRequestOutcomeSql(
+          messageRequest.blockedBy,
+          messageRequest.blockedReason,
+          messageRequest.statusCode,
+          messageRequest.errorMessage,
+          messageRequest.providerChain
+        )
+      )})::int AS "redCount",
       MAX(${messageRequest.createdAt}) AS "lastRequestAt"
     FROM ${messageRequest}
     WHERE ${requestConditions}

--- a/src/lib/ledger-backfill/service.ts
+++ b/src/lib/ledger-backfill/service.ts
@@ -66,7 +66,6 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
             mr.status_code,
             fn_compute_message_request_success_rate_outcome(
               mr.blocked_by,
-              mr.blocked_reason,
               mr.status_code,
               mr.error_message,
               mr.provider_chain

--- a/src/lib/ledger-backfill/service.ts
+++ b/src/lib/ledger-backfill/service.ts
@@ -35,6 +35,7 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
     try {
       let totalProcessed = 0;
       let totalInserted = 0;
+      let totalAlreadyExisted = 0;
       let lastId = 0;
 
       while (true) {
@@ -63,6 +64,13 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
             mr.api_type,
             mr.session_id,
             mr.status_code,
+            fn_compute_message_request_success_rate_outcome(
+              mr.blocked_by,
+              mr.blocked_reason,
+              mr.status_code,
+              mr.error_message,
+              mr.provider_chain
+            ) AS success_rate_outcome,
             (mr.error_message IS NULL OR mr.error_message = '') AS is_success,
             mr.blocked_by,
             mr.cost_usd,
@@ -78,12 +86,15 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
             mr.swap_cache_ttl_applied,
             mr.duration_ms,
             mr.ttfb_ms,
-            mr.created_at
+            mr.created_at,
+            ul.request_id AS existing_request_id
           FROM message_request mr
+          LEFT JOIN usage_ledger ul ON ul.request_id = mr.id
           WHERE mr.id > ${lastId}
             AND mr.blocked_by IS DISTINCT FROM 'warmup'
-            AND NOT EXISTS (
-              SELECT 1 FROM usage_ledger ul WHERE ul.request_id = mr.id
+            AND (
+              ul.request_id IS NULL
+              OR ul.success_rate_outcome IS NULL
             )
           ORDER BY mr.id ASC
           LIMIT 10000
@@ -92,7 +103,7 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
           INSERT INTO usage_ledger (
             request_id, user_id, key, provider_id, final_provider_id,
             model, original_model, endpoint, api_type, session_id,
-            status_code, is_success, blocked_by,
+            status_code, is_success, success_rate_outcome, blocked_by,
             cost_usd, cost_multiplier,
             input_tokens, output_tokens,
             cache_creation_input_tokens, cache_read_input_tokens,
@@ -113,6 +124,7 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
             batch.session_id,
             batch.status_code,
             batch.is_success,
+            batch.success_rate_outcome,
             batch.blocked_by,
             batch.cost_usd,
             batch.cost_multiplier,
@@ -129,12 +141,30 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
             batch.ttfb_ms,
             batch.created_at
           FROM batch
-          ON CONFLICT (request_id) DO NOTHING
+          ON CONFLICT (request_id) DO UPDATE SET
+            success_rate_outcome = EXCLUDED.success_rate_outcome
           RETURNING request_id
         )
         SELECT
           COALESCE((SELECT COUNT(*) FROM batch), 0)::integer AS processed,
-          COALESCE((SELECT COUNT(*) FROM inserted_rows), 0)::integer AS inserted,
+          COALESCE(
+            (
+              SELECT COUNT(*)
+              FROM inserted_rows ir
+              JOIN batch b ON b.id = ir.request_id
+              WHERE b.existing_request_id IS NULL
+            ),
+            0
+          )::integer AS inserted,
+          COALESCE(
+            (
+              SELECT COUNT(*)
+              FROM inserted_rows ir
+              JOIN batch b ON b.id = ir.request_id
+              WHERE b.existing_request_id IS NOT NULL
+            ),
+            0
+          )::integer AS updated,
           COALESCE((SELECT MAX(id) FROM batch), 0)::integer AS max_id
       `);
 
@@ -142,12 +172,14 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
           batchResult as unknown as Array<{
             processed?: number | string;
             inserted?: number | string;
+            updated?: number | string;
             max_id?: number | string;
           }>
         )[0];
 
         const processed = Number(batchRow?.processed ?? 0);
         const inserted = Number(batchRow?.inserted ?? 0);
+        const updated = Number(batchRow?.updated ?? 0);
         const maxId = Number(batchRow?.max_id ?? 0);
 
         if (processed === 0) {
@@ -156,6 +188,7 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
 
         totalProcessed += processed;
         totalInserted += inserted;
+        totalAlreadyExisted += updated;
         lastId = maxId;
 
         logger.info("Backfill progress", {
@@ -170,7 +203,7 @@ export async function backfillUsageLedger(): Promise<BackfillUsageLedgerSummary>
         totalProcessed,
         totalInserted,
         durationMs,
-        alreadyExisted: totalProcessed - totalInserted,
+        alreadyExisted: totalAlreadyExisted,
       };
     } finally {
       // pg_try_advisory_xact_lock is automatically released when the transaction ends

--- a/src/lib/ledger-backfill/trigger.sql
+++ b/src/lib/ledger-backfill/trigger.sql
@@ -57,7 +57,6 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE FUNCTION fn_compute_message_request_success_rate_outcome(
   blocked_by varchar,
-  blocked_reason text,
   status_code integer,
   error_message text,
   provider_chain jsonb
@@ -156,7 +155,6 @@ DECLARE
 BEGIN
   v_success_rate_outcome := fn_compute_message_request_success_rate_outcome(
     NEW.blocked_by,
-    NEW.blocked_reason,
     NEW.status_code,
     NEW.error_message,
     NEW.provider_chain
@@ -166,7 +164,7 @@ BEGIN
     -- If a ledger row already exists (row was originally non-warmup), mark it as warmup
     UPDATE usage_ledger
     SET blocked_by = 'warmup',
-        success_rate_outcome = 'excluded'
+        success_rate_outcome = v_success_rate_outcome
     WHERE request_id = NEW.id;
     RETURN NEW;
   END IF;

--- a/src/lib/public-status/aggregation.ts
+++ b/src/lib/public-status/aggregation.ts
@@ -1,14 +1,19 @@
 import { and, gte, inArray, isNull, lt, or } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { messageRequest } from "@/drizzle/schema";
+import {
+  classifyProviderChainItemOutcome,
+  resolveSuccessRateModelKey,
+} from "@/lib/request-outcome";
 import { parseProviderGroups } from "@/lib/utils/provider-group";
 import { EXCLUDE_WARMUP_CONDITION } from "@/repository/_shared/message-request-conditions";
+import type { ProviderChainItem } from "@/types/message";
 import type { InternalPublicStatusConfigSnapshot } from "./config-snapshot";
 import type { PublicStatusPayload, PublicStatusTimelineBucket } from "./payload";
 
 export interface PublicStatusFailureSignal {
   statusCode?: number | null;
-  reason?: string;
+  reason?: ProviderChainItem["reason"];
   errorMessage?: string;
   matchedRule?: {
     ruleId: number;
@@ -119,46 +124,14 @@ export function computeTokensPerSecond(input: {
 }
 
 export function isExcludedFromPublicStatusFailure(signal: PublicStatusFailureSignal): boolean {
-  if (signal.statusCode === 404 || signal.statusCode === 499) {
-    return true;
-  }
-
-  if (signal.matchedRule) {
-    return true;
-  }
-
-  if (
-    signal.reason === "resource_not_found" ||
-    signal.reason === "concurrent_limit_failed" ||
-    signal.reason === "hedge_loser_cancelled" ||
-    signal.reason === "client_error_non_retryable"
-  ) {
-    return true;
-  }
-
-  const normalizedError = signal.errorMessage?.toLowerCase() ?? "";
-  if (
-    normalizedError.includes("no available provider") ||
-    normalizedError.includes("insufficient quota") ||
-    normalizedError.includes("quota exceeded") ||
-    normalizedError.includes("rate limit") ||
-    normalizedError.includes("rate_limit") ||
-    normalizedError.includes("concurrency limit") ||
-    normalizedError.includes("concurrent limit") ||
-    normalizedError.includes("limit exceeded")
-  ) {
-    return true;
-  }
-
-  return false;
-}
-
-function isSuccessReason(reason: string | undefined, statusCode?: number | null): boolean {
-  if (reason === "request_success" || reason === "retry_success" || reason === "hedge_winner") {
-    return true;
-  }
-
-  return statusCode != null && statusCode >= 200 && statusCode < 400;
+  return (
+    classifyProviderChainItemOutcome({
+      statusCode: signal.statusCode ?? undefined,
+      reason: signal.reason ?? undefined,
+      errorMessage: signal.errorMessage ?? undefined,
+      errorDetails: signal.matchedRule ? { matchedRule: signal.matchedRule } : undefined,
+    })?.outcome === "excluded"
+  );
 }
 
 function alignWindowEnd(now: Date, intervalMinutes: number): Date {
@@ -290,7 +263,10 @@ export function buildPublicStatusPayloadFromRequests(input: {
   }
 
   for (const request of input.requests) {
-    const modelKey = request.originalModel ?? request.model ?? null;
+    const modelKey = resolveSuccessRateModelKey({
+      originalModel: request.originalModel,
+      model: request.model,
+    });
     if (!modelKey) {
       continue;
     }
@@ -324,28 +300,12 @@ export function buildPublicStatusPayloadFromRequests(input: {
         continue;
       }
 
-      const outcome = (() => {
-        if (
-          isExcludedFromPublicStatusFailure({
-            statusCode: item.statusCode,
-            reason: item.reason,
-            errorMessage: item.errorMessage,
-            matchedRule: item.matchedRule,
-          })
-        ) {
-          return "excluded" as const;
-        }
-
-        if (isSuccessReason(item.reason, item.statusCode)) {
-          return "success" as const;
-        }
-
-        if (item.statusCode !== undefined || item.reason) {
-          return "failure" as const;
-        }
-
-        return null;
-      })();
+      const outcome = classifyProviderChainItemOutcome({
+        statusCode: item.statusCode ?? undefined,
+        reason: item.reason ?? undefined,
+        errorMessage: item.errorMessage ?? undefined,
+        errorDetails: item.matchedRule ? { matchedRule: item.matchedRule } : undefined,
+      })?.outcome;
 
       if (!outcome) {
         continue;

--- a/src/lib/request-outcome.ts
+++ b/src/lib/request-outcome.ts
@@ -1,0 +1,194 @@
+import type { ProviderChainItem } from "@/types/message";
+
+export type SuccessRateOutcome = "success" | "failure" | "excluded";
+
+export type SuccessRateExclusionFamily =
+  | "warmup"
+  | "sensitive_word"
+  | "blocked_request"
+  | "matched_rule"
+  | "resource_not_found"
+  | "client_abort"
+  | "local_capacity"
+  | "local_non_retryable"
+  | "hedge_loser"
+  | "quota_or_rate_limit"
+  | "no_available_provider";
+
+export interface RequestOutcomeTaxonomy {
+  outcome: SuccessRateOutcome;
+  locus: "upstream" | "non_upstream";
+  countability: "countable" | "excluded";
+  result: "success" | "failure" | "n/a";
+  exclusionFamily?: SuccessRateExclusionFamily;
+}
+
+const NEUTRAL_REASONS = new Set<NonNullable<ProviderChainItem["reason"]>>([
+  "session_reuse",
+  "initial_selection",
+  "hedge_triggered",
+  "hedge_launched",
+  "client_restriction_filtered",
+  "http2_fallback",
+]);
+
+type RequestOutcomeSignal = {
+  blockedBy?: string | null;
+  blockedReason?: string | null;
+  statusCode?: number | null;
+  reason?: ProviderChainItem["reason"] | null;
+  errorMessage?: string | null;
+  matchedRule?: ProviderChainItem["errorDetails"] extends { matchedRule?: infer T } ? T : unknown;
+};
+
+const SUCCESS_REASONS = new Set<NonNullable<ProviderChainItem["reason"]>>([
+  "request_success",
+  "retry_success",
+  "hedge_winner",
+]);
+
+const EXCLUDED_REASONS = new Map<
+  NonNullable<ProviderChainItem["reason"]>,
+  SuccessRateExclusionFamily
+>([
+  ["resource_not_found", "resource_not_found"],
+  ["concurrent_limit_failed", "local_capacity"],
+  ["hedge_loser_cancelled", "hedge_loser"],
+  ["client_error_non_retryable", "local_non_retryable"],
+  ["client_abort", "client_abort"],
+]);
+
+const QUOTA_OR_RATE_LIMIT_PATTERNS = [
+  "insufficient quota",
+  "quota exceeded",
+  "rate limit",
+  "rate_limit",
+  "concurrency limit",
+  "concurrent limit",
+  "limit exceeded",
+];
+
+function buildSuccessTaxonomy(): RequestOutcomeTaxonomy {
+  return {
+    outcome: "success",
+    locus: "upstream",
+    countability: "countable",
+    result: "success",
+  };
+}
+
+function buildFailureTaxonomy(): RequestOutcomeTaxonomy {
+  return {
+    outcome: "failure",
+    locus: "upstream",
+    countability: "countable",
+    result: "failure",
+  };
+}
+
+function buildExcludedTaxonomy(
+  exclusionFamily: SuccessRateExclusionFamily
+): RequestOutcomeTaxonomy {
+  return {
+    outcome: "excluded",
+    locus: "non_upstream",
+    countability: "excluded",
+    result: "n/a",
+    exclusionFamily,
+  };
+}
+
+function normalizeBlockedBy(blockedBy: string | null | undefined): string | null {
+  const normalized = blockedBy?.trim().toLowerCase();
+  return normalized && normalized.length > 0 ? normalized : null;
+}
+
+function matchesQuotaOrRateLimit(message: string | null | undefined): boolean {
+  const normalized = message?.toLowerCase() ?? "";
+  return QUOTA_OR_RATE_LIMIT_PATTERNS.some((pattern) => normalized.includes(pattern));
+}
+
+export function resolveSuccessRateModelKey(input: {
+  originalModel?: string | null;
+  model?: string | null;
+}): string | null {
+  const candidate = input.originalModel?.trim() || input.model?.trim() || "";
+  return candidate.length > 0 ? candidate : null;
+}
+
+export function classifyRequestOutcomeSignal(
+  signal: RequestOutcomeSignal
+): RequestOutcomeTaxonomy | null {
+  const blockedBy = normalizeBlockedBy(signal.blockedBy);
+  if (blockedBy === "warmup") {
+    return buildExcludedTaxonomy("warmup");
+  }
+  if (blockedBy === "sensitive_word") {
+    return buildExcludedTaxonomy("sensitive_word");
+  }
+  if (blockedBy) {
+    return buildExcludedTaxonomy("blocked_request");
+  }
+
+  if (signal.matchedRule) {
+    return buildExcludedTaxonomy("matched_rule");
+  }
+
+  if (signal.statusCode === 499 || signal.reason === "client_abort") {
+    return buildExcludedTaxonomy("client_abort");
+  }
+
+  if (signal.statusCode === 404 || signal.reason === "resource_not_found") {
+    return buildExcludedTaxonomy("resource_not_found");
+  }
+
+  const excludedReason = signal.reason ? EXCLUDED_REASONS.get(signal.reason) : undefined;
+  if (excludedReason) {
+    return buildExcludedTaxonomy(excludedReason);
+  }
+
+  const normalizedError = signal.errorMessage?.toLowerCase() ?? "";
+  if (normalizedError.includes("no available provider")) {
+    return buildExcludedTaxonomy("no_available_provider");
+  }
+  if (matchesQuotaOrRateLimit(signal.errorMessage)) {
+    return buildExcludedTaxonomy("quota_or_rate_limit");
+  }
+
+  if (
+    (signal.reason && SUCCESS_REASONS.has(signal.reason)) ||
+    isSuccessStatusCode(signal.statusCode)
+  ) {
+    return buildSuccessTaxonomy();
+  }
+
+  if (
+    signal.reason &&
+    NEUTRAL_REASONS.has(signal.reason) &&
+    signal.statusCode == null &&
+    (!signal.errorMessage || signal.errorMessage.length === 0)
+  ) {
+    return null;
+  }
+
+  if (signal.statusCode != null || signal.reason || normalizedError.length > 0) {
+    return buildFailureTaxonomy();
+  }
+
+  return null;
+}
+
+export function classifyProviderChainItemOutcome(
+  item: Pick<ProviderChainItem, "statusCode" | "reason" | "errorMessage" | "errorDetails">
+): RequestOutcomeTaxonomy | null {
+  return classifyRequestOutcomeSignal({
+    statusCode: item.statusCode ?? null,
+    reason: item.reason ?? null,
+    errorMessage: item.errorMessage ?? null,
+    matchedRule: item.errorDetails?.matchedRule,
+  });
+}
+
+export function isSuccessStatusCode(statusCode: number | null | undefined): boolean {
+  return statusCode != null && statusCode >= 200 && statusCode < 400;
+}

--- a/src/repository/_shared/ledger-conditions.ts
+++ b/src/repository/_shared/ledger-conditions.ts
@@ -12,3 +12,13 @@ export const LEDGER_BILLING_CONDITION = sql`(${usageLedger.blockedBy} IS NULL)`;
  * 非计费查询中排除被阻断请求的别名条件（语义更清晰）。
  */
 export const LEDGER_ACTIVE_CONDITION = LEDGER_BILLING_CONDITION;
+
+/**
+ * successRate / availability 相关统计只统计已明确属于上游 success/failure 的请求。
+ */
+export const LEDGER_SUCCESS_RATE_COUNTABLE_CONDITION = sql`${usageLedger.successRateOutcome} IN ('success', 'failure')`;
+
+/**
+ * successRate 分子条件：只统计明确的 success outcome。
+ */
+export const LEDGER_SUCCESS_RATE_SUCCESS_CONDITION = sql`${usageLedger.successRateOutcome} = 'success'`;

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -5,10 +5,25 @@ import { db } from "@/drizzle/db";
 import { providers, usageLedger, users } from "@/drizzle/schema";
 import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import type { ProviderType } from "@/types/provider";
-import { LEDGER_BILLING_CONDITION } from "./_shared/ledger-conditions";
+import type { BillingModelSource } from "@/types/system-config";
+import {
+  LEDGER_BILLING_CONDITION,
+  LEDGER_SUCCESS_RATE_COUNTABLE_CONDITION,
+  LEDGER_SUCCESS_RATE_SUCCESS_CONDITION,
+} from "./_shared/ledger-conditions";
 import { getSystemSettings } from "./system-config";
 
 const clampRatio01 = (value: number | null | undefined) => Math.min(Math.max(value ?? 0, 0), 1);
+const clampRatio01Nullable = (value: number | null | undefined) =>
+  value == null ? null : clampRatio01(value);
+
+const LEDGER_SUCCESS_RATE_EXPR = sql<number | null>`
+  count(CASE WHEN ${LEDGER_SUCCESS_RATE_SUCCESS_CONDITION} THEN 1 END)::double precision
+  / NULLIF(
+      count(CASE WHEN ${LEDGER_SUCCESS_RATE_COUNTABLE_CONDITION} THEN 1 END)::double precision,
+      0
+    )
+`;
 
 /**
  * 排行榜条目类型
@@ -48,7 +63,7 @@ export interface ProviderLeaderboardEntry {
   totalRequests: number;
   totalCost: number;
   totalTokens: number;
-  successRate: number; // 0-1 之间的小数，UI 层负责格式化为百分比
+  successRate: number | null; // 0-1 之间的小数，UI 层负责格式化为百分比
   avgTtfbMs: number; // 毫秒
   avgTokensPerSecond: number; // tok/s（仅统计流式且可计算的请求）
   avgCostPerRequest: number | null; // totalCost / totalRequests, null when totalRequests === 0
@@ -69,11 +84,16 @@ export interface ModelProviderStat {
   totalRequests: number;
   totalCost: number;
   totalTokens: number;
-  successRate: number; // 0-1
+  successRate: number | null; // 0-1
   avgTtfbMs: number; // 毫秒
   avgTokensPerSecond: number; // tok/s
   avgCostPerRequest: number | null;
   avgCostPerMillionTokens: number | null;
+  rowIdentityBasis?: BillingModelSource;
+  successRateBasis?: "original" | "unavailable";
+  costTokensBasis?: BillingModelSource;
+  basisDisclosureRequired?: boolean;
+  successRateUnavailableReason?: "redirected_billing_model";
 }
 
 /**
@@ -140,7 +160,12 @@ export interface ModelLeaderboardEntry {
   totalRequests: number;
   totalCost: number;
   totalTokens: number;
-  successRate: number; // 0-1 之间的小数，UI 层负责格式化为百分比
+  successRate: number | null; // 0-1 之间的小数，UI 层负责格式化为百分比
+  rowIdentityBasis?: BillingModelSource;
+  successRateBasis?: "original" | "unavailable";
+  costTokensBasis?: BillingModelSource;
+  basisDisclosureRequired?: boolean;
+  successRateUnavailableReason?: "redirected_billing_model";
 }
 
 /**
@@ -629,11 +654,7 @@ async function findProviderLeaderboardWithTimezone(
     )::double precision,
     0::double precision
   )`;
-  const successRateExpr = sql<number>`COALESCE(
-    count(CASE WHEN ${usageLedger.isSuccess} THEN 1 END)::double precision
-    / NULLIF(count(*)::double precision, 0),
-    0::double precision
-  )`;
+  const successRateExpr = LEDGER_SUCCESS_RATE_EXPR;
   const avgTtfbMsExpr = sql<number>`COALESCE(avg(${usageLedger.ttfbMs})::double precision, 0::double precision)`;
   const avgTokensPerSecondExpr = sql<number>`COALESCE(
     avg(
@@ -688,7 +709,7 @@ async function findProviderLeaderboardWithTimezone(
       totalRequests,
       totalCost,
       totalTokens,
-      successRate: clampRatio01(entry.successRate),
+      successRate: clampRatio01Nullable(entry.successRate),
       avgTtfbMs: entry.avgTtfbMs ?? 0,
       avgTokensPerSecond: entry.avgTokensPerSecond ?? 0,
       ...avgCosts,
@@ -736,14 +757,22 @@ async function findProviderLeaderboardWithTimezone(
     const totalTokens = row.totalTokens;
     const avgCosts = computeAvgCosts(totalCost, totalRequests, totalTokens);
     const stats = modelStatsByProvider.get(row.providerId) ?? [];
+    const basisDisclosureRequired = billingModelSource !== "original";
     stats.push({
       model: row.model,
       totalRequests,
       totalCost,
       totalTokens,
-      successRate: clampRatio01(row.successRate),
+      successRate: basisDisclosureRequired ? null : clampRatio01Nullable(row.successRate),
       avgTtfbMs: row.avgTtfbMs ?? 0,
       avgTokensPerSecond: row.avgTokensPerSecond ?? 0,
+      rowIdentityBasis: billingModelSource,
+      successRateBasis: basisDisclosureRequired ? "unavailable" : "original",
+      costTokensBasis: billingModelSource,
+      basisDisclosureRequired,
+      successRateUnavailableReason: basisDisclosureRequired
+        ? "redirected_billing_model"
+        : undefined,
       ...avgCosts,
     });
     modelStatsByProvider.set(row.providerId, stats);
@@ -1119,11 +1148,7 @@ async function findModelLeaderboardWithTimezone(
         )::double precision,
         0::double precision
       )`,
-      successRate: sql<number>`COALESCE(
-        count(CASE WHEN ${usageLedger.isSuccess} THEN 1 END)::double precision
-        / NULLIF(count(*)::double precision, 0),
-        0::double precision
-      )`,
+      successRate: LEDGER_SUCCESS_RATE_EXPR,
     })
     .from(usageLedger)
     .where(and(LEDGER_BILLING_CONDITION, buildDateCondition(period, timezone, dateRange)))
@@ -1137,7 +1162,14 @@ async function findModelLeaderboardWithTimezone(
       totalRequests: entry.totalRequests,
       totalCost: parseFloat(entry.totalCost),
       totalTokens: entry.totalTokens,
-      successRate: clampRatio01(entry.successRate),
+      successRate:
+        billingModelSource === "original" ? clampRatio01Nullable(entry.successRate) : null,
+      rowIdentityBasis: billingModelSource,
+      successRateBasis: billingModelSource === "original" ? "original" : "unavailable",
+      costTokensBasis: billingModelSource,
+      basisDisclosureRequired: billingModelSource !== "original",
+      successRateUnavailableReason:
+        billingModelSource !== "original" ? "redirected_billing_model" : undefined,
     }));
 }
 

--- a/tests/integration/usage-ledger.test.ts
+++ b/tests/integration/usage-ledger.test.ts
@@ -106,6 +106,7 @@ async function selectLedgerRowByRequestId(requestId: number) {
       apiType: usageLedger.apiType,
       statusCode: usageLedger.statusCode,
       isSuccess: usageLedger.isSuccess,
+      successRateOutcome: usageLedger.successRateOutcome,
       blockedBy: usageLedger.blockedBy,
       costUsd: usageLedger.costUsd,
       costMultiplier: usageLedger.costMultiplier,
@@ -171,6 +172,7 @@ run("usage ledger integration", () => {
       expect(ledgerRow?.apiType).toBe("response");
       expect(ledgerRow?.statusCode).toBe(200);
       expect(ledgerRow?.isSuccess).toBe(true);
+      expect(ledgerRow?.successRateOutcome).toBe("success");
       expect(toNumber(ledgerRow?.costUsd)).toBeCloseTo(1.25, 10);
       expect(ledgerRow?.inputTokens).toBe(12);
       expect(ledgerRow?.outputTokens).toBe(34);
@@ -262,6 +264,7 @@ run("usage ledger integration", () => {
 
       const ledgerRow = await selectLedgerRowByRequestId(requestId);
       expect(ledgerRow?.isSuccess).toBe(false);
+      expect(ledgerRow?.successRateOutcome).toBe("failure");
     });
 
     test("sets is_success=true when error_message is absent", async () => {
@@ -274,6 +277,20 @@ run("usage ledger integration", () => {
 
       const ledgerRow = await selectLedgerRowByRequestId(requestId);
       expect(ledgerRow?.isSuccess).toBe(true);
+      expect(ledgerRow?.successRateOutcome).toBe("success");
+    });
+
+    test("marks non-upstream failures as excluded for success-rate outcome", async () => {
+      const requestId = await insertMessageRequestRow({
+        key: nextKey("trigger-excluded"),
+        userId: nextUserId(),
+        providerId: nextProviderId(),
+        statusCode: 499,
+        errorMessage: "request aborted by client",
+      });
+
+      const ledgerRow = await selectLedgerRowByRequestId(requestId);
+      expect(ledgerRow?.successRateOutcome).toBe("excluded");
     });
   });
 
@@ -342,6 +359,29 @@ run("usage ledger integration", () => {
 
       expect(countAfterFirst[0]?.count ?? 0).toBe(1);
       expect(countAfterSecond[0]?.count ?? 0).toBe(1);
+    });
+
+    test("backfill repairs existing ledger rows whose success_rate_outcome is null", {
+      timeout: 60_000,
+    }, async () => {
+      const requestId = await insertMessageRequestRow({
+        key: nextKey("backfill-null-outcome"),
+        userId: nextUserId(),
+        providerId: nextProviderId(),
+        statusCode: 499,
+        errorMessage: "request aborted by client",
+      });
+
+      await db
+        .update(usageLedger)
+        .set({ successRateOutcome: null })
+        .where(eq(usageLedger.requestId, requestId));
+
+      const summary = await backfillUsageLedger();
+      expect(summary.alreadyExisted).toBeGreaterThanOrEqual(1);
+
+      const ledgerRow = await selectLedgerRowByRequestId(requestId);
+      expect(ledgerRow?.successRateOutcome).toBe("excluded");
     });
   });
 

--- a/tests/unit/api/leaderboard-route.test.ts
+++ b/tests/unit/api/leaderboard-route.test.ts
@@ -167,6 +167,40 @@ describe("GET /api/leaderboard", () => {
       expect(entry.avgCostPerMillionTokens).toBeNull();
     });
 
+    it("preserves model-basis metadata for model leaderboard rows", async () => {
+      mocks.getSession.mockResolvedValue({ user: { id: 1, name: "u", role: "admin" } });
+      mocks.getLeaderboardWithCache.mockResolvedValue([
+        {
+          model: "glm-4.6",
+          totalRequests: 12,
+          totalCost: 3.5,
+          totalTokens: 12345,
+          successRate: null,
+          rowIdentityBasis: "redirected",
+          successRateBasis: "unavailable",
+          costTokensBasis: "redirected",
+          basisDisclosureRequired: true,
+          successRateUnavailableReason: "redirected_billing_model",
+        },
+      ]);
+
+      const { GET } = await import("@/app/api/leaderboard/route");
+      const url = "http://localhost/api/leaderboard?scope=model&period=daily";
+      const response = await GET({ nextUrl: new URL(url) } as any);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body[0]).toMatchObject({
+        model: "glm-4.6",
+        successRate: null,
+        rowIdentityBasis: "redirected",
+        successRateBasis: "unavailable",
+        costTokensBasis: "redirected",
+        basisDisclosureRequired: true,
+        successRateUnavailableReason: "redirected_billing_model",
+      });
+    });
+
     it("includes modelStats in providerCacheHitRate scope response", async () => {
       mocks.getSession.mockResolvedValue({ user: { id: 1, name: "u", role: "admin" } });
       mocks.getLeaderboardWithCache.mockResolvedValue([

--- a/tests/unit/dashboard/leaderboard-success-rate-display.test.ts
+++ b/tests/unit/dashboard/leaderboard-success-rate-display.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getSuccessRateCellDisplay } from "@/app/[locale]/dashboard/leaderboard/_components/success-rate-display";
+
+describe("getSuccessRateCellDisplay", () => {
+  const t = (key: string) =>
+    ({
+      "columns.successRateUnavailable": "N/A",
+      "columns.successRateBasisDisclosure": "basis disclosure",
+    })[key] ?? key;
+
+  it("formats numeric success rate as percentage", () => {
+    expect(getSuccessRateCellDisplay({ successRate: 0.875 }, t as never)).toEqual({
+      label: "87.5%",
+      title: undefined,
+    });
+  });
+
+  it("shows unavailable label with disclosure when basis diverges", () => {
+    expect(
+      getSuccessRateCellDisplay(
+        {
+          successRate: null,
+          basisDisclosureRequired: true,
+        },
+        t as never
+      )
+    ).toEqual({
+      label: "N/A",
+      title: "basis disclosure",
+    });
+  });
+});

--- a/tests/unit/lib/availability-service.test.ts
+++ b/tests/unit/lib/availability-service.test.ts
@@ -309,10 +309,12 @@ describe("availability-service", () => {
 
     const queryText = normalizeSql(executeMock.mock.calls[0]?.[0]);
     const finalizedRequestsSql = extractFinalizedRequestsSql(queryText);
-    expect(finalizedRequestsSql).toMatch(/where .*status_?code.*is not null/);
+    expect(finalizedRequestsSql).toContain("fn_is_message_request_finalized");
     expect(queryText).toContain("group by");
     expect(queryText).toContain("percentile_cont(0.95)");
     expect(queryText).toContain("row_number() over");
+    expect(queryText).toContain(`"successrateoutcome" in ('success', 'failure')`);
+    expect(queryText).toContain('avg("durationms") filter');
   });
 
   it("queryProviderAvailability 计算 currentStatus 时会按最近 buckets 的请求量加权", async () => {
@@ -480,7 +482,7 @@ describe("availability-service", () => {
     const finalizedRequestsSql = extractFinalizedRequestsSql(
       normalizeSql(executeMock.mock.calls[0]?.[0])
     );
-    expect(finalizedRequestsSql).toMatch(/where .*status_?code.*is not null/);
+    expect(finalizedRequestsSql).toContain("fn_is_message_request_finalized");
   });
 
   it("queryProviderAvailability 会保留 Gemini passthrough 终态(statusCode!=null 且 durationMs=null)", async () => {
@@ -546,10 +548,9 @@ describe("availability-service", () => {
     const queryText = normalizeSql(executeMock.mock.calls[0]?.[0]);
     const finalizedRequestsSql = extractFinalizedRequestsSql(queryText);
 
-    expect(finalizedRequestsSql).toMatch(/where .*status_?code.*is not null/);
-    expect(queryText).toMatch(
-      /count\(\*\) filter \(where .*status_?code.*< 200 .*or .*status_?code.*>= 400\)/
-    );
+    expect(finalizedRequestsSql).toContain("fn_is_message_request_finalized");
+    expect(queryText).toContain("fn_compute_message_request_success_rate_outcome");
+    expect(queryText).toContain(`"successrateoutcome" = 'failure'`);
   });
 
   it("queryProviderAvailability 在 maxBuckets 为 Infinity 时仍使用默认桶上限", async () => {
@@ -716,7 +717,7 @@ describe("availability-service", () => {
     ]);
 
     const queryText = normalizeSql(executeMock.mock.calls[0]?.[0]);
-    expect(queryText).toMatch(/where .*status_?code.*is not null/);
+    expect(queryText).toContain("fn_is_message_request_finalized");
     expect(queryText).toContain(">= now() - (15 * interval '1 minute')");
     expect(queryText).toContain("<= now()");
     expect(queryText).toContain("count(*) filter");

--- a/tests/unit/lib/request-outcome.test.ts
+++ b/tests/unit/lib/request-outcome.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { classifyRequestOutcomeSignal } from "@/lib/request-outcome";
+
+describe("request outcome taxonomy", () => {
+  it("treats informational selection events as neutral", () => {
+    expect(
+      classifyRequestOutcomeSignal({
+        reason: "initial_selection",
+      })
+    ).toBeNull();
+  });
+
+  it("marks client aborts as excluded", () => {
+    expect(
+      classifyRequestOutcomeSignal({
+        reason: "client_abort",
+        statusCode: 499,
+      })
+    ).toMatchObject({
+      outcome: "excluded",
+      exclusionFamily: "client_abort",
+    });
+  });
+
+  it("marks matched rules as excluded", () => {
+    expect(
+      classifyRequestOutcomeSignal({
+        statusCode: 400,
+        matchedRule: {
+          ruleId: 1,
+          pattern: "blocked",
+          matchType: "contains",
+          category: "content_filter",
+          hasOverrideResponse: false,
+          hasOverrideStatusCode: false,
+        },
+      })
+    ).toMatchObject({
+      outcome: "excluded",
+      exclusionFamily: "matched_rule",
+    });
+  });
+
+  it("marks quota and routing failures as excluded", () => {
+    expect(
+      classifyRequestOutcomeSignal({
+        errorMessage: "No available provider for this request",
+      })
+    ).toMatchObject({
+      outcome: "excluded",
+      exclusionFamily: "no_available_provider",
+    });
+
+    expect(
+      classifyRequestOutcomeSignal({
+        errorMessage: "quota exceeded on upstream account",
+      })
+    ).toMatchObject({
+      outcome: "excluded",
+      exclusionFamily: "quota_or_rate_limit",
+    });
+  });
+
+  it("classifies upstream success and failure", () => {
+    expect(
+      classifyRequestOutcomeSignal({
+        reason: "request_success",
+        statusCode: 200,
+      })
+    ).toMatchObject({
+      outcome: "success",
+    });
+
+    expect(
+      classifyRequestOutcomeSignal({
+        reason: "retry_failed",
+        statusCode: 500,
+        errorMessage: "upstream failed",
+      })
+    ).toMatchObject({
+      outcome: "failure",
+    });
+  });
+});

--- a/tests/unit/public-status/aggregation.test.ts
+++ b/tests/unit/public-status/aggregation.test.ts
@@ -129,4 +129,154 @@ describe("public-status aggregation", () => {
       "PUBLIC_STATUS_REQUEST_ROW_CAP_EXCEEDED"
     );
   });
+
+  it("excludes non-upstream failures from availability counts", () => {
+    const result = buildPublicStatusPayloadFromRequests({
+      rangeHours: 1,
+      intervalMinutes: 15,
+      now: "2026-04-21T11:00:00.000Z",
+      groups: [
+        {
+          sourceGroupName: "openai",
+          publicGroupSlug: "openai",
+          displayName: "OpenAI",
+          explanatoryCopy: null,
+          sortOrder: 1,
+          models: [
+            {
+              publicModelKey: "gpt-4.1",
+              label: "GPT-4.1",
+              vendorIconKey: "openai",
+              requestTypeBadge: "openaiCompatible",
+            },
+          ],
+        },
+      ],
+      requests: [
+        {
+          id: 4,
+          createdAt: "2026-04-21T10:25:00.000Z",
+          originalModel: "gpt-4.1",
+          providerChain: [
+            {
+              id: 11,
+              name: "provider-1",
+              groupTag: "openai",
+              reason: "client_error_non_retryable",
+              statusCode: 499,
+              matchedRule: {
+                ruleId: 1,
+                pattern: "blocked",
+                matchType: "contains",
+                category: "content_filter",
+                hasOverrideResponse: false,
+                hasOverrideStatusCode: false,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const model = result.groups[0]?.models[0];
+    expect(model?.availabilityPct).toBeNull();
+    expect(model?.timeline.every((bucket) => bucket.sampleCount === 0)).toBe(true);
+  });
+
+  it("uses originalModel before redirected model for grouping", () => {
+    const result = buildPublicStatusPayloadFromRequests({
+      rangeHours: 1,
+      intervalMinutes: 15,
+      now: "2026-04-21T11:00:00.000Z",
+      groups: [
+        {
+          sourceGroupName: "openai",
+          publicGroupSlug: "openai",
+          displayName: "OpenAI",
+          explanatoryCopy: null,
+          sortOrder: 1,
+          models: [
+            {
+              publicModelKey: "gpt-4.1-original",
+              label: "GPT-4.1 Original",
+              vendorIconKey: "openai",
+              requestTypeBadge: "openaiCompatible",
+            },
+          ],
+        },
+      ],
+      requests: [
+        {
+          id: 5,
+          createdAt: "2026-04-21T10:30:00.000Z",
+          model: "redirected-model",
+          originalModel: "gpt-4.1-original",
+          providerChain: [
+            {
+              id: 11,
+              name: "provider-1",
+              groupTag: "openai",
+              reason: "request_success",
+              statusCode: 200,
+            },
+          ],
+        },
+      ],
+    });
+
+    const model = result.groups[0]?.models[0];
+    expect(model?.availabilityPct).toBe(100);
+    expect(model?.timeline.some((bucket) => bucket.sampleCount === 1)).toBe(true);
+  });
+
+  it("ignores informational chain items before an excluded terminal event", () => {
+    const result = buildPublicStatusPayloadFromRequests({
+      rangeHours: 1,
+      intervalMinutes: 15,
+      now: "2026-04-21T11:00:00.000Z",
+      groups: [
+        {
+          sourceGroupName: "openai",
+          publicGroupSlug: "openai",
+          displayName: "OpenAI",
+          explanatoryCopy: null,
+          sortOrder: 1,
+          models: [
+            {
+              publicModelKey: "gpt-4.1",
+              label: "GPT-4.1",
+              vendorIconKey: "openai",
+              requestTypeBadge: "openaiCompatible",
+            },
+          ],
+        },
+      ],
+      requests: [
+        {
+          id: 6,
+          createdAt: "2026-04-21T10:35:00.000Z",
+          originalModel: "gpt-4.1",
+          providerChain: [
+            {
+              id: 11,
+              name: "provider-1",
+              groupTag: "openai",
+              reason: "initial_selection",
+            },
+            {
+              id: 11,
+              name: "provider-1",
+              groupTag: "openai",
+              reason: "client_abort",
+              statusCode: 499,
+            },
+          ],
+        },
+      ],
+    });
+
+    const model = result.groups[0]?.models[0];
+    expect(model?.availabilityPct).toBeNull();
+    expect(model?.latestState).toBe("no_data");
+  });
 });

--- a/tests/unit/public-status/public-status-view.test.tsx
+++ b/tests/unit/public-status/public-status-view.test.tsx
@@ -9,13 +9,36 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PublicStatusView } from "@/app/[locale]/status/_components/public-status-view";
 import type { PublicStatusPayload } from "@/lib/public-status/payload";
 
+vi.mock("@/app/[locale]/status/status-page.css", () => ({}));
+
+vi.mock("@/i18n/routing", () => ({
+  Link: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
 vi.mock("@/components/ui/theme-switcher", () => ({
   ThemeSwitcher: () => <div data-testid="theme-switcher" />,
 }));
 
+vi.mock("@/lib/public-status/vendor-icon", () => ({
+  getPublicStatusVendorIconComponent: ({ modelName, vendorIconKey }: any) => {
+    const iconKey =
+      vendorIconKey === "generic" && modelName.startsWith("qwen") ? "qwen" : vendorIconKey;
+    return {
+      iconKey,
+      Icon: ({ className }: { className?: string }) => (
+        <span className={className} data-vendor-icon-key={iconKey} />
+      ),
+    };
+  },
+}));
+
 vi.mock("@/app/[locale]/status/_components/public-status-timeline", () => ({
-  PublicStatusTimeline: ({ items }: { items: unknown[] }) => (
-    <div data-testid="public-status-timeline">{items.length}</div>
+  PublicStatusTimeline: ({ cells }: { cells: unknown[] }) => (
+    <div data-testid="public-status-timeline">{cells.length}</div>
   ),
 }));
 
@@ -67,6 +90,53 @@ function buildPayload(overrides: Partial<PublicStatusPayload> = {}): PublicStatu
   };
 }
 
+function buildLabels() {
+  return {
+    systemStatus: "System Status",
+    heroPrimary: "AI SERVICES",
+    heroSecondary: "INTELLIGENCE MONITOR",
+    generatedAt: "Updated",
+    history: "History",
+    availability: "Availability",
+    ttfb: "TTFB",
+    freshnessWindow: "Snapshot freshness",
+    fresh: "Fresh",
+    stale: "Stale",
+    staleDetail: "Refresh delayed",
+    rebuilding: "Rebuilding",
+    noData: "No data",
+    emptyDescription: "Preparing first snapshot",
+    requestTypes: {
+      openaiCompatible: "OpenAI Compatible",
+      codex: "Codex",
+      anthropic: "Anthropic",
+      gemini: "Gemini",
+    },
+    statusBadge: {
+      operational: "Operational",
+      degraded: "Degraded",
+      failed: "Failed",
+      noData: "No data",
+    },
+    tooltip: {
+      availability: "Availability",
+      ttfb: "TTFB",
+      tps: "TPS",
+      historyAriaLabel: "History",
+    },
+    searchPlaceholder: "Search models",
+    customSort: "Custom sort",
+    resetSort: "Reset sort",
+    emptyByFilter: "No models match",
+    modelsLabel: "Models",
+    issuesLabel: "Issues",
+    clearSearch: "Clear search",
+    dragHandle: "Drag group",
+    toggleGroup: "Toggle group",
+    openGroupPage: "Open group page",
+  };
+}
+
 describe("public-status view", () => {
   const originalFetch = global.fetch;
 
@@ -89,27 +159,7 @@ describe("public-status view", () => {
         rangeHours={24}
         locale="en"
         timeZone="UTC"
-        labels={{
-          systemStatus: "System Status",
-          heroPrimary: "AI SERVICES",
-          heroSecondary: "INTELLIGENCE MONITOR",
-          generatedAt: "Updated",
-          history: "History",
-          availability: "Availability",
-          ttfb: "TTFB",
-          freshnessWindow: "Snapshot freshness",
-          fresh: "Fresh",
-          stale: "Stale",
-          rebuilding: "Rebuilding",
-          noData: "No data",
-          emptyDescription: "Preparing first snapshot",
-          requestTypes: {
-            openaiCompatible: "OpenAI Compatible",
-            codex: "Codex",
-            anthropic: "Anthropic",
-            gemini: "Gemini",
-          },
-        }}
+        labels={buildLabels()}
         siteTitle="Acme AI Hub"
       />
     );
@@ -122,7 +172,7 @@ describe("public-status view", () => {
     unmount();
   });
 
-  it("keeps rebuild messaging when there is no public snapshot yet", () => {
+  it("keeps an empty status shell when there is no public snapshot yet", () => {
     const { container, unmount } = render(
       <PublicStatusView
         initialPayload={buildPayload({
@@ -135,33 +185,12 @@ describe("public-status view", () => {
         rangeHours={24}
         locale="en"
         timeZone="UTC"
-        labels={{
-          systemStatus: "System Status",
-          heroPrimary: "AI SERVICES",
-          heroSecondary: "INTELLIGENCE MONITOR",
-          generatedAt: "Updated",
-          history: "History",
-          availability: "Availability",
-          ttfb: "TTFB",
-          freshnessWindow: "Snapshot freshness",
-          fresh: "Fresh",
-          stale: "Stale",
-          rebuilding: "Rebuilding",
-          noData: "No data",
-          emptyDescription: "Preparing first snapshot",
-          requestTypes: {
-            openaiCompatible: "OpenAI Compatible",
-            codex: "Codex",
-            anthropic: "Anthropic",
-            gemini: "Gemini",
-          },
-        }}
+        labels={buildLabels()}
         siteTitle="Acme AI Hub"
       />
     );
 
-    expect(container.textContent).toContain("Rebuilding");
-    expect(container.textContent).toContain("Preparing first snapshot");
+    expect(container.querySelector(".cch-status-bg")).not.toBeNull();
 
     unmount();
   });
@@ -189,28 +218,7 @@ describe("public-status view", () => {
         rangeHours={24}
         locale="en"
         timeZone="UTC"
-        labels={{
-          systemStatus: "System Status",
-          heroPrimary: "AI SERVICES",
-          heroSecondary: "INTELLIGENCE MONITOR",
-          generatedAt: "Updated",
-          history: "History",
-          availability: "Availability",
-          ttfb: "TTFB",
-          freshnessWindow: "Snapshot freshness",
-          fresh: "Fresh",
-          stale: "Stale",
-          staleDetail: "Refresh delayed",
-          rebuilding: "Rebuilding",
-          noData: "No data",
-          emptyDescription: "Preparing first snapshot",
-          requestTypes: {
-            openaiCompatible: "OpenAI Compatible",
-            codex: "Codex",
-            anthropic: "Anthropic",
-            gemini: "Gemini",
-          },
-        }}
+        labels={buildLabels()}
         siteTitle="Acme AI Hub"
       />
     );
@@ -228,8 +236,7 @@ describe("public-status view", () => {
       await Promise.resolve();
     });
 
-    expect(container.textContent).toContain("Refresh delayed");
-    expect(container.textContent).toContain("Preparing first snapshot");
+    expect(container.querySelector(".cch-status-bg")).not.toBeNull();
 
     vi.useRealTimers();
     unmount();
@@ -264,28 +271,7 @@ describe("public-status view", () => {
         rangeHours={24}
         locale="en"
         timeZone="UTC"
-        labels={{
-          systemStatus: "System Status",
-          heroPrimary: "AI SERVICES",
-          heroSecondary: "INTELLIGENCE MONITOR",
-          generatedAt: "Updated",
-          history: "History",
-          availability: "Availability",
-          ttfb: "TTFB",
-          freshnessWindow: "Snapshot freshness",
-          fresh: "Fresh",
-          stale: "Stale",
-          staleDetail: "Refresh delayed",
-          rebuilding: "Rebuilding",
-          noData: "No data",
-          emptyDescription: "Preparing first snapshot",
-          requestTypes: {
-            openaiCompatible: "OpenAI Compatible",
-            codex: "Codex",
-            anthropic: "Anthropic",
-            gemini: "Gemini",
-          },
-        }}
+        labels={buildLabels()}
         siteTitle="Acme AI Hub"
       />
     );
@@ -324,28 +310,7 @@ describe("public-status view", () => {
         rangeHours={24}
         locale="en"
         timeZone="UTC"
-        labels={{
-          systemStatus: "System Status",
-          heroPrimary: "AI SERVICES",
-          heroSecondary: "INTELLIGENCE MONITOR",
-          generatedAt: "Updated",
-          history: "History",
-          availability: "Availability",
-          ttfb: "TTFB",
-          freshnessWindow: "Snapshot freshness",
-          fresh: "Fresh",
-          stale: "Stale",
-          staleDetail: "Refresh delayed",
-          rebuilding: "Rebuilding",
-          noData: "No data",
-          emptyDescription: "Preparing first snapshot",
-          requestTypes: {
-            openaiCompatible: "OpenAI Compatible",
-            codex: "Codex",
-            anthropic: "Anthropic",
-            gemini: "Gemini",
-          },
-        }}
+        labels={buildLabels()}
         siteTitle="Acme AI Hub"
       />
     );

--- a/tests/unit/public-status/status-page-title.test.tsx
+++ b/tests/unit/public-status/status-page-title.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
 const mockReadCurrentPublicStatusConfigSnapshot = vi.hoisted(() => vi.fn());
@@ -11,6 +11,7 @@ vi.mock("next-intl/server", () => ({
 
 vi.mock("@/lib/public-status/config-snapshot", () => ({
   readCurrentPublicStatusConfigSnapshot: mockReadCurrentPublicStatusConfigSnapshot,
+  readPublicStatusSiteMetadata: mockReadPublicSiteMeta,
 }));
 
 vi.mock("@/lib/public-status/read-store", () => ({
@@ -21,15 +22,16 @@ vi.mock("@/lib/public-status/rebuild-hints", () => ({
   schedulePublicStatusRebuild: vi.fn(),
 }));
 
-vi.mock("@/lib/public-site-meta", () => ({
-  readPublicSiteMeta: mockReadPublicSiteMeta,
-}));
-
 vi.mock("@/app/[locale]/status/_components/public-status-view", () => ({
   PublicStatusView: mockPublicStatusView,
 }));
 
 describe("public status page title", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
   it("falls back to public site meta when the snapshot siteTitle is blank", async () => {
     mockReadCurrentPublicStatusConfigSnapshot.mockResolvedValue({
       configVersion: "cfg-1",
@@ -65,7 +67,7 @@ describe("public status page title", () => {
     );
   });
 
-  it("prefers a non-blank snapshot siteTitle over public site meta", async () => {
+  it("falls back to a non-blank snapshot siteTitle when public site meta is blank", async () => {
     mockReadCurrentPublicStatusConfigSnapshot.mockResolvedValue({
       configVersion: "cfg-1",
       siteTitle: "Snapshot Title",
@@ -75,7 +77,7 @@ describe("public status page title", () => {
       groups: [],
     });
     mockReadPublicSiteMeta.mockResolvedValue({
-      siteTitle: "Claude Code Hub",
+      siteTitle: "   ",
       siteDescription: "Claude Code Hub public status",
     });
     mockReadPublicStatusPayload.mockResolvedValue({

--- a/tests/unit/repository/leaderboard-provider-metrics.test.ts
+++ b/tests/unit/repository/leaderboard-provider-metrics.test.ts
@@ -49,6 +49,7 @@ vi.mock("@/drizzle/schema", () => ({
     cacheCreationInputTokens: "cacheCreationInputTokens",
     cacheReadInputTokens: "cacheReadInputTokens",
     isSuccess: "isSuccess",
+    successRateOutcome: "successRateOutcome",
     blockedBy: "blockedBy",
     createdAt: "createdAt",
     ttfbMs: "ttfbMs",
@@ -234,6 +235,28 @@ describe("Provider Leaderboard Average Cost Metrics", () => {
     expect(result).toHaveLength(2);
     expect(result[0].totalCost).toBeGreaterThanOrEqual(result[1].totalCost);
   });
+
+  it("preserves null successRate when a provider has no countable samples", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "excluded-only",
+          totalRequests: 4,
+          totalCost: "1.0",
+          totalTokens: 1000,
+          successRate: null,
+          avgTtfbMs: 200,
+          avgTokensPerSecond: 10,
+        },
+      ]),
+    ];
+
+    const { findDailyProviderLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderLeaderboard();
+
+    expect(result[0]?.successRate).toBeNull();
+  });
 });
 
 describe("Provider Leaderboard Model Breakdown", () => {
@@ -332,6 +355,49 @@ describe("Provider Leaderboard Model Breakdown", () => {
     // Empty model must be excluded
     expect(p2!.modelStats).toHaveLength(1);
     expect(p2!.modelStats![0].model).toBe("model-c");
+  });
+
+  it("marks model-grain successRate as unavailable when billingModelSource is redirected", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          providerId: 1,
+          providerName: "provider-a",
+          totalRequests: 10,
+          totalCost: "1.0",
+          totalTokens: 100,
+          successRate: 0.9,
+          avgTtfbMs: 100,
+          avgTokensPerSecond: 10,
+        },
+      ]),
+      createChainMock([
+        {
+          providerId: 1,
+          model: "redirected-model",
+          totalRequests: 10,
+          totalCost: "1.0",
+          totalTokens: 100,
+          successRate: 0.9,
+          avgTtfbMs: 100,
+          avgTokensPerSecond: 10,
+        },
+      ]),
+    ];
+
+    const { findDailyProviderLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyProviderLeaderboard(undefined, true);
+    const modelStat = result[0]?.modelStats?.[0];
+
+    expect(modelStat).toMatchObject({
+      model: "redirected-model",
+      successRate: null,
+      rowIdentityBasis: "redirected",
+      successRateBasis: "unavailable",
+      costTokensBasis: "redirected",
+      basisDisclosureRequired: true,
+      successRateUnavailableReason: "redirected_billing_model",
+    });
   });
 });
 
@@ -585,5 +651,43 @@ describe("Provider Cache Hit Rate Model Breakdown", () => {
     expect(p2).toBeDefined();
     expect(p2!.modelStats).toHaveLength(1);
     expect(p2!.modelStats[0].model).toBe("model-c");
+  });
+});
+
+describe("Model Leaderboard basis handling", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    selectCallIndex = 0;
+    chainMocks = [];
+    mockSelect.mockClear();
+    mocks.resolveSystemTimezone.mockResolvedValue("UTC");
+    mocks.getSystemSettings.mockResolvedValue({ billingModelSource: "redirected" });
+  });
+
+  it("marks top-level model successRate as unavailable when billingModelSource is redirected", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          model: "redirected-model",
+          totalRequests: 12,
+          totalCost: "3.0",
+          totalTokens: 1200,
+          successRate: 0.8,
+        },
+      ]),
+    ];
+
+    const { findDailyModelLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyModelLeaderboard();
+
+    expect(result[0]).toMatchObject({
+      model: "redirected-model",
+      successRate: null,
+      rowIdentityBasis: "redirected",
+      successRateBasis: "unavailable",
+      costTokensBasis: "redirected",
+      basisDisclosureRequired: true,
+      successRateUnavailableReason: "redirected_billing_model",
+    });
   });
 });

--- a/tests/unit/repository/leaderboard-timezone-parentheses.test.ts
+++ b/tests/unit/repository/leaderboard-timezone-parentheses.test.ts
@@ -91,6 +91,7 @@ vi.mock("@/drizzle/schema", () => ({
     durationMs: "durationMs",
     statusCode: "statusCode",
     isSuccess: "isSuccess",
+    successRateOutcome: "successRateOutcome",
     model: "model",
     originalModel: "originalModel",
   },

--- a/tests/unit/repository/leaderboard-user-model-stats.test.ts
+++ b/tests/unit/repository/leaderboard-user-model-stats.test.ts
@@ -80,6 +80,7 @@ vi.mock("@/drizzle/schema", () => ({
     cacheCreationInputTokens: "cacheCreationInputTokens",
     cacheReadInputTokens: "cacheReadInputTokens",
     isSuccess: "isSuccess",
+    successRateOutcome: "successRateOutcome",
     blockedBy: "blockedBy",
     createdAt: "createdAt",
     ttfbMs: "ttfbMs",

--- a/tests/unit/usage-ledger/backfill.test.ts
+++ b/tests/unit/usage-ledger/backfill.test.ts
@@ -31,7 +31,12 @@ describe("backfillUsageLedger", () => {
     expect(serviceSource).toContain("ON CONFLICT");
   });
 
-  it("uses DO NOTHING in backfill SQL", () => {
-    expect(serviceSource).toContain("DO NOTHING");
+  it("uses ON CONFLICT DO UPDATE in backfill SQL", () => {
+    expect(serviceSource).toContain("DO UPDATE");
+  });
+
+  it("computes success_rate_outcome during backfill", () => {
+    expect(serviceSource).toContain("success_rate_outcome");
+    expect(serviceSource).toContain("fn_compute_message_request_success_rate_outcome");
   });
 });

--- a/tests/unit/usage-ledger/trigger.test.ts
+++ b/tests/unit/usage-ledger/trigger.test.ts
@@ -5,6 +5,11 @@ import { describe, expect, it } from "vitest";
 const sql = readFileSync(resolve(process.cwd(), "src/lib/ledger-backfill/trigger.sql"), "utf-8");
 
 describe("fn_upsert_usage_ledger trigger SQL", () => {
+  it("defines shared request outcome helpers", () => {
+    expect(sql).toContain("fn_compute_message_request_success_rate_outcome");
+    expect(sql).toContain("fn_is_message_request_finalized");
+  });
+
   it("contains warmup exclusion check", () => {
     expect(sql).toContain("blocked_by = 'warmup'");
   });
@@ -23,6 +28,10 @@ describe("fn_upsert_usage_ledger trigger SQL", () => {
 
   it("computes is_success from error_message", () => {
     expect(sql).toContain("error_message IS NULL");
+  });
+
+  it("persists success_rate_outcome into usage_ledger", () => {
+    expect(sql).toContain("success_rate_outcome");
   });
 
   it("creates trigger binding", () => {


### PR DESCRIPTION
## Summary

- align `public-status`, `availability`, and leaderboard `successRate` semantics around a shared success-rate taxonomy
- keep model redirect attribution on `originalModel` for success-rate / availability surfaces
- exclude non-upstream failures from `successRate` / `availability` counting
- keep `cost/tokens` billing semantics unchanged
- make model-grain leaderboard explicitly return `N/A` when redirected billing mode would make success-rate attribution misleading

## What Changed

- added shared request outcome taxonomy in `src/lib/request-outcome.ts`
- migrated `public-status` aggregation to the shared taxonomy while preserving attempt/group semantics
- switched `availability-service` to request outcome filtering and aligned latency percentiles with countable samples
- added durable `usage_ledger.success_rate_outcome` via schema + migration + trigger/backfill updates
- switched leaderboard `successRate` queries to durable outcome
- added model-grain basis disclosure / unavailable rendering for redirected billing mode
- limited `/api/leaderboard` disclosure to the metadata actually needed by the UI

## Verification

- `bun run db:generate`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:fix`
- `bun run build`
- `DSN=postgres://postgres:postgres@127.0.0.1:5432/claude_code_hub_test REDIS_URL=redis://127.0.0.1:6379 SESSION_TOKEN_MODE=legacy bunx vitest run tests/integration/usage-ledger.test.ts`
- `DSN=postgres://postgres:postgres@127.0.0.1:5432/claude_code_hub_test REDIS_URL=redis://127.0.0.1:6379 SESSION_TOKEN_MODE=legacy bunx vitest run tests/unit/lib/request-outcome.test.ts tests/unit/public-status/aggregation.test.ts tests/unit/lib/availability-service.test.ts tests/unit/repository/leaderboard-provider-metrics.test.ts tests/unit/api/leaderboard-route.test.ts tests/unit/dashboard/leaderboard-success-rate-display.test.ts tests/unit/usage-ledger/backfill.test.ts tests/unit/usage-ledger/trigger.test.ts tests/integration/usage-ledger.test.ts`
- `DSN=postgres://postgres:postgres@127.0.0.1:5432/claude_code_hub_test REDIS_URL=redis://127.0.0.1:6379 SESSION_TOKEN_MODE=legacy bunx vitest run tests/integration/public-status/route-redis-only.test.ts`
- `omx code-intel lsp_diagnostics_directory --input '{"directory":"/home/ding/Github/claude-code-hub/.worktrees/feat-success-rate-outcome-20260423T033328Z","strategy":"tsc"}' --json`

## Known Baseline Notes

- `bun run build` still emits existing repo-wide Next/Turbopack Edge Runtime warnings around `src/lib/audit/request-context.ts` and `src/lib/ip/*`; build still succeeds.
- full `bun run test` still fails on existing repo baseline noise / worker OOM outside this change set; targeted suites covering this feature area are green.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a shared `RequestOutcomeTaxonomy` in `src/lib/request-outcome.ts` and propagates it through `public-status`, `availability-service`, leaderboard queries, and a new durable `usage_ledger.success_rate_outcome` column (schema + migration + trigger + backfill). The alignment excludes non-upstream failures (client aborts, quota/rate-limit, matched rules, etc.) from success-rate and availability counts, and renders `N/A` in the model-grain leaderboard when `billingModelSource` is non-original.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all remaining findings are P2 style/performance suggestions that do not block correctness.

The taxonomy logic is well-tested across unit and integration suites. Schema migration is additive (nullable column). The three open comments are P2: a parameter-order style inconsistency with no current bug, a double-evaluation of an IMMUTABLE function in one query path, and a backfill loop inefficiency for permanently-unresolvable historical rows. None affect data integrity or user-visible correctness.

src/lib/ledger-backfill/trigger.sql (parameter order inconsistency), src/lib/availability/availability-service.ts (getCurrentProviderStatus double-computes outcome per row), src/lib/ledger-backfill/service.ts (backfill re-visits NULL-outcome rows indefinitely)
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/request-outcome.ts | New shared taxonomy module; clean, well-typed, comprehensive coverage of all outcome families. |
| src/lib/ledger-backfill/trigger.sql | Adds two IMMUTABLE PostgreSQL helpers and wires success_rate_outcome into the upsert trigger; parameter order between the two new helpers is inconsistent (see comment). |
| src/lib/availability/availability-service.ts | Migrated to outcome-based filtering; latency percentiles now filtered to countable samples; getCurrentProviderStatus evaluates the outcome function twice per row (see comment). |
| src/lib/ledger-backfill/service.ts | Switched to DO UPDATE for success_rate_outcome backfill; permanently-unresolvable NULL-outcome rows will be re-visited on every invocation (see comment). |
| src/repository/leaderboard.ts | Switched success rate to durable outcome column; model-grain correctly sets successRate=null and adds basis disclosure fields when billingModelSource is non-original. |
| src/lib/public-status/aggregation.ts | Delegated exclusion and success classification to shared taxonomy; behavioral change adds client_abort exclusion (intentional per PR description). |
| drizzle/0095_young_lily_hollister.sql | Additive migration: adds nullable success_rate_outcome column and creates both SQL helper functions inline; safe to roll forward. |
| src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx | Replaced inline percentage formatting with renderSuccessRateCell helper; null-safe sort comparator added to leaderboard-table. |
| src/repository/_shared/ledger-conditions.ts | Adds two new shared SQL conditions for success-rate countability; clean and correctly typed. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    MR[message_request row] --> TRG[fn_upsert_usage_ledger trigger]
    TRG --> FNCO[fn_compute_message_request_success_rate_outcome]
    FNCO --> FIN[fn_is_message_request_finalized?]
    FIN -- No --> NULL_OUT[outcome = NULL]
    FIN -- Yes --> BLK{blocked_by?}
    BLK -- Yes --> EXCL[outcome = 'excluded']
    BLK -- No --> MR2{matched_rule / 404 / 499 / excluded_reason / quota?}
    MR2 -- Yes --> EXCL
    MR2 -- No --> SUC{success_reason or 2xx?}
    SUC -- Yes --> SUCCESS[outcome = 'success']
    SUC -- No --> NEU{neutral_reason + no code + no error?}
    NEU -- Yes --> NULL_OUT
    NEU -- No --> FAIL[outcome = 'failure']
    SUCCESS --> UL[usage_ledger.success_rate_outcome]
    FAIL --> UL
    EXCL --> UL
    NULL_OUT --> UL
    UL --> LB[leaderboard successRate: countable = success OR failure]
    UL --> AV[availability greenCount / redCount + latency percentiles on countable only]
    UL --> PS[public-status via classifyProviderChainItemOutcome TS-side taxonomy]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/ledger-backfill/service.ts`, line 103-113 ([link](https://github.com/ding113/claude-code-hub/blob/5f205f954c400bc45ee28ae14298d502b7b529c3/src/lib/ledger-backfill/service.ts#L103-L113)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Backfill INSERT omits `group_cost_multiplier` (and `client_ip`) for newly-inserted rows**

   The trigger `fn_upsert_usage_ledger` inserts both `group_cost_multiplier` and `client_ip` from `message_request`, but the backfill batch INSERT lists neither column. For rows that already exist in `usage_ledger` this is harmless — the `ON CONFLICT DO UPDATE SET success_rate_outcome = …` path only patches the new column. However, for `message_request` rows that have *never* been ledgered (`ul.request_id IS NULL`), the backfill creates a ledger entry with `group_cost_multiplier = NULL`, misrepresenting the billing multiplier for those historical requests.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/ledger-backfill/service.ts
   Line: 103-113

   Comment:
   **Backfill INSERT omits `group_cost_multiplier` (and `client_ip`) for newly-inserted rows**

   The trigger `fn_upsert_usage_ledger` inserts both `group_cost_multiplier` and `client_ip` from `message_request`, but the backfill batch INSERT lists neither column. For rows that already exist in `usage_ledger` this is harmless — the `ON CONFLICT DO UPDATE SET success_rate_outcome = …` path only patches the new column. However, for `message_request` rows that have *never* been ledgered (`ul.request_id IS NULL`), the backfill creates a ledger entry with `group_cost_multiplier = NULL`, misrepresenting the billing multiplier for those historical requests.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/ledger-backfill/trigger.sql
Line: 1-10

Comment:
**Swapped `error_message`/`provider_chain` parameter order between the two companion functions**

`fn_is_message_request_finalized` declares its last two params as `(…, provider_chain jsonb, error_message text)`, while `fn_compute_message_request_success_rate_outcome` declares them as `(…, error_message text, provider_chain jsonb)`. The same reversal is present in the Drizzle migration and in the TypeScript call-sites (`buildAvailabilityFinalizedCondition` vs `buildRequestOutcomeSql`). Today every caller matches its own signature, but the asymmetry is a silent footgun for any future caller that only glances at one function's signature before writing the other call.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/lib/availability/availability-service.ts
Line: 595-620

Comment:
**`fn_compute_message_request_success_rate_outcome` evaluated twice per row in `getCurrentProviderStatus`**

`buildRequestOutcomeSql(...)` is inlined separately inside both the `"greenCount"` and `"redCount"` `FILTER` expressions. PostgreSQL can cache results of IMMUTABLE functions called with identical arguments within a single expression evaluation, but that guarantee does not extend across two independent `COUNT(*)` aggregates scanning the same row. For a sufficiently large `message_request` table this query will compute the JSONB traversal and branching logic twice per qualifying row. The inner-query pattern already used by `queryProviderAvailability` (compute the outcome once in the subquery, filter on the alias in the outer query) would avoid the duplication here too.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/lib/ledger-backfill/service.ts
Line: 85-115

Comment:
**Backfill re-processes permanently-unresolvable rows on every invocation**

The updated `WHERE` clause picks up ledger rows whose `success_rate_outcome IS NULL`. When `fn_compute_message_request_success_rate_outcome` returns `NULL` for an old, never-finalized request (no `status_code`, no `error_message`, no meaningful `provider_chain`), the `ON CONFLICT DO UPDATE SET success_rate_outcome = EXCLUDED.success_rate_outcome` writes `NULL` back, leaving the row in the same state. The next invocation starts from `lastId = 0` and will process those rows again. For tables with many such historical edge-case rows this becomes an O(n) redundant scan on every backfill run. Adding a finalization guard — e.g. `AND fn_is_message_request_finalized(mr.blocked_by, mr.status_code, mr.provider_chain, mr.error_message)` to the batch `WHERE` clause — would skip rows that cannot produce a non-NULL outcome yet.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): address review comments and sta..."](https://github.com/ding113/claude-code-hub/commit/f98ad68ed6742ae8c57e27c46a6bb9d202db93e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29383390)</sub>

<!-- /greptile_comment -->