### PR TITLE
fix(i18n): pin locale in root layout

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@ import "../globals.css";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages } from "next-intl/server";
+import { getMessages, setRequestLocale } from "next-intl/server";
 import { Footer } from "@/components/customs/footer";
 import { Toaster } from "@/components/ui/sonner";
 import { type Locale, locales } from "@/i18n/config";
@@ -82,6 +82,9 @@ export default async function RootLayout({
     notFound();
   }
 
+  // 将路由段 locale 固定到 next-intl 请求上下文，避免后续导航回落到默认语言。
+  setRequestLocale(locale);
+
   // Load translation messages
   const messages = await getMessages({ locale });
   const timeZone = isPublicStatusRequest
@@ -93,7 +96,7 @@ export default async function RootLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       <body className="antialiased">
-        <NextIntlClientProvider messages={messages} timeZone={timeZone} now={now}>
+        <NextIntlClientProvider locale={locale} messages={messages} timeZone={timeZone} now={now}>
           <AppProviders>
             <div className="flex min-h-[var(--cch-viewport-height,100vh)] flex-col bg-background text-foreground">
               <div className="flex-1">{children}</div>

--- a/tests/unit/i18n/locale-layout-request-locale.test.tsx
+++ b/tests/unit/i18n/locale-layout-request-locale.test.tsx
@@ -1,0 +1,106 @@
+import type { ReactElement, ReactNode } from "react";
+import { describe, expect, test, vi } from "vitest";
+
+const nextIntlMocks = vi.hoisted(() => ({
+  provider: vi.fn(({ children }: { children: ReactNode }) => children),
+  getMessages: vi.fn(async () => ({ dashboard: { nav: { dashboard: "Dashboard" } } })),
+  setRequestLocale: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  NextIntlClientProvider: nextIntlMocks.provider,
+}));
+
+vi.mock("next-intl/server", () => ({
+  getMessages: nextIntlMocks.getMessages,
+  setRequestLocale: nextIntlMocks.setRequestLocale,
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({
+    get: vi.fn(() => null),
+  })),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("notFound");
+  }),
+}));
+
+vi.mock("@/components/customs/footer", () => ({
+  Footer: () => null,
+}));
+
+vi.mock("@/components/ui/sonner", () => ({
+  Toaster: () => null,
+}));
+
+vi.mock("@/lib/layout-site-metadata", () => ({
+  resolveDefaultLayoutTimeZone: vi.fn(async () => "UTC"),
+  resolveDefaultSiteMetadataSource: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/public-status/layout-metadata", () => ({
+  resolveLayoutTimeZone: vi.fn(async () => "UTC"),
+  resolveSiteMetadataSource: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/app/providers", () => ({
+  AppProviders: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/app/globals.css", () => ({}));
+
+function findProviderElement(node: ReactNode): ReactElement | null {
+  if (!node || typeof node !== "object") {
+    return null;
+  }
+
+  if (!("props" in node)) {
+    return null;
+  }
+
+  const element = node as ReactElement<{ children?: ReactNode }>;
+
+  if (element.type === nextIntlMocks.provider) {
+    return element;
+  }
+
+  const children = element.props.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const match = findProviderElement(child);
+      if (match) return match;
+    }
+    return null;
+  }
+
+  return findProviderElement(children);
+}
+
+describe("locale root layout", () => {
+  test("pins next-intl request locale and provider locale to the route segment", async () => {
+    const { default: RootLayout } = await import("@/app/[locale]/layout");
+
+    const tree = await RootLayout({
+      children: <main />,
+      params: Promise.resolve({ locale: "en" }),
+    });
+
+    expect.soft(nextIntlMocks.setRequestLocale).toHaveBeenCalledWith("en");
+    expect(nextIntlMocks.getMessages).toHaveBeenCalledWith({ locale: "en" });
+
+    const provider = findProviderElement(tree);
+    expect.soft(provider?.props).toMatchObject({
+      locale: "en",
+      timeZone: "UTC",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the root layout to properly pin the route segment locale into next-intl's request and client context, preventing cached client navigation from falling back to the wrong language after a language switch.

## Problem
The NEXT_LOCALE cookie was being updated correctly on language switches, but the root layout did not pin the route segment locale into next-intl's request context. This caused cached client navigation to continue treating the previous locale (e.g., zh-CN) as the active locale even after switching to English, resulting in Chinese-prefixed routes being generated incorrectly.

## Solution
1. Call setRequestLocale(locale) after validating the [locale] segment to ensure next-intl request state follows the route locale
2. Pass locale={locale} to NextIntlClientProvider so client navigation and locale-aware links maintain the selected language

## Related PRs
- Follow-up to #1105 - #1105 fixed locale-aware routing at the proxy and pathname normalization level; this PR completes the fix by pinning the locale at the root layout level
- Related to #1096 - Both PRs address locale state persistence in navigation
- Related to #1098 - Part of the broader v0.7 i18n regression fixes

## Changes

### Core Changes
- src/app/[locale]/layout.tsx - Add setRequestLocale(locale) call and pass locale prop to NextIntlClientProvider

### Supporting Changes
- tests/unit/i18n/locale-layout-request-locale.test.tsx (new) - Regression test verifying setRequestLocale is called with the correct locale and that NextIntlClientProvider receives the locale prop

## Verification

### Automated Tests
- bunx vitest run tests/unit/i18n/locale-layout-request-locale.test.tsx --reporter=verbose
- bunx vitest run tests/unit/i18n/locale-pathname.test.ts tests/unit/public-status/public-path.test.ts --reporter=verbose
- All tests pass

### Build & Quality
- bun run typecheck - passed
- bun run lint - passed
- bun run lint:fix - no fixes applied
- bun run build - completed successfully

### Manual Testing
Chrome headless smoke test:
1. Start at /zh-CN/login - Chinese text visible
2. Switch language to English
3. Result: path /en/login, cookie NEXT_LOCALE=en, text Login Panel visible
4. Click Usage Documentation link
5. Result: path remains /en/usage-doc, cookie persists, English docs visible

Screenshot: https://i.111666.best/image/pVELWiOGgizlluUQzKeX1w.png

## Root Cause Detail
NEXT_LOCALE was updated correctly, but the root layout did not pin the route segment locale into next-intl's request/client context. After a language switch, cached client navigation could still treat zh-CN as the active locale and generate Chinese-prefixed routes.

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Unit test added for regression
- [x] Tests pass locally
- [x] Build passes
- [x] Browser smoke test completed
