### PR TITLE
feat(proxy): OpenAI Responses WebSocket support for Codex providers

### DIFF
--- a/drizzle/0099_worthless_gauntlet.sql
+++ b/drizzle/0099_worthless_gauntlet.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "system_settings" ADD COLUMN IF NOT EXISTS "enable_openai_responses_websocket" boolean DEFAULT true NOT NULL;

--- a/drizzle/meta/0099_snapshot.json
+++ b/drizzle/meta/0099_snapshot.json
@@ -1,0 +1,4478 @@
+{
+  "id": "f475eec8-aa3e-4c45-8b70-85400b73a776",
+  "prevId": "6014bb32-638d-4ca1-bb4b-16d9f3fe0e01",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action_category": {
+          "name": "action_category",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_value": {
+          "name": "before_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_value": {
+          "name": "after_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_user_id": {
+          "name": "operator_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_user_name": {
+          "name": "operator_user_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_key_id": {
+          "name": "operator_key_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_key_name": {
+          "name": "operator_key_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_ip": {
+          "name": "operator_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_category_created_at": {
+          "name": "idx_audit_log_category_created_at",
+          "columns": [
+            {
+              "expression": "action_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_operator_user_created_at": {
+          "name": "idx_audit_log_operator_user_created_at",
+          "columns": [
+            {
+              "expression": "operator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"operator_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_operator_ip_created_at": {
+          "name": "idx_audit_log_operator_ip_created_at",
+          "columns": [
+            {
+              "expression": "operator_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"operator_ip\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_target": {
+          "name": "idx_audit_log_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"target_type\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_created_at_id": {
+          "name": "idx_audit_log_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_rules": {
+      "name": "error_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regex'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_response": {
+          "name": "override_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_status_code": {
+          "name": "override_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_rules_enabled": {
+          "name": "idx_error_rules_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_pattern": {
+          "name": "unique_pattern",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_category": {
+          "name": "idx_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_match_type": {
+          "name": "idx_match_type",
+          "columns": [
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_login_web_ui": {
+          "name": "can_login_web_ui",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_reset_mode": {
+          "name": "limit_5h_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rolling'"
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_reset_at": {
+          "name": "cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_keys_user_id": {
+          "name": "idx_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_key": {
+          "name": "idx_keys_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_created_at": {
+          "name": "idx_keys_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_deleted_at": {
+          "name": "idx_keys_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_request": {
+      "name": "message_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_cost_multiplier": {
+          "name": "group_cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_breakdown": {
+          "name": "cost_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "provider_chain": {
+          "name": "provider_chain",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_response_model": {
+          "name": "actual_response_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "swap_cache_ttl_applied": {
+          "name": "swap_cache_ttl_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "special_settings": {
+          "name": "special_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_cause": {
+          "name": "error_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages_count": {
+          "name": "messages_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_message_request_user_date_cost": {
+          "name": "idx_message_request_user_date_cost",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_created_at_cost_stats": {
+          "name": "idx_message_request_user_created_at_cost_stats",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_query": {
+          "name": "idx_message_request_user_query",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_created_at_active": {
+          "name": "idx_message_request_provider_created_at_active",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_created_at_finalized_active": {
+          "name": "idx_message_request_provider_created_at_finalized_active",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"status_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_id": {
+          "name": "idx_message_request_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_id_prefix": {
+          "name": "idx_message_request_session_id_prefix",
+          "columns": [
+            {
+              "expression": "\"session_id\" varchar_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_seq": {
+          "name": "idx_message_request_session_seq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_endpoint": {
+          "name": "idx_message_request_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_blocked_by": {
+          "name": "idx_message_request_blocked_by",
+          "columns": [
+            {
+              "expression": "blocked_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_id": {
+          "name": "idx_message_request_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_id": {
+          "name": "idx_message_request_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key": {
+          "name": "idx_message_request_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_created_at_id": {
+          "name": "idx_message_request_key_created_at_id",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_model_active": {
+          "name": "idx_message_request_key_model_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"model\" IS NOT NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_endpoint_active": {
+          "name": "idx_message_request_key_endpoint_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"endpoint\" IS NOT NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_created_at_id_active": {
+          "name": "idx_message_request_created_at_id_active",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_model_active": {
+          "name": "idx_message_request_model_active",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"model\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_status_code_active": {
+          "name": "idx_message_request_status_code_active",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"status_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_created_at": {
+          "name": "idx_message_request_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_deleted_at": {
+          "name": "idx_message_request_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_last_active": {
+          "name": "idx_message_request_key_last_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_cost_active": {
+          "name": "idx_message_request_key_cost_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_user_info": {
+          "name": "idx_message_request_session_user_info",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_client_ip_created_at": {
+          "name": "idx_message_request_client_ip_created_at",
+          "columns": [
+            {
+              "expression": "client_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"client_ip\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_prices": {
+      "name": "model_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_data": {
+          "name": "price_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'litellm'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_prices_latest": {
+          "name": "idx_model_prices_latest",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_model_name": {
+          "name": "idx_model_prices_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_created_at": {
+          "name": "idx_model_prices_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_source": {
+          "name": "idx_model_prices_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_legacy_mode": {
+          "name": "use_legacy_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_enabled": {
+          "name": "circuit_breaker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_webhook": {
+          "name": "circuit_breaker_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_enabled": {
+          "name": "daily_leaderboard_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "daily_leaderboard_webhook": {
+          "name": "daily_leaderboard_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_time": {
+          "name": "daily_leaderboard_time",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'09:00'"
+        },
+        "daily_leaderboard_top_n": {
+          "name": "daily_leaderboard_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cost_alert_enabled": {
+          "name": "cost_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cost_alert_webhook": {
+          "name": "cost_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_alert_threshold": {
+          "name": "cost_alert_threshold",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.80'"
+        },
+        "cost_alert_check_interval": {
+          "name": "cost_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "cache_hit_rate_alert_enabled": {
+          "name": "cache_hit_rate_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_hit_rate_alert_webhook": {
+          "name": "cache_hit_rate_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit_rate_alert_window_mode": {
+          "name": "cache_hit_rate_alert_window_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "cache_hit_rate_alert_check_interval": {
+          "name": "cache_hit_rate_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cache_hit_rate_alert_historical_lookback_days": {
+          "name": "cache_hit_rate_alert_historical_lookback_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 7
+        },
+        "cache_hit_rate_alert_min_eligible_requests": {
+          "name": "cache_hit_rate_alert_min_eligible_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 20
+        },
+        "cache_hit_rate_alert_min_eligible_tokens": {
+          "name": "cache_hit_rate_alert_min_eligible_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cache_hit_rate_alert_abs_min": {
+          "name": "cache_hit_rate_alert_abs_min",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "cache_hit_rate_alert_drop_rel": {
+          "name": "cache_hit_rate_alert_drop_rel",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.3'"
+        },
+        "cache_hit_rate_alert_drop_abs": {
+          "name": "cache_hit_rate_alert_drop_abs",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.1'"
+        },
+        "cache_hit_rate_alert_cooldown_minutes": {
+          "name": "cache_hit_rate_alert_cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cache_hit_rate_alert_top_n": {
+          "name": "cache_hit_rate_alert_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_target_bindings": {
+      "name": "notification_target_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule_cron": {
+          "name": "schedule_cron",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_timezone": {
+          "name": "schedule_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_override": {
+          "name": "template_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_notification_target_binding": {
+          "name": "unique_notification_target_binding",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_type": {
+          "name": "idx_notification_bindings_type",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_target": {
+          "name": "idx_notification_bindings_target",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_target_bindings_target_id_webhook_targets_id_fk": {
+          "name": "notification_target_bindings_target_id_webhook_targets_id_fk",
+          "tableFrom": "notification_target_bindings",
+          "tableTo": "webhook_targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoint_probe_logs": {
+      "name": "provider_endpoint_probe_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_endpoint_probe_logs_endpoint_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_endpoint_created_at",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoint_probe_logs_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk": {
+          "name": "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk",
+          "tableFrom": "provider_endpoint_probe_logs",
+          "tableTo": "provider_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoints": {
+      "name": "provider_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_probed_at": {
+          "name": "last_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_ok": {
+          "name": "last_probe_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_status_code": {
+          "name": "last_probe_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_latency_ms": {
+          "name": "last_probe_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_type": {
+          "name": "last_probe_error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_message": {
+          "name": "last_probe_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uniq_provider_endpoints_vendor_type_url": {
+          "name": "uniq_provider_endpoints_vendor_type_url",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_vendor_type": {
+          "name": "idx_provider_endpoints_vendor_type",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_enabled": {
+          "name": "idx_provider_endpoints_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_pick_enabled": {
+          "name": "idx_provider_endpoints_pick_enabled",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_created_at": {
+          "name": "idx_provider_endpoints_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_deleted_at": {
+          "name": "idx_provider_endpoints_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoints_vendor_id_provider_vendors_id_fk": {
+          "name": "provider_endpoints_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "provider_endpoints",
+          "tableTo": "provider_vendors",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_groups": {
+      "name": "provider_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_groups_name_unique": {
+          "name": "provider_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_vendors": {
+      "name": "provider_vendors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "website_domain": {
+          "name": "website_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_provider_vendors_website_domain": {
+          "name": "uniq_provider_vendors_website_domain",
+          "columns": [
+            {
+              "expression": "website_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_vendors_created_at": {
+          "name": "idx_provider_vendors_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_vendor_id": {
+          "name": "provider_vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "group_priorities": {
+          "name": "group_priorities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.0'"
+        },
+        "group_tag": {
+          "name": "group_tag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "preserve_client_ip": {
+          "name": "preserve_client_ip",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disable_session_reuse": {
+          "name": "disable_session_reuse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_redirects": {
+          "name": "model_redirects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_clients": {
+          "name": "blocked_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active_time_start": {
+          "name": "active_time_start",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_end": {
+          "name": "active_time_end",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_instructions_strategy": {
+          "name": "codex_instructions_strategy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "mcp_passthrough_type": {
+          "name": "mcp_passthrough_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "mcp_passthrough_url": {
+          "name": "mcp_passthrough_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_reset_mode": {
+          "name": "limit_5h_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rolling'"
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost_reset_at": {
+          "name": "total_cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_retry_attempts": {
+          "name": "max_retry_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circuit_breaker_failure_threshold": {
+          "name": "circuit_breaker_failure_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "circuit_breaker_open_duration": {
+          "name": "circuit_breaker_open_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1800000
+        },
+        "circuit_breaker_half_open_success_threshold": {
+          "name": "circuit_breaker_half_open_success_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "first_byte_timeout_streaming_ms": {
+          "name": "first_byte_timeout_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "streaming_idle_timeout_ms": {
+          "name": "streaming_idle_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_timeout_non_streaming_ms": {
+          "name": "request_timeout_non_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swap_cache_ttl_billing": {
+          "name": "swap_cache_ttl_billing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "context_1m_preference": {
+          "name": "context_1m_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_effort_preference": {
+          "name": "codex_reasoning_effort_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_summary_preference": {
+          "name": "codex_reasoning_summary_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_text_verbosity_preference": {
+          "name": "codex_text_verbosity_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_parallel_tool_calls_preference": {
+          "name": "codex_parallel_tool_calls_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_service_tier_preference": {
+          "name": "codex_service_tier_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_max_tokens_preference": {
+          "name": "anthropic_max_tokens_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_thinking_budget_preference": {
+          "name": "anthropic_thinking_budget_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_adaptive_thinking": {
+          "name": "anthropic_adaptive_thinking",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "gemini_google_search_preference": {
+          "name": "gemini_google_search_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tpm": {
+          "name": "tpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpm": {
+          "name": "rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpd": {
+          "name": "rpd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cc": {
+          "name": "cc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_providers_enabled_priority": {
+          "name": "idx_providers_enabled_priority",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_group": {
+          "name": "idx_providers_group",
+          "columns": [
+            {
+              "expression": "group_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_vendor_type_url_active": {
+          "name": "idx_providers_vendor_type_url_active",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_created_at": {
+          "name": "idx_providers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_deleted_at": {
+          "name": "idx_providers_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_vendor_type": {
+          "name": "idx_providers_vendor_type",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_enabled_vendor_type": {
+          "name": "idx_providers_enabled_vendor_type",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL AND \"providers\".\"is_enabled\" = true AND \"providers\".\"provider_vendor_id\" IS NOT NULL AND \"providers\".\"provider_vendor_id\" > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "providers_provider_vendor_id_provider_vendors_id_fk": {
+          "name": "providers_provider_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "provider_vendors",
+          "columnsFrom": [
+            "provider_vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_filters": {
+      "name": "request_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement": {
+          "name": "replacement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "provider_ids": {
+          "name": "provider_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_tags": {
+          "name": "group_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_mode": {
+          "name": "rule_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simple'"
+        },
+        "execution_phase": {
+          "name": "execution_phase",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guard'"
+        },
+        "operations": {
+          "name": "operations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_request_filters_enabled": {
+          "name": "idx_request_filters_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_scope": {
+          "name": "idx_request_filters_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_action": {
+          "name": "idx_request_filters_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_binding": {
+          "name": "idx_request_filters_binding",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_phase": {
+          "name": "idx_request_filters_phase",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "execution_phase",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sensitive_words": {
+      "name": "sensitive_words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contains'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sensitive_words_enabled": {
+          "name": "idx_sensitive_words_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sensitive_words_created_at": {
+          "name": "idx_sensitive_words_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_title": {
+          "name": "site_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Claude Code Hub'"
+        },
+        "allow_global_usage_view": {
+          "name": "allow_global_usage_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "currency_display": {
+          "name": "currency_display",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "billing_model_source": {
+          "name": "billing_model_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'original'"
+        },
+        "codex_priority_billing_source": {
+          "name": "codex_priority_billing_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_auto_cleanup": {
+          "name": "enable_auto_cleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cleanup_retention_days": {
+          "name": "cleanup_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cleanup_schedule": {
+          "name": "cleanup_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 2 * * *'"
+        },
+        "cleanup_batch_size": {
+          "name": "cleanup_batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10000
+        },
+        "enable_client_version_check": {
+          "name": "enable_client_version_check",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verbose_provider_error": {
+          "name": "verbose_provider_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pass_through_upstream_error_message": {
+          "name": "pass_through_upstream_error_message",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_http2": {
+          "name": "enable_http2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_openai_responses_websocket": {
+          "name": "enable_openai_responses_websocket",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_high_concurrency_mode": {
+          "name": "enable_high_concurrency_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "intercept_anthropic_warmup_requests": {
+          "name": "intercept_anthropic_warmup_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_thinking_signature_rectifier": {
+          "name": "enable_thinking_signature_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_thinking_budget_rectifier": {
+          "name": "enable_thinking_budget_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_billing_header_rectifier": {
+          "name": "enable_billing_header_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_response_input_rectifier": {
+          "name": "enable_response_input_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allow_non_conversation_endpoint_provider_fallback": {
+          "name": "allow_non_conversation_endpoint_provider_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_codex_session_id_completion": {
+          "name": "enable_codex_session_id_completion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_claude_metadata_user_id_injection": {
+          "name": "enable_claude_metadata_user_id_injection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_response_fixer": {
+          "name": "enable_response_fixer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "response_fixer_config": {
+          "name": "response_fixer_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"fixTruncatedJson\":true,\"fixSseFormat\":true,\"fixEncoding\":true,\"maxJsonDepth\":200,\"maxFixSize\":1048576}'::jsonb"
+        },
+        "quota_db_refresh_interval_seconds": {
+          "name": "quota_db_refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "quota_lease_percent_5h": {
+          "name": "quota_lease_percent_5h",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_daily": {
+          "name": "quota_lease_percent_daily",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_weekly": {
+          "name": "quota_lease_percent_weekly",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_monthly": {
+          "name": "quota_lease_percent_monthly",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_cap_usd": {
+          "name": "quota_lease_cap_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_extraction_config": {
+          "name": "ip_extraction_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_geo_lookup_enabled": {
+          "name": "ip_geo_lookup_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_status_window_hours": {
+          "name": "public_status_window_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "public_status_aggregation_interval_minutes": {
+          "name": "public_status_aggregation_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_ledger": {
+      "name": "usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_provider_id": {
+          "name": "final_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_response_model": {
+          "name": "actual_response_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_success": {
+          "name": "is_success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "success_rate_outcome": {
+          "name": "success_rate_outcome",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_cost_multiplier": {
+          "name": "group_cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "swap_cache_ttl_applied": {
+          "name": "swap_cache_ttl_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_ledger_request_id": {
+          "name": "idx_usage_ledger_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_user_created_at": {
+          "name": "idx_usage_ledger_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_key_created_at": {
+          "name": "idx_usage_ledger_key_created_at",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_provider_created_at": {
+          "name": "idx_usage_ledger_provider_created_at",
+          "columns": [
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_created_at_minute": {
+          "name": "idx_usage_ledger_created_at_minute",
+          "columns": [
+            {
+              "expression": "date_trunc('minute', \"created_at\" AT TIME ZONE 'UTC')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_created_at_desc_id": {
+          "name": "idx_usage_ledger_created_at_desc_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_session_id": {
+          "name": "idx_usage_ledger_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"session_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_model": {
+          "name": "idx_usage_ledger_model",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"model\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_key_cost": {
+          "name": "idx_usage_ledger_key_cost",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_user_cost_cover": {
+          "name": "idx_usage_ledger_user_cost_cover",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_provider_cost_cover": {
+          "name": "idx_usage_ledger_provider_cost_cover",
+          "columns": [
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_key_created_at_desc_cover": {
+          "name": "idx_usage_ledger_key_created_at_desc_cover",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC NULLS LAST",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "rpm_limit": {
+          "name": "rpm_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_limit_usd": {
+          "name": "daily_limit_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_reset_mode": {
+          "name": "limit_5h_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rolling'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_reset_at": {
+          "name": "cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_cost_reset_at": {
+          "name": "limit_5h_cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_clients": {
+          "name": "blocked_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_active_role_sort": {
+          "name": "idx_users_active_role_sort",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_enabled_expires_at": {
+          "name": "idx_users_enabled_expires_at",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_tags_gin": {
+          "name": "idx_users_tags_gin",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_deleted_at": {
+          "name": "idx_users_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_targets": {
+      "name": "webhook_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "webhook_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_bot_token": {
+          "name": "telegram_bot_token",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dingtalk_secret": {
+          "name": "dingtalk_secret",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_template": {
+          "name": "custom_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_test_at": {
+          "name": "last_test_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_result": {
+          "name": "last_test_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.daily_reset_mode": {
+      "name": "daily_reset_mode",
+      "schema": "public",
+      "values": [
+        "fixed",
+        "rolling"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "circuit_breaker",
+        "daily_leaderboard",
+        "cost_alert",
+        "cache_hit_rate_alert"
+      ]
+    },
+    "public.webhook_provider_type": {
+      "name": "webhook_provider_type",
+      "schema": "public",
+      "values": [
+        "wechat",
+        "feishu",
+        "dingtalk",
+        "telegram",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -694,6 +694,13 @@
       "when": 1776965161943,
       "tag": "0098_equal_selene",
       "breakpoints": true
+    },
+    {
+      "idx": 99,
+      "version": "7",
+      "when": 1777047297106,
+      "tag": "0099_worthless_gauntlet",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/en/settings/config.json
+++ b/messages/en/settings/config.json
@@ -56,6 +56,8 @@
     "enableAutoCleanupDesc": "Automatically clean up historical log data on schedule",
     "enableHttp2": "Enable HTTP/2",
     "enableHttp2Desc": "When enabled, proxy requests will prefer HTTP/2 protocol. Automatically falls back to HTTP/1.1 on failure.",
+    "enableOpenaiResponsesWebsocket": "Enable OpenAI Responses WebSocket",
+    "enableOpenaiResponsesWebsocketDesc": "When enabled, if a client opens a WebSocket connection to /v1/responses and the selected provider is a Codex type, CCH will attempt a sibling WebSocket to the upstream. If the upstream does not support WebSocket or the handshake fails, CCH gracefully falls back to standard HTTP Responses while keeping the client WebSocket open; the fallback is not counted toward circuit breakers. Non-WebSocket clients and non-Codex providers are unaffected.",
     "enableHighConcurrencyMode": "Enable High-Concurrency Mode",
     "enableHighConcurrencyModeDesc": "When enabled, CCH disables part of the Redis debug snapshots and real-time session observability writes to reduce CPU and IO pressure under high RPM. Forwarding, rectifiers, fake-200 detection, billing, and quota enforcement remain unchanged, but Sessions debugging details may be reduced or delayed.",
     "enableResponseFixer": "Enable Response Fixer",

--- a/messages/ja/settings/config.json
+++ b/messages/ja/settings/config.json
@@ -56,6 +56,8 @@
     "enableAutoCleanupDesc": "スケジュールに従って履歴ログを自動的にクリーンアップします",
     "enableHttp2": "HTTP/2 を有効にする",
     "enableHttp2Desc": "有効にすると、プロキシ要求は優先的に HTTP/2 を使用します。HTTP/2 が失敗した場合は自動的に HTTP/1.1 にフォールバックします。",
+    "enableOpenaiResponsesWebsocket": "OpenAI Responses WebSocket を有効化",
+    "enableOpenaiResponsesWebsocketDesc": "有効にすると、クライアントが /v1/responses に WebSocket 接続し、かつ Codex タイプのプロバイダーが選択された場合、CCH は上流にも WebSocket 接続を試みます。上流が WebSocket をサポートしない、またはハンドシェイクに失敗した場合は、クライアント WebSocket を開いたまま通常の HTTP Responses に優雅にフォールバックします。このフォールバックはサーキットブレーカーにカウントされません。非 WebSocket クライアントと非 Codex プロバイダーの動作は変わりません。",
     "enableHighConcurrencyMode": "高並行モードを有効化",
     "enableHighConcurrencyModeDesc": "有効にすると、高 RPM 時の CPU / IO 負荷を下げるため、Redis の一部デバッグスナップショットとリアルタイム Session 観測書き込みを停止します。転送、整流、fake 200 検知、課金、制限処理は維持されますが、Sessions のデバッグ詳細は減少または遅延する場合があります。",
     "enableResponseFixer": "レスポンス整流を有効化",

--- a/messages/ru/settings/config.json
+++ b/messages/ru/settings/config.json
@@ -56,6 +56,8 @@
     "enableAutoCleanupDesc": "Автоматически очищать исторические логи по расписанию",
     "enableHttp2": "Включить HTTP/2",
     "enableHttp2Desc": "При включении прокси-запросы будут отдавать приоритет HTTP/2. Если HTTP/2 не удастся, произойдёт автоматическое понижение до HTTP/1.1.",
+    "enableOpenaiResponsesWebsocket": "Включить OpenAI Responses WebSocket",
+    "enableOpenaiResponsesWebsocketDesc": "Если включено, то когда клиент открывает WebSocket-соединение с /v1/responses и выбирается провайдер типа Codex, CCH попытается установить WebSocket-соединение с вышестоящим сервером. Если сервер не поддерживает WebSocket или рукопожатие не удастся, CCH плавно переключится на обычный HTTP Responses, сохраняя WebSocket клиента открытым; этот fallback не учитывается в circuit breaker. Клиенты без WebSocket и провайдеры, отличные от Codex, работают без изменений.",
     "enableHighConcurrencyMode": "Включить режим высокой нагрузки",
     "enableHighConcurrencyModeDesc": "Если включено, CCH отключит часть Redis-снимков для отладки и записи real-time Session-наблюдения, чтобы снизить нагрузку на CPU и IO при высоком RPM. Пересылка, rectifier-логика, обнаружение fake 200, биллинг и лимиты сохраняются, но детализация отладки в Sessions может уменьшиться или запаздывать.",
     "enableResponseFixer": "Включить исправление ответов",

--- a/messages/zh-CN/settings/config.json
+++ b/messages/zh-CN/settings/config.json
@@ -48,6 +48,8 @@
     "passThroughUpstreamErrorMessageDesc": "开启后，CCH 会在能提取出安全脱敏后的上游错误消息时替换 `error.message`；否则 `error.message` 回退到通用代理错误。它不会关闭“详细供应商错误信息”控制的 `error.details` 诊断。",
     "enableHttp2": "启用 HTTP/2",
     "enableHttp2Desc": "启用后，代理请求将优先使用 HTTP/2 协议。如果 HTTP/2 失败，将自动降级到 HTTP/1.1。",
+    "enableOpenaiResponsesWebsocket": "启用 OpenAI Responses WebSocket",
+    "enableOpenaiResponsesWebsocketDesc": "启用后，当客户端以 WebSocket 连接 /v1/responses 且选中 Codex 类型供应商时，CCH 会尝试与上游建立 WebSocket。若上游不支持或握手失败，将优雅降级到普通 HTTP Responses，客户端 WebSocket 保持打开；降级不计入熔断。非 WebSocket 客户端与非 Codex 供应商行为不变。",
     "enableHighConcurrencyMode": "启用高并发模式",
     "enableHighConcurrencyModeDesc": "开启后，将关闭部分 Redis 调试快照与实时会话观测写入，以降低高并发下的 CPU 与 IO 开销。不会影响转发、整流、fake 200 检测、计费与限额，但 Sessions 调试详情会减少或延后。",
     "interceptAnthropicWarmupRequests": "拦截 Warmup 请求（Anthropic）",

--- a/messages/zh-TW/settings/config.json
+++ b/messages/zh-TW/settings/config.json
@@ -56,6 +56,8 @@
     "enableAutoCleanupDesc": "定時自動清理歷史日誌資料",
     "enableHttp2": "啟用 HTTP/2",
     "enableHttp2Desc": "啟用後，代理請求將優先使用 HTTP/2 協定；若 HTTP/2 失敗，將自動降級為 HTTP/1.1。",
+    "enableOpenaiResponsesWebsocket": "啟用 OpenAI Responses WebSocket",
+    "enableOpenaiResponsesWebsocketDesc": "啟用後，當客戶端以 WebSocket 連線 /v1/responses 且命中 Codex 類型供應商時，CCH 會嘗試與上游建立 WebSocket 連線。若上游不支援或握手失敗，將優雅降級為一般 HTTP Responses，客戶端 WebSocket 保持開啟；降級不計入熔斷。非 WebSocket 客戶端與非 Codex 供應商行為不變。",
     "enableHighConcurrencyMode": "啟用高並發模式",
     "enableHighConcurrencyModeDesc": "開啟後，將關閉部分 Redis 除錯快照與即時 Session 觀測寫入，以降低高並發下的 CPU 與 IO 開銷。轉發、整流、fake 200 偵測、計費與限額不受影響，但 Sessions 除錯詳情會減少或延後。",
     "enableResponseFixer": "啟用回應整流",

--- a/next.config.ts
+++ b/next.config.ts
@@ -27,7 +27,14 @@ const nextConfig: NextConfig = {
   // Next.js 依赖追踪无法正确追踪动态导入和类型导入的传递依赖
   // 参考: https://nextjs.org/docs/app/api-reference/config/next-config-js/output
   outputFileTracingIncludes: {
-    "/**": ["./node_modules/undici/**/*", "./node_modules/fetch-socks/**/*"],
+    "/**": [
+      "./node_modules/undici/**/*",
+      "./node_modules/fetch-socks/**/*",
+      // 自定义 Node 服务器使用 next 的 programmatic API 与 ws 处理 WebSocket 升级，
+      // 需要强制追踪这两个包到 standalone 输出。
+      "./node_modules/next/**/*",
+      "./node_modules/ws/**/*",
+    ],
   },
 
   // 文件上传大小限制（用于数据库备份导入）

--- a/next.config.ts
+++ b/next.config.ts
@@ -30,10 +30,16 @@ const nextConfig: NextConfig = {
     "/**": [
       "./node_modules/undici/**/*",
       "./node_modules/fetch-socks/**/*",
-      // 自定义 Node 服务器使用 next 的 programmatic API 与 ws 处理 WebSocket 升级，
-      // 需要强制追踪这两个包到 standalone 输出。
-      "./node_modules/next/**/*",
+      // 自定义 Node 服务器（server.js）只用到 `ws` 与 next 的入口；
+      // 让 Next 的依赖追踪决定从 next 包里收纳什么文件，避免把 next 整个
+      // node_modules 都拖进 standalone 产物（约数十 MB）。仅显式追加：
+      //  - ws：standalone 默认追踪基于 import 静态分析，server.js 是 CJS
+      //    根入口，未被 Next 编译，必须手工列出。
+      //  - next/dist：自定义 server 通过 require("next") 进入；保留 dist
+      //    子树确保 programmatic API 可用。
       "./node_modules/ws/**/*",
+      "./node_modules/next/dist/**/*",
+      "./node_modules/next/package.json",
     ],
   },
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "tsgo -p tsconfig.json --noEmit && next dev --port 13500",
-    "build": "tsgo -p tsconfig.json --noEmit && next build && (node scripts/copy-version-to-standalone.cjs || bun scripts/copy-version-to-standalone.cjs)",
-    "start": "next start",
+    "dev:server": "NODE_ENV=development node server.js",
+    "build": "tsgo -p tsconfig.json --noEmit && next build && (node scripts/copy-version-to-standalone.cjs || bun scripts/copy-version-to-standalone.cjs) && (node scripts/copy-custom-server-to-standalone.cjs || bun scripts/copy-custom-server-to-standalone.cjs)",
+    "start": "node server.js",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "typecheck": "tsgo -p tsconfig.json --noEmit",
@@ -111,6 +112,7 @@
     "tw-animate-css": "^1",
     "undici": "^7",
     "vaul": "^1",
+    "ws": "^8",
     "zod": "^4"
   },
   "devDependencies": {
@@ -122,6 +124,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/react-syntax-highlighter": "^15",
+    "@types/ws": "^8",
     "@typescript/native-preview": "7.0.0-dev.20260321.1",
     "@vitest/coverage-v8": "^4",
     "@vitest/ui": "^4",

--- a/scripts/copy-custom-server-to-standalone.cjs
+++ b/scripts/copy-custom-server-to-standalone.cjs
@@ -1,0 +1,31 @@
+/**
+ * Copy the custom Node server (with WebSocket upgrade support) into the
+ * Next.js standalone output, overwriting the generated server.js so Docker
+ * runtime (`CMD ["node", "server.js"]`) boots the custom one instead.
+ *
+ * The generated standalone server.js is the default Next.js minimal server;
+ * ours wraps Next.js programmatically plus adds WebSocket upgrade handling
+ * on /v1/responses. See server.js at the repo root for the full rationale.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const src = path.resolve(process.cwd(), "server.js");
+const dstDir = path.resolve(process.cwd(), ".next", "standalone");
+const dst = path.join(dstDir, "server.js");
+
+if (!fs.existsSync(src)) {
+  console.error(`[copy-custom-server] Custom server not found at ${src}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(dstDir)) {
+  console.warn(
+    `[copy-custom-server] Standalone output dir missing at ${dstDir}; skipping (did next build run?)`
+  );
+  process.exit(0);
+}
+
+fs.copyFileSync(src, dst);
+console.log(`[copy-custom-server] Copied ${src} -> ${dst}`);

--- a/server.js
+++ b/server.js
@@ -28,9 +28,21 @@ const dev = process.env.NODE_ENV !== "production";
 const hostname = process.env.HOSTNAME || "0.0.0.0";
 const port = parseInt(process.env.PORT || (dev ? "13500" : "3000"), 10);
 
+// Loopback target for the in-process WS->HTTP tunnel. When the public bind
+// hostname is a wildcard (0.0.0.0 / ::), tunnel via 127.0.0.1; otherwise use
+// the configured hostname so we still hit the local listener even when bound
+// to a specific interface.
+const INTERNAL_TUNNEL_HOST =
+  hostname === "0.0.0.0" || hostname === "::" || hostname === "*" ? "127.0.0.1" : hostname;
+
 const WS_PATH = "/v1/responses";
 const CLIENT_TRANSPORT_HEADER = "x-cch-client-transport";
 const WS_FORWARD_FLAG_HEADER = "x-cch-responses-ws-forward";
+
+// Per-WebSocket-connection guardrails: cap the queue depth and total queued
+// bytes to make a misbehaving / malicious client a bounded-memory event.
+const MAX_PENDING_FRAMES = 64;
+const MAX_PENDING_BYTES = 4 * 1024 * 1024; // 4 MiB across all queued frames
 
 const TERMINAL_EVENT_TYPES = new Set([
   "response.completed",
@@ -38,6 +50,10 @@ const TERMINAL_EVENT_TYPES = new Set([
   "response.incomplete",
   "error",
 ]);
+
+// Query-string keys we explicitly never want to log on the connection event.
+// Anything outside this list is masked to "***".
+const ALLOWED_LOGGED_QUERY_KEYS = new Set(["model"]);
 
 function log(level, msg, extra) {
   const line = { ts: new Date().toISOString(), level, msg, ...(extra || {}) };
@@ -67,18 +83,56 @@ function emitErrorEvent(ws, code, message) {
   });
 }
 
+function sanitizedRequestPath(rawUrl) {
+  if (typeof rawUrl !== "string" || rawUrl.length === 0) {
+    return "/";
+  }
+  try {
+    const parsed = new URL(rawUrl, "http://localhost");
+    const masked = new URLSearchParams();
+    parsed.searchParams.forEach((value, key) => {
+      masked.append(key, ALLOWED_LOGGED_QUERY_KEYS.has(key.toLowerCase()) ? value : "***");
+    });
+    const qs = masked.toString();
+    return qs.length > 0 ? `${parsed.pathname}?${qs}` : parsed.pathname;
+  } catch {
+    return "/";
+  }
+}
+
 async function handleWebSocketConnection(ws, req) {
   const url = new URL(req.url, `http://${req.headers.host || "localhost"}`);
   const queryModel = url.searchParams.get("model");
   let inFlight = false;
   const pending = [];
+  let pendingBytes = 0;
   let closed = false;
+  // Track the in-flight internal HTTP ClientRequest so we can abort it when
+  // the client WebSocket disconnects mid-stream — otherwise the SSE consumer
+  // (and provider concurrency / breaker counters) keep running for minutes.
+  let currentInternalReq = null;
 
   const finalize = () => {
     closed = true;
+    if (currentInternalReq) {
+      try {
+        currentInternalReq.destroy();
+      } catch {
+        // ignore
+      }
+      currentInternalReq = null;
+    }
+    pending.length = 0;
+    pendingBytes = 0;
   };
+
   ws.on("close", finalize);
-  ws.on("error", finalize);
+  ws.on("error", (err) => {
+    log("warn", "ws_client_error", {
+      error: String(err && err.message ? err.message : err),
+    });
+    finalize();
+  });
 
   const processFrame = async (raw) => {
     if (closed) return;
@@ -97,7 +151,11 @@ async function handleWebSocketConnection(ws, req) {
     try {
       frame = JSON.parse(raw);
     } catch (err) {
-      emitErrorEvent(ws, "invalid_json", `Invalid JSON frame: ${err && err.message ? err.message : "parse error"}`);
+      emitErrorEvent(
+        ws,
+        "invalid_json",
+        `Invalid JSON frame: ${err && err.message ? err.message : "parse error"}`
+      );
       return;
     }
 
@@ -107,11 +165,15 @@ async function handleWebSocketConnection(ws, req) {
     }
 
     if (frame.type !== "response.create") {
-      emitErrorEvent(ws, "unsupported_event_type", `Only type=response.create is supported; received: ${frame.type ?? "(missing)"}`);
+      emitErrorEvent(
+        ws,
+        "unsupported_event_type",
+        `Only type=response.create is supported; received: ${frame.type ?? "(missing)"}`
+      );
       return;
     }
 
-    const { type, ...rawBody } = frame;
+    const { type: _type, ...rawBody } = frame;
     const body = { ...rawBody };
     // body.model wins over query; only fill from query when body lacks a model
     // (LiteLLM/other compat). Drop transport-only fields.
@@ -119,20 +181,37 @@ async function handleWebSocketConnection(ws, req) {
       body.model = queryModel;
     }
 
-    await forwardToInternalHttp(ws, req, body);
+    await forwardToInternalHttp(ws, req, body, (clientReq) => {
+      currentInternalReq = clientReq;
+    });
+    if (!closed) {
+      currentInternalReq = null;
+    }
   };
 
   const drain = async () => {
     if (inFlight) return;
     const next = pending.shift();
-    if (!next) return;
+    if (next === undefined) return;
+    pendingBytes -= Buffer.byteLength(next, "utf8");
+    if (pendingBytes < 0) pendingBytes = 0;
     inFlight = true;
     try {
       await processFrame(next);
     } finally {
       inFlight = false;
       if (pending.length > 0 && !closed) {
-        void drain();
+        void drain().catch((err) => {
+          log("error", "ws_drain_failed", {
+            error: String(err && err.message ? err.message : err),
+          });
+          emitErrorEvent(ws, "internal_error", "Failed to process queued request");
+          try {
+            ws.close(1011, "internal_error");
+          } catch {
+            // ignore
+          }
+        });
       }
     }
   };
@@ -148,12 +227,39 @@ async function handleWebSocketConnection(ws, req) {
       }
       return;
     }
-    pending.push(data.toString("utf8"));
-    void drain();
+    const text = data.toString("utf8");
+    const size = Buffer.byteLength(text, "utf8");
+    if (pending.length >= MAX_PENDING_FRAMES || pendingBytes + size > MAX_PENDING_BYTES) {
+      log("warn", "ws_pending_overflow", {
+        pendingFrames: pending.length,
+        pendingBytes,
+        attemptedFrameSize: size,
+      });
+      emitErrorEvent(ws, "too_many_requests", "Pending frame limit exceeded");
+      try {
+        ws.close(1008, "too_many_requests");
+      } catch {
+        // ignore
+      }
+      return;
+    }
+    pending.push(text);
+    pendingBytes += size;
+    void drain().catch((err) => {
+      log("error", "ws_drain_failed", {
+        error: String(err && err.message ? err.message : err),
+      });
+      emitErrorEvent(ws, "internal_error", "Failed to process request");
+      try {
+        ws.close(1011, "internal_error");
+      } catch {
+        // ignore
+      }
+    });
   });
 }
 
-async function forwardToInternalHttp(ws, originalReq, body) {
+async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq) {
   const internalHeaders = {};
   for (const [k, v] of Object.entries(originalReq.headers)) {
     // Skip hop-by-hop / WS-specific headers; keep app-level auth/session etc.
@@ -195,7 +301,7 @@ async function forwardToInternalHttp(ws, originalReq, body) {
     const req = http.request(
       {
         method: "POST",
-        hostname: "127.0.0.1",
+        hostname: INTERNAL_TUNNEL_HOST,
         port,
         path: "/v1/responses",
         headers: internalHeaders,
@@ -220,9 +326,10 @@ async function forwardToInternalHttp(ws, originalReq, body) {
             if (res.statusCode && res.statusCode >= 400) {
               safeSend(ws, {
                 type: "error",
-                error: typeof parsed === "object" && parsed && parsed.error
-                  ? parsed.error
-                  : { code: `http_${res.statusCode}`, message: text.slice(0, 512) },
+                error:
+                  typeof parsed === "object" && parsed && parsed.error
+                    ? parsed.error
+                    : { code: `http_${res.statusCode}`, message: text.slice(0, 512) },
               });
             } else {
               safeSend(ws, {
@@ -233,31 +340,40 @@ async function forwardToInternalHttp(ws, originalReq, body) {
             resolve();
           });
           res.on("error", (err) => {
-            emitErrorEvent(ws, "internal_response_error", String(err && err.message ? err.message : err));
+            emitErrorEvent(
+              ws,
+              "internal_response_error",
+              String(err && err.message ? err.message : err)
+            );
             resolve();
           });
           return;
         }
 
         // SSE path: decode `data:` events and emit each as a WS JSON frame.
+        // Accept both LF (`\n\n`) and CRLF (`\r\n\r\n`) event separators since
+        // upstreams in the wild emit either form.
         let buffer = "";
         let sawTerminal = false;
+        const EVENT_DELIMITER = /\r?\n\r?\n/;
 
         const flushEvents = () => {
-          let idx;
-          while ((idx = buffer.indexOf("\n\n")) !== -1) {
-            const chunk = buffer.slice(0, idx);
-            buffer = buffer.slice(idx + 2);
+          const parts = buffer.split(EVENT_DELIMITER);
+          // Last part may be a partial event still arriving — keep it buffered.
+          buffer = parts.pop() ?? "";
+          for (const chunk of parts) {
             const lines = chunk.split(/\r?\n/);
             const dataLines = [];
             for (const line of lines) {
               if (line.startsWith("data:")) {
-                dataLines.push(line.slice(5).trimStart());
+                // Trim CR / leading whitespace so trailing \r from CRLF lines
+                // doesn't end up inside the payload.
+                dataLines.push(line.slice(5).trim());
               }
             }
             if (dataLines.length === 0) continue;
             const dataText = dataLines.join("\n");
-            if (dataText === "[DONE]") {
+            if (dataText.trim() === "[DONE]") {
               if (!sawTerminal) {
                 // Some upstreams close SSE with [DONE] without a preceding
                 // response.completed. Synthesize one so the client sees a
@@ -303,17 +419,34 @@ async function forwardToInternalHttp(ws, originalReq, body) {
           resolve();
         });
         res.on("error", (err) => {
-          emitErrorEvent(ws, "internal_response_error", String(err && err.message ? err.message : err));
+          emitErrorEvent(
+            ws,
+            "internal_response_error",
+            String(err && err.message ? err.message : err)
+          );
           resolve();
         });
       }
     );
 
     req.on("error", (err) => {
-      emitErrorEvent(ws, "internal_request_error", String(err && err.message ? err.message : err));
+      // ECONNRESET when we destroy() the request on client disconnect is
+      // expected; downgrade to debug to avoid noisy logs in normal traffic.
+      const errCode = err && (err.code || err.name);
+      const isAbort = errCode === "ECONNRESET" || errCode === "ERR_STREAM_PREMATURE_CLOSE";
+      if (!isAbort) {
+        emitErrorEvent(
+          ws,
+          "internal_request_error",
+          String(err && err.message ? err.message : err)
+        );
+      }
       resolve();
     });
 
+    if (typeof registerInternalReq === "function") {
+      registerInternalReq(req);
+    }
     req.write(payload);
     req.end();
   });
@@ -334,7 +467,9 @@ async function main() {
     // eslint-disable-next-line global-require
     nextModule = require("next");
   } catch (err) {
-    log("error", "next_import_failed", { error: String(err && err.message ? err.message : err) });
+    log("error", "next_import_failed", {
+      error: String(err && err.message ? err.message : err),
+    });
     process.exit(1);
     return;
   }
@@ -360,7 +495,9 @@ async function main() {
       const parsedUrl = parse(req.url, true);
       await handler(req, res, parsedUrl);
     } catch (err) {
-      log("error", "http_handler_error", { error: String(err && err.message ? err.message : err) });
+      log("error", "http_handler_error", {
+        error: String(err && err.message ? err.message : err),
+      });
       if (!res.headersSent) {
         res.statusCode = 500;
         res.end("Internal Server Error");
@@ -377,9 +514,11 @@ async function main() {
         return;
       }
       wss.handleUpgrade(req, socket, head, (ws) => {
-        log("info", "ws_client_connected", { path: req.url });
+        log("info", "ws_client_connected", { path: sanitizedRequestPath(req.url) });
         handleWebSocketConnection(ws, req).catch((err) => {
-          log("error", "ws_handler_error", { error: String(err && err.message ? err.message : err) });
+          log("error", "ws_handler_error", {
+            error: String(err && err.message ? err.message : err),
+          });
           try {
             ws.close(1011, "internal_error");
           } catch {
@@ -395,11 +534,23 @@ async function main() {
   }
 
   server.listen(port, hostname, () => {
-    log("info", "server_listening", { hostname, port, wsEnabled: !!WebSocketServer });
+    log("info", "server_listening", {
+      hostname,
+      port,
+      internalTunnelHost: INTERNAL_TUNNEL_HOST,
+      wsEnabled: !!WebSocketServer,
+    });
   });
 }
 
-main().catch((err) => {
-  log("error", "server_bootstrap_failed", { error: String(err && err.stack ? err.stack : err) });
-  process.exit(1);
-});
+// Exposed for tests; not part of the long-lived server entrypoint.
+module.exports = { sanitizedRequestPath };
+
+if (require.main === module) {
+  main().catch((err) => {
+    log("error", "server_bootstrap_failed", {
+      error: String(err && err.stack ? err.stack : err),
+    });
+    process.exit(1);
+  });
+}

--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@
 "use strict";
 
 const http = require("node:http");
+const { randomUUID } = require("node:crypto");
 const { parse } = require("node:url");
 
 const dev = process.env.NODE_ENV !== "production";
@@ -38,11 +39,24 @@ const INTERNAL_TUNNEL_HOST =
 const WS_PATH = "/v1/responses";
 const CLIENT_TRANSPORT_HEADER = "x-cch-client-transport";
 const WS_FORWARD_FLAG_HEADER = "x-cch-responses-ws-forward";
+const INTERNAL_SECRET_HEADER = "x-cch-internal-secret";
+const INTERNAL_SECRET_ENV = "CCH_RESPONSES_WS_INTERNAL_SECRET";
+
+// Header names a client must NEVER be allowed to set on inbound traffic.
+// Anything starting with "x-cch-" is reserved for internal markers; the WS
+// edge strips the entire prefix from inbound requests so an attacker cannot
+// pre-set the WS-tunnel marker headers when they connect.
+const RESERVED_INTERNAL_HEADER_PREFIX = "x-cch-";
 
 // Per-WebSocket-connection guardrails: cap the queue depth and total queued
 // bytes to make a misbehaving / malicious client a bounded-memory event.
 const MAX_PENDING_FRAMES = 64;
 const MAX_PENDING_BYTES = 4 * 1024 * 1024; // 4 MiB across all queued frames
+
+// Maximum payload size for any single inbound WS frame. The default `ws`
+// limit is 100 MiB, far larger than a Responses create body needs to be and
+// dangerous for a public endpoint.
+const WS_MAX_PAYLOAD_BYTES = 1 * 1024 * 1024; // 1 MiB per frame
 
 const TERMINAL_EVENT_TYPES = new Set([
   "response.completed",
@@ -262,8 +276,8 @@ async function handleWebSocketConnection(ws, req) {
 async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq) {
   const internalHeaders = {};
   for (const [k, v] of Object.entries(originalReq.headers)) {
-    // Skip hop-by-hop / WS-specific headers; keep app-level auth/session etc.
     const lower = k.toLowerCase();
+    // Strip hop-by-hop / WS-specific transport headers.
     if (
       lower === "host" ||
       lower === "connection" ||
@@ -277,6 +291,13 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
     ) {
       continue;
     }
+    // Strip any `x-cch-*` header the client may have set: those names are
+    // reserved for internal markers that we'll attach below. Without this an
+    // external attacker could try to forge `x-cch-internal-secret` /
+    // `x-cch-responses-ws-forward` and bypass the loopback-only check.
+    if (lower.startsWith(RESERVED_INTERNAL_HEADER_PREFIX)) {
+      continue;
+    }
     if (Array.isArray(v)) {
       internalHeaders[k] = v.join(", ");
     } else if (typeof v === "string") {
@@ -287,6 +308,14 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
   internalHeaders["content-type"] = "application/json";
   internalHeaders[CLIENT_TRANSPORT_HEADER] = "websocket";
   internalHeaders[WS_FORWARD_FLAG_HEADER] = "1";
+  // Per-process loopback secret. Read from process.env so it can be picked
+  // up by any code path that needs to verify (the TS forwarder reads the
+  // same env var via `internal-secret.ts`). The secret is generated at
+  // startup if no operator value is preset.
+  const internalSecret = process.env[INTERNAL_SECRET_ENV];
+  if (internalSecret) {
+    internalHeaders[INTERNAL_SECRET_HEADER] = internalSecret;
+  }
 
   // Force streaming so we can translate SSE events to WS frames incrementally.
   // The upstream pipeline will strip transport-only fields (stream, background)
@@ -486,6 +515,14 @@ async function main() {
     WebSocketServer = null;
   }
 
+  // Initialize the per-process internal secret BEFORE next.prepare() so that
+  // any module loaded by Next can read the same value from process.env.
+  // Operators may pre-seed the env var; otherwise we generate one. Either
+  // way the secret never leaves this process.
+  if (!process.env[INTERNAL_SECRET_ENV]) {
+    process.env[INTERNAL_SECRET_ENV] = randomUUID();
+  }
+
   const app = nextFactory({ dev, hostname, port });
   const handler = app.getRequestHandler();
   await app.prepare();
@@ -506,7 +543,7 @@ async function main() {
   });
 
   if (WebSocketServer) {
-    const wss = new WebSocketServer({ noServer: true });
+    const wss = new WebSocketServer({ noServer: true, maxPayload: WS_MAX_PAYLOAD_BYTES });
 
     server.on("upgrade", (req, socket, head) => {
       if (!isResponsesWsUpgrade(req)) {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,405 @@
+// Custom Node.js server for claude-code-hub.
+//
+// Purpose: add WebSocket upgrade support on /v1/responses so clients that speak
+// the OpenAI Responses WebSocket protocol (text JSON frames with
+// type=response.create) can proxy through CCH. All other HTTP traffic is
+// delegated to the Next.js App Router handler unchanged.
+//
+// Architecture: this server is a thin tunnel. For each client WebSocket frame,
+// we build an equivalent HTTP POST against the same app's /v1/responses
+// endpoint (with an x-cch-client-transport header) so that auth, provider
+// selection, guard pipeline, forwarder, circuit breakers, observability, and
+// all existing TypeScript business logic run exactly once. Upstream WebSocket
+// attempts live inside that TypeScript pipeline (forwarder), not here.
+//
+// Compatibility:
+// - Non-WebSocket clients: unaffected. HTTP still flows through Next.js.
+// - Non-Codex providers: the forwarder never attempts upstream WS; client WS
+//   is still accepted and tunneled through HTTP SSE.
+// - Setting disabled: client WS handshake still succeeds (so clients don't
+//   break), but every frame is tunneled over HTTP with no upstream-WS attempt.
+
+"use strict";
+
+const http = require("node:http");
+const { parse } = require("node:url");
+
+const dev = process.env.NODE_ENV !== "production";
+const hostname = process.env.HOSTNAME || "0.0.0.0";
+const port = parseInt(process.env.PORT || (dev ? "13500" : "3000"), 10);
+
+const WS_PATH = "/v1/responses";
+const CLIENT_TRANSPORT_HEADER = "x-cch-client-transport";
+const WS_FORWARD_FLAG_HEADER = "x-cch-responses-ws-forward";
+
+const TERMINAL_EVENT_TYPES = new Set([
+  "response.completed",
+  "response.failed",
+  "response.incomplete",
+  "error",
+]);
+
+function log(level, msg, extra) {
+  const line = { ts: new Date().toISOString(), level, msg, ...(extra || {}) };
+  try {
+    process.stdout.write(`${JSON.stringify(line)}\n`);
+  } catch {
+    // ignore
+  }
+}
+
+function safeSend(ws, data) {
+  try {
+    if (ws.readyState === 1 /* OPEN */) {
+      ws.send(typeof data === "string" ? data : JSON.stringify(data));
+      return true;
+    }
+  } catch (err) {
+    log("warn", "ws_send_failed", { error: String(err) });
+  }
+  return false;
+}
+
+function emitErrorEvent(ws, code, message) {
+  safeSend(ws, {
+    type: "error",
+    error: { code, message },
+  });
+}
+
+async function handleWebSocketConnection(ws, req) {
+  const url = new URL(req.url, `http://${req.headers.host || "localhost"}`);
+  const queryModel = url.searchParams.get("model");
+  let inFlight = false;
+  const pending = [];
+  let closed = false;
+
+  const finalize = () => {
+    closed = true;
+  };
+  ws.on("close", finalize);
+  ws.on("error", finalize);
+
+  const processFrame = async (raw) => {
+    if (closed) return;
+
+    if (typeof raw !== "string") {
+      emitErrorEvent(ws, "invalid_frame_type", "Only text WebSocket frames are supported");
+      try {
+        ws.close(1003, "binary_not_supported");
+      } catch {
+        // ignore
+      }
+      return;
+    }
+
+    let frame;
+    try {
+      frame = JSON.parse(raw);
+    } catch (err) {
+      emitErrorEvent(ws, "invalid_json", `Invalid JSON frame: ${err && err.message ? err.message : "parse error"}`);
+      return;
+    }
+
+    if (!frame || typeof frame !== "object") {
+      emitErrorEvent(ws, "invalid_frame", "Frame must be a JSON object");
+      return;
+    }
+
+    if (frame.type !== "response.create") {
+      emitErrorEvent(ws, "unsupported_event_type", `Only type=response.create is supported; received: ${frame.type ?? "(missing)"}`);
+      return;
+    }
+
+    const { type, ...rawBody } = frame;
+    const body = { ...rawBody };
+    // body.model wins over query; only fill from query when body lacks a model
+    // (LiteLLM/other compat). Drop transport-only fields.
+    if (queryModel && (body.model === undefined || body.model === null || body.model === "")) {
+      body.model = queryModel;
+    }
+
+    await forwardToInternalHttp(ws, req, body);
+  };
+
+  const drain = async () => {
+    if (inFlight) return;
+    const next = pending.shift();
+    if (!next) return;
+    inFlight = true;
+    try {
+      await processFrame(next);
+    } finally {
+      inFlight = false;
+      if (pending.length > 0 && !closed) {
+        void drain();
+      }
+    }
+  };
+
+  ws.on("message", (data, isBinary) => {
+    if (closed) return;
+    if (isBinary) {
+      emitErrorEvent(ws, "invalid_frame_type", "Only text WebSocket frames are supported");
+      try {
+        ws.close(1003, "binary_not_supported");
+      } catch {
+        // ignore
+      }
+      return;
+    }
+    pending.push(data.toString("utf8"));
+    void drain();
+  });
+}
+
+async function forwardToInternalHttp(ws, originalReq, body) {
+  const internalHeaders = {};
+  for (const [k, v] of Object.entries(originalReq.headers)) {
+    // Skip hop-by-hop / WS-specific headers; keep app-level auth/session etc.
+    const lower = k.toLowerCase();
+    if (
+      lower === "host" ||
+      lower === "connection" ||
+      lower === "upgrade" ||
+      lower === "sec-websocket-key" ||
+      lower === "sec-websocket-version" ||
+      lower === "sec-websocket-extensions" ||
+      lower === "sec-websocket-protocol" ||
+      lower === "content-length" ||
+      lower === "transfer-encoding"
+    ) {
+      continue;
+    }
+    if (Array.isArray(v)) {
+      internalHeaders[k] = v.join(", ");
+    } else if (typeof v === "string") {
+      internalHeaders[k] = v;
+    }
+  }
+  internalHeaders["accept"] = "text/event-stream";
+  internalHeaders["content-type"] = "application/json";
+  internalHeaders[CLIENT_TRANSPORT_HEADER] = "websocket";
+  internalHeaders[WS_FORWARD_FLAG_HEADER] = "1";
+
+  // Force streaming so we can translate SSE events to WS frames incrementally.
+  // The upstream pipeline will strip transport-only fields (stream, background)
+  // before forwarding to upstream WebSocket.
+  const bodyForHttp = { ...body, stream: true };
+  delete bodyForHttp.background;
+
+  const payload = Buffer.from(JSON.stringify(bodyForHttp), "utf8");
+  internalHeaders["content-length"] = String(payload.length);
+
+  await new Promise((resolve) => {
+    const req = http.request(
+      {
+        method: "POST",
+        hostname: "127.0.0.1",
+        port,
+        path: "/v1/responses",
+        headers: internalHeaders,
+      },
+      (res) => {
+        const contentType = (res.headers["content-type"] || "").toLowerCase();
+        const isSse = contentType.includes("text/event-stream");
+
+        if (!isSse) {
+          // Upstream returned non-stream JSON (e.g. error response). Collect
+          // and emit as a single terminal event.
+          const chunks = [];
+          res.on("data", (c) => chunks.push(c));
+          res.on("end", () => {
+            const text = Buffer.concat(chunks).toString("utf8");
+            let parsed;
+            try {
+              parsed = JSON.parse(text);
+            } catch {
+              parsed = { raw: text };
+            }
+            if (res.statusCode && res.statusCode >= 400) {
+              safeSend(ws, {
+                type: "error",
+                error: typeof parsed === "object" && parsed && parsed.error
+                  ? parsed.error
+                  : { code: `http_${res.statusCode}`, message: text.slice(0, 512) },
+              });
+            } else {
+              safeSend(ws, {
+                type: "response.completed",
+                response: parsed,
+              });
+            }
+            resolve();
+          });
+          res.on("error", (err) => {
+            emitErrorEvent(ws, "internal_response_error", String(err && err.message ? err.message : err));
+            resolve();
+          });
+          return;
+        }
+
+        // SSE path: decode `data:` events and emit each as a WS JSON frame.
+        let buffer = "";
+        let sawTerminal = false;
+
+        const flushEvents = () => {
+          let idx;
+          while ((idx = buffer.indexOf("\n\n")) !== -1) {
+            const chunk = buffer.slice(0, idx);
+            buffer = buffer.slice(idx + 2);
+            const lines = chunk.split(/\r?\n/);
+            const dataLines = [];
+            for (const line of lines) {
+              if (line.startsWith("data:")) {
+                dataLines.push(line.slice(5).trimStart());
+              }
+            }
+            if (dataLines.length === 0) continue;
+            const dataText = dataLines.join("\n");
+            if (dataText === "[DONE]") {
+              if (!sawTerminal) {
+                // Some upstreams close SSE with [DONE] without a preceding
+                // response.completed. Synthesize one so the client sees a
+                // clean terminal event.
+                safeSend(ws, { type: "response.completed", response: null });
+                sawTerminal = true;
+              }
+              continue;
+            }
+            let event;
+            try {
+              event = JSON.parse(dataText);
+            } catch {
+              // Not JSON; forward as raw string event.
+              safeSend(ws, { type: "response.output_text.delta", delta: dataText });
+              continue;
+            }
+            safeSend(ws, event);
+            if (event && typeof event.type === "string" && TERMINAL_EVENT_TYPES.has(event.type)) {
+              sawTerminal = true;
+            }
+          }
+        };
+
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          buffer += chunk;
+          flushEvents();
+        });
+        res.on("end", () => {
+          // Flush any remaining buffered event
+          if (buffer.trim().length > 0) {
+            buffer += "\n\n";
+            flushEvents();
+          }
+          if (!sawTerminal) {
+            emitErrorEvent(
+              ws,
+              "stream_ended_without_terminal",
+              "Upstream stream ended before emitting a terminal response event"
+            );
+          }
+          resolve();
+        });
+        res.on("error", (err) => {
+          emitErrorEvent(ws, "internal_response_error", String(err && err.message ? err.message : err));
+          resolve();
+        });
+      }
+    );
+
+    req.on("error", (err) => {
+      emitErrorEvent(ws, "internal_request_error", String(err && err.message ? err.message : err));
+      resolve();
+    });
+
+    req.write(payload);
+    req.end();
+  });
+}
+
+function isResponsesWsUpgrade(req) {
+  if (!req.url) return false;
+  const parsed = parse(req.url);
+  return parsed.pathname === WS_PATH;
+}
+
+async function main() {
+  // Import Next programmatically. We require it lazily so that the server can
+  // still report a clean error if Next is not installed (unlikely but possible
+  // in a misconfigured deployment).
+  let nextModule;
+  try {
+    // eslint-disable-next-line global-require
+    nextModule = require("next");
+  } catch (err) {
+    log("error", "next_import_failed", { error: String(err && err.message ? err.message : err) });
+    process.exit(1);
+    return;
+  }
+  const nextFactory = typeof nextModule === "function" ? nextModule : nextModule.default;
+
+  let WebSocketServer;
+  try {
+    // eslint-disable-next-line global-require
+    WebSocketServer = require("ws").WebSocketServer;
+  } catch (err) {
+    log("warn", "ws_module_unavailable_ws_disabled", {
+      error: String(err && err.message ? err.message : err),
+    });
+    WebSocketServer = null;
+  }
+
+  const app = nextFactory({ dev, hostname, port });
+  const handler = app.getRequestHandler();
+  await app.prepare();
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const parsedUrl = parse(req.url, true);
+      await handler(req, res, parsedUrl);
+    } catch (err) {
+      log("error", "http_handler_error", { error: String(err && err.message ? err.message : err) });
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.end("Internal Server Error");
+      }
+    }
+  });
+
+  if (WebSocketServer) {
+    const wss = new WebSocketServer({ noServer: true });
+
+    server.on("upgrade", (req, socket, head) => {
+      if (!isResponsesWsUpgrade(req)) {
+        socket.destroy();
+        return;
+      }
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        log("info", "ws_client_connected", { path: req.url });
+        handleWebSocketConnection(ws, req).catch((err) => {
+          log("error", "ws_handler_error", { error: String(err && err.message ? err.message : err) });
+          try {
+            ws.close(1011, "internal_error");
+          } catch {
+            // ignore
+          }
+        });
+      });
+    });
+  } else {
+    server.on("upgrade", (_req, socket) => {
+      socket.destroy();
+    });
+  }
+
+  server.listen(port, hostname, () => {
+    log("info", "server_listening", { hostname, port, wsEnabled: !!WebSocketServer });
+  });
+}
+
+main().catch((err) => {
+  log("error", "server_bootstrap_failed", { error: String(err && err.stack ? err.stack : err) });
+  process.exit(1);
+});

--- a/src/actions/system-config.ts
+++ b/src/actions/system-config.ts
@@ -65,6 +65,7 @@ export async function saveSystemSettings(formData: {
   verboseProviderError?: boolean;
   passThroughUpstreamErrorMessage?: boolean;
   enableHttp2?: boolean;
+  enableOpenaiResponsesWebsocket?: boolean;
   enableHighConcurrencyMode?: boolean;
   interceptAnthropicWarmupRequests?: boolean;
   enableThinkingSignatureRectifier?: boolean;
@@ -113,6 +114,7 @@ export async function saveSystemSettings(formData: {
       verboseProviderError: validated.verboseProviderError,
       passThroughUpstreamErrorMessage: validated.passThroughUpstreamErrorMessage,
       enableHttp2: validated.enableHttp2,
+      enableOpenaiResponsesWebsocket: validated.enableOpenaiResponsesWebsocket,
       enableHighConcurrencyMode: validated.enableHighConcurrencyMode,
       interceptAnthropicWarmupRequests: validated.interceptAnthropicWarmupRequests,
       enableThinkingSignatureRectifier: validated.enableThinkingSignatureRectifier,

--- a/src/app/[locale]/settings/config/_components/system-settings-form.tsx
+++ b/src/app/[locale]/settings/config/_components/system-settings-form.tsx
@@ -11,6 +11,7 @@ import {
   MapPin,
   Network,
   Pencil,
+  Radio,
   Terminal,
   Thermometer,
   Wrench,
@@ -64,6 +65,7 @@ interface SystemSettingsFormProps {
     | "verboseProviderError"
     | "passThroughUpstreamErrorMessage"
     | "enableHttp2"
+    | "enableOpenaiResponsesWebsocket"
     | "enableHighConcurrencyMode"
     | "interceptAnthropicWarmupRequests"
     | "enableThinkingSignatureRectifier"
@@ -125,6 +127,9 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
     initialSettings.passThroughUpstreamErrorMessage
   );
   const [enableHttp2, setEnableHttp2] = useState(initialSettings.enableHttp2);
+  const [enableOpenaiResponsesWebsocket, setEnableOpenaiResponsesWebsocket] = useState(
+    initialSettings.enableOpenaiResponsesWebsocket
+  );
   const [enableHighConcurrencyMode, setEnableHighConcurrencyMode] = useState(
     initialSettings.enableHighConcurrencyMode
   );
@@ -244,6 +249,7 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
         verboseProviderError,
         passThroughUpstreamErrorMessage,
         enableHttp2,
+        enableOpenaiResponsesWebsocket,
         enableHighConcurrencyMode,
         interceptAnthropicWarmupRequests,
         enableThinkingSignatureRectifier,
@@ -280,6 +286,7 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
         setVerboseProviderError(result.data.verboseProviderError);
         setPassThroughUpstreamErrorMessage(result.data.passThroughUpstreamErrorMessage);
         setEnableHttp2(result.data.enableHttp2);
+        setEnableOpenaiResponsesWebsocket(result.data.enableOpenaiResponsesWebsocket);
         setEnableHighConcurrencyMode(result.data.enableHighConcurrencyMode);
         setInterceptAnthropicWarmupRequests(result.data.interceptAnthropicWarmupRequests);
         setEnableThinkingSignatureRectifier(result.data.enableThinkingSignatureRectifier);
@@ -550,6 +557,29 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
             id="enable-http2"
             checked={enableHttp2}
             onCheckedChange={(checked) => setEnableHttp2(checked)}
+            disabled={isPending}
+          />
+        </div>
+
+        {/* Enable OpenAI Responses WebSocket (Codex only) */}
+        <div className="p-4 rounded-xl bg-white/[0.02] border border-white/5 flex items-center justify-between hover:bg-white/[0.04] transition-colors">
+          <div className="flex items-start gap-3">
+            <div className="w-8 h-8 flex items-center justify-center rounded-lg bg-cyan-500/10 text-cyan-400 shrink-0">
+              <Radio className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                {t("enableOpenaiResponsesWebsocket")}
+              </p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {t("enableOpenaiResponsesWebsocketDesc")}
+              </p>
+            </div>
+          </div>
+          <Switch
+            id="enable-openai-responses-websocket"
+            checked={enableOpenaiResponsesWebsocket}
+            onCheckedChange={(checked) => setEnableOpenaiResponsesWebsocket(checked)}
             disabled={isPending}
           />
         </div>

--- a/src/app/[locale]/settings/config/_components/system-settings-form.tsx
+++ b/src/app/[locale]/settings/config/_components/system-settings-form.tsx
@@ -578,6 +578,7 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
           </div>
           <Switch
             id="enable-openai-responses-websocket"
+            aria-label={t("enableOpenaiResponsesWebsocket")}
             checked={enableOpenaiResponsesWebsocket}
             onCheckedChange={(checked) => setEnableOpenaiResponsesWebsocket(checked)}
             disabled={isPending}

--- a/src/app/[locale]/settings/config/page.tsx
+++ b/src/app/[locale]/settings/config/page.tsx
@@ -49,6 +49,7 @@ async function SettingsConfigContent() {
             verboseProviderError: settings.verboseProviderError,
             passThroughUpstreamErrorMessage: settings.passThroughUpstreamErrorMessage,
             enableHttp2: settings.enableHttp2,
+            enableOpenaiResponsesWebsocket: settings.enableOpenaiResponsesWebsocket,
             enableHighConcurrencyMode: settings.enableHighConcurrencyMode,
             interceptAnthropicWarmupRequests: settings.interceptAnthropicWarmupRequests,
             enableThinkingSignatureRectifier: settings.enableThinkingSignatureRectifier,

--- a/src/app/api/admin/system-config/route.ts
+++ b/src/app/api/admin/system-config/route.ts
@@ -71,6 +71,7 @@ export async function POST(req: Request) {
       verboseProviderError: validated.verboseProviderError,
       passThroughUpstreamErrorMessage: validated.passThroughUpstreamErrorMessage,
       enableHttp2: validated.enableHttp2,
+      enableOpenaiResponsesWebsocket: validated.enableOpenaiResponsesWebsocket,
       enableHighConcurrencyMode: validated.enableHighConcurrencyMode,
       interceptAnthropicWarmupRequests: validated.interceptAnthropicWarmupRequests,
       enableThinkingSignatureRectifier: validated.enableThinkingSignatureRectifier,

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -2894,7 +2894,14 @@ export class ProxyForwarder {
                 attemptNumber: undefined,
               });
             } else {
-              markResponsesWsUnsupported(provider.id, responsesWsEndpointId, wsResult.reason);
+              // Only cache when the failure proves the endpoint does not
+              // speak the WS protocol (HTTP 4xx / 501 on the upgrade). Any
+              // transient failure (network, auth, silent upstream) should
+              // re-probe on the next request rather than skipping WS for
+              // the full TTL.
+              if (wsResult.cacheableAsUnsupported) {
+                markResponsesWsUnsupported(provider.id, responsesWsEndpointId, wsResult.reason);
+              }
               logger.info(
                 "ProxyForwarder: Upstream Responses WebSocket unavailable, falling back to HTTP",
                 {
@@ -2902,6 +2909,7 @@ export class ProxyForwarder {
                   providerName: provider.name,
                   endpointId: responsesWsEndpointId,
                   reason: wsResult.reason,
+                  cacheable: wsResult.cacheableAsUnsupported,
                   message: wsResult.message,
                 }
               );

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -47,6 +47,9 @@ import type {
 import { GeminiAuth } from "../gemini/auth";
 import { GEMINI_PROTOCOL } from "../gemini/protocol";
 import { HeaderProcessor, resolveAnthropicAuthHeaders } from "../headers";
+import { evaluateResponsesWsEligibility } from "../responses-ws/eligibility";
+import { markResponsesWsUnsupported } from "../responses-ws/unsupported-cache";
+import { tryResponsesWebsocketUpstream } from "../responses-ws/upstream-adapter";
 import { buildProxyUrl } from "../url";
 import { rectifyBillingHeader } from "./billing-header-rectifier";
 import { deriveClientSafeUpstreamErrorMessage } from "./client-error-message";
@@ -2817,19 +2820,96 @@ export class ProxyForwarder {
 
       (init as Record<string, unknown>).verbose = true;
 
+      // ⭐ OpenAI Responses WebSocket 上游尝试（仅 Codex 供应商 + 开关开启 + 客户端以 WS 接入）
+      // 若握手失败或首帧前关闭，降级到下面的 HTTP 路径；不计入熔断器。
+      let responsesWsResponse: Response | null = null;
+      try {
+        const wsEligibility = await evaluateResponsesWsEligibility({
+          headers: processedHeaders,
+          provider,
+          endpointId: null,
+        });
+
+        if (wsEligibility.eligible) {
+          const requestMessage = session.request.message;
+          const requestBodyJson =
+            requestMessage && typeof requestMessage === "object"
+              ? (requestMessage as Record<string, unknown>)
+              : null;
+
+          if (requestBodyJson) {
+            const wsResult = await tryResponsesWebsocketUpstream({
+              provider,
+              upstreamUrl: proxyUrl,
+              upstreamHeaders: processedHeaders,
+              body: requestBodyJson,
+              abortSignal: combinedSignal,
+            });
+
+            if ("response" in wsResult) {
+              responsesWsResponse = wsResult.response;
+              logger.info("ProxyForwarder: Upstream Responses WebSocket connected", {
+                providerId: provider.id,
+                providerName: provider.name,
+                connected: wsResult.connected,
+              });
+              session.addProviderToChain(provider, {
+                reason: "responses_ws_attempted",
+                attemptNumber: undefined,
+              });
+            } else {
+              markResponsesWsUnsupported(provider.id, null, wsResult.reason);
+              logger.info(
+                "ProxyForwarder: Upstream Responses WebSocket unavailable, falling back to HTTP",
+                {
+                  providerId: provider.id,
+                  providerName: provider.name,
+                  reason: wsResult.reason,
+                  message: wsResult.message,
+                }
+              );
+              session.addProviderToChain(provider, {
+                reason: "responses_ws_fallback",
+                errorMessage: wsResult.message,
+                attemptNumber: undefined,
+              });
+            }
+          }
+        } else if (wsEligibility.isWebsocketClient && wsEligibility.downgradeReason) {
+          session.addProviderToChain(provider, {
+            reason: "responses_ws_fallback",
+            errorMessage: wsEligibility.downgradeReason,
+            attemptNumber: undefined,
+          });
+        }
+      } catch (wsError) {
+        logger.warn(
+          "ProxyForwarder: Upstream Responses WebSocket attempt threw, falling back to HTTP",
+          {
+            providerId: provider.id,
+            providerName: provider.name,
+            error: String(
+              wsError && (wsError as Error).message ? (wsError as Error).message : wsError
+            ),
+          }
+        );
+      }
+
       // ⭐ 所有供应商使用 undici.request 绕过 fetch 的自动解压
       // 原因：undici fetch 无法关闭自动解压，上游可能无视 accept-encoding: identity 返回 gzip
       // 当 gzip 流被提前终止时（如连接关闭），undici Gunzip 会抛出 "TypeError: terminated"
-      response = useErrorTolerantFetch
-        ? await ProxyForwarder.fetchWithoutAutoDecode(
-            proxyUrl,
-            init,
-            provider.id,
-            provider.name,
-            session,
-            deferDetailSnapshotPersistence
-          )
-        : await fetch(proxyUrl, init);
+      response = responsesWsResponse
+        ? responsesWsResponse
+        : useErrorTolerantFetch
+          ? await ProxyForwarder.fetchWithoutAutoDecode(
+              proxyUrl,
+              init,
+              provider.id,
+              provider.name,
+              session,
+              deferDetailSnapshotPersistence
+            )
+          : await fetch(proxyUrl, init);
       // ⭐ fetch 成功：收到 HTTP 响应头，保留响应超时继续监控
       // 注意：undici 的 fetch 在收到 HTTP 响应头后就 resolve，但实际数据（SSE 首字节 / 完整 JSON）
       // 还没到达。responseTimeoutId 需要延续到 response-handler 中才能真正控制"首字节"或"总耗时"

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -93,6 +93,37 @@ import {
 export const DEFAULT_CODEX_USER_AGENT =
   "codex_cli_rs/0.93.0 (Windows 10.0.26200; x86_64) vscode/1.108.1";
 
+/**
+ * Best-effort decode of the *final* outgoing request body into a JSON object.
+ *
+ * The Responses WebSocket adapter needs the same payload that would have been
+ * sent over HTTP — including all filterPrivateParameters() / request-filter
+ * rewrites. The forwarder represents that body as a `BodyInit` (Buffer,
+ * string, FormData, ReadableStream, etc.). We only support the byte/string
+ * shapes here; multipart and stream shapes return null so the caller falls
+ * back to the HTTP path.
+ */
+function decodeRequestBodyAsJson(body: BodyInit | undefined): Record<string, unknown> | null {
+  if (body == null) return null;
+  let text: string | null = null;
+  if (typeof body === "string") {
+    text = body;
+  } else if (Buffer.isBuffer(body)) {
+    text = body.toString("utf8");
+  } else if (body instanceof Uint8Array) {
+    text = Buffer.from(body).toString("utf8");
+  }
+  if (text == null) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 const OUTBOUND_TRANSPORT_HEADER_BLACKLIST = ["content-length", "connection", "transfer-encoding"];
 
 const RETRY_LIMITS = PROVIDER_LIMITS.MAX_RETRY_ATTEMPTS;
@@ -2820,22 +2851,24 @@ export class ProxyForwarder {
 
       (init as Record<string, unknown>).verbose = true;
 
-      // ⭐ OpenAI Responses WebSocket 上游尝试（仅 Codex 供应商 + 开关开启 + 客户端以 WS 接入）
+      // OpenAI Responses WebSocket 上游尝试（仅 Codex 供应商 + 开关开启 + 客户端以 WS 接入）
       // 若握手失败或首帧前关闭，降级到下面的 HTTP 路径；不计入熔断器。
       let responsesWsResponse: Response | null = null;
+      const responsesWsEndpointId = endpointAudit?.endpointId ?? null;
       try {
         const wsEligibility = await evaluateResponsesWsEligibility({
           headers: processedHeaders,
           provider,
-          endpointId: null,
+          endpointId: responsesWsEndpointId,
         });
 
         if (wsEligibility.eligible) {
-          const requestMessage = session.request.message;
-          const requestBodyJson =
-            requestMessage && typeof requestMessage === "object"
-              ? (requestMessage as Record<string, unknown>)
-              : null;
+          // Use the *final* outgoing body so the WS frame matches the HTTP
+          // path: it has been through filterPrivateParameters() and any
+          // request-filter transformations. Falling back to
+          // session.request.message would skip those rewrites and could leak
+          // private fields or cause the upstream to reject the request.
+          const requestBodyJson = decodeRequestBodyAsJson(requestBody);
 
           if (requestBodyJson) {
             const wsResult = await tryResponsesWebsocketUpstream({
@@ -2851,25 +2884,31 @@ export class ProxyForwarder {
               logger.info("ProxyForwarder: Upstream Responses WebSocket connected", {
                 providerId: provider.id,
                 providerName: provider.name,
+                endpointId: responsesWsEndpointId,
                 connected: wsResult.connected,
               });
               session.addProviderToChain(provider, {
                 reason: "responses_ws_attempted",
+                endpointId: responsesWsEndpointId,
+                endpointUrl: endpointAudit?.endpointUrl,
                 attemptNumber: undefined,
               });
             } else {
-              markResponsesWsUnsupported(provider.id, null, wsResult.reason);
+              markResponsesWsUnsupported(provider.id, responsesWsEndpointId, wsResult.reason);
               logger.info(
                 "ProxyForwarder: Upstream Responses WebSocket unavailable, falling back to HTTP",
                 {
                   providerId: provider.id,
                   providerName: provider.name,
+                  endpointId: responsesWsEndpointId,
                   reason: wsResult.reason,
                   message: wsResult.message,
                 }
               );
               session.addProviderToChain(provider, {
                 reason: "responses_ws_fallback",
+                endpointId: responsesWsEndpointId,
+                endpointUrl: endpointAudit?.endpointUrl,
                 errorMessage: wsResult.message,
                 attemptNumber: undefined,
               });
@@ -2878,6 +2917,8 @@ export class ProxyForwarder {
         } else if (wsEligibility.isWebsocketClient && wsEligibility.downgradeReason) {
           session.addProviderToChain(provider, {
             reason: "responses_ws_fallback",
+            endpointId: responsesWsEndpointId,
+            endpointUrl: endpointAudit?.endpointUrl,
             errorMessage: wsEligibility.downgradeReason,
             attemptNumber: undefined,
           });

--- a/src/app/v1/_lib/proxy/session.ts
+++ b/src/app/v1/_lib/proxy/session.ts
@@ -546,6 +546,8 @@ export class ProxySession {
         | "retry_with_cached_instructions" // Codex instructions 智能重试（缓存）
         | "client_error_non_retryable" // 不可重试的客户端错误（Prompt 超限、内容过滤、PDF 限制、Thinking 格式）
         | "http2_fallback" // HTTP/2 协议错误，回退到 HTTP/1.1（不切换供应商、不计入熔断器）
+        | "responses_ws_attempted" // 已尝试上游 OpenAI Responses WebSocket 建连（信息性记录）
+        | "responses_ws_fallback" // 上游 WebSocket 不可用，回退到 HTTP（不切换供应商、不计入熔断器）
         | "endpoint_pool_exhausted" // 端点池耗尽（strict endpoint policy 阻止了 fallback）
         | "vendor_type_all_timeout" // 供应商类型全端点超时（524），触发 vendor-type 临时熔断
         | "client_restriction_filtered" // 供应商因客户端限制被跳过（会话复用路径）

--- a/src/app/v1/_lib/responses-ws/__tests__/eligibility.test.ts
+++ b/src/app/v1/_lib/responses-ws/__tests__/eligibility.test.ts
@@ -1,16 +1,40 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Provider } from "@/types/provider";
 import {
   CLIENT_TRANSPORT_HEADER,
   evaluateResponsesWsEligibility,
   isWebsocketClientRequest,
 } from "../eligibility";
+import {
+  ensureInternalSecret,
+  INTERNAL_SECRET_HEADER,
+  WS_FORWARD_FLAG_HEADER,
+} from "../internal-secret";
 import { clearResponsesWsUnsupportedCache, markResponsesWsUnsupported } from "../unsupported-cache";
 
 const isOpenaiResponsesWebsocketEnabledMock = vi.fn();
 vi.mock("@/lib/config/system-settings-cache", () => ({
   isOpenaiResponsesWebsocketEnabled: () => isOpenaiResponsesWebsocketEnabledMock(),
 }));
+
+let TEST_SECRET = "";
+const originalSecret = process.env.CCH_RESPONSES_WS_INTERNAL_SECRET;
+
+beforeAll(() => {
+  // Tests run in the same Node process; the eligibility check verifies
+  // against `process.env.CCH_RESPONSES_WS_INTERNAL_SECRET`. Pin a known
+  // value so tests are deterministic.
+  process.env.CCH_RESPONSES_WS_INTERNAL_SECRET = "test-loopback-secret";
+  TEST_SECRET = ensureInternalSecret();
+});
+
+afterAll(() => {
+  if (originalSecret === undefined) {
+    delete process.env.CCH_RESPONSES_WS_INTERNAL_SECRET;
+  } else {
+    process.env.CCH_RESPONSES_WS_INTERNAL_SECRET = originalSecret;
+  }
+});
 
 function codexProvider(id = 1): Provider {
   return {
@@ -25,7 +49,6 @@ function codexProvider(id = 1): Provider {
     costMultiplier: 1,
     groupTag: null,
     providerVendorId: null,
-    // minimum required shape for our code path; other fields are unused here
   } as unknown as Provider;
 }
 
@@ -45,32 +68,80 @@ function claudeProvider(id = 2): Provider {
   } as unknown as Provider;
 }
 
+/**
+ * Build a request that LOOKS like the trusted internal tunnel: it has the
+ * client-transport marker AND the per-process secret AND the forward flag.
+ * Use this whenever you want eligibility to behave as for a true WS request.
+ */
+function trustedInternalHeaders(extra?: Record<string, string>): Headers {
+  const h = new Headers();
+  h.set(CLIENT_TRANSPORT_HEADER, "websocket");
+  h.set(INTERNAL_SECRET_HEADER, TEST_SECRET);
+  h.set(WS_FORWARD_FLAG_HEADER, "1");
+  if (extra) {
+    for (const [k, v] of Object.entries(extra)) h.set(k, v);
+  }
+  return h;
+}
+
 describe("isWebsocketClientRequest", () => {
-  it("detects websocket via Headers object", () => {
-    const h = new Headers();
-    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
-    expect(isWebsocketClientRequest(h)).toBe(true);
+  it("treats request with client-transport + valid secret + forward flag as a WS client", () => {
+    expect(isWebsocketClientRequest(trustedInternalHeaders())).toBe(true);
   });
 
-  it("detects websocket via plain record", () => {
-    expect(
-      isWebsocketClientRequest({ [CLIENT_TRANSPORT_HEADER]: "WebSocket" } as Record<string, string>)
-    ).toBe(true);
+  it("rejects requests with client-transport but no internal secret (spoofing attempt)", () => {
+    const h = new Headers();
+    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
+    expect(isWebsocketClientRequest(h)).toBe(false);
+  });
+
+  it("rejects requests with client-transport + forward flag but no secret", () => {
+    const h = new Headers();
+    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
+    h.set(WS_FORWARD_FLAG_HEADER, "1");
+    expect(isWebsocketClientRequest(h)).toBe(false);
+  });
+
+  it("rejects requests with a wrong internal secret", () => {
+    const h = new Headers();
+    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
+    h.set(INTERNAL_SECRET_HEADER, "wrong-secret");
+    h.set(WS_FORWARD_FLAG_HEADER, "1");
+    expect(isWebsocketClientRequest(h)).toBe(false);
+  });
+
+  it("rejects requests with a valid secret but no forward flag", () => {
+    const h = new Headers();
+    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
+    h.set(INTERNAL_SECRET_HEADER, TEST_SECRET);
+    expect(isWebsocketClientRequest(h)).toBe(false);
   });
 
   it("returns false when header is absent or other transport", () => {
     expect(isWebsocketClientRequest({})).toBe(false);
     expect(
-      isWebsocketClientRequest({ [CLIENT_TRANSPORT_HEADER]: "http" } as Record<string, string>)
+      isWebsocketClientRequest({
+        [CLIENT_TRANSPORT_HEADER]: "http",
+        [INTERNAL_SECRET_HEADER]: TEST_SECRET,
+        [WS_FORWARD_FLAG_HEADER]: "1",
+      } as Record<string, string>)
     ).toBe(false);
   });
 
   it("handles record keys regardless of case (HTTP header semantics)", () => {
     expect(
-      isWebsocketClientRequest({ "X-Cch-Client-Transport": "websocket" } as Record<string, string>)
+      isWebsocketClientRequest({
+        "X-Cch-Client-Transport": "websocket",
+        "X-Cch-Internal-Secret": TEST_SECRET,
+        "X-Cch-Responses-Ws-Forward": "1",
+      } as Record<string, string>)
     ).toBe(true);
     expect(
-      isWebsocketClientRequest({ "X-CCH-Client-TRANSPORT": "WEBSOCKET" } as Record<string, string>)
+      isWebsocketClientRequest({
+        "X-CCH-Client-TRANSPORT": "WEBSOCKET",
+        "X-CCH-INTERNAL-SECRET": TEST_SECRET,
+        "X-CCH-Responses-WS-Forward": "1",
+      } as Record<string, string>)
     ).toBe(true);
   });
 });
@@ -91,12 +162,42 @@ describe("evaluateResponsesWsEligibility", () => {
     expect(result).toEqual({ isWebsocketClient: false, eligible: false });
   });
 
-  it("records provider_not_codex for non-codex upstreams", async () => {
+  it("treats spoofed requests (no internal secret) as non-WS clients (HTTP path)", async () => {
+    isOpenaiResponsesWebsocketEnabledMock.mockResolvedValue(true);
+    const spoofed = new Headers();
+    spoofed.set(CLIENT_TRANSPORT_HEADER, "websocket");
+    spoofed.set(WS_FORWARD_FLAG_HEADER, "1");
+    // intentionally no INTERNAL_SECRET_HEADER
+
+    const result = await evaluateResponsesWsEligibility({
+      headers: spoofed,
+      provider: codexProvider(),
+      endpointId: null,
+    });
+    // Spoofing must NOT be reported as a "ws downgrade" — there was never a
+    // legitimate WS client. Return the same shape as a regular HTTP request.
+    expect(result).toEqual({ isWebsocketClient: false, eligible: false });
+  });
+
+  it("treats requests with a wrong internal secret as non-WS clients", async () => {
     isOpenaiResponsesWebsocketEnabledMock.mockResolvedValue(true);
     const h = new Headers();
     h.set(CLIENT_TRANSPORT_HEADER, "websocket");
+    h.set(INTERNAL_SECRET_HEADER, "definitely-not-the-secret");
+    h.set(WS_FORWARD_FLAG_HEADER, "1");
+
     const result = await evaluateResponsesWsEligibility({
       headers: h,
+      provider: codexProvider(),
+      endpointId: null,
+    });
+    expect(result).toEqual({ isWebsocketClient: false, eligible: false });
+  });
+
+  it("records provider_not_codex for non-codex upstreams", async () => {
+    isOpenaiResponsesWebsocketEnabledMock.mockResolvedValue(true);
+    const result = await evaluateResponsesWsEligibility({
+      headers: trustedInternalHeaders(),
       provider: claudeProvider(),
       endpointId: null,
     });
@@ -107,10 +208,8 @@ describe("evaluateResponsesWsEligibility", () => {
 
   it("records setting_disabled when global toggle is off", async () => {
     isOpenaiResponsesWebsocketEnabledMock.mockResolvedValue(false);
-    const h = new Headers();
-    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
     const result = await evaluateResponsesWsEligibility({
-      headers: h,
+      headers: trustedInternalHeaders(),
       provider: codexProvider(),
       endpointId: null,
     });
@@ -123,10 +222,8 @@ describe("evaluateResponsesWsEligibility", () => {
     isOpenaiResponsesWebsocketEnabledMock.mockResolvedValue(true);
     const provider = codexProvider(99);
     markResponsesWsUnsupported(provider.id, null, "ws_upgrade_rejected");
-    const h = new Headers();
-    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
     const result = await evaluateResponsesWsEligibility({
-      headers: h,
+      headers: trustedInternalHeaders(),
       provider,
       endpointId: null,
     });
@@ -136,10 +233,8 @@ describe("evaluateResponsesWsEligibility", () => {
 
   it("returns eligible when all conditions are met", async () => {
     isOpenaiResponsesWebsocketEnabledMock.mockResolvedValue(true);
-    const h = new Headers();
-    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
     const result = await evaluateResponsesWsEligibility({
-      headers: h,
+      headers: trustedInternalHeaders(),
       provider: codexProvider(),
       endpointId: null,
     });

--- a/src/app/v1/_lib/responses-ws/__tests__/eligibility.test.ts
+++ b/src/app/v1/_lib/responses-ws/__tests__/eligibility.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Provider } from "@/types/provider";
+import {
+  CLIENT_TRANSPORT_HEADER,
+  evaluateResponsesWsEligibility,
+  isWebsocketClientRequest,
+} from "../eligibility";
+import { clearResponsesWsUnsupportedCache, markResponsesWsUnsupported } from "../unsupported-cache";
+
+const isOpenaiResponsesWebsocketEnabledMock = vi.fn();
+vi.mock("@/lib/config/system-settings-cache", () => ({
+  isOpenaiResponsesWebsocketEnabled: () => isOpenaiResponsesWebsocketEnabledMock(),
+}));
+
+function codexProvider(id = 1): Provider {
+  return {
+    id,
+    name: `codex-${id}`,
+    providerType: "codex",
+    baseUrl: "https://api.openai.com/v1",
+    apiKey: "sk-test",
+    enabled: true,
+    weight: 1,
+    priority: 1,
+    costMultiplier: 1,
+    groupTag: null,
+    providerVendorId: null,
+    // minimum required shape for our code path; other fields are unused here
+  } as unknown as Provider;
+}
+
+function claudeProvider(id = 2): Provider {
+  return {
+    id,
+    name: `claude-${id}`,
+    providerType: "claude",
+    baseUrl: "https://api.anthropic.com/v1",
+    apiKey: "sk-test",
+    enabled: true,
+    weight: 1,
+    priority: 1,
+    costMultiplier: 1,
+    groupTag: null,
+    providerVendorId: null,
+  } as unknown as Provider;
+}
+
+describe("isWebsocketClientRequest", () => {
+  it("detects websocket via Headers object", () => {
+    const h = new Headers();
+    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
+    expect(isWebsocketClientRequest(h)).toBe(true);
+  });
+
+  it("detects websocket via plain record", () => {
+    expect(
+      isWebsocketClientRequest({ [CLIENT_TRANSPORT_HEADER]: "WebSocket" } as Record<string, string>)
+    ).toBe(true);
+  });
+
+  it("returns false when header is absent or other transport", () => {
+    expect(isWebsocketClientRequest({})).toBe(false);
+    expect(
+      isWebsocketClientRequest({ [CLIENT_TRANSPORT_HEADER]: "http" } as Record<string, string>)
+    ).toBe(false);
+  });
+});
+
+describe("evaluateResponsesWsEligibility", () => {
+  beforeEach(() => {
+    isOpenaiResponsesWebsocketEnabledMock.mockReset();
+    clearResponsesWsUnsupportedCache();
+  });
+
+  it("returns not-websocket-client when header is absent", async () => {
+    isOpenaiResponsesWebsocketEnabledMock.mockResolvedValue(true);
+    const result = await evaluateResponsesWsEligibility({
+      headers: new Headers(),
+      provider: codexProvider(),
+      endpointId: null,
+    });
+    expect(result).toEqual({ isWebsocketClient: false, eligible: false });
+  });
+
+  it("records provider_not_codex for non-codex upstreams", async () => {
+    isOpenaiResponsesWebsocketEnabledMock.mockResolvedValue(true);
+    const h = new Headers();
+    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
+    const result = await evaluateResponsesWsEligibility({
+      headers: h,
+      provider: claudeProvider(),
+      endpointId: null,
+    });
+    expect(result.isWebsocketClient).toBe(true);
+    expect(result.eligible).toBe(false);
+    expect(result.downgradeReason).toBe("provider_not_codex");
+  });
+
+  it("records setting_disabled when global toggle is off", async () => {
+    isOpenaiResponsesWebsocketEnabledMock.mockResolvedValue(false);
+    const h = new Headers();
+    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
+    const result = await evaluateResponsesWsEligibility({
+      headers: h,
+      provider: codexProvider(),
+      endpointId: null,
+    });
+    expect(result.isWebsocketClient).toBe(true);
+    expect(result.eligible).toBe(false);
+    expect(result.downgradeReason).toBe("setting_disabled");
+  });
+
+  it("records endpoint_ws_unsupported_cached when cache flag present", async () => {
+    isOpenaiResponsesWebsocketEnabledMock.mockResolvedValue(true);
+    const provider = codexProvider(99);
+    markResponsesWsUnsupported(provider.id, null, "ws_upgrade_rejected");
+    const h = new Headers();
+    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
+    const result = await evaluateResponsesWsEligibility({
+      headers: h,
+      provider,
+      endpointId: null,
+    });
+    expect(result.eligible).toBe(false);
+    expect(result.downgradeReason).toBe("endpoint_ws_unsupported_cached");
+  });
+
+  it("returns eligible when all conditions are met", async () => {
+    isOpenaiResponsesWebsocketEnabledMock.mockResolvedValue(true);
+    const h = new Headers();
+    h.set(CLIENT_TRANSPORT_HEADER, "websocket");
+    const result = await evaluateResponsesWsEligibility({
+      headers: h,
+      provider: codexProvider(),
+      endpointId: null,
+    });
+    expect(result).toMatchObject({
+      isWebsocketClient: true,
+      eligible: true,
+    });
+  });
+});

--- a/src/app/v1/_lib/responses-ws/__tests__/eligibility.test.ts
+++ b/src/app/v1/_lib/responses-ws/__tests__/eligibility.test.ts
@@ -64,6 +64,15 @@ describe("isWebsocketClientRequest", () => {
       isWebsocketClientRequest({ [CLIENT_TRANSPORT_HEADER]: "http" } as Record<string, string>)
     ).toBe(false);
   });
+
+  it("handles record keys regardless of case (HTTP header semantics)", () => {
+    expect(
+      isWebsocketClientRequest({ "X-Cch-Client-Transport": "websocket" } as Record<string, string>)
+    ).toBe(true);
+    expect(
+      isWebsocketClientRequest({ "X-CCH-Client-TRANSPORT": "WEBSOCKET" } as Record<string, string>)
+    ).toBe(true);
+  });
 });
 
 describe("evaluateResponsesWsEligibility", () => {

--- a/src/app/v1/_lib/responses-ws/__tests__/internal-secret.test.ts
+++ b/src/app/v1/_lib/responses-ws/__tests__/internal-secret.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ensureInternalSecret,
+  getInternalSecret,
+  INTERNAL_SECRET_HEADER,
+  RESERVED_INTERNAL_HEADERS,
+  verifyInternalRequest,
+  WS_FORWARD_FLAG_HEADER,
+} from "../internal-secret";
+
+const ENV_VAR = "CCH_RESPONSES_WS_INTERNAL_SECRET";
+
+describe("internal-secret", () => {
+  let originalSecret: string | undefined;
+
+  beforeEach(() => {
+    originalSecret = process.env[ENV_VAR];
+    delete process.env[ENV_VAR];
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env[ENV_VAR];
+    } else {
+      process.env[ENV_VAR] = originalSecret;
+    }
+  });
+
+  it("returns null when the secret has not been initialized", () => {
+    expect(getInternalSecret()).toBeNull();
+  });
+
+  it("ensureInternalSecret generates a UUID when none is preset", () => {
+    const secret = ensureInternalSecret();
+    expect(secret).toMatch(/^[0-9a-f-]{36}$/);
+    expect(getInternalSecret()).toBe(secret);
+  });
+
+  it("ensureInternalSecret honors a pre-set value", () => {
+    process.env[ENV_VAR] = "operator-supplied-secret";
+    expect(ensureInternalSecret()).toBe("operator-supplied-secret");
+  });
+
+  it("ensureInternalSecret is idempotent", () => {
+    const a = ensureInternalSecret();
+    const b = ensureInternalSecret();
+    expect(a).toBe(b);
+  });
+
+  it("verifyInternalRequest rejects when no secret is configured", () => {
+    const h = new Headers();
+    h.set(INTERNAL_SECRET_HEADER, "anything");
+    h.set(WS_FORWARD_FLAG_HEADER, "1");
+    expect(verifyInternalRequest(h)).toBe(false);
+  });
+
+  it("verifyInternalRequest rejects when the secret header is missing", () => {
+    process.env[ENV_VAR] = "real-secret";
+    const h = new Headers();
+    h.set(WS_FORWARD_FLAG_HEADER, "1");
+    expect(verifyInternalRequest(h)).toBe(false);
+  });
+
+  it("verifyInternalRequest rejects when the secret is wrong", () => {
+    process.env[ENV_VAR] = "real-secret";
+    const h = new Headers();
+    h.set(INTERNAL_SECRET_HEADER, "spoofed-secret");
+    h.set(WS_FORWARD_FLAG_HEADER, "1");
+    expect(verifyInternalRequest(h)).toBe(false);
+  });
+
+  it("verifyInternalRequest rejects when the forward flag is missing", () => {
+    process.env[ENV_VAR] = "real-secret";
+    const h = new Headers();
+    h.set(INTERNAL_SECRET_HEADER, "real-secret");
+    expect(verifyInternalRequest(h)).toBe(false);
+  });
+
+  it("verifyInternalRequest accepts when secret + forward flag are correct", () => {
+    process.env[ENV_VAR] = "real-secret";
+    const h = new Headers();
+    h.set(INTERNAL_SECRET_HEADER, "real-secret");
+    h.set(WS_FORWARD_FLAG_HEADER, "1");
+    expect(verifyInternalRequest(h)).toBe(true);
+  });
+
+  it("verifyInternalRequest works with plain Record<string,string> regardless of case", () => {
+    process.env[ENV_VAR] = "real-secret";
+    expect(
+      verifyInternalRequest({
+        "X-Cch-Internal-Secret": "real-secret",
+        "X-Cch-Responses-Ws-Forward": "1",
+      })
+    ).toBe(true);
+  });
+
+  it("RESERVED_INTERNAL_HEADERS lists the secret + forward flag + transport markers", () => {
+    expect(RESERVED_INTERNAL_HEADERS).toContain(INTERNAL_SECRET_HEADER);
+    expect(RESERVED_INTERNAL_HEADERS).toContain(WS_FORWARD_FLAG_HEADER);
+    expect(RESERVED_INTERNAL_HEADERS).toContain("x-cch-client-transport");
+  });
+});

--- a/src/app/v1/_lib/responses-ws/__tests__/server-helpers.test.ts
+++ b/src/app/v1/_lib/responses-ws/__tests__/server-helpers.test.ts
@@ -1,0 +1,34 @@
+// Co-located smoke test for the small helpers exported from `server.js`. We
+// only validate the log-sanitization helper here; the full custom server is
+// integration-tested separately.
+import { describe, expect, it } from "vitest";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { sanitizedRequestPath } = require("../../../../../../server.js") as {
+  sanitizedRequestPath: (rawUrl: string) => string;
+};
+
+describe("server.js sanitizedRequestPath", () => {
+  it("returns the path unchanged when there is no query string", () => {
+    expect(sanitizedRequestPath("/v1/responses")).toBe("/v1/responses");
+  });
+
+  it("preserves the model query parameter (allow-listed)", () => {
+    expect(sanitizedRequestPath("/v1/responses?model=gpt-5")).toBe("/v1/responses?model=gpt-5");
+  });
+
+  it("masks unknown / sensitive query parameters", () => {
+    const out = sanitizedRequestPath("/v1/responses?api_key=sk-secret&token=abc&user=alice");
+    expect(out).toContain("api_key=***");
+    expect(out).toContain("token=***");
+    expect(out).toContain("user=***");
+    expect(out).not.toContain("sk-secret");
+    expect(out).not.toContain("alice");
+  });
+
+  it("falls back to root when the URL is unparseable", () => {
+    // `new URL` accepts most inputs against http://localhost; pass an obvious
+    // non-string sentinel to trigger the catch branch.
+    expect(sanitizedRequestPath(undefined as unknown as string)).toBe("/");
+  });
+});

--- a/src/app/v1/_lib/responses-ws/__tests__/unsupported-cache.test.ts
+++ b/src/app/v1/_lib/responses-ws/__tests__/unsupported-cache.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearResponsesWsUnsupportedCache,
+  isResponsesWsUnsupported,
+  markResponsesWsUnsupported,
+} from "../unsupported-cache";
+
+describe("responses-ws unsupported-cache", () => {
+  beforeEach(() => {
+    clearResponsesWsUnsupportedCache();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-24T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearResponsesWsUnsupportedCache();
+  });
+
+  it("returns not unsupported by default", () => {
+    expect(isResponsesWsUnsupported(1, null)).toEqual({ unsupported: false });
+  });
+
+  it("records and reads back unsupported flag per (provider, endpoint)", () => {
+    markResponsesWsUnsupported(1, 10, "ws_upgrade_rejected");
+    expect(isResponsesWsUnsupported(1, 10)).toEqual({
+      unsupported: true,
+      reason: "ws_upgrade_rejected",
+    });
+    // Same provider, different endpoint: not affected
+    expect(isResponsesWsUnsupported(1, 11)).toEqual({ unsupported: false });
+    // Different provider, same endpoint number: not affected
+    expect(isResponsesWsUnsupported(2, 10)).toEqual({ unsupported: false });
+  });
+
+  it("expires after TTL", () => {
+    markResponsesWsUnsupported(42, null, "ws_closed_before_first_event", 1000);
+    expect(isResponsesWsUnsupported(42, null).unsupported).toBe(true);
+    vi.advanceTimersByTime(2000);
+    expect(isResponsesWsUnsupported(42, null).unsupported).toBe(false);
+  });
+
+  it("treats null and undefined endpointId as the same 'default' bucket", () => {
+    markResponsesWsUnsupported(7, null, "ws_upgrade_rejected");
+    expect(isResponsesWsUnsupported(7, undefined).unsupported).toBe(true);
+  });
+});

--- a/src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts
+++ b/src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts
@@ -237,6 +237,138 @@ describe("tryResponsesWebsocketUpstream", () => {
     expect(receivedHeaders["content-length"]).not.toBe("999");
   });
 
+  it("preserves store=false and previous_response_id across continuous WS turns", async () => {
+    const receivedFrames: Array<Record<string, unknown>> = [];
+    server = await startMockServer((socket) => {
+      let turn = 0;
+      socket.on("message", (data) => {
+        try {
+          receivedFrames.push(JSON.parse(data.toString("utf8")) as Record<string, unknown>);
+        } catch {
+          // ignore
+        }
+        const responseId = `resp_${++turn}`;
+        socket.send(
+          JSON.stringify({
+            type: "response.created",
+            response: { id: responseId },
+          })
+        );
+        socket.send(
+          JSON.stringify({
+            type: "response.completed",
+            response: { id: responseId, prompt_cache_key: "tenantA:s1" },
+          })
+        );
+      });
+    });
+
+    // Turn 1: full input, store=false, no previous_response_id yet.
+    const turn1 = await tryResponsesWebsocketUpstream({
+      provider: codexProvider(),
+      upstreamUrl: `http://127.0.0.1:${server.port}/v1/responses`,
+      upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+      body: {
+        model: "gpt-5",
+        store: false,
+        prompt_cache_key: "tenantA:s1",
+        input: [{ role: "user", content: "hello" }],
+      },
+    });
+    expect("response" in turn1).toBe(true);
+    if (!("response" in turn1)) return;
+    await collectSseBody(turn1.response);
+
+    // Turn 2: send only the new input + previous_response_id, with store=false
+    // preserved. The adapter must forward both fields untouched so the
+    // upstream can re-use its in-connection state.
+    const turn2 = await tryResponsesWebsocketUpstream({
+      provider: codexProvider(),
+      upstreamUrl: `http://127.0.0.1:${server.port}/v1/responses`,
+      upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+      body: {
+        model: "gpt-5",
+        store: false,
+        prompt_cache_key: "tenantA:s1",
+        previous_response_id: "resp_1",
+        input: [
+          {
+            type: "function_call_output",
+            call_id: "call_1",
+            output: '{"ok":true}',
+          },
+        ],
+      },
+    });
+    expect("response" in turn2).toBe(true);
+    if (!("response" in turn2)) return;
+    await collectSseBody(turn2.response);
+
+    expect(receivedFrames).toHaveLength(2);
+    const [first, second] = receivedFrames;
+    expect(first.type).toBe("response.create");
+    expect(first.store).toBe(false);
+    expect(first.prompt_cache_key).toBe("tenantA:s1");
+    expect(first.previous_response_id).toBeUndefined();
+
+    expect(second.type).toBe("response.create");
+    expect(second.store).toBe(false);
+    expect(second.previous_response_id).toBe("resp_1");
+    expect(second.prompt_cache_key).toBe("tenantA:s1");
+    // input was passed through untouched
+    expect(Array.isArray(second.input)).toBe(true);
+  });
+
+  it("classifies HTTP 426 / 404 / 501 upgrade failures as cacheable-unsupported", async () => {
+    const http = await import("node:http");
+    for (const status of [426, 404, 501]) {
+      const httpServer = http.createServer((_req, res) => {
+        res.statusCode = status;
+        res.end(`status ${status}`);
+      });
+      await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+      const addr = httpServer.address() as AddressInfo;
+      try {
+        const result = await tryResponsesWebsocketUpstream({
+          provider: codexProvider(),
+          upstreamUrl: `http://127.0.0.1:${addr.port}/v1/responses`,
+          upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+          body: { model: "gpt-5", input: "hi" },
+        });
+        expect("failed" in result).toBe(true);
+        if (!("failed" in result)) continue;
+        expect(result.cacheableAsUnsupported).toBe(true);
+      } finally {
+        await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+      }
+    }
+  });
+
+  it("classifies 401 / 5xx / network errors as NOT cacheable-unsupported", async () => {
+    const http = await import("node:http");
+    for (const status of [401, 503]) {
+      const httpServer = http.createServer((_req, res) => {
+        res.statusCode = status;
+        res.end(`status ${status}`);
+      });
+      await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+      const addr = httpServer.address() as AddressInfo;
+      try {
+        const result = await tryResponsesWebsocketUpstream({
+          provider: codexProvider(),
+          upstreamUrl: `http://127.0.0.1:${addr.port}/v1/responses`,
+          upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+          body: { model: "gpt-5", input: "hi" },
+        });
+        expect("failed" in result).toBe(true);
+        if (!("failed" in result)) continue;
+        expect(result.cacheableAsUnsupported).toBe(false);
+      } finally {
+        await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+      }
+    }
+  });
+
   it("emits an error frame when upstream WS fails mid-stream after the first event", async () => {
     server = await startMockServer((socket) => {
       socket.on("message", () => {

--- a/src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts
+++ b/src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts
@@ -1,0 +1,197 @@
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import type { Provider } from "@/types/provider";
+import { tryResponsesWebsocketUpstream } from "../upstream-adapter";
+
+type ServerHandle = {
+  wss: WebSocketServer;
+  port: number;
+  close: () => Promise<void>;
+};
+
+function startMockServer(
+  handler: (socket: import("ws").WebSocket, req: import("http").IncomingMessage) => void
+): Promise<ServerHandle> {
+  return new Promise((resolve, reject) => {
+    const wss = new WebSocketServer({ port: 0 });
+    wss.on("error", reject);
+    wss.on("listening", () => {
+      const address = wss.address() as AddressInfo;
+      wss.on("connection", handler);
+      resolve({
+        wss,
+        port: address.port,
+        close: () =>
+          new Promise<void>((resolveClose) => {
+            wss.close(() => resolveClose());
+          }),
+      });
+    });
+  });
+}
+
+function codexProvider(): Provider {
+  return {
+    id: 1,
+    name: "mock-codex",
+    providerType: "codex",
+    baseUrl: "http://mock/",
+    apiKey: "sk-mock",
+    enabled: true,
+    priority: 1,
+    weight: 1,
+    costMultiplier: 1,
+    groupTag: null,
+    providerVendorId: null,
+  } as unknown as Provider;
+}
+
+async function collectSseBody(response: Response): Promise<string> {
+  expect(response.body).toBeTruthy();
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  out += decoder.decode();
+  return out;
+}
+
+describe("tryResponsesWebsocketUpstream", () => {
+  let server: ServerHandle | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await server.close();
+      server = null;
+    }
+  });
+
+  it("yields SSE body with Responses events when upstream WS succeeds", async () => {
+    server = await startMockServer((socket) => {
+      socket.on("message", () => {
+        socket.send(JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
+        socket.send(JSON.stringify({ type: "response.output_text.delta", delta: "hi" }));
+        socket.send(
+          JSON.stringify({
+            type: "response.completed",
+            response: { id: "resp_1", usage: { input_tokens: 1, output_tokens: 1 } },
+          })
+        );
+      });
+    });
+
+    const result = await tryResponsesWebsocketUpstream({
+      provider: codexProvider(),
+      upstreamUrl: `http://127.0.0.1:${server.port}/v1/responses`,
+      upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+      body: { model: "gpt-5", input: [{ role: "user", content: "hi" }] },
+    });
+
+    expect("response" in result).toBe(true);
+    if (!("response" in result)) return;
+    expect(result.response.status).toBe(200);
+    expect(result.response.headers.get("content-type")).toContain("text/event-stream");
+    expect(result.response.headers.get("x-cch-upstream-transport")).toBe("websocket");
+
+    const body = await collectSseBody(result.response);
+    expect(body).toContain('"type":"response.created"');
+    expect(body).toContain('"type":"response.output_text.delta"');
+    expect(body).toContain('"type":"response.completed"');
+  });
+
+  it("returns failure when upstream rejects the WS upgrade", async () => {
+    // Create a plain http server that returns 404 on /v1/responses to simulate
+    // providers that don't speak WS on that path.
+    const http = await import("node:http");
+    const httpServer = http.createServer((_req, res) => {
+      res.statusCode = 404;
+      res.end("not found");
+    });
+    await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+    const addr = httpServer.address() as AddressInfo;
+
+    try {
+      const result = await tryResponsesWebsocketUpstream({
+        provider: codexProvider(),
+        upstreamUrl: `http://127.0.0.1:${addr.port}/v1/responses`,
+        upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+        body: { model: "gpt-5", input: "hi" },
+      });
+
+      expect("failed" in result).toBe(true);
+      if (!("failed" in result)) return;
+      expect(result.reason).toBe("ws_upgrade_rejected");
+    } finally {
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    }
+  });
+
+  it("returns ws_closed_before_first_event when upstream accepts but closes immediately", async () => {
+    server = await startMockServer((socket) => {
+      socket.on("message", () => {
+        socket.close(1011, "internal");
+      });
+    });
+
+    const result = await tryResponsesWebsocketUpstream({
+      provider: codexProvider(),
+      upstreamUrl: `http://127.0.0.1:${server.port}/v1/responses`,
+      upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+      body: { model: "gpt-5", input: "hi" },
+    });
+
+    expect("failed" in result).toBe(true);
+    if (!("failed" in result)) return;
+    expect(
+      result.reason === "ws_closed_before_first_event" ||
+        result.reason === "ws_error_pre_first_event"
+    ).toBe(true);
+  });
+
+  it("strips stream and background transport-only fields from the forwarded frame", async () => {
+    let receivedFrame: unknown = null;
+    server = await startMockServer((socket) => {
+      socket.on("message", (data) => {
+        try {
+          receivedFrame = JSON.parse(data.toString("utf8"));
+        } catch {
+          receivedFrame = null;
+        }
+        socket.send(
+          JSON.stringify({
+            type: "response.completed",
+            response: { id: "resp_1" },
+          })
+        );
+      });
+    });
+
+    const result = await tryResponsesWebsocketUpstream({
+      provider: codexProvider(),
+      upstreamUrl: `http://127.0.0.1:${server.port}/v1/responses`,
+      upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+      body: {
+        model: "gpt-5",
+        input: "hi",
+        stream: true,
+        background: false,
+        store: false,
+      },
+    });
+
+    expect("response" in result).toBe(true);
+    if (!("response" in result)) return;
+    await collectSseBody(result.response);
+
+    expect(receivedFrame).toBeTruthy();
+    expect((receivedFrame as Record<string, unknown>).type).toBe("response.create");
+    expect((receivedFrame as Record<string, unknown>).stream).toBeUndefined();
+    expect((receivedFrame as Record<string, unknown>).background).toBeUndefined();
+    expect((receivedFrame as Record<string, unknown>).store).toBe(false);
+  });
+});

--- a/src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts
+++ b/src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts
@@ -194,4 +194,78 @@ describe("tryResponsesWebsocketUpstream", () => {
     expect((receivedFrame as Record<string, unknown>).background).toBeUndefined();
     expect((receivedFrame as Record<string, unknown>).store).toBe(false);
   });
+
+  it("filters hop-by-hop and shape headers regardless of input shape", async () => {
+    let receivedHeaders: Record<string, string | string[] | undefined> = {};
+    server = await startMockServer((socket, req) => {
+      receivedHeaders = req.headers as Record<string, string | string[] | undefined>;
+      socket.on("message", () => {
+        socket.send(JSON.stringify({ type: "response.completed", response: { id: "x" } }));
+      });
+    });
+
+    const plainHeaders: Record<string, string> = {
+      authorization: "Bearer sk-mock",
+      // These must be filtered out regardless of the input shape:
+      connection: "keep-alive",
+      host: "evil.example.com",
+      "content-length": "999",
+      "transfer-encoding": "chunked",
+      accept: "application/json",
+      "content-type": "application/json",
+      // Custom header should pass through:
+      "x-cch-tenant": "tenant-a",
+    };
+
+    const result = await tryResponsesWebsocketUpstream({
+      provider: codexProvider(),
+      upstreamUrl: `http://127.0.0.1:${server.port}/v1/responses`,
+      upstreamHeaders: plainHeaders,
+      body: { model: "gpt-5", input: "hi" },
+    });
+
+    expect("response" in result).toBe(true);
+    if (!("response" in result)) return;
+    await collectSseBody(result.response);
+
+    expect(receivedHeaders.authorization).toBe("Bearer sk-mock");
+    expect(receivedHeaders["x-cch-tenant"]).toBe("tenant-a");
+    // The host the upstream observed must come from the actual TCP target,
+    // never the value we passed in the plain Record (which we filter):
+    expect(receivedHeaders.host).not.toBe("evil.example.com");
+    // ws-package-managed headers must be set by ws, not echoed from input:
+    expect(receivedHeaders["content-length"]).not.toBe("999");
+  });
+
+  it("emits an error frame when upstream WS fails mid-stream after the first event", async () => {
+    server = await startMockServer((socket) => {
+      socket.on("message", () => {
+        socket.send(JSON.stringify({ type: "response.created", response: { id: "resp_1" } }));
+        // Simulate an abrupt protocol-level failure; no terminal event is sent.
+        setTimeout(() => {
+          try {
+            socket.terminate();
+          } catch {
+            // ignore
+          }
+        }, 5);
+      });
+    });
+
+    const result = await tryResponsesWebsocketUpstream({
+      provider: codexProvider(),
+      upstreamUrl: `http://127.0.0.1:${server.port}/v1/responses`,
+      upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+      body: { model: "gpt-5", input: "hi" },
+    });
+
+    expect("response" in result).toBe(true);
+    if (!("response" in result)) return;
+    const body = await collectSseBody(result.response);
+    expect(body).toContain('"type":"response.created"');
+    // The mid-stream failure must surface as an error event so the downstream
+    // pipeline does not mistake the truncated stream for a clean success.
+    expect(body).toContain('"type":"error"');
+    expect(body).toContain("upstream_ws_mid_stream_error");
+  });
 });

--- a/src/app/v1/_lib/responses-ws/eligibility.ts
+++ b/src/app/v1/_lib/responses-ws/eligibility.ts
@@ -15,6 +15,7 @@
 
 import { isOpenaiResponsesWebsocketEnabled } from "@/lib/config/system-settings-cache";
 import type { Provider } from "@/types/provider";
+import { verifyInternalRequest } from "./internal-secret";
 import { isResponsesWsUnsupported } from "./unsupported-cache";
 
 export const CLIENT_TRANSPORT_HEADER = "x-cch-client-transport";
@@ -32,6 +33,18 @@ export interface ResponsesWsEligibility {
   endpointId?: number | null;
 }
 
+/**
+ * Treat the request as a WebSocket-tunneled request only when:
+ *   1. it carries `x-cch-client-transport: websocket`, AND
+ *   2. it carries a valid per-process internal loopback secret AND the
+ *      forward flag (see internal-secret.ts).
+ *
+ * Condition (2) is what defends against an external client crafting an HTTP
+ * request with the public marker header to trick the forwarder into
+ * attempting an upstream WebSocket dial. server.js sets the secret on every
+ * internal tunnel request and strips inbound `x-cch-*` headers from clients,
+ * so external requests cannot pass this check.
+ */
 export function isWebsocketClientRequest(headers: Headers | Record<string, string>): boolean {
   let value: string | null | undefined;
   if (headers instanceof Headers) {
@@ -46,7 +59,8 @@ export function isWebsocketClientRequest(headers: Headers | Record<string, strin
       }
     }
   }
-  return typeof value === "string" && value.toLowerCase() === "websocket";
+  if (typeof value !== "string" || value.toLowerCase() !== "websocket") return false;
+  return verifyInternalRequest(headers);
 }
 
 export async function evaluateResponsesWsEligibility(options: {

--- a/src/app/v1/_lib/responses-ws/eligibility.ts
+++ b/src/app/v1/_lib/responses-ws/eligibility.ts
@@ -1,0 +1,87 @@
+/**
+ * Decides whether a request forwarded by the proxy should attempt an OpenAI
+ * Responses WebSocket connection to the upstream. Returns a small discriminated
+ * result so the forwarder can both (a) decide whether to call the adapter and
+ * (b) record a structured downgrade reason on the decision chain when it
+ * declines.
+ *
+ * Eligibility requires ALL of:
+ *   - request entered CCH via a WebSocket (`x-cch-client-transport: websocket`
+ *     header injected by the custom Node server)
+ *   - provider type is `codex`
+ *   - global `enableOpenaiResponsesWebsocket` setting is on
+ *   - the specific provider/endpoint is NOT in the short-TTL unsupported cache
+ */
+
+import { isOpenaiResponsesWebsocketEnabled } from "@/lib/config/system-settings-cache";
+import type { Provider } from "@/types/provider";
+import { isResponsesWsUnsupported } from "./unsupported-cache";
+
+export const CLIENT_TRANSPORT_HEADER = "x-cch-client-transport";
+
+export type ResponsesWsDowngradeReason =
+  | "setting_disabled"
+  | "provider_not_codex"
+  | "endpoint_ws_unsupported_cached"
+  | "ws_not_yet_implemented";
+
+export interface ResponsesWsEligibility {
+  isWebsocketClient: boolean;
+  eligible: boolean;
+  downgradeReason?: ResponsesWsDowngradeReason;
+  endpointId?: number | null;
+}
+
+export function isWebsocketClientRequest(headers: Headers | Record<string, string>): boolean {
+  const value =
+    headers instanceof Headers
+      ? headers.get(CLIENT_TRANSPORT_HEADER)
+      : (headers[CLIENT_TRANSPORT_HEADER] as string | undefined);
+  return typeof value === "string" && value.toLowerCase() === "websocket";
+}
+
+export async function evaluateResponsesWsEligibility(options: {
+  headers: Headers | Record<string, string>;
+  provider: Provider;
+  endpointId?: number | null;
+}): Promise<ResponsesWsEligibility> {
+  const websocketClient = isWebsocketClientRequest(options.headers);
+  if (!websocketClient) {
+    return { isWebsocketClient: false, eligible: false };
+  }
+
+  if (options.provider.providerType !== "codex") {
+    return {
+      isWebsocketClient: true,
+      eligible: false,
+      downgradeReason: "provider_not_codex",
+      endpointId: options.endpointId ?? null,
+    };
+  }
+
+  const settingEnabled = await isOpenaiResponsesWebsocketEnabled();
+  if (!settingEnabled) {
+    return {
+      isWebsocketClient: true,
+      eligible: false,
+      downgradeReason: "setting_disabled",
+      endpointId: options.endpointId ?? null,
+    };
+  }
+
+  const cache = isResponsesWsUnsupported(options.provider.id, options.endpointId);
+  if (cache.unsupported) {
+    return {
+      isWebsocketClient: true,
+      eligible: false,
+      downgradeReason: "endpoint_ws_unsupported_cached",
+      endpointId: options.endpointId ?? null,
+    };
+  }
+
+  return {
+    isWebsocketClient: true,
+    eligible: true,
+    endpointId: options.endpointId ?? null,
+  };
+}

--- a/src/app/v1/_lib/responses-ws/eligibility.ts
+++ b/src/app/v1/_lib/responses-ws/eligibility.ts
@@ -33,10 +33,19 @@ export interface ResponsesWsEligibility {
 }
 
 export function isWebsocketClientRequest(headers: Headers | Record<string, string>): boolean {
-  const value =
-    headers instanceof Headers
-      ? headers.get(CLIENT_TRANSPORT_HEADER)
-      : (headers[CLIENT_TRANSPORT_HEADER] as string | undefined);
+  let value: string | null | undefined;
+  if (headers instanceof Headers) {
+    value = headers.get(CLIENT_TRANSPORT_HEADER);
+  } else {
+    // Plain record: header keys may be in any case (e.g. `X-Cch-Client-Transport`).
+    // Normalize to lowercase before comparing to avoid silent misses.
+    for (const [k, v] of Object.entries(headers)) {
+      if (k.toLowerCase() === CLIENT_TRANSPORT_HEADER) {
+        value = v;
+        break;
+      }
+    }
+  }
   return typeof value === "string" && value.toLowerCase() === "websocket";
 }
 

--- a/src/app/v1/_lib/responses-ws/internal-secret.ts
+++ b/src/app/v1/_lib/responses-ws/internal-secret.ts
@@ -1,0 +1,116 @@
+/**
+ * Per-process internal secret for the WS -> HTTP loopback tunnel.
+ *
+ * Why this exists:
+ * - server.js accepts client WebSocket upgrades on /v1/responses and tunnels
+ *   each frame as an internal HTTP POST against the same listener. To let the
+ *   forwarder know the request originated from a real WS client (so it
+ *   should attempt an upstream WebSocket dial), we attach internal marker
+ *   headers (x-cch-client-transport: websocket, x-cch-responses-ws-forward:
+ *   1).
+ * - Those headers travel over plain HTTP and would also be settable by an
+ *   external attacker simply curl'ing /v1/responses with the right header
+ *   names. Without an authentication step, that lets any HTTP client trick
+ *   the forwarder into attempting an upstream WS dial.
+ *
+ * How this fixes it:
+ * - At startup the custom server populates `CCH_RESPONSES_WS_INTERNAL_SECRET`
+ *   in `process.env` with a single, random per-process secret (or a value
+ *   provided by the operator). The custom server adds that secret as the
+ *   `x-cch-internal-secret` header on every internal tunnel request.
+ * - The eligibility check in the forwarder cross-checks the secret against
+ *   the live process value. Internal requests pass; external requests fail
+ *   even if they spoof the public marker headers.
+ * - server.js ALSO strips any inbound `x-cch-*` headers from the client WS
+ *   handshake before tunneling, so this secret is never echoed back to a
+ *   third party. That is defense-in-depth on top of the secret check.
+ *
+ * The secret never leaves this Node process and is never logged.
+ */
+
+import { randomUUID } from "node:crypto";
+
+export const INTERNAL_SECRET_HEADER = "x-cch-internal-secret";
+export const WS_FORWARD_FLAG_HEADER = "x-cch-responses-ws-forward";
+const ENV_VAR = "CCH_RESPONSES_WS_INTERNAL_SECRET";
+
+/**
+ * Reserved internal markers. Headers with these names are stripped from any
+ * inbound client request at the WS edge, so an attacker cannot inject them
+ * even alongside other valid markers.
+ */
+export const RESERVED_INTERNAL_HEADERS = [
+  "x-cch-client-transport",
+  WS_FORWARD_FLAG_HEADER,
+  INTERNAL_SECRET_HEADER,
+];
+
+/**
+ * Read the live per-process secret. Returns null when not initialized — this
+ * is the safe default and means `verifyInternalRequest` will reject any
+ * caller, including the local tunnel, until the secret is available.
+ */
+export function getInternalSecret(): string | null {
+  const value = process.env[ENV_VAR];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Initialize the per-process secret. Called once at server startup. Returns
+ * the resolved secret. If the operator preset `CCH_RESPONSES_WS_INTERNAL_SECRET`
+ * we honor that; otherwise a UUIDv4 is generated.
+ *
+ * Idempotent — repeated calls return the existing value so test harnesses
+ * can safely re-run setup.
+ */
+export function ensureInternalSecret(): string {
+  const existing = getInternalSecret();
+  if (existing) return existing;
+  const generated = randomUUID();
+  process.env[ENV_VAR] = generated;
+  return generated;
+}
+
+/**
+ * Constant-time secret compare to avoid trivial timing oracles. The secret
+ * is short (UUID), so this is just hygiene; the real protection is that the
+ * value is never sent off-process.
+ */
+function safeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function readHeader(headers: Headers | Record<string, string>, name: string): string | undefined {
+  const lower = name.toLowerCase();
+  if (headers instanceof Headers) {
+    return headers.get(lower) ?? undefined;
+  }
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() === lower) return v;
+  }
+  return undefined;
+}
+
+/**
+ * Returns true iff the request carries the live per-process internal secret
+ * AND the WS-forward flag. Any external client trying to mark itself as a
+ * WS-tunnel request without knowing the secret is rejected here.
+ */
+export function verifyInternalRequest(headers: Headers | Record<string, string>): boolean {
+  const secret = getInternalSecret();
+  if (!secret) return false;
+  const provided = readHeader(headers, INTERNAL_SECRET_HEADER);
+  if (typeof provided !== "string" || provided.length === 0) return false;
+  if (!safeEquals(secret, provided)) return false;
+  // Belt-and-braces: even with a valid secret, the call must include the
+  // explicit forward flag. Misses here would only happen if server.js
+  // forgets to set it — surfacing that as a hard fail prevents accidental
+  // bypass via shared secret leakage to other internal callers.
+  const forwardFlag = readHeader(headers, WS_FORWARD_FLAG_HEADER);
+  return forwardFlag === "1";
+}

--- a/src/app/v1/_lib/responses-ws/unsupported-cache.ts
+++ b/src/app/v1/_lib/responses-ws/unsupported-cache.ts
@@ -1,0 +1,53 @@
+/**
+ * Short-TTL in-memory cache for provider endpoints known to NOT support the
+ * OpenAI Responses WebSocket transport.
+ *
+ * Populated when an upstream WebSocket handshake is rejected or closes before
+ * emitting any response event. Used by the forwarder to skip the WS attempt
+ * and go straight to HTTP for the duration of the TTL. Not persisted to Redis
+ * or disk; a process restart clears the cache (which is fine — the next
+ * request simply re-probes once and re-caches if still unsupported).
+ */
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+type Entry = {
+  expiresAt: number;
+  reason: string;
+};
+
+const cache = new Map<string, Entry>();
+
+function buildKey(providerId: number, endpointId: number | null | undefined): string {
+  return `${providerId}:${endpointId ?? "default"}`;
+}
+
+export function markResponsesWsUnsupported(
+  providerId: number,
+  endpointId: number | null | undefined,
+  reason: string,
+  ttlMs: number = DEFAULT_TTL_MS
+): void {
+  cache.set(buildKey(providerId, endpointId), {
+    expiresAt: Date.now() + Math.max(1000, ttlMs),
+    reason,
+  });
+}
+
+export function isResponsesWsUnsupported(
+  providerId: number,
+  endpointId: number | null | undefined
+): { unsupported: boolean; reason?: string } {
+  const key = buildKey(providerId, endpointId);
+  const entry = cache.get(key);
+  if (!entry) return { unsupported: false };
+  if (Date.now() >= entry.expiresAt) {
+    cache.delete(key);
+    return { unsupported: false };
+  }
+  return { unsupported: true, reason: entry.reason };
+}
+
+export function clearResponsesWsUnsupportedCache(): void {
+  cache.clear();
+}

--- a/src/app/v1/_lib/responses-ws/upstream-adapter.ts
+++ b/src/app/v1/_lib/responses-ws/upstream-adapter.ts
@@ -36,6 +36,15 @@ export interface UpstreamWsFailure {
   failed: true;
   reason: UpstreamWsFallbackReason;
   message?: string;
+  /**
+   * True only for failures that prove the endpoint does not speak the
+   * Responses WebSocket protocol (e.g. HTTP 4xx / 501 on the upgrade).
+   * Used by the caller to decide whether to cache the endpoint as
+   * WS-unsupported. Network-level failures (ECONNREFUSED, ETIMEDOUT,
+   * silent upstream, mid-handshake aborts) are NOT cacheable — they may
+   * recover on the next request.
+   */
+  cacheableAsUnsupported: boolean;
 }
 
 export type UpstreamWsResult = UpstreamWsOutcome | UpstreamWsFailure;
@@ -53,6 +62,18 @@ const HANDSHAKE_TIMEOUT_MS = 10_000;
 // connection, half-open socket). Without a separate first-event timer the
 // `await openPromise` below would hang forever and tie up the request slot.
 const FIRST_EVENT_TIMEOUT_MS = 20_000;
+
+// Hard limit on bytes we will buffer between the upstream WebSocket and the
+// downstream SSE consumer. If the consumer stalls (or upstream sends faster
+// than the SSE reader drains) we cap memory growth and abort the WS rather
+// than spilling into the heap unboundedly.
+const MAX_BUFFERED_QUEUE_BYTES = 8 * 1024 * 1024; // 8 MiB
+
+// HTTP statuses on the upgrade handshake that we treat as a definitive
+// "this endpoint does not speak WebSocket" signal and cache as unsupported.
+// 401 / 403 are NOT in this list because they reflect auth state, not
+// protocol support.
+const PROTOCOL_UNSUPPORTED_HTTP_STATUSES = new Set([400, 404, 405, 426, 501]);
 
 // Hop-by-hop and request-shape headers that must NOT be forwarded into the
 // outbound WebSocket upgrade. The `ws` package handles Connection /
@@ -122,7 +143,7 @@ export async function tryResponsesWebsocketUpstream(options: {
     | (typeof WebSocketType & { new (url: string, opts?: unknown): WebSocketType })
     | null;
   if (!WsCtor) {
-    return { failed: true, reason: "ws_module_unavailable" };
+    return { failed: true, reason: "ws_module_unavailable", cacheableAsUnsupported: false };
   }
 
   const wssUrl = toWsUrl(options.upstreamUrl);
@@ -144,23 +165,29 @@ export async function tryResponsesWebsocketUpstream(options: {
       failed: true,
       reason: "ws_upgrade_rejected",
       message: String(err && (err as Error).message ? (err as Error).message : err),
+      // Constructor throws are typically URL parsing / TLS configuration —
+      // not a server-side protocol negative signal — so don't cache.
+      cacheableAsUnsupported: false,
     };
   }
 
+  type OpenResult =
+    | { ok: true }
+    | {
+        ok: false;
+        reason: UpstreamWsFallbackReason;
+        message?: string;
+        cacheableAsUnsupported: boolean;
+      };
+
   let firstEventSeen = false;
   let openResolved = false;
-  let openPromiseResolve: (
-    v: { ok: true } | { ok: false; reason: UpstreamWsFallbackReason; message?: string }
-  ) => void;
-  const openPromise = new Promise<
-    { ok: true } | { ok: false; reason: UpstreamWsFallbackReason; message?: string }
-  >((resolve) => {
+  let openPromiseResolve: (v: OpenResult) => void;
+  const openPromise = new Promise<OpenResult>((resolve) => {
     openPromiseResolve = resolve;
   });
 
-  const finishOpen = (
-    result: { ok: true } | { ok: false; reason: UpstreamWsFallbackReason; message?: string }
-  ) => {
+  const finishOpen = (result: OpenResult) => {
     if (openResolved) return;
     openResolved = true;
     openPromiseResolve(result);
@@ -174,6 +201,8 @@ export async function tryResponsesWebsocketUpstream(options: {
         ok: false,
         reason: "ws_error_pre_first_event",
         message: String(err && (err as Error).message ? (err as Error).message : err),
+        // Local send failure (closed underlying socket, etc.) is transient.
+        cacheableAsUnsupported: false,
       });
       try {
         ws.close(1011);
@@ -186,10 +215,16 @@ export async function tryResponsesWebsocketUpstream(options: {
   ws.on(
     "unexpected-response",
     (_req: unknown, res: { statusCode?: number; statusMessage?: string }) => {
+      const status = typeof res.statusCode === "number" ? res.statusCode : undefined;
+      const cacheable =
+        typeof status === "number" && PROTOCOL_UNSUPPORTED_HTTP_STATUSES.has(status);
       finishOpen({
         ok: false,
         reason: "ws_upgrade_rejected",
-        message: `HTTP ${res.statusCode ?? "?"} ${res.statusMessage ?? ""}`.trim(),
+        message: `HTTP ${status ?? "?"} ${res.statusMessage ?? ""}`.trim(),
+        // Only definitive protocol negatives (4xx/501 on the upgrade path)
+        // are cacheable. 401/403/5xx/etc. are auth or transient state.
+        cacheableAsUnsupported: cacheable,
       });
       try {
         ws.close(1011);
@@ -202,6 +237,7 @@ export async function tryResponsesWebsocketUpstream(options: {
   const messageQueue: string[] = [];
   let queueResolver: ((value: string | null) => void) | null = null;
   let closed = false;
+  let queuedBytes = 0;
   // Marks an upstream failure observed AFTER the first event was emitted.
   // The downstream pipeline must see this as an error rather than a clean
   // end-of-stream so it doesn't treat a half-streamed response as success.
@@ -210,6 +246,7 @@ export async function tryResponsesWebsocketUpstream(options: {
 
   ws.on("message", (data: Buffer | string) => {
     const text = typeof data === "string" ? data : data.toString("utf8");
+    const size = Buffer.byteLength(text, "utf8");
     if (!firstEventSeen) {
       firstEventSeen = true;
       if (firstEventTimer) {
@@ -222,9 +259,29 @@ export async function tryResponsesWebsocketUpstream(options: {
       const resolve = queueResolver;
       queueResolver = null;
       resolve(text);
-    } else {
-      messageQueue.push(text);
+      return;
     }
+    // Hard cap on buffered bytes so a stalled SSE consumer cannot let us
+    // accumulate unbounded heap growth.
+    if (queuedBytes + size > MAX_BUFFERED_QUEUE_BYTES) {
+      logger.warn("[ResponsesWsAdapter] upstream queue overflow, terminating WS", {
+        queuedBytes,
+        attemptedSize: size,
+      });
+      midStreamError = {
+        code: "upstream_ws_queue_overflow",
+        message: `buffered upstream payload exceeded ${MAX_BUFFERED_QUEUE_BYTES} bytes`,
+      };
+      closed = true;
+      try {
+        ws.close(1011);
+      } catch {
+        // ignore
+      }
+      return;
+    }
+    messageQueue.push(text);
+    queuedBytes += size;
   });
 
   ws.on("error", (err: Error) => {
@@ -237,6 +294,9 @@ export async function tryResponsesWebsocketUpstream(options: {
         ok: false,
         reason: "ws_error_pre_first_event",
         message: String(err?.message ? err.message : err),
+        // Network errors (ECONNREFUSED, ETIMEDOUT, ECONNRESET, TLS) are
+        // transient — never cache them as endpoint-unsupported.
+        cacheableAsUnsupported: false,
       });
     } else {
       midStreamError = {
@@ -258,6 +318,11 @@ export async function tryResponsesWebsocketUpstream(options: {
       finishOpen({
         ok: false,
         reason: "ws_closed_before_first_event",
+        // Endpoint upgraded successfully but closed without a frame. That
+        // could be transient (server restart, reload) or it could be a
+        // half-broken WS implementation. Conservative default: don't cache,
+        // re-probe on the next request.
+        cacheableAsUnsupported: false,
       });
     }
     if (queueResolver) {
@@ -290,6 +355,9 @@ export async function tryResponsesWebsocketUpstream(options: {
       ok: false,
       reason: "ws_error_pre_first_event",
       message: "timeout_waiting_for_first_event",
+      // A silent upstream is most likely transient (load, latency); the
+      // next request should re-probe rather than skip the WS path.
+      cacheableAsUnsupported: false,
     });
     try {
       ws.close(1011);
@@ -309,7 +377,12 @@ export async function tryResponsesWebsocketUpstream(options: {
     } catch {
       // ignore
     }
-    return { failed: true, reason: openResult.reason, message: openResult.message };
+    return {
+      failed: true,
+      reason: openResult.reason,
+      message: openResult.message,
+      cacheableAsUnsupported: openResult.cacheableAsUnsupported,
+    };
   }
 
   // Upstream WS is open and at least one event was received. Build an SSE
@@ -338,9 +411,18 @@ export async function tryResponsesWebsocketUpstream(options: {
         return false;
       };
 
+      const popMessage = (): string | undefined => {
+        const msg = messageQueue.shift();
+        if (msg !== undefined) {
+          queuedBytes -= Buffer.byteLength(msg, "utf8");
+          if (queuedBytes < 0) queuedBytes = 0;
+        }
+        return msg;
+      };
+
       // Drain queued first-event(s)
       while (messageQueue.length > 0) {
-        const msg = messageQueue.shift();
+        const msg = popMessage();
         if (msg === undefined) break;
         if (processText(msg)) {
           controller.close();
@@ -356,7 +438,7 @@ export async function tryResponsesWebsocketUpstream(options: {
       while (!closed) {
         const next = await new Promise<string | null>((resolve) => {
           if (messageQueue.length > 0) {
-            resolve(messageQueue.shift() ?? null);
+            resolve(popMessage() ?? null);
             return;
           }
           queueResolver = resolve;
@@ -376,7 +458,7 @@ export async function tryResponsesWebsocketUpstream(options: {
       // Drain any messages enqueued after the loop's last `await` resolved
       // with `null` (race between shift() and `closed` becoming true).
       while (messageQueue.length > 0) {
-        const msg = messageQueue.shift();
+        const msg = popMessage();
         if (msg === undefined) break;
         if (processText(msg)) {
           controller.close();

--- a/src/app/v1/_lib/responses-ws/upstream-adapter.ts
+++ b/src/app/v1/_lib/responses-ws/upstream-adapter.ts
@@ -1,0 +1,357 @@
+/**
+ * OpenAI Responses WebSocket upstream adapter (Codex providers only).
+ *
+ * Attempts a WebSocket connection to the upstream's `/v1/responses` endpoint.
+ * On success, events received from the upstream WS are re-emitted as SSE
+ * frames so that the forwarder's downstream pipeline (fake-200 detection,
+ * prompt_cache_key extraction, usage aggregation, finalization) treats the
+ * response exactly like an HTTP Responses SSE stream.
+ *
+ * On handshake rejection, close-before-first-event, or other fallback-safe
+ * errors, returns null so the caller can fall back to the HTTP path. No
+ * circuit-breaker accounting happens here — the fallback is purely informational.
+ *
+ * Scope: this adapter only handles the pre-flight connection attempt. It does
+ * NOT re-use connections across requests (first pass); each call opens and
+ * closes its own WebSocket. A future revision can add per-socket pooling and
+ * previous_response_id delta frames.
+ */
+
+import type WebSocketType from "ws";
+import { logger } from "@/lib/logger";
+import type { Provider } from "@/types/provider";
+
+export interface UpstreamWsOutcome {
+  response: Response;
+  connected: boolean;
+}
+
+export type UpstreamWsFallbackReason =
+  | "ws_module_unavailable"
+  | "ws_upgrade_rejected"
+  | "ws_closed_before_first_event"
+  | "ws_error_pre_first_event";
+
+export interface UpstreamWsFailure {
+  failed: true;
+  reason: UpstreamWsFallbackReason;
+  message?: string;
+}
+
+export type UpstreamWsResult = UpstreamWsOutcome | UpstreamWsFailure;
+
+const TERMINAL_EVENT_TYPES = new Set([
+  "response.completed",
+  "response.failed",
+  "response.incomplete",
+  "error",
+]);
+
+const HANDSHAKE_TIMEOUT_MS = 10_000;
+
+function toWsUrl(httpUrl: string): string {
+  const url = new URL(httpUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.toString();
+}
+
+function stripTransportOnlyFields<T extends Record<string, unknown>>(body: T): T {
+  const copy: Record<string, unknown> = { ...body };
+  delete copy.stream;
+  delete copy.background;
+  return copy as T;
+}
+
+async function loadWsModule(): Promise<typeof WebSocketType | null> {
+  try {
+    const mod = await import("ws");
+    return (mod.default ?? mod) as unknown as typeof WebSocketType;
+  } catch (err) {
+    logger.warn("[ResponsesWsAdapter] ws module unavailable, falling back to HTTP", {
+      error: String(err),
+    });
+    return null;
+  }
+}
+
+export async function tryResponsesWebsocketUpstream(options: {
+  provider: Provider;
+  upstreamUrl: string;
+  upstreamHeaders: Headers | Record<string, string>;
+  body: Record<string, unknown>;
+  abortSignal?: AbortSignal;
+}): Promise<UpstreamWsResult> {
+  const WsCtor = (await loadWsModule()) as
+    | (typeof WebSocketType & { new (url: string, opts?: unknown): WebSocketType })
+    | null;
+  if (!WsCtor) {
+    return { failed: true, reason: "ws_module_unavailable" };
+  }
+
+  const wssUrl = toWsUrl(options.upstreamUrl);
+  const headers: Record<string, string> = {};
+  if (options.upstreamHeaders instanceof Headers) {
+    options.upstreamHeaders.forEach((value, key) => {
+      const lower = key.toLowerCase();
+      // ws package handles Connection/Upgrade/Sec-WebSocket-* itself.
+      if (
+        lower === "connection" ||
+        lower === "upgrade" ||
+        lower === "sec-websocket-key" ||
+        lower === "sec-websocket-version" ||
+        lower === "sec-websocket-extensions" ||
+        lower === "sec-websocket-protocol" ||
+        lower === "host" ||
+        lower === "content-length" ||
+        lower === "transfer-encoding" ||
+        lower === "accept" ||
+        lower === "content-type"
+      ) {
+        return;
+      }
+      headers[key] = value;
+    });
+  } else {
+    for (const [k, v] of Object.entries(options.upstreamHeaders)) {
+      headers[k] = v;
+    }
+  }
+
+  const frame = {
+    type: "response.create",
+    ...stripTransportOnlyFields(options.body),
+  };
+
+  let ws: WebSocketType;
+  try {
+    ws = new (WsCtor as unknown as new (url: string, opts?: unknown) => WebSocketType)(wssUrl, {
+      headers,
+      handshakeTimeout: HANDSHAKE_TIMEOUT_MS,
+    });
+  } catch (err) {
+    return {
+      failed: true,
+      reason: "ws_upgrade_rejected",
+      message: String(err && (err as Error).message ? (err as Error).message : err),
+    };
+  }
+
+  let firstEventSeen = false;
+  let openResolved = false;
+  let openPromiseResolve: (
+    v: { ok: true } | { ok: false; reason: UpstreamWsFallbackReason; message?: string }
+  ) => void;
+  const openPromise = new Promise<
+    { ok: true } | { ok: false; reason: UpstreamWsFallbackReason; message?: string }
+  >((resolve) => {
+    openPromiseResolve = resolve;
+  });
+
+  const finishOpen = (
+    result: { ok: true } | { ok: false; reason: UpstreamWsFallbackReason; message?: string }
+  ) => {
+    if (openResolved) return;
+    openResolved = true;
+    openPromiseResolve(result);
+  };
+
+  ws.on("open", () => {
+    try {
+      ws.send(JSON.stringify(frame));
+    } catch (err) {
+      finishOpen({
+        ok: false,
+        reason: "ws_error_pre_first_event",
+        message: String(err && (err as Error).message ? (err as Error).message : err),
+      });
+      try {
+        ws.close(1011);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  ws.on(
+    "unexpected-response",
+    (_req: unknown, res: { statusCode?: number; statusMessage?: string }) => {
+      finishOpen({
+        ok: false,
+        reason: "ws_upgrade_rejected",
+        message: `HTTP ${res.statusCode ?? "?"} ${res.statusMessage ?? ""}`.trim(),
+      });
+      try {
+        ws.close(1011);
+      } catch {
+        // ignore
+      }
+    }
+  );
+
+  const messageQueue: string[] = [];
+  let queueResolver: ((value: string | null) => void) | null = null;
+  let closed = false;
+  let closeReason: UpstreamWsFallbackReason | null = null;
+
+  ws.on("message", (data: Buffer | string) => {
+    const text = typeof data === "string" ? data : data.toString("utf8");
+    if (!firstEventSeen) {
+      firstEventSeen = true;
+      finishOpen({ ok: true });
+    }
+    if (queueResolver) {
+      const resolve = queueResolver;
+      queueResolver = null;
+      resolve(text);
+    } else {
+      messageQueue.push(text);
+    }
+  });
+
+  ws.on("error", (err: Error) => {
+    logger.warn("[ResponsesWsAdapter] upstream ws error", {
+      error: String(err?.message ? err.message : err),
+      firstEventSeen,
+    });
+    if (!firstEventSeen) {
+      finishOpen({
+        ok: false,
+        reason: "ws_error_pre_first_event",
+        message: String(err?.message ? err.message : err),
+      });
+    }
+    closed = true;
+    closeReason = firstEventSeen ? null : "ws_error_pre_first_event";
+    if (queueResolver) {
+      const resolve = queueResolver;
+      queueResolver = null;
+      resolve(null);
+    }
+  });
+
+  ws.on("close", () => {
+    closed = true;
+    if (!firstEventSeen) {
+      finishOpen({
+        ok: false,
+        reason: "ws_closed_before_first_event",
+      });
+    }
+    if (queueResolver) {
+      const resolve = queueResolver;
+      queueResolver = null;
+      resolve(null);
+    }
+  });
+
+  if (options.abortSignal) {
+    options.abortSignal.addEventListener(
+      "abort",
+      () => {
+        try {
+          ws.close(1000);
+        } catch {
+          // ignore
+        }
+      },
+      { once: true }
+    );
+  }
+
+  const openResult = await openPromise;
+  if (!openResult.ok) {
+    try {
+      ws.terminate?.();
+    } catch {
+      // ignore
+    }
+    return { failed: true, reason: openResult.reason, message: openResult.message };
+  }
+
+  // Upstream WS is open and at least one event was received. Build an SSE
+  // ReadableStream that replays queued messages and streams future ones until
+  // a terminal event arrives or the connection closes.
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const writeLine = (obj: string) => {
+        controller.enqueue(encoder.encode(`data: ${obj}\n\n`));
+      };
+
+      const processText = (text: string): boolean => {
+        writeLine(text);
+        try {
+          const parsed = JSON.parse(text);
+          if (parsed && typeof parsed.type === "string" && TERMINAL_EVENT_TYPES.has(parsed.type)) {
+            return true;
+          }
+        } catch {
+          // Non-JSON upstream text: still forwarded, not terminal.
+        }
+        return false;
+      };
+
+      // Drain queued first-event(s)
+      while (messageQueue.length > 0) {
+        const msg = messageQueue.shift();
+        if (msg === undefined) break;
+        if (processText(msg)) {
+          controller.close();
+          try {
+            ws.close(1000);
+          } catch {
+            // ignore
+          }
+          return;
+        }
+      }
+
+      while (!closed) {
+        const next = await new Promise<string | null>((resolve) => {
+          if (messageQueue.length > 0) {
+            resolve(messageQueue.shift() ?? null);
+            return;
+          }
+          queueResolver = resolve;
+        });
+        if (next === null) break;
+        if (processText(next)) {
+          controller.close();
+          try {
+            ws.close(1000);
+          } catch {
+            // ignore
+          }
+          return;
+        }
+      }
+
+      if (closeReason === "ws_error_pre_first_event") {
+        // Shouldn't happen: we only reach here if firstEventSeen=true.
+        controller.error(new Error("upstream_ws_mid_stream_error"));
+        return;
+      }
+
+      controller.close();
+    },
+    cancel() {
+      try {
+        ws.close(1000);
+      } catch {
+        // ignore
+      }
+    },
+  });
+
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache, no-transform",
+        "x-cch-upstream-transport": "websocket",
+      },
+    }),
+    connected: true,
+  };
+}

--- a/src/app/v1/_lib/responses-ws/upstream-adapter.ts
+++ b/src/app/v1/_lib/responses-ws/upstream-adapter.ts
@@ -48,6 +48,29 @@ const TERMINAL_EVENT_TYPES = new Set([
 ]);
 
 const HANDSHAKE_TIMEOUT_MS = 10_000;
+// `handshakeTimeout` only covers the HTTP -> WS upgrade. Once upgrade
+// succeeds, an upstream may still hang without sending any event (bug, dead
+// connection, half-open socket). Without a separate first-event timer the
+// `await openPromise` below would hang forever and tie up the request slot.
+const FIRST_EVENT_TIMEOUT_MS = 20_000;
+
+// Hop-by-hop and request-shape headers that must NOT be forwarded into the
+// outbound WebSocket upgrade. The `ws` package handles Connection /
+// Upgrade / Sec-WebSocket-* itself; the body-shape headers belong to HTTP
+// only and would either be ignored or cause handshake rejection.
+const FORBIDDEN_UPSTREAM_WS_HEADERS = new Set([
+  "connection",
+  "upgrade",
+  "sec-websocket-key",
+  "sec-websocket-version",
+  "sec-websocket-extensions",
+  "sec-websocket-protocol",
+  "host",
+  "content-length",
+  "transfer-encoding",
+  "accept",
+  "content-type",
+]);
 
 function toWsUrl(httpUrl: string): string {
   const url = new URL(httpUrl);
@@ -60,6 +83,20 @@ function stripTransportOnlyFields<T extends Record<string, unknown>>(body: T): T
   delete copy.stream;
   delete copy.background;
   return copy as T;
+}
+
+function buildUpstreamWsHeaders(source: Headers | Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  const push = (key: string, value: string) => {
+    if (FORBIDDEN_UPSTREAM_WS_HEADERS.has(key.toLowerCase())) return;
+    out[key] = value;
+  };
+  if (source instanceof Headers) {
+    source.forEach((value, key) => push(key, value));
+  } else {
+    for (const [k, v] of Object.entries(source)) push(k, v);
+  }
+  return out;
 }
 
 async function loadWsModule(): Promise<typeof WebSocketType | null> {
@@ -89,33 +126,7 @@ export async function tryResponsesWebsocketUpstream(options: {
   }
 
   const wssUrl = toWsUrl(options.upstreamUrl);
-  const headers: Record<string, string> = {};
-  if (options.upstreamHeaders instanceof Headers) {
-    options.upstreamHeaders.forEach((value, key) => {
-      const lower = key.toLowerCase();
-      // ws package handles Connection/Upgrade/Sec-WebSocket-* itself.
-      if (
-        lower === "connection" ||
-        lower === "upgrade" ||
-        lower === "sec-websocket-key" ||
-        lower === "sec-websocket-version" ||
-        lower === "sec-websocket-extensions" ||
-        lower === "sec-websocket-protocol" ||
-        lower === "host" ||
-        lower === "content-length" ||
-        lower === "transfer-encoding" ||
-        lower === "accept" ||
-        lower === "content-type"
-      ) {
-        return;
-      }
-      headers[key] = value;
-    });
-  } else {
-    for (const [k, v] of Object.entries(options.upstreamHeaders)) {
-      headers[k] = v;
-    }
-  }
+  const headers = buildUpstreamWsHeaders(options.upstreamHeaders);
 
   const frame = {
     type: "response.create",
@@ -191,12 +202,20 @@ export async function tryResponsesWebsocketUpstream(options: {
   const messageQueue: string[] = [];
   let queueResolver: ((value: string | null) => void) | null = null;
   let closed = false;
-  let closeReason: UpstreamWsFallbackReason | null = null;
+  // Marks an upstream failure observed AFTER the first event was emitted.
+  // The downstream pipeline must see this as an error rather than a clean
+  // end-of-stream so it doesn't treat a half-streamed response as success.
+  let midStreamError: { code: string; message?: string } | null = null;
+  let firstEventTimer: ReturnType<typeof setTimeout> | null = null;
 
   ws.on("message", (data: Buffer | string) => {
     const text = typeof data === "string" ? data : data.toString("utf8");
     if (!firstEventSeen) {
       firstEventSeen = true;
+      if (firstEventTimer) {
+        clearTimeout(firstEventTimer);
+        firstEventTimer = null;
+      }
       finishOpen({ ok: true });
     }
     if (queueResolver) {
@@ -219,9 +238,13 @@ export async function tryResponsesWebsocketUpstream(options: {
         reason: "ws_error_pre_first_event",
         message: String(err?.message ? err.message : err),
       });
+    } else {
+      midStreamError = {
+        code: "upstream_ws_mid_stream_error",
+        message: String(err?.message ? err.message : err),
+      };
     }
     closed = true;
-    closeReason = firstEventSeen ? null : "ws_error_pre_first_event";
     if (queueResolver) {
       const resolve = queueResolver;
       queueResolver = null;
@@ -258,7 +281,28 @@ export async function tryResponsesWebsocketUpstream(options: {
     );
   }
 
+  // Bound the wait for the first event so a silent upstream cannot pin a
+  // request slot indefinitely. Cleared on first message or any other
+  // resolution.
+  firstEventTimer = setTimeout(() => {
+    if (firstEventSeen) return;
+    finishOpen({
+      ok: false,
+      reason: "ws_error_pre_first_event",
+      message: "timeout_waiting_for_first_event",
+    });
+    try {
+      ws.close(1011);
+    } catch {
+      // ignore
+    }
+  }, FIRST_EVENT_TIMEOUT_MS);
+
   const openResult = await openPromise;
+  if (firstEventTimer) {
+    clearTimeout(firstEventTimer);
+    firstEventTimer = null;
+  }
   if (!openResult.ok) {
     try {
       ws.terminate?.();
@@ -274,6 +318,8 @@ export async function tryResponsesWebsocketUpstream(options: {
   const encoder = new TextEncoder();
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
+      let sawTerminalEvent = false;
+
       const writeLine = (obj: string) => {
         controller.enqueue(encoder.encode(`data: ${obj}\n\n`));
       };
@@ -283,6 +329,7 @@ export async function tryResponsesWebsocketUpstream(options: {
         try {
           const parsed = JSON.parse(text);
           if (parsed && typeof parsed.type === "string" && TERMINAL_EVENT_TYPES.has(parsed.type)) {
+            sawTerminalEvent = true;
             return true;
           }
         } catch {
@@ -326,10 +373,31 @@ export async function tryResponsesWebsocketUpstream(options: {
         }
       }
 
-      if (closeReason === "ws_error_pre_first_event") {
-        // Shouldn't happen: we only reach here if firstEventSeen=true.
-        controller.error(new Error("upstream_ws_mid_stream_error"));
-        return;
+      // Drain any messages enqueued after the loop's last `await` resolved
+      // with `null` (race between shift() and `closed` becoming true).
+      while (messageQueue.length > 0) {
+        const msg = messageQueue.shift();
+        if (msg === undefined) break;
+        if (processText(msg)) {
+          controller.close();
+          return;
+        }
+      }
+
+      // If the upstream WS hung up before sending a terminal event, the
+      // downstream pipeline must see this as an error rather than a clean
+      // end-of-stream — otherwise a truncated body would be billed as a
+      // successful response.
+      if (!sawTerminalEvent) {
+        const failure = midStreamError ?? {
+          code: "upstream_ws_mid_stream_error",
+          message: "upstream WebSocket closed before emitting a terminal response event",
+        };
+        const errorFrame = JSON.stringify({
+          type: "error",
+          error: failure,
+        });
+        controller.enqueue(encoder.encode(`data: ${errorFrame}\n\n`));
       }
 
       controller.close();

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -757,6 +757,13 @@ export const systemSettings = pgTable('system_settings', {
   // 启用 HTTP/2 连接供应商（默认关闭，启用后自动回退到 HTTP/1.1 失败时）
   enableHttp2: boolean('enable_http2').notNull().default(false),
 
+  // 启用 OpenAI Responses WebSocket 支持（默认开启，仅对 Codex 类型供应商生效）
+  // 开启后：当客户端以 WebSocket 建连至 /v1/responses 时，CCH 会尝试与上游建立 WS 连接；
+  // 若上游不支持或握手失败，优雅降级为普通 HTTP Responses 请求，客户端 WebSocket 保持打开。
+  enableOpenaiResponsesWebsocket: boolean('enable_openai_responses_websocket')
+    .notNull()
+    .default(true),
+
   // 高并发模式（默认关闭）
   // 开启后：关闭部分 Redis 调试快照与实时观测写入，降低高并发下的 CPU 与 IO 开销
   enableHighConcurrencyMode: boolean('enable_high_concurrency_mode').notNull().default(false),

--- a/src/lib/config/system-settings-cache.ts
+++ b/src/lib/config/system-settings-cache.ts
@@ -35,6 +35,7 @@ export function getCachedSystemSettingsOnlyCache(): SystemSettings | null {
 const DEFAULT_SETTINGS: Pick<
   SystemSettings,
   | "enableHttp2"
+  | "enableOpenaiResponsesWebsocket"
   | "enableHighConcurrencyMode"
   | "interceptAnthropicWarmupRequests"
   | "codexPriorityBillingSource"
@@ -52,6 +53,7 @@ const DEFAULT_SETTINGS: Pick<
   | "publicStatusAggregationIntervalMinutes"
 > = {
   enableHttp2: false,
+  enableOpenaiResponsesWebsocket: true,
   enableHighConcurrencyMode: false,
   interceptAnthropicWarmupRequests: false,
   codexPriorityBillingSource: "requested",
@@ -135,6 +137,7 @@ export async function getCachedSystemSettings(): Promise<SystemSettings> {
       cleanupBatchSize: 10000,
       enableClientVersionCheck: false,
       enableHttp2: DEFAULT_SETTINGS.enableHttp2,
+      enableOpenaiResponsesWebsocket: DEFAULT_SETTINGS.enableOpenaiResponsesWebsocket,
       enableHighConcurrencyMode: DEFAULT_SETTINGS.enableHighConcurrencyMode,
       interceptAnthropicWarmupRequests: DEFAULT_SETTINGS.interceptAnthropicWarmupRequests,
       enableThinkingSignatureRectifier: DEFAULT_SETTINGS.enableThinkingSignatureRectifier,
@@ -172,6 +175,17 @@ export async function getCachedSystemSettings(): Promise<SystemSettings> {
 export async function isHttp2Enabled(): Promise<boolean> {
   const settings = await getCachedSystemSettings();
   return settings.enableHttp2;
+}
+
+/**
+ * Get only the OpenAI Responses WebSocket enabled setting.
+ * Only effective for Codex-type providers.
+ *
+ * @returns Whether OpenAI Responses WebSocket support is enabled globally.
+ */
+export async function isOpenaiResponsesWebsocketEnabled(): Promise<boolean> {
+  const settings = await getCachedSystemSettings();
+  return settings.enableOpenaiResponsesWebsocket;
 }
 
 /**

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -960,6 +960,8 @@ export const UpdateSystemSettingsSchema = z.object({
   passThroughUpstreamErrorMessage: z.boolean().optional(),
   // 启用 HTTP/2 连接供应商（可选）
   enableHttp2: z.boolean().optional(),
+  // 启用 OpenAI Responses WebSocket 支持（可选，仅 Codex 类型供应商生效）
+  enableOpenaiResponsesWebsocket: z.boolean().optional(),
   // 高并发模式（可选）
   enableHighConcurrencyMode: z.boolean().optional(),
   // 可选拦截 Anthropic Warmup 请求（可选）

--- a/src/repository/_shared/transformers.test.ts
+++ b/src/repository/_shared/transformers.test.ts
@@ -287,6 +287,7 @@ describe("src/repository/_shared/transformers.ts", () => {
       expect(result.verboseProviderError).toBe(false);
       expect(result.passThroughUpstreamErrorMessage).toBe(true);
       expect(result.enableHttp2).toBe(false);
+      expect(result.enableOpenaiResponsesWebsocket).toBe(true);
       expect(result.interceptAnthropicWarmupRequests).toBe(false);
       expect(result.createdAt).toEqual(now);
       expect(result.updatedAt).toEqual(now);

--- a/src/repository/_shared/transformers.ts
+++ b/src/repository/_shared/transformers.ts
@@ -219,6 +219,7 @@ export function toSystemSettings(dbSettings: any): SystemSettings {
     verboseProviderError: dbSettings?.verboseProviderError ?? false,
     passThroughUpstreamErrorMessage: dbSettings?.passThroughUpstreamErrorMessage ?? true,
     enableHttp2: dbSettings?.enableHttp2 ?? false,
+    enableOpenaiResponsesWebsocket: dbSettings?.enableOpenaiResponsesWebsocket ?? true,
     enableHighConcurrencyMode: dbSettings?.enableHighConcurrencyMode ?? false,
     interceptAnthropicWarmupRequests: dbSettings?.interceptAnthropicWarmupRequests ?? false,
     enableThinkingSignatureRectifier: dbSettings?.enableThinkingSignatureRectifier ?? true,

--- a/src/repository/system-config.ts
+++ b/src/repository/system-config.ts
@@ -152,6 +152,7 @@ function createFallbackSettings(): SystemSettings {
     verboseProviderError: false,
     passThroughUpstreamErrorMessage: true,
     enableHttp2: false,
+    enableOpenaiResponsesWebsocket: true,
     enableHighConcurrencyMode: false,
     interceptAnthropicWarmupRequests: false,
     enableThinkingSignatureRectifier: true,
@@ -268,9 +269,13 @@ export async function getSystemSettings(): Promise<SystemSettings> {
       createdAt: systemSettings.createdAt,
       updatedAt: systemSettings.updatedAt,
     };
-    const fullSelection = {
+    const selectionWithoutOpenaiResponsesWebsocket = {
       passThroughUpstreamErrorMessage: systemSettings.passThroughUpstreamErrorMessage,
       ...selectionWithoutPassThrough,
+    };
+    const fullSelection = {
+      ...selectionWithoutOpenaiResponsesWebsocket,
+      enableOpenaiResponsesWebsocket: systemSettings.enableOpenaiResponsesWebsocket,
     };
 
     try {
@@ -287,12 +292,32 @@ export async function getSystemSettings(): Promise<SystemSettings> {
           error,
         });
 
+        // 第零层降级：仅移除最新增加的 enableOpenaiResponsesWebsocket 列，
+        // 其它已迁移的现代字段保留。
+        try {
+          const [row] = await db
+            .select(selectionWithoutOpenaiResponsesWebsocket)
+            .from(systemSettings)
+            .orderBy(asc(systemSettings.id))
+            .limit(1);
+          return row ?? null;
+        } catch (openaiResponsesWebsocketFallbackError) {
+          if (!isUndefinedColumnError(openaiResponsesWebsocketFallbackError)) {
+            throw openaiResponsesWebsocketFallbackError;
+          }
+
+          logger.warn(
+            "system_settings 表除 enableOpenaiResponsesWebsocket 外仍有列缺失，继续回退。",
+            { error: openaiResponsesWebsocketFallbackError }
+          );
+        }
+
         // 第一层降级：仅移除本次新增的 allowNonConversationEndpointProviderFallback 列，
         // 其它已迁移的现代字段保留，避免只缺该列时其它设置被连带默认化。
         const {
           allowNonConversationEndpointProviderFallback: _omitNonConversationFallback,
           ...selectionWithoutNonConversationFallback
-        } = fullSelection;
+        } = selectionWithoutOpenaiResponsesWebsocket;
 
         try {
           const [row] = await db
@@ -531,9 +556,13 @@ export async function updateSystemSettings(
     createdAt: systemSettings.createdAt,
     updatedAt: systemSettings.updatedAt,
   };
-  const fullReturning = {
+  const returningWithoutOpenaiResponsesWebsocket = {
     passThroughUpstreamErrorMessage: systemSettings.passThroughUpstreamErrorMessage,
     ...returningWithoutPassThrough,
+  };
+  const fullReturning = {
+    ...returningWithoutOpenaiResponsesWebsocket,
+    enableOpenaiResponsesWebsocket: systemSettings.enableOpenaiResponsesWebsocket,
   };
 
   try {
@@ -602,6 +631,11 @@ export async function updateSystemSettings(
     // HTTP/2 配置字段（如果提供）
     if (payload.enableHttp2 !== undefined) {
       updates.enableHttp2 = payload.enableHttp2;
+    }
+
+    // OpenAI Responses WebSocket 支持开关（如果提供，仅 Codex 类型供应商生效）
+    if (payload.enableOpenaiResponsesWebsocket !== undefined) {
+      updates.enableOpenaiResponsesWebsocket = payload.enableOpenaiResponsesWebsocket;
     }
 
     // 高并发模式开关（如果提供）
@@ -714,16 +748,44 @@ export async function updateSystemSettings(
         error,
       });
 
+      // 第零层降级：仅移除最新增加的 enableOpenaiResponsesWebsocket 列，
+      // 其它字段继续原值更新/返回。
+      const {
+        enableOpenaiResponsesWebsocket: _omitUpdateOpenaiResponsesWebsocket,
+        ...updatesWithoutOpenaiResponsesWebsocket
+      } = updates;
+
+      try {
+        [updated] = await executor
+          .update(systemSettings)
+          .set(updatesWithoutOpenaiResponsesWebsocket)
+          .where(eq(systemSettings.id, current.id))
+          .returning(returningWithoutOpenaiResponsesWebsocket);
+      } catch (openaiResponsesWebsocketFallbackError) {
+        if (!isUndefinedColumnError(openaiResponsesWebsocketFallbackError)) {
+          throw openaiResponsesWebsocketFallbackError;
+        }
+
+        logger.warn(
+          "system_settings 表除 enableOpenaiResponsesWebsocket 外仍有列缺失，继续降级更新。",
+          { error: openaiResponsesWebsocketFallbackError }
+        );
+      }
+
+      if (updated) {
+        return toSystemSettings(updated);
+      }
+
       // 第一层降级：仅移除本次新增的 allowNonConversationEndpointProviderFallback 列，
       // 其它字段继续原值更新 / 返回，避免只缺该列时连带丢失 codex/highConcurrency 等更新。
       const {
         allowNonConversationEndpointProviderFallback: _omitUpdate,
         ...updatesWithoutNonConversationFallback
-      } = updates;
+      } = updatesWithoutOpenaiResponsesWebsocket;
       const {
         allowNonConversationEndpointProviderFallback: _omitReturning,
         ...returningWithoutNonConversationFallback
-      } = fullReturning;
+      } = returningWithoutOpenaiResponsesWebsocket;
 
       try {
         [updated] = await executor
@@ -744,6 +806,7 @@ export async function updateSystemSettings(
         try {
           const withoutPassThroughUpdates = { ...updates };
           delete withoutPassThroughUpdates.passThroughUpstreamErrorMessage;
+          delete withoutPassThroughUpdates.enableOpenaiResponsesWebsocket;
           [updated] = await executor
             .update(systemSettings)
             .set(withoutPassThroughUpdates)
@@ -761,6 +824,7 @@ export async function updateSystemSettings(
           delete downgradedUpdates.publicStatusAggregationIntervalMinutes;
           delete downgradedUpdates.ipExtractionConfig;
           delete downgradedUpdates.ipGeoLookupEnabled;
+          delete downgradedUpdates.enableOpenaiResponsesWebsocket;
 
           const legacyUpdates = { ...downgradedUpdates };
           delete legacyUpdates.codexPriorityBillingSource;

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -36,6 +36,8 @@ export interface ProviderChainItem {
     | "retry_with_cached_instructions" // Codex instructions 智能重试（缓存）
     | "client_error_non_retryable" // 不可重试的客户端错误（Prompt 超限、内容过滤、PDF 限制、Thinking 格式）
     | "http2_fallback" // HTTP/2 协议错误，回退到 HTTP/1.1（不切换供应商、不计入熔断器）
+    | "responses_ws_attempted" // 已尝试与上游建立 OpenAI Responses WebSocket 连接（信息性，无论最终成功或降级）
+    | "responses_ws_fallback" // 上游 WebSocket 不支持或握手/首帧前失败，回退到 HTTP（不切换供应商、不计入熔断器）
     | "endpoint_pool_exhausted" // 端点池耗尽（所有端点熔断或不可用，严格模式阻止降级）
     | "vendor_type_all_timeout" // 供应商类型全端点超时（524），触发 vendor-type 临时熔断
     | "client_restriction_filtered" // Provider skipped due to client restriction (neutral, no circuit breaker)
@@ -220,6 +222,26 @@ export interface ProviderChainItem {
     // --- 重试特有 ---
     excludedProviderIds?: number[]; // 已排除的供应商 ID 列表
     retryReason?: string; // 重试原因
+
+    // --- OpenAI Responses WebSocket 特有（clientTransport==="websocket" 时相关） ---
+    // 客户端进入本次请求使用的传输层
+    clientTransport?: "http" | "websocket";
+    // 是否尝试了上游 WebSocket 建连（仅当 clientTransport==="websocket" 且供应商为 codex 且全局开关开启时才会为 true）
+    upstreamWsAttempted?: boolean;
+    // 上游 WebSocket 是否至少建连并收到一个事件
+    upstreamWsConnected?: boolean;
+    // 是否最终降级到 HTTP Responses（不计入熔断器）
+    downgradedToHttp?: boolean;
+    // 降级原因（仅当 downgradedToHttp===true 时填充）
+    downgradeReason?:
+      | "setting_disabled"
+      | "provider_not_codex"
+      | "endpoint_ws_unsupported_cached"
+      | "ws_upgrade_rejected"
+      | "ws_closed_before_first_event"
+      | "ws_module_unavailable"
+      | "ws_not_yet_implemented"
+      | "ws_error_pre_first_event";
   };
 }
 

--- a/src/types/system-config.ts
+++ b/src/types/system-config.ts
@@ -50,6 +50,11 @@ export interface SystemSettings {
   // 启用 HTTP/2 连接供应商
   enableHttp2: boolean;
 
+  // 启用 OpenAI Responses WebSocket 支持（仅 Codex 类型供应商生效）
+  // 目标：让客户端以 WebSocket 连接 /v1/responses 时，CCH 与上游也以 WS 建连；
+  // 上游不支持时优雅降级为 HTTP，客户端 WebSocket 保持打开。
+  enableOpenaiResponsesWebsocket: boolean;
+
   // 高并发模式（默认关闭）
   // 目标：关闭部分 Redis 调试快照与实时观测写入，降低高并发下的 CPU 与 IO 开销
   enableHighConcurrencyMode: boolean;
@@ -145,6 +150,9 @@ export interface UpdateSystemSettingsInput {
 
   // 启用 HTTP/2 连接供应商（可选）
   enableHttp2?: boolean;
+
+  // 启用 OpenAI Responses WebSocket 支持（可选，仅 Codex 类型供应商生效）
+  enableOpenaiResponsesWebsocket?: boolean;
 
   // 高并发模式（可选）
   enableHighConcurrencyMode?: boolean;

--- a/tests/unit/dashboard/leaderboard-view-filter-gating.test.tsx
+++ b/tests/unit/dashboard/leaderboard-view-filter-gating.test.tsx
@@ -46,7 +46,7 @@ vi.mock("@/app/[locale]/dashboard/leaderboard/_components/leaderboard-table", ()
 }));
 
 vi.mock("@/components/ui/tag-input", () => ({
-  TagInput: ({ ["data-testid"]: testId }: { "data-testid"?: string }) => (
+  TagInput: ({ "data-testid": testId }: { "data-testid"?: string }) => (
     <div data-testid={testId ?? "leaderboard-tag-input"} />
   ),
 }));

--- a/tests/unit/dashboard/leaderboard-view-tab-grouping.test.tsx
+++ b/tests/unit/dashboard/leaderboard-view-tab-grouping.test.tsx
@@ -46,7 +46,7 @@ vi.mock("@/app/[locale]/dashboard/leaderboard/_components/leaderboard-table", ()
 }));
 
 vi.mock("@/components/ui/tag-input", () => ({
-  TagInput: ({ ["data-testid"]: testId }: { "data-testid"?: string }) => (
+  TagInput: ({ "data-testid": testId }: { "data-testid"?: string }) => (
     <div data-testid={testId ?? "leaderboard-tag-input"} />
   ),
 }));


### PR DESCRIPTION
## Summary

- Adds a new global system setting `enableOpenaiResponsesWebsocket` (default: **on**) that, for **Codex providers only**, lets CCH accept WebSocket upgrades on `/v1/responses` and pre-flight an upstream Responses WebSocket connection. When upstream WS is unsupported, handshake fails, or closes before any event, CCH gracefully falls back to the existing HTTP/SSE path while keeping the **client** WebSocket open. Fallbacks are recorded on the decision chain and do **not** count toward provider, endpoint, or vendor-type circuit-breaker accounting (mirroring the existing `http2_fallback` isolation pattern).
- All non-WebSocket clients, non-Codex providers, and existing HTTP/SSE behavior on `/v1/responses`, `/v1/messages`, and `/v1/chat/completions` are unchanged.
- Production runtime now boots a small custom Node server (`server.js`) that wraps the Next.js handler and owns the `upgrade` event for `/v1/responses`. Each client WS frame is tunneled to the existing HTTP pipeline with an `x-cch-client-transport: websocket` marker, so all auth, provider selection, guards, forwarder, and observability run exactly once.

## Related Issues & PRs

- Resolves #1095 - User requesting OpenAI WebSocket feature release
- Related to #1100 - Parallel implementation using `src/server/` pipeline architecture (different approach)
- Supersedes #887 - Previous WS attempt (closed; had streaming and URL bugs)
- Supersedes #882 - First WS attempt (closed; had body consumption and reader leak bugs)

## What's added

| Layer | Change |
|------|--------|
| Schema / settings | New column `enable_openai_responses_websocket` (default `true`); cascade through `SystemSettings`, `UpdateSystemSettingsSchema`, transformer, repository selections + degradation tiers, server action, admin API route, and `system-settings-cache` (new `isOpenaiResponsesWebsocketEnabled()` helper next to `isHttp2Enabled`). Migration `drizzle/0099_worthless_gauntlet.sql`. |
| Admin UI | New toggle under HTTP/2 in `system-settings-form.tsx` with strings in zh-CN, zh-TW, en, ja, ru. |
| Runtime | `server.js` (custom Node entrypoint) loads Next programmatically, mounts `ws.WebSocketServer` on `/v1/responses`, and tunnels client WS frames into the existing HTTP pipeline as SSE; events stream back as WS JSON frames. `next.config.ts` extends `outputFileTracingIncludes` so `next` and `ws` end up in the standalone output. New `scripts/copy-custom-server-to-standalone.cjs` overrides Next's generated `server.js` at build time. `package.json` `start` now runs `node server.js`; new `dev:server` script for local WS testing. |
| Upstream adapter | `src/app/v1/_lib/responses-ws/upstream-adapter.ts` dials `wss://<provider>/v1/responses` (Codex only), strips `stream`/`background` transport-only fields, and re-emits Responses events as SSE so the existing forwarder downstream pipeline (fake-200 detection, prompt_cache_key extraction, finalization) treats the response identically to an HTTP SSE stream. |
| Eligibility + cache | `eligibility.ts` gates the WS attempt on (a) `x-cch-client-transport: websocket` header (b) `providerType === "codex"` (c) global setting on (d) endpoint not in short-TTL `unsupported-cache.ts`. Endpoints that reject the upgrade or close before first event are auto-cached as unsupported for 5 minutes. |
| Forwarder | Pre-flight WS attempt inserted just before the existing `undici.request` call. On success, the WS-derived SSE Response is used in place of HTTP. On failure (handshake rejected / close before first event / `ws` module missing), falls through to HTTP unchanged. Records `responses_ws_attempted` / `responses_ws_fallback` on the decision chain. **No** circuit-breaker recording for the WS fallback itself. |
| Decision chain | `ProviderChainItem` extended with new `reason` values and `decisionContext` fields: `clientTransport`, `upstreamWsAttempted`, `upstreamWsConnected`, `downgradedToHttp`, `downgradeReason`. |

## Verification

```bash
bun run typecheck   # passes (only pre-existing maplibre-gl env errors unrelated to this PR)
bun run lint        # passes (only pre-existing leaderboard test infos unrelated to this PR)
bunx vitest run src/app/v1/_lib/responses-ws \
  src/repository/_shared/transformers.test.ts \
  tests/unit/actions/system-config-save.test.ts
# 5 files, 61 tests pass
bunx vitest run tests/unit/proxy/proxy-forwarder.test.ts
# 19 tests pass (no regressions in forwarder)
bunx vitest run tests/unit/settings/
# 48 files, 346 tests pass (no regressions in settings)
```

New unit tests:
- `src/app/v1/_lib/responses-ws/__tests__/unsupported-cache.test.ts` -- TTL, isolation per (provider, endpoint), null/undefined endpoint bucket equivalence
- `src/app/v1/_lib/responses-ws/__tests__/eligibility.test.ts` -- every gate (header absent, non-codex provider, setting off, unsupported cache hit, eligible)
- `src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts` -- success path with real `ws` mock server, handshake rejection on plain HTTP server, close-before-first-event, transport-only field stripping (`stream`/`background`)

## Test plan

- [ ] CI green: typecheck, lint, build, unit + integration tests
- [ ] Manual: with the toggle on, a `wscat`/`websocat` client to `/v1/responses` against a Codex provider receives Responses event JSON frames (no SSE wrapping). Confirm decision chain shows `clientTransport=websocket`, `upstreamWsAttempted=true` and either connected or downgraded with a reason
- [ ] Manual: with the toggle on but the upstream `/v1/responses` rejecting the WS upgrade, the client WebSocket stays open and receives events tunneled from the HTTP fallback. Confirm decision chain shows `responses_ws_fallback`
- [ ] Manual: with the toggle off, client WS upgrade still succeeds (so existing clients don't break) but every frame is tunneled over HTTP with `downgradeReason=setting_disabled`
- [ ] Manual: non-Codex provider with WS-client request -- HTTP path used, `downgradeReason=provider_not_codex`

## Out of scope (deliberate)

- OpenAI Realtime API (different endpoint and protocol semantics)
- Persistent upstream WS connection pooling and `previous_response_id` delta frames (current implementation opens a fresh WS per request; pooling is a follow-up)
- Provider-level WS capability matrix UI

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds OpenAI Responses WebSocket support for Codex providers: a custom Node.js server (`server.js`) accepts client WS upgrades on `/v1/responses`, tunnels each frame as an internal HTTP POST, and the forwarder optionally pre-flights an upstream WS connection before falling back to HTTP/SSE. The architecture is well-layered with a loopback secret, bounded queues, abort-on-disconnect, and a graceful degradation tier for the new DB column.

- **P1 security**: `FORBIDDEN_UPSTREAM_WS_HEADERS` in `upstream-adapter.ts` is missing `x-cch-internal-secret`, `x-cch-client-transport`, and `x-cch-responses-ws-forward`. Because `buildHeaders` passes `session.headers` through a blacklist that does not cover `x-cch-*`, the per-process loopback secret is forwarded verbatim to the upstream Codex provider on every WS upgrade request.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge until the internal secret header is stripped from upstream WS upgrade requests.

One confirmed P1 security finding: the per-process loopback secret is forwarded to upstream Codex providers on every WS upgrade. The fix is a small addition to FORBIDDEN_UPSTREAM_WS_HEADERS. Everything else — the loopback secret scheme, queue bounds, abort-on-disconnect, DB degradation tiers — is well-implemented.

src/app/v1/_lib/responses-ws/upstream-adapter.ts — FORBIDDEN_UPSTREAM_WS_HEADERS must be extended with the three internal x-cch-* header names.
</details>


<details open><summary><h3>Security Review</h3></summary>

- **Internal secret header leaked to upstream providers** (`src/app/v1/_lib/responses-ws/upstream-adapter.ts`): `x-cch-internal-secret` (the per-process loopback UUID), along with `x-cch-client-transport` and `x-cch-responses-ws-forward`, are not in `FORBIDDEN_UPSTREAM_WS_HEADERS` and are therefore forwarded verbatim to the upstream Codex provider's WebSocket server on every upgrade request. Any provider that logs or inspects request headers can observe the secret.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| server.js | New custom Node.js entrypoint that owns WebSocket upgrades on `/v1/responses`; tunnels each frame as an internal HTTP POST with bounded pending queue, loopback secret, and request abort on client disconnect. |
| src/app/v1/_lib/responses-ws/upstream-adapter.ts | Dials upstream WS and re-emits events as SSE; `FORBIDDEN_UPSTREAM_WS_HEADERS` is missing the three internal `x-cch-*` headers, so the per-process loopback secret is forwarded to the upstream provider on every WS upgrade. |
| src/app/v1/_lib/responses-ws/eligibility.ts | Gates WS upstream attempt behind header check, provider type, global setting, and unsupported cache; now correctly requires both `x-cch-client-transport` and a valid loopback secret via `verifyInternalRequest`. |
| src/app/v1/_lib/responses-ws/internal-secret.ts | Per-process loopback secret management with constant-time comparison; well-structured with idempotent initialisation and belt-and-braces forward-flag check. |
| src/app/v1/_lib/proxy/forwarder.ts | Inserts the WS pre-flight attempt before the existing `undici.request` call; passes `processedHeaders` (which retains internal `x-cch-*` headers) directly to the upstream adapter. |
| src/app/v1/_lib/responses-ws/unsupported-cache.ts | Simple in-memory TTL cache for endpoints that reject WS upgrades; correct per-provider/endpoint key isolation and lazy expiry. |
| src/repository/system-config.ts | Adds a graceful degradation tier for the new `enable_openai_responses_websocket` column, consistent with the established pattern for previous schema additions. |
| scripts/copy-custom-server-to-standalone.cjs | Build-time script that overwrites the generated Next.js standalone `server.js` with the custom entrypoint; correct guard for missing source/destination. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as WS Client
    participant S as server.js (Node)
    participant N as Next.js /v1/responses
    participant F as ProxyForwarder
    participant U as Upstream (Codex)

    C->>S: WS Upgrade /v1/responses
    S->>S: Strip x-cch-* from client headers
    S->>S: Set x-cch-client-transport, x-cch-internal-secret
    S->>N: HTTP POST /v1/responses (internal tunnel)
    N->>F: Route to forwarder
    F->>F: evaluateResponsesWsEligibility()
    alt eligible (Codex + setting on + not cached)
        F->>U: WS Upgrade wss://upstream/v1/responses
        Note over F,U: x-cch-internal-secret forwarded here (bug)
        U-->>F: WS events (re-emitted as SSE)
        F-->>N: SSE Response
    else not eligible / fallback
        F->>U: HTTP POST (undici)
        U-->>F: HTTP SSE
        F-->>N: SSE Response
    end
    N-->>S: SSE stream
    S-->>C: WS JSON frames
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/app/v1/_lib/responses-ws/eligibility.ts`, line 573-579 ([link](https://github.com/ding113/claude-code-hub/blob/19b1f9f3bdb83b4bafd400375a291e2fd04a440d/src/app/v1/_lib/responses-ws/eligibility.ts#L573-L579)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`x-cch-client-transport` can be spoofed by any HTTP client**

   `server.js` sets two internal headers when tunnelling a real WebSocket client: `x-cch-client-transport: websocket` and `x-cch-responses-ws-forward: 1`. Only the first one is ever checked here; the second is never validated anywhere in the TypeScript pipeline, so it is effectively dead code.

   Any authenticated HTTP client can set `x-cch-client-transport: websocket` in a normal POST to `/v1/responses` and cause `evaluateResponsesWsEligibility` to return `eligible: true`. The forwarder then opens an upstream WebSocket, which (a) wastes a WS connection per spoofed request, (b) can incorrectly populate the `unsupported-cache` for a legitimate provider/endpoint combination, and (c) returns WS-event-formatted SSE instead of the expected HTTP Responses stream to the HTTP client.

   The fix is to also require `x-cch-responses-ws-forward: 1` in the eligibility check:

   ```ts
   const WS_FORWARD_FLAG_HEADER = "x-cch-responses-ws-forward";

   export function isWebsocketClientRequest(headers: Headers | Record<string, string>): boolean {
     const transport =
       headers instanceof Headers
         ? headers.get(CLIENT_TRANSPORT_HEADER)
         : (headers[CLIENT_TRANSPORT_HEADER] as string | undefined);
     const forward =
       headers instanceof Headers
         ? headers.get(WS_FORWARD_FLAG_HEADER)
         : (headers[WS_FORWARD_FLAG_HEADER] as string | undefined);
     return (
       typeof transport === "string" &&
       transport.toLowerCase() === "websocket" &&
       forward === "1"
     );
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/v1/_lib/responses-ws/eligibility.ts
   Line: 573-579

   Comment:
   **`x-cch-client-transport` can be spoofed by any HTTP client**

   `server.js` sets two internal headers when tunnelling a real WebSocket client: `x-cch-client-transport: websocket` and `x-cch-responses-ws-forward: 1`. Only the first one is ever checked here; the second is never validated anywhere in the TypeScript pipeline, so it is effectively dead code.

   Any authenticated HTTP client can set `x-cch-client-transport: websocket` in a normal POST to `/v1/responses` and cause `evaluateResponsesWsEligibility` to return `eligible: true`. The forwarder then opens an upstream WebSocket, which (a) wastes a WS connection per spoofed request, (b) can incorrectly populate the `unsupported-cache` for a legitimate provider/endpoint combination, and (c) returns WS-event-formatted SSE instead of the expected HTTP Responses stream to the HTTP client.

   The fix is to also require `x-cch-responses-ws-forward: 1` in the eligibility check:

   ```ts
   const WS_FORWARD_FLAG_HEADER = "x-cch-responses-ws-forward";

   export function isWebsocketClientRequest(headers: Headers | Record<string, string>): boolean {
     const transport =
       headers instanceof Headers
         ? headers.get(CLIENT_TRANSPORT_HEADER)
         : (headers[CLIENT_TRANSPORT_HEADER] as string | undefined);
     const forward =
       headers instanceof Headers
         ? headers.get(WS_FORWARD_FLAG_HEADER)
         : (headers[WS_FORWARD_FLAG_HEADER] as string | undefined);
     return (
       typeof transport === "string" &&
       transport.toLowerCase() === "websocket" &&
       forward === "1"
     );
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/app/v1/_lib/responses-ws/upstream-adapter.ts`, line 829-835 ([link](https://github.com/ding113/claude-code-hub/blob/19b1f9f3bdb83b4bafd400375a291e2fd04a440d/src/app/v1/_lib/responses-ws/upstream-adapter.ts#L829-L835)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **No timeout waiting for the first upstream WS message**

   `handshakeTimeout: HANDSHAKE_TIMEOUT_MS` (10 s) only covers the HTTP-upgrade phase. Once the upgrade succeeds and `ws.on("open")` fires, `openPromise` waits indefinitely for the first `message` event before resolving with `{ ok: true }`. If the upstream server accepts the WS but then stalls, the forwarder hangs indefinitely.

   Add an explicit deadline after the `open` event:

   ```ts
   const FIRST_EVENT_TIMEOUT_MS = 30_000;

   ws.on("open", () => {
     const tid = setTimeout(() => {
       finishOpen({ ok: false, reason: "ws_closed_before_first_event", message: "first event timeout" });
       try { ws.close(1001); } catch { /* ignore */ }
     }, FIRST_EVENT_TIMEOUT_MS);
     ws.once("message", () => clearTimeout(tid));
     try {
       ws.send(JSON.stringify(frame));
     } catch (err) {
       clearTimeout(tid);
       finishOpen({ ok: false, reason: "ws_error_pre_first_event", message: String((err as Error)?.message ?? err) });
       try { ws.close(1011); } catch { /* ignore */ }
     }
   });
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/v1/_lib/responses-ws/upstream-adapter.ts
   Line: 829-835

   Comment:
   **No timeout waiting for the first upstream WS message**

   `handshakeTimeout: HANDSHAKE_TIMEOUT_MS` (10 s) only covers the HTTP-upgrade phase. Once the upgrade succeeds and `ws.on("open")` fires, `openPromise` waits indefinitely for the first `message` event before resolving with `{ ok: true }`. If the upstream server accepts the WS but then stalls, the forwarder hangs indefinitely.

   Add an explicit deadline after the `open` event:

   ```ts
   const FIRST_EVENT_TIMEOUT_MS = 30_000;

   ws.on("open", () => {
     const tid = setTimeout(() => {
       finishOpen({ ok: false, reason: "ws_closed_before_first_event", message: "first event timeout" });
       try { ws.close(1001); } catch { /* ignore */ }
     }, FIRST_EVENT_TIMEOUT_MS);
     ws.once("message", () => clearTimeout(tid));
     try {
       ws.send(JSON.stringify(frame));
     } catch (err) {
       clearTimeout(tid);
       finishOpen({ ok: false, reason: "ws_error_pre_first_event", message: String((err as Error)?.message ?? err) });
       try { ws.close(1011); } catch { /* ignore */ }
     }
   });
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `src/app/v1/_lib/proxy/forwarder.ts`, line 434-438 ([link](https://github.com/ding113/claude-code-hub/blob/19b1f9f3bdb83b4bafd400375a291e2fd04a440d/src/app/v1/_lib/proxy/forwarder.ts#L434-L438)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`endpointId: null` coarsens unsupported-cache granularity to provider level**

   Both `evaluateResponsesWsEligibility` and `markResponsesWsUnsupported` are called with `endpointId: null`, so the cache key is always `${providerId}:default`. If a Codex provider has multiple endpoints and only one rejects the WS upgrade, all endpoints for that provider are suppressed for the full 5-minute TTL. The per-endpoint isolation tested in `unsupported-cache.test.ts` is never exercised at this call site. Consider passing the actual endpoint identifier when available, or documenting why `null` is intentional here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/v1/_lib/proxy/forwarder.ts
   Line: 434-438

   Comment:
   **`endpointId: null` coarsens unsupported-cache granularity to provider level**

   Both `evaluateResponsesWsEligibility` and `markResponsesWsUnsupported` are called with `endpointId: null`, so the cache key is always `${providerId}:default`. If a Codex provider has multiple endpoints and only one rejects the WS upgrade, all endpoints for that provider are suppressed for the full 5-minute TTL. The per-endpoint isolation tested in `unsupported-cache.test.ts` is never exercised at this call site. Consider passing the actual endpoint identifier when available, or documenting why `null` is intentional here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/responses-ws/upstream-adapter.ts
Line: 82-94

Comment:
**Internal CCH headers forwarded to upstream provider**

`FORBIDDEN_UPSTREAM_WS_HEADERS` does not include `x-cch-internal-secret`, `x-cch-client-transport`, or `x-cch-responses-ws-forward`. Because `buildHeaders` in `forwarder.ts` only blacklists transport/auth headers (not `x-cch-*`), those internal markers survive into `processedHeaders`. `buildUpstreamWsHeaders` then forwards them verbatim to the upstream WebSocket server, so every upstream Codex provider receives the per-process loopback secret on each WS upgrade request.

The fix is to add the three internal header names to `FORBIDDEN_UPSTREAM_WS_HEADERS` so they are stripped before the outbound upgrade headers are built.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/v1/_lib/responses-ws/upstream-adapter.ts
Line: 59-64

Comment:
**`firstEventTimer` starts before handshake completes, shrinking the post-open window**

`firstEventTimer` (20 s) is set synchronously before `await openPromise`, so it starts counting from the moment `tryResponsesWebsocketUpstream` is called — not from when `ws.on("open")` fires. If the TLS + upgrade handshake consumes nearly all of `HANDSHAKE_TIMEOUT_MS` (10 s), the effective time left to receive the first event after `open` can be as little as ~10 s instead of the documented 20 s. The comments imply the timer is scoped to the post-open phase; starting it after `await openPromise` (but only when `openResult.ok`) would give callers the full budget reliably.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: server.js
Line: 383-388

Comment:
**SSE `buffer` string is unbounded**

`buffer` accumulates raw SSE bytes without a size cap. A very slow upstream that emits data in small chunks without double-newline separators (or an intentionally slow/malformed response) can grow this string without bound inside the HTTP handler, eventually exhausting heap memory. Consider adding a maximum buffer size guard similar to the `MAX_PENDING_BYTES` cap used for the WebSocket pending queue.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(proxy): harden responses websocket a..."](https://github.com/ding113/claude-code-hub/commit/ec98ee617595589dd5c49f62ba5c194170892078) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29684894)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->