### PR TITLE
feat(quota): 用户/Key 限额数字支持快捷编辑（设置 + 增量）

### DIFF
--- a/messages/en/quota.json
+++ b/messages/en/quota.json
@@ -384,5 +384,24 @@
         }
       }
     }
+  },
+  "quickEdit": {
+    "title": "Adjust Limit",
+    "currentLabel": "Current",
+    "noLimit": "Unlimited",
+    "tabs": {
+      "set": "Set value",
+      "add": "Add value"
+    },
+    "setPlaceholder": "Enter new limit (empty = unlimited)",
+    "addPlaceholder": "Enter increment",
+    "preview": "New limit: {value}",
+    "previewNoLimit": "Will clear limit (unlimited)",
+    "save": "Save",
+    "cancel": "Cancel",
+    "saveSuccess": "Limit updated",
+    "saveFailed": "Update failed",
+    "invalidNumber": "Please enter a valid number",
+    "negativeNotAllowed": "Cannot be negative"
   }
 }

--- a/messages/ja/quota.json
+++ b/messages/ja/quota.json
@@ -361,5 +361,24 @@
         }
       }
     }
+  },
+  "quickEdit": {
+    "title": "上限の調整",
+    "currentLabel": "現在",
+    "noLimit": "無制限",
+    "tabs": {
+      "set": "値を設定",
+      "add": "値を追加"
+    },
+    "setPlaceholder": "新しい上限を入力（空=無制限）",
+    "addPlaceholder": "追加する値を入力",
+    "preview": "新しい上限：{value}",
+    "previewNoLimit": "上限をクリア（無制限）",
+    "save": "保存",
+    "cancel": "キャンセル",
+    "saveSuccess": "上限を更新しました",
+    "saveFailed": "更新に失敗しました",
+    "invalidNumber": "有効な数値を入力してください",
+    "negativeNotAllowed": "負の値は入力できません"
   }
 }

--- a/messages/ru/quota.json
+++ b/messages/ru/quota.json
@@ -384,5 +384,24 @@
         }
       }
     }
+  },
+  "quickEdit": {
+    "title": "Изменить лимит",
+    "currentLabel": "Текущий",
+    "noLimit": "Без лимита",
+    "tabs": {
+      "set": "Задать значение",
+      "add": "Увеличить"
+    },
+    "setPlaceholder": "Введите новый лимит (пусто = без лимита)",
+    "addPlaceholder": "Введите прирост",
+    "preview": "Новый лимит: {value}",
+    "previewNoLimit": "Лимит будет снят (без лимита)",
+    "save": "Сохранить",
+    "cancel": "Отмена",
+    "saveSuccess": "Лимит обновлён",
+    "saveFailed": "Ошибка обновления",
+    "invalidNumber": "Введите корректное число",
+    "negativeNotAllowed": "Не может быть отрицательным"
   }
 }

--- a/messages/zh-CN/quota.json
+++ b/messages/zh-CN/quota.json
@@ -384,5 +384,24 @@
         }
       }
     }
+  },
+  "quickEdit": {
+    "title": "调整限额",
+    "currentLabel": "当前",
+    "noLimit": "无限额",
+    "tabs": {
+      "set": "设置值",
+      "add": "增加值"
+    },
+    "setPlaceholder": "输入新限额（留空=无限额）",
+    "addPlaceholder": "输入要增加的值",
+    "preview": "新限额：{value}",
+    "previewNoLimit": "将清除限额（无限额）",
+    "save": "保存",
+    "cancel": "取消",
+    "saveSuccess": "限额已更新",
+    "saveFailed": "更新失败",
+    "invalidNumber": "请输入有效数字",
+    "negativeNotAllowed": "不能为负数"
   }
 }

--- a/messages/zh-TW/quota.json
+++ b/messages/zh-TW/quota.json
@@ -359,5 +359,24 @@
         }
       }
     }
+  },
+  "quickEdit": {
+    "title": "調整限額",
+    "currentLabel": "當前",
+    "noLimit": "無限額",
+    "tabs": {
+      "set": "設定值",
+      "add": "增加值"
+    },
+    "setPlaceholder": "輸入新限額（留空=無限額）",
+    "addPlaceholder": "輸入要增加的值",
+    "preview": "新限額：{value}",
+    "previewNoLimit": "將清除限額（無限額）",
+    "save": "儲存",
+    "cancel": "取消",
+    "saveSuccess": "限額已更新",
+    "saveFailed": "更新失敗",
+    "invalidNumber": "請輸入有效數字",
+    "negativeNotAllowed": "不能為負數"
   }
 }

--- a/src/actions/keys.ts
+++ b/src/actions/keys.ts
@@ -1402,3 +1402,137 @@ export async function renewKeyExpiresAt(
     return { ok: false, error: message, errorCode: ERROR_CODES.UPDATE_FAILED };
   }
 }
+
+/**
+ * 仅更新密钥的某个限额字段，避免触发完整 KeyFormSchema 默认值覆盖（保护 providerGroup
+ * / canLoginWebUi / dailyResetMode 等未传字段）。
+ *
+ * 用于 Key 限额使用情况弹窗 / 限额管理页的快捷编辑。
+ */
+export type PatchKeyLimitField =
+  | "limit5hUsd"
+  | "limitDailyUsd"
+  | "limitWeeklyUsd"
+  | "limitMonthlyUsd"
+  | "limitTotalUsd"
+  | "limitConcurrentSessions";
+
+export async function patchKeyLimit(
+  keyId: number,
+  field: PatchKeyLimitField,
+  value: number | null
+): Promise<ActionResult> {
+  try {
+    const tError = await getTranslations("errors");
+
+    const session = await getSession();
+    if (!session) {
+      return {
+        ok: false,
+        error: tError("UNAUTHORIZED"),
+        errorCode: ERROR_CODES.UNAUTHORIZED,
+      };
+    }
+
+    const key = await findKeyById(keyId);
+    if (!key) {
+      return { ok: false, error: tError("KEY_NOT_FOUND"), errorCode: ERROR_CODES.NOT_FOUND };
+    }
+
+    if (session.user.role !== "admin" && session.user.id !== key.userId) {
+      return {
+        ok: false,
+        error: tError("PERMISSION_DENIED"),
+        errorCode: ERROR_CODES.PERMISSION_DENIED,
+      };
+    }
+
+    // 校验：负数与整数列
+    if (field === "limitConcurrentSessions") {
+      if (value == null || !Number.isInteger(value) || value < 0 || value > 1000) {
+        return {
+          ok: false,
+          error: tError("INVALID_FORMAT"),
+          errorCode: ERROR_CODES.INVALID_FORMAT,
+        };
+      }
+    } else if (value != null && (!Number.isFinite(value) || value < 0)) {
+      return { ok: false, error: tError("INVALID_FORMAT"), errorCode: ERROR_CODES.INVALID_FORMAT };
+    }
+
+    // 服务端校验：Key 限额不能超过用户限额
+    const { findUserById } = await import("@/repository/user");
+    const user = await findUserById(key.userId);
+    if (!user) {
+      return { ok: false, error: "用户不存在" };
+    }
+
+    const checkExceed = (
+      keyVal: number | null,
+      userVal: number | null | undefined,
+      errKey: string
+    ): ActionResult | null => {
+      if (keyVal != null && keyVal > 0 && userVal != null && userVal > 0 && keyVal > userVal) {
+        return {
+          ok: false,
+          error: tError(errKey, { keyLimit: String(keyVal), userLimit: String(userVal) }),
+        };
+      }
+      return null;
+    };
+
+    const exceed =
+      field === "limit5hUsd"
+        ? checkExceed(value, user.limit5hUsd, "KEY_LIMIT_5H_EXCEEDS_USER_LIMIT")
+        : field === "limitDailyUsd"
+          ? checkExceed(value, user.dailyQuota, "KEY_LIMIT_DAILY_EXCEEDS_USER_LIMIT")
+          : field === "limitWeeklyUsd"
+            ? checkExceed(value, user.limitWeeklyUsd, "KEY_LIMIT_WEEKLY_EXCEEDS_USER_LIMIT")
+            : field === "limitMonthlyUsd"
+              ? checkExceed(value, user.limitMonthlyUsd, "KEY_LIMIT_MONTHLY_EXCEEDS_USER_LIMIT")
+              : field === "limitTotalUsd"
+                ? checkExceed(value, user.limitTotalUsd, "KEY_LIMIT_TOTAL_EXCEEDS_USER_LIMIT")
+                : field === "limitConcurrentSessions"
+                  ? checkExceed(
+                      value,
+                      user.limitConcurrentSessions,
+                      "KEY_LIMIT_CONCURRENT_EXCEEDS_USER_LIMIT"
+                    )
+                  : null;
+    if (exceed) return exceed;
+
+    // 字段映射：camelCase → snake_case（updateKey 仓库层只写 defined 字段）
+    const dbFieldMap: Record<PatchKeyLimitField, string> = {
+      limit5hUsd: "limit_5h_usd",
+      limitDailyUsd: "limit_daily_usd",
+      limitWeeklyUsd: "limit_weekly_usd",
+      limitMonthlyUsd: "limit_monthly_usd",
+      limitTotalUsd: "limit_total_usd",
+      limitConcurrentSessions: "limit_concurrent_sessions",
+    };
+
+    await updateKey(keyId, {
+      [dbFieldMap[field]]: value,
+    } as Parameters<typeof updateKey>[1]);
+
+    await invalidateCachedKey(key.key).catch(() => null);
+    revalidatePath("/dashboard");
+
+    emitActionAudit({
+      category: "key",
+      action: "key.update",
+      targetType: "key",
+      targetId: String(keyId),
+      targetName: key.name,
+      after: { [field]: value },
+      success: true,
+    });
+
+    return { ok: true };
+  } catch (error) {
+    logger.error("快捷更新密钥限额失败:", error);
+    const tError = await getTranslations("errors");
+    const message = error instanceof Error ? error.message : tError("UPDATE_KEY_FAILED");
+    return { ok: false, error: message, errorCode: ERROR_CODES.UPDATE_FAILED };
+  }
+}

--- a/src/app/[locale]/dashboard/_components/user/key-quota-usage-dialog.tsx
+++ b/src/app/[locale]/dashboard/_components/user/key-quota-usage-dialog.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { getKeyQuotaUsage, type KeyQuotaItem, type KeyQuotaUsageResult } from "@/actions/key-quota";
-import { editKey } from "@/actions/keys";
+import { type PatchKeyLimitField, patchKeyLimit } from "@/actions/keys";
 import { QuotaProgress } from "@/components/quota/quota-progress";
 import { QuotaQuickEditPopover } from "@/components/quota/quota-quick-edit-popover";
 import { Button } from "@/components/ui/button";
@@ -17,6 +17,15 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { type CurrencyCode, formatCurrency } from "@/lib/utils";
+
+const KEY_FIELD_MAP: Record<KeyQuotaItem["type"], PatchKeyLimitField> = {
+  limit5h: "limit5hUsd",
+  limitDaily: "limitDailyUsd",
+  limitWeekly: "limitWeeklyUsd",
+  limitMonthly: "limitMonthlyUsd",
+  limitTotal: "limitTotalUsd",
+  limitSessions: "limitConcurrentSessions",
+};
 
 export interface KeyQuotaUsageDialogProps {
   open: boolean;
@@ -112,15 +121,6 @@ export function KeyQuotaUsageDialog({
     return LIMIT_TYPE_ORDER.indexOf(a.type) - LIMIT_TYPE_ORDER.indexOf(b.type);
   });
 
-  const KEY_FIELD_MAP: Record<KeyQuotaItem["type"], string> = {
-    limit5h: "limit5hUsd",
-    limitDaily: "limitDailyUsd",
-    limitWeekly: "limitWeeklyUsd",
-    limitMonthly: "limitMonthlyUsd",
-    limitTotal: "limitTotalUsd",
-    limitSessions: "limitConcurrentSessions",
-  };
-
   const handleSaveLimit = useCallback(
     async (type: KeyQuotaItem["type"], newLimit: number | null) => {
       const field = KEY_FIELD_MAP[type];
@@ -128,10 +128,7 @@ export function KeyQuotaUsageDialog({
       try {
         const value =
           type === "limitSessions" ? (newLimit == null ? 0 : Math.round(newLimit)) : newLimit;
-        const res = await editKey(keyId, {
-          name: data?.keyName || keyName,
-          [field]: value,
-        } as Parameters<typeof editKey>[1]);
+        const res = await patchKeyLimit(keyId, field, value);
         if (!res.ok) {
           toast.error(res.error || tEdit("saveFailed"));
           return false;
@@ -145,7 +142,7 @@ export function KeyQuotaUsageDialog({
         return false;
       }
     },
-    [keyId, keyName, data?.keyName, fetchData, tEdit]
+    [keyId, fetchData, tEdit]
   );
 
   return (

--- a/src/app/[locale]/dashboard/_components/user/key-quota-usage-dialog.tsx
+++ b/src/app/[locale]/dashboard/_components/user/key-quota-usage-dialog.tsx
@@ -5,7 +5,9 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { getKeyQuotaUsage, type KeyQuotaItem, type KeyQuotaUsageResult } from "@/actions/key-quota";
+import { editKey } from "@/actions/keys";
 import { QuotaProgress } from "@/components/quota/quota-progress";
+import { QuotaQuickEditPopover } from "@/components/quota/quota-quick-edit-popover";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -41,6 +43,7 @@ export function KeyQuotaUsageDialog({
   currencyCode: propCurrencyCode,
 }: KeyQuotaUsageDialogProps) {
   const t = useTranslations("dashboard.userManagement.keyQuotaUsageDialog");
+  const tEdit = useTranslations("quota.quickEdit");
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<KeyQuotaUsageResult | null>(null);
   const [error, setError] = useState(false);
@@ -109,6 +112,42 @@ export function KeyQuotaUsageDialog({
     return LIMIT_TYPE_ORDER.indexOf(a.type) - LIMIT_TYPE_ORDER.indexOf(b.type);
   });
 
+  const KEY_FIELD_MAP: Record<KeyQuotaItem["type"], string> = {
+    limit5h: "limit5hUsd",
+    limitDaily: "limitDailyUsd",
+    limitWeekly: "limitWeeklyUsd",
+    limitMonthly: "limitMonthlyUsd",
+    limitTotal: "limitTotalUsd",
+    limitSessions: "limitConcurrentSessions",
+  };
+
+  const handleSaveLimit = useCallback(
+    async (type: KeyQuotaItem["type"], newLimit: number | null) => {
+      const field = KEY_FIELD_MAP[type];
+      if (!field) return false;
+      try {
+        const value =
+          type === "limitSessions" ? (newLimit == null ? 0 : Math.round(newLimit)) : newLimit;
+        const res = await editKey(keyId, {
+          name: data?.keyName || keyName,
+          [field]: value,
+        } as Parameters<typeof editKey>[1]);
+        if (!res.ok) {
+          toast.error(res.error || tEdit("saveFailed"));
+          return false;
+        }
+        toast.success(tEdit("saveSuccess"));
+        await fetchData();
+        return true;
+      } catch (err) {
+        console.error("[KeyQuotaUsageDialog] save failed", err);
+        toast.error(tEdit("saveFailed"));
+        return false;
+      }
+    },
+    [keyId, keyName, data?.keyName, fetchData, tEdit]
+  );
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -147,8 +186,24 @@ export function KeyQuotaUsageDialog({
               <div key={item.type} className="space-y-1.5">
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-muted-foreground">{t(getLabelKey(item.type))}</span>
-                  <span className="font-medium">
-                    {formatValue(item.type, item.current)} / {formatLimit(item.type, item.limit)}
+                  <span className="font-medium tabular-nums">
+                    {formatValue(item.type, item.current)} /{" "}
+                    <QuotaQuickEditPopover
+                      currentLimit={item.limit}
+                      label={t(getLabelKey(item.type))}
+                      unit={item.type === "limitSessions" ? "integer" : "currency"}
+                      currencyCode={currencyCode}
+                      onSave={(newLimit) => handleSaveLimit(item.type, newLimit)}
+                      allowClear={item.type !== "limitSessions"}
+                    >
+                      <button
+                        type="button"
+                        className="underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded-sm cursor-pointer"
+                        aria-label={t(getLabelKey(item.type))}
+                      >
+                        {formatLimit(item.type, item.limit)}
+                      </button>
+                    </QuotaQuickEditPopover>
                   </span>
                 </div>
                 {item.limit !== null && item.limit > 0 && (

--- a/src/app/[locale]/dashboard/_components/user/user-key-table-row.tsx
+++ b/src/app/[locale]/dashboard/_components/user/user-key-table-row.tsx
@@ -234,6 +234,7 @@ export function UserKeyTableRow({
       }
       toast.success(tQuickEdit("saveSuccess"));
       clearUsageCache(user.id);
+      queryClient.invalidateQueries({ queryKey: ["users"] });
       router.refresh();
       return true;
     } catch (err) {
@@ -435,6 +436,7 @@ export function UserKeyTableRow({
               label={translations.columns.limitRpm}
               unit="integer"
               onSave={(v) => handleSaveUserLimit("rpm", v)}
+              allowClear={false}
             >
               <Badge
                 variant={rpm ? "secondary" : "outline"}

--- a/src/app/[locale]/dashboard/_components/user/user-key-table-row.tsx
+++ b/src/app/[locale]/dashboard/_components/user/user-key-table-row.tsx
@@ -15,15 +15,18 @@ import { useLocale, useTranslations } from "next-intl";
 import { useEffect, useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { removeKey } from "@/actions/keys";
-import { toggleUserEnabled } from "@/actions/users";
+import { editUser, toggleUserEnabled } from "@/actions/users";
+import { QuotaQuickEditPopover } from "@/components/quota/quota-quick-edit-popover";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useRouter } from "@/i18n/routing";
+import { clearUsageCache } from "@/lib/dashboard/user-limit-usage-cache";
 import { cn } from "@/lib/utils";
 import { getContrastTextColor, getGroupColor } from "@/lib/utils/color";
+import type { CurrencyCode } from "@/lib/utils/currency";
 import { getCurrencySymbol } from "@/lib/utils/currency";
 import { formatDate } from "@/lib/utils/date-format";
 import { parseProviderGroups } from "@/lib/utils/provider-group";
@@ -204,6 +207,43 @@ export function UserKeyTableRow({
 
   // Convert currencyCode to symbol for display
   const currencySymbol = getCurrencySymbol(currencyCode);
+  const tQuickEdit = useTranslations("quota.quickEdit");
+
+  type UserLimitField =
+    | "rpm"
+    | "dailyQuota"
+    | "limit5hUsd"
+    | "limitWeeklyUsd"
+    | "limitMonthlyUsd"
+    | "limitTotalUsd"
+    | "limitConcurrentSessions";
+
+  const handleSaveUserLimit = async (
+    field: UserLimitField,
+    newLimit: number | null
+  ): Promise<boolean> => {
+    if (!isAdmin) return false;
+    try {
+      // 整数字段：rpm / sessions
+      const isInt = field === "rpm" || field === "limitConcurrentSessions";
+      const value = isInt ? (newLimit == null ? 0 : Math.round(newLimit)) : newLimit;
+      const res = await editUser(user.id, { [field]: value } as Parameters<typeof editUser>[1]);
+      if (!res.ok) {
+        toast.error(res.error || tQuickEdit("saveFailed"));
+        return false;
+      }
+      toast.success(tQuickEdit("saveSuccess"));
+      clearUsageCache(user.id);
+      router.refresh();
+      return true;
+    } catch (err) {
+      console.error("[UserKeyTableRow] save user limit failed", err);
+      toast.error(tQuickEdit("saveFailed"));
+      return false;
+    }
+  };
+
+  const editableCurrencyCode = (currencyCode || "USD") as CurrencyCode;
 
   const handleDeleteKey = (keyId: number) => {
     startTransition(async () => {
@@ -389,14 +429,32 @@ export function UserKeyTableRow({
 
         {/* RPM 限额 */}
         <div className="px-2 flex items-center justify-center">
-          <Badge
-            variant={rpm ? "secondary" : "outline"}
-            className="px-2 py-0.5 tabular-nums text-xs"
-            title={`${translations.columns.limitRpm}: ${rpm ?? "-"}`}
-            aria-label={`${translations.columns.limitRpm}: ${rpm ?? "-"}`}
-          >
-            {rpm ?? "-"}
-          </Badge>
+          {isAdmin ? (
+            <QuotaQuickEditPopover
+              currentLimit={rpm}
+              label={translations.columns.limitRpm}
+              unit="integer"
+              onSave={(v) => handleSaveUserLimit("rpm", v)}
+            >
+              <Badge
+                variant={rpm ? "secondary" : "outline"}
+                className="px-2 py-0.5 tabular-nums text-xs cursor-pointer hover:ring-1 hover:ring-ring"
+                title={`${translations.columns.limitRpm}: ${rpm ?? "-"}`}
+                aria-label={`${translations.columns.limitRpm}: ${rpm ?? "-"}`}
+              >
+                {rpm ?? "-"}
+              </Badge>
+            </QuotaQuickEditPopover>
+          ) : (
+            <Badge
+              variant={rpm ? "secondary" : "outline"}
+              className="px-2 py-0.5 tabular-nums text-xs"
+              title={`${translations.columns.limitRpm}: ${rpm ?? "-"}`}
+              aria-label={`${translations.columns.limitRpm}: ${rpm ?? "-"}`}
+            >
+              {rpm ?? "-"}
+            </Badge>
+          )}
         </div>
 
         {/* 5h 限额 */}
@@ -407,6 +465,10 @@ export function UserKeyTableRow({
             limit={limit5h}
             label={translations.columns.limit5h}
             unit={currencySymbol}
+            editable={isAdmin}
+            onSave={(v) => handleSaveUserLimit("limit5hUsd", v)}
+            currencyCode={editableCurrencyCode}
+            editUnit="currency"
           />
         </div>
 
@@ -418,6 +480,10 @@ export function UserKeyTableRow({
             limit={limitDaily}
             label={translations.columns.limitDaily}
             unit={currencySymbol}
+            editable={isAdmin}
+            onSave={(v) => handleSaveUserLimit("dailyQuota", v)}
+            currencyCode={editableCurrencyCode}
+            editUnit="currency"
           />
         </div>
 
@@ -429,6 +495,10 @@ export function UserKeyTableRow({
             limit={limitWeekly}
             label={translations.columns.limitWeekly}
             unit={currencySymbol}
+            editable={isAdmin}
+            onSave={(v) => handleSaveUserLimit("limitWeeklyUsd", v)}
+            currencyCode={editableCurrencyCode}
+            editUnit="currency"
           />
         </div>
 
@@ -440,6 +510,10 @@ export function UserKeyTableRow({
             limit={limitMonthly}
             label={translations.columns.limitMonthly}
             unit={currencySymbol}
+            editable={isAdmin}
+            onSave={(v) => handleSaveUserLimit("limitMonthlyUsd", v)}
+            currencyCode={editableCurrencyCode}
+            editUnit="currency"
           />
         </div>
 
@@ -451,19 +525,42 @@ export function UserKeyTableRow({
             limit={limitTotal}
             label={translations.columns.limitTotal}
             unit={currencySymbol}
+            editable={isAdmin}
+            onSave={(v) => handleSaveUserLimit("limitTotalUsd", v)}
+            currencyCode={editableCurrencyCode}
+            editUnit="currency"
           />
         </div>
 
         {/* 并发限额 */}
         <div className="px-2 flex items-center justify-center">
-          <Badge
-            variant={limitSessions ? "secondary" : "outline"}
-            className="px-2 py-0.5 tabular-nums text-xs"
-            title={`${translations.columns.limitSessions}: ${limitSessions ?? "-"}`}
-            aria-label={`${translations.columns.limitSessions}: ${limitSessions ?? "-"}`}
-          >
-            {limitSessions ?? "-"}
-          </Badge>
+          {isAdmin ? (
+            <QuotaQuickEditPopover
+              currentLimit={limitSessions}
+              label={translations.columns.limitSessions}
+              unit="integer"
+              onSave={(v) => handleSaveUserLimit("limitConcurrentSessions", v)}
+              allowClear={false}
+            >
+              <Badge
+                variant={limitSessions ? "secondary" : "outline"}
+                className="px-2 py-0.5 tabular-nums text-xs cursor-pointer hover:ring-1 hover:ring-ring"
+                title={`${translations.columns.limitSessions}: ${limitSessions ?? "-"}`}
+                aria-label={`${translations.columns.limitSessions}: ${limitSessions ?? "-"}`}
+              >
+                {limitSessions ?? "-"}
+              </Badge>
+            </QuotaQuickEditPopover>
+          ) : (
+            <Badge
+              variant={limitSessions ? "secondary" : "outline"}
+              className="px-2 py-0.5 tabular-nums text-xs"
+              title={`${translations.columns.limitSessions}: ${limitSessions ?? "-"}`}
+              aria-label={`${translations.columns.limitSessions}: ${limitSessions ?? "-"}`}
+            >
+              {limitSessions ?? "-"}
+            </Badge>
+          )}
         </div>
 
         {/* 操作 */}

--- a/src/app/[locale]/dashboard/_components/user/user-limit-badge.tsx
+++ b/src/app/[locale]/dashboard/_components/user/user-limit-badge.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { QuotaQuickEditPopover } from "@/components/quota/quota-quick-edit-popover";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  clearUsageCache,
   getSharedUserLimitUsage,
   type LimitUsageData,
   peekCachedUserLimitUsage,
 } from "@/lib/dashboard/user-limit-usage-cache";
 import { cn } from "@/lib/utils";
+import type { CurrencyCode } from "@/lib/utils/currency";
 
 export type LimitType = "5h" | "daily" | "weekly" | "monthly" | "total";
 
@@ -18,6 +21,12 @@ export interface UserLimitBadgeProps {
   limit: number | null;
   label: string;
   unit?: string;
+  /** 可选：允许点击编辑。传入 onSave 后，Badge 成为可点击触发器 */
+  editable?: boolean;
+  onSave?: (newLimit: number | null) => Promise<boolean>;
+  currencyCode?: CurrencyCode;
+  /** 编辑器的数值类型（默认 currency） */
+  editUnit?: "currency" | "integer";
 }
 
 function formatPercentage(usage: number, limit: number): string {
@@ -55,6 +64,10 @@ export function UserLimitBadge({
   limit,
   label,
   unit = "",
+  editable = false,
+  onSave,
+  currencyCode = "USD",
+  editUnit = "currency",
 }: UserLimitBadgeProps) {
   const [usageData, setUsageData] = useState<LimitUsageData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -111,16 +124,37 @@ export function UserLimitBadge({
 
   // No limit set - show "-"
   if (limit === null || limit === undefined) {
-    return (
+    const noLimitBadge = (
       <Badge
         variant="outline"
-        className="px-2 py-0.5 tabular-nums text-xs"
+        className={cn(
+          "px-2 py-0.5 tabular-nums text-xs",
+          editable && onSave && "cursor-pointer hover:ring-1 hover:ring-ring"
+        )}
         title={`${label}: -`}
         aria-label={`${label}: -`}
       >
         -
       </Badge>
     );
+    if (editable && onSave) {
+      return (
+        <QuotaQuickEditPopover
+          currentLimit={null}
+          label={label}
+          unit={editUnit}
+          currencyCode={currencyCode}
+          onSave={async (v) => {
+            const ok = await onSave(v);
+            if (ok) clearUsageCache(userId);
+            return ok;
+          }}
+        >
+          {noLimitBadge}
+        </QuotaQuickEditPopover>
+      );
+    }
+    return noLimitBadge;
   }
 
   // Loading state
@@ -130,16 +164,37 @@ export function UserLimitBadge({
 
   // Error state - show just the limit value
   if (error || !usageData) {
-    return (
+    const errorBadge = (
       <Badge
         variant="secondary"
-        className="px-2 py-0.5 tabular-nums text-xs"
+        className={cn(
+          "px-2 py-0.5 tabular-nums text-xs",
+          editable && onSave && "cursor-pointer hover:ring-1 hover:ring-ring"
+        )}
         title={`${label}: ${formatValue(limit, unit)}`}
         aria-label={`${label}: ${formatValue(limit, unit)}`}
       >
         {formatValue(limit, unit)}
       </Badge>
     );
+    if (editable && onSave) {
+      return (
+        <QuotaQuickEditPopover
+          currentLimit={limit}
+          label={label}
+          unit={editUnit}
+          currencyCode={currencyCode}
+          onSave={async (v) => {
+            const ok = await onSave(v);
+            if (ok) clearUsageCache(userId);
+            return ok;
+          }}
+        >
+          {errorBadge}
+        </QuotaQuickEditPopover>
+      );
+    }
+    return errorBadge;
   }
 
   // Get usage for this limit type
@@ -152,14 +207,36 @@ export function UserLimitBadge({
   const colorClass = getPercentageColor(usage, limit);
   const statusText = `${formatValue(usage, unit)} / ${formatValue(limit, unit)}`;
 
-  return (
+  const percentBadge = (
     <Badge
       variant="secondary"
-      className={cn("px-2 py-0.5 tabular-nums text-xs", colorClass)}
+      className={cn(
+        "px-2 py-0.5 tabular-nums text-xs",
+        colorClass,
+        editable && onSave && "cursor-pointer hover:ring-1 hover:ring-ring"
+      )}
       title={`${label}: ${statusText}`}
       aria-label={`${label}: ${statusText}`}
     >
       {percentage}
     </Badge>
   );
+  if (editable && onSave) {
+    return (
+      <QuotaQuickEditPopover
+        currentLimit={limit}
+        label={label}
+        unit={editUnit}
+        currencyCode={currencyCode}
+        onSave={async (v) => {
+          const ok = await onSave(v);
+          if (ok) clearUsageCache(userId);
+          return ok;
+        }}
+      >
+        {percentBadge}
+      </QuotaQuickEditPopover>
+    );
+  }
+  return percentBadge;
 }

--- a/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
-import { editKey } from "@/actions/keys";
+import { type PatchKeyLimitField, patchKeyLimit } from "@/actions/keys";
 import { QuotaCountdownCompact } from "@/components/quota/quota-countdown";
 import { QuotaProgress } from "@/components/quota/quota-progress";
 import { QuotaQuickEditPopover } from "@/components/quota/quota-quick-edit-popover";
@@ -28,12 +28,7 @@ import { formatCurrency } from "@/lib/utils/currency";
 import { getUsageRate, hasKeyQuotaSet, isUserExceeded } from "@/lib/utils/quota-helpers";
 import { EditKeyQuotaDialog } from "./edit-key-quota-dialog";
 
-type KeyLimitField =
-  | "limit5hUsd"
-  | "limitDailyUsd"
-  | "limitWeeklyUsd"
-  | "limitMonthlyUsd"
-  | "limitConcurrentSessions";
+type KeyLimitField = PatchKeyLimitField;
 
 interface KeyQuota {
   cost5h: { current: number; limit: number | null; resetAt?: Date };
@@ -94,7 +89,7 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
   const handleSaveLimit = useCallback(
     async (
       keyId: number,
-      keyName: string,
+      _keyName: string,
       field: KeyLimitField,
       newLimit: number | null
     ): Promise<boolean> => {
@@ -105,10 +100,7 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
               ? 0
               : Math.round(newLimit)
             : newLimit;
-        const res = await editKey(keyId, {
-          name: keyName,
-          [field]: value,
-        } as Parameters<typeof editKey>[1]);
+        const res = await patchKeyLimit(keyId, field, value);
         if (!res.ok) {
           toast.error(res.error || tEdit("saveFailed"));
           return false;

--- a/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { Settings } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { editKey } from "@/actions/keys";
 import { QuotaCountdownCompact } from "@/components/quota/quota-countdown";
 import { QuotaProgress } from "@/components/quota/quota-progress";
+import { QuotaQuickEditPopover } from "@/components/quota/quota-quick-edit-popover";
 import { QuotaWindowType } from "@/components/quota/quota-window-type";
 import { UserQuotaHeader } from "@/components/quota/user-quota-header";
 import { Badge } from "@/components/ui/badge";
@@ -23,6 +27,13 @@ import type { CurrencyCode } from "@/lib/utils/currency";
 import { formatCurrency } from "@/lib/utils/currency";
 import { getUsageRate, hasKeyQuotaSet, isUserExceeded } from "@/lib/utils/quota-helpers";
 import { EditKeyQuotaDialog } from "./edit-key-quota-dialog";
+
+type KeyLimitField =
+  | "limit5hUsd"
+  | "limitDailyUsd"
+  | "limitWeeklyUsd"
+  | "limitMonthlyUsd"
+  | "limitConcurrentSessions";
 
 interface KeyQuota {
   cost5h: { current: number; limit: number | null; resetAt?: Date };
@@ -63,6 +74,8 @@ interface KeysQuotaClientProps {
 
 export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClientProps) {
   const t = useTranslations("quota.keys");
+  const tEdit = useTranslations("quota.quickEdit");
+  const router = useRouter();
   // 默认展开所有用户组
   const [openUsers, setOpenUsers] = useState<Set<number>>(new Set(users.map((user) => user.id)));
 
@@ -77,6 +90,40 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
       return newSet;
     });
   };
+
+  const handleSaveLimit = useCallback(
+    async (
+      keyId: number,
+      keyName: string,
+      field: KeyLimitField,
+      newLimit: number | null
+    ): Promise<boolean> => {
+      try {
+        const value =
+          field === "limitConcurrentSessions"
+            ? newLimit == null
+              ? 0
+              : Math.round(newLimit)
+            : newLimit;
+        const res = await editKey(keyId, {
+          name: keyName,
+          [field]: value,
+        } as Parameters<typeof editKey>[1]);
+        if (!res.ok) {
+          toast.error(res.error || tEdit("saveFailed"));
+          return false;
+        }
+        toast.success(tEdit("saveSuccess"));
+        router.refresh();
+        return true;
+      } catch (err) {
+        console.error("[KeysQuotaClient] save failed", err);
+        toast.error(tEdit("saveFailed"));
+        return false;
+      }
+    },
+    [router, tEdit]
+  );
 
   if (users.length === 0) {
     return (
@@ -162,7 +209,22 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
                                 <div className="flex items-center gap-2">
                                   <span className="text-xs font-mono">
                                     {formatCurrency(key.quota.cost5h.current, currencyCode)}/
-                                    {formatCurrency(key.quota.cost5h.limit, currencyCode)}
+                                    <QuotaQuickEditPopover
+                                      currentLimit={key.quota.cost5h.limit}
+                                      label={t("table.cost5h")}
+                                      unit="currency"
+                                      currencyCode={currencyCode}
+                                      onSave={(v) =>
+                                        handleSaveLimit(key.id, key.name, "limit5hUsd", v)
+                                      }
+                                    >
+                                      <button
+                                        type="button"
+                                        className="underline-offset-4 hover:underline cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                      >
+                                        {formatCurrency(key.quota.cost5h.limit, currencyCode)}
+                                      </button>
+                                    </QuotaQuickEditPopover>
                                   </span>
                                 </div>
                                 <QuotaProgress
@@ -196,7 +258,22 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
                                 <div className="flex items-center gap-2">
                                   <span className="text-xs font-mono">
                                     {formatCurrency(key.quota.costDaily.current, currencyCode)}/
-                                    {formatCurrency(key.quota.costDaily.limit, currencyCode)}
+                                    <QuotaQuickEditPopover
+                                      currentLimit={key.quota.costDaily.limit}
+                                      label={t("table.costDaily")}
+                                      unit="currency"
+                                      currencyCode={currencyCode}
+                                      onSave={(v) =>
+                                        handleSaveLimit(key.id, key.name, "limitDailyUsd", v)
+                                      }
+                                    >
+                                      <button
+                                        type="button"
+                                        className="underline-offset-4 hover:underline cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                      >
+                                        {formatCurrency(key.quota.costDaily.limit, currencyCode)}
+                                      </button>
+                                    </QuotaQuickEditPopover>
                                   </span>
                                 </div>
                                 <QuotaProgress
@@ -231,7 +308,22 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
                                 <div className="flex items-center gap-2">
                                   <span className="text-xs font-mono">
                                     {formatCurrency(key.quota.costWeekly.current, currencyCode)}/
-                                    {formatCurrency(key.quota.costWeekly.limit, currencyCode)}
+                                    <QuotaQuickEditPopover
+                                      currentLimit={key.quota.costWeekly.limit}
+                                      label={t("table.costWeekly")}
+                                      unit="currency"
+                                      currencyCode={currencyCode}
+                                      onSave={(v) =>
+                                        handleSaveLimit(key.id, key.name, "limitWeeklyUsd", v)
+                                      }
+                                    >
+                                      <button
+                                        type="button"
+                                        className="underline-offset-4 hover:underline cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                      >
+                                        {formatCurrency(key.quota.costWeekly.limit, currencyCode)}
+                                      </button>
+                                    </QuotaQuickEditPopover>
                                   </span>
                                 </div>
                                 <QuotaProgress
@@ -268,7 +360,22 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
                                 <div className="flex items-center gap-2">
                                   <span className="text-xs font-mono">
                                     {formatCurrency(key.quota.costMonthly.current, currencyCode)}/
-                                    {formatCurrency(key.quota.costMonthly.limit, currencyCode)}
+                                    <QuotaQuickEditPopover
+                                      currentLimit={key.quota.costMonthly.limit}
+                                      label={t("table.costMonthly")}
+                                      unit="currency"
+                                      currencyCode={currencyCode}
+                                      onSave={(v) =>
+                                        handleSaveLimit(key.id, key.name, "limitMonthlyUsd", v)
+                                      }
+                                    >
+                                      <button
+                                        type="button"
+                                        className="underline-offset-4 hover:underline cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                      >
+                                        {formatCurrency(key.quota.costMonthly.limit, currencyCode)}
+                                      </button>
+                                    </QuotaQuickEditPopover>
                                   </span>
                                 </div>
                                 <QuotaProgress
@@ -296,7 +403,27 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
                                 <div className="flex items-center gap-2">
                                   <span className="text-xs font-mono">
                                     {key.quota.concurrentSessions.current}/
-                                    {key.quota.concurrentSessions.limit}
+                                    <QuotaQuickEditPopover
+                                      currentLimit={key.quota.concurrentSessions.limit}
+                                      label={t("table.concurrentSessions")}
+                                      unit="integer"
+                                      onSave={(v) =>
+                                        handleSaveLimit(
+                                          key.id,
+                                          key.name,
+                                          "limitConcurrentSessions",
+                                          v
+                                        )
+                                      }
+                                      allowClear={false}
+                                    >
+                                      <button
+                                        type="button"
+                                        className="underline-offset-4 hover:underline cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                      >
+                                        {key.quota.concurrentSessions.limit}
+                                      </button>
+                                    </QuotaQuickEditPopover>
                                   </span>
                                 </div>
                                 <QuotaProgress

--- a/src/components/quota/quota-quick-edit-popover.tsx
+++ b/src/components/quota/quota-quick-edit-popover.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type * as React from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useMediaQuery } from "@/lib/hooks/use-media-query";
+import { type CurrencyCode, formatCurrency, getCurrencySymbol } from "@/lib/utils/currency";
+
+export type QuickEditMode = "set" | "add";
+export type QuickEditUnit = "currency" | "integer";
+
+/** 解析输入串为合法数值（整数模式下只接受整数） */
+export function parseQuickEditDraft(
+  draft: string,
+  unit: QuickEditUnit
+): number | null {
+  const trimmed = draft.trim();
+  if (trimmed.length === 0) return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n)) return null;
+  if (unit === "integer" && !Number.isInteger(n)) return null;
+  return n;
+}
+
+/** 根据当前限额、输入和模式计算最终限额（null = 无限额） */
+export function computeQuickEditLimit(
+  mode: QuickEditMode,
+  draft: string,
+  currentLimit: number | null,
+  unit: QuickEditUnit,
+  allowClear: boolean
+): number | null {
+  const parsed = parseQuickEditDraft(draft, unit);
+  if (mode === "add") {
+    if (parsed == null) return null;
+    return (currentLimit ?? 0) + parsed;
+  }
+  // set 模式
+  if (draft.trim().length === 0) return null;
+  if (parsed == null) return null;
+  if (allowClear && parsed === 0) return null;
+  return parsed;
+}
+
+export interface QuotaQuickEditPopoverProps {
+  /** 当前限额值，null 表示未设置 */
+  currentLimit: number | null;
+  /** 字段人类可读名称，如「5小时限额」 */
+  label: string;
+  /** 数值类型 */
+  unit?: QuickEditUnit;
+  /** unit=currency 时使用 */
+  currencyCode?: CurrencyCode;
+  /** 保存回调，返回 true 表示成功 */
+  onSave: (newLimit: number | null) => Promise<boolean>;
+  /** 是否禁用 */
+  disabled?: boolean;
+  /** 触发器节点 */
+  children: React.ReactNode;
+  /** 是否允许置空（设置为无限额）。整数列（如 sessions）通常不允许 */
+  allowClear?: boolean;
+}
+
+function formatPreview(
+  value: number,
+  unit: QuickEditUnit,
+  currencyCode: CurrencyCode = "USD"
+): string {
+  if (unit === "currency") return formatCurrency(value, currencyCode);
+  return String(Math.round(value));
+}
+
+export function QuotaQuickEditPopover({
+  currentLimit,
+  label,
+  unit = "currency",
+  currencyCode = "USD",
+  onSave,
+  disabled = false,
+  children,
+  allowClear = true,
+}: QuotaQuickEditPopoverProps) {
+  const t = useTranslations("quota.quickEdit");
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<QuickEditMode>("set");
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const trimmed = draft.trim();
+
+  const parsedDelta = useMemo(
+    () => parseQuickEditDraft(draft, unit),
+    [draft, unit]
+  );
+
+  // 计算最终限额
+  const computedLimit = useMemo<number | null>(
+    () => computeQuickEditLimit(mode, draft, currentLimit, unit, allowClear),
+    [mode, draft, currentLimit, unit, allowClear]
+  );
+
+  const validationError = useMemo<string | null>(() => {
+    if (trimmed.length === 0) {
+      // set 模式允许空（=清除）；add 模式必须填
+      if (mode === "add") return null;
+      return null;
+    }
+    if (parsedDelta == null) return t("invalidNumber");
+    if (parsedDelta < 0) return t("negativeNotAllowed");
+    if (mode === "add" && (currentLimit ?? 0) + parsedDelta < 0) {
+      return t("negativeNotAllowed");
+    }
+    return null;
+  }, [trimmed, parsedDelta, mode, currentLimit, t]);
+
+  const canSave = useMemo(() => {
+    if (disabled || saving || validationError != null) return false;
+    if (mode === "add") {
+      // 增量模式：必须输入大于 0 的值
+      return parsedDelta != null && parsedDelta > 0;
+    }
+    // set 模式：允许空（清除）或有效数值
+    if (trimmed.length === 0) return allowClear;
+    return parsedDelta != null;
+  }, [disabled, saving, validationError, mode, parsedDelta, trimmed, allowClear]);
+
+  // 打开时聚焦
+  useEffect(() => {
+    if (!open) return;
+    const raf = requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [open]);
+
+  const stopPropagation = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (disabled && next) return;
+    if (next) {
+      setMode("set");
+      setDraft("");
+      setSaving(false);
+    }
+    setOpen(next);
+  };
+
+  const handleCancel = () => {
+    setOpen(false);
+  };
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      const ok = await onSave(computedLimit);
+      if (ok) setOpen(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const currentDisplay =
+    currentLimit == null
+      ? t("noLimit")
+      : unit === "currency"
+        ? formatCurrency(currentLimit, currencyCode)
+        : String(currentLimit);
+
+  const previewText = useMemo(() => {
+    if (mode === "add") {
+      if (parsedDelta == null || parsedDelta <= 0) return null;
+      if (computedLimit == null) return null;
+      const base = currentLimit ?? 0;
+      return `${formatPreview(base, unit, currencyCode)} + ${formatPreview(parsedDelta, unit, currencyCode)} = ${formatPreview(computedLimit, unit, currencyCode)}`;
+    }
+    if (computedLimit == null) return t("previewNoLimit");
+    return t("preview", { value: formatPreview(computedLimit, unit, currencyCode) });
+  }, [mode, parsedDelta, computedLimit, currentLimit, unit, currencyCode, t]);
+
+  const suffix = unit === "currency" ? getCurrencySymbol(currencyCode) : null;
+
+  const formContent = (
+    <div className="grid gap-3 min-w-[260px]">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-medium">{label}</span>
+        <span className="text-xs text-muted-foreground tabular-nums">
+          {t("currentLabel")}: {currentDisplay}
+        </span>
+      </div>
+
+      <Tabs value={mode} onValueChange={(v) => setMode(v as QuickEditMode)}>
+        <TabsList className="grid w-full grid-cols-2 h-8">
+          <TabsTrigger value="set" className="text-xs">
+            {t("tabs.set")}
+          </TabsTrigger>
+          <TabsTrigger value="add" className="text-xs">
+            {t("tabs.add")}
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      <div className="flex items-center gap-2">
+        {suffix && <span className="text-sm text-muted-foreground">{suffix}</span>}
+        <Input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          disabled={disabled || saving}
+          className="tabular-nums"
+          aria-label={label}
+          aria-invalid={validationError != null}
+          type="number"
+          inputMode="decimal"
+          step={unit === "integer" ? "1" : "any"}
+          min="0"
+          placeholder={mode === "add" ? t("addPlaceholder") : t("setPlaceholder")}
+          onPointerDown={stopPropagation}
+          onClick={stopPropagation}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === "Escape") {
+              e.preventDefault();
+              handleCancel();
+            } else if (e.key === "Enter") {
+              e.preventDefault();
+              void handleSave();
+            }
+          }}
+        />
+      </div>
+
+      {validationError ? (
+        <div className="text-xs text-destructive">{validationError}</div>
+      ) : previewText ? (
+        <div className="text-xs text-muted-foreground tabular-nums">{previewText}</div>
+      ) : null}
+
+      <div className="flex items-center justify-end gap-2 pt-1">
+        <Button type="button" size="sm" variant="outline" onClick={handleCancel} disabled={saving}>
+          {t("cancel")}
+        </Button>
+        <Button type="button" size="sm" onClick={handleSave} disabled={!canSave}>
+          {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {t("save")}
+        </Button>
+      </div>
+    </div>
+  );
+
+  if (!isDesktop) {
+    return (
+      <>
+        <span
+          onClick={(e) => {
+            if (disabled) return;
+            e.stopPropagation();
+            handleOpenChange(true);
+          }}
+        >
+          {children}
+        </span>
+        <Drawer open={open} onOpenChange={handleOpenChange}>
+          <DrawerContent>
+            <DrawerHeader>
+              <DrawerTitle>{label}</DrawerTitle>
+            </DrawerHeader>
+            <div className="px-4 pb-6">{formContent}</div>
+          </DrawerContent>
+        </Drawer>
+      </>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent
+        align="center"
+        side="bottom"
+        sideOffset={6}
+        className="w-auto p-3"
+        onPointerDown={stopPropagation}
+        onClick={stopPropagation}
+      >
+        {formContent}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/quota/quota-quick-edit-popover.tsx
+++ b/src/components/quota/quota-quick-edit-popover.tsx
@@ -39,6 +39,7 @@ export function computeQuickEditLimit(
     return (currentLimit ?? 0) + parsed;
   }
   // set 模式
+  // 空输入：仅在允许 clear 时视为「清除限额」，否则视为非法（返回 null 由调用方拒绝保存）
   if (draft.trim().length === 0) return null;
   if (parsed == null) return null;
   if (allowClear && parsed === 0) return null;
@@ -123,9 +124,13 @@ export function QuotaQuickEditPopover({
       // 增量模式：必须输入大于 0 的值
       return parsedDelta != null && parsedDelta > 0;
     }
-    // set 模式：允许空（清除）或有效数值
+    // set 模式：
+    // - 空输入：仅 allowClear=true 时允许（=清除限额）
+    // - 有效数值：allowClear=false 时禁止 0（避免「封禁」语义如 RPM）
     if (trimmed.length === 0) return allowClear;
-    return parsedDelta != null;
+    if (parsedDelta == null) return false;
+    if (!allowClear && parsedDelta === 0) return false;
+    return true;
   }, [disabled, saving, validationError, mode, parsedDelta, trimmed, allowClear]);
 
   // 打开时聚焦
@@ -258,15 +263,23 @@ export function QuotaQuickEditPopover({
   if (!isDesktop) {
     return (
       <>
-        <span
+        <button
+          type="button"
+          disabled={disabled}
+          className={
+            disabled
+              ? "inline-flex items-center cursor-default"
+              : "inline-flex items-center cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          }
           onClick={(e) => {
             if (disabled) return;
             e.stopPropagation();
             handleOpenChange(true);
           }}
+          onPointerDown={(e) => e.stopPropagation()}
         >
           {children}
-        </span>
+        </button>
         <Drawer open={open} onOpenChange={handleOpenChange}>
           <DrawerContent>
             <DrawerHeader>
@@ -281,7 +294,15 @@ export function QuotaQuickEditPopover({
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverTrigger asChild>
+        <span
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          {children}
+        </span>
+      </PopoverTrigger>
       <PopoverContent
         align="center"
         side="bottom"

--- a/src/components/quota/quota-quick-edit-popover.tsx
+++ b/src/components/quota/quota-quick-edit-popover.tsx
@@ -16,10 +16,7 @@ export type QuickEditMode = "set" | "add";
 export type QuickEditUnit = "currency" | "integer";
 
 /** 解析输入串为合法数值（整数模式下只接受整数） */
-export function parseQuickEditDraft(
-  draft: string,
-  unit: QuickEditUnit
-): number | null {
+export function parseQuickEditDraft(draft: string, unit: QuickEditUnit): number | null {
   const trimmed = draft.trim();
   if (trimmed.length === 0) return null;
   const n = Number(trimmed);
@@ -98,10 +95,7 @@ export function QuotaQuickEditPopover({
 
   const trimmed = draft.trim();
 
-  const parsedDelta = useMemo(
-    () => parseQuickEditDraft(draft, unit),
-    [draft, unit]
-  );
+  const parsedDelta = useMemo(() => parseQuickEditDraft(draft, unit), [draft, unit]);
 
   // 计算最终限额
   const computedLimit = useMemo<number | null>(

--- a/tests/unit/components/quota-quick-edit-popover.test.tsx
+++ b/tests/unit/components/quota-quick-edit-popover.test.tsx
@@ -35,11 +35,15 @@ describe("computeQuickEditLimit - set 模式", () => {
     expect(computeQuickEditLimit("set", "", 100, "currency", true)).toBeNull();
   });
 
+  test("空输入 + allowClear=false → null（拒绝清除，由 canSave 阻止保存）", () => {
+    expect(computeQuickEditLimit("set", "", 100, "integer", false)).toBeNull();
+  });
+
   test("输入 0 + allowClear=true → null", () => {
     expect(computeQuickEditLimit("set", "0", 100, "currency", true)).toBeNull();
   });
 
-  test("输入 0 + allowClear=false → 0（保留）", () => {
+  test("输入 0 + allowClear=false → 0（保留，由调用方逻辑/canSave 判定）", () => {
     expect(computeQuickEditLimit("set", "0", 100, "integer", false)).toBe(0);
   });
 

--- a/tests/unit/components/quota-quick-edit-popover.test.tsx
+++ b/tests/unit/components/quota-quick-edit-popover.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+  computeQuickEditLimit,
+  parseQuickEditDraft,
+} from "@/components/quota/quota-quick-edit-popover";
+
+describe("parseQuickEditDraft", () => {
+  test("空字符串返回 null", () => {
+    expect(parseQuickEditDraft("", "currency")).toBeNull();
+    expect(parseQuickEditDraft("   ", "currency")).toBeNull();
+  });
+
+  test("非法数字返回 null", () => {
+    expect(parseQuickEditDraft("abc", "currency")).toBeNull();
+    expect(parseQuickEditDraft("1.2.3", "currency")).toBeNull();
+  });
+
+  test("currency 接受小数", () => {
+    expect(parseQuickEditDraft("12.5", "currency")).toBe(12.5);
+    expect(parseQuickEditDraft("0", "currency")).toBe(0);
+  });
+
+  test("integer 拒绝小数", () => {
+    expect(parseQuickEditDraft("12.5", "integer")).toBeNull();
+    expect(parseQuickEditDraft("12", "integer")).toBe(12);
+  });
+});
+
+describe("computeQuickEditLimit - set 模式", () => {
+  test("空输入 + allowClear=true → null（清除限额）", () => {
+    expect(computeQuickEditLimit("set", "", 100, "currency", true)).toBeNull();
+  });
+
+  test("输入 0 + allowClear=true → null", () => {
+    expect(computeQuickEditLimit("set", "0", 100, "currency", true)).toBeNull();
+  });
+
+  test("输入 0 + allowClear=false → 0（保留）", () => {
+    expect(computeQuickEditLimit("set", "0", 100, "integer", false)).toBe(0);
+  });
+
+  test("输入有效金额 → 该金额", () => {
+    expect(computeQuickEditLimit("set", "200", 100, "currency", true)).toBe(200);
+    expect(computeQuickEditLimit("set", "200", null, "currency", true)).toBe(200);
+  });
+
+  test("非法输入 → null", () => {
+    expect(computeQuickEditLimit("set", "abc", 100, "currency", true)).toBeNull();
+  });
+});
+
+describe("computeQuickEditLimit - add 模式", () => {
+  test("currentLimit=100 + 增加 50 = 150", () => {
+    expect(computeQuickEditLimit("add", "50", 100, "currency", true)).toBe(150);
+  });
+
+  test("currentLimit=null（无限额）+ 增加 50 = 50（视作从 0 起算）", () => {
+    expect(computeQuickEditLimit("add", "50", null, "currency", true)).toBe(50);
+  });
+
+  test("空输入 → null", () => {
+    expect(computeQuickEditLimit("add", "", 100, "currency", true)).toBeNull();
+  });
+
+  test("integer 模式拒绝小数增量", () => {
+    expect(computeQuickEditLimit("add", "1.5", 10, "integer", false)).toBeNull();
+    expect(computeQuickEditLimit("add", "5", 10, "integer", false)).toBe(15);
+  });
+
+  test("浮点累加（避免不必要四舍五入）", () => {
+    expect(computeQuickEditLimit("add", "0.1", 0.2, "currency", true)).toBeCloseTo(
+      0.3,
+      10
+    );
+  });
+});

--- a/tests/unit/components/quota-quick-edit-popover.test.tsx
+++ b/tests/unit/components/quota-quick-edit-popover.test.tsx
@@ -72,9 +72,6 @@ describe("computeQuickEditLimit - add 模式", () => {
   });
 
   test("浮点累加（避免不必要四舍五入）", () => {
-    expect(computeQuickEditLimit("add", "0.1", 0.2, "currency", true)).toBeCloseTo(
-      0.3,
-      10
-    );
+    expect(computeQuickEditLimit("add", "0.1", 0.2, "currency", true)).toBeCloseTo(0.3, 10);
   });
 });


### PR DESCRIPTION
## Summary

在三个高频查看入口让限额数字原地可点击，弹出 Popover/Drawer 进行快捷调整：

- **用户管理列表表格** — 7 个限额列（RPM / 5h / Daily / Weekly / Monthly / Total / Sessions）的 Badge 全部可点
- **密钥限额使用情况弹窗**（用户管理 → key 操作菜单）— 每行 limit 数字可点
- **限额管理页 `/dashboard/quotas/keys`** — 5h / Daily / Weekly / Monthly / 并发 limit 数字可点（仅独立限额行）

弹窗提供两个 Tab：
- **设置值** — 直接输入新限额（留空=清除限额）
- **增加值** — 输入增量，实时显示 `当前 + 增量 = 新值` 预览

## Implementation

- 新增 `src/components/quota/quota-quick-edit-popover.tsx` 通用组件（响应式 Popover/Drawer）
- 导出纯函数 `computeQuickEditLimit` / `parseQuickEditDraft` 便于单测
- 扩展 `UserLimitBadge` 增加 `editable / onSave / currencyCode / editUnit` 4 个可选 prop
- 复用现有 `editKey` / `editUser` server action
- 保存成功后调用 `clearUsageCache(userId)` 失效用量缓存并 `router.refresh()`
- 仅 `isAdmin` 时启用编辑能力（用户表格 7 列）
- 5 语言 `quota.json` 补齐 `quickEdit` 翻译键

## Changes

| File | Type | Description |
|------|------|-------------|
| `src/components/quota/quota-quick-edit-popover.tsx` | Added | Reusable quick-edit component with Popover (desktop) / Drawer (mobile), set/add modes, validation, and currency formatting |
| `src/app/[locale]/dashboard/_components/user/user-limit-badge.tsx` | Modified | Extended `UserLimitBadge` with `editable`/`onSave`/`currencyCode`/`editUnit` props; wraps Badge in `QuotaQuickEditPopover` when editable |
| `src/app/[locale]/dashboard/_components/user/user-key-table-row.tsx` | Modified | Adds `handleSaveUserLimit` handler; wraps RPM and Sessions badges in `QuotaQuickEditPopover` for admin users; passes `editable`/`onSave` to `UserLimitBadge` for 5 currency columns |
| `src/app/[locale]/dashboard/_components/user/key-quota-usage-dialog.tsx` | Modified | Makes limit values clickable inside the key quota usage dialog; adds `handleSaveLimit` with field mapping per quota type |
| `src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx` | Modified | Adds `handleSaveLimit` for the quota management page; wraps 5 cost limits + concurrent sessions in `QuotaQuickEditPopover` (independent keys only) |
| `messages/{en,ja,ru,zh-CN,zh-TW}/quota.json` | Modified | Adds `quickEdit` i18n keys (title, tabs, placeholders, validation, toast messages) |
| `tests/unit/components/quota-quick-edit-popover.test.tsx` | Added | 14 unit tests covering `parseQuickEditDraft` and `computeQuickEditLimit` for both set/add modes, integer/currency units, and clear semantics |

## Related Work

- Follows inline editing pattern from #486 (provider priority/weight inline editing)
- Extends quick-action UX established in #414 (quick toggle/renew for users and keys)
- Builds on the quota management page introduced in #610 and key quota dialog from #794

## Test plan

- [x] `bun run typecheck` 通过
- [x] `bun run lint` 通过
- [x] `bun run build` 通过
- [x] 新增 14 条单测覆盖 set/add 模式、整数/小数校验、清除语义
- [ ] 手动验证：用户管理列表点击百分比 Badge → 弹出编辑器 → 设置值/增加值均生效
- [ ] 手动验证：密钥限额使用情况弹窗点击 limit → 编辑后弹窗内即刻刷新
- [ ] 手动验证：限额管理页继承限额行不可点击；独立限额行可点
- [ ] 手动验证：非 admin 用户表格的 Badge 不可点

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds inline quick-edit popovers (Popover on desktop, Drawer on mobile) to seven quota fields across three admin surfaces: the user management table, the key quota usage dialog, and the quota management page. A new `patchKeyLimit` server action handles atomic field updates with proper auth, ceiling validation against user-level quotas, cache invalidation, and audit logging, while the existing `editUser` action handles user-level limits.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all remaining findings are P2 style/UX suggestions with no data integrity or correctness impact.

The core logic (computeQuickEditLimit, patchKeyLimit auth + ceiling checks, cache invalidation, isAdmin/hasKeyQuota gating) is correct and well-tested. Prior P1 concerns from earlier rounds (KEY_FIELD_MAP placement, RPM clear → ban, dead branch) appear to be addressed. The two new findings are both P2: a hardcoded Chinese string in an error path and a placeholder/preview inconsistency when allowClear=false.

src/actions/keys.ts (hardcoded 用户不存在), src/components/quota/quota-quick-edit-popover.tsx (placeholder/preview with allowClear=false)
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/quota/quota-quick-edit-popover.tsx | New reusable Popover/Drawer quick-edit component; core logic is correct and well-tested, but placeholder/preview text is inconsistent when allowClear=false |
| src/actions/keys.ts | New patchKeyLimit server action with proper auth, ceiling checks, and audit logging; one hardcoded Chinese error string breaks i18n |
| src/app/[locale]/dashboard/_components/user/key-quota-usage-dialog.tsx | KEY_FIELD_MAP correctly moved to module scope; handleSaveLimit uses useCallback with correct deps; limit values now clickable via QuotaQuickEditPopover |
| src/app/[locale]/dashboard/_components/user/user-key-table-row.tsx | 7 limit columns made editable for admins; RPM and Sessions use allowClear=false correctly; handleSaveUserLimit lacks useCallback (noted in prior threads) |
| src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx | Edit popovers correctly gated behind hasKeyQuota check, so inherited-limit rows remain read-only as intended; handleSaveLimit properly wrapped in useCallback |
| src/app/[locale]/dashboard/_components/user/user-limit-badge.tsx | Clean extension of UserLimitBadge with 4 optional props; all three render paths (no-limit, error, percentage) correctly wrap in QuotaQuickEditPopover when editable |
| tests/unit/components/quota-quick-edit-popover.test.tsx | 14 unit tests covering parseQuickEditDraft and computeQuickEditLimit for both modes, integer/currency units, clear semantics, and floating-point edge cases |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Admin
    participant QuotaQuickEditPopover
    participant handleSaveLimit
    participant patchKeyLimit / editUser
    participant DB

    Admin->>QuotaQuickEditPopover: Click limit Badge/button
    QuotaQuickEditPopover->>Admin: Show Popover (desktop) / Drawer (mobile)
    Admin->>QuotaQuickEditPopover: Enter value, select Set/Add mode
    Note over QuotaQuickEditPopover: computeQuickEditLimit()<br/>validates & computes final value
    Admin->>QuotaQuickEditPopover: Click Save
    QuotaQuickEditPopover->>handleSaveLimit: onSave(computedLimit)
    handleSaveLimit->>patchKeyLimit / editUser: Server Action(field, value)
    patchKeyLimit / editUser->>DB: Auth check → ceiling check → updateKey/editUser
    DB-->>patchKeyLimit / editUser: OK
    patchKeyLimit / editUser->>patchKeyLimit / editUser: invalidateCachedKey + revalidatePath
    patchKeyLimit / editUser-->>handleSaveLimit: {ok: true}
    handleSaveLimit->>handleSaveLimit: toast.success + router.refresh()
    handleSaveLimit-->>QuotaQuickEditPopover: true (close popover)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/actions/keys.ts
Line: 215-217

Comment:
**Hardcoded Chinese error string breaks i18n**

This error message is hardcoded in Chinese instead of going through the i18n system. For non-Chinese locales this string will appear untranslated. The rest of the function already uses `tError(...)` — the same pattern should apply here.

```suggestion
      return { ok: false, error: tError("USER_NOT_FOUND") };
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/quota/quota-quick-edit-popover.tsx
Line: 1143-1152

Comment:
**Placeholder and preview text mislead when `allowClear=false`**

When `allowClear={false}` (e.g. the sessions column or RPM badge), two things are inconsistent:

1. `setPlaceholder` — `"Enter new limit (empty = unlimited)"` — still shows the "empty = unlimited" hint even though clearing is disallowed; `canSave` silently blocks the action rather than explaining why.
2. `previewText` — when the user clears the input in set-mode, `computedLimit` is `null` so the preview shows `t("previewNoLimit")` ("Will clear limit (unlimited)") even though the Save button is disabled.

Consider branching the placeholder and preview on `allowClear` so users get actionable feedback rather than a contradictory hint + disabled button.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(quota): 修复 bugbot 评论中的 P1/Major 问题"](https://github.com/ding113/claude-code-hub/commit/83ef5c5c9ca389c26fc66d5419889acc0ac60477) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29450525)</sub>

<!-- /greptile_comment -->