### PR TITLE
fix(proxy): tighten numeric error status boundaries

### DIFF
--- a/src/lib/utils/upstream-error-detection.ts
+++ b/src/lib/utils/upstream-error-detection.ts
@@ -95,77 +95,77 @@ const ERROR_STATUS_MATCHERS: Array<{ statusCode: number; matcherId: string; re: 
   {
     statusCode: 429,
     matcherId: "rate_limit",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+429\b|\b429\s+too\s+many\s+requests\b|\btoo\s+many\s+requests\b|\brate\s*limit(?:ed|ing)?\b|\bthrottl(?:e|ed|ing)\b|\bretry-after\b|\bRESOURCE_EXHAUSTED\b|\bRequestLimitExceeded\b|\bThrottling(?:Exception)?\b|\bError\s*1015\b|超出频率|请求过于频繁|限流|稍后重试)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+429(?!\d|\.\d)|(?<![\d.])429(?!\d|\.\d)\s+too\s+many\s+requests\b|\btoo\s+many\s+requests\b|\brate\s*limit(?:ed|ing)?\b|\bthrottl(?:e|ed|ing)\b|\bretry-after\b|\bRESOURCE_EXHAUSTED\b|\bRequestLimitExceeded\b|\bThrottling(?:Exception)?\b|\bError\s*1015(?!\d|\.\d)|超出频率|请求过于频繁|限流|稍后重试)/iu,
   },
   {
     statusCode: 402,
     matcherId: "payment_required",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+402\b|\bpayment\s+required\b|\binsufficient\s+(?:balance|funds|credits)\b|\b(?:out\s+of|no)\s+credits\b|\binsufficient_balance\b|\bbilling_hard_limit_reached\b|\bcard\s+(?:declined|expired)\b|\bpayment\s+(?:method|failed)\b|余额不足|欠费|请充值|支付(?:失败|方式))/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+402(?!\d|\.\d)|\bpayment\s+required\b|\binsufficient\s+(?:balance|funds|credits)\b|\b(?:out\s+of|no)\s+credits\b|\binsufficient_balance\b|\bbilling_hard_limit_reached\b|\bcard\s+(?:declined|expired)\b|\bpayment\s+(?:method|failed)\b|余额不足|欠费|请充值|支付(?:失败|方式))/iu,
   },
   {
     statusCode: 401,
     matcherId: "unauthorized",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+401\b|\bunauthori(?:sed|zed)\b|\bunauthenticated\b|\bauthentication\s+failed\b|\b(?:invalid|incorrect|missing)\s+api[-_ ]?key\b|\binvalid\s+token\b|\bexpired\s+token\b|\bsignature\s+(?:invalid|mismatch)\b|\bUNAUTHENTICATED\b|未授权|鉴权失败|密钥无效|token\s*过期)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+401(?!\d|\.\d)|\bunauthori(?:sed|zed)\b|\bunauthenticated\b|\bauthentication\s+failed\b|\b(?:invalid|incorrect|missing)\s+api[-_ ]?key\b|\binvalid\s+token\b|\bexpired\s+token\b|\bsignature\s+(?:invalid|mismatch)\b|\bUNAUTHENTICATED\b|未授权|鉴权失败|密钥无效|token\s*过期)/iu,
   },
   {
     statusCode: 403,
     matcherId: "forbidden",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+403\b|\bforbidden\b|\bpermission\s+denied\b|\baccess\s+denied\b|\bnot\s+allowed\b|\baccount\s+(?:disabled|suspended|banned)\b|\bnot\s+whitelisted\b|\bPERMISSION_DENIED\b|\bAccessDenied(?:Exception)?\b|\bError\s*1020\b|\b(?:region|country)\b[\s\S]{0,40}\b(?:not\s+supported|blocked)\b|地区不支持|禁止访问|无权限|权限不足|账号被封|地区(?:限制|屏蔽))/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+403(?!\d|\.\d)|\bforbidden\b|\bpermission\s+denied\b|\baccess\s+denied\b|\bnot\s+allowed\b|\baccount\s+(?:disabled|suspended|banned)\b|\bnot\s+whitelisted\b|\bPERMISSION_DENIED\b|\bAccessDenied(?:Exception)?\b|\bError\s*1020(?!\d|\.\d)|\b(?:region|country)\b[\s\S]{0,40}\b(?:not\s+supported|blocked)\b|地区不支持|禁止访问|无权限|权限不足|账号被封|地区(?:限制|屏蔽))/iu,
   },
   {
     statusCode: 404,
     matcherId: "not_found",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+404\b|\b(?:model|deployment|endpoint|resource|route|path|api|service|url)\s+not\s+found\b|\bunknown\s+model\b|\bdoes\s+not\s+exist\b|\bNOT_FOUND\b|\bResourceNotFoundException\b|未找到|不存在|模型不存在)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+404(?!\d|\.\d)|\b(?:model|deployment|endpoint|resource|route|path|api|service|url)\s+not\s+found\b|\bunknown\s+model\b|\bdoes\s+not\s+exist\b|\bNOT_FOUND\b|\bResourceNotFoundException\b|未找到|不存在|模型不存在)/iu,
   },
   {
     statusCode: 413,
     matcherId: "payload_too_large",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+413\b|\bpayload\s+too\s+large\b|\brequest\s+entity\s+too\s+large\b|\bbody\s+too\s+large\b|\bContent-Length\b[\s\S]{0,40}\btoo\s+large\b|\bexceed(?:s|ed)?\b[\s\S]{0,40}\b(?:max(?:imum)?|limit)\b[\s\S]{0,40}\b(?:size|length)\b|请求体过大|内容过大|超过最大)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+413(?!\d|\.\d)|\bpayload\s+too\s+large\b|\brequest\s+entity\s+too\s+large\b|\bbody\s+too\s+large\b|\bContent-Length\b[\s\S]{0,40}\btoo\s+large\b|\bexceed(?:s|ed)?\b[\s\S]{0,40}\b(?:max(?:imum)?|limit)\b[\s\S]{0,40}\b(?:size|length)\b|请求体过大|内容过大|超过最大)/iu,
   },
   {
     statusCode: 415,
     matcherId: "unsupported_media_type",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+415\b|\bunsupported\s+media\s+type\b|\binvalid\s+content-type\b|\bContent-Type\b[\s\S]{0,40}\b(?:must\s+be|required)\b|不支持的媒体类型|Content-Type\s*错误)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+415(?!\d|\.\d)|\bunsupported\s+media\s+type\b|\binvalid\s+content-type\b|\bContent-Type\b[\s\S]{0,40}\b(?:must\s+be|required)\b|不支持的媒体类型|Content-Type\s*错误)/iu,
   },
   {
     statusCode: 409,
     matcherId: "conflict",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+409\b|\bconflict\b|\bidempotency(?:-key)?\b|\bABORTED\b|冲突|幂等)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+409(?!\d|\.\d)|\bconflict\b|\bidempotency(?:-key)?\b|\bABORTED\b|冲突|幂等)/iu,
   },
   {
     statusCode: 422,
     matcherId: "unprocessable_entity",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+422\b|\bunprocessable\s+entity\b|\bINVALID_ARGUMENT\b[\s\S]{0,40}\bvalidation\b|\bschema\s+validation\b|实体无法处理)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+422(?!\d|\.\d)|\bunprocessable\s+entity\b|\bINVALID_ARGUMENT\b[\s\S]{0,40}\bvalidation\b|\bschema\s+validation\b|实体无法处理)/iu,
   },
   {
     statusCode: 408,
     matcherId: "request_timeout",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+408\b|\brequest\s+timeout\b|请求\s*超时)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+408(?!\d|\.\d)|\brequest\s+timeout\b|请求\s*超时)/iu,
   },
   {
     statusCode: 451,
     matcherId: "legal_restriction",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+451\b|\bunavailable\s+for\s+legal\s+reasons\b|\bexport\s+control\b|\bsanctions?\b|法律原因不可用|合规限制|出口管制)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+451(?!\d|\.\d)|\bunavailable\s+for\s+legal\s+reasons\b|\bexport\s+control\b|\bsanctions?\b|法律原因不可用|合规限制|出口管制)/iu,
   },
   {
     statusCode: 503,
     matcherId: "service_unavailable",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+503\b|\bservice\s+unavailable\b|\boverloaded\b|\bserver\s+is\s+busy\b|\btry\s+again\s+later\b|\btemporarily\s+unavailable\b|\bmaintenance\b|\bUNAVAILABLE\b|\bServiceUnavailableException\b|\bError\s*521\b|服务不可用|过载|系统繁忙|维护中)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+503(?!\d|\.\d)|\bservice\s+unavailable\b|\boverloaded\b|\bserver\s+is\s+busy\b|\btry\s+again\s+later\b|\btemporarily\s+unavailable\b|\bmaintenance\b|\bUNAVAILABLE\b|\bServiceUnavailableException\b|\bError\s*521(?!\d|\.\d)|服务不可用|过载|系统繁忙|维护中)/iu,
   },
   {
     statusCode: 504,
     matcherId: "gateway_timeout",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+504\b|\bgateway\s+timeout\b|\bupstream\b[\s\S]{0,40}\btim(?:e|ed)\s*out\b|\bDEADLINE_EXCEEDED\b|\bError\s*522\b|\bError\s*524\b|网关超时|上游超时)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+504(?!\d|\.\d)|\bgateway\s+timeout\b|\bupstream\b[\s\S]{0,40}\btim(?:e|ed)\s*out\b|\bDEADLINE_EXCEEDED\b|\bError\s*522(?!\d|\.\d)|\bError\s*524(?!\d|\.\d)|网关超时|上游超时)/iu,
   },
   {
     statusCode: 500,
     matcherId: "internal_server_error",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+500\b|\binternal\s+server\s+error\b|\bInternalServerException\b|\bINTERNAL\b|内部错误|服务器错误)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+500(?!\d|\.\d)|\binternal\s+server\s+error\b|\bInternalServerException\b|\bINTERNAL\b|内部错误|服务器错误)/iu,
   },
   {
     statusCode: 400,
     matcherId: "bad_request",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+400\b|\bbad\s+request\b|\bINVALID_ARGUMENT\b|\bjson\s+parse\b|\binvalid\s+json\b|\bunexpected\s+token\b|无效请求|格式错误|JSON\s*解析失败)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+400(?!\d|\.\d)|\bbad\s+request\b|\bINVALID_ARGUMENT\b|\bjson\s+parse\b|\binvalid\s+json\b|\bunexpected\s+token\b|无效请求|格式错误|JSON\s*解析失败)/iu,
   },
 ];
 

--- a/src/lib/utils/upstream-error-detection.ts
+++ b/src/lib/utils/upstream-error-detection.ts
@@ -95,77 +95,77 @@ const ERROR_STATUS_MATCHERS: Array<{ statusCode: number; matcherId: string; re: 
   {
     statusCode: 429,
     matcherId: "rate_limit",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+429(?![\p{L}\p{N}_.])|(?<![\p{L}\p{N}_.])429(?![\p{L}\p{N}_.])\s+too\s+many\s+requests\b|\btoo\s+many\s+requests\b|\brate\s*limit(?:ed|ing)?\b|\bthrottl(?:e|ed|ing)\b|\bretry-after\b|\bRESOURCE_EXHAUSTED\b|\bRequestLimitExceeded\b|\bThrottling(?:Exception)?\b|\bError\s*1015(?![\p{L}\p{N}_.])|超出频率|请求过于频繁|限流|稍后重试)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+429(?![\p{L}\p{N}_]|\.\d)|(?<![\p{L}\p{N}_.])429(?![\p{L}\p{N}_]|\.\d)\s+too\s+many\s+requests\b|\btoo\s+many\s+requests\b|\brate\s*limit(?:ed|ing)?\b|\bthrottl(?:e|ed|ing)\b|\bretry-after\b|\bRESOURCE_EXHAUSTED\b|\bRequestLimitExceeded\b|\bThrottling(?:Exception)?\b|\bError\s*1015(?![\p{L}\p{N}_]|\.\d)|超出频率|请求过于频繁|限流|稍后重试)/iu,
   },
   {
     statusCode: 402,
     matcherId: "payment_required",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+402(?![\p{L}\p{N}_.])|\bpayment\s+required\b|\binsufficient\s+(?:balance|funds|credits)\b|\b(?:out\s+of|no)\s+credits\b|\binsufficient_balance\b|\bbilling_hard_limit_reached\b|\bcard\s+(?:declined|expired)\b|\bpayment\s+(?:method|failed)\b|余额不足|欠费|请充值|支付(?:失败|方式))/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+402(?![\p{L}\p{N}_]|\.\d)|\bpayment\s+required\b|\binsufficient\s+(?:balance|funds|credits)\b|\b(?:out\s+of|no)\s+credits\b|\binsufficient_balance\b|\bbilling_hard_limit_reached\b|\bcard\s+(?:declined|expired)\b|\bpayment\s+(?:method|failed)\b|余额不足|欠费|请充值|支付(?:失败|方式))/iu,
   },
   {
     statusCode: 401,
     matcherId: "unauthorized",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+401(?![\p{L}\p{N}_.])|\bunauthori(?:sed|zed)\b|\bunauthenticated\b|\bauthentication\s+failed\b|\b(?:invalid|incorrect|missing)\s+api[-_ ]?key\b|\binvalid\s+token\b|\bexpired\s+token\b|\bsignature\s+(?:invalid|mismatch)\b|\bUNAUTHENTICATED\b|未授权|鉴权失败|密钥无效|token\s*过期)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+401(?![\p{L}\p{N}_]|\.\d)|\bunauthori(?:sed|zed)\b|\bunauthenticated\b|\bauthentication\s+failed\b|\b(?:invalid|incorrect|missing)\s+api[-_ ]?key\b|\binvalid\s+token\b|\bexpired\s+token\b|\bsignature\s+(?:invalid|mismatch)\b|\bUNAUTHENTICATED\b|未授权|鉴权失败|密钥无效|token\s*过期)/iu,
   },
   {
     statusCode: 403,
     matcherId: "forbidden",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+403(?![\p{L}\p{N}_.])|\bforbidden\b|\bpermission\s+denied\b|\baccess\s+denied\b|\bnot\s+allowed\b|\baccount\s+(?:disabled|suspended|banned)\b|\bnot\s+whitelisted\b|\bPERMISSION_DENIED\b|\bAccessDenied(?:Exception)?\b|\bError\s*1020(?![\p{L}\p{N}_.])|\b(?:region|country)\b[\s\S]{0,40}\b(?:not\s+supported|blocked)\b|地区不支持|禁止访问|无权限|权限不足|账号被封|地区(?:限制|屏蔽))/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+403(?![\p{L}\p{N}_]|\.\d)|\bforbidden\b|\bpermission\s+denied\b|\baccess\s+denied\b|\bnot\s+allowed\b|\baccount\s+(?:disabled|suspended|banned)\b|\bnot\s+whitelisted\b|\bPERMISSION_DENIED\b|\bAccessDenied(?:Exception)?\b|\bError\s*1020(?![\p{L}\p{N}_]|\.\d)|\b(?:region|country)\b[\s\S]{0,40}\b(?:not\s+supported|blocked)\b|地区不支持|禁止访问|无权限|权限不足|账号被封|地区(?:限制|屏蔽))/iu,
   },
   {
     statusCode: 404,
     matcherId: "not_found",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+404(?![\p{L}\p{N}_.])|\b(?:model|deployment|endpoint|resource|route|path|api|service|url)\s+not\s+found\b|\bunknown\s+model\b|\bdoes\s+not\s+exist\b|\bNOT_FOUND\b|\bResourceNotFoundException\b|未找到|不存在|模型不存在)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+404(?![\p{L}\p{N}_]|\.\d)|\b(?:model|deployment|endpoint|resource|route|path|api|service|url)\s+not\s+found\b|\bunknown\s+model\b|\bdoes\s+not\s+exist\b|\bNOT_FOUND\b|\bResourceNotFoundException\b|未找到|不存在|模型不存在)/iu,
   },
   {
     statusCode: 413,
     matcherId: "payload_too_large",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+413(?![\p{L}\p{N}_.])|\bpayload\s+too\s+large\b|\brequest\s+entity\s+too\s+large\b|\bbody\s+too\s+large\b|\bContent-Length\b[\s\S]{0,40}\btoo\s+large\b|\bexceed(?:s|ed)?\b[\s\S]{0,40}\b(?:max(?:imum)?|limit)\b[\s\S]{0,40}\b(?:size|length)\b|请求体过大|内容过大|超过最大)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+413(?![\p{L}\p{N}_]|\.\d)|\bpayload\s+too\s+large\b|\brequest\s+entity\s+too\s+large\b|\bbody\s+too\s+large\b|\bContent-Length\b[\s\S]{0,40}\btoo\s+large\b|\bexceed(?:s|ed)?\b[\s\S]{0,40}\b(?:max(?:imum)?|limit)\b[\s\S]{0,40}\b(?:size|length)\b|请求体过大|内容过大|超过最大)/iu,
   },
   {
     statusCode: 415,
     matcherId: "unsupported_media_type",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+415(?![\p{L}\p{N}_.])|\bunsupported\s+media\s+type\b|\binvalid\s+content-type\b|\bContent-Type\b[\s\S]{0,40}\b(?:must\s+be|required)\b|不支持的媒体类型|Content-Type\s*错误)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+415(?![\p{L}\p{N}_]|\.\d)|\bunsupported\s+media\s+type\b|\binvalid\s+content-type\b|\bContent-Type\b[\s\S]{0,40}\b(?:must\s+be|required)\b|不支持的媒体类型|Content-Type\s*错误)/iu,
   },
   {
     statusCode: 409,
     matcherId: "conflict",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+409(?![\p{L}\p{N}_.])|\bconflict\b|\bidempotency(?:-key)?\b|\bABORTED\b|冲突|幂等)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+409(?![\p{L}\p{N}_]|\.\d)|\bconflict\b|\bidempotency(?:-key)?\b|\bABORTED\b|冲突|幂等)/iu,
   },
   {
     statusCode: 422,
     matcherId: "unprocessable_entity",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+422(?![\p{L}\p{N}_.])|\bunprocessable\s+entity\b|\bINVALID_ARGUMENT\b[\s\S]{0,40}\bvalidation\b|\bschema\s+validation\b|实体无法处理)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+422(?![\p{L}\p{N}_]|\.\d)|\bunprocessable\s+entity\b|\bINVALID_ARGUMENT\b[\s\S]{0,40}\bvalidation\b|\bschema\s+validation\b|实体无法处理)/iu,
   },
   {
     statusCode: 408,
     matcherId: "request_timeout",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+408(?![\p{L}\p{N}_.])|\brequest\s+timeout\b|请求\s*超时)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+408(?![\p{L}\p{N}_]|\.\d)|\brequest\s+timeout\b|请求\s*超时)/iu,
   },
   {
     statusCode: 451,
     matcherId: "legal_restriction",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+451(?![\p{L}\p{N}_.])|\bunavailable\s+for\s+legal\s+reasons\b|\bexport\s+control\b|\bsanctions?\b|法律原因不可用|合规限制|出口管制)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+451(?![\p{L}\p{N}_]|\.\d)|\bunavailable\s+for\s+legal\s+reasons\b|\bexport\s+control\b|\bsanctions?\b|法律原因不可用|合规限制|出口管制)/iu,
   },
   {
     statusCode: 503,
     matcherId: "service_unavailable",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+503(?![\p{L}\p{N}_.])|\bservice\s+unavailable\b|\boverloaded\b|\bserver\s+is\s+busy\b|\btry\s+again\s+later\b|\btemporarily\s+unavailable\b|\bmaintenance\b|\bUNAVAILABLE\b|\bServiceUnavailableException\b|\bError\s*521(?![\p{L}\p{N}_.])|服务不可用|过载|系统繁忙|维护中)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+503(?![\p{L}\p{N}_]|\.\d)|\bservice\s+unavailable\b|\boverloaded\b|\bserver\s+is\s+busy\b|\btry\s+again\s+later\b|\btemporarily\s+unavailable\b|\bmaintenance\b|\bUNAVAILABLE\b|\bServiceUnavailableException\b|\bError\s*521(?![\p{L}\p{N}_]|\.\d)|服务不可用|过载|系统繁忙|维护中)/iu,
   },
   {
     statusCode: 504,
     matcherId: "gateway_timeout",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+504(?![\p{L}\p{N}_.])|\bgateway\s+timeout\b|\bupstream\b[\s\S]{0,40}\btim(?:e|ed)\s*out\b|\bDEADLINE_EXCEEDED\b|\bError\s*522(?![\p{L}\p{N}_.])|\bError\s*524(?![\p{L}\p{N}_.])|网关超时|上游超时)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+504(?![\p{L}\p{N}_]|\.\d)|\bgateway\s+timeout\b|\bupstream\b[\s\S]{0,40}\btim(?:e|ed)\s*out\b|\bDEADLINE_EXCEEDED\b|\bError\s*522(?![\p{L}\p{N}_]|\.\d)|\bError\s*524(?![\p{L}\p{N}_]|\.\d)|网关超时|上游超时)/iu,
   },
   {
     statusCode: 500,
     matcherId: "internal_server_error",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+500(?![\p{L}\p{N}_.])|\binternal\s+server\s+error\b|\bInternalServerException\b|\bINTERNAL\b|内部错误|服务器错误)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+500(?![\p{L}\p{N}_]|\.\d)|\binternal\s+server\s+error\b|\bInternalServerException\b|\bINTERNAL\b|内部错误|服务器错误)/iu,
   },
   {
     statusCode: 400,
     matcherId: "bad_request",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+400(?![\p{L}\p{N}_.])|\bbad\s+request\b|\bINVALID_ARGUMENT\b|\bjson\s+parse\b|\binvalid\s+json\b|\bunexpected\s+token\b|无效请求|格式错误|JSON\s*解析失败)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+400(?![\p{L}\p{N}_]|\.\d)|\bbad\s+request\b|\bINVALID_ARGUMENT\b|\bjson\s+parse\b|\binvalid\s+json\b|\bunexpected\s+token\b|无效请求|格式错误|JSON\s*解析失败)/iu,
   },
 ];
 

--- a/src/lib/utils/upstream-error-detection.ts
+++ b/src/lib/utils/upstream-error-detection.ts
@@ -95,77 +95,77 @@ const ERROR_STATUS_MATCHERS: Array<{ statusCode: number; matcherId: string; re: 
   {
     statusCode: 429,
     matcherId: "rate_limit",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+429(?!\d|\.\d)|(?<![\d.])429(?!\d|\.\d)\s+too\s+many\s+requests\b|\btoo\s+many\s+requests\b|\brate\s*limit(?:ed|ing)?\b|\bthrottl(?:e|ed|ing)\b|\bretry-after\b|\bRESOURCE_EXHAUSTED\b|\bRequestLimitExceeded\b|\bThrottling(?:Exception)?\b|\bError\s*1015(?!\d|\.\d)|超出频率|请求过于频繁|限流|稍后重试)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+429(?![\p{L}\p{N}_.])|(?<![\p{L}\p{N}_.])429(?![\p{L}\p{N}_.])\s+too\s+many\s+requests\b|\btoo\s+many\s+requests\b|\brate\s*limit(?:ed|ing)?\b|\bthrottl(?:e|ed|ing)\b|\bretry-after\b|\bRESOURCE_EXHAUSTED\b|\bRequestLimitExceeded\b|\bThrottling(?:Exception)?\b|\bError\s*1015(?![\p{L}\p{N}_.])|超出频率|请求过于频繁|限流|稍后重试)/iu,
   },
   {
     statusCode: 402,
     matcherId: "payment_required",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+402(?!\d|\.\d)|\bpayment\s+required\b|\binsufficient\s+(?:balance|funds|credits)\b|\b(?:out\s+of|no)\s+credits\b|\binsufficient_balance\b|\bbilling_hard_limit_reached\b|\bcard\s+(?:declined|expired)\b|\bpayment\s+(?:method|failed)\b|余额不足|欠费|请充值|支付(?:失败|方式))/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+402(?![\p{L}\p{N}_.])|\bpayment\s+required\b|\binsufficient\s+(?:balance|funds|credits)\b|\b(?:out\s+of|no)\s+credits\b|\binsufficient_balance\b|\bbilling_hard_limit_reached\b|\bcard\s+(?:declined|expired)\b|\bpayment\s+(?:method|failed)\b|余额不足|欠费|请充值|支付(?:失败|方式))/iu,
   },
   {
     statusCode: 401,
     matcherId: "unauthorized",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+401(?!\d|\.\d)|\bunauthori(?:sed|zed)\b|\bunauthenticated\b|\bauthentication\s+failed\b|\b(?:invalid|incorrect|missing)\s+api[-_ ]?key\b|\binvalid\s+token\b|\bexpired\s+token\b|\bsignature\s+(?:invalid|mismatch)\b|\bUNAUTHENTICATED\b|未授权|鉴权失败|密钥无效|token\s*过期)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+401(?![\p{L}\p{N}_.])|\bunauthori(?:sed|zed)\b|\bunauthenticated\b|\bauthentication\s+failed\b|\b(?:invalid|incorrect|missing)\s+api[-_ ]?key\b|\binvalid\s+token\b|\bexpired\s+token\b|\bsignature\s+(?:invalid|mismatch)\b|\bUNAUTHENTICATED\b|未授权|鉴权失败|密钥无效|token\s*过期)/iu,
   },
   {
     statusCode: 403,
     matcherId: "forbidden",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+403(?!\d|\.\d)|\bforbidden\b|\bpermission\s+denied\b|\baccess\s+denied\b|\bnot\s+allowed\b|\baccount\s+(?:disabled|suspended|banned)\b|\bnot\s+whitelisted\b|\bPERMISSION_DENIED\b|\bAccessDenied(?:Exception)?\b|\bError\s*1020(?!\d|\.\d)|\b(?:region|country)\b[\s\S]{0,40}\b(?:not\s+supported|blocked)\b|地区不支持|禁止访问|无权限|权限不足|账号被封|地区(?:限制|屏蔽))/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+403(?![\p{L}\p{N}_.])|\bforbidden\b|\bpermission\s+denied\b|\baccess\s+denied\b|\bnot\s+allowed\b|\baccount\s+(?:disabled|suspended|banned)\b|\bnot\s+whitelisted\b|\bPERMISSION_DENIED\b|\bAccessDenied(?:Exception)?\b|\bError\s*1020(?![\p{L}\p{N}_.])|\b(?:region|country)\b[\s\S]{0,40}\b(?:not\s+supported|blocked)\b|地区不支持|禁止访问|无权限|权限不足|账号被封|地区(?:限制|屏蔽))/iu,
   },
   {
     statusCode: 404,
     matcherId: "not_found",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+404(?!\d|\.\d)|\b(?:model|deployment|endpoint|resource|route|path|api|service|url)\s+not\s+found\b|\bunknown\s+model\b|\bdoes\s+not\s+exist\b|\bNOT_FOUND\b|\bResourceNotFoundException\b|未找到|不存在|模型不存在)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+404(?![\p{L}\p{N}_.])|\b(?:model|deployment|endpoint|resource|route|path|api|service|url)\s+not\s+found\b|\bunknown\s+model\b|\bdoes\s+not\s+exist\b|\bNOT_FOUND\b|\bResourceNotFoundException\b|未找到|不存在|模型不存在)/iu,
   },
   {
     statusCode: 413,
     matcherId: "payload_too_large",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+413(?!\d|\.\d)|\bpayload\s+too\s+large\b|\brequest\s+entity\s+too\s+large\b|\bbody\s+too\s+large\b|\bContent-Length\b[\s\S]{0,40}\btoo\s+large\b|\bexceed(?:s|ed)?\b[\s\S]{0,40}\b(?:max(?:imum)?|limit)\b[\s\S]{0,40}\b(?:size|length)\b|请求体过大|内容过大|超过最大)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+413(?![\p{L}\p{N}_.])|\bpayload\s+too\s+large\b|\brequest\s+entity\s+too\s+large\b|\bbody\s+too\s+large\b|\bContent-Length\b[\s\S]{0,40}\btoo\s+large\b|\bexceed(?:s|ed)?\b[\s\S]{0,40}\b(?:max(?:imum)?|limit)\b[\s\S]{0,40}\b(?:size|length)\b|请求体过大|内容过大|超过最大)/iu,
   },
   {
     statusCode: 415,
     matcherId: "unsupported_media_type",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+415(?!\d|\.\d)|\bunsupported\s+media\s+type\b|\binvalid\s+content-type\b|\bContent-Type\b[\s\S]{0,40}\b(?:must\s+be|required)\b|不支持的媒体类型|Content-Type\s*错误)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+415(?![\p{L}\p{N}_.])|\bunsupported\s+media\s+type\b|\binvalid\s+content-type\b|\bContent-Type\b[\s\S]{0,40}\b(?:must\s+be|required)\b|不支持的媒体类型|Content-Type\s*错误)/iu,
   },
   {
     statusCode: 409,
     matcherId: "conflict",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+409(?!\d|\.\d)|\bconflict\b|\bidempotency(?:-key)?\b|\bABORTED\b|冲突|幂等)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+409(?![\p{L}\p{N}_.])|\bconflict\b|\bidempotency(?:-key)?\b|\bABORTED\b|冲突|幂等)/iu,
   },
   {
     statusCode: 422,
     matcherId: "unprocessable_entity",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+422(?!\d|\.\d)|\bunprocessable\s+entity\b|\bINVALID_ARGUMENT\b[\s\S]{0,40}\bvalidation\b|\bschema\s+validation\b|实体无法处理)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+422(?![\p{L}\p{N}_.])|\bunprocessable\s+entity\b|\bINVALID_ARGUMENT\b[\s\S]{0,40}\bvalidation\b|\bschema\s+validation\b|实体无法处理)/iu,
   },
   {
     statusCode: 408,
     matcherId: "request_timeout",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+408(?!\d|\.\d)|\brequest\s+timeout\b|请求\s*超时)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+408(?![\p{L}\p{N}_.])|\brequest\s+timeout\b|请求\s*超时)/iu,
   },
   {
     statusCode: 451,
     matcherId: "legal_restriction",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+451(?!\d|\.\d)|\bunavailable\s+for\s+legal\s+reasons\b|\bexport\s+control\b|\bsanctions?\b|法律原因不可用|合规限制|出口管制)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+451(?![\p{L}\p{N}_.])|\bunavailable\s+for\s+legal\s+reasons\b|\bexport\s+control\b|\bsanctions?\b|法律原因不可用|合规限制|出口管制)/iu,
   },
   {
     statusCode: 503,
     matcherId: "service_unavailable",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+503(?!\d|\.\d)|\bservice\s+unavailable\b|\boverloaded\b|\bserver\s+is\s+busy\b|\btry\s+again\s+later\b|\btemporarily\s+unavailable\b|\bmaintenance\b|\bUNAVAILABLE\b|\bServiceUnavailableException\b|\bError\s*521(?!\d|\.\d)|服务不可用|过载|系统繁忙|维护中)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+503(?![\p{L}\p{N}_.])|\bservice\s+unavailable\b|\boverloaded\b|\bserver\s+is\s+busy\b|\btry\s+again\s+later\b|\btemporarily\s+unavailable\b|\bmaintenance\b|\bUNAVAILABLE\b|\bServiceUnavailableException\b|\bError\s*521(?![\p{L}\p{N}_.])|服务不可用|过载|系统繁忙|维护中)/iu,
   },
   {
     statusCode: 504,
     matcherId: "gateway_timeout",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+504(?!\d|\.\d)|\bgateway\s+timeout\b|\bupstream\b[\s\S]{0,40}\btim(?:e|ed)\s*out\b|\bDEADLINE_EXCEEDED\b|\bError\s*522(?!\d|\.\d)|\bError\s*524(?!\d|\.\d)|网关超时|上游超时)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+504(?![\p{L}\p{N}_.])|\bgateway\s+timeout\b|\bupstream\b[\s\S]{0,40}\btim(?:e|ed)\s*out\b|\bDEADLINE_EXCEEDED\b|\bError\s*522(?![\p{L}\p{N}_.])|\bError\s*524(?![\p{L}\p{N}_.])|网关超时|上游超时)/iu,
   },
   {
     statusCode: 500,
     matcherId: "internal_server_error",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+500(?!\d|\.\d)|\binternal\s+server\s+error\b|\bInternalServerException\b|\bINTERNAL\b|内部错误|服务器错误)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+500(?![\p{L}\p{N}_.])|\binternal\s+server\s+error\b|\bInternalServerException\b|\bINTERNAL\b|内部错误|服务器错误)/iu,
   },
   {
     statusCode: 400,
     matcherId: "bad_request",
-    re: /(?:\bHTTP\/\d(?:\.\d)?\s+400(?!\d|\.\d)|\bbad\s+request\b|\bINVALID_ARGUMENT\b|\bjson\s+parse\b|\binvalid\s+json\b|\bunexpected\s+token\b|无效请求|格式错误|JSON\s*解析失败)/iu,
+    re: /(?:\bHTTP\/\d(?:\.\d)?\s+400(?![\p{L}\p{N}_.])|\bbad\s+request\b|\bINVALID_ARGUMENT\b|\bjson\s+parse\b|\binvalid\s+json\b|\bunexpected\s+token\b|无效请求|格式错误|JSON\s*解析失败)/iu,
   },
 ];
 

--- a/tests/unit/lib/upstream-error-detection-status.test.ts
+++ b/tests/unit/lib/upstream-error-detection-status.test.ts
@@ -54,6 +54,18 @@ describe("inferUpstreamErrorStatusCodeFromText numeric boundaries", () => {
     expect(inferUpstreamErrorStatusCodeFromText(`HTTP/1.1 ${statusCode}12`)).toBeNull();
   });
 
+  it.each(
+    httpStatusCases
+  )("does not treat HTTP $statusCode followed by a letter as a status token", ({ statusCode }) => {
+    expect(inferUpstreamErrorStatusCodeFromText(`HTTP/1.1 ${statusCode}abc`)).toBeNull();
+  });
+
+  it.each(httpStatusCases)("does not treat HTTP $statusCode followed by a dot as a status token", ({
+    statusCode,
+  }) => {
+    expect(inferUpstreamErrorStatusCodeFromText(`HTTP/1.1 ${statusCode}.`)).toBeNull();
+  });
+
   it.each(cloudflareErrorCases)("keeps matching a standalone Cloudflare Error $code token", ({
     code,
     statusCode,
@@ -81,13 +93,25 @@ describe("inferUpstreamErrorStatusCodeFromText numeric boundaries", () => {
     expect(inferUpstreamErrorStatusCodeFromText(`Error ${code}7`)).toBeNull();
   });
 
+  it.each(
+    cloudflareErrorCases
+  )("does not treat Cloudflare Error $code followed by a letter as a code token", ({ code }) => {
+    expect(inferUpstreamErrorStatusCodeFromText(`Error ${code}x`)).toBeNull();
+  });
+
+  it.each(
+    cloudflareErrorCases
+  )("does not treat Cloudflare Error $code followed by a dot as a code token", ({ code }) => {
+    expect(inferUpstreamErrorStatusCodeFromText(`Error ${code}.`)).toBeNull();
+  });
+
   it("does not infer service_unavailable from an AWS request id containing 503", () => {
     const text = "request id: 202604250550399959";
 
     expect(inferUpstreamErrorStatusCodeFromText(text)).toBeNull();
   });
 
-  it("does not infer overloaded status from a decimal price containing 529", () => {
+  it("does not infer any status from a decimal price sample", () => {
     const text = "需要预扣费额度：¥0.352942";
 
     expect(inferUpstreamErrorStatusCodeFromText(text)).toBeNull();

--- a/tests/unit/lib/upstream-error-detection-status.test.ts
+++ b/tests/unit/lib/upstream-error-detection-status.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { inferUpstreamErrorStatusCodeFromText } from "@/lib/utils/upstream-error-detection";
+
+const httpStatusCases = [
+  { statusCode: 429, matcherId: "rate_limit" },
+  { statusCode: 402, matcherId: "payment_required" },
+  { statusCode: 401, matcherId: "unauthorized" },
+  { statusCode: 403, matcherId: "forbidden" },
+  { statusCode: 404, matcherId: "not_found" },
+  { statusCode: 413, matcherId: "payload_too_large" },
+  { statusCode: 415, matcherId: "unsupported_media_type" },
+  { statusCode: 409, matcherId: "conflict" },
+  { statusCode: 422, matcherId: "unprocessable_entity" },
+  { statusCode: 408, matcherId: "request_timeout" },
+  { statusCode: 451, matcherId: "legal_restriction" },
+  { statusCode: 503, matcherId: "service_unavailable" },
+  { statusCode: 504, matcherId: "gateway_timeout" },
+  { statusCode: 500, matcherId: "internal_server_error" },
+  { statusCode: 400, matcherId: "bad_request" },
+] as const;
+
+const cloudflareErrorCases = [
+  { code: 1015, statusCode: 429, matcherId: "rate_limit" },
+  { code: 1020, statusCode: 403, matcherId: "forbidden" },
+  { code: 521, statusCode: 503, matcherId: "service_unavailable" },
+  { code: 522, statusCode: 504, matcherId: "gateway_timeout" },
+  { code: 524, statusCode: 504, matcherId: "gateway_timeout" },
+] as const;
+
+describe("inferUpstreamErrorStatusCodeFromText numeric boundaries", () => {
+  it.each(httpStatusCases)("keeps matching a standalone HTTP $statusCode status token", ({
+    statusCode,
+    matcherId,
+  }) => {
+    expect(inferUpstreamErrorStatusCodeFromText(`HTTP/1.1 ${statusCode}`)).toEqual({
+      statusCode,
+      matcherId,
+    });
+  });
+
+  it.each(
+    httpStatusCases
+  )("does not treat HTTP $statusCode followed by a decimal fraction as a status token", ({
+    statusCode,
+  }) => {
+    expect(inferUpstreamErrorStatusCodeFromText(`HTTP/1.1 ${statusCode}.12`)).toBeNull();
+  });
+
+  it.each(
+    httpStatusCases
+  )("does not treat HTTP $statusCode embedded in a longer number as a status token", ({
+    statusCode,
+  }) => {
+    expect(inferUpstreamErrorStatusCodeFromText(`HTTP/1.1 ${statusCode}12`)).toBeNull();
+  });
+
+  it.each(cloudflareErrorCases)("keeps matching a standalone Cloudflare Error $code token", ({
+    code,
+    statusCode,
+    matcherId,
+  }) => {
+    expect(inferUpstreamErrorStatusCodeFromText(`Error ${code}`)).toEqual({
+      statusCode,
+      matcherId,
+    });
+  });
+
+  it.each(
+    cloudflareErrorCases
+  )("does not treat Cloudflare Error $code followed by a decimal fraction as a code token", ({
+    code,
+  }) => {
+    expect(inferUpstreamErrorStatusCodeFromText(`Error ${code}.7`)).toBeNull();
+  });
+
+  it.each(
+    cloudflareErrorCases
+  )("does not treat Cloudflare Error $code embedded in a longer number as a code token", ({
+    code,
+  }) => {
+    expect(inferUpstreamErrorStatusCodeFromText(`Error ${code}7`)).toBeNull();
+  });
+
+  it("does not infer service_unavailable from an AWS request id containing 503", () => {
+    const text = "request id: 202604250550399959";
+
+    expect(inferUpstreamErrorStatusCodeFromText(text)).toBeNull();
+  });
+
+  it("does not infer overloaded status from a decimal price containing 529", () => {
+    const text = "需要预扣费额度：¥0.352942";
+
+    expect(inferUpstreamErrorStatusCodeFromText(text)).toBeNull();
+  });
+});

--- a/tests/unit/lib/upstream-error-detection-status.test.ts
+++ b/tests/unit/lib/upstream-error-detection-status.test.ts
@@ -60,10 +60,14 @@ describe("inferUpstreamErrorStatusCodeFromText numeric boundaries", () => {
     expect(inferUpstreamErrorStatusCodeFromText(`HTTP/1.1 ${statusCode}abc`)).toBeNull();
   });
 
-  it.each(httpStatusCases)("does not treat HTTP $statusCode followed by a dot as a status token", ({
+  it.each(httpStatusCases)("keeps matching HTTP $statusCode followed by sentence punctuation", ({
     statusCode,
+    matcherId,
   }) => {
-    expect(inferUpstreamErrorStatusCodeFromText(`HTTP/1.1 ${statusCode}.`)).toBeNull();
+    expect(inferUpstreamErrorStatusCodeFromText(`HTTP/1.1 ${statusCode}.`)).toEqual({
+      statusCode,
+      matcherId,
+    });
   });
 
   it.each(cloudflareErrorCases)("keeps matching a standalone Cloudflare Error $code token", ({
@@ -101,8 +105,15 @@ describe("inferUpstreamErrorStatusCodeFromText numeric boundaries", () => {
 
   it.each(
     cloudflareErrorCases
-  )("does not treat Cloudflare Error $code followed by a dot as a code token", ({ code }) => {
-    expect(inferUpstreamErrorStatusCodeFromText(`Error ${code}.`)).toBeNull();
+  )("keeps matching Cloudflare Error $code followed by sentence punctuation", ({
+    code,
+    statusCode,
+    matcherId,
+  }) => {
+    expect(inferUpstreamErrorStatusCodeFromText(`Error ${code}.`)).toEqual({
+      statusCode,
+      matcherId,
+    });
   });
 
   it("does not infer service_unavailable from an AWS request id containing 503", () => {

--- a/tests/unit/repository/error-rules-default-numeric-boundaries.test.ts
+++ b/tests/unit/repository/error-rules-default-numeric-boundaries.test.ts
@@ -105,17 +105,24 @@ async function loadDefaultRules(): Promise<CapturedDefaultRule[]> {
   return [...capturedInsertedRules];
 }
 
+function matchesRule(rule: CapturedDefaultRule, sample: string): boolean {
+  if (rule.matchType === "exact") return sample === rule.pattern;
+  if (rule.matchType === "contains")
+    return sample.toLowerCase().includes(rule.pattern.toLowerCase());
+
+  return new RegExp(rule.pattern, "i").test(sample);
+}
+
 describe("syncDefaultErrorRules numeric boundaries", () => {
-  test("default regex rules do not match numeric substrings in request ids or prices", async () => {
-    const regexRules = (await loadDefaultRules()).filter((rule) => rule.matchType === "regex");
+  test("default rules do not match numeric substrings in request ids or prices", async () => {
+    const defaultRules = await loadDefaultRules();
     const samples = ["request id: 202604250550399959", "需要预扣费额度：¥0.352942"];
 
-    expect(regexRules.length).toBeGreaterThan(0);
+    expect(defaultRules.length).toBeGreaterThan(0);
 
-    const accidentalMatches = regexRules.flatMap((rule) => {
-      const pattern = new RegExp(rule.pattern, "i");
+    const accidentalMatches = defaultRules.flatMap((rule) => {
       return samples
-        .filter((sample) => pattern.test(sample))
+        .filter((sample) => matchesRule(rule, sample))
         .map((sample) => ({ category: rule.category, pattern: rule.pattern, sample }));
     });
 

--- a/tests/unit/repository/error-rules-default-numeric-boundaries.test.ts
+++ b/tests/unit/repository/error-rules-default-numeric-boundaries.test.ts
@@ -110,6 +110,8 @@ describe("syncDefaultErrorRules numeric boundaries", () => {
     const regexRules = (await loadDefaultRules()).filter((rule) => rule.matchType === "regex");
     const samples = ["request id: 202604250550399959", "需要预扣费额度：¥0.352942"];
 
+    expect(regexRules.length).toBeGreaterThan(0);
+
     const accidentalMatches = regexRules.flatMap((rule) => {
       const pattern = new RegExp(rule.pattern, "i");
       return samples

--- a/tests/unit/repository/error-rules-default-numeric-boundaries.test.ts
+++ b/tests/unit/repository/error-rules-default-numeric-boundaries.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test, vi } from "vitest";
+
+process.env.DSN = "";
+process.env.AUTO_CLEANUP_TEST_DATA = "false";
+
+type CapturedDefaultRule = {
+  pattern: string;
+  matchType: "contains" | "exact" | "regex";
+  category: string;
+};
+
+type MockTransaction = {
+  query: {
+    errorRules: {
+      findMany: () => Promise<unknown[]>;
+    };
+  };
+  delete: () => {
+    where: () => Promise<unknown[]>;
+  };
+  insert: () => {
+    values: (rule: CapturedDefaultRule) => {
+      onConflictDoNothing: () => {
+        returning: () => Promise<Array<{ id: number }>>;
+      };
+    };
+  };
+  update: () => {
+    set: () => {
+      where: () => Promise<unknown[]>;
+    };
+  };
+};
+
+const capturedInsertedRules: CapturedDefaultRule[] = [];
+
+vi.mock("drizzle-orm", () => ({
+  desc: vi.fn((...args: unknown[]) => ({ args, op: "desc" })),
+  eq: vi.fn((...args: unknown[]) => ({ args, op: "eq" })),
+  inArray: vi.fn((...args: unknown[]) => ({ args, op: "inArray" })),
+}));
+
+vi.mock("@/drizzle/schema", () => ({
+  errorRules: {
+    id: "error_rules.id",
+    pattern: "error_rules.pattern",
+    isDefault: "error_rules.is_default",
+  },
+}));
+
+vi.mock("@/drizzle/db", () => ({
+  db: {
+    transaction: vi.fn(async (fn: (tx: MockTransaction) => Promise<void>) => {
+      const tx: MockTransaction = {
+        query: {
+          errorRules: {
+            findMany: vi.fn(async () => []),
+          },
+        },
+        delete: vi.fn(() => ({
+          where: vi.fn(async () => []),
+        })),
+        insert: vi.fn(() => ({
+          values: (rule: CapturedDefaultRule) => {
+            capturedInsertedRules.push(rule);
+            return {
+              onConflictDoNothing: () => ({
+                returning: vi.fn(async () => [{ id: 1 }]),
+              }),
+            };
+          },
+        })),
+        update: vi.fn(() => ({
+          set: vi.fn(() => ({
+            where: vi.fn(async () => []),
+          })),
+        })),
+      };
+
+      await fn(tx);
+    }),
+  },
+}));
+
+vi.mock("@/lib/emit-event", () => ({
+  emitErrorRulesUpdated: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+async function loadDefaultRules(): Promise<CapturedDefaultRule[]> {
+  capturedInsertedRules.length = 0;
+  vi.resetModules();
+
+  const { syncDefaultErrorRules } = await import("@/repository/error-rules");
+  await syncDefaultErrorRules();
+
+  return [...capturedInsertedRules];
+}
+
+describe("syncDefaultErrorRules numeric boundaries", () => {
+  test("default regex rules do not match numeric substrings in request ids or prices", async () => {
+    const regexRules = (await loadDefaultRules()).filter((rule) => rule.matchType === "regex");
+    const samples = ["request id: 202604250550399959", "需要预扣费额度：¥0.352942"];
+
+    const accidentalMatches = regexRules.flatMap((rule) => {
+      const pattern = new RegExp(rule.pattern, "i");
+      return samples
+        .filter((sample) => pattern.test(sample))
+        .map((sample) => ({ category: rule.category, pattern: rule.pattern, sample }));
+    });
+
+    expect(accidentalMatches).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Tighten the built-in `ERROR_STATUS_MATCHERS` regexes and guard the default error-rule catalog against false-positive numeric substring matches. Numeric HTTP status tokens (e.g. `503`) and Cloudflare Error codes (e.g. `521`, `524`) previously matched inside longer digit sequences such as AWS request IDs (`...05503999959...`) or decimal prices (`0.352942`), causing incorrect upstream-error-status inference.

**Related:**
- Related to #1103 - companion fix at the classification layer (category-aware whitelist); this PR tightens the regex boundary layer
- Partially addresses #1005 - prevents built-in matchers from spuriously matching numeric substrings in upstream response bodies
- Follow-up to #735 - tightens the `ERROR_STATUS_MATCHERS` regexes introduced in the fake-200 detection feature

## Problem

When an upstream returns a fake-200 response body containing a request ID or price, the numeric HTTP status regexes in `ERROR_STATUS_MATCHERS` could match a numeric substring and infer the wrong error status code. For example:

- `request id: 202604250550399959` contains `503` at positions 13-15, causing `service_unavailable` inference
- `需要预扣费额度：¥0.352942` contains `529` inside the decimal price, potentially triggering rate-limit inference

The root cause was that the status-code alternations used only `\b` word boundaries, which allow a match when the digits are followed by more digits or a decimal point (e.g. `503.12`, `521.7`).

## Solution

Replace bare `\b` word-boundary assertions on numeric status tokens with negative lookaheads `(?\!\d|\.\d)` that reject matches followed by additional digits or decimal fractions. Apply the same boundary tightening to Cloudflare Error codes (`1015`, `1020`, `521`, `522`, `524`). For the `429` HTTP status alternation, also add a negative lookbehind `(?<\![\d.])` to prevent matching when preceded by digits or a decimal point (e.g. inside a price).

## Changes

### Core Changes
- `src/lib/utils/upstream-error-detection.ts` (+15/-15) - Replace `\b` boundaries with `(?\!\d|\.\d)` on all 15 HTTP status code alternations and 5 Cloudflare Error code alternations; add `(?<\![\d.])` lookbehind on the `429` standalone status alternation

### Test Coverage
- `tests/unit/lib/upstream-error-detection-status.test.ts` (new, 95 lines) - 63 test cases covering: standalone HTTP status matches (still work), decimal-suffix rejection (`503.12`), longer-number rejection (`50312`), Cloudflare Error standalone matches, Cloudflare decimal/longer-number rejection, and regression tests for the reported request-id and price samples
- `tests/unit/repository/error-rules-default-numeric-boundaries.test.ts` (new, 122 lines) - Validates that all default `regex` error rules loaded by `syncDefaultErrorRules()` do not accidentally match the reported request-id and price samples

## Verification

- `bunx vitest run tests/unit/lib/upstream-error-detection-status.test.ts tests/unit/repository/error-rules-default-numeric-boundaries.test.ts` -> 2 files / 63 tests passed
- `bun run lint:fix` -> exit 0; fixed formatting only
- `bun run lint` -> exit 0; 3 existing info-level suggestions in unrelated leaderboard tests
- `bun run typecheck` -> exit 0
- `bun run build` -> exit 0
- `bunx vitest run tests/unit/public-status/config-publisher.test.ts` -> exit 0 after investigating the full-suite timeout
- `VITEST_MAX_WORKERS=4 bun run test` -> 547 files / 5136 tests passed, 13 skipped

## Notes

- Plain `bun run test` hit an unrelated 20s timeout in `tests/unit/public-status/config-publisher.test.ts`; the same test passes alone in ~15s and the full suite passes with reduced workers, matching the repo's configurable worker guidance.
- No breaking changes. The tightened boundaries only reject previously-incorrect matches; all legitimate standalone status/code tokens continue to match.

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens the numeric boundary guards in `ERROR_STATUS_MATCHERS` by replacing trailing `\b` word-boundary assertions with `(?![\p{L}\p{N}_]|\.\d)` negative lookaheads on all 15 HTTP status alternations and 5 Cloudflare Error code alternations, and adds a `(?<![\p{L}\p{N}_.])` lookbehind on the standalone `429` alternative. Two new test files provide 63 parametrised unit tests for the regex changes and a mock-based integration check against the default DB rules.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the regex changes are mechanically uniform, fully backward-compatible, and backed by comprehensive parametrised tests.

No P0 or P1 findings. The single P2 (missing `u` flag in test helper) is latent and harmless while DB rules remain free of Unicode property escapes. Core logic in the production file is correct.

tests/unit/repository/error-rules-default-numeric-boundaries.test.ts — the `matchesRule` helper uses `new RegExp(pattern, "i")` without `u`; benign today but could mask failures if DB rules adopt `\p{…}` patterns in the future.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/utils/upstream-error-detection.ts | Replaces trailing `\b` with `(?![\p{L}\p{N}_]|\.\d)` lookahead on all 15 HTTP status alternations and 5 Cloudflare Error alternations; adds `(?<![\p{L}\p{N}_.])` lookbehind on the standalone 429 alternative. Logic is correct and consistent across all entries. |
| tests/unit/lib/upstream-error-detection-status.test.ts | New test file with 63 parametrised cases covering standalone match, decimal-suffix rejection, longer-number rejection, letter-suffix rejection, punctuation passthrough for both HTTP statuses and Cloudflare codes, plus two regression samples. Coverage is thorough and correct. |
| tests/unit/repository/error-rules-default-numeric-boundaries.test.ts | New test that intercepts `syncDefaultErrorRules()` via mocks and asserts no default rule matches the two reported false-positive samples. Minor: `matchesRule` compiles regexes with only the `"i"` flag, missing `"u"`, which would cause a SyntaxError if any future DB rule uses Unicode property escapes. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Upstream fake-200 response body text"] --> B["inferUpstreamErrorStatusCodeFromText()"]
    B --> C["Trim + BOM strip + truncate to 64 KB"]
    C --> D["Iterate ERROR_STATUS_MATCHERS"]
    D --> E{"matcher.re.test(text)"}
    E -- "match" --> F["Return { statusCode, matcherId }"]
    E -- "no match" --> G{"More matchers?"}
    G -- "yes" --> D
    G -- "no" --> H["Return null"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/unit/repository/error-rules-default-numeric-boundaries.test.ts
Line: 113

Comment:
**Missing `u` flag in test regex compilation**

`matchesRule` constructs regexes with only `"i"` but the production matchers use `"iu"`. If any future default rule stores a pattern with a Unicode property escape (`\p{L}`, `\p{N}`, etc.), this line would throw a `SyntaxError` rather than failing a normal assertion, making the test failure misleading. Using `"iu"` here keeps the test semantics consistent with how the rules are applied in production.

```suggestion
  return new RegExp(rule.pattern, "iu").test(sample);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(proxy): allow punctuation after nume..."](https://github.com/ding113/claude-code-hub/commit/14a50c0ed6db5eb61e0e3fc6040702af246c3948) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29704434)</sub>

<!-- /greptile_comment -->