### PR TITLE
test(proxy): cover pre-aborted abort listener review

### DIFF
--- a/src/app/v1/_lib/proxy/client-abort-listener.ts
+++ b/src/app/v1/_lib/proxy/client-abort-listener.ts
@@ -1,3 +1,9 @@
+/**
+ * 绑定客户端中止监听器，返回幂等清理函数。
+ *
+ * 注意：如果传入的 signal 已经 aborted，会在当前调用栈同步执行 onAbort。
+ * 调用方必须先初始化 onAbort 闭包会访问的控制器、任务 ID 等资源。
+ */
 export function bindClientAbortListener(
   signal: AbortSignal | null | undefined,
   onAbort: () => void

--- a/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
+++ b/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
@@ -286,7 +286,6 @@ describe("ProxyResponseHandler client abort listener cleanup", () => {
     controller.abort();
     const addSpy = vi.spyOn(controller.signal, "addEventListener");
     const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
-    const localAbortSpy = vi.spyOn(AbortController.prototype, "abort");
     const session = makeSession(controller.signal, true);
     const upstreamResponse = new Response(
       'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
@@ -302,6 +301,5 @@ describe("ProxyResponseHandler client abort listener cleanup", () => {
     expect(addSpy.mock.calls.filter(([type]) => type === "abort")).toHaveLength(0);
     expect(removeSpy.mock.calls.filter(([type]) => type === "abort")).toHaveLength(0);
     expect(testState.cancelTask).toHaveBeenCalledTimes(1);
-    expect(localAbortSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
+++ b/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
@@ -110,7 +110,7 @@ function makeProvider(overrides: Partial<Provider> = {}): Provider {
   return {
     id: 99,
     name: "test-provider",
-    providerType: "openai",
+    providerType: "openai-compatible",
     baseUrl: "https://api.test.invalid",
     priority: 1,
     weight: 1,
@@ -166,7 +166,7 @@ function makeSession(clientAbortSignal: AbortSignal | null, stream: boolean): Pr
     sessionId: null,
     requestSequence: 1,
     originalFormat: "openai",
-    providerType: "openai",
+    providerType: "openai-compatible",
     originalModelName: "gpt-5.4",
     originalUrlPathname: "/v1/chat/completions",
     providerChain: [],
@@ -279,5 +279,29 @@ describe("ProxyResponseHandler client abort listener cleanup", () => {
     expect(addSpy.mock.calls.filter(([type]) => type === "abort")).toHaveLength(0);
     expect(removeSpy.mock.calls.filter(([type]) => type === "abort")).toHaveLength(0);
     expect(testState.cancelTask).toHaveBeenCalled();
+  });
+
+  it("invokes stream cancel once when client signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+    const localAbortSpy = vi.spyOn(AbortController.prototype, "abort");
+    const session = makeSession(controller.signal, true);
+    const upstreamResponse = new Response(
+      'data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n',
+      {
+        headers: { "content-type": "text/event-stream" },
+      }
+    );
+
+    const response = await ProxyResponseHandler.dispatch(session, upstreamResponse);
+    await response.text();
+    await drainAsyncTasks();
+
+    expect(addSpy.mock.calls.filter(([type]) => type === "abort")).toHaveLength(0);
+    expect(removeSpy.mock.calls.filter(([type]) => type === "abort")).toHaveLength(0);
+    expect(testState.cancelTask).toHaveBeenCalledTimes(1);
+    expect(localAbortSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
Documentation and test coverage improvements for pre-aborted abort listener handling in the proxy pipeline. This is a follow-up PR addressing review feedback from #1113.

## Related Issues & PRs
- **Follow-up to #1113** - Addresses review feedback after the client abort listener cleanup fix was merged
- **Related to #1083** - The original issue about excessive 499 errors caused by abort listener memory leaks

## Changes

### Documentation
- Added inline documentation to `bindClientAbortListener()` explaining synchronous `onAbort` invocation for pre-aborted signals
- Documented the requirement for callers to initialize resources before calling the function

### Test Improvements
- **Fixed test fixture**: Aligned `Provider.providerType` values with the real union type (`"openai-compatible"` instead of `"openai"`)
- **Added new test case**: `invokes stream cancel once when client signal is already aborted`
  - Verifies that when a client signal is already aborted, no event listeners are registered
  - Ensures `cancelTask` is called exactly once and `localAbort` fires once
  - Covers the edge case where cleanup is a no-op because `onAbort` was invoked synchronously

## Files Changed
| File | Changes |
|------|---------|
| `src/app/v1/_lib/proxy/client-abort-listener.ts` | Added JSDoc comments documenting pre-aborted behavior |
| `tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts` | Fixed providerType values; added pre-aborted signal test case |

## Validation
```bash
# Run the specific new tests
bunx vitest run tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts tests/unit/lib/async-task-manager-edge-runtime.test.ts --reporter=dot

# Full check
bun run build
bun run lint
bun run lint:fix
bun run typecheck
bun run test
```

## Checklist
- [x] Documentation added for pre-aborted signal behavior
- [x] Test coverage added for pre-aborted cleanup path
- [x] Test fixtures aligned with actual type definitions
- [x] All validation commands pass

---
*This PR addresses review feedback from #1113 to ensure complete test coverage of edge cases in the abort listener lifecycle.*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This follow-up PR adds a JSDoc comment to `bindClientAbortListener` documenting its synchronous-invocation behavior for pre-aborted signals, fixes `providerType` fixture values (`"openai"` → `"openai-compatible"`), and adds a new test case covering the streaming + pre-aborted signal edge case.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — documentation and test-only changes with no production logic modifications.

No production logic was changed; changes are limited to a JSDoc comment and test improvements. The only finding is a P2 style inconsistency between two assertion strengths in the test file.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/client-abort-listener.ts | Added JSDoc comment (in Chinese, consistent with existing inline comments) documenting synchronous onAbort invocation for pre-aborted signals and caller initialization requirement; no logic changes. |
| tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts | Fixed providerType fixture values from "openai" to "openai-compatible"; added new test covering streaming + pre-aborted signal path. Minor inconsistency: old pre-aborted test uses toHaveBeenCalled() while new test uses toHaveBeenCalledTimes(1) for the same behavioral contract. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bindClientAbortListener called] --> B{signal null/undefined?}
    B -- yes --> C[return no-op cleanup]
    B -- no --> D{signal.aborted?}
    D -- yes --> E[invoke onAbort synchronously]
    E --> F[return no-op cleanup]
    D -- no --> G[addEventListener abort, once:true]
    G --> H[return idempotent cleanup fn]
    H --> I{cleanup called?}
    I -- yes --> J[removeEventListener abort]
    I -- already cleaned --> K[no-op]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
Line: 281

Comment:
**Weaker assertion in the analogous non-stream pre-aborted test**

The existing non-stream pre-aborted test uses `toHaveBeenCalled()` (≥ 1 time) while the new stream test uses `toHaveBeenCalledTimes(1)` (exactly once). Both paths exercise the same `bindClientAbortListener` synchronous-invoke branch, so `cancelTask` should fire exactly once in both cases. Consider tightening the older assertion for consistency and to catch any future double-invocation regression on the non-stream path.

```suggestion
    expect(testState.cancelTask).toHaveBeenCalledTimes(1);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(proxy): avoid global abort prototyp..."](https://github.com/ding113/claude-code-hub/commit/1b5e31ff8fceb75896fcbf8fd15435111ad71816) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29747133)</sub>

<!-- /greptile_comment -->