### PR TITLE
fix(i18n): refresh server chrome on locale switch

### DIFF
--- a/src/app/[locale]/dashboard/_components/dashboard-header.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-header.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 import { VersionUpdateNotifier } from "@/components/customs/version-update-notifier";
 import { Button } from "@/components/ui/button";
 import { LanguageSwitcher } from "@/components/ui/language-switcher";
@@ -11,10 +11,11 @@ import { UserMenu } from "./user-menu";
 
 interface DashboardHeaderProps {
   session: AuthSession | null;
+  locale: string;
 }
 
-export function DashboardHeader({ session }: DashboardHeaderProps) {
-  const t = useTranslations("dashboard.nav");
+export async function DashboardHeader({ session, locale }: DashboardHeaderProps) {
+  const t = await getTranslations({ locale, namespace: "dashboard.nav" });
   const isAdmin = session?.user.role === "admin";
 
   const NAV_ITEMS: (DashboardNavItem & { adminOnly?: boolean })[] = [

--- a/src/app/[locale]/dashboard/_components/dashboard-sections.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-sections.tsx
@@ -32,7 +32,13 @@ export async function DashboardStatisticsSection() {
   );
 }
 
-export async function DashboardLeaderboardSection({ isAdmin }: { isAdmin: boolean }) {
+export async function DashboardLeaderboardSection({
+  isAdmin,
+  locale,
+}: {
+  isAdmin: boolean;
+  locale: string;
+}) {
   const systemSettings = await getCachedSystemSettings();
   const canViewLeaderboard = isAdmin || systemSettings.allowGlobalUsageView;
 
@@ -40,7 +46,7 @@ export async function DashboardLeaderboardSection({ isAdmin }: { isAdmin: boolea
     return null;
   }
 
-  const t = await getTranslations("dashboard");
+  const t = await getTranslations({ locale, namespace: "dashboard" });
 
   return (
     <div className="space-y-4">

--- a/src/app/[locale]/dashboard/audit-logs/page.tsx
+++ b/src/app/[locale]/dashboard/audit-logs/page.tsx
@@ -17,7 +17,7 @@ export default async function AuditLogsPage({ params }: { params: Promise<{ loca
     return redirect({ href: "/dashboard", locale });
   }
 
-  const t = await getTranslations("auditLogs");
+  const t = await getTranslations({ locale, namespace: "auditLogs" });
 
   return (
     <div className="space-y-6">

--- a/src/app/[locale]/dashboard/availability/page.tsx
+++ b/src/app/[locale]/dashboard/availability/page.tsx
@@ -10,8 +10,13 @@ import { AvailabilityDashboardSkeleton } from "./_components/availability-skelet
 
 export const dynamic = "force-dynamic";
 
-export default async function AvailabilityPage() {
-  const t = await getTranslations("dashboard");
+export default async function AvailabilityPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "dashboard" });
   const session = await getSession();
 
   // Only admin can access availability monitoring

--- a/src/app/[locale]/dashboard/layout.tsx
+++ b/src/app/[locale]/dashboard/layout.tsx
@@ -28,7 +28,7 @@ export default async function DashboardLayout({
 
   return (
     <div className="min-h-[var(--cch-viewport-height,100vh)] bg-background">
-      <DashboardHeader session={session} />
+      <DashboardHeader session={session} locale={locale} />
       <DashboardMain>{children}</DashboardMain>
       <WebhookMigrationDialog />
     </div>

--- a/src/app/[locale]/dashboard/leaderboard/page.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/page.tsx
@@ -10,8 +10,9 @@ import { LeaderboardView } from "./_components/leaderboard-view";
 
 export const dynamic = "force-dynamic";
 
-export default async function LeaderboardPage() {
-  const t = await getTranslations("dashboard");
+export default async function LeaderboardPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "dashboard" });
   // 获取用户 session 和系统设置
   const session = await getSession();
   const systemSettings = await getSystemSettings();

--- a/src/app/[locale]/dashboard/my-quota/page.tsx
+++ b/src/app/[locale]/dashboard/my-quota/page.tsx
@@ -9,13 +9,13 @@ export const dynamic = "force-dynamic";
 
 export default async function MyQuotaPage({ params }: { params: Promise<{ locale: string }> }) {
   // Await params to ensure locale is available in the async context
-  await params;
+  const { locale } = await params;
 
   const [quotaResult, systemSettings, tNav, tCommon] = await Promise.all([
     getMyQuota(),
     getSystemSettings(),
-    getTranslations("dashboard.nav"),
-    getTranslations("common"),
+    getTranslations({ locale, namespace: "dashboard.nav" }),
+    getTranslations({ locale, namespace: "common" }),
   ]);
 
   // Handle error state

--- a/src/app/[locale]/dashboard/providers/page.tsx
+++ b/src/app/[locale]/dashboard/providers/page.tsx
@@ -30,7 +30,7 @@ export default async function DashboardProvidersPage({
   // TypeScript: session is guaranteed to be non-null after the redirect check
   const currentUser = session!.user;
 
-  const t = await getTranslations("settings");
+  const t = await getTranslations({ locale, namespace: "settings" });
   const providers = await getProviders();
 
   return (

--- a/src/app/[locale]/dashboard/quotas/layout.tsx
+++ b/src/app/[locale]/dashboard/quotas/layout.tsx
@@ -2,8 +2,15 @@ import { getTranslations } from "next-intl/server";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Link } from "@/i18n/routing";
 
-export default async function QuotasLayout({ children }: { children: React.ReactNode }) {
-  const t = await getTranslations("quota.layout");
+export default async function QuotasLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "quota.layout" });
 
   return (
     <div className="space-y-6">

--- a/src/app/[locale]/dashboard/quotas/providers/page.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/page.tsx
@@ -53,7 +53,7 @@ export default async function ProvidersQuotaPage({
     redirect({ href: session ? "/dashboard/my-quota" : "/login", locale });
   }
 
-  const t = await getTranslations("quota.providers");
+  const t = await getTranslations({ locale, namespace: "quota.providers" });
 
   return (
     <div className="space-y-4">
@@ -64,18 +64,18 @@ export default async function ProvidersQuotaPage({
       </div>
 
       <Suspense fallback={<ProvidersQuotaSkeleton />}>
-        <ProvidersQuotaContent />
+        <ProvidersQuotaContent locale={locale} />
       </Suspense>
     </div>
   );
 }
 
-async function ProvidersQuotaContent() {
+async function ProvidersQuotaContent({ locale }: { locale: string }) {
   const [providers, systemSettings] = await Promise.all([
     getProvidersWithQuotas(),
     getSystemSettings(),
   ]);
-  const t = await getTranslations("quota.providers");
+  const t = await getTranslations({ locale, namespace: "quota.providers" });
 
   return (
     <div className="space-y-3">

--- a/src/app/[locale]/dashboard/quotas/users/page.tsx
+++ b/src/app/[locale]/dashboard/quotas/users/page.tsx
@@ -129,7 +129,7 @@ export default async function UsersQuotaPage({ params }: { params: Promise<{ loc
     return redirect({ href: session ? "/dashboard/my-quota" : "/login", locale });
   }
 
-  const t = await getTranslations("quota.users");
+  const t = await getTranslations({ locale, namespace: "quota.users" });
 
   return (
     <div className="space-y-4">
@@ -162,15 +162,15 @@ export default async function UsersQuotaPage({ params }: { params: Promise<{ loc
       />
 
       <Suspense fallback={<UsersQuotaSkeleton />}>
-        <UsersQuotaContent />
+        <UsersQuotaContent locale={locale} />
       </Suspense>
     </div>
   );
 }
 
-async function UsersQuotaContent() {
+async function UsersQuotaContent({ locale }: { locale: string }) {
   const [users, systemSettings] = await Promise.all([getUsersWithQuotas(), getSystemSettings()]);
-  const t = await getTranslations("quota.users");
+  const t = await getTranslations({ locale, namespace: "quota.users" });
 
   return (
     <div className="space-y-3">

--- a/src/app/[locale]/dashboard/rate-limits/page.tsx
+++ b/src/app/[locale]/dashboard/rate-limits/page.tsx
@@ -17,7 +17,7 @@ export default async function RateLimitsPage({ params }: { params: Promise<{ loc
     return redirect({ href: "/dashboard", locale });
   }
 
-  const t = await getTranslations("dashboard.rateLimits");
+  const t = await getTranslations({ locale, namespace: "dashboard.rateLimits" });
 
   return (
     <div className="space-y-6">

--- a/src/app/[locale]/settings/_lib/nav-items.ts
+++ b/src/app/[locale]/settings/_lib/nav-items.ts
@@ -108,8 +108,8 @@ export const SETTINGS_NAV_ITEMS: SettingsNavItem[] = [
 ];
 
 // Helper function to get translated nav items
-export async function getTranslatedNavItems(): Promise<SettingsNavItem[]> {
-  const t = await getTranslations("settings");
+export async function getTranslatedNavItems(locale: string): Promise<SettingsNavItem[]> {
+  const t = await getTranslations({ locale, namespace: "settings" });
   return SETTINGS_NAV_ITEMS.map((item) => ({
     ...item,
     label: item.labelKey ? t(item.labelKey) : item.label,

--- a/src/app/[locale]/settings/client-versions/page.tsx
+++ b/src/app/[locale]/settings/client-versions/page.tsx
@@ -21,7 +21,7 @@ export default async function ClientVersionsPage({
   // Await params to ensure locale is available in the async context
   const { locale } = await params;
 
-  const t = await getTranslations("settings");
+  const t = await getTranslations({ locale, namespace: "settings" });
   const session = await getSession();
 
   if (!session || session.user.role !== "admin") {
@@ -55,7 +55,7 @@ export default async function ClientVersionsPage({
         iconColor="text-[#E25706]"
       >
         <Suspense fallback={<ClientVersionsTableSkeleton />}>
-          <ClientVersionsStatsContent />
+          <ClientVersionsStatsContent locale={locale} />
         </Suspense>
       </SettingsSection>
     </div>
@@ -71,8 +71,8 @@ async function ClientVersionsSettingsContent() {
   return <ClientVersionToggle enabled={enableClientVersionCheck} />;
 }
 
-async function ClientVersionsStatsContent() {
-  const t = await getTranslations("settings");
+async function ClientVersionsStatsContent({ locale }: { locale: string }) {
+  const t = await getTranslations({ locale, namespace: "settings" });
   const statsResult = await fetchClientVersionStats();
   const stats = statsResult.ok ? statsResult.data : [];
 

--- a/src/app/[locale]/settings/config/page.tsx
+++ b/src/app/[locale]/settings/config/page.tsx
@@ -9,8 +9,13 @@ import { SystemSettingsForm } from "./_components/system-settings-form";
 
 export const dynamic = "force-dynamic";
 
-export default async function SettingsConfigPage() {
-  const t = await getTranslations("settings");
+export default async function SettingsConfigPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
 
   return (
     <>
@@ -20,14 +25,14 @@ export default async function SettingsConfigPage() {
         icon="settings"
       />
       <Suspense fallback={<SettingsConfigSkeleton />}>
-        <SettingsConfigContent />
+        <SettingsConfigContent locale={locale} />
       </Suspense>
     </>
   );
 }
 
-async function SettingsConfigContent() {
-  const t = await getTranslations("settings");
+async function SettingsConfigContent({ locale }: { locale: string }) {
+  const t = await getTranslations({ locale, namespace: "settings" });
   const settings = await getSystemSettings();
 
   return (

--- a/src/app/[locale]/settings/error-rules/page.tsx
+++ b/src/app/[locale]/settings/error-rules/page.tsx
@@ -12,8 +12,9 @@ import { RuleListTable } from "./_components/rule-list-table";
 
 export const dynamic = "force-dynamic";
 
-export default async function ErrorRulesPage() {
-  const t = await getTranslations("settings");
+export default async function ErrorRulesPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
 
   return (
     <>

--- a/src/app/[locale]/settings/layout.tsx
+++ b/src/app/[locale]/settings/layout.tsx
@@ -28,11 +28,11 @@ export default async function SettingsLayout({
   }
 
   // Get translated navigation items
-  const translatedNavItems = await getTranslatedNavItems();
+  const translatedNavItems = await getTranslatedNavItems(locale);
 
   return (
     <div className="min-h-[var(--cch-viewport-height,100vh)] bg-background">
-      <DashboardHeader session={session} />
+      <DashboardHeader session={session} locale={locale} />
       <main className="mx-auto w-full max-w-7xl px-4 py-6 md:px-6 md:py-8 pb-24 md:pb-8">
         <div className="space-y-6">
           {/* Desktop: Grid layout with sidebar */}

--- a/src/app/[locale]/settings/logs/page.tsx
+++ b/src/app/[locale]/settings/logs/page.tsx
@@ -5,8 +5,13 @@ import { LogLevelForm } from "./_components/log-level-form";
 
 export const dynamic = "force-dynamic";
 
-export default async function SettingsLogsPage() {
-  const t = await getTranslations("settings");
+export default async function SettingsLogsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
 
   return (
     <>

--- a/src/app/[locale]/settings/prices/page.tsx
+++ b/src/app/[locale]/settings/prices/page.tsx
@@ -11,20 +11,29 @@ import { UploadPriceDialog } from "./_components/upload-price-dialog";
 
 export const dynamic = "force-dynamic";
 
+type SettingsPricesSearchParams = {
+  required?: string;
+  page?: string;
+  pageSize?: string;
+  size?: string;
+  search?: string;
+  source?: string;
+  litellmProvider?: string;
+};
+
 interface SettingsPricesPageProps {
-  searchParams: Promise<{
-    required?: string;
-    page?: string;
-    pageSize?: string;
-    size?: string;
-    search?: string;
-    source?: string;
-    litellmProvider?: string;
+  params: Promise<{
+    locale: string;
   }>;
+  searchParams: Promise<SettingsPricesSearchParams>;
 }
 
-export default async function SettingsPricesPage({ searchParams }: SettingsPricesPageProps) {
-  const t = await getTranslations("settings");
+export default async function SettingsPricesPage({
+  params,
+  searchParams,
+}: SettingsPricesPageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
 
   return (
     <>
@@ -34,14 +43,20 @@ export default async function SettingsPricesPage({ searchParams }: SettingsPrice
         icon="dollar-sign"
       />
       <Suspense fallback={<PricesSkeleton />}>
-        <SettingsPricesContent searchParams={searchParams} />
+        <SettingsPricesContent locale={locale} searchParams={searchParams} />
       </Suspense>
     </>
   );
 }
 
-async function SettingsPricesContent({ searchParams }: SettingsPricesPageProps) {
-  const t = await getTranslations("settings");
+async function SettingsPricesContent({
+  locale,
+  searchParams,
+}: {
+  locale: string;
+  searchParams: Promise<SettingsPricesSearchParams>;
+}) {
+  const t = await getTranslations({ locale, namespace: "settings" });
   const params = await searchParams;
 
   // 解析分页参数

--- a/src/app/[locale]/settings/providers/page.tsx
+++ b/src/app/[locale]/settings/providers/page.tsx
@@ -14,8 +14,13 @@ import { SchedulingRulesDialog } from "./_components/scheduling-rules-dialog";
 
 export const dynamic = "force-dynamic";
 
-export default async function SettingsProvidersPage() {
-  const t = await getTranslations("settings");
+export default async function SettingsProvidersPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
   const session = await getSession();
   const providers = await getProviders();
 

--- a/src/app/[locale]/settings/request-filters/page.tsx
+++ b/src/app/[locale]/settings/request-filters/page.tsx
@@ -9,8 +9,13 @@ import { RequestFiltersTableSkeleton } from "./_components/request-filters-skele
 
 export const dynamic = "force-dynamic";
 
-export default async function RequestFiltersPage() {
-  const t = await getTranslations("settings.requestFilters");
+export default async function RequestFiltersPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings.requestFilters" });
 
   return (
     <>

--- a/src/app/[locale]/settings/sensitive-words/page.tsx
+++ b/src/app/[locale]/settings/sensitive-words/page.tsx
@@ -11,8 +11,13 @@ import { WordListTable } from "./_components/word-list-table";
 
 export const dynamic = "force-dynamic";
 
-export default async function SensitiveWordsPage() {
-  const t = await getTranslations("settings");
+export default async function SensitiveWordsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
 
   return (
     <>

--- a/src/app/[locale]/settings/status-page/page.tsx
+++ b/src/app/[locale]/settings/status-page/page.tsx
@@ -5,8 +5,13 @@ import { loadStatusPageSettings } from "./loader";
 
 export const dynamic = "force-dynamic";
 
-export default async function StatusPageSettingsPage() {
-  const t = await getTranslations("settings");
+export default async function StatusPageSettingsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
   const settings = await loadStatusPageSettings();
 
   return (

--- a/src/app/[locale]/status/[slug]/page.tsx
+++ b/src/app/[locale]/status/[slug]/page.tsx
@@ -34,7 +34,7 @@ export default async function PublicStatusGroupPage({
   params: Promise<{ locale: string; slug: string }>;
 }) {
   const { locale, slug } = await params;
-  const t = await getTranslations("settings");
+  const t = await getTranslations({ locale, namespace: "settings" });
   const {
     followServerDefaults,
     initialPayload,

--- a/src/app/[locale]/usage-doc/layout.tsx
+++ b/src/app/[locale]/usage-doc/layout.tsx
@@ -45,7 +45,7 @@ export default async function UsageDocLayout({
     <div className="min-h-[var(--cch-viewport-height,100vh)] bg-background">
       {/* 条件渲染头部：已登录显示 DashboardHeader，未登录显示简化版头部 */}
       {session ? (
-        <DashboardHeader session={session} />
+        <DashboardHeader session={session} locale={locale} />
       ) : (
         <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
           <div className="container flex h-14 items-center justify-between px-6">

--- a/src/components/ui/__tests__/language-switcher.test.tsx
+++ b/src/components/ui/__tests__/language-switcher.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { LanguageSwitcher } from "@/components/ui/language-switcher";
+import type { Locale } from "@/i18n/config";
+
+const testState = vi.hoisted(() => ({
+  currentLocale: "zh-CN" as Locale,
+  pathname: "/zh-CN/settings/config",
+  router: {
+    push: vi.fn(),
+    refresh: vi.fn(),
+  },
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => testState.currentLocale,
+}));
+
+vi.mock("@/i18n/routing", () => ({
+  usePathname: () => testState.pathname,
+  useRouter: () => testState.router,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+function render(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(node);
+  });
+
+  return {
+    container,
+    rerender: (nextNode: ReactNode) => {
+      act(() => {
+        root.render(nextNode);
+      });
+    },
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function click(element: Element) {
+  act(() => {
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("LanguageSwitcher", () => {
+  let view: ReturnType<typeof render> | null = null;
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    testState.currentLocale = "zh-CN";
+    testState.pathname = "/zh-CN/settings/config";
+    testState.router.push.mockReset();
+    testState.router.refresh.mockReset();
+  });
+
+  afterEach(() => {
+    view?.unmount();
+    view = null;
+  });
+
+  test("refreshes the current route after the locale provider catches up", () => {
+    view = render(<LanguageSwitcher />);
+
+    const englishOption = Array.from(view.container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("English")
+    );
+
+    expect(englishOption).toBeTruthy();
+    click(englishOption!);
+
+    expect(testState.router.push).toHaveBeenCalledWith("/settings/config", { locale: "en" });
+    expect(testState.router.refresh).not.toHaveBeenCalled();
+
+    testState.currentLocale = "en";
+    view.rerender(<LanguageSwitcher />);
+
+    expect(testState.router.refresh).toHaveBeenCalledTimes(1);
+    const trigger = view.container.querySelector<HTMLButtonElement>(
+      "button[aria-label='Select language']"
+    );
+    expect(trigger?.disabled).toBe(false);
+  });
+
+  test("restores the pending refresh after the switcher remounts during navigation", () => {
+    view = render(<LanguageSwitcher />);
+
+    const englishOption = Array.from(view.container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("English")
+    );
+
+    expect(englishOption).toBeTruthy();
+    click(englishOption!);
+
+    expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBe("en");
+
+    view.unmount();
+    view = null;
+
+    testState.currentLocale = "en";
+    view = render(<LanguageSwitcher />);
+
+    expect(testState.router.refresh).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBeNull();
+  });
+});

--- a/src/components/ui/__tests__/language-switcher.test.tsx
+++ b/src/components/ui/__tests__/language-switcher.test.tsx
@@ -11,7 +11,7 @@ import type { Locale } from "@/i18n/config";
 
 const testState = vi.hoisted(() => ({
   currentLocale: "zh-CN" as Locale,
-  pathname: "/zh-CN/settings/config",
+  pathname: "/settings/config",
   router: {
     push: vi.fn(),
     refresh: vi.fn(),
@@ -75,7 +75,7 @@ describe("LanguageSwitcher", () => {
   beforeEach(() => {
     window.sessionStorage.clear();
     testState.currentLocale = "zh-CN";
-    testState.pathname = "/zh-CN/settings/config";
+    testState.pathname = "/settings/config";
     testState.router.push.mockReset();
     testState.router.refresh.mockReset();
   });
@@ -128,5 +128,15 @@ describe("LanguageSwitcher", () => {
 
     expect(testState.router.refresh).toHaveBeenCalledTimes(1);
     expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBeNull();
+  });
+
+  test("does not refresh from a stale stored locale marker on mount", () => {
+    window.sessionStorage.setItem("cch.pendingLocaleRefresh", "en");
+    testState.currentLocale = "en";
+
+    view = render(<LanguageSwitcher />);
+
+    expect(testState.router.refresh).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBe("en");
   });
 });

--- a/src/components/ui/__tests__/language-switcher.test.tsx
+++ b/src/components/ui/__tests__/language-switcher.test.tsx
@@ -130,6 +130,40 @@ describe("LanguageSwitcher", () => {
     expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBeNull();
   });
 
+  test("keeps the pending refresh after remount when sessionStorage is blocked", () => {
+    const setItemSpy = vi.spyOn(window.sessionStorage, "setItem").mockImplementation(() => {
+      throw new Error("blocked storage");
+    });
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    view = render(<LanguageSwitcher />);
+
+    const englishOption = Array.from(view.container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("English")
+    );
+
+    expect(englishOption).toBeTruthy();
+    click(englishOption!);
+
+    expect(testState.router.push).toHaveBeenCalledWith("/settings/config", { locale: "en" });
+    expect(testState.router.refresh).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to persist pending locale refresh target:",
+      expect.any(Error)
+    );
+
+    view.unmount();
+    view = null;
+    setItemSpy.mockRestore();
+
+    testState.currentLocale = "en";
+    view = render(<LanguageSwitcher />);
+
+    expect(testState.router.refresh).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
+  });
+
   test("does not refresh from a stale stored locale marker on mount", () => {
     window.sessionStorage.setItem("cch.pendingLocaleRefresh", "en");
     testState.currentLocale = "en";

--- a/src/components/ui/language-switcher.tsx
+++ b/src/components/ui/language-switcher.tsx
@@ -15,9 +15,48 @@ import { normalizePathnameForLocaleNavigation } from "@/i18n/pathname";
 import { usePathname, useRouter } from "@/i18n/routing";
 import { cn } from "@/lib/utils/index";
 
+const pendingLocaleRefreshKey = "cch.pendingLocaleRefresh";
+
 interface LanguageSwitcherProps {
   className?: string;
   size?: "sm" | "default";
+}
+
+function getPendingLocaleRefreshTarget(): Locale | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const value = window.sessionStorage.getItem(pendingLocaleRefreshKey);
+    return locales.some((locale) => locale === value) ? (value as Locale) : null;
+  } catch {
+    return null;
+  }
+}
+
+function setPendingLocaleRefreshTarget(locale: Locale) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(pendingLocaleRefreshKey, locale);
+  } catch {
+    // 存储失败不影响路由切换，只会跳过额外的 RSC 刷新兜底。
+  }
+}
+
+function clearPendingLocaleRefreshTarget() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.removeItem(pendingLocaleRefreshKey);
+  } catch {
+    // 清理失败可忽略，下一次读取会重新校验 locale 是否有效。
+  }
 }
 
 /**
@@ -31,6 +70,21 @@ export function LanguageSwitcher({ className, size = "sm" }: LanguageSwitcherPro
   const router = useRouter();
   const pathname = usePathname();
   const [isTransitioning, setIsTransitioning] = React.useState(false);
+  const [pendingLocale, setPendingLocale] = React.useState<Locale | null>(null);
+
+  React.useEffect(() => {
+    const refreshTarget = pendingLocale ?? getPendingLocaleRefreshTarget();
+
+    if (refreshTarget !== currentLocale) {
+      return;
+    }
+
+    // Locale route 已切换后刷新当前 RSC 树，避免布局与服务端标题继续显示旧语言。
+    router.refresh();
+    clearPendingLocaleRefreshTarget();
+    setPendingLocale(null);
+    setIsTransitioning(false);
+  }, [currentLocale, pendingLocale, router]);
 
   const handleLocaleChange = React.useCallback(
     (newLocale: Locale) => {
@@ -39,11 +93,15 @@ export function LanguageSwitcher({ className, size = "sm" }: LanguageSwitcherPro
       }
 
       setIsTransitioning(true);
+      setPendingLocale(newLocale);
+      setPendingLocaleRefreshTarget(newLocale);
 
       try {
         router.push(normalizePathnameForLocaleNavigation(pathname), { locale: newLocale });
       } catch (error) {
         console.error("Failed to switch locale:", error);
+        clearPendingLocaleRefreshTarget();
+        setPendingLocale(null);
         setIsTransitioning(false);
       }
     },

--- a/src/components/ui/language-switcher.tsx
+++ b/src/components/ui/language-switcher.tsx
@@ -31,7 +31,8 @@ function getPendingLocaleRefreshTarget(): Locale | null {
   try {
     const value = window.sessionStorage.getItem(pendingLocaleRefreshKey);
     return locales.some((locale) => locale === value) ? (value as Locale) : null;
-  } catch {
+  } catch (error) {
+    console.error("Failed to read pending locale refresh target:", error);
     return null;
   }
 }
@@ -45,8 +46,8 @@ function setPendingLocaleRefreshTarget(locale: Locale) {
 
   try {
     window.sessionStorage.setItem(pendingLocaleRefreshKey, locale);
-  } catch {
-    // 存储失败不影响路由切换，只会跳过额外的 RSC 刷新兜底。
+  } catch (error) {
+    console.error("Failed to persist pending locale refresh target:", error);
   }
 }
 
@@ -59,8 +60,8 @@ function clearPendingLocaleRefreshTarget() {
 
   try {
     window.sessionStorage.removeItem(pendingLocaleRefreshKey);
-  } catch {
-    // 清理失败可忽略，下一次读取会重新校验 locale 是否有效。
+  } catch (error) {
+    console.error("Failed to clear pending locale refresh target:", error);
   }
 }
 
@@ -79,10 +80,8 @@ export function LanguageSwitcher({ className, size = "sm" }: LanguageSwitcherPro
 
   React.useEffect(() => {
     const storedRefreshTarget =
-      pendingLocale !== null || activePendingLocaleRefreshTarget !== null
-        ? getPendingLocaleRefreshTarget()
-        : null;
-    const refreshTarget = pendingLocale ?? storedRefreshTarget;
+      activePendingLocaleRefreshTarget === null ? null : getPendingLocaleRefreshTarget();
+    const refreshTarget = pendingLocale ?? activePendingLocaleRefreshTarget ?? storedRefreshTarget;
 
     if (refreshTarget !== currentLocale) {
       return;

--- a/src/components/ui/language-switcher.tsx
+++ b/src/components/ui/language-switcher.tsx
@@ -16,6 +16,7 @@ import { usePathname, useRouter } from "@/i18n/routing";
 import { cn } from "@/lib/utils/index";
 
 const pendingLocaleRefreshKey = "cch.pendingLocaleRefresh";
+let activePendingLocaleRefreshTarget: Locale | null = null;
 
 interface LanguageSwitcherProps {
   className?: string;
@@ -36,6 +37,8 @@ function getPendingLocaleRefreshTarget(): Locale | null {
 }
 
 function setPendingLocaleRefreshTarget(locale: Locale) {
+  activePendingLocaleRefreshTarget = locale;
+
   if (typeof window === "undefined") {
     return;
   }
@@ -48,6 +51,8 @@ function setPendingLocaleRefreshTarget(locale: Locale) {
 }
 
 function clearPendingLocaleRefreshTarget() {
+  activePendingLocaleRefreshTarget = null;
+
   if (typeof window === "undefined") {
     return;
   }
@@ -73,7 +78,11 @@ export function LanguageSwitcher({ className, size = "sm" }: LanguageSwitcherPro
   const [pendingLocale, setPendingLocale] = React.useState<Locale | null>(null);
 
   React.useEffect(() => {
-    const refreshTarget = pendingLocale ?? getPendingLocaleRefreshTarget();
+    const storedRefreshTarget =
+      pendingLocale !== null || activePendingLocaleRefreshTarget !== null
+        ? getPendingLocaleRefreshTarget()
+        : null;
+    const refreshTarget = pendingLocale ?? storedRefreshTarget;
 
     if (refreshTarget !== currentLocale) {
       return;

--- a/tests/unit/i18n/locale-server-translations.test.ts
+++ b/tests/unit/i18n/locale-server-translations.test.ts
@@ -1,0 +1,41 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return walk(fullPath);
+    }
+    return /\.(ts|tsx)$/.test(entry.name) ? [fullPath] : [];
+  });
+}
+
+function isRouteOrServerChromeFile(filePath: string): boolean {
+  const fileName = basename(filePath);
+
+  return (
+    fileName === "page.tsx" ||
+    fileName === "layout.tsx" ||
+    filePath.endsWith("dashboard-header.tsx") ||
+    filePath.endsWith("dashboard-sections.tsx") ||
+    filePath.endsWith("settings/_lib/nav-items.ts")
+  );
+}
+
+describe("locale server translations", () => {
+  test("route pages and server chrome pass locale explicitly to getTranslations", () => {
+    const files = walk("src/app/[locale]").filter(isRouteOrServerChromeFile);
+    const violations = files.flatMap((file) => {
+      const content = readFileSync(file, "utf8");
+      return content
+        .split("\n")
+        .map((line, index) => ({ line, lineNumber: index + 1 }))
+        .filter(({ line }) => /getTranslations\(\s*["']/.test(line))
+        .map(({ line, lineNumber }) => `${file}:${lineNumber}: ${line.trim()}`);
+    });
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes stale desktop navigation and server-rendered heading/description copy after switching locale.
- Passes the `[locale]` route param explicitly to server-side `getTranslations` calls for route chrome and page headers.
- Adds a locale-switch refresh guard so remounted client navigation can refresh the current RSC tree after the provider locale catches up.
- Adds regression coverage for the language switcher remount path and for implicit server translation calls in route pages/layouts.

## Root Cause

App Router can refresh only the nested RSC tree during locale navigation. Some dashboard/settings route chrome and page headers relied on implicit `getTranslations("...")`, which depends on request locale context from the root layout. On partial refreshes, those server-rendered segments could keep the previous locale while client components under the new `NextIntlClientProvider` updated correctly.

## Screenshots

Desktop settings page after `zh-CN -> en` switch:

[Desktop i18n switch fixed](https://i.111666.best/image/KUFAlIqfbxvMZWF4zBw2K1.png)

Mobile settings page after `zh-CN -> en` switch:

[Mobile i18n switch fixed](https://i.111666.best/image/VdB0jHrA45i9WhpfPqtMwC.png)

## Verification

- `bun run build`
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- Browser smoke, production mode on `localhost:13528`:
  - desktop `zh-CN/settings/config -> en/settings/config`: nav, sidebar, h1, h2, descriptions switched to English
  - mobile `zh-CN/settings/config -> en/settings/config`: bottom nav, h1, h2, descriptions switched to English

Notes: `bun run lint` still reports pre-existing Biome warnings in unrelated files (`leaderboard-view-*` tests and `src/i18n/pathname.ts`) but exits successfully. `bun run build` still reports existing `node:net` Edge Runtime warnings in IP utilities but exits successfully.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes stale server-rendered translations after a locale switch in the App Router by threading the `[locale]` route param explicitly into every `getTranslations` call across dashboard and settings pages, and adds a client-side `router.refresh()` guard in `LanguageSwitcher` so the RSC tree re-renders after the provider locale catches up. The mechanical server-side changes are consistent and covered by a new regression test; the refresh-guard logic in `language-switcher.tsx` has one subtle dead-code path (see inline comment).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the single P2 finding is a dead-code path in the sessionStorage fallback that does not affect observable behaviour

All server-side changes are straightforward and correct locale-threading. The refresh-guard logic works correctly in all tested scenarios; the sessionStorage fallback being unreachable as the deciding value is a maintainability concern, not a runtime bug. No P0/P1 issues found.

src/components/ui/language-switcher.tsx — the storedRefreshTarget dead-code path warrants a closer look
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/ui/language-switcher.tsx | Adds locale-switch refresh guard using module-level variable + sessionStorage; the sessionStorage read path is logically unreachable as the deciding value (see comment) |
| src/app/[locale]/dashboard/_components/dashboard-header.tsx | Correctly converted from client `useTranslations` to async server `getTranslations` with explicit locale prop |
| src/app/[locale]/settings/layout.tsx | Passes locale explicitly to `getTranslatedNavItems` and `DashboardHeader`; consistent with rest of the fix |
| tests/unit/i18n/locale-server-translations.test.ts | Regression guard that walks the `[locale]` tree and asserts no implicit `getTranslations("…")` calls remain in route/chrome files |
| src/components/ui/__tests__/language-switcher.test.tsx | New unit tests covering the refresh-guard effect, remount persistence, blocked-storage fallback, and stale-marker guard; test 4 (stale marker) implicitly validates the current inverted-guard behaviour |
| src/app/[locale]/dashboard/quotas/providers/page.tsx | Both `ProvidersQuotaPage` and the inner `ProvidersQuotaContent` updated to accept and forward locale explicitly |
| src/app/[locale]/settings/prices/page.tsx | Adds `params` to page props, extracts locale, and forwards it to both `SettingsPricesPage` and `SettingsPricesContent`; correct refactor |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant LanguageSwitcher
    participant Router
    participant NextIntlProvider
    participant RSCTree

    User->>LanguageSwitcher: click "English"
    LanguageSwitcher->>LanguageSwitcher: setIsTransitioning(true)<br/>setPendingLocale("en")<br/>setPendingLocaleRefreshTarget("en")
    LanguageSwitcher->>Router: push(pathname, { locale: "en" })
    Router->>NextIntlProvider: navigate to /en/…
    NextIntlProvider-->>LanguageSwitcher: currentLocale = "en" (re-render)
    Note over LanguageSwitcher: useEffect: pendingLocale("en") === currentLocale("en")
    LanguageSwitcher->>Router: router.refresh()
    LanguageSwitcher->>LanguageSwitcher: clearPendingLocaleRefreshTarget()<br/>setPendingLocale(null)
    Router->>RSCTree: re-fetch server components with explicit locale
    RSCTree-->>User: updated translations rendered
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/ui/language-switcher.tsx
Line: 82-84

Comment:
**`storedRefreshTarget` is unreachable as the deciding value**

`storedRefreshTarget` is derived from `sessionStorage` only when `activePendingLocaleRefreshTarget !== null`, but in the `??` chain `activePendingLocaleRefreshTarget` always takes priority over `storedRefreshTarget`. Conversely, when `activePendingLocaleRefreshTarget === null`, `storedRefreshTarget` is forced to `null` and the `sessionStorage` read is skipped. This means the stored session value can never be the final non-null `refreshTarget` — the sessionStorage persistence acts as a write-only fallback that is never actually read as a recovery path.

If the intent is to recover from a module re-initialisation (e.g. HMR between the click and remount), the guard condition should be inverted:

```ts
// read sessionStorage only as a cold-start fallback (no active in-memory signal)
const storedRefreshTarget =
  activePendingLocaleRefreshTarget === null ? getPendingLocaleRefreshTarget() : null;
const refreshTarget = pendingLocale ?? activePendingLocaleRefreshTarget ?? storedRefreshTarget;
```

Note: this would also need the "stale stored marker on mount" test to be updated so that a stale entry is cleaned up rather than silently ignored, because without the `activePendingLocaleRefreshTarget` guard the condition `refreshTarget === currentLocale` could fire on a leftover entry. The test at line 737 would need adjustment accordingly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(i18n): log locale refresh storage fa..."](https://github.com/ding113/claude-code-hub/commit/74c999fe4b3e8545a02184df1ebb5edd2de07871) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29803858)</sub>

<!-- /greptile_comment -->