### PR TITLE
fix(proxy): classify errors by rule category to preserve failover for service errors

### DIFF
--- a/src/app/v1/_lib/proxy/errors.ts
+++ b/src/app/v1/_lib/proxy/errors.ts
@@ -571,6 +571,61 @@ function extractErrorContentForDetection(error: Error): string {
 }
 
 /**
+ * 真正属于 "客户端输入错误" 的规则 category 白名单
+ *
+ * 仅当匹配的规则 category 落入此集合时，对应错误才被分类为
+ * NON_RETRYABLE_CLIENT_ERROR（不重试 + 不计入熔断器 + 直接返回）。
+ *
+ * 设计原因：
+ * - error_rules 表允许用户自定义规则，category 字段可以是任意字符串
+ * - 历史实现中，任何匹配规则都会被当作 NON_RETRYABLE_CLIENT_ERROR
+ * - 但 service_error / network_error / rate_limit 这类 category 实际是
+ *   供应商侧或网络侧的可恢复错误，应进入正常 failover/熔断器流程，而不是
+ *   被白名单化导致 "stopping immediately" 不再切换供应商
+ *
+ * 通过显式白名单，确保只有真正的客户端输入错误（如 prompt_limit、
+ * validation_error、content_filter 等）触发不可重试逻辑。
+ *
+ * 此集合的设计原则：
+ * - 仅包含官方默认规则（DEFAULT_ERROR_RULES）实际使用的客户端错误 category
+ * - 用户自定义规则若使用集合外的 category（如 service_error），将不再
+ *   被错误地白名单化；这些错误会回退到 ProxyError 的标准分类逻辑
+ */
+const NON_RETRYABLE_CLIENT_ERROR_CATEGORIES = new Set<string>([
+  "prompt_limit",
+  "input_limit",
+  "context_limit",
+  "token_limit",
+  "content_filter",
+  "validation_error",
+  "thinking_error",
+  "parameter_error",
+  "pdf_limit",
+  "media_limit",
+  "cache_limit",
+  "invalid_request",
+  "model_error",
+  "store_error",
+]);
+
+/**
+ * 判断已匹配的检测结果是否应触发 NON_RETRYABLE_CLIENT_ERROR 分类
+ *
+ * @param result - errorRuleDetector 返回的检测结果
+ * @returns true = 视为不可重试客户端错误；false = 不触发该分类（让标准分类逻辑处理）
+ */
+function shouldTreatMatchedRuleAsNonRetryable(result: ErrorDetectionResult): boolean {
+  if (!result.matched) {
+    return false;
+  }
+  // category 必须显式存在，且落在白名单集合内
+  return (
+    typeof result.category === "string" &&
+    NON_RETRYABLE_CLIENT_ERROR_CATEGORIES.has(result.category)
+  );
+}
+
+/**
  * 错误规则检测结果缓存
  *
  * 使用 WeakMap 避免内存泄漏，同一个 Error 对象只检测一次
@@ -623,7 +678,7 @@ export async function getErrorDetectionResultAsync(error: Error): Promise<ErrorD
 export function isNonRetryableClientError(error: Error): boolean {
   const cached = errorDetectionCache.get(error);
   if (cached) {
-    return cached.matched;
+    return shouldTreatMatchedRuleAsNonRetryable(cached);
   }
 
   const content = extractErrorContentForDetection(error);
@@ -637,7 +692,7 @@ export function isNonRetryableClientError(error: Error): boolean {
     void detectErrorRuleOnceAsync(error).catch(() => undefined);
   }
 
-  return result.matched;
+  return shouldTreatMatchedRuleAsNonRetryable(result);
 }
 
 /**
@@ -645,11 +700,25 @@ export function isNonRetryableClientError(error: Error): boolean {
  *
  * 此函数会确保错误规则已加载后再进行检测
  * 生产代码路径（forwarder、error-handler）应优先使用此版本
+ *
+ * 仅当匹配规则的 category 落入 NON_RETRYABLE_CLIENT_ERROR_CATEGORIES 白名单时
+ * 才返回 true。其他 category（如 service_error、network_error 等）即使匹配也
+ * 会回退到 ProxyError 的标准分类（PROVIDER_ERROR/SYSTEM_ERROR），从而保留
+ * 故障转移和熔断器逻辑。
  */
 export async function isNonRetryableClientErrorAsync(error: Error): Promise<boolean> {
   // 使用缓存的检测结果，避免重复执行规则匹配
   const result = await detectErrorRuleOnceAsync(error);
-  return result.matched;
+  return shouldTreatMatchedRuleAsNonRetryable(result);
+}
+
+/**
+ * 暴露内部白名单常量供测试使用
+ *
+ * 注意：这是只读副本，外部不应修改运行时白名单。
+ */
+export function getNonRetryableClientErrorCategoriesForTesting(): ReadonlySet<string> {
+  return NON_RETRYABLE_CLIENT_ERROR_CATEGORIES;
 }
 
 /**

--- a/tests/unit/proxy/error-category-aware-classification.test.ts
+++ b/tests/unit/proxy/error-category-aware-classification.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Error rule category-aware classification tests
+ *
+ * Validates that isNonRetryableClientErrorAsync (and the sync companion)
+ * only classify a matched error as NON_RETRYABLE_CLIENT_ERROR when the
+ * matched rule's category is one of the recognised client-input categories.
+ *
+ * Without this guard, user-added rules with category like "service_error"
+ * or "network_error" would be incorrectly white-listed, causing
+ * categorizeErrorAsync to short-circuit failover/circuit-breaker logic
+ * for upstream/transport problems that should be retried or routed to a
+ * different provider.
+ *
+ * Repro context (CCH 0.7.2 production):
+ * - User added rule pattern "529|service.overloaded" with category=service_error
+ * - Upstream INSUFFICIENT_BALANCE response body contained substring "529"
+ *   (e.g. inside "0.352942" price amount or request id)
+ * - Old logic flagged the error as NON_RETRYABLE_CLIENT_ERROR -> stopped
+ *   failover -> client received generic "permission_error"
+ * - Expected: service_error category should NOT be white-listed; the error
+ *   falls back to PROVIDER_ERROR and standard failover applies.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  return {
+    getActiveErrorRules: vi.fn(),
+    subscribeCacheInvalidation: vi.fn(async () => undefined),
+    eventEmitter: {
+      on(event: string, handler: (...args: unknown[]) => void) {
+        const current = listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
+        current.add(handler);
+        listeners.set(event, current);
+      },
+      emit(event: string, ...args: unknown[]) {
+        for (const handler of listeners.get(event) ?? []) {
+          handler(...args);
+        }
+      },
+      removeAllListeners() {
+        listeners.clear();
+      },
+    },
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      trace: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/repository/error-rules", () => ({
+  getActiveErrorRules: mocks.getActiveErrorRules,
+}));
+
+vi.mock("@/lib/event-emitter", () => ({
+  eventEmitter: mocks.eventEmitter,
+}));
+
+vi.mock("@/lib/redis/pubsub", () => ({
+  CHANNEL_ERROR_RULES_UPDATED: "errorRulesUpdated",
+  subscribeCacheInvalidation: mocks.subscribeCacheInvalidation,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: mocks.logger,
+}));
+
+interface BuildRuleOverrides {
+  id?: number;
+  pattern?: string;
+  matchType?: "regex" | "contains" | "exact";
+  category?: string;
+  description?: string;
+  isEnabled?: boolean;
+  isDefault?: boolean;
+  priority?: number;
+}
+
+function buildRule(overrides: BuildRuleOverrides = {}) {
+  return {
+    id: 100,
+    pattern: "default-pattern",
+    matchType: "contains" as const,
+    category: "validation_error",
+    description: "test rule",
+    overrideResponse: undefined,
+    overrideStatusCode: undefined,
+    isEnabled: true,
+    isDefault: false,
+    priority: 10,
+    createdAt: new Date("2026-04-25T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-25T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+async function loadDetectorWithRules(rules: ReturnType<typeof buildRule>[]) {
+  mocks.getActiveErrorRules.mockResolvedValue(rules);
+
+  const { errorRuleDetector } = await import("@/lib/error-rule-detector");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await errorRuleDetector.reload();
+
+  return errorRuleDetector;
+}
+
+describe("isNonRetryableClientErrorAsync - category-aware white-list", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.eventEmitter.removeAllListeners();
+  });
+
+  afterEach(() => {
+    mocks.eventEmitter.removeAllListeners();
+  });
+
+  test("matches rule with white-listed category (validation_error) -> NON_RETRYABLE", async () => {
+    await loadDetectorWithRules([
+      buildRule({ pattern: "ValidationException", category: "validation_error" }),
+    ]);
+
+    const { isNonRetryableClientErrorAsync, ProxyError } = await import(
+      "@/app/v1/_lib/proxy/errors"
+    );
+    const error = new ProxyError("ValidationException: bad input", 400, {
+      body: '{"error":{"type":"validation","message":"ValidationException"}}',
+      parsed: null,
+      providerId: 1,
+      providerName: "test",
+    });
+
+    expect(await isNonRetryableClientErrorAsync(error)).toBe(true);
+  });
+
+  test("matches rule with non-white-listed category (service_error) -> NOT NON_RETRYABLE", async () => {
+    await loadDetectorWithRules([
+      buildRule({
+        id: 40,
+        pattern: "529|service.overloaded",
+        matchType: "regex",
+        category: "service_error",
+      }),
+    ]);
+
+    const { isNonRetryableClientErrorAsync, ProxyError } = await import(
+      "@/app/v1/_lib/proxy/errors"
+    );
+    // Reproduces real-world false positive: substring "529" appears inside
+    // the price amount "0.352942" of an INSUFFICIENT_BALANCE response body.
+    const error = new ProxyError("Provider returned 403: insufficient balance", 403, {
+      body: '{"error":{"type":"new_api_error","message":"insufficient balance, remaining: 0.214220, required: 0.352942"}}',
+      parsed: null,
+      providerId: 92,
+      providerName: "test-upstream",
+    });
+
+    expect(await isNonRetryableClientErrorAsync(error)).toBe(false);
+  });
+
+  test("matches rule with non-white-listed category (network_error) -> NOT NON_RETRYABLE", async () => {
+    await loadDetectorWithRules([
+      buildRule({
+        id: 38,
+        pattern: "ECONNREFUSED|ECONNRESET",
+        matchType: "regex",
+        category: "network_error",
+      }),
+    ]);
+
+    const { isNonRetryableClientErrorAsync } = await import("@/app/v1/_lib/proxy/errors");
+    const error = new Error("connect ECONNREFUSED 127.0.0.1:8080");
+
+    expect(await isNonRetryableClientErrorAsync(error)).toBe(false);
+  });
+
+  test("matches rule with non-white-listed category (rate_limit) -> NOT NON_RETRYABLE", async () => {
+    await loadDetectorWithRules([
+      buildRule({
+        id: 36,
+        pattern: "rate_limit_error|rate.limit",
+        matchType: "regex",
+        category: "rate_limit",
+      }),
+    ]);
+
+    const { isNonRetryableClientErrorAsync, ProxyError } = await import(
+      "@/app/v1/_lib/proxy/errors"
+    );
+    const error = new ProxyError("Provider returned 429: rate_limit_error", 429, {
+      body: '{"error":{"type":"rate_limit_error"}}',
+      parsed: null,
+      providerId: 1,
+      providerName: "test",
+    });
+
+    expect(await isNonRetryableClientErrorAsync(error)).toBe(false);
+  });
+
+  test("no rule match -> NOT NON_RETRYABLE", async () => {
+    await loadDetectorWithRules([
+      buildRule({ pattern: "completely-unrelated-pattern", category: "validation_error" }),
+    ]);
+
+    const { isNonRetryableClientErrorAsync } = await import("@/app/v1/_lib/proxy/errors");
+    const error = new Error("a totally different error message");
+
+    expect(await isNonRetryableClientErrorAsync(error)).toBe(false);
+  });
+
+  test("each white-listed category triggers NON_RETRYABLE classification", async () => {
+    const { getNonRetryableClientErrorCategoriesForTesting } = await import(
+      "@/app/v1/_lib/proxy/errors"
+    );
+    const categories = Array.from(getNonRetryableClientErrorCategoriesForTesting());
+
+    expect(categories.length).toBeGreaterThan(0);
+
+    for (let i = 0; i < categories.length; i++) {
+      const category = categories[i];
+      vi.resetModules();
+      vi.clearAllMocks();
+      mocks.eventEmitter.removeAllListeners();
+
+      const sentinel = `__sentinel_${i}_${category}__`;
+      await loadDetectorWithRules([
+        buildRule({
+          id: 200 + i,
+          pattern: sentinel,
+          matchType: "contains",
+          category,
+        }),
+      ]);
+
+      const { isNonRetryableClientErrorAsync: detect } = await import("@/app/v1/_lib/proxy/errors");
+      const error = new Error(`upstream said: ${sentinel}`);
+
+      expect(
+        await detect(error),
+        `category="${category}" should be classified as NON_RETRYABLE`
+      ).toBe(true);
+    }
+  });
+});
+
+describe("categorizeErrorAsync - regression: service_error rule must not stop failover", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.eventEmitter.removeAllListeners();
+  });
+
+  afterEach(() => {
+    mocks.eventEmitter.removeAllListeners();
+  });
+
+  test("substring match on user-added service_error rule still produces PROVIDER_ERROR", async () => {
+    // User-added rule with substring-prone pattern (no \b boundary).
+    await loadDetectorWithRules([
+      buildRule({
+        id: 41,
+        pattern: "503|service.unavailable",
+        matchType: "regex",
+        category: "service_error",
+      }),
+    ]);
+
+    const { ErrorCategory, categorizeErrorAsync, ProxyError } = await import(
+      "@/app/v1/_lib/proxy/errors"
+    );
+
+    // INSUFFICIENT_BALANCE 403 response body where "503" appears as a
+    // substring inside the request-id token.
+    const error = new ProxyError("Provider returned 403: insufficient balance", 403, {
+      body: '{"error":{"message":"insufficient balance (request id: 202604250550399959166838268d9d6K9sUhgdW)"}}',
+      parsed: null,
+      providerId: 85,
+      providerName: "synai996_Aws",
+    });
+
+    // Without the fix, this would return NON_RETRYABLE_CLIENT_ERROR
+    // because the rule's `matched=true` short-circuits classification.
+    expect(await categorizeErrorAsync(error)).toBe(ErrorCategory.PROVIDER_ERROR);
+  });
+
+  test("network_error rule on Error instance still produces SYSTEM_ERROR", async () => {
+    await loadDetectorWithRules([
+      buildRule({
+        id: 37,
+        pattern: "timeout|timed.out|ETIMEDOUT",
+        matchType: "regex",
+        category: "network_error",
+      }),
+    ]);
+
+    const { ErrorCategory, categorizeErrorAsync } = await import("@/app/v1/_lib/proxy/errors");
+
+    const error = new Error("ETIMEDOUT: connection timed out after 30000ms");
+    expect(await categorizeErrorAsync(error)).toBe(ErrorCategory.SYSTEM_ERROR);
+  });
+
+  test("validation_error rule (white-listed) still produces NON_RETRYABLE_CLIENT_ERROR", async () => {
+    await loadDetectorWithRules([
+      buildRule({
+        id: 5,
+        pattern: "ValidationException",
+        matchType: "contains",
+        category: "validation_error",
+      }),
+    ]);
+
+    const { ErrorCategory, categorizeErrorAsync, ProxyError } = await import(
+      "@/app/v1/_lib/proxy/errors"
+    );
+    const error = new ProxyError("Provider returned 400: ValidationException", 400, {
+      body: '{"error":"ValidationException: invalid model"}',
+      parsed: null,
+      providerId: 1,
+      providerName: "test",
+    });
+
+    expect(await categorizeErrorAsync(error)).toBe(ErrorCategory.NON_RETRYABLE_CLIENT_ERROR);
+  });
+});
+
+describe("isNonRetryableClientError (sync) - category-aware white-list", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.eventEmitter.removeAllListeners();
+  });
+
+  afterEach(() => {
+    mocks.eventEmitter.removeAllListeners();
+  });
+
+  test("sync version respects white-list when cache hit", async () => {
+    await loadDetectorWithRules([
+      buildRule({
+        id: 40,
+        pattern: "service-overloaded-token",
+        matchType: "contains",
+        category: "service_error",
+      }),
+    ]);
+
+    const { isNonRetryableClientError, isNonRetryableClientErrorAsync } = await import(
+      "@/app/v1/_lib/proxy/errors"
+    );
+
+    const error = new Error("upstream said: service-overloaded-token");
+    // Prime the cache via async path first so sync path hits the cached entry.
+    await isNonRetryableClientErrorAsync(error);
+    expect(isNonRetryableClientError(error)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`isNonRetryableClientErrorAsync` (and its sync companion) previously treated **any** matched error rule as `NON_RETRYABLE_CLIENT_ERROR`, ignoring the rule's `category` field. This caused user-added rules with categories like `service_error` or `network_error` to short-circuit failover/circuit-breaker logic for upstream/transport problems that should actually be retried or routed to a different provider.

This PR adds an explicit category **white-list** of client-input categories. Only matches whose `category` falls within this set are classified as `NON_RETRYABLE_CLIENT_ERROR`; others fall back to the standard `ProxyError`-based classification (typically `PROVIDER_ERROR` or `SYSTEM_ERROR`), preserving failover and circuit-breaker behaviour.

**Related Issues:**
- Partially addresses #1005 - Service overloaded errors with `service_error` category were not triggering retry/failover, causing Codex to stop
- Related to #1004 - Same symptom of provider errors stopping the system instead of failing over
- Follow-up to #911 - Companion fix to the network error reclassification work; both address errors being incorrectly classified as `NON_RETRYABLE_CLIENT_ERROR`

## Reproduction (CCH 0.7.2 production, observed 2026-04-25)

A user added a regex rule with the pattern `529|service.overloaded` and `category=service_error` (and another `503|service.unavailable` for `service_error`). When an upstream provider returned `403 INSUFFICIENT_BALANCE`:

```json
{
  "error": {
    "type": "new_api_error",
    "message": "预扣费额度失败, 用户剩余额度: ¥0.214220, 需要预扣费额度: ¥0.352942 (request id: 20260425055420369306260Kfzayl7j)"
  }
}
```

The substring `529` matched inside the price `0.352942` (positions 3–5 of `352942`). The old logic:

1. `matched=true` → `isNonRetryableClientErrorAsync` returned `true`
2. `categorizeErrorAsync` returned `NON_RETRYABLE_CLIENT_ERROR`
3. `forwarder.ts` logged `"White-listed client error … stopping immediately"` and aborted failover
4. The client received a generic `permission_error: 上游拒绝了本次请求 (cch_session_id: …)` with no upstream detail. The user could not tell that the real cause was an exhausted upstream balance.

Symmetric symptom for `503|service.unavailable` matching `503` inside a request ID like `2026042505**503**99959…`.

After this PR:
- The match still happens (the regex bug in user-added rules is out of scope), but `category=service_error` is **not** in the white-list, so the error falls back to `PROVIDER_ERROR`. Failover and circuit-breaker logic resume normally.
- Real client-input errors (`prompt_limit`, `validation_error`, `content_filter`, etc.) continue to be white-listed and short-circuit retries as before.

## White-list contents

Aligned with the categories actually used by `DEFAULT_ERROR_RULES`:

```
prompt_limit, input_limit, context_limit, token_limit,
content_filter, validation_error, thinking_error, parameter_error,
pdf_limit, media_limit, cache_limit, invalid_request,
model_error, store_error
```

User-added rules with categories outside this list (e.g. `service_error`, `network_error`, `rate_limit`) will no longer be wrongly white-listed. Their underlying errors will be classified by the existing `ProxyError`-based rules, which is the correct behaviour for upstream/transport failures.

## Changes

- `src/app/v1/_lib/proxy/errors.ts`
  - New `NON_RETRYABLE_CLIENT_ERROR_CATEGORIES` set
  - New `shouldTreatMatchedRuleAsNonRetryable(result)` helper
  - `isNonRetryableClientError` (sync) and `isNonRetryableClientErrorAsync` (async) now use the helper instead of returning `result.matched` directly
  - New `getNonRetryableClientErrorCategoriesForTesting()` accessor exposing a read-only view of the set for unit tests
- `tests/unit/proxy/error-category-aware-classification.test.ts` (new) — 10 unit tests covering:
  - White-listed category (`validation_error`) → `NON_RETRYABLE`
  - Non-white-listed categories (`service_error`, `network_error`, `rate_limit`) → not `NON_RETRYABLE`
  - No rule match → not `NON_RETRYABLE`
  - Each white-listed category triggers `NON_RETRYABLE` (data-driven)
  - `categorizeErrorAsync` regression: substring match on `service_error` rule still produces `PROVIDER_ERROR`
  - `categorizeErrorAsync` regression: `network_error` rule on plain `Error` still produces `SYSTEM_ERROR`
  - `categorizeErrorAsync`: `validation_error` rule still produces `NON_RETRYABLE_CLIENT_ERROR`
  - Sync `isNonRetryableClientError` respects white-list when cache-hit

## Test results

```
✓ tests/unit/proxy/error-category-aware-classification.test.ts (10/10 passed)
✓ tests/unit/proxy/client-abort-vs-upstream-499.test.ts (regression, 16/16 passed)
✓ tests/unit/lib/error-rule-detector-reload-queue.test.ts (regression, passed)
✓ tests/unit/repository/error-rules-default-codex-responses.test.ts (regression, passed)
✓ tests/unit/repository/error-rules-default-thinking-tooluse.test.ts (regression, passed)
```

`bun run typecheck` passes cleanly. `bunx biome check` is clean on the two changed files.

## Backward compatibility / migration

- No schema or data migration required.
- For users who currently rely on the previous behaviour (i.e. who added rules with `service_error`/`network_error`/etc. categories *intending* to short-circuit retries), the behaviour change is the entire point of this PR — those errors should retry/failover, which is what the existing `ProxyError`-based classification already does correctly.
- If a deployment still wants to white-list a custom category, that should be a follow-up feature (e.g. a `non_retryable: boolean` column on `error_rules`), not a hidden side-effect of `category`.

## Out of scope (tracked separately)

- The user-added regex rules with substring-prone patterns (`503|service.unavailable`, `529|service.overloaded`) are user data, not part of CCH's defaults — the upstream `is_default=true` rules are unaffected. Users should still tighten those patterns with `\b` boundaries; that is operator hygiene, not an upstream bug.
- The 403 fallback message `上游拒绝了本次请求` in `error-handler.ts` and the aggressive sanitisation in `client-error-message.ts` strip operationally useful upstream details (e.g. balance amounts). This deserves a separate discussion / issue about how to safely expose business-error context to clients.

## PR Checklist

- [x] Target branch is `dev`
- [x] Conventional Commit format
- [x] No emoji in code
- [x] No hardcoded user-facing strings (no UI strings touched)
- [x] `bun run typecheck` passes
- [x] `bunx biome check` clean on changed files
- [x] New tests added; existing related tests still pass
- [x] No DB schema / migration changes

---
*Description enhanced by Claude AI*