### PR TITLE
fix(logs): preserve locale for filter navigation

### DIFF
--- a/src/app/[locale]/dashboard/_components/bento/leaderboard-card.tsx
+++ b/src/app/[locale]/dashboard/_components/bento/leaderboard-card.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Award, ChevronRight, Medal, Trophy } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/routing";
 import { cn, formatCurrency, formatTokenAmount } from "@/lib/utils";
 import type { CurrencyCode } from "@/lib/utils/currency";
 import { BentoCard } from "./bento-grid";

--- a/src/app/[locale]/dashboard/_components/bento/live-sessions-panel.tsx
+++ b/src/app/[locale]/dashboard/_components/bento/live-sessions-panel.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { Activity, AlertCircle, Circle, XCircle } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useRouter } from "@/i18n/routing";
 import {
   getSessionDisplayStatus,
   SESSION_DISPLAY_STATUS,

--- a/src/app/[locale]/dashboard/_components/user-menu.tsx
+++ b/src/app/[locale]/dashboard/_components/user-menu.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { LogOut } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { useRouter } from "@/i18n/routing";
 
 interface UserMenuProps {
   user: {

--- a/src/app/[locale]/dashboard/_components/webhook-migration-dialog.tsx
+++ b/src/app/[locale]/dashboard/_components/webhook-migration-dialog.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { AlertCircle, ArrowRight, CheckCircle2, Loader2, Settings, Webhook } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useLocale, useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 import { getNotificationSettingsAction } from "@/actions/notifications";
 import { Badge } from "@/components/ui/badge";
@@ -22,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useRouter } from "@/i18n/routing";
 import { logger } from "@/lib/logger";
 import { setOnboardingCompleted, shouldShowOnboarding } from "@/lib/onboarding";
 import { cn } from "@/lib/utils";
@@ -63,7 +63,6 @@ const MIGRATION_STEPS: MigrationStep[] = ["intro", "platform-select", "migrating
 
 export function WebhookMigrationDialog() {
   const t = useTranslations("dashboard.webhookMigration");
-  const locale = useLocale();
   const router = useRouter();
 
   const [open, setOpen] = useState(false);
@@ -217,8 +216,8 @@ export function WebhookMigrationDialog() {
 
   const handleGoToSettings = useCallback(() => {
     setOpen(false);
-    router.push(`/${locale}/settings/notifications`);
-  }, [router, locale]);
+    router.push("/settings/notifications");
+  }, [router]);
 
   // Render step indicator
   const renderStepIndicator = () => {

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.test.tsx
@@ -160,8 +160,8 @@ function renderUsageLogsView() {
 }
 
 function clickButton(container: HTMLElement, text: string) {
-  const button = Array.from(container.querySelectorAll("button")).find((item) =>
-    item.textContent?.includes(text)
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (item) => item.textContent?.trim() === text
   );
   if (!button) {
     throw new Error(`Button not found: ${text}`);

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.test.tsx
@@ -1,0 +1,213 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UsageLogFilters } from "./filters/types";
+
+const routerMocks = vi.hoisted(() => ({
+  pushedHref: "",
+  push: vi.fn((href: string) => {
+    routerMocks.pushedHref = href.startsWith("/") ? `/zh-CN${href}` : href;
+  }),
+}));
+
+const searchParamMocks = vi.hoisted(() => ({
+  value: new URLSearchParams(),
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "zh-CN",
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamMocks.value,
+  useRouter: () => {
+    throw new Error("logs navigation must use the locale-aware i18n router");
+  },
+}));
+
+vi.mock("@/i18n/routing", () => ({
+  useRouter: () => ({
+    push: routerMocks.push,
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined, isLoading: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-fullscreen", () => ({
+  useFullscreen: () => ({
+    supported: false,
+    isFullscreen: false,
+    request: vi.fn(),
+    exit: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/column-visibility", () => ({
+  getHiddenColumns: () => [],
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/collapsible", () => ({
+  Collapsible: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/switch", () => ({
+  Switch: () => <button type="button" role="switch" />,
+}));
+
+vi.mock("./column-visibility-dropdown", () => ({
+  ColumnVisibilityDropdown: () => <div data-testid="column-visibility-dropdown" />,
+}));
+
+vi.mock("./usage-logs-stats-panel", () => ({
+  UsageLogsStatsPanel: () => <div data-testid="usage-logs-stats-panel" />,
+}));
+
+vi.mock("./virtualized-logs-table", () => ({
+  VirtualizedLogsTable: () => <div data-testid="virtualized-logs-table" />,
+}));
+
+vi.mock("./usage-logs-filters", () => ({
+  UsageLogsFilters: ({
+    onChange,
+    onReset,
+  }: {
+    onChange: (filters: UsageLogFilters) => void;
+    onReset: () => void;
+  }) => (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          onChange({
+            userId: 2,
+            keyId: 3,
+            providerId: 4,
+            sessionId: "session-abc",
+            startTime: 1000,
+            endTime: 2000,
+            statusCode: 500,
+            model: "claude-sonnet",
+            endpoint: "/v1/messages",
+            minRetryCount: 1,
+          })
+        }
+      >
+        apply all filters
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onChange({
+            excludeStatusCode200: true,
+          })
+        }
+      >
+        apply exclude 200
+      </button>
+      <button type="button" onClick={onReset}>
+        reset filters
+      </button>
+    </div>
+  ),
+}));
+
+import { UsageLogsViewVirtualized } from "./usage-logs-view-virtualized";
+
+function renderUsageLogsView() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <UsageLogsViewVirtualized
+        isAdmin={true}
+        userId={1}
+        providers={[]}
+        initialKeys={[]}
+        searchParams={{}}
+        currencyCode="USD"
+        billingModelSource="original"
+      />
+    );
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function clickButton(container: HTMLElement, text: string) {
+  const button = Array.from(container.querySelectorAll("button")).find((item) =>
+    item.textContent?.includes(text)
+  );
+  if (!button) {
+    throw new Error(`Button not found: ${text}`);
+  }
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("UsageLogsViewVirtualized filter navigation", () => {
+  beforeEach(() => {
+    routerMocks.pushedHref = "";
+    routerMocks.push.mockClear();
+    searchParamMocks.value = new URLSearchParams();
+    document.body.innerHTML = "";
+  });
+
+  it("applies every logs filter through the locale-aware dashboard route", () => {
+    const { container, unmount } = renderUsageLogsView();
+
+    clickButton(container, "apply all filters");
+
+    expect(routerMocks.pushedHref).toBe(
+      "/zh-CN/dashboard/logs?userId=2&keyId=3&providerId=4&sessionId=session-abc&startTime=1000&endTime=2000&statusCode=500&model=claude-sonnet&endpoint=%2Fv1%2Fmessages&minRetry=1"
+    );
+
+    unmount();
+  });
+
+  it("applies exclude-200 status filter through the locale-aware dashboard route", () => {
+    const { container, unmount } = renderUsageLogsView();
+
+    clickButton(container, "apply exclude 200");
+
+    expect(routerMocks.pushedHref).toBe("/zh-CN/dashboard/logs?statusCode=%21200");
+
+    unmount();
+  });
+
+  it("resets logs filters through the locale-aware dashboard route", () => {
+    const { container, unmount } = renderUsageLogsView();
+
+    clickButton(container, "reset filters");
+
+    expect(routerMocks.pushedHref).toBe("/zh-CN/dashboard/logs");
+
+    unmount();
+  });
+});

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx
@@ -255,34 +255,7 @@ function UsageLogsViewContent({
     };
   }, []);
 
-  const statsFilters = useMemo(
-    () => ({
-      userId: filters.userId,
-      keyId: filters.keyId,
-      providerId: filters.providerId,
-      sessionId: filters.sessionId,
-      startTime: filters.startTime,
-      endTime: filters.endTime,
-      statusCode: filters.statusCode,
-      excludeStatusCode200: filters.excludeStatusCode200,
-      model: filters.model,
-      endpoint: filters.endpoint,
-      minRetryCount: filters.minRetryCount,
-    }),
-    [
-      filters.userId,
-      filters.keyId,
-      filters.providerId,
-      filters.sessionId,
-      filters.startTime,
-      filters.endTime,
-      filters.statusCode,
-      filters.excludeStatusCode200,
-      filters.model,
-      filters.endpoint,
-      filters.minRetryCount,
-    ]
-  );
+  const statsFilters = filters;
 
   const hasStatsFilters = Object.values(statsFilters).some((v) => v !== undefined && v !== false);
 

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, Expand, Filter, Minimize2, RefreshCw } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Switch } from "@/components/ui/switch";
 import { useFullscreen } from "@/hooks/use-fullscreen";
+import { useRouter } from "@/i18n/routing";
 import { getHiddenColumns, type LogsTableColumn } from "@/lib/column-visibility";
 import { cn } from "@/lib/utils";
 import type { CurrencyCode } from "@/lib/utils/currency";
@@ -254,19 +255,34 @@ function UsageLogsViewContent({
     };
   }, []);
 
-  const statsFilters = {
-    userId: filters.userId,
-    keyId: filters.keyId,
-    providerId: filters.providerId,
-    sessionId: filters.sessionId,
-    startTime: filters.startTime,
-    endTime: filters.endTime,
-    statusCode: filters.statusCode,
-    excludeStatusCode200: filters.excludeStatusCode200,
-    model: filters.model,
-    endpoint: filters.endpoint,
-    minRetryCount: filters.minRetryCount,
-  };
+  const statsFilters = useMemo(
+    () => ({
+      userId: filters.userId,
+      keyId: filters.keyId,
+      providerId: filters.providerId,
+      sessionId: filters.sessionId,
+      startTime: filters.startTime,
+      endTime: filters.endTime,
+      statusCode: filters.statusCode,
+      excludeStatusCode200: filters.excludeStatusCode200,
+      model: filters.model,
+      endpoint: filters.endpoint,
+      minRetryCount: filters.minRetryCount,
+    }),
+    [
+      filters.userId,
+      filters.keyId,
+      filters.providerId,
+      filters.sessionId,
+      filters.startTime,
+      filters.endTime,
+      filters.statusCode,
+      filters.excludeStatusCode200,
+      filters.model,
+      filters.endpoint,
+      filters.minRetryCount,
+    ]
+  );
 
   const hasStatsFilters = Object.values(statsFilters).some((v) => v !== undefined && v !== false);
 

--- a/src/app/[locale]/dashboard/logs/_utils/logs-query.test.ts
+++ b/src/app/[locale]/dashboard/logs/_utils/logs-query.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { buildLogsUrlQuery, parseLogsUrlFilters } from "./logs-query";
+
+describe("logs-query", () => {
+  it("builds query params for every logs filter field", () => {
+    const query = buildLogsUrlQuery({
+      userId: 2,
+      keyId: 3,
+      providerId: 4,
+      sessionId: "session-abc",
+      startTime: 1000,
+      endTime: 2000,
+      statusCode: 500,
+      model: "claude-sonnet",
+      endpoint: "/v1/messages",
+      minRetryCount: 1,
+      page: 3,
+    });
+
+    expect(query.toString()).toBe(
+      "userId=2&keyId=3&providerId=4&sessionId=session-abc&startTime=1000&endTime=2000&statusCode=500&model=claude-sonnet&endpoint=%2Fv1%2Fmessages&minRetry=1&page=3"
+    );
+  });
+
+  it("uses !200 when excluding successful status codes", () => {
+    const query = buildLogsUrlQuery({
+      statusCode: 500,
+      excludeStatusCode200: true,
+    });
+
+    expect(query.toString()).toBe("statusCode=%21200");
+  });
+
+  it("parses logs url filters back from search params", () => {
+    expect(
+      parseLogsUrlFilters({
+        userId: "2",
+        keyId: "3",
+        providerId: "4",
+        sessionId: " session-abc ",
+        startTime: "1000",
+        endTime: "2000",
+        statusCode: "!200",
+        model: "claude-sonnet",
+        endpoint: "/v1/messages",
+        minRetry: "1",
+        page: "3",
+      })
+    ).toEqual({
+      userId: 2,
+      keyId: 3,
+      providerId: 4,
+      sessionId: "session-abc",
+      startTime: 1000,
+      endTime: 2000,
+      statusCode: undefined,
+      excludeStatusCode200: true,
+      model: "claude-sonnet",
+      endpoint: "/v1/messages",
+      minRetryCount: 1,
+      page: 3,
+    });
+  });
+});

--- a/src/app/[locale]/settings/prices/_components/upload-price-dialog.tsx
+++ b/src/app/[locale]/settings/prices/_components/upload-price-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { AlertCircle, CheckCircle, FileJson, Loader2, Upload, XCircle } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
@@ -16,6 +15,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { useRouter } from "@/i18n/routing";
 import type { PriceUpdateResult } from "@/types/model-price";
 
 interface PageLoadingOverlayProps {

--- a/src/components/customs/concurrent-sessions-card.tsx
+++ b/src/components/customs/concurrent-sessions-card.tsx
@@ -2,10 +2,10 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Activity } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { getConcurrentSessions } from "@/actions/concurrent-sessions";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useRouter } from "@/i18n/routing";
 
 const REFRESH_INTERVAL = 5000; // 5秒刷新一次
 

--- a/src/components/customs/overview-panel.tsx
+++ b/src/components/customs/overview-panel.tsx
@@ -2,11 +2,11 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Activity, Clock, DollarSign, TrendingUp } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import type { OverviewData } from "@/actions/overview";
 import { getOverviewData } from "@/actions/overview";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useRouter } from "@/i18n/routing";
 import type { CurrencyCode } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
 import { ActiveSessionsList } from "./active-sessions-list";

--- a/tests/unit/dashboard-logs-fullscreen-overlay-ui.test.tsx
+++ b/tests/unit/dashboard-logs-fullscreen-overlay-ui.test.tsx
@@ -18,8 +18,11 @@ vi.mock("next-intl", () => ({
 }));
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn() }),
   useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/i18n/routing", () => ({
+  useRouter: () => ({ push: vi.fn() }),
 }));
 
 const invalidateQueriesMock = vi.fn();

--- a/tests/unit/dashboard/live-sessions-panel-dynamic-items.test.tsx
+++ b/tests/unit/dashboard/live-sessions-panel-dynamic-items.test.tsx
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { LiveSessionsPanel } from "@/app/[locale]/dashboard/_components/bento/live-sessions-panel";
 import type { ActiveSessionInfo } from "@/types/session";
 
-vi.mock("next/navigation", () => ({
+vi.mock("@/i18n/routing", () => ({
   useRouter: () => ({
     push: vi.fn(),
   }),

--- a/tests/unit/settings/prices/upload-price-dialog-cloud-model-count.test.tsx
+++ b/tests/unit/settings/prices/upload-price-dialog-cloud-model-count.test.tsx
@@ -11,7 +11,7 @@ import { UploadPriceDialog } from "@/app/[locale]/settings/prices/_components/up
 import { loadMessages } from "./test-messages";
 
 // 测试环境不加载 next/navigation 的真实实现（避免 Next.js 运行时依赖）
-vi.mock("next/navigation", () => ({
+vi.mock("@/i18n/routing", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));
 

--- a/tests/unit/settings/prices/upload-price-dialog-cloud-model-count.test.tsx
+++ b/tests/unit/settings/prices/upload-price-dialog-cloud-model-count.test.tsx
@@ -10,7 +10,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { UploadPriceDialog } from "@/app/[locale]/settings/prices/_components/upload-price-dialog";
 import { loadMessages } from "./test-messages";
 
-// 测试环境不加载 next/navigation 的真实实现（避免 Next.js 运行时依赖）
+// 测试环境不加载 `@/i18n/routing` 的真实实现（避免 next-intl / Next.js 运行时依赖）
 vi.mock("@/i18n/routing", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));

--- a/tests/unit/settings/prices/upload-price-dialog-upload-flow.test.tsx
+++ b/tests/unit/settings/prices/upload-price-dialog-upload-flow.test.tsx
@@ -25,13 +25,13 @@ const sonnerMocks = vi.hoisted(() => ({
 vi.mock("sonner", () => sonnerMocks);
 
 const navigationMocks = vi.hoisted(() => {
-  const push = vi.fn();
+  const push = vi.fn((href: string) => (href.startsWith("/") ? `/en${href}` : href));
   return {
     __push: push,
     useRouter: () => ({ push }),
   };
 });
-vi.mock("next/navigation", () => ({
+vi.mock("@/i18n/routing", () => ({
   useRouter: navigationMocks.useRouter,
 }));
 
@@ -359,7 +359,7 @@ describe("UploadPriceDialog: 上传流程", () => {
     unmount();
   });
 
-  test("isRequired=true 且有更新时，点击底部按钮应跳转 /dashboard", async () => {
+  test("isRequired=true 且有更新时，点击底部按钮应通过本地化路由跳转 dashboard", async () => {
     const messages = loadMessages();
     const originalFetch = globalThis.fetch;
     const fetchMock = vi.fn().mockResolvedValue({
@@ -405,7 +405,7 @@ describe("UploadPriceDialog: 上传流程", () => {
       await flushPromises();
     });
 
-    expect(navigationMocks.__push).toHaveBeenCalledWith("/dashboard");
+    expect(navigationMocks.__push).toHaveReturnedWith("/en/dashboard");
 
     globalThis.fetch = originalFetch;
     unmount();

--- a/tests/unit/settings/prices/upload-price-dialog-upload-flow.test.tsx
+++ b/tests/unit/settings/prices/upload-price-dialog-upload-flow.test.tsx
@@ -405,7 +405,7 @@ describe("UploadPriceDialog: 上传流程", () => {
       await flushPromises();
     });
 
-    expect(navigationMocks.__push).toHaveReturnedWith("/en/dashboard");
+    expect(navigationMocks.__push).toHaveBeenCalledWith("/dashboard");
 
     globalThis.fetch = originalFetch;
     unmount();

--- a/tests/unit/settings/prices/upload-price-dialog-upload-flow.test.tsx
+++ b/tests/unit/settings/prices/upload-price-dialog-upload-flow.test.tsx
@@ -25,7 +25,7 @@ const sonnerMocks = vi.hoisted(() => ({
 vi.mock("sonner", () => sonnerMocks);
 
 const navigationMocks = vi.hoisted(() => {
-  const push = vi.fn((href: string) => (href.startsWith("/") ? `/en${href}` : href));
+  const push = vi.fn();
   return {
     __push: push,
     useRouter: () => ({ push }),


### PR DESCRIPTION
## Summary

Fixes a localized routing regression on the request logs page. Applying filters from `/zh-CN/dashboard/logs` was building `/dashboard/logs?...` with the raw Next.js router, dropping the active locale prefix and causing a reproducible 404.

## Root Cause

The logs filter view used `useRouter` from `next/navigation` while building dashboard-relative hrefs. In this app, dashboard routes live under the `next-intl` locale segment, so navigation that changes user-facing paths must use the project's `@/i18n/routing` wrapper.

## Changes

- Switch logs filter Apply/Reset navigation to the locale-aware router.
- Add regression tests for every logs filter query field, reset navigation, and `excludeStatusCode200` (`statusCode=!200`).
- Convert same-class dashboard/settings in-app navigation call sites from raw `next/navigation` router to `@/i18n/routing`.
- Update unit test mocks to match locale-aware routing behavior.

## Validation

- `bun run typecheck` -> exit 0
- `bun run lint` -> exit 0
- Related tests -> 8 files / 28 tests passed
- `bun run build` -> exit 0
- `git diff --check` -> clean
- Raw router risk scan -> no `next/navigation useRouter` `push/replace` call sites remain in `src`

## Notes

Full `bun run test` was attempted repeatedly. The test cases themselves reported passing (`544 passed | 2 skipped`, `5049 passed | 13 skipped`), but Vitest exited non-zero because a worker hit `ERR_WORKER_OUT_OF_MEMORY`. This appears to be a runner/resource issue rather than an assertion failure from this change.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a localized routing regression where applying filters on `/zh-CN/dashboard/logs` dropped the locale prefix, producing a bare `/dashboard/logs?…` URL and a 404. The fix consistently replaces `useRouter` from `next/navigation` with the `next-intl`-aware `useRouter` from `@/i18n/routing` across 9 components, removes the now-redundant `useLocale` + manual prefix pattern in `webhook-migration-dialog.tsx`, and backs the change with new regression tests for every filter field and the `excludeStatusCode200` encoding.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted import swaps with no logic changes, well-covered by new regression tests, and typecheck/lint/build all pass.

All changes are mechanical import replacements or direct consequences of the router swap. The one behavioral change (statsFilters = filters) is safe because page is already stripped from the filters object. The only previously noted P2 (trailing ?) is a pre-existing edge case that is out of scope for this fix and has already been flagged in a prior review thread.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx | Core fix: switches filter navigation from raw next/navigation router to locale-aware @/i18n/routing; also simplifies statsFilters to a direct reference (safe, since page is already excluded from the filters object). |
| src/app/[locale]/dashboard/_components/webhook-migration-dialog.tsx | Removes useLocale dependency and simplifies hardcoded locale path from /${locale}/settings/notifications to /settings/notifications, letting the i18n router inject the prefix. |
| src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.test.tsx | New regression test file; deliberately throws from next/navigation useRouter to enforce locale-aware routing, and simulates locale prefix injection in the @/i18n/routing mock. |
| src/app/[locale]/dashboard/logs/_utils/logs-query.test.ts | New unit tests covering buildLogsUrlQuery and parseLogsUrlFilters, including the excludeStatusCode200 → statusCode=!200 encoding. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant FilterComponent as UsageLogsFilters
    participant LogsView as UsageLogsViewVirtualized
    participant I18nRouter as useRouter (@/i18n/routing)
    participant NextJS as Next.js App Router

    User->>FilterComponent: Apply/Reset filters
    FilterComponent->>LogsView: onChange(filters) / onReset()
    LogsView->>LogsView: buildLogsUrlQuery(newFilters)
    LogsView->>I18nRouter: push("/dashboard/logs?...")
    I18nRouter->>I18nRouter: Prepend active locale prefix
    I18nRouter->>NextJS: push("/zh-CN/dashboard/logs?...")
    NextJS-->>User: Correct localized URL rendered
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx`, line 246-248 ([link](https://github.com/ding113/claude-code-hub/blob/15219f72555338172c888f49a39dc4e477e51561/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx#L246-L248)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Trailing `?` when query is empty**

   `query.toString()` can be `""` when `newFilters` has no active fields, producing the URL `/dashboard/logs?`. The trailing question-mark is benign in most browsers, but it's cleaner to omit it. Since `onReset` already handles the no-filter case via a separate path, this is only a risk if `onChange` is called with an all-undefined filters object.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx
   Line: 246-248

   Comment:
   **Trailing `?` when query is empty**

   `query.toString()` can be `""` when `newFilters` has no active fields, producing the URL `/dashboard/logs?`. The trailing question-mark is benign in most browsers, but it's cleaner to omit it. Since `onReset` already handles the no-filter case via a separate path, this is only a risk if `onChange` is called with an all-undefined filters object.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["test(logs): make router assertions direc..."](https://github.com/ding113/claude-code-hub/commit/e8e5a4fb1664a8c770c464a584894f6fc3a495a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29563861)</sub>

<!-- /greptile_comment -->