### PR TITLE
release v0.7.2

### DIFF
--- a/src/app/[locale]/settings/config/_components/auto-cleanup-form.tsx
+++ b/src/app/[locale]/settings/config/_components/auto-cleanup-form.tsx
@@ -29,6 +29,7 @@ interface AutoCleanupFormProps {
 
 export function AutoCleanupForm({ settings, onSuccess }: AutoCleanupFormProps) {
   const t = useTranslations("settings.config.form");
+  const tCommon = useTranslations("settings.common");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const {
@@ -190,7 +191,7 @@ export function AutoCleanupForm({ settings, onSuccess }: AutoCleanupFormProps) {
           {isSubmitting ? (
             <>
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              {t("common.saving")}
+              {tCommon("saving")}
             </>
           ) : (
             t("saveConfig")

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,6 @@
+import { defaultLocale } from "@/i18n/config";
+import { redirect } from "@/i18n/routing";
+
+export default function RootPage() {
+  redirect({ href: "/dashboard", locale: defaultLocale });
+}

--- a/src/components/ui/__tests__/map.test.tsx
+++ b/src/components/ui/__tests__/map.test.tsx
@@ -31,45 +31,47 @@ const maplibreMocks = vi.hoisted(() => {
     constructor(options: Record<string, unknown>) {
       this.options = options;
       this.offset = options.offset ?? 16;
+      popups.push(this);
     }
 
-    setMaxWidth(value: string) {
+    setMaxWidth = vi.fn((value: string) => {
       this.maxWidth = value;
       return this;
-    }
+    });
 
-    setDOMContent(node: HTMLElement) {
+    setDOMContent = vi.fn((node: HTMLElement) => {
       this.container = node;
       if (!node.isConnected) {
         document.body.appendChild(node);
       }
       return this;
-    }
+    });
 
-    setLngLat([lng, lat]: [number, number]) {
+    setLngLat = vi.fn((next: [number, number] | { lng: number; lat: number }) => {
+      const [lng, lat] = Array.isArray(next) ? next : [next.lng, next.lat];
       this.lngLat = { lng, lat };
       return this;
-    }
+    });
 
-    getLngLat() {
-      return this.lngLat;
-    }
-
-    setOffset(value: unknown) {
-      this.offset = value;
-      return this;
-    }
-
-    addTo() {
+    addTo = vi.fn(() => {
       this.isOpenFlag = true;
       return this;
-    }
+    });
 
-    remove() {
+    remove = vi.fn(() => {
       this.isOpenFlag = false;
       this.events.get("close")?.forEach((handler) => handler());
       this.container?.remove();
       return this;
+    });
+
+    setOffset = vi.fn((value: unknown) => {
+      this.offset = value;
+      return this;
+    });
+
+    getLngLat() {
+      return this.lngLat;
     }
 
     isOpen() {
@@ -117,9 +119,7 @@ const maplibreMocks = vi.hoisted(() => {
       return this;
     }
 
-    remove() {
-      return this;
-    }
+    remove = vi.fn(() => this);
 
     getElement() {
       return this.element;
@@ -187,6 +187,7 @@ const maplibreMocks = vi.hoisted(() => {
 
   const maps: FakeMap[] = [];
   const markers: FakeMarker[] = [];
+  const popups: FakePopup[] = [];
 
   class FakeMap {
     container: HTMLElement;
@@ -361,6 +362,7 @@ const maplibreMocks = vi.hoisted(() => {
     FakePopup,
     maps,
     markers,
+    popups,
   };
 });
 
@@ -381,6 +383,7 @@ import {
   MapPopup,
   MapRoute,
   MarkerContent,
+  MarkerTooltip,
 } from "@/components/ui/map";
 
 function render(node: ReactNode) {
@@ -427,6 +430,7 @@ describe("Map UI", () => {
   beforeEach(() => {
     maplibreMocks.maps.length = 0;
     maplibreMocks.markers.length = 0;
+    maplibreMocks.popups.length = 0;
     document.body.innerHTML = "";
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -729,6 +733,155 @@ describe("Map UI", () => {
     const map = maplibreMocks.maps.at(-1);
     const source = Array.from(map?.sources.values() ?? [])[0];
     expect(source?.data).toBe("https://example.com/b.geojson");
+
+    unmount();
+  });
+
+  test("MapPopup reopens when coordinates change after manual close", async () => {
+    const { rerender, unmount } = render(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [10, 20], zoom: 4 }}>
+          <MapPopup longitude={10} latitude={20} closeButton closeLabel="关闭地图弹窗">
+            <div>first popup</div>
+          </MapPopup>
+        </Map>
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    const popup = maplibreMocks.popups[0];
+    const button = document.querySelector('[aria-label="关闭地图弹窗"]') as HTMLButtonElement;
+    click(button);
+
+    expect(popup?.isOpen()).toBe(false);
+    expect(document.body.textContent ?? "").not.toContain("first popup");
+
+    rerender(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [10, 20], zoom: 4 }}>
+          <MapPopup longitude={30} latitude={40} closeButton closeLabel="关闭地图弹窗">
+            <div>second popup</div>
+          </MapPopup>
+        </Map>
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    expect(popup?.setLngLat).toHaveBeenLastCalledWith([30, 40]);
+    expect(popup?.addTo).toHaveBeenCalledTimes(2);
+    expect(document.body.textContent ?? "").toContain("second popup");
+
+    unmount();
+  });
+
+  test("MapPopup recreates construction-only options when they change", async () => {
+    const { rerender, unmount } = render(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }}>
+          <MapPopup longitude={1} latitude={2} anchor="bottom">
+            <div>popup</div>
+          </MapPopup>
+        </Map>
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    expect(maplibreMocks.popups).toHaveLength(1);
+    expect(maplibreMocks.popups[0]?.options.anchor).toBe("bottom");
+
+    rerender(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }}>
+          <MapPopup longitude={1} latitude={2} anchor="top">
+            <div>popup</div>
+          </MapPopup>
+        </Map>
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    expect(maplibreMocks.popups).toHaveLength(2);
+    expect(maplibreMocks.popups[1]?.options.anchor).toBe("top");
+
+    unmount();
+  });
+
+  test("MarkerTooltip syncs open tooltip options after render", async () => {
+    const { rerender, unmount } = render(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }}>
+          <MapMarker longitude={1} latitude={2}>
+            <MarkerTooltip offset={8} maxWidth="120px">
+              tooltip
+            </MarkerTooltip>
+          </MapMarker>
+        </Map>
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    const marker = maplibreMocks.markers[0];
+    const tooltip = maplibreMocks.popups[0];
+
+    act(() => {
+      marker?.getElement().dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    });
+
+    expect(tooltip?.isOpen()).toBe(true);
+
+    rerender(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }}>
+          <MapMarker longitude={1} latitude={2}>
+            <MarkerTooltip offset={24} maxWidth="240px">
+              tooltip
+            </MarkerTooltip>
+          </MapMarker>
+        </Map>
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    expect(tooltip?.setOffset).toHaveBeenLastCalledWith(24);
+    expect(tooltip?.setMaxWidth).toHaveBeenLastCalledWith("240px");
+
+    unmount();
+  });
+
+  test("MapMarker removes recreated markers once", async () => {
+    const { rerender, unmount } = render(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }}>
+          <MapMarker longitude={1} latitude={2} anchor="bottom">
+            <MarkerContent>marker</MarkerContent>
+          </MapMarker>
+        </Map>
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    const initialMarker = maplibreMocks.markers[0];
+
+    rerender(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }}>
+          <MapMarker longitude={1} latitude={2} anchor="top">
+            <MarkerContent>marker</MarkerContent>
+          </MapMarker>
+        </Map>
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    expect(initialMarker?.remove).toHaveBeenCalledTimes(1);
 
     unmount();
   });

--- a/src/components/ui/__tests__/map.test.tsx
+++ b/src/components/ui/__tests__/map.test.tsx
@@ -95,9 +95,13 @@ const maplibreMocks = vi.hoisted(() => {
     draggable = false;
     popup: FakePopup | null = null;
     element = globalThis.document?.createElement("div") ?? ({} as HTMLElement);
+    options: Record<string, unknown>;
+    events = new globalThis.Map<string, Set<() => void>>();
 
     constructor(options: Record<string, unknown>) {
+      this.options = options;
       this.draggable = Boolean(options.draggable);
+      markers.push(this);
     }
 
     setLngLat([lng, lat]: [number, number]) {
@@ -166,9 +170,23 @@ const maplibreMocks = vi.hoisted(() => {
     getPitchAlignment() {
       return "auto";
     }
+
+    on(event: string, handler: () => void) {
+      if (!this.events.has(event)) {
+        this.events.set(event, new Set());
+      }
+      this.events.get(event)?.add(handler);
+      return this;
+    }
+
+    off(event: string, handler: () => void) {
+      this.events.get(event)?.delete(handler);
+      return this;
+    }
   }
 
   const maps: FakeMap[] = [];
+  const markers: FakeMarker[] = [];
 
   class FakeMap {
     container: HTMLElement;
@@ -176,6 +194,7 @@ const maplibreMocks = vi.hoisted(() => {
     zoom: number;
     bearing: number;
     pitch: number;
+    projection: unknown;
     style: unknown;
     sources = new globalThis.Map<string, FakeGeoJSONSource>();
     layers = new globalThis.Map<string, Record<string, unknown>>();
@@ -204,8 +223,11 @@ const maplibreMocks = vi.hoisted(() => {
         this.pitch = next.pitch ?? this.pitch;
       }
     );
-    setProjection = vi.fn();
+    setProjection = vi.fn((nextProjection: unknown) => {
+      this.projection = nextProjection;
+    });
     setPaintProperty = vi.fn();
+    resize = vi.fn();
 
     constructor(options: Record<string, unknown>) {
       this.container = options.container as HTMLElement;
@@ -213,6 +235,7 @@ const maplibreMocks = vi.hoisted(() => {
       this.zoom = (options.zoom as number | undefined) ?? 0;
       this.bearing = (options.bearing as number | undefined) ?? 0;
       this.pitch = (options.pitch as number | undefined) ?? 0;
+      this.projection = options.projection;
       this.style = options.style;
       this.container.requestFullscreen = vi.fn(async () => undefined);
       maps.push(this);
@@ -337,6 +360,7 @@ const maplibreMocks = vi.hoisted(() => {
     FakeMarker,
     FakePopup,
     maps,
+    markers,
   };
 });
 
@@ -349,7 +373,15 @@ vi.mock("maplibre-gl", () => ({
   },
 }));
 
-import { Map, MapClusterLayer, MapControls, MapPopup, MapRoute } from "@/components/ui/map";
+import {
+  Map,
+  MapClusterLayer,
+  MapControls,
+  MapMarker,
+  MapPopup,
+  MapRoute,
+  MarkerContent,
+} from "@/components/ui/map";
 
 function render(node: ReactNode) {
   const container = document.createElement("div");
@@ -394,6 +426,7 @@ function click(element: Element) {
 describe("Map UI", () => {
   beforeEach(() => {
     maplibreMocks.maps.length = 0;
+    maplibreMocks.markers.length = 0;
     document.body.innerHTML = "";
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
@@ -538,6 +571,54 @@ describe("Map UI", () => {
     unmount();
   });
 
+  test("projection updates sync without recreating the map", async () => {
+    const { rerender, unmount } = render(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }} projection={{ type: "mercator" }} />
+      </div>
+    );
+
+    await flushMicrotasks();
+    const map = maplibreMocks.maps.at(-1);
+    expect(maplibreMocks.maps.length).toBe(1);
+    expect(map?.projection).toEqual({ type: "mercator" });
+    expect(map?.setProjection).toHaveBeenLastCalledWith({ type: "mercator" });
+    const initialProjectionCalls = map?.setProjection.mock.calls.length ?? 0;
+
+    rerender(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }} projection={{ type: "mercator" }} />
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    expect(map?.setProjection).toHaveBeenCalledTimes(initialProjectionCalls);
+
+    rerender(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }} projection={{ type: "globe" }} />
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    expect(maplibreMocks.maps.length).toBe(1);
+    expect(map?.setProjection).toHaveBeenLastCalledWith({ type: "globe" });
+
+    rerender(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }} />
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    expect(map?.setProjection).toHaveBeenLastCalledWith({ type: "mercator" });
+
+    unmount();
+  });
+
   test("MapRoute clears rendered geometry when coordinates shrink below two points", async () => {
     const { rerender, unmount } = render(
       <div className="h-60 w-60">
@@ -612,6 +693,78 @@ describe("Map UI", () => {
     await flushMicrotasks();
 
     expect(source?.setData).toHaveBeenLastCalledWith("https://example.com/b.geojson");
+
+    unmount();
+  });
+
+  test("MapClusterLayer re-adds recreated sources with the latest data", async () => {
+    const { rerender, unmount } = render(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }}>
+          <MapClusterLayer data="https://example.com/a.geojson" clusterRadius={50} />
+        </Map>
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    rerender(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }}>
+          <MapClusterLayer data="https://example.com/b.geojson" clusterRadius={50} />
+        </Map>
+      </div>
+    );
+    await flushMicrotasks();
+
+    rerender(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }}>
+          <MapClusterLayer data="https://example.com/b.geojson" clusterRadius={60} />
+        </Map>
+      </div>
+    );
+    await flushMicrotasks();
+
+    const map = maplibreMocks.maps.at(-1);
+    const source = Array.from(map?.sources.values() ?? [])[0];
+    expect(source?.data).toBe("https://example.com/b.geojson");
+
+    unmount();
+  });
+
+  test("MapMarker recreates construction-only options outside render", async () => {
+    const { rerender, unmount } = render(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }}>
+          <MapMarker longitude={1} latitude={2} anchor="bottom" color="#111111">
+            <MarkerContent>marker</MarkerContent>
+          </MapMarker>
+        </Map>
+      </div>
+    );
+
+    await flushMicrotasks();
+
+    expect(maplibreMocks.markers).toHaveLength(1);
+    expect(maplibreMocks.markers[0]?.options.anchor).toBe("bottom");
+    expect(maplibreMocks.markers[0]?.options.color).toBe("#111111");
+
+    rerender(
+      <div className="h-60 w-60">
+        <Map viewport={{ center: [1, 2], zoom: 3 }}>
+          <MapMarker longitude={1} latitude={2} anchor="top" color="#222222">
+            <MarkerContent>marker</MarkerContent>
+          </MapMarker>
+        </Map>
+      </div>
+    );
+    await flushMicrotasks();
+
+    expect(maplibreMocks.maps.length).toBe(1);
+    expect(maplibreMocks.markers).toHaveLength(2);
+    expect(maplibreMocks.markers[1]?.options.anchor).toBe("top");
+    expect(maplibreMocks.markers[1]?.options.color).toBe("#222222");
 
     unmount();
   });

--- a/src/components/ui/map.tsx
+++ b/src/components/ui/map.tsx
@@ -9,6 +9,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useEffectEvent,
   useId,
   useImperativeHandle,
   useMemo,
@@ -504,7 +505,9 @@ function MapMarker({
     marker.addTo(map);
 
     return () => {
-      marker.remove();
+      if (markerRef.current === marker) {
+        marker.remove();
+      }
     };
   }, [map, marker]);
 
@@ -603,20 +606,41 @@ function MarkerPopup({
 }: MarkerPopupProps) {
   const { marker, map } = useMarkerContext();
   const container = useMemo(() => document.createElement("div"), []);
-  const prevPopupOptions = useRef(popupOptions);
-
-  const popupRef = useRef<MapLibreGL.Popup | null>(null);
-  if (!popupRef.current) {
-    popupRef.current = new MapLibreGL.Popup({
-      offset: 16,
-      ...popupOptions,
-      closeButton: false,
-    })
-      .setMaxWidth("none")
-      .setDOMContent(container);
-  }
-
-  const popup = popupRef.current;
+  const popupConstructionOptions = useMemo(
+    () => ({
+      anchor: popupOptions.anchor,
+      closeOnClick: popupOptions.closeOnClick,
+      closeOnMove: popupOptions.closeOnMove,
+      focusAfterOpen: popupOptions.focusAfterOpen,
+      subpixelPositioning: popupOptions.subpixelPositioning,
+      locationOccludedOpacity: popupOptions.locationOccludedOpacity,
+      padding: popupOptions.padding,
+    }),
+    [
+      popupOptions.anchor,
+      popupOptions.closeOnClick,
+      popupOptions.closeOnMove,
+      popupOptions.focusAfterOpen,
+      popupOptions.subpixelPositioning,
+      popupOptions.locationOccludedOpacity,
+      popupOptions.padding,
+    ]
+  );
+  const popup = useMemo(
+    () =>
+      new MapLibreGL.Popup({
+        offset: 16,
+        ...popupConstructionOptions,
+        closeButton: false,
+      })
+        .setMaxWidth("none")
+        .setDOMContent(container),
+    [container, popupConstructionOptions]
+  );
+  const updatePopupOptions = useEffectEvent(() => {
+    popup.setOffset(popupOptions.offset ?? 16);
+    popup.setMaxWidth(popupOptions.maxWidth ?? "none");
+  });
 
   useEffect(() => {
     if (!map) return;
@@ -626,22 +650,15 @@ function MarkerPopup({
 
     return () => {
       marker.setPopup(null);
+      if (popup.isOpen()) {
+        popup.remove();
+      }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [map, popup.setDOMContent, marker.setPopup, container, popup]);
+  }, [map, marker, popup, container]);
 
-  if (popup.isOpen()) {
-    const prev = prevPopupOptions.current;
-
-    if (prev.offset !== popupOptions.offset) {
-      popup.setOffset(popupOptions.offset ?? 16);
-    }
-    if (prev.maxWidth !== popupOptions.maxWidth && popupOptions.maxWidth) {
-      popup.setMaxWidth(popupOptions.maxWidth ?? "none");
-    }
-
-    prevPopupOptions.current = popupOptions;
-  }
+  useEffect(() => {
+    updatePopupOptions();
+  });
 
   const handleClose = () => popup.remove();
 
@@ -679,61 +696,65 @@ type MarkerTooltipProps = {
 function MarkerTooltip({ children, className, ...popupOptions }: MarkerTooltipProps) {
   const { marker, map } = useMarkerContext();
   const container = useMemo(() => document.createElement("div"), []);
-  const prevTooltipOptions = useRef(popupOptions);
+  const tooltipConstructionOptions = useMemo(
+    () => ({
+      anchor: popupOptions.anchor,
+      closeOnMove: popupOptions.closeOnMove,
+      focusAfterOpen: popupOptions.focusAfterOpen,
+      subpixelPositioning: popupOptions.subpixelPositioning,
+      locationOccludedOpacity: popupOptions.locationOccludedOpacity,
+      padding: popupOptions.padding,
+    }),
+    [
+      popupOptions.anchor,
+      popupOptions.closeOnMove,
+      popupOptions.focusAfterOpen,
+      popupOptions.subpixelPositioning,
+      popupOptions.locationOccludedOpacity,
+      popupOptions.padding,
+    ]
+  );
+  const tooltip = useMemo(
+    () =>
+      new MapLibreGL.Popup({
+        offset: 16,
+        ...tooltipConstructionOptions,
+        closeOnClick: true,
+        closeButton: false,
+      }).setMaxWidth("none"),
+    [tooltipConstructionOptions]
+  );
+  const updateTooltipOptions = useEffectEvent(() => {
+    if (!tooltip.isOpen()) return;
 
-  const tooltipRef = useRef<MapLibreGL.Popup | null>(null);
-  if (!tooltipRef.current) {
-    tooltipRef.current = new MapLibreGL.Popup({
-      offset: 16,
-      ...popupOptions,
-      closeOnClick: true,
-      closeButton: false,
-    }).setMaxWidth("none");
-  }
-
-  const tooltip = tooltipRef.current;
+    tooltip.setOffset(popupOptions.offset ?? 16);
+    tooltip.setMaxWidth(popupOptions.maxWidth ?? "none");
+  });
 
   useEffect(() => {
     if (!map) return;
 
     tooltip.setDOMContent(container);
 
+    const markerElement = marker.getElement();
     const handleMouseEnter = () => {
       tooltip.setLngLat(marker.getLngLat()).addTo(map);
     };
     const handleMouseLeave = () => tooltip.remove();
 
-    marker.getElement()?.addEventListener("mouseenter", handleMouseEnter);
-    marker.getElement()?.addEventListener("mouseleave", handleMouseLeave);
+    markerElement.addEventListener("mouseenter", handleMouseEnter);
+    markerElement.addEventListener("mouseleave", handleMouseLeave);
 
     return () => {
-      marker.getElement()?.removeEventListener("mouseenter", handleMouseEnter);
-      marker.getElement()?.removeEventListener("mouseleave", handleMouseLeave);
+      markerElement.removeEventListener("mouseenter", handleMouseEnter);
+      markerElement.removeEventListener("mouseleave", handleMouseLeave);
       tooltip.remove();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    map,
-    container,
-    tooltip.remove,
-    marker.getElement,
-    tooltip.setLngLat,
-    tooltip.setDOMContent,
-    marker.getLngLat,
-  ]);
+  }, [map, marker, tooltip, container]);
 
-  if (tooltip.isOpen()) {
-    const prev = prevTooltipOptions.current;
-
-    if (prev.offset !== popupOptions.offset) {
-      tooltip.setOffset(popupOptions.offset ?? 16);
-    }
-    if (prev.maxWidth !== popupOptions.maxWidth && popupOptions.maxWidth) {
-      tooltip.setMaxWidth(popupOptions.maxWidth ?? "none");
-    }
-
-    prevTooltipOptions.current = popupOptions;
-  }
+  useEffect(() => {
+    updateTooltipOptions();
+  });
 
   return createPortal(
     <div
@@ -1026,25 +1047,45 @@ function MapPopup({
   ...popupOptions
 }: MapPopupProps) {
   const { map } = useMap();
-  const popupOptionsRef = useRef({
-    offset: popupOptions.offset,
-    maxWidth: popupOptions.maxWidth,
-  });
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
+  const initialPositionRef = useRef<[number, number]>([longitude, latitude]);
   const container = useMemo(() => document.createElement("div"), []);
-
-  const popupRef = useRef<MapLibreGL.Popup | null>(null);
-  if (!popupRef.current) {
-    popupRef.current = new MapLibreGL.Popup({
-      offset: 16,
-      ...popupOptions,
-      closeButton: false,
-    })
-      .setMaxWidth("none")
-      .setLngLat([longitude, latitude]);
-  }
-  const popup = popupRef.current;
+  const popupConstructionOptions = useMemo(
+    () => ({
+      anchor: popupOptions.anchor,
+      closeOnClick: popupOptions.closeOnClick,
+      closeOnMove: popupOptions.closeOnMove,
+      focusAfterOpen: popupOptions.focusAfterOpen,
+      subpixelPositioning: popupOptions.subpixelPositioning,
+      locationOccludedOpacity: popupOptions.locationOccludedOpacity,
+      padding: popupOptions.padding,
+    }),
+    [
+      popupOptions.anchor,
+      popupOptions.closeOnClick,
+      popupOptions.closeOnMove,
+      popupOptions.focusAfterOpen,
+      popupOptions.subpixelPositioning,
+      popupOptions.locationOccludedOpacity,
+      popupOptions.padding,
+    ]
+  );
+  const popup = useMemo(
+    () =>
+      new MapLibreGL.Popup({
+        offset: 16,
+        ...popupConstructionOptions,
+        closeButton: false,
+      })
+        .setMaxWidth("none")
+        .setLngLat(initialPositionRef.current),
+    [popupConstructionOptions]
+  );
+  const updatePopupOptions = useEffectEvent(() => {
+    popup.setOffset(popupOptions.offset ?? 16);
+    popup.setMaxWidth(popupOptions.maxWidth ?? "none");
+  });
 
   useEffect(() => {
     if (!map) return;
@@ -1052,7 +1093,6 @@ function MapPopup({
     const onCloseProp = () => onCloseRef.current?.();
 
     popup.on("close", onCloseProp);
-
     popup.setDOMContent(container);
     popup.addTo(map);
 
@@ -1062,38 +1102,23 @@ function MapPopup({
         popup.remove();
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    map,
-    popup.setDOMContent,
-    popup.remove,
-    popup.on,
-    container,
-    popup.off,
-    popup.isOpen,
-    popup.addTo,
-  ]);
+  }, [map, popup, container]);
 
   useEffect(() => {
-    if (!popup.isOpen()) return;
-
-    const prev = popupOptionsRef.current;
+    if (!map) return;
 
     if (popup.getLngLat().lng !== longitude || popup.getLngLat().lat !== latitude) {
       popup.setLngLat([longitude, latitude]);
     }
+    if (!popup.isOpen()) {
+      popup.setDOMContent(container);
+      popup.addTo(map);
+    }
+  }, [map, popup, longitude, latitude, container]);
 
-    if (prev.offset !== popupOptions.offset) {
-      popup.setOffset(popupOptions.offset ?? 16);
-    }
-    if (prev.maxWidth !== popupOptions.maxWidth && popupOptions.maxWidth) {
-      popup.setMaxWidth(popupOptions.maxWidth ?? "none");
-    }
-    popupOptionsRef.current = {
-      offset: popupOptions.offset,
-      maxWidth: popupOptions.maxWidth,
-    };
-  }, [popup, longitude, latitude, popupOptions.offset, popupOptions.maxWidth]);
+  useEffect(() => {
+    updatePopupOptions();
+  });
 
   const handleClose = () => {
     popup.remove();

--- a/src/components/ui/map.tsx
+++ b/src/components/ui/map.tsx
@@ -24,6 +24,9 @@ const defaultStyles = {
   light: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
 };
 
+const defaultMarkerOffset: NonNullable<MarkerOptions["offset"]> = [0, 0];
+const defaultProjection: MapLibreGL.ProjectionSpecification = { type: "mercator" };
+
 type Theme = "light" | "dark";
 
 // Check document class for theme (works with next-themes, etc.)
@@ -169,6 +172,14 @@ function getViewport(map: MapLibreGL.Map): MapViewport {
   };
 }
 
+function getProjectionKey(projection?: MapLibreGL.ProjectionSpecification) {
+  return projection ? JSON.stringify(projection) : "";
+}
+
+function getMarkerOffsetTuple(offset: NonNullable<MarkerOptions["offset"]>): [number, number] {
+  return Array.isArray(offset) ? [offset[0], offset[1]] : [offset.x, offset.y];
+}
+
 const Map = forwardRef<MapRef, MapProps>(function Map(
   {
     children,
@@ -204,6 +215,15 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
     }),
     [styles]
   );
+  const projectionKey = useMemo(() => getProjectionKey(projection), [projection]);
+  const projectionRef = useRef(projection);
+  projectionRef.current = projection;
+  const syncProjection = useCallback((targetMap: MapLibreGL.Map, nextProjectionKey: string) => {
+    const nextProjection = projectionRef.current;
+    if (nextProjectionKey && !nextProjection) return;
+
+    targetMap.setProjection(nextProjection ?? defaultProjection);
+  }, []);
 
   // Expose the map instance to the parent component
   useImperativeHandle(ref, () => mapInstance as MapLibreGL.Map, [mapInstance]);
@@ -225,15 +245,13 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
       },
       ...props,
       ...viewport,
+      ...(projectionRef.current ? { projection: projectionRef.current } : {}),
     });
 
     const loadHandler = () => setIsLoaded(true);
     const syncStyleReady = () => {
       if (!map.isStyleLoaded()) return;
       setIsStyleLoaded(true);
-      if (projection) {
-        map.setProjection(projection);
-      }
     };
     const styleDataHandler = () => syncStyleReady();
     const idleHandler = () => syncStyleReady();
@@ -250,7 +268,12 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
     map.on("move", handleMove);
     setMapInstance(map);
 
+    const resizeFrame = window.requestAnimationFrame(() => {
+      map.resize();
+    });
+
     return () => {
+      window.cancelAnimationFrame(resizeFrame);
       map.off("load", loadHandler);
       map.off("idle", idleHandler);
       map.off("styledata", styleDataHandler);
@@ -261,7 +284,7 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
       setMapInstance(null);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resolvedTheme, mapStyles.light, viewport, projection, props, mapStyles.dark]);
+  }, []);
 
   // Sync controlled viewport to map
   useEffect(() => {
@@ -304,6 +327,12 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
 
     mapInstance.setStyle(newStyle, { diff: true });
   }, [mapInstance, resolvedTheme, mapStyles]);
+
+  useEffect(() => {
+    if (!mapInstance || !isStyleLoaded) return;
+
+    syncProjection(mapInstance, projectionKey);
+  }, [mapInstance, projectionKey, isStyleLoaded, syncProjection]);
 
   const contextValue = useMemo(
     () => ({
@@ -392,43 +421,84 @@ function MapMarker({
     onDragEnd,
   };
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: marker instance is intentionally stable
-  const marker = useMemo(() => {
-    const markerInstance = new MapLibreGL.Marker({
-      ...markerOptions,
+  const markerRef = useRef<MapLibreGL.Marker | null>(null);
+  const markerOptionsRef = useRef(markerOptions);
+  markerOptionsRef.current = markerOptions;
+  const markerStateRef = useRef({ longitude, latitude, draggable });
+  markerStateRef.current = { longitude, latitude, draggable };
+  const [marker, setMarker] = useState<MapLibreGL.Marker | null>(null);
+  const markerAnchor = markerOptions.anchor;
+  const markerClickTolerance = markerOptions.clickTolerance;
+  const markerColor = markerOptions.color;
+  const markerScale = markerOptions.scale;
+  const markerConstructorOptions = useMemo(
+    () => ({
+      anchor: markerAnchor,
+      clickTolerance: markerClickTolerance,
+      color: markerColor,
+      scale: markerScale,
+    }),
+    [markerAnchor, markerClickTolerance, markerColor, markerScale]
+  );
+  const markerOffset = markerOptions.offset ?? defaultMarkerOffset;
+  const [markerOffsetX, markerOffsetY] = getMarkerOffsetTuple(markerOffset);
+  const markerRotation = markerOptions.rotation ?? 0;
+  const markerRotationAlignment = markerOptions.rotationAlignment ?? "auto";
+  const markerPitchAlignment = markerOptions.pitchAlignment ?? "auto";
+
+  useEffect(() => {
+    const initialState = markerStateRef.current;
+    const nextMarker = new MapLibreGL.Marker({
+      ...markerOptionsRef.current,
+      ...markerConstructorOptions,
       element: document.createElement("div"),
-      draggable,
-    }).setLngLat([longitude, latitude]);
+      draggable: initialState.draggable,
+    }).setLngLat([initialState.longitude, initialState.latitude]);
+    markerRef.current = nextMarker;
 
-    const handleClick = (e: MouseEvent) => callbacksRef.current.onClick?.(e);
-    const handleMouseEnter = (e: MouseEvent) => callbacksRef.current.onMouseEnter?.(e);
-    const handleMouseLeave = (e: MouseEvent) => callbacksRef.current.onMouseLeave?.(e);
+    const handleClick = (event: MouseEvent) => callbacksRef.current.onClick?.(event);
+    const handleMouseEnter = (event: MouseEvent) => callbacksRef.current.onMouseEnter?.(event);
+    const handleMouseLeave = (event: MouseEvent) => callbacksRef.current.onMouseLeave?.(event);
 
-    markerInstance.getElement()?.addEventListener("click", handleClick);
-    markerInstance.getElement()?.addEventListener("mouseenter", handleMouseEnter);
-    markerInstance.getElement()?.addEventListener("mouseleave", handleMouseLeave);
+    const element = nextMarker.getElement();
+    element.addEventListener("click", handleClick);
+    element.addEventListener("mouseenter", handleMouseEnter);
+    element.addEventListener("mouseleave", handleMouseLeave);
 
     const handleDragStart = () => {
-      const lngLat = markerInstance.getLngLat();
+      const lngLat = nextMarker.getLngLat();
       callbacksRef.current.onDragStart?.({ lng: lngLat.lng, lat: lngLat.lat });
     };
     const handleDrag = () => {
-      const lngLat = markerInstance.getLngLat();
+      const lngLat = nextMarker.getLngLat();
       callbacksRef.current.onDrag?.({ lng: lngLat.lng, lat: lngLat.lat });
     };
     const handleDragEnd = () => {
-      const lngLat = markerInstance.getLngLat();
+      const lngLat = nextMarker.getLngLat();
       callbacksRef.current.onDragEnd?.({ lng: lngLat.lng, lat: lngLat.lat });
     };
 
-    markerInstance.on("dragstart", handleDragStart);
-    markerInstance.on("drag", handleDrag);
-    markerInstance.on("dragend", handleDragEnd);
+    nextMarker.on("dragstart", handleDragStart);
+    nextMarker.on("drag", handleDrag);
+    nextMarker.on("dragend", handleDragEnd);
+    setMarker(nextMarker);
 
-    return markerInstance;
-  }, [longitude, markerOptions, draggable, latitude]);
+    return () => {
+      element.removeEventListener("click", handleClick);
+      element.removeEventListener("mouseenter", handleMouseEnter);
+      element.removeEventListener("mouseleave", handleMouseLeave);
+      nextMarker.off("dragstart", handleDragStart);
+      nextMarker.off("drag", handleDrag);
+      nextMarker.off("dragend", handleDragEnd);
+      nextMarker.remove();
+      if (markerRef.current === nextMarker) {
+        markerRef.current = null;
+      }
+    };
+  }, [markerConstructorOptions]);
 
   useEffect(() => {
+    if (!marker) return;
     if (!map) return;
 
     marker.addTo(map);
@@ -436,35 +506,47 @@ function MapMarker({
     return () => {
       marker.remove();
     };
+  }, [map, marker]);
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [map, marker.addTo, marker.remove]);
+  useEffect(() => {
+    if (!marker) return;
 
-  if (marker.getLngLat().lng !== longitude || marker.getLngLat().lat !== latitude) {
-    marker.setLngLat([longitude, latitude]);
-  }
-  if (marker.isDraggable() !== draggable) {
-    marker.setDraggable(draggable);
-  }
+    const currentLngLat = marker.getLngLat();
+    if (currentLngLat.lng !== longitude || currentLngLat.lat !== latitude) {
+      marker.setLngLat([longitude, latitude]);
+    }
 
-  const currentOffset = marker.getOffset();
-  const newOffset = markerOptions.offset ?? [0, 0];
-  const [newOffsetX, newOffsetY] = Array.isArray(newOffset)
-    ? newOffset
-    : [newOffset.x, newOffset.y];
-  if (currentOffset.x !== newOffsetX || currentOffset.y !== newOffsetY) {
-    marker.setOffset(newOffset);
-  }
+    if (marker.isDraggable() !== draggable) {
+      marker.setDraggable(draggable);
+    }
 
-  if (marker.getRotation() !== markerOptions.rotation) {
-    marker.setRotation(markerOptions.rotation ?? 0);
-  }
-  if (marker.getRotationAlignment() !== markerOptions.rotationAlignment) {
-    marker.setRotationAlignment(markerOptions.rotationAlignment ?? "auto");
-  }
-  if (marker.getPitchAlignment() !== markerOptions.pitchAlignment) {
-    marker.setPitchAlignment(markerOptions.pitchAlignment ?? "auto");
-  }
+    const currentOffset = marker.getOffset();
+    if (currentOffset.x !== markerOffsetX || currentOffset.y !== markerOffsetY) {
+      marker.setOffset([markerOffsetX, markerOffsetY]);
+    }
+
+    if (marker.getRotation() !== markerRotation) {
+      marker.setRotation(markerRotation);
+    }
+    if (marker.getRotationAlignment() !== markerRotationAlignment) {
+      marker.setRotationAlignment(markerRotationAlignment);
+    }
+    if (marker.getPitchAlignment() !== markerPitchAlignment) {
+      marker.setPitchAlignment(markerPitchAlignment);
+    }
+  }, [
+    marker,
+    longitude,
+    latitude,
+    draggable,
+    markerOffsetX,
+    markerOffsetY,
+    markerRotation,
+    markerRotationAlignment,
+    markerPitchAlignment,
+  ]);
+
+  if (!marker) return null;
 
   return <MarkerContext.Provider value={{ marker, map }}>{children}</MarkerContext.Provider>;
 }
@@ -523,18 +605,18 @@ function MarkerPopup({
   const container = useMemo(() => document.createElement("div"), []);
   const prevPopupOptions = useRef(popupOptions);
 
-  const popup = useMemo(() => {
-    const popupInstance = new MapLibreGL.Popup({
+  const popupRef = useRef<MapLibreGL.Popup | null>(null);
+  if (!popupRef.current) {
+    popupRef.current = new MapLibreGL.Popup({
       offset: 16,
       ...popupOptions,
       closeButton: false,
     })
       .setMaxWidth("none")
       .setDOMContent(container);
+  }
 
-    return popupInstance;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [container, popupOptions]);
+  const popup = popupRef.current;
 
   useEffect(() => {
     if (!map) return;
@@ -599,17 +681,17 @@ function MarkerTooltip({ children, className, ...popupOptions }: MarkerTooltipPr
   const container = useMemo(() => document.createElement("div"), []);
   const prevTooltipOptions = useRef(popupOptions);
 
-  const tooltip = useMemo(() => {
-    const tooltipInstance = new MapLibreGL.Popup({
+  const tooltipRef = useRef<MapLibreGL.Popup | null>(null);
+  if (!tooltipRef.current) {
+    tooltipRef.current = new MapLibreGL.Popup({
       offset: 16,
       ...popupOptions,
       closeOnClick: true,
       closeButton: false,
     }).setMaxWidth("none");
+  }
 
-    return tooltipInstance;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [popupOptions]);
+  const tooltip = tooltipRef.current;
 
   useEffect(() => {
     if (!map) return;
@@ -944,23 +1026,25 @@ function MapPopup({
   ...popupOptions
 }: MapPopupProps) {
   const { map } = useMap();
-  const popupOptionsRef = useRef(popupOptions);
+  const popupOptionsRef = useRef({
+    offset: popupOptions.offset,
+    maxWidth: popupOptions.maxWidth,
+  });
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
   const container = useMemo(() => document.createElement("div"), []);
 
-  const popup = useMemo(() => {
-    const popupInstance = new MapLibreGL.Popup({
+  const popupRef = useRef<MapLibreGL.Popup | null>(null);
+  if (!popupRef.current) {
+    popupRef.current = new MapLibreGL.Popup({
       offset: 16,
       ...popupOptions,
       closeButton: false,
     })
       .setMaxWidth("none")
       .setLngLat([longitude, latitude]);
-
-    return popupInstance;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [longitude, latitude, popupOptions]);
+  }
+  const popup = popupRef.current;
 
   useEffect(() => {
     if (!map) return;
@@ -990,7 +1074,9 @@ function MapPopup({
     popup.addTo,
   ]);
 
-  if (popup.isOpen()) {
+  useEffect(() => {
+    if (!popup.isOpen()) return;
+
     const prev = popupOptionsRef.current;
 
     if (popup.getLngLat().lng !== longitude || popup.getLngLat().lat !== latitude) {
@@ -1003,8 +1089,11 @@ function MapPopup({
     if (prev.maxWidth !== popupOptions.maxWidth && popupOptions.maxWidth) {
       popup.setMaxWidth(popupOptions.maxWidth ?? "none");
     }
-    popupOptionsRef.current = popupOptions;
-  }
+    popupOptionsRef.current = {
+      offset: popupOptions.offset,
+      maxWidth: popupOptions.maxWidth,
+    };
+  }, [popup, longitude, latitude, popupOptions.offset, popupOptions.maxWidth]);
 
   const handleClose = () => {
     popup.remove();
@@ -1219,6 +1308,8 @@ function MapClusterLayer<P extends GeoJSON.GeoJsonProperties = GeoJSON.GeoJsonPr
     clusterThresholds,
     pointColor,
   });
+  const latestDataRef = useRef(data);
+  latestDataRef.current = data;
 
   // Add source and layers on mount
   useEffect(() => {
@@ -1227,7 +1318,7 @@ function MapClusterLayer<P extends GeoJSON.GeoJsonProperties = GeoJSON.GeoJsonPr
     // Add clustered GeoJSON source
     map.addSource(sourceId, {
       type: "geojson",
-      data,
+      data: latestDataRef.current,
       cluster: true,
       clusterMaxZoom,
       clusterRadius,
@@ -1314,7 +1405,6 @@ function MapClusterLayer<P extends GeoJSON.GeoJsonProperties = GeoJSON.GeoJsonPr
     clusterThresholds[1],
     clusterMaxZoom,
     clusterRadius,
-    data,
     pointColor,
     clusterLayerId,
     clusterCountLayerId,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -104,7 +104,10 @@ function proxyHandler(request: NextRequest) {
     // Preserve locale in redirect
     const locale = isLocaleInPath ? potentialLocale : routing.defaultLocale;
     url.pathname = `/${locale}/login`;
-    url.searchParams.set("from", pathWithoutLocale || "/dashboard");
+    url.searchParams.set(
+      "from",
+      !pathWithoutLocale || pathWithoutLocale === "/" ? "/dashboard" : pathWithoutLocale
+    );
     return NextResponse.redirect(url);
   }
 

--- a/src/repository/system-config.ts
+++ b/src/repository/system-config.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { systemSettings } from "@/drizzle/schema";
 import { logger } from "@/lib/logger";
@@ -274,7 +274,11 @@ export async function getSystemSettings(): Promise<SystemSettings> {
     };
 
     try {
-      const [row] = await db.select(fullSelection).from(systemSettings).limit(1);
+      const [row] = await db
+        .select(fullSelection)
+        .from(systemSettings)
+        .orderBy(asc(systemSettings.id))
+        .limit(1);
       return row ?? null;
     } catch (error) {
       // 兼容旧版本数据库：system_settings 表存在但列未迁移齐全
@@ -294,6 +298,7 @@ export async function getSystemSettings(): Promise<SystemSettings> {
           const [row] = await db
             .select(selectionWithoutNonConversationFallback)
             .from(systemSettings)
+            .orderBy(asc(systemSettings.id))
             .limit(1);
           return row ?? null;
         } catch (nonConversationFallbackError) {
@@ -308,7 +313,11 @@ export async function getSystemSettings(): Promise<SystemSettings> {
         }
 
         try {
-          const [row] = await db.select(selectionWithoutPassThrough).from(systemSettings).limit(1);
+          const [row] = await db
+            .select(selectionWithoutPassThrough)
+            .from(systemSettings)
+            .orderBy(asc(systemSettings.id))
+            .limit(1);
           return row ?? null;
         } catch (passThroughFallbackError) {
           if (!isUndefinedColumnError(passThroughFallbackError)) {
@@ -326,6 +335,7 @@ export async function getSystemSettings(): Promise<SystemSettings> {
             const [row] = await db
               .select(selectionWithoutHighConcurrencyMode)
               .from(systemSettings)
+              .orderBy(asc(systemSettings.id))
               .limit(1);
             return row ?? null;
           } catch (fallbackError) {
@@ -341,6 +351,7 @@ export async function getSystemSettings(): Promise<SystemSettings> {
               const [row] = await db
                 .select(selectionWithoutCodexAndHighConcurrency)
                 .from(systemSettings)
+                .orderBy(asc(systemSettings.id))
                 .limit(1);
               return row ?? null;
             } catch (legacyFallbackError) {
@@ -363,7 +374,11 @@ export async function getSystemSettings(): Promise<SystemSettings> {
                 updatedAt: systemSettings.updatedAt,
               };
 
-              const [row] = await db.select(minimalSelection).from(systemSettings).limit(1);
+              const [row] = await db
+                .select(minimalSelection)
+                .from(systemSettings)
+                .orderBy(asc(systemSettings.id))
+                .limit(1);
               return row ?? null;
             }
           }

--- a/tests/unit/actions/system-config-non-chat-retry-setting.test.ts
+++ b/tests/unit/actions/system-config-non-chat-retry-setting.test.ts
@@ -148,6 +148,7 @@ describe("non-chat fallback system setting", () => {
         select: vi.fn(() => {
           const query: any = {};
           query.from = vi.fn(() => query);
+          query.orderBy = vi.fn(() => query);
           query.limit = vi.fn(() => Promise.reject({ code: "42P01" }));
           return query;
         }),

--- a/tests/unit/public-status/public-path.test.ts
+++ b/tests/unit/public-status/public-path.test.ts
@@ -47,6 +47,24 @@ describe("public status proxy path", () => {
     expect(response.headers.get("location")).toContain("/en/login");
   });
 
+  it("redirects bare root to locale login with a dashboard fallback", async () => {
+    const { default: proxyHandler } = await import("@/proxy");
+    const response = proxyHandler(new NextRequest("http://localhost/"));
+    const location = response.headers.get("location");
+
+    expect(location).toContain("/zh-CN/login");
+    expect(location).toContain("from=%2Fdashboard");
+  });
+
+  it("redirects locale root to login with a dashboard fallback", async () => {
+    const { default: proxyHandler } = await import("@/proxy");
+    const response = proxyHandler(new NextRequest("http://localhost/en"));
+    const location = response.headers.get("location");
+
+    expect(location).toContain("/en/login");
+    expect(location).toContain("from=%2Fdashboard");
+  });
+
   it("strips spoofed x-cch-public-status on non-status requests", async () => {
     const { default: proxyHandler } = await import("@/proxy");
     const response = proxyHandler(

--- a/tests/unit/repository/system-config-update-missing-columns.test.ts
+++ b/tests/unit/repository/system-config-update-missing-columns.test.ts
@@ -4,6 +4,7 @@ function createThenableQuery<T>(result: T) {
   const query: any = Promise.resolve(result);
 
   query.from = vi.fn(() => query);
+  query.orderBy = vi.fn(() => query);
   query.limit = vi.fn(() => query);
 
   query.set = vi.fn(() => query);
@@ -20,6 +21,7 @@ function createRejectedThenableQuery(error: unknown) {
   const query: any = {};
 
   query.from = vi.fn(() => query);
+  query.orderBy = vi.fn(() => query);
   query.limit = vi.fn(() => Promise.reject(error));
 
   query.set = vi.fn(() => query);
@@ -33,6 +35,88 @@ function createRejectedThenableQuery(error: unknown) {
 }
 
 describe("SystemSettings：数据库缺列时的保存兜底", () => {
+  test("getSystemSettings 应稳定按最早记录读取，避免无序 LIMIT 1 丢失 IP 提取配置", async () => {
+    vi.resetModules();
+
+    const now = new Date("2026-04-24T00:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    const selectQuery = createThenableQuery([
+      {
+        id: 1,
+        siteTitle: "AutoBits Claude Code Hub",
+        allowGlobalUsageView: false,
+        currencyDisplay: "USD",
+        billingModelSource: "original",
+        codexPriorityBillingSource: "requested",
+        timezone: null,
+        enableAutoCleanup: false,
+        cleanupRetentionDays: 30,
+        cleanupSchedule: "0 2 * * *",
+        cleanupBatchSize: 10000,
+        enableClientVersionCheck: false,
+        verboseProviderError: false,
+        passThroughUpstreamErrorMessage: true,
+        enableHttp2: false,
+        enableHighConcurrencyMode: false,
+        interceptAnthropicWarmupRequests: false,
+        enableThinkingSignatureRectifier: true,
+        enableThinkingBudgetRectifier: true,
+        enableBillingHeaderRectifier: true,
+        enableResponseInputRectifier: true,
+        allowNonConversationEndpointProviderFallback: true,
+        enableCodexSessionIdCompletion: true,
+        enableClaudeMetadataUserIdInjection: true,
+        enableResponseFixer: true,
+        responseFixerConfig: {
+          fixTruncatedJson: true,
+          fixSseFormat: true,
+          fixEncoding: true,
+          maxJsonDepth: 200,
+          maxFixSize: 1024 * 1024,
+        },
+        quotaDbRefreshIntervalSeconds: 10,
+        quotaLeasePercent5h: "0.05",
+        quotaLeasePercentDaily: "0.05",
+        quotaLeasePercentWeekly: "0.05",
+        quotaLeasePercentMonthly: "0.05",
+        quotaLeaseCapUsd: null,
+        publicStatusWindowHours: 24,
+        publicStatusAggregationIntervalMinutes: 5,
+        ipExtractionConfig: {
+          headers: [
+            { name: "cf-connecting-ip" },
+            { name: "x-real-ip" },
+            { name: "x-forwarded-for", pick: "rightmost" },
+          ],
+        },
+        ipGeoLookupEnabled: true,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    const selectMock = vi.fn(() => selectQuery);
+
+    vi.doMock("@/drizzle/db", () => ({
+      db: {
+        select: selectMock,
+        update: vi.fn(() => createThenableQuery([])),
+        insert: vi.fn(() => createThenableQuery([])),
+        execute: vi.fn(async () => ({ count: 0 })),
+      },
+    }));
+
+    const { getSystemSettings } = await import("@/repository/system-config");
+
+    const result = await getSystemSettings();
+
+    expect(selectQuery.orderBy).toHaveBeenCalledTimes(1);
+    expect(result.ipExtractionConfig?.headers[0]?.name).toBe("cf-connecting-ip");
+
+    vi.useRealTimers();
+  });
+
   test("updateSystemSettings 遇到 42703（列缺失）应返回可行动的错误信息", async () => {
     vi.resetModules();
 


### PR DESCRIPTION
## Summary

Release v0.7.2 — bundles the regression fixes from #1098 to address root-path 404, IP detail map instability, settings i18n, and non-deterministic system-settings reads introduced in v0.7.1.

## Problem

Four regressions were reported after v0.7.1:

1. **Root path 404** — navigating to `/` returned a 404 instead of redirecting to the locale-aware dashboard or login page.
2. **IP detail map not rendering** — the MapLibre map on the IP details page had lifecycle instability causing remount flicker, stale projection state, and stale cluster data.
3. **Settings i18n missing key** — the auto-cleanup form's saving button displayed a raw key path (`common.saving`) instead of the translated string.
4. **Non-deterministic system settings** — `getSystemSettings()` used unordered `LIMIT 1` queries, which could return an incorrect row when multiple `system_settings` rows existed, bypassing the configured `ip_extraction_config`.

**Related Issues:**
- Fixes #1097 — root path returns 404 when authenticated

**Related PRs:**
- Contains #1098 — fix: repair settings i18n and IP routing regressions
- Related to #1032 — original IP geo map panel (map component source)

## Solution

Each regression is addressed with targeted fixes:

1. **Root path** — Added `src/app/page.tsx` with a `RootPage` component that redirects `/` to `/{defaultLocale}/dashboard`. Fixed `src/proxy.ts` to default the login `from` param to `/dashboard` for both bare `/` and locale-root paths.
2. **Map stability** — Refactored `map.tsx` to use stable mount effects (empty dependency array), dedicated projection-sync effect, ref-based marker lifecycle with proper cleanup, and `requestAnimationFrame` resize on mount. Popups and tooltips are stabilized via refs instead of `useMemo` with changing dependencies.
3. **Settings i18n** — Added `useTranslations("settings.common")` hook to auto-cleanup form so the saving label resolves correctly.
4. **Deterministic settings** — Added `orderBy(asc(systemSettings.id))` to all six `LIMIT 1` query paths in `getSystemSettings()`, ensuring the first-inserted settings row is always returned.

## Changes

### Core Changes
- `src/app/page.tsx` — New bare root redirect page
- `src/proxy.ts` — Fixed `from` param fallback for root/locale-root paths
- `src/components/ui/map.tsx` — Stabilized MapLibre lifecycle: stable mount effect, projection sync, marker ref lifecycle, popup/tooltip refs, cluster data freshness
- `src/app/[locale]/settings/config/_components/auto-cleanup-form.tsx` — Fixed i18n key namespace for saving label
- `src/repository/system-config.ts` — Added deterministic `ORDER BY id ASC` to all settings queries

### Tests
- `src/components/ui/__tests__/map.test.tsx` — Added tests for projection sync, cluster data re-creation, and marker construction-option changes
- `tests/unit/public-status/public-path.test.ts` — Added tests for root/locale-root redirect behavior
- `tests/unit/repository/system-config-update-missing-columns.test.ts` — Added test verifying deterministic settings read with IP extraction config
- `tests/unit/actions/system-config-non-chat-retry-setting.test.ts` — Updated mock chain to include `orderBy`

## Breaking Changes

None.

## Verification

From #1098 — all checks passed:
- `bun run build` — passed
- `bun run lint` / `lint:fix` — passed
- `bun run typecheck` — passed
- `bun run test` — 545 test files passed, 5060 tests passed

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This release bundles four targeted regression fixes from #1098: a new `src/app/page.tsx` root redirect, a corrected `from`-param fallback in `proxy.ts`, the `settings.common` i18n namespace fix in the auto-cleanup form, and deterministic `ORDER BY id ASC` applied to all six `LIMIT 1` paths in `getSystemSettings()`. The most substantial change is the `map.tsx` lifecycle refactor (stable mount effect, separate projection-sync effect, ref-backed marker lifecycle, `useEffectEvent`-based popup/tooltip option sync), which is thoroughly covered by the new test suite.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all regressions are addressed with targeted fixes and 545 passing tests; the only finding is a minor style inconsistency in map.tsx.

All four regressions are fixed with minimal, well-tested changes. The single comment is a P2 style inconsistency (unconditional vs guarded useEffectEvent call) that has no runtime impact. No P0 or P1 issues were identified.

No files require special attention; src/components/ui/map.tsx carries the most complexity but is covered by the new test suite.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/ui/map.tsx | Significant lifecycle stabilisation: map-creation effect now has an empty dep array, projection is synced in a dedicated effect, markers are managed via useEffect+useState+ref, and popup/tooltip options are synced via useEffectEvent. One minor inconsistency: MarkerPopup.updatePopupOptions calls setOffset/setMaxWidth unconditionally on every render, while MarkerTooltip.updateTooltipOptions correctly guards with if (!tooltip.isOpen()) return. |
| src/repository/system-config.ts | Adds orderBy(asc(systemSettings.id)) to all six LIMIT 1 query paths in getSystemSettings(), making the read deterministic so the first-inserted row (which carries the configured ip_extraction_config) is always returned. |
| src/proxy.ts | Fixes the from param on unauthenticated redirects: treats both an empty path and / as the dashboard default, preventing a potential redirect loop to / after login. |
| src/app/page.tsx | New server component at the bare / route that calls redirect() to /{defaultLocale}/dashboard, eliminating the 404 that previously occurred when navigating to the root path. |
| src/app/[locale]/settings/config/_components/auto-cleanup-form.tsx | Adds a second translation hook useTranslations("settings.common") and replaces the broken t("common.saving") key lookup with tCommon("saving") — a minimal, correct i18n fix. |
| src/components/ui/__tests__/map.test.tsx | Comprehensive new tests covering projection sync, cluster data freshness, popup reopen on coordinate change, construction-option recreation for both MapPopup and MapMarker, tooltip option sync, and the single-removal invariant for markers. |
| tests/unit/repository/system-config-update-missing-columns.test.ts | Adds a test asserting that getSystemSettings() calls orderBy exactly once and returns the correct ipExtractionConfig from the mock first-row result, and updates query builder mocks to include .orderBy(). |
| tests/unit/public-status/public-path.test.ts | Adds two proxy tests verifying that bare / and locale-root /en both redirect to login with from=%2Fdashboard, directly covering the regression fixed in proxy.ts. |
| tests/unit/actions/system-config-non-chat-retry-setting.test.ts | Adds .orderBy to the mock query chain in the existing non-chat-retry test so it doesn't break under the updated getSystemSettings() which now always calls .orderBy(). |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["GET /"] --> B{"src/app/page.tsx"}
    B --> C["redirect /{defaultLocale}/dashboard"]

    D["GET /{locale}/protected"] --> E{"proxy.ts"}
    E --> F{"Authenticated?"}
    F -- No --> G["Redirect /{locale}/login?from=..."]
    G --> H{"pathWithoutLocale empty or '/'?"}
    H -- Yes --> I["from = /dashboard"]
    H -- No --> J["from = pathWithoutLocale"]
    F -- Yes --> K["Pass through"]

    L["getSystemSettings()"] --> M["db.select.from.orderBy(asc(id)).limit(1)"]
    M --> N{"Column error?"}
    N -- Yes --> O["Fallback select\norderBy(asc(id)).limit(1)"]
    N -- No --> P["Return row"]
    O --> P
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/ui/map.tsx
Line: 659-661

Comment:
**`MarkerPopup.updatePopupOptions` runs unconditionally on every render**

`setOffset` and `setMaxWidth` are called on every render regardless of whether the popup is currently open, while `MarkerTooltip.updateTooltipOptions` consistently guards with `if (!tooltip.isOpen()) return`. For `MarkerPopup` the popup may not be shown yet (it's opened by marker interaction), so the calls are a no-op at that point but inconsistent with the tooltip approach. Consider adding the same guard for symmetry:

```suggestion
  useEffect(() => {
    if (popup.isOpen()) updatePopupOptions();
  });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(map): repair popup lifecycle regress..."](https://github.com/ding113/claude-code-hub/commit/680f5dda51af3ad344223bd15a721401d478378d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29616528)</sub>

<!-- /greptile_comment -->