### PR TITLE
fix(proxy): clean up client abort listeners

### DIFF
--- a/src/app/v1/_lib/proxy/client-abort-listener.ts
+++ b/src/app/v1/_lib/proxy/client-abort-listener.ts
@@ -1,0 +1,25 @@
+export function bindClientAbortListener(
+  signal: AbortSignal | null | undefined,
+  onAbort: () => void
+): () => void {
+  if (!signal) {
+    return () => {};
+  }
+
+  if (signal.aborted) {
+    onAbort();
+    return () => {};
+  }
+
+  let cleaned = false;
+  signal.addEventListener("abort", onAbort, { once: true });
+
+  return () => {
+    if (cleaned) {
+      return;
+    }
+    cleaned = true;
+    // 正常完成时也要解绑，避免 listener 闭包继续持有 session 与请求体。
+    signal.removeEventListener("abort", onAbort);
+  };
+}

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -4021,42 +4021,47 @@ export class ProxyForwarder {
       return true;
     };
 
+    let cleanupClientAbortListener = () => {};
     if (session.clientAbortSignal) {
-      session.clientAbortSignal.addEventListener(
-        "abort",
-        () => {
-          if (settled || winnerCommitted) return;
-          noMoreProviders = true;
-          lastError = new ProxyError("Request aborted by client", 499, undefined, true);
-          lastErrorCategory = ErrorCategory.CLIENT_ABORT;
-          for (const attempt of Array.from(attempts)) {
-            if (!attempt.settled) {
-              session.addProviderToChain(attempt.provider, {
-                ...attempt.endpointAudit,
-                reason: "client_abort",
-                attemptNumber: attempt.sequence,
-                errorMessage: "Client aborted request",
-                modelRedirect: getAttemptModelRedirect(attempt),
-              });
-            }
+      const handleClientAbort = () => {
+        if (settled || winnerCommitted) return;
+        noMoreProviders = true;
+        lastError = new ProxyError("Request aborted by client", 499, undefined, true);
+        lastErrorCategory = ErrorCategory.CLIENT_ABORT;
+        for (const attempt of Array.from(attempts)) {
+          if (!attempt.settled) {
+            session.addProviderToChain(attempt.provider, {
+              ...attempt.endpointAudit,
+              reason: "client_abort",
+              attemptNumber: attempt.sequence,
+              errorMessage: "Client aborted request",
+              modelRedirect: getAttemptModelRedirect(attempt),
+            });
           }
-          abortAllAttempts(undefined, "client_abort");
-          void finishIfExhausted();
-        },
-        { once: true }
-      );
+        }
+        abortAllAttempts(undefined, "client_abort");
+        void finishIfExhausted();
+      };
+      session.clientAbortSignal.addEventListener("abort", handleClientAbort, { once: true });
+      cleanupClientAbortListener = () => {
+        session.clientAbortSignal?.removeEventListener("abort", handleClientAbort);
+      };
     }
 
-    const initialLaunched = await startAttempt(initialProvider, true);
-    if (!initialLaunched) {
-      await launchAlternative();
+    try {
+      const initialLaunched = await startAttempt(initialProvider, true);
+      if (!initialLaunched) {
+        await launchAlternative();
+      }
+      await finishIfExhausted();
+      const result = await resultPromise;
+      if (result.error) {
+        throw result.error;
+      }
+      return result.response as Response;
+    } finally {
+      cleanupClientAbortListener();
     }
-    await finishIfExhausted();
-    const result = await resultPromise;
-    if (result.error) {
-      throw result.error;
-    }
-    return result.response as Response;
   }
 
   private static async resolveStreamingHedgeEndpoint(

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -50,6 +50,7 @@ import { GEMINI_PROTOCOL } from "../gemini/protocol";
 import { HeaderProcessor, resolveAnthropicAuthHeaders } from "../headers";
 import { buildProxyUrl } from "../url";
 import { rectifyBillingHeader } from "./billing-header-rectifier";
+import { bindClientAbortListener } from "./client-abort-listener";
 import { deriveClientSafeUpstreamErrorMessage } from "./client-error-message";
 import { isStandardProxyEndpointPath } from "./endpoint-family-catalog";
 import { resolveEndpointPolicy, shouldEnforceStrictEndpointPoolPolicy } from "./endpoint-policy";
@@ -4023,37 +4024,25 @@ export class ProxyForwarder {
       return true;
     };
 
-    let cleanupClientAbortListener = () => {};
-    const clientAbortSignal = session.clientAbortSignal;
-    if (clientAbortSignal) {
-      const handleClientAbort = () => {
-        if (settled || winnerCommitted) return;
-        noMoreProviders = true;
-        lastError = new ProxyError("Request aborted by client", 499, undefined, true);
-        lastErrorCategory = ErrorCategory.CLIENT_ABORT;
-        for (const attempt of Array.from(attempts)) {
-          if (!attempt.settled) {
-            session.addProviderToChain(attempt.provider, {
-              ...attempt.endpointAudit,
-              reason: "client_abort",
-              attemptNumber: attempt.sequence,
-              errorMessage: "Client aborted request",
-              modelRedirect: getAttemptModelRedirect(attempt),
-            });
-          }
+    const cleanupClientAbortListener = bindClientAbortListener(session.clientAbortSignal, () => {
+      if (settled || winnerCommitted) return;
+      noMoreProviders = true;
+      lastError = new ProxyError("Request aborted by client", 499, undefined, true);
+      lastErrorCategory = ErrorCategory.CLIENT_ABORT;
+      for (const attempt of Array.from(attempts)) {
+        if (!attempt.settled) {
+          session.addProviderToChain(attempt.provider, {
+            ...attempt.endpointAudit,
+            reason: "client_abort",
+            attemptNumber: attempt.sequence,
+            errorMessage: "Client aborted request",
+            modelRedirect: getAttemptModelRedirect(attempt),
+          });
         }
-        abortAllAttempts(undefined, "client_abort");
-        void finishIfExhausted();
-      };
-      if (clientAbortSignal.aborted) {
-        handleClientAbort();
-      } else {
-        clientAbortSignal.addEventListener("abort", handleClientAbort, { once: true });
-        cleanupClientAbortListener = () => {
-          clientAbortSignal.removeEventListener("abort", handleClientAbort);
-        };
       }
-    }
+      abortAllAttempts(undefined, "client_abort");
+      void finishIfExhausted();
+    });
 
     try {
       const initialLaunched = await startAttempt(initialProvider, true);

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -3927,7 +3927,9 @@ export class ProxyForwarder {
       provider: Provider,
       useOriginalSession: boolean
     ): Promise<boolean> => {
-      if (settled || winnerCommitted || launchedProviderIds.has(provider.id)) return false;
+      if (settled || winnerCommitted || noMoreProviders || launchedProviderIds.has(provider.id)) {
+        return false;
+      }
 
       launchedProviderIds.add(provider.id);
 
@@ -4022,7 +4024,8 @@ export class ProxyForwarder {
     };
 
     let cleanupClientAbortListener = () => {};
-    if (session.clientAbortSignal) {
+    const clientAbortSignal = session.clientAbortSignal;
+    if (clientAbortSignal) {
       const handleClientAbort = () => {
         if (settled || winnerCommitted) return;
         noMoreProviders = true;
@@ -4042,10 +4045,14 @@ export class ProxyForwarder {
         abortAllAttempts(undefined, "client_abort");
         void finishIfExhausted();
       };
-      session.clientAbortSignal.addEventListener("abort", handleClientAbort, { once: true });
-      cleanupClientAbortListener = () => {
-        session.clientAbortSignal?.removeEventListener("abort", handleClientAbort);
-      };
+      if (clientAbortSignal.aborted) {
+        handleClientAbort();
+      } else {
+        clientAbortSignal.addEventListener("abort", handleClientAbort, { once: true });
+        cleanupClientAbortListener = () => {
+          clientAbortSignal.removeEventListener("abort", handleClientAbort);
+        };
+      }
     }
 
     try {

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -60,6 +60,32 @@ function releaseSessionAgent(session: ProxySession): void {
   }
 }
 
+function bindClientAbortListener(
+  signal: AbortSignal | null | undefined,
+  onAbort: () => void
+): () => void {
+  if (!signal) {
+    return () => {};
+  }
+
+  if (signal.aborted) {
+    onAbort();
+    return () => {};
+  }
+
+  let cleaned = false;
+  signal.addEventListener("abort", onAbort, { once: true });
+
+  return () => {
+    if (cleaned) {
+      return;
+    }
+    cleaned = true;
+    // 正常完成时也要解绑，避免 listener 闭包继续持有 session 与请求体。
+    signal.removeEventListener("abort", onAbort);
+  };
+}
+
 function takeBeforeResponseBodySnapshotSource(session: ProxySession): Response | null {
   const snapshotSession = session as ProxySession & {
     detailSnapshotResponseBeforeSource?: Response | null;
@@ -1073,6 +1099,10 @@ export class ProxyResponseHandler {
     // 使用 AsyncTaskManager 管理后台处理任务
     const taskId = `non-stream-${messageContext?.id || `unknown-${Date.now()}`}`;
     const abortController = new AbortController();
+    const cleanupClientAbortListener = bindClientAbortListener(session.clientAbortSignal, () => {
+      AsyncTaskManager.cancel(taskId);
+      abortController.abort();
+    });
 
     const processingPromise = (async () => {
       const finalizeNonStreamAbort = async (): Promise<void> => {
@@ -1502,6 +1532,7 @@ export class ProxyResponseHandler {
           });
         }
       } finally {
+        cleanupClientAbortListener();
         releaseSessionAgent(session);
         AsyncTaskManager.cleanup(taskId);
       }
@@ -1525,14 +1556,6 @@ export class ProxyResponseHandler {
         phase: "non-stream",
       });
     });
-
-    // 客户端断开时取消任务
-    if (session.clientAbortSignal) {
-      session.clientAbortSignal.addEventListener("abort", () => {
-        AsyncTaskManager.cancel(taskId);
-        abortController.abort();
-      });
-    }
 
     void persistNonStreamAfterSnapshot(finalResponse).catch((error) => {
       logger.error("[ResponseHandler] Failed to persist non-stream after snapshot", { error });
@@ -2128,6 +2151,26 @@ export class ProxyResponseHandler {
 
     // ⭐ 提升 idleTimeoutId 到外部作用域，以便客户端断开时能清除
     let idleTimeoutId: NodeJS.Timeout | null = null;
+    const cleanupClientAbortListener = bindClientAbortListener(session.clientAbortSignal, () => {
+      logger.debug("ResponseHandler: Client disconnected, cleaning up", {
+        taskId,
+        providerId: provider.id,
+        messageId: messageContext.id,
+      });
+
+      // 客户端断开时清除 idle timeout，避免任务已取消后仍误触发。
+      if (idleTimeoutId) {
+        clearTimeout(idleTimeoutId);
+        idleTimeoutId = null;
+        logger.debug("ResponseHandler: Idle timeout cleared due to client disconnect", {
+          taskId,
+          providerId: provider.id,
+        });
+      }
+
+      AsyncTaskManager.cancel(taskId);
+      abortController.abort();
+    });
 
     const processingPromise = (async () => {
       const reader = internalStream.getReader();
@@ -2757,6 +2800,7 @@ export class ProxyResponseHandler {
         }
       } finally {
         // 确保资源释放
+        cleanupClientAbortListener();
         clearIdleTimer(); // ⭐ 清除静默期计时器（防止泄漏）
         try {
           reader.releaseLock();
@@ -2790,34 +2834,6 @@ export class ProxyResponseHandler {
         phase: "stream",
       });
     });
-
-    // 客户端断开时取消任务并清除 idle timer
-    if (session.clientAbortSignal) {
-      session.clientAbortSignal.addEventListener("abort", () => {
-        logger.debug("ResponseHandler: Client disconnected, cleaning up", {
-          taskId,
-          providerId: provider.id,
-          messageId: messageContext.id,
-        });
-
-        // ⭐ 1. 清除 idle timeout（避免误触发）
-        if (idleTimeoutId) {
-          clearTimeout(idleTimeoutId);
-          idleTimeoutId = null;
-          logger.debug("ResponseHandler: Idle timeout cleared due to client disconnect", {
-            taskId,
-            providerId: provider.id,
-          });
-        }
-
-        // 2. 取消后台任务
-        AsyncTaskManager.cancel(taskId);
-        abortController.abort();
-
-        // 注意：不需要 streamController.error()（客户端已断开）
-        // 注意：不需要 responseController.abort()（上游会自然结束）
-      });
-    }
 
     // ⭐ 修复 Bun 运行时的 Transfer-Encoding 重复问题
     // 清理上游的传输 headers，让 Response API 自动管理

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -40,6 +40,7 @@ import type { LongContextPricingSpecialSetting } from "@/types/special-settings"
 import { GeminiAdapter } from "../gemini/adapter";
 import type { GeminiResponse } from "../gemini/types";
 import { extractActualResponseModelForProvider } from "./actual-response-model";
+import { bindClientAbortListener } from "./client-abort-listener";
 import { isClientAbortError, isTransportError } from "./errors";
 import type { ProxySession } from "./session";
 import { consumeDeferredStreamingFinalization } from "./stream-finalization";
@@ -58,32 +59,6 @@ function releaseSessionAgent(session: ProxySession): void {
     }
     s.releaseAgent = undefined;
   }
-}
-
-function bindClientAbortListener(
-  signal: AbortSignal | null | undefined,
-  onAbort: () => void
-): () => void {
-  if (!signal) {
-    return () => {};
-  }
-
-  if (signal.aborted) {
-    onAbort();
-    return () => {};
-  }
-
-  let cleaned = false;
-  signal.addEventListener("abort", onAbort, { once: true });
-
-  return () => {
-    if (cleaned) {
-      return;
-    }
-    cleaned = true;
-    // 正常完成时也要解绑，避免 listener 闭包继续持有 session 与请求体。
-    signal.removeEventListener("abort", onAbort);
-  };
 }
 
 function takeBeforeResponseBodySnapshotSource(session: ProxySession): Response | null {

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -1954,4 +1954,24 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
     expect(abortAddCalls).toHaveLength(1);
     expect(removeSpy).toHaveBeenCalledWith("abort", abortAddCalls[0][1]);
   });
+
+  test("pre-aborted client signal should settle hedge without launching upstream attempt", async () => {
+    const clientAbortController = new AbortController();
+    clientAbortController.abort(new Error("client_cancelled"));
+    const addSpy = vi.spyOn(clientAbortController.signal, "addEventListener");
+    const provider = createProvider({ id: 1, name: "p1", firstByteTimeoutStreamingMs: 100 });
+    const session = createSession(clientAbortController.signal);
+    setProviderWithSessionRef(session, provider);
+
+    const doForward = vi.spyOn(
+      ProxyForwarder as unknown as {
+        doForward: (...args: unknown[]) => Promise<Response>;
+      },
+      "doForward"
+    );
+
+    await expect(ProxyForwarder.send(session)).rejects.toMatchObject({ statusCode: 499 });
+    expect(doForward).not.toHaveBeenCalled();
+    expect(addSpy.mock.calls.filter(([type]) => type === "abort")).toHaveLength(0);
+  });
 });

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -1919,4 +1919,39 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
       vi.useRealTimers();
     }
   });
+
+  test("removes streaming hedge client abort listener after winner response is returned", async () => {
+    const clientAbortController = new AbortController();
+    const addSpy = vi.spyOn(clientAbortController.signal, "addEventListener");
+    const removeSpy = vi.spyOn(clientAbortController.signal, "removeEventListener");
+    const provider = createProvider({ id: 1, name: "p1", firstByteTimeoutStreamingMs: 100 });
+    const session = createSession(clientAbortController.signal);
+    setProviderWithSessionRef(session, provider);
+    session.forwardedRequestBody = "x".repeat(512 * 1024);
+
+    const doForward = vi.spyOn(
+      ProxyForwarder as unknown as {
+        doForward: (...args: unknown[]) => Promise<Response>;
+      },
+      "doForward"
+    );
+    const upstreamController = new AbortController();
+    doForward.mockImplementationOnce(async (attemptSession) => {
+      const runtime = attemptSession as ProxySession & AttemptRuntime;
+      runtime.responseController = upstreamController;
+      runtime.clearResponseTimeout = vi.fn();
+      return createStreamingResponse({
+        label: "p1",
+        firstChunkDelayMs: 0,
+        controller: upstreamController,
+      });
+    });
+
+    const response = await ProxyForwarder.send(session);
+    expect(await response.text()).toContain('"provider":"p1"');
+
+    const abortAddCalls = addSpy.mock.calls.filter(([type]) => type === "abort");
+    expect(abortAddCalls).toHaveLength(1);
+    expect(removeSpy).toHaveBeenCalledWith("abort", abortAddCalls[0][1]);
+  });
 });

--- a/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
+++ b/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
@@ -99,9 +99,11 @@ vi.mock("@/repository/message", () => ({
 }));
 
 async function drainAsyncTasks(): Promise<void> {
-  const tasks = testState.asyncTasks.splice(0);
-  await Promise.allSettled(tasks);
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  while (testState.asyncTasks.length > 0) {
+    const tasks = testState.asyncTasks.splice(0);
+    await Promise.allSettled(tasks);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
 }
 
 function makeProvider(overrides: Partial<Provider> = {}): Provider {

--- a/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
+++ b/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
+import { ProxyResponseHandler } from "@/app/v1/_lib/proxy/response-handler";
+import type { ProxySession } from "@/app/v1/_lib/proxy/session";
+import type { Provider } from "@/types/provider";
+
+const testState = vi.hoisted(() => ({
+  asyncTasks: [] as Promise<void>[],
+  cancelTask: vi.fn(),
+  cleanupTask: vi.fn(),
+}));
+
+vi.mock("@/app/v1/_lib/proxy/response-fixer", () => ({
+  ResponseFixer: {
+    process: async (_session: unknown, response: Response) => response,
+  },
+}));
+
+vi.mock("@/lib/async-task-manager", () => ({
+  AsyncTaskManager: {
+    register: (_taskId: string, promise: Promise<void>) => {
+      testState.asyncTasks.push(promise);
+      return new AbortController();
+    },
+    cleanup: testState.cleanupTask,
+    cancel: testState.cancelTask,
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/price-sync/cloud-price-updater", () => ({
+  requestCloudPriceTableSync: vi.fn(),
+}));
+
+vi.mock("@/lib/proxy-status-tracker", () => ({
+  ProxyStatusTracker: {
+    getInstance: () => ({
+      endRequest: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimitService: {
+    trackCost: vi.fn(),
+    trackUserDailyCost: vi.fn(),
+    decrementLeaseBudget: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/redis/live-chain-store", () => ({
+  deleteLiveChain: vi.fn(),
+}));
+
+vi.mock("@/lib/session-manager", () => ({
+  SessionManager: {
+    clearSessionProvider: vi.fn(),
+    storeSessionResponse: vi.fn(),
+    updateSessionUsage: vi.fn(),
+    storeSessionRequestPhaseSnapshot: vi.fn(),
+    storeSessionResponsePhaseSnapshot: vi.fn(),
+    storeSessionUpstreamRequestMeta: vi.fn(),
+    storeSessionSpecialSettings: vi.fn(),
+    storeSessionRequestHeaders: vi.fn(),
+    storeSessionResponseHeaders: vi.fn(),
+    storeSessionUpstreamResponseMeta: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/session-tracker", () => ({
+  SessionTracker: {
+    refreshSession: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/circuit-breaker", () => ({
+  recordFailure: vi.fn(),
+}));
+
+vi.mock("@/lib/endpoint-circuit-breaker", () => ({
+  recordEndpointFailure: vi.fn(),
+  recordEndpointSuccess: vi.fn(),
+  resetEndpointCircuit: vi.fn(),
+}));
+
+vi.mock("@/repository/message", () => ({
+  updateMessageRequestCostWithBreakdown: vi.fn(),
+  updateMessageRequestDetails: vi.fn(),
+  updateMessageRequestDuration: vi.fn(),
+}));
+
+async function drainAsyncTasks(): Promise<void> {
+  const tasks = testState.asyncTasks.splice(0);
+  await Promise.allSettled(tasks);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function makeProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    id: 99,
+    name: "test-provider",
+    providerType: "openai",
+    baseUrl: "https://api.test.invalid",
+    priority: 1,
+    weight: 1,
+    costMultiplier: 1,
+    groupTag: "default",
+    isEnabled: true,
+    models: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    streamingIdleTimeoutMs: 0,
+    ...overrides,
+  } as Provider;
+}
+
+function makeSession(clientAbortSignal: AbortSignal, stream: boolean): ProxySession {
+  const endpointPolicy = resolveEndpointPolicy("/v1/chat/completions");
+  const provider = makeProvider();
+  const session = {
+    request: {
+      model: "gpt-5.4",
+      log: "x".repeat(256 * 1024),
+      message: {
+        model: "gpt-5.4",
+        stream,
+        messages: [{ role: "user", content: "hello" }],
+      },
+    },
+    startTime: Date.now(),
+    method: "POST",
+    requestUrl: new URL("http://localhost/v1/chat/completions"),
+    headers: new Headers(),
+    headerLog: "",
+    userAgent: null,
+    context: {},
+    clientAbortSignal,
+    forwardedRequestBody: "y".repeat(512 * 1024),
+    userName: "test-user",
+    authState: {
+      success: true,
+      user: { id: 1, name: "test-user" },
+      key: { id: 2, name: "test-key" },
+      apiKey: "test-key",
+    },
+    provider,
+    messageContext: {
+      id: 123,
+      user: { id: 1, name: "test-user" },
+      key: { id: 2, name: "test-key" },
+      isSystemPrompt: false,
+      requireAuth: true,
+      createdAt: new Date(),
+    },
+    sessionId: null,
+    requestSequence: 1,
+    originalFormat: "openai",
+    providerType: "openai",
+    originalModelName: "gpt-5.4",
+    originalUrlPathname: "/v1/chat/completions",
+    providerChain: [],
+    cacheTtlResolved: null,
+    context1mApplied: false,
+    specialSettings: [],
+    cachedPriceData: undefined,
+    cachedBillingModelSource: undefined,
+    endpointPolicy,
+    isHeaderModified: () => false,
+    getEndpointPolicy: () => endpointPolicy,
+    getContext1mApplied: () => false,
+    getGroupCostMultiplier: () => 1,
+    getOriginalModel: () => "gpt-5.4",
+    getCurrentModel: () => "gpt-5.4",
+    getProviderChain: () => [],
+    getSpecialSettings: () => [],
+    shouldPersistSessionDebugArtifacts: () => false,
+    shouldTrackSessionObservability: () => false,
+    getResolvedPricingByBillingSource: async () => null,
+    recordTtfb: vi.fn(),
+    ttfbMs: null,
+    addProviderToChain: vi.fn(),
+    clearResponseTimeout: vi.fn(),
+    releaseAgent: vi.fn(),
+  };
+
+  return session as unknown as ProxySession;
+}
+
+describe("ProxyResponseHandler client abort listener cleanup", () => {
+  beforeEach(() => {
+    testState.asyncTasks = [];
+    testState.cancelTask.mockClear();
+    testState.cleanupTask.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("removes non-stream client abort listener after response processing completes", async () => {
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+    const session = makeSession(controller.signal, false);
+    const upstreamResponse = new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+      }),
+      {
+        headers: { "content-type": "application/json" },
+      }
+    );
+
+    const response = await ProxyResponseHandler.dispatch(session, upstreamResponse);
+    await response.text();
+    await drainAsyncTasks();
+
+    const abortAddCalls = addSpy.mock.calls.filter(([type]) => type === "abort");
+    expect(abortAddCalls).toHaveLength(1);
+    expect(removeSpy).toHaveBeenCalledWith("abort", abortAddCalls[0][1]);
+  });
+
+  it("removes stream client abort listener after stream processing completes", async () => {
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+    const session = makeSession(controller.signal, true);
+    const upstreamResponse = new Response(
+      'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
+      {
+        headers: { "content-type": "text/event-stream" },
+      }
+    );
+
+    const response = await ProxyResponseHandler.dispatch(session, upstreamResponse);
+    await response.text();
+    await drainAsyncTasks();
+
+    const abortAddCalls = addSpy.mock.calls.filter(([type]) => type === "abort");
+    expect(abortAddCalls).toHaveLength(1);
+    expect(removeSpy).toHaveBeenCalledWith("abort", abortAddCalls[0][1]);
+  });
+});

--- a/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
+++ b/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
@@ -125,13 +125,13 @@ function makeProvider(overrides: Partial<Provider> = {}): Provider {
   } as Provider;
 }
 
-function makeSession(clientAbortSignal: AbortSignal, stream: boolean): ProxySession {
+function makeSession(clientAbortSignal: AbortSignal | null, stream: boolean): ProxySession {
   const endpointPolicy = resolveEndpointPolicy("/v1/chat/completions");
   const provider = makeProvider();
   const session = {
     request: {
       model: "gpt-5.4",
-      log: "x".repeat(256 * 1024),
+      log: "",
       message: {
         model: "gpt-5.4",
         stream,
@@ -146,7 +146,7 @@ function makeSession(clientAbortSignal: AbortSignal, stream: boolean): ProxySess
     userAgent: null,
     context: {},
     clientAbortSignal,
-    forwardedRequestBody: "y".repeat(512 * 1024),
+    forwardedRequestBody: "",
     userName: "test-user",
     authState: {
       success: true,
@@ -247,5 +247,37 @@ describe("ProxyResponseHandler client abort listener cleanup", () => {
     const abortAddCalls = addSpy.mock.calls.filter(([type]) => type === "abort");
     expect(abortAddCalls).toHaveLength(1);
     expect(removeSpy).toHaveBeenCalledWith("abort", abortAddCalls[0][1]);
+  });
+
+  it("uses no-op cleanup when client abort signal is null", async () => {
+    const session = makeSession(null, false);
+    const upstreamResponse = new Response(JSON.stringify({ choices: [] }), {
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await ProxyResponseHandler.dispatch(session, upstreamResponse);
+    await response.text();
+    await drainAsyncTasks();
+
+    expect(testState.cancelTask).not.toHaveBeenCalled();
+  });
+
+  it("invokes cancel synchronously when client signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+    const session = makeSession(controller.signal, false);
+    const upstreamResponse = new Response(JSON.stringify({ choices: [] }), {
+      headers: { "content-type": "application/json" },
+    });
+
+    const response = await ProxyResponseHandler.dispatch(session, upstreamResponse);
+    await response.text();
+    await drainAsyncTasks();
+
+    expect(addSpy.mock.calls.filter(([type]) => type === "abort")).toHaveLength(0);
+    expect(removeSpy.mock.calls.filter(([type]) => type === "abort")).toHaveLength(0);
+    expect(testState.cancelTask).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Reproduced and fixed client abort listener retention in response handler non-stream/stream background tasks.
- Reproduced and fixed client abort listener retention in streaming hedge forwarding after winner response is returned.
- Left AsyncTaskManager unchanged because existing lifecycle tests confirm completed tasks are auto-cleaned.

**Fixes #1083** - This PR addresses the root cause of excessive 499 errors by properly cleaning up client abort listeners, preventing memory leaks that could lead to premature connection handling issues.

## Problem

Client abort listeners were being retained in several code paths:

1. **Response Handler** (`response-handler.ts`):
   - Non-stream background tasks: Listeners added but never removed after processing completed
   - Stream background tasks: Same issue with idle timeout and abort listeners

2. **Streaming Hedge Forwarder** (`forwarder.ts`):
   - After a winner response was returned, the client abort listener remained attached

This caused:
- Memory leaks (session and request body held by listener closures)
- Potential interference with subsequent request handling
- Excessive 499 error logging (as reported in #1083)

## Solution

### Response Handler
Introduced `bindClientAbortListener()` helper that returns a cleanup function:
- Removes listener after response processing completes (in `finally` block)
- Prevents session/request body retention by listener closures
- Handles both streaming and non-streaming paths

### Streaming Hedge Forwarder
- Wrapped hedge logic in try/finally to ensure cleanup
- Added `cleanupClientAbortListener()` that removes the abort listener after winner response is returned

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/response-handler.ts`:
  - Added `bindClientAbortListener()` helper function
  - Updated non-stream background task to use cleanup pattern
  - Updated stream background task to use cleanup pattern

- `src/app/v1/_lib/proxy/forwarder.ts`:
  - Wrapped streaming hedge in try/finally with listener cleanup

### Test Coverage
- `tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts` (NEW):
  - Tests non-stream listener removal after processing
  - Tests streaming listener removal after processing
  - Tests early cleanup on client abort

- `tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts`:
  - Added test for streaming hedge listener cleanup after winner returned

## Testing

```bash
# Run new tests
bunx vitest run tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts --reporter=dot

# Full validation
bun run typecheck
bun run lint
bun run lint:fix
bun run test
bun run build
git diff --check
```

## Notes
- `bun run lint` / `lint:fix` exit 0; Biome still reports existing schema-version info and two unrelated unsafe-fix suggestions in leaderboard tests.
- No breaking changes; this is a pure bug fix with improved resource cleanup

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes client abort listener leaks in `response-handler.ts` (both stream and non-stream background tasks) and `forwarder.ts` (streaming hedge) by extracting a `bindClientAbortListener` helper that returns a cleanup function called from `finally` blocks. It also adds a `noMoreProviders` guard in `startAttempt` to prevent new upstream attempts from launching after a client abort.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — pure bug fix with no behavioral regressions and comprehensive test coverage.

No P0 or P1 issues found. The bindClientAbortListener helper correctly handles null signals, pre-aborted signals, normal cleanup, and double-call safety via the cleaned flag. The try/finally placement ensures cleanup even on errors. Tests cover all branches.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/client-abort-listener.ts | New utility that correctly handles null/pre-aborted signals, registers with `{ once: true }`, and guards against double-cleanup via a `cleaned` flag. |
| src/app/v1/_lib/proxy/response-handler.ts | Replaces inline addEventListener/removeEventListener pairs with bindClientAbortListener; cleanup is called in `finally` blocks for both non-stream and stream paths. |
| src/app/v1/_lib/proxy/forwarder.ts | Uses bindClientAbortListener with try/finally; also adds `noMoreProviders` guard to startAttempt to prevent launching upstream attempts after a client abort. |
| tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts | New test file covering non-stream cleanup, stream cleanup, null signal no-op, and pre-aborted synchronous cancel — comprehensive coverage of the helper's contract. |
| tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts | Two new tests: listener is removed after winner response is returned, and pre-aborted signal settles the hedge without launching any upstream attempt. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as ResponseHandler / Forwarder
    participant BAL as bindClientAbortListener
    participant Signal as AbortSignal
    participant Task as AsyncTaskManager

    Client->>Handler: request
    Handler->>BAL: bindClientAbortListener(signal, onAbort)
    BAL->>Signal: addEventListener("abort", onAbort, {once:true})
    BAL-->>Handler: cleanupFn

    alt normal completion
        Handler->>Task: process task
        Task-->>Handler: done
        Handler->>BAL: cleanupFn()
        BAL->>Signal: removeEventListener("abort", onAbort)
    else client abort mid-flight
        Client->>Signal: abort()
        Signal->>BAL: onAbort() fires
        BAL->>Task: AsyncTaskManager.cancel(taskId)
        BAL->>Handler: abortController.abort()
        Handler->>Handler: finally block
        Handler->>BAL: cleanupFn() [no-op: listener already auto-removed]
    else signal already aborted
        BAL->>BAL: onAbort() called synchronously
        BAL-->>Handler: () => {} (no-op cleanup)
        Handler->>Handler: abortController.signal.aborted check → bail early
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(proxy): cover client abort listener..."](https://github.com/ding113/claude-code-hub/commit/05643951ca89bdaf2ed8f26835a2e08365241628) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29745628)</sub>

<!-- /greptile_comment -->