### PR TITLE
fix(public-status): attribute default group consistently

### DIFF
--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -50,7 +50,11 @@ import {
 } from "@/lib/redis/circuit-breaker-config";
 import { RedisKVStore } from "@/lib/redis/redis-kv-store";
 import { SessionManager } from "@/lib/session-manager";
-import { normalizeProviderGroupTag, parseProviderGroups } from "@/lib/utils/provider-group";
+import {
+  normalizeProviderGroupTag,
+  parseProviderGroups,
+  resolveProviderGroupsWithDefault,
+} from "@/lib/utils/provider-group";
 import { maskKey } from "@/lib/utils/validation";
 import { extractZodErrorCode, formatZodError } from "@/lib/utils/zod-i18n";
 import { validateProviderUrlForConnectivity } from "@/lib/validation/provider-url";
@@ -471,12 +475,7 @@ export async function getProviderGroupsWithCount(): Promise<
     const groupCounts = new Map<string, number>();
 
     for (const provider of providers) {
-      const groups = parseProviderGroups(provider.groupTag);
-      if (groups.length === 0) {
-        groupCounts.set(PROVIDER_GROUP.DEFAULT, (groupCounts.get(PROVIDER_GROUP.DEFAULT) || 0) + 1);
-        continue;
-      }
-
+      const groups = resolveProviderGroupsWithDefault(provider.groupTag);
       for (const group of groups) {
         groupCounts.set(group, (groupCounts.get(group) || 0) + 1);
       }

--- a/src/actions/request-filters.ts
+++ b/src/actions/request-filters.ts
@@ -3,10 +3,11 @@
 import { revalidatePath } from "next/cache";
 import safeRegex from "safe-regex";
 import { getSession } from "@/lib/auth";
+import { PROVIDER_GROUP } from "@/lib/constants/provider.constants";
 import { logger } from "@/lib/logger";
 import { requestFilterEngine } from "@/lib/request-filter-engine";
 import type { FilterMatcher, FilterOperation, InsertOp } from "@/lib/request-filter-types";
-import { parseProviderGroups } from "@/lib/utils/provider-group";
+import { resolveProviderGroupsWithDefault } from "@/lib/utils/provider-group";
 import {
   createRequestFilter,
   deleteRequestFilter,
@@ -443,30 +444,31 @@ export async function getDistinctProviderGroupsAction(): Promise<ActionResult<st
   try {
     const { db } = await import("@/drizzle/db");
     const { providers } = await import("@/drizzle/schema");
-    const { isNull, isNotNull, ne, and } = await import("drizzle-orm");
+    const { isNull } = await import("drizzle-orm");
 
     const result = await db
       .selectDistinct({ groupTag: providers.groupTag })
       .from(providers)
-      .where(
-        and(
-          isNull(providers.deletedAt),
-          and(isNotNull(providers.groupTag), ne(providers.groupTag, ""))
-        )
-      );
+      .where(isNull(providers.deletedAt));
 
-    // Parse comma-separated tags and flatten into unique array
+    // Request-filter 配置面也要能选择 default 组：null/blank provider tags 视为 default。
     const allTags = new Set<string>();
     for (const row of result) {
-      if (row.groupTag) {
-        const tags = parseProviderGroups(row.groupTag);
-        for (const tag of tags) {
-          if (tag) allTags.add(tag);
-        }
+      const tags = resolveProviderGroupsWithDefault(row.groupTag);
+      for (const tag of tags) {
+        if (tag) allTags.add(tag);
       }
     }
 
-    return { ok: true, data: Array.from(allTags).sort() };
+    const sorted = Array.from(allTags).sort();
+    if (!sorted.includes(PROVIDER_GROUP.DEFAULT)) {
+      return { ok: true, data: sorted };
+    }
+
+    return {
+      ok: true,
+      data: [PROVIDER_GROUP.DEFAULT, ...sorted.filter((tag) => tag !== PROVIDER_GROUP.DEFAULT)],
+    };
   } catch (error) {
     logger.error("[RequestFiltersAction] Failed to get distinct group tags", { error });
     return { ok: false, error: "获取 Group Tags 失败" };

--- a/src/actions/request-filters.ts
+++ b/src/actions/request-filters.ts
@@ -451,8 +451,8 @@ export async function getDistinctProviderGroupsAction(): Promise<ActionResult<st
       .from(providers)
       .where(isNull(providers.deletedAt));
 
-    // Request-filter 配置面也要能选择 default 组：null/blank provider tags 视为 default。
-    const allTags = new Set<string>();
+    // Request-filter 配置面始终暴露 default，支持提前为默认组配置规则。
+    const allTags = new Set<string>([PROVIDER_GROUP.DEFAULT]);
     for (const row of result) {
       const tags = resolveProviderGroupsWithDefault(row.groupTag);
       for (const tag of tags) {
@@ -460,14 +460,15 @@ export async function getDistinctProviderGroupsAction(): Promise<ActionResult<st
       }
     }
 
-    const sorted = Array.from(allTags).sort();
-    if (!sorted.includes(PROVIDER_GROUP.DEFAULT)) {
-      return { ok: true, data: sorted };
-    }
+    const sorted = Array.from(allTags).sort((a, b) => {
+      if (a === PROVIDER_GROUP.DEFAULT) return -1;
+      if (b === PROVIDER_GROUP.DEFAULT) return 1;
+      return a.localeCompare(b);
+    });
 
     return {
       ok: true,
-      data: [PROVIDER_GROUP.DEFAULT, ...sorted.filter((tag) => tag !== PROVIDER_GROUP.DEFAULT)],
+      data: sorted,
     };
   } catch (error) {
     logger.error("[RequestFiltersAction] Failed to get distinct group tags", { error });

--- a/src/app/[locale]/settings/providers/_components/provider-group-tab.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-group-tab.tsx
@@ -52,7 +52,7 @@ import { getProviderTypeConfig, getProviderTypeTranslationKey } from "@/lib/prov
 import { parsePublicStatusDescription } from "@/lib/public-status/config";
 import { exceedsProviderGroupDescriptionLimit } from "@/lib/public-status/description-limit";
 import { cn } from "@/lib/utils";
-import { parseProviderGroups } from "@/lib/utils/provider-group";
+import { resolveProviderGroupsWithDefault } from "@/lib/utils/provider-group";
 import type { ProviderDisplay } from "@/types/provider";
 import { ProviderBatchActions, ProviderBatchDialog, ProviderBatchToolbar } from "./batch-edit";
 import { InlineEditPopover } from "./inline-edit-popover";
@@ -523,12 +523,9 @@ export function ProviderGroupTab({
 }
 
 function filterGroupMembers(providers: ProviderDisplay[], groupName: string): ProviderDisplay[] {
-  return providers.filter((provider) => {
-    const tags = parseProviderGroups(provider.groupTag);
-    if (tags.includes(groupName)) return true;
-    if (groupName === PROVIDER_GROUP.DEFAULT && tags.length === 0) return true;
-    return false;
-  });
+  return providers.filter((provider) =>
+    resolveProviderGroupsWithDefault(provider.groupTag).includes(groupName)
+  );
 }
 
 interface GroupMembersPanelProps {

--- a/src/app/[locale]/settings/providers/_components/provider-manager.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-manager.tsx
@@ -27,7 +27,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import { useDebounce } from "@/lib/hooks/use-debounce";
 import type { CurrencyCode } from "@/lib/utils/currency";
-import { parseProviderGroups } from "@/lib/utils/provider-group";
+import { parseProviderGroups, resolveProviderGroupsWithDefault } from "@/lib/utils/provider-group";
 import type { ProviderDisplay, ProviderStatisticsMap, ProviderType } from "@/types/provider";
 import type { User } from "@/types/user";
 import {
@@ -158,18 +158,14 @@ export function ProviderManager({
     const groups = new Set<string>();
     let hasDefaultGroup = false;
     providers.forEach((p) => {
-      const tags = parseProviderGroups(p.groupTag);
-      if (!tags || tags.length === 0) {
-        hasDefaultGroup = true;
-      } else {
-        tags.forEach((g) => {
-          if (g === "default") {
-            hasDefaultGroup = true;
-          } else {
-            groups.add(g);
-          }
-        });
-      }
+      const tags = resolveProviderGroupsWithDefault(p.groupTag);
+      tags.forEach((g) => {
+        if (g === "default") {
+          hasDefaultGroup = true;
+        } else {
+          groups.add(g);
+        }
+      });
     });
 
     // Sort groups: "default" first, then alphabetically
@@ -217,13 +213,7 @@ export function ProviderManager({
     // Filter by groups
     if (groupFilter.length > 0) {
       result = result.filter((p) => {
-        const providerGroups = parseProviderGroups(p.groupTag);
-
-        // If provider has no groups and "default" is selected, include it
-        if (providerGroups.length === 0 && groupFilter.includes("default")) {
-          return true;
-        }
-
+        const providerGroups = resolveProviderGroupsWithDefault(p.groupTag);
         return groupFilter.some((g) => providerGroups.includes(g));
       });
     }
@@ -347,8 +337,8 @@ export function ProviderManager({
       setSelectedProviderIds((prev) => {
         const next = new Set(prev);
         for (const p of filteredProviders) {
-          const tags = parseProviderGroups(p.groupTag);
-          if (tags.includes(group) || (group === "default" && tags.length === 0)) {
+          const tags = resolveProviderGroupsWithDefault(p.groupTag);
+          if (tags.includes(group)) {
             next.add(p.id);
           }
         }

--- a/src/app/v1/_lib/proxy/provider-selector.ts
+++ b/src/app/v1/_lib/proxy/provider-selector.ts
@@ -4,7 +4,7 @@ import { PROVIDER_GROUP } from "@/lib/constants/provider.constants";
 import { logger } from "@/lib/logger";
 import { RateLimitService } from "@/lib/rate-limit";
 import { SessionManager } from "@/lib/session-manager";
-import { parseProviderGroups } from "@/lib/utils/provider-group";
+import { parseProviderGroups, resolveProviderGroupsWithDefault } from "@/lib/utils/provider-group";
 import { isProviderActiveNow } from "@/lib/utils/provider-schedule";
 import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import { isVendorTypeCircuitOpen } from "@/lib/vendor-type-circuit-breaker";
@@ -84,9 +84,7 @@ function checkProviderGroupMatch(providerGroupTag: string | null, userGroups: st
     return true;
   }
 
-  const providerTags = providerGroupTag
-    ? parseProviderGroups(providerGroupTag)
-    : [PROVIDER_GROUP.DEFAULT];
+  const providerTags = resolveProviderGroupsWithDefault(providerGroupTag);
 
   return providerTags.some((tag) => groups.includes(tag));
 }

--- a/src/lib/provider-groups/bootstrap.ts
+++ b/src/lib/provider-groups/bootstrap.ts
@@ -1,6 +1,5 @@
-import { PROVIDER_GROUP } from "@/lib/constants/provider.constants";
 import { logger } from "@/lib/logger";
-import { parseProviderGroups } from "@/lib/utils/provider-group";
+import { resolveProviderGroupsWithDefault } from "@/lib/utils/provider-group";
 import { findAllProvidersFresh } from "@/repository/provider";
 import { ensureProviderGroupsExist, findAllProviderGroups } from "@/repository/provider-groups";
 import type { ProviderGroup } from "@/types/provider-group";
@@ -39,13 +38,7 @@ export async function bootstrapProviderGroupsFromProviders(
   const referenced = new Set<string>();
   const groupCounts = new Map<string, number>();
   for (const provider of providers) {
-    const parsed = parseProviderGroups(provider.groupTag);
-    if (parsed.length === 0) {
-      referenced.add(PROVIDER_GROUP.DEFAULT);
-      groupCounts.set(PROVIDER_GROUP.DEFAULT, (groupCounts.get(PROVIDER_GROUP.DEFAULT) || 0) + 1);
-      continue;
-    }
-
+    const parsed = resolveProviderGroupsWithDefault(provider.groupTag);
     for (const name of parsed) {
       referenced.add(name);
       groupCounts.set(name, (groupCounts.get(name) || 0) + 1);

--- a/src/lib/public-status/aggregation.ts
+++ b/src/lib/public-status/aggregation.ts
@@ -5,7 +5,7 @@ import {
   classifyProviderChainItemOutcome,
   resolveSuccessRateModelKey,
 } from "@/lib/request-outcome";
-import { parseProviderGroups } from "@/lib/utils/provider-group";
+import { resolveProviderGroupsWithDefault } from "@/lib/utils/provider-group";
 import { EXCLUDE_WARMUP_CONDITION } from "@/repository/_shared/message-request-conditions";
 import type { ProviderChainItem } from "@/types/message";
 import type { InternalPublicStatusConfigSnapshot } from "./config-snapshot";
@@ -295,10 +295,8 @@ export function buildPublicStatusPayloadFromRequests(input: {
 
     const groupOutcome = new Map<string, "success" | "failure" | "excluded">();
     for (const item of request.providerChain ?? []) {
-      const itemGroups = Array.from(new Set(parseProviderGroups(item.groupTag)));
-      if (itemGroups.length === 0) {
-        continue;
-      }
+      // public status 只在存在 chain item 时，把空 groupTag 视为 default 归因。
+      const itemGroups = Array.from(new Set(resolveProviderGroupsWithDefault(item.groupTag)));
 
       const outcome = classifyProviderChainItemOutcome({
         statusCode: item.statusCode ?? undefined,

--- a/src/lib/request-filter-engine.ts
+++ b/src/lib/request-filter-engine.ts
@@ -9,7 +9,7 @@ import type {
   RemoveOp,
   SetOp,
 } from "@/lib/request-filter-types";
-import { parseProviderGroups } from "@/lib/utils/provider-group";
+import { resolveProviderGroupsWithDefault } from "@/lib/utils/provider-group";
 import type {
   RequestFilter,
   RequestFilterAction,
@@ -471,7 +471,7 @@ export class RequestFilterEngine {
     let providerTagsSet: Set<string> | null = null;
     if (this.hasGroupBasedFilters) {
       const providerGroupTag = session.provider.groupTag;
-      providerTagsSet = new Set(parseProviderGroups(providerGroupTag));
+      providerTagsSet = new Set(resolveProviderGroupsWithDefault(providerGroupTag));
     }
 
     for (const filter of this.providerGuardFilters) {
@@ -561,7 +561,7 @@ export class RequestFilterEngine {
       let providerTagsSet: Set<string> | null = null;
       if (this.hasGroupBasedFinalFilters) {
         const providerGroupTag = session.provider.groupTag;
-        providerTagsSet = new Set(parseProviderGroups(providerGroupTag));
+        providerTagsSet = new Set(resolveProviderGroupsWithDefault(providerGroupTag));
       }
 
       for (const filter of this.providerFinalFilters) {

--- a/src/lib/utils/provider-group.test.ts
+++ b/src/lib/utils/provider-group.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeProviderGroup,
   normalizeProviderGroupTag,
   parseProviderGroups,
+  resolveProviderGroupsWithDefault,
 } from "./provider-group";
 
 describe("provider-group utils", () => {
@@ -20,5 +21,16 @@ describe("provider-group utils", () => {
 
   test("normalizeProviderGroupTag 在空输入时应返回 null", () => {
     expect(normalizeProviderGroupTag("  ， \n  ")).toBeNull();
+  });
+
+  test("returns default membership for null or blank group tags", () => {
+    expect(resolveProviderGroupsWithDefault(null)).toEqual(["default"]);
+    expect(resolveProviderGroupsWithDefault("   ")).toEqual(["default"]);
+    expect(resolveProviderGroupsWithDefault("openai,default")).toEqual(["openai", "default"]);
+  });
+
+  test("keeps raw parse semantics unchanged for empty input", () => {
+    expect(parseProviderGroups(null)).toEqual([]);
+    expect(parseProviderGroups("   ")).toEqual([]);
   });
 });

--- a/src/lib/utils/provider-group.ts
+++ b/src/lib/utils/provider-group.ts
@@ -46,3 +46,16 @@ export function normalizeProviderGroupTag(value: unknown): string | null {
 export function parseProviderGroups(value: unknown): string[] {
   return splitProviderGroupValue(value);
 }
+
+/**
+ * 仅在明确需要“未分组 provider 也属于 default 组”语义的调用点使用。
+ * 原始解析语义保持不变：空输入仍然由 parseProviderGroups 返回 []。
+ */
+export function resolveProviderGroupsWithDefault(value: unknown): string[] {
+  const groups = parseProviderGroups(value);
+  if (groups.length === 0) {
+    return [PROVIDER_GROUP.DEFAULT];
+  }
+
+  return groups;
+}

--- a/tests/integration/public-status/config-publish.test.ts
+++ b/tests/integration/public-status/config-publish.test.ts
@@ -244,6 +244,51 @@ describe("public-status config publish integration", () => {
     expect(mockSchedulePublicStatusRebuild).not.toHaveBeenCalled();
   });
 
+  it("accepts groupName default with a custom slug and still queues publish + rebuild", async () => {
+    mockFindAllProviderGroups.mockResolvedValue([
+      {
+        id: 20,
+        name: "default",
+        description: null,
+      },
+    ]);
+    mockFindProviderGroupById.mockResolvedValue({
+      id: 20,
+      name: "default",
+      description: null,
+    });
+
+    const { savePublicStatusSettings } = await import("@/actions/public-status");
+
+    const result = await savePublicStatusSettings({
+      publicStatusWindowHours: 24,
+      publicStatusAggregationIntervalMinutes: 5,
+      groups: [
+        {
+          groupName: "default",
+          displayName: "Platform",
+          publicGroupSlug: "platform",
+          publicModels: [{ modelKey: "gpt-4.1" }],
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockUpdateProviderGroup).toHaveBeenCalledWith(
+      20,
+      expect.objectContaining({
+        description: expect.stringContaining('"publicGroupSlug":"platform"'),
+      }),
+      {}
+    );
+    expect(mockPublishCurrentPublicStatusConfigProjection).toHaveBeenCalledTimes(1);
+    expect(mockSchedulePublicStatusRebuild).toHaveBeenCalledWith({
+      intervalMinutes: 5,
+      rangeHours: 24,
+      reason: "config-updated",
+    });
+  });
+
   it("rejects aggregation intervals outside the public allowlist", async () => {
     const { savePublicStatusSettings } = await import("@/actions/public-status");
 

--- a/tests/integration/public-status/rebuild-lifecycle.test.ts
+++ b/tests/integration/public-status/rebuild-lifecycle.test.ts
@@ -24,4 +24,18 @@ describe("public-status rebuild lifecycle", () => {
     expect(result.rebuildState).toBe("rebuilding");
     expect(mockRedisSet).toHaveBeenCalledTimes(1);
   });
+
+  it("persists a rebuild hint for default-group refresh reasons", async () => {
+    const mod = await import("@/lib/public-status/rebuild-hints");
+
+    const result = await mod.schedulePublicStatusRebuild({
+      intervalMinutes: 5,
+      rangeHours: 24,
+      reason: "default-group-refresh",
+    });
+
+    expect(result.accepted).toBe(true);
+    expect(result.rebuildState).toBe("rebuilding");
+    expect(mockRedisSet).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/integration/public-status/rebuild-lifecycle.test.ts
+++ b/tests/integration/public-status/rebuild-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockRedisSet = vi.hoisted(() => vi.fn());
 
@@ -11,6 +11,10 @@ vi.mock("@/lib/redis", () => ({
 }));
 
 describe("public-status rebuild lifecycle", () => {
+  beforeEach(() => {
+    mockRedisSet.mockClear();
+  });
+
   it("persists a rebuild hint for widened ranges and cold starts", async () => {
     const mod = await import("@/lib/public-status/rebuild-hints");
 

--- a/tests/integration/public-status/route-redis-only.test.ts
+++ b/tests/integration/public-status/route-redis-only.test.ts
@@ -85,6 +85,46 @@ describe("GET /api/public-status", () => {
     });
   });
 
+  it("returns 200 for a configured default-group custom slug and preserves hasConfiguredGroups", async () => {
+    mockReadCurrentPublicStatusConfigSnapshot.mockResolvedValue({
+      defaultIntervalMinutes: 5,
+      defaultRangeHours: 24,
+      groups: [{ slug: "platform" }],
+    });
+    mockReadPublicStatusPayload.mockResolvedValue({
+      rebuildState: "fresh",
+      sourceGeneration: "gen-platform",
+      generatedAt: "2026-04-21T10:00:00.000Z",
+      freshUntil: "2026-04-21T10:05:00.000Z",
+      groups: [
+        {
+          publicGroupSlug: "platform",
+          displayName: "Platform",
+          explanatoryCopy: "Default group",
+          models: [],
+        },
+      ],
+    });
+
+    const { GET } = await import("@/app/api/public-status/route");
+    const response = await GET(new Request("http://localhost/api/public-status"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "ready",
+      rebuildState: {
+        state: "fresh",
+        hasSnapshot: true,
+        reason: null,
+      },
+    });
+    expect(mockReadPublicStatusPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasConfiguredGroups: true,
+      })
+    );
+  });
+
   it("returns 200 with stale payload and queues rebuild for the default query", async () => {
     mockReadCurrentPublicStatusConfigSnapshot.mockResolvedValue({
       configVersion: "cfg-1",
@@ -121,6 +161,66 @@ describe("GET /api/public-status", () => {
         reason: null,
       },
     });
+    expect(mockSchedulePublicStatusRebuild).toHaveBeenCalledWith({
+      intervalMinutes: 5,
+      rangeHours: 24,
+      reason: "stale-generation",
+    });
+  });
+
+  it("returns 200 with stale payload for a configured default-group custom slug", async () => {
+    mockReadCurrentPublicStatusConfigSnapshot.mockResolvedValue({
+      configVersion: "cfg-platform",
+      defaultIntervalMinutes: 5,
+      defaultRangeHours: 24,
+      groups: [{ slug: "platform" }],
+    });
+    mockReadPublicStatusPayload.mockImplementation(
+      async ({ triggerRebuildHint }: { triggerRebuildHint: (reason: string) => Promise<void> }) => {
+        await triggerRebuildHint("stale-generation");
+        return {
+          rebuildState: "stale",
+          sourceGeneration: "gen-platform-stale",
+          generatedAt: "2026-04-21T09:55:00.000Z",
+          freshUntil: "2026-04-21T10:00:00.000Z",
+          groups: [
+            {
+              publicGroupSlug: "platform",
+              displayName: "Platform",
+              explanatoryCopy: "Default group",
+              models: [],
+            },
+          ],
+        };
+      }
+    );
+    mockSchedulePublicStatusRebuild.mockResolvedValue({
+      accepted: true,
+      rebuildState: "rebuilding",
+    });
+
+    const { GET } = await import("@/app/api/public-status/route");
+    const response = await GET(
+      new Request("http://localhost/api/public-status?groupSlug=platform")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "stale",
+      rebuildState: {
+        state: "stale",
+        hasSnapshot: true,
+        reason: null,
+      },
+      resolvedQuery: expect.objectContaining({
+        groupSlugs: ["platform"],
+      }),
+    });
+    expect(mockReadPublicStatusPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasConfiguredGroups: true,
+      })
+    );
     expect(mockSchedulePublicStatusRebuild).toHaveBeenCalledWith({
       intervalMinutes: 5,
       rangeHours: 24,

--- a/tests/unit/actions/providers-group-count.test.ts
+++ b/tests/unit/actions/providers-group-count.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const getSessionMock = vi.fn();
-const findAllProvidersFreshMock = vi.fn();
-const findProviderByIdMock = vi.fn();
-const getProviderStatisticsMock = vi.fn();
-const createProviderMock = vi.fn();
-const updateProviderMock = vi.fn();
-const deleteProviderMock = vi.fn();
-const updateProviderPrioritiesBatchMock = vi.fn();
+const getSessionMock = vi.hoisted(() => vi.fn());
+const findAllProvidersFreshMock = vi.hoisted(() => vi.fn());
+const findProviderByIdMock = vi.hoisted(() => vi.fn());
+const getProviderStatisticsMock = vi.hoisted(() => vi.fn());
+const createProviderMock = vi.hoisted(() => vi.fn());
+const updateProviderMock = vi.hoisted(() => vi.fn());
+const deleteProviderMock = vi.hoisted(() => vi.fn());
+const updateProviderPrioritiesBatchMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth", () => ({
   getSession: getSessionMock,

--- a/tests/unit/actions/providers-group-count.test.ts
+++ b/tests/unit/actions/providers-group-count.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+const findAllProvidersFreshMock = vi.fn();
+const findProviderByIdMock = vi.fn();
+const getProviderStatisticsMock = vi.fn();
+const createProviderMock = vi.fn();
+const updateProviderMock = vi.fn();
+const deleteProviderMock = vi.fn();
+const updateProviderPrioritiesBatchMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+}));
+
+vi.mock("@/repository/provider", () => ({
+  createProvider: createProviderMock,
+  deleteProvider: deleteProviderMock,
+  findAllProviders: vi.fn(async () => []),
+  findAllProvidersFresh: findAllProvidersFreshMock,
+  findProviderById: findProviderByIdMock,
+  getProviderStatistics: getProviderStatisticsMock,
+  resetProviderTotalCostResetAt: vi.fn(async () => {}),
+  updateProvider: updateProviderMock,
+  updateProviderPrioritiesBatch: updateProviderPrioritiesBatchMock,
+  updateProvidersBatch: vi.fn(async () => 0),
+}));
+
+vi.mock("@/lib/cache/provider-cache", () => ({
+  publishProviderCacheInvalidation: vi.fn(),
+}));
+
+vi.mock("@/lib/redis/circuit-breaker-config", () => ({
+  deleteProviderCircuitConfig: vi.fn(),
+  saveProviderCircuitConfig: vi.fn(),
+}));
+
+vi.mock("@/lib/circuit-breaker", () => ({
+  clearConfigCache: vi.fn(),
+  clearProviderState: vi.fn(),
+  forceCloseCircuitState: vi.fn(),
+  getAllHealthStatusAsync: vi.fn(async () => ({})),
+  publishCircuitBreakerConfigInvalidation: vi.fn(),
+  resetCircuit: vi.fn(),
+}));
+
+vi.mock("@/lib/session-manager", () => ({
+  SessionManager: {
+    terminateProviderSessionsBatch: vi.fn(async () => 0),
+    terminateStickySessionsForProviders: vi.fn(async () => 0),
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+describe("getProviderGroupsWithCount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
+    findAllProvidersFreshMock.mockResolvedValue([
+      { groupTag: null },
+      { groupTag: "   " },
+      { groupTag: "default" },
+      { groupTag: "premium" },
+    ]);
+    findProviderByIdMock.mockResolvedValue(null);
+    getProviderStatisticsMock.mockResolvedValue([]);
+    createProviderMock.mockResolvedValue(null);
+    updateProviderMock.mockResolvedValue(null);
+    deleteProviderMock.mockResolvedValue(undefined);
+    updateProviderPrioritiesBatchMock.mockResolvedValue(0);
+  });
+
+  it("counts null or blank group tags under default", async () => {
+    const { getProviderGroupsWithCount } = await import("@/actions/providers");
+
+    const result = await getProviderGroupsWithCount();
+
+    expect(result).toEqual({
+      ok: true,
+      data: [
+        { group: "default", providerCount: 3 },
+        { group: "premium", providerCount: 1 },
+      ],
+    });
+  });
+});

--- a/tests/unit/actions/request-filters-provider-groups.test.ts
+++ b/tests/unit/actions/request-filters-provider-groups.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+const selectDistinctMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/request-filter-engine", () => ({
+  requestFilterEngine: {
+    reload: vi.fn(async () => {}),
+    getStats: vi.fn(() => ({ count: 0 })),
+  },
+}));
+
+vi.mock("@/repository/request-filters", () => ({
+  createRequestFilter: vi.fn(),
+  deleteRequestFilter: vi.fn(),
+  getAllRequestFilters: vi.fn(async () => []),
+  getRequestFilterById: vi.fn(async () => null),
+  updateRequestFilter: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/drizzle/db", () => ({
+  db: {
+    selectDistinct: selectDistinctMock,
+  },
+}));
+
+vi.mock("@/drizzle/schema", () => ({
+  providers: {
+    groupTag: "providers.group_tag",
+    deletedAt: "providers.deleted_at",
+  },
+}));
+
+vi.mock("drizzle-orm", async () => {
+  const actual = await vi.importActual<typeof import("drizzle-orm")>("drizzle-orm");
+  return {
+    ...actual,
+    isNull: vi.fn((value) => value),
+  };
+});
+
+describe("getDistinctProviderGroupsAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
+    selectDistinctMock.mockReturnValue({
+      from: () => ({
+        where: async () => [
+          { groupTag: null },
+          { groupTag: "   " },
+          { groupTag: "default" },
+          { groupTag: "premium,default" },
+          { groupTag: "beta" },
+        ],
+      }),
+    });
+  });
+
+  it("returns default first for null or blank provider group tags", async () => {
+    const { getDistinctProviderGroupsAction } = await import("@/actions/request-filters");
+
+    const result = await getDistinctProviderGroupsAction();
+
+    expect(result).toEqual({
+      ok: true,
+      data: ["default", "beta", "premium"],
+    });
+  });
+});

--- a/tests/unit/actions/request-filters-provider-groups.test.ts
+++ b/tests/unit/actions/request-filters-provider-groups.test.ts
@@ -81,4 +81,21 @@ describe("getDistinctProviderGroupsAction", () => {
       data: ["default", "beta", "premium"],
     });
   });
+
+  it("keeps default selectable even when no provider currently belongs to it", async () => {
+    selectDistinctMock.mockReturnValue({
+      from: () => ({
+        where: async () => [{ groupTag: "premium" }, { groupTag: "beta" }],
+      }),
+    });
+
+    const { getDistinctProviderGroupsAction } = await import("@/actions/request-filters");
+
+    const result = await getDistinctProviderGroupsAction();
+
+    expect(result).toEqual({
+      ok: true,
+      data: ["default", "beta", "premium"],
+    });
+  });
 });

--- a/tests/unit/proxy/provider-group-match.test.ts
+++ b/tests/unit/proxy/provider-group-match.test.ts
@@ -23,6 +23,16 @@ describe("checkProviderGroupMatch - 供应商分组匹配逻辑", () => {
       expect(checkProviderGroupMatch(null, "cli,default")).toBe(true);
     });
 
+    test("供应商分组为空字符串，用户分组包含 default，应匹配", () => {
+      expect(checkProviderGroupMatch("", "default")).toBe(true);
+      expect(checkProviderGroupMatch("  ", "cli,default")).toBe(true);
+    });
+
+    test("供应商分组显式为 default，用户分组包含 default，应匹配", () => {
+      expect(checkProviderGroupMatch("default", "default")).toBe(true);
+      expect(checkProviderGroupMatch("default", "cli,default")).toBe(true);
+    });
+
     test("供应商分组为 null，用户分组不包含 default，应不匹配", () => {
       expect(checkProviderGroupMatch(null, "premium")).toBe(false);
       expect(checkProviderGroupMatch(null, "cli,chat")).toBe(false);

--- a/tests/unit/public-status/aggregation.test.ts
+++ b/tests/unit/public-status/aggregation.test.ts
@@ -229,6 +229,144 @@ describe("public-status aggregation", () => {
     expect(model?.timeline.some((bucket) => bucket.sampleCount === 1)).toBe(true);
   });
 
+  it("counts null or blank provider-chain group tags inside the default group", () => {
+    const result = buildPublicStatusPayloadFromRequests({
+      rangeHours: 1,
+      intervalMinutes: 15,
+      now: "2026-04-21T11:00:00.000Z",
+      groups: [
+        {
+          sourceGroupName: "default",
+          publicGroupSlug: "platform",
+          displayName: "Platform",
+          explanatoryCopy: "Default group",
+          sortOrder: 1,
+          models: [
+            {
+              publicModelKey: "gpt-4.1",
+              label: "GPT-4.1",
+              vendorIconKey: "openai",
+              requestTypeBadge: "openaiCompatible",
+            },
+          ],
+        },
+      ],
+      requests: [
+        {
+          id: 7,
+          createdAt: "2026-04-21T10:10:00.000Z",
+          originalModel: "gpt-4.1",
+          providerChain: [
+            {
+              id: 71,
+              name: "provider-1",
+              groupTag: null,
+              reason: "request_success",
+              statusCode: 200,
+            },
+          ],
+        },
+        {
+          id: 8,
+          createdAt: "2026-04-21T10:20:00.000Z",
+          originalModel: "gpt-4.1",
+          providerChain: [
+            {
+              id: 81,
+              name: "provider-2",
+              groupTag: "",
+              reason: "retry_failed",
+              statusCode: 500,
+            },
+          ],
+        },
+        {
+          id: 9,
+          createdAt: "2026-04-21T10:30:00.000Z",
+          originalModel: "gpt-4.1",
+          providerChain: [
+            {
+              id: 91,
+              name: "provider-3",
+              groupTag: "default",
+              reason: "request_success",
+              statusCode: 200,
+            },
+          ],
+        },
+        {
+          id: 10,
+          createdAt: "2026-04-21T10:45:00.000Z",
+          originalModel: "gpt-4.1",
+          providerChain: null,
+        },
+      ],
+    });
+
+    const model = result.groups[0]?.models[0];
+    expect(model?.timeline.reduce((sum, bucket) => sum + bucket.sampleCount, 0)).toBe(3);
+    expect(model?.latestState).toBe("operational");
+  });
+
+  it("does not leak ungrouped traffic into named groups", () => {
+    const result = buildPublicStatusPayloadFromRequests({
+      rangeHours: 1,
+      intervalMinutes: 15,
+      now: "2026-04-21T11:00:00.000Z",
+      groups: [
+        {
+          sourceGroupName: "openai",
+          publicGroupSlug: "openai",
+          displayName: "OpenAI",
+          explanatoryCopy: null,
+          sortOrder: 1,
+          models: [
+            {
+              publicModelKey: "gpt-4.1",
+              label: "GPT-4.1",
+              vendorIconKey: "openai",
+              requestTypeBadge: "openaiCompatible",
+            },
+          ],
+        },
+      ],
+      requests: [
+        {
+          id: 11,
+          createdAt: "2026-04-21T10:10:00.000Z",
+          originalModel: "gpt-4.1",
+          providerChain: [
+            {
+              id: 111,
+              name: "provider-1",
+              groupTag: null,
+              reason: "request_success",
+              statusCode: 200,
+            },
+          ],
+        },
+        {
+          id: 12,
+          createdAt: "2026-04-21T10:25:00.000Z",
+          originalModel: "gpt-4.1",
+          providerChain: [
+            {
+              id: 121,
+              name: "provider-2",
+              groupTag: "openai",
+              reason: "request_success",
+              statusCode: 200,
+            },
+          ],
+        },
+      ],
+    });
+
+    const model = result.groups[0]?.models[0];
+    expect(model?.timeline.reduce((sum, bucket) => sum + bucket.sampleCount, 0)).toBe(1);
+    expect(model?.latestState).toBe("operational");
+  });
+
   it("ignores informational chain items before an excluded terminal event", () => {
     const result = buildPublicStatusPayloadFromRequests({
       rangeHours: 1,

--- a/tests/unit/public-status/config-publisher.test.ts
+++ b/tests/unit/public-status/config-publisher.test.ts
@@ -225,4 +225,55 @@ describe("public-status config publisher", () => {
       })
     );
   });
+
+  it("publishes internal snapshot sourceGroupName for default group while public snapshot keeps custom slug", async () => {
+    mockFindAllProviderGroups.mockResolvedValue([
+      {
+        id: 2,
+        name: "default",
+        description: JSON.stringify({
+          version: 2,
+          publicStatus: {
+            displayName: "Platform",
+            publicGroupSlug: "platform",
+            explanatoryCopy: "Default group status",
+            sortOrder: 2,
+            publicModels: [{ modelKey: "gpt-4.1", providerTypeOverride: "openai-compatible" }],
+          },
+        }),
+      },
+    ]);
+
+    const mod = await import("@/lib/public-status/config-publisher");
+    await mod.publishCurrentPublicStatusConfigProjection({
+      reason: "test",
+      configVersion: "cfg-test",
+    });
+
+    expect(mockPublishInternalPublicStatusConfigSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          groups: [
+            expect.objectContaining({
+              sourceGroupName: "default",
+              slug: "platform",
+              displayName: "Platform",
+            }),
+          ],
+        }),
+      })
+    );
+    expect(mockPublishPublicStatusConfigSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          groups: [
+            expect.objectContaining({
+              slug: "platform",
+              displayName: "Platform",
+            }),
+          ],
+        }),
+      })
+    );
+  }, 20_000);
 });

--- a/tests/unit/public-status/public-status-view.test.tsx
+++ b/tests/unit/public-status/public-status-view.test.tsx
@@ -402,4 +402,111 @@ describe("public-status view", () => {
 
     unmount();
   });
+
+  it("keeps filterSlug-scoped default group after polling refresh", async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn(async () => ({
+      status: 200,
+      json: async () =>
+        buildRouteResponse({
+          groups: [
+            {
+              publicGroupSlug: "platform",
+              displayName: "Platform",
+              explanatoryCopy: "Default group",
+              models: [
+                {
+                  publicModelKey: "platform-model",
+                  label: "Platform Model",
+                  vendorIconKey: "openai",
+                  requestTypeBadge: "openaiCompatible",
+                  latestState: "operational",
+                  availabilityPct: 99.9,
+                  latestTtfbMs: 420,
+                  latestTps: null,
+                  timeline: [],
+                },
+              ],
+            },
+            {
+              publicGroupSlug: "openai",
+              displayName: "OpenAI",
+              explanatoryCopy: "Named group",
+              models: [
+                {
+                  publicModelKey: "openai-model",
+                  label: "OpenAI Model",
+                  vendorIconKey: "openai",
+                  requestTypeBadge: "openaiCompatible",
+                  latestState: "failed",
+                  availabilityPct: 50,
+                  latestTtfbMs: 700,
+                  latestTps: null,
+                  timeline: [],
+                },
+              ],
+            },
+          ],
+        }),
+    }));
+    global.fetch = fetchMock as typeof global.fetch;
+
+    const { container, unmount } = render(
+      <PublicStatusView
+        initialPayload={buildPayload({
+          groups: [
+            {
+              publicGroupSlug: "platform",
+              displayName: "Platform",
+              explanatoryCopy: "Default group",
+              models: [
+                {
+                  publicModelKey: "platform-model",
+                  label: "Platform Model",
+                  vendorIconKey: "openai",
+                  requestTypeBadge: "openaiCompatible",
+                  latestState: "operational",
+                  availabilityPct: 99.9,
+                  latestTtfbMs: 420,
+                  latestTps: null,
+                  timeline: [],
+                },
+              ],
+            },
+          ],
+        })}
+        initialStatus="ready"
+        intervalMinutes={5}
+        rangeHours={24}
+        followServerDefaults={true}
+        filterSlug="platform"
+        locale="en"
+        timeZone="UTC"
+        labels={buildLabels()}
+        siteTitle="Acme AI Hub"
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/public-status?groupSlug=platform", {
+      cache: "no-store",
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+      await Promise.resolve();
+    });
+
+    const text = container.textContent || "";
+    expect(text).toContain("Platform Model");
+    expect(text).not.toContain("OpenAI Model");
+    expect(container.querySelectorAll('[data-testid="sortable-group-panel"]')).toHaveLength(1);
+
+    vi.useRealTimers();
+    unmount();
+  });
 });

--- a/tests/unit/public-status/rebuild-worker.test.ts
+++ b/tests/unit/public-status/rebuild-worker.test.ts
@@ -238,6 +238,81 @@ describe("public-status rebuild worker", () => {
     expect(result.groups[0]?.models[0]?.latestState).toBe("failed");
   });
 
+  it("keeps default group samples when provider-chain tags are null blank or explicit default", async () => {
+    const mod = await importAggregationModule();
+
+    const result = mod.buildPublicStatusPayloadFromRequests({
+      rangeHours: 1,
+      intervalMinutes: 15,
+      now: "2026-04-21T11:00:00.000Z",
+      groups: [
+        {
+          sourceGroupName: "default",
+          publicGroupSlug: "platform",
+          displayName: "Platform",
+          explanatoryCopy: "Default group",
+          sortOrder: 1,
+          models: [
+            {
+              publicModelKey: "gpt-4.1",
+              label: "GPT-4.1",
+              vendorIconKey: "openai",
+              requestTypeBadge: "openaiCompatible",
+            },
+          ],
+        },
+      ],
+      requests: [
+        {
+          id: 31,
+          createdAt: "2026-04-21T10:10:00.000Z",
+          originalModel: "gpt-4.1",
+          providerChain: [
+            {
+              id: 311,
+              name: "provider-1",
+              groupTag: null,
+              reason: "request_success",
+              statusCode: 200,
+            },
+          ],
+        },
+        {
+          id: 32,
+          createdAt: "2026-04-21T10:20:00.000Z",
+          originalModel: "gpt-4.1",
+          providerChain: [
+            {
+              id: 321,
+              name: "provider-2",
+              groupTag: "",
+              reason: "retry_failed",
+              statusCode: 500,
+            },
+          ],
+        },
+        {
+          id: 33,
+          createdAt: "2026-04-21T10:30:00.000Z",
+          originalModel: "gpt-4.1",
+          providerChain: [
+            {
+              id: 331,
+              name: "provider-3",
+              groupTag: "default",
+              reason: "request_success",
+              statusCode: 200,
+            },
+          ],
+        },
+      ],
+    });
+
+    const model = result.groups[0]?.models[0];
+    expect(model?.timeline.reduce((sum, bucket) => sum + bucket.sampleCount, 0)).toBe(3);
+    expect(model?.latestState).toBe("operational");
+  });
+
   it("collapses concurrent rebuild requests into a single in-flight computation", async () => {
     const mod = await importRebuildWorkerModule();
 

--- a/tests/unit/public-status/status-page-title.test.tsx
+++ b/tests/unit/public-status/status-page-title.test.tsx
@@ -89,4 +89,54 @@ describe("public status page title", () => {
       undefined
     );
   });
+
+  it("accepts a default-group payload on the root status page", async () => {
+    mockLoadPublicStatusPageData.mockResolvedValue({
+      initialPayload: {
+        rebuildState: "fresh",
+        sourceGeneration: "",
+        generatedAt: "2026-04-22T00:00:00.000Z",
+        freshUntil: null,
+        groups: [
+          {
+            publicGroupSlug: "platform",
+            displayName: "Platform",
+            explanatoryCopy: "Default group",
+            models: [],
+          },
+        ],
+      },
+      status: "ready",
+      intervalMinutes: 5,
+      rangeHours: 24,
+      followServerDefaults: true,
+      siteTitle: "Claude Code Hub",
+      timeZone: "UTC",
+      meta: {
+        siteTitle: "Claude Code Hub",
+        siteDescription: "Claude Code Hub public status",
+        timeZone: "UTC",
+      },
+    });
+
+    const mod = await import("@/app/[locale]/status/page");
+    const pageElement = await mod.default({
+      params: Promise.resolve({ locale: "en" }),
+    });
+    renderToStaticMarkup(pageElement);
+
+    expect(mockPublicStatusView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialPayload: expect.objectContaining({
+          groups: [
+            expect.objectContaining({
+              publicGroupSlug: "platform",
+              displayName: "Platform",
+            }),
+          ],
+        }),
+      }),
+      undefined
+    );
+  });
 });

--- a/tests/unit/public-status/status-slug-page.test.tsx
+++ b/tests/unit/public-status/status-slug-page.test.tsx
@@ -133,4 +133,52 @@ describe("public status slug page", () => {
     });
     expect(mockNotFound).not.toHaveBeenCalled();
   });
+
+  it("resolves a custom default-group slug for metadata and page rendering", async () => {
+    mockLoadPublicStatusPageData.mockResolvedValue({
+      initialPayload: {
+        rebuildState: "fresh",
+        sourceGeneration: "",
+        generatedAt: "2026-04-22T00:00:00.000Z",
+        freshUntil: null,
+        groups: [
+          {
+            publicGroupSlug: "platform",
+            displayName: "Platform",
+            explanatoryCopy: "Default group status",
+            models: [],
+          },
+        ],
+      },
+      status: "ready",
+      intervalMinutes: 5,
+      rangeHours: 24,
+      followServerDefaults: true,
+      siteTitle: "Claude Code Hub",
+      timeZone: "UTC",
+      meta: {
+        siteTitle: "Claude Code Hub",
+        siteDescription: "Claude Code Hub public status",
+        timeZone: "UTC",
+      },
+      response: {} as never,
+    });
+
+    const mod = await import("@/app/[locale]/status/[slug]/page");
+    const metadata = (await mod.generateMetadata({
+      params: Promise.resolve({ slug: "platform" }),
+    })) as Metadata;
+
+    expect(metadata).toMatchObject({
+      title: "Platform · Claude Code Hub",
+      description: "Default group status",
+    });
+
+    await expect(
+      mod.default({
+        params: Promise.resolve({ locale: "en", slug: "platform" }),
+      })
+    ).resolves.toBeTruthy();
+    expect(mockLoadPublicStatusPageData).toHaveBeenCalledWith({ groupSlug: "platform" });
+  });
 });

--- a/tests/unit/request-filter-advanced.test.ts
+++ b/tests/unit/request-filter-advanced.test.ts
@@ -957,6 +957,56 @@ describe("Advanced Mode - Final Phase Integration", () => {
     expect(body.other_applied).toBeUndefined();
   });
 
+  test("group binding in final phase treats null or blank provider tags as default", async () => {
+    const defaultFilter = createAdvancedFilter(
+      [{ op: "set", scope: "body", path: "default_applied", value: true }],
+      {
+        bindingType: "groups",
+        groupTags: ["default"],
+      }
+    );
+    const premiumFilter = createAdvancedFilter(
+      [{ op: "set", scope: "body", path: "premium_applied", value: true }],
+      {
+        bindingType: "groups",
+        groupTags: ["premium"],
+      }
+    );
+    requestFilterEngine.setFiltersForTest([defaultFilter, premiumFilter]);
+
+    const nullBody: Record<string, unknown> = {};
+    const blankBody: Record<string, unknown> = {};
+    const premiumBody: Record<string, unknown> = {};
+    const headers = new Headers();
+
+    await requestFilterEngine.applyFinal(
+      { provider: { id: 1, groupTag: null } } as Parameters<
+        typeof requestFilterEngine.applyFinal
+      >[0],
+      nullBody,
+      headers
+    );
+    await requestFilterEngine.applyFinal(
+      { provider: { id: 2, groupTag: "   " } } as Parameters<
+        typeof requestFilterEngine.applyFinal
+      >[0],
+      blankBody,
+      headers
+    );
+    await requestFilterEngine.applyFinal(
+      { provider: { id: 3, groupTag: "premium" } } as Parameters<
+        typeof requestFilterEngine.applyFinal
+      >[0],
+      premiumBody,
+      headers
+    );
+
+    expect(nullBody.default_applied).toBe(true);
+    expect(blankBody.default_applied).toBe(true);
+    expect(premiumBody.default_applied).toBeUndefined();
+    expect(premiumBody.premium_applied).toBe(true);
+  });
+
   test("simple mode filters in final phase use existing logic on body/headers", async () => {
     const filter = createFilter({
       ruleMode: "simple",

--- a/tests/unit/request-filter-binding.test.ts
+++ b/tests/unit/request-filter-binding.test.ts
@@ -424,8 +424,8 @@ describe("Request Filter Engine - Binding Types", () => {
       expect(session.headers.has("x-special")).toBe(false);
     });
 
-    test("should NOT apply filter when provider has no groupTag (null)", async () => {
-      const filter = createGroupFilter(["any-tag"], "header", "set", "x-null", "applied");
+    test("should apply default group filter when provider has no groupTag (null)", async () => {
+      const filter = createGroupFilter(["default"], "header", "set", "x-null", "applied");
       requestFilterEngine.setFiltersForTest([filter]);
 
       const session = createSessionWithProvider(1, null);
@@ -434,11 +434,11 @@ describe("Request Filter Engine - Binding Types", () => {
         session as Parameters<typeof requestFilterEngine.applyForProvider>[0]
       );
 
-      expect(session.headers.has("x-null")).toBe(false);
+      expect(session.headers.get("x-null")).toBe("applied");
     });
 
-    test("should NOT apply filter when provider has empty groupTag", async () => {
-      const filter = createGroupFilter(["tag"], "header", "set", "x-empty-tag", "applied");
+    test("should apply default group filter when provider has empty groupTag", async () => {
+      const filter = createGroupFilter(["default"], "header", "set", "x-empty-tag", "applied");
       requestFilterEngine.setFiltersForTest([filter]);
 
       const session = createSessionWithProvider(1, "");
@@ -447,7 +447,20 @@ describe("Request Filter Engine - Binding Types", () => {
         session as Parameters<typeof requestFilterEngine.applyForProvider>[0]
       );
 
-      expect(session.headers.has("x-empty-tag")).toBe(false);
+      expect(session.headers.get("x-empty-tag")).toBe("applied");
+    });
+
+    test("should NOT apply default group filter to explicitly named non-default provider", async () => {
+      const filter = createGroupFilter(["default"], "header", "set", "x-default-only", "applied");
+      requestFilterEngine.setFiltersForTest([filter]);
+
+      const session = createSessionWithProvider(1, "premium");
+
+      await requestFilterEngine.applyForProvider(
+        session as Parameters<typeof requestFilterEngine.applyForProvider>[0]
+      );
+
+      expect(session.headers.has("x-default-only")).toBe(false);
     });
 
     test("should skip group filter with empty groupTags array", async () => {

--- a/tests/unit/settings/providers/provider-group-bootstrap.test.ts
+++ b/tests/unit/settings/providers/provider-group-bootstrap.test.ts
@@ -59,6 +59,8 @@ describe("provider-group bootstrap", () => {
       findAllProviderGroups: async () => currentGroups,
       findAllProvidersFresh: async () => [
         { groupTag: null },
+        { groupTag: "   " },
+        { groupTag: "default" },
         { groupTag: "openai,premium" },
         { groupTag: "premium" },
       ],
@@ -80,7 +82,7 @@ describe("provider-group bootstrap", () => {
 
     expect(ensureProviderGroupsExist).toHaveBeenCalledWith(["premium"]);
     expect(result.groups.map((group) => group.name)).toEqual(["default", "openai", "premium"]);
-    expect(result.groupCounts.get("default")).toBe(1);
+    expect(result.groupCounts.get("default")).toBe(3);
     expect(result.groupCounts.get("openai")).toBe(1);
     expect(result.groupCounts.get("premium")).toBe(2);
   });

--- a/tests/unit/settings/providers/provider-group-tab.test.tsx
+++ b/tests/unit/settings/providers/provider-group-tab.test.tsx
@@ -249,4 +249,57 @@ describe("ProviderGroupTab", () => {
 
     unmount();
   });
+
+  it("default group member list includes null-tag provider", async () => {
+    mockGetProviderGroups.mockResolvedValueOnce({
+      ok: true,
+      data: [
+        {
+          id: 7,
+          name: "default",
+          costMultiplier: 1,
+          description: null,
+          providerCount: 2,
+        },
+      ],
+    });
+
+    const providers = [
+      makeProvider({ id: 1, name: "Ungrouped Provider", groupTag: null, groupPriorities: null }),
+      makeProvider({
+        id: 2,
+        name: "Explicit Default Provider",
+        groupTag: "default",
+        groupPriorities: { default: 1 },
+      }),
+      makeProvider({
+        id: 3,
+        name: "Premium Provider",
+        groupTag: "premium",
+        groupPriorities: { premium: 1 },
+      }),
+    ];
+
+    const { container, unmount } = render(
+      <ProviderGroupTab providers={providers} isAdmin={true} onRequestEditProvider={() => {}} />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const expandButton = container.querySelector('button[aria-label="groupMembers"]');
+    expect(expandButton).toBeTruthy();
+
+    act(() => {
+      expandButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const text = container.textContent || "";
+    expect(text).toContain("Ungrouped Provider");
+    expect(text).toContain("Explicit Default Provider");
+    expect(text).not.toContain("Premium Provider");
+
+    unmount();
+  });
 });

--- a/tests/unit/settings/providers/provider-manager.test.tsx
+++ b/tests/unit/settings/providers/provider-manager.test.tsx
@@ -497,3 +497,45 @@ describe("ProviderManager layered circuit labels", () => {
     unmount();
   });
 });
+
+describe("ProviderManager default group filtering", () => {
+  test("default filter includes ungrouped providers", () => {
+    const providers = [
+      makeProvider({ id: 1, name: "Ungrouped Provider", groupTag: null, groupPriorities: null }),
+      makeProvider({
+        id: 2,
+        name: "Explicit Default Provider",
+        groupTag: "default",
+        groupPriorities: { default: 1 },
+      }),
+      makeProvider({
+        id: 3,
+        name: "Premium Provider",
+        groupTag: "premium",
+        groupPriorities: { premium: 1 },
+      }),
+    ];
+
+    const { unmount, container } = renderWithProviders(
+      <ProviderManager providers={providers} healthStatus={{}} enableMultiProviderTypes={true} />
+    );
+
+    const defaultFilterButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "default"
+    );
+    expect(defaultFilterButton).toBeTruthy();
+
+    act(() => {
+      defaultFilterButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const providerNames = Array.from(container.querySelectorAll("[data-testid^='provider-']")).map(
+      (node) => node.textContent
+    );
+    expect(providerNames).toContain("Ungrouped Provider");
+    expect(providerNames).toContain("Explicit Default Provider");
+    expect(providerNames).not.toContain("Premium Provider");
+
+    unmount();
+  });
+});

--- a/tests/unit/settings/status-page/public-status-settings-form.test.tsx
+++ b/tests/unit/settings/status-page/public-status-settings-form.test.tsx
@@ -325,4 +325,53 @@ describe("public-status settings form", () => {
 
     unmount();
   });
+
+  it("default group keeps groupName while submitting a custom public slug", async () => {
+    const { container, unmount } = render(
+      <PublicStatusSettingsForm
+        initialWindowHours={24}
+        initialAggregationIntervalMinutes={5}
+        initialGroups={
+          [
+            {
+              groupName: "default",
+              enabled: true,
+              displayName: "Platform",
+              publicGroupSlug: "platform",
+              explanatoryCopy: "Default route",
+              sortOrder: 2,
+              publicModels: [{ modelKey: "gpt-4.1", providerTypeOverride: "openai-compatible" }],
+            },
+          ] as never
+        }
+      />
+    );
+
+    const submitButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("statusPage.form.save")
+    );
+    expect(submitButton).toBeTruthy();
+
+    await act(async () => {
+      submitButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(mockSavePublicStatusSettings).toHaveBeenLastCalledWith({
+      publicStatusWindowHours: 24,
+      publicStatusAggregationIntervalMinutes: 5,
+      groups: [
+        {
+          groupName: "default",
+          displayName: "Platform",
+          publicGroupSlug: "platform",
+          explanatoryCopy: "Default route",
+          sortOrder: 2,
+          publicModels: [{ modelKey: "gpt-4.1", providerTypeOverride: "openai-compatible" }],
+        },
+      ],
+    });
+
+    unmount();
+  });
 });

--- a/tests/unit/settings/status-page/status-page-loader.test.tsx
+++ b/tests/unit/settings/status-page/status-page-loader.test.tsx
@@ -59,4 +59,50 @@ describe("status-page loader", () => {
       ],
     });
   });
+
+  it("hydrates default groupName while preserving custom public slug and metadata", async () => {
+    mockGetSystemSettings.mockResolvedValue({
+      publicStatusWindowHours: 48,
+      publicStatusAggregationIntervalMinutes: 15,
+    });
+    mockBootstrapProviderGroupsFromProviders.mockResolvedValue({
+      groups: [
+        {
+          id: 2,
+          name: "default",
+          description: JSON.stringify({
+            version: 2,
+            note: "Default public note",
+            publicStatus: {
+              displayName: "Platform",
+              publicGroupSlug: "platform",
+              explanatoryCopy: "Default group status",
+              sortOrder: 3,
+              publicModels: [{ modelKey: "gpt-4.1", providerTypeOverride: "openai-compatible" }],
+            },
+          }),
+        },
+      ],
+      groupCounts: new Map(),
+    });
+
+    const mod = await import("@/app/[locale]/settings/status-page/loader");
+    const result = await mod.loadStatusPageSettings();
+
+    expect(result).toEqual({
+      initialWindowHours: 48,
+      initialAggregationIntervalMinutes: 15,
+      initialGroups: [
+        {
+          groupName: "default",
+          enabled: true,
+          displayName: "Platform",
+          publicGroupSlug: "platform",
+          explanatoryCopy: "Default group status",
+          sortOrder: 3,
+          publicModels: [{ modelKey: "gpt-4.1", providerTypeOverride: "openai-compatible" }],
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- treat blank/null provider group tags as the `default` group consistently across public status aggregation, provider bootstrap/group counts, proxy provider matching, and request-filter binding
- expose `default` in request-filter provider-group options and keep it ordered first for admin selection flows
- add regression coverage for public-status publishing/routes/views, provider settings UI, proxy group matching, and request-filter default fallback behavior

## Problem

Provider group tags that were blank, null, or undefined were handled inconsistently across the codebase:

- **Public status aggregation** (`src/lib/public-status/aggregation.ts`) - providers with empty group tags were excluded from aggregation entirely
- **Provider bootstrap** (`src/lib/provider-groups/bootstrap.ts`) - empty tags defaulted to `default` but with ad-hoc logic
- **Request filters** (`src/actions/request-filters.ts`) - providers with null/blank tags were excluded from group selection options
- **Proxy matching** (`src/app/v1/_lib/proxy/provider-selector.ts`) - inconsistent fallback handling for null tags
- **Provider manager UI** - `default` group wasn't consistently available for selection

This inconsistency caused providers without explicit group tags to appear/disappear from group-based filtering and public status pages depending on which code path handled them.

## Solution

Introduced `resolveProviderGroupsWithDefault()` utility in `src/lib/utils/provider-group.ts` that centralizes the "blank/null → default" resolution logic. This single source of truth is now used across:

| Component | Before | After |
|-----------|--------|-------|
| Public status aggregation | Skip empty groups | Attribute to `default` group |
| Provider bootstrap | Ad-hoc default handling | `resolveProviderGroupsWithDefault()` |
| Request filter groups | Exclude null/blank tags | Include `default` in options |
| Proxy group matching | Inline null check | Centralized resolution |
| Provider manager UI | Manual default detection | Unified filtering |

## Related PRs

- Follow-up to #1078 — Redis-backed public status runtime (where default group attribution was first identified as inconsistent)
- Related to #1081 — Public status APIs (this fix ensures consistent group behavior in API responses)
- Part of the public-status feature series: #1056 → #1076 → #1077 → #1078 → #1080 → #1081

## Changes

### Core Changes
- `src/lib/utils/provider-group.ts` - Added `resolveProviderGroupsWithDefault()` utility
- `src/lib/public-status/aggregation.ts` - Use `resolveProviderGroupsWithDefault()` for chain item group attribution
- `src/lib/provider-groups/bootstrap.ts` - Replace ad-hoc default handling with utility
- `src/actions/providers.ts` - Use utility for group count aggregation
- `src/actions/request-filters.ts` - Include `default` in selectable groups, ordered first
- `src/app/v1/_lib/proxy/provider-selector.ts` - Consistent group matching with utility
- `src/lib/request-filter-engine.ts` - Use utility for filter binding

### UI Changes
- `src/app/[locale]/settings/providers/_components/provider-group-tab.tsx` - Unified group filtering
- `src/app/[locale]/settings/providers/_components/provider-manager.tsx` - Consistent default group handling in filters and batch selection

### Test Coverage (19 files, 148 tests)
- `tests/unit/actions/providers-group-count.test.ts` (new) - Group count with default fallback
- `tests/unit/actions/request-filters-provider-groups.test.ts` (new) - Default group in filter options
- `tests/unit/public-status/aggregation.test.ts` - Default group attribution in aggregation
- `tests/unit/public-status/config-publisher.test.ts` - Config publishing with groups
- `tests/unit/public-status/rebuild-worker.test.ts` - Rebuild lifecycle
- `tests/unit/public-status/public-status-view.test.tsx` - UI view tests
- `tests/unit/public-status/status-page-title.test.tsx` - Page metadata
- `tests/unit/public-status/status-slug-page.test.tsx` - Slug-based status pages
- `tests/unit/proxy/provider-group-match.test.ts` - Proxy group matching
- `tests/unit/settings/providers/provider-group-bootstrap.test.ts` - Bootstrap logic
- `tests/unit/settings/providers/provider-group-tab.test.tsx` - Group tab UI
- `tests/unit/settings/providers/provider-manager.test.tsx` - Provider manager
- `tests/unit/settings/status-page/public-status-settings-form.test.tsx` - Settings form
- `tests/unit/settings/status-page/status-page-loader.test.tsx` - Data loading
- `tests/unit/request-filter-binding.test.ts` - Filter binding logic
- `tests/unit/request-filter-advanced.test.ts` - Advanced filters
- `tests/integration/public-status/config-publish.test.ts` - End-to-end publishing
- `tests/integration/public-status/route-redis-only.test.ts` - Redis-only route tests
- `tests/integration/public-status/rebuild-lifecycle.test.ts` - Full rebuild lifecycle

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bunx vitest run tests/unit/actions/providers-group-count.test.ts tests/unit/actions/request-filters-provider-groups.test.ts tests/unit/request-filter-binding.test.ts tests/unit/request-filter-advanced.test.ts tests/unit/public-status/aggregation.test.ts tests/unit/public-status/rebuild-worker.test.ts tests/unit/public-status/config-publisher.test.ts tests/unit/public-status/public-status-view.test.tsx tests/unit/public-status/status-page-title.test.tsx tests/unit/public-status/status-slug-page.test.tsx tests/unit/proxy/provider-group-match.test.ts tests/unit/settings/providers/provider-group-bootstrap.test.ts tests/unit/settings/providers/provider-group-tab.test.tsx tests/unit/settings/providers/provider-manager.test.tsx tests/unit/settings/status-page/public-status-settings-form.test.tsx tests/unit/settings/status-page/status-page-loader.test.tsx tests/integration/public-status/config-publish.test.ts tests/integration/public-status/route-redis-only.test.ts tests/integration/public-status/rebuild-lifecycle.test.ts`
  - `19 files / 148 tests passed`

## Known Baseline

- full `bun run test` still fails on the pre-existing OOM in `src/components/ui/__tests__/map.test.tsx`
- reproduced in both this worktree and the root `dev` checkout
- evidence: `.sisyphus/evidence/repo-test.txt`, `.sisyphus/evidence/map-test-repro.txt`, `.sisyphus/evidence/map-test-repro-root.txt`

## Smoke

- local DB/Redis via `make -C dev db`
- local app smoke verified `/en/status` and `/en/status/platform` with `Platform` / `GPT-4.1`
- screenshot (EN): https://i.111666.best/image/COf2FI2EhCZFOEqnBJPN8b.png
- screenshot (ZH): https://i.111666.best/image/nok779Ey8WCLRhP074foYB.png

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR centralizes blank/null provider group tag resolution into a new `resolveProviderGroupsWithDefault()` utility and applies it consistently across aggregation, bootstrap, proxy matching, request-filter binding, and the provider manager UI. The implementation is clean and the 148-test suite covers all affected code paths thoroughly.

No blocking issues were found; the change is a straightforward refactor that removes duplicated ad-hoc logic and makes the \"no group tag → default group\" behaviour uniform across the codebase.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — clean refactor with no logic regressions, all call sites verified, 148 tests pass.

All changes are mechanical substitutions of ad-hoc null-guard logic with a well-tested central utility. No new code paths, no schema changes, no security concerns. Both imports of the old parseProviderGroups that remain are intentional and still correct for user-group parsing and search. All remaining notes are P2 style observations only.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/utils/provider-group.ts | Adds resolveProviderGroupsWithDefault(): returns [PROVIDER_GROUP.DEFAULT] for empty/null/blank input, delegates to existing parseProviderGroups otherwise. Implementation is correct and minimal. |
| src/lib/public-status/aggregation.ts | Replaces parseProviderGroups + early-continue guard with resolveProviderGroupsWithDefault, so chain items with null/blank groupTag are now attributed to the default group rather than silently skipped. |
| src/lib/provider-groups/bootstrap.ts | Replaces ad-hoc empty-groups branch with resolveProviderGroupsWithDefault, removing ~7 lines of bespoke default-group attribution logic. |
| src/actions/providers.ts | getProviderGroupsWithCount uses the new utility instead of a manual isEmpty branch; behaviour is unchanged but logic is now DRY. |
| src/actions/request-filters.ts | getDistinctProviderGroupsAction simplifies the DB query (drops isNotNull/ne filter), seeds the Set with PROVIDER_GROUP.DEFAULT so the group is always present, and orders default first. Logic is correct. |
| src/app/v1/_lib/proxy/provider-selector.ts | checkProviderGroupMatch replaces inline ternary null-guard with resolveProviderGroupsWithDefault; parseProviderGroups is still correctly used for the user-side group parsing paths on lines 81 and 1128. |
| src/lib/request-filter-engine.ts | Both applyForProvider Set constructions (guard filters and final filters) now use resolveProviderGroupsWithDefault, enabling default-group filter rules to apply to providers with no explicit groupTag. |
| src/app/[locale]/settings/providers/_components/provider-manager.tsx | Group enumeration, filter, and batch-select paths all migrated to resolveProviderGroupsWithDefault; parseProviderGroups is retained for the two unrelated user-facing search/group-parse operations. |
| src/app/[locale]/settings/providers/_components/provider-group-tab.tsx | filterGroupMembers simplified from a 5-line predicate to a one-liner using the new utility; semantics are identical. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["provider.groupTag (null / blank / 'a,b')"] --> B["resolveProviderGroupsWithDefault()"]
    B -->|"empty after parse"| C["['default']"]
    B -->|"non-empty after parse"| D["['a', 'b', ...]"]

    C --> E1["Public Status Aggregation\naggregation.ts"]
    C --> E2["Provider Bootstrap\nbootstrap.ts"]
    C --> E3["Group Count\nproviders.ts"]
    C --> E4["Request Filter Binding\nrequest-filter-engine.ts"]
    C --> E5["Proxy Group Match\nprovider-selector.ts"]
    C --> E6["Provider Manager UI\nprovider-manager.tsx\nprovider-group-tab.tsx"]
    C --> E7["Request Filter Options\nrequest-filters.ts"]

    D --> E1
    D --> E2
    D --> E3
    D --> E4
    D --> E5
    D --> E6
    D --> E7
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tests): address default-group review..."](https://github.com/ding113/claude-code-hub/commit/ee1ebe762764faeee903d5ad2d53e30a19a54be0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29426676)</sub>

<!-- /greptile_comment -->