### PR TITLE
fix(billing): charge redirected per-request image responses

### DIFF
--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -411,6 +411,43 @@ function isNonBillingUsageEndpoint(session: ProxySession): boolean {
   return isNonBillingEndpoint(session.getEndpoint());
 }
 
+function hasBillableInputCostPerRequest(priceData: { input_cost_per_request?: unknown }): boolean {
+  const inputCostPerRequest = priceData.input_cost_per_request;
+  return (
+    typeof inputCostPerRequest === "number" &&
+    Number.isFinite(inputCostPerRequest) &&
+    inputCostPerRequest >= 0
+  );
+}
+
+async function resolveBillableUsageMetricsForCost(
+  session: ProxySession,
+  provider: Provider | null,
+  usageMetrics: UsageMetrics | null,
+  statusCode: number
+): Promise<UsageMetrics | null> {
+  if (isNonBillingUsageEndpoint(session)) {
+    return null;
+  }
+
+  if (usageMetrics) {
+    return usageMetrics;
+  }
+
+  if (statusCode < 200 || statusCode >= 300) {
+    return null;
+  }
+
+  const resolvedPricing = await session.getResolvedPricingByBillingSource(provider);
+  if (!resolvedPricing?.priceData || !hasBillableInputCostPerRequest(resolvedPricing.priceData)) {
+    return null;
+  }
+
+  // 成功响应可能没有 token usage（例如 OpenAI Images），但本地价格表仍可配置按次价格。
+  // 这里用空 usage 只承载 input_cost_per_request，不新增按图、按 token 等语义。
+  return {};
+}
+
 type FinalizeDeferredStreamingResult = {
   /**
    * “内部结算用”的状态码。
@@ -1145,11 +1182,9 @@ export class ProxyResponseHandler {
         if (sessionWithCleanup.clearResponseTimeout) {
           sessionWithCleanup.clearResponseTimeout();
         }
-        let usageRecord: Record<string, unknown> | null = null;
         let usageMetrics: UsageMetrics | null = null;
 
         const usageResult = parseUsageFromResponseText(responseText, provider.providerType);
-        usageRecord = usageResult.usageRecord;
         usageMetrics = usageResult.usageMetrics;
         const actualServiceTier = parseServiceTierFromResponseText(responseText);
         const codexPriorityBillingDecision = await resolveCodexPriorityBillingDecision(
@@ -1172,8 +1207,12 @@ export class ProxyResponseHandler {
         // 关键：必须在 normalizeUsageWithSwap 之后再快照 billable 视图，
         // 否则 updateRequestCostFromUsage / trackCostToRedis 会用未归一化的旧值，
         // 导致缓存 TTL swap、bucket 归一化等场景下的账单与限流统计错位。
-        const billableUsageMetrics =
-          usageMetrics && !isNonBillingUsageEndpoint(session) ? usageMetrics : null;
+        const billableUsageMetrics = await resolveBillableUsageMetricsForCost(
+          session,
+          provider,
+          usageMetrics,
+          statusCode
+        );
 
         if (billableUsageMetrics) {
           maybeSetCodexContext1m(session, provider, billableUsageMetrics.input_tokens);
@@ -1221,7 +1260,7 @@ export class ProxyResponseHandler {
           });
         }
 
-        if (usageRecord && billableUsageMetrics && messageContext) {
+        if (billableUsageMetrics && messageContext) {
           const costUpdateResult = await updateRequestCostFromUsage(
             messageContext.id,
             session,
@@ -1315,12 +1354,16 @@ export class ProxyResponseHandler {
         }
 
         // 更新 session 使用量到 Redis（用于实时监控）
-        if (session.sessionId && usageMetrics && session.shouldTrackSessionObservability()) {
+        if (
+          session.sessionId &&
+          (usageMetrics || costUsdStr !== undefined) &&
+          session.shouldTrackSessionObservability()
+        ) {
           void SessionManager.updateSessionUsage(session.sessionId, {
-            inputTokens: usageMetrics.input_tokens,
-            outputTokens: usageMetrics.output_tokens,
-            cacheCreationInputTokens: usageMetrics.cache_creation_input_tokens,
-            cacheReadInputTokens: usageMetrics.cache_read_input_tokens,
+            inputTokens: usageMetrics?.input_tokens,
+            outputTokens: usageMetrics?.output_tokens,
+            cacheCreationInputTokens: usageMetrics?.cache_creation_input_tokens,
+            cacheReadInputTokens: usageMetrics?.cache_read_input_tokens,
             costUsd: costUsdStr,
             status: statusCode >= 200 && statusCode < 300 ? "completed" : "error",
             statusCode: statusCode,
@@ -2336,8 +2379,12 @@ export class ProxyResponseHandler {
           }
         }
 
-        const billableUsageForCost =
-          usageForCost && !isNonBillingUsageEndpoint(session) ? usageForCost : null;
+        const billableUsageForCost = await resolveBillableUsageMetricsForCost(
+          session,
+          provider,
+          usageForCost,
+          effectiveStatusCode
+        );
 
         const costUpdateResult = await updateRequestCostFromUsage(
           messageContext.id,
@@ -2443,6 +2490,8 @@ export class ProxyResponseHandler {
             payload.outputTokens = usageForCost.output_tokens;
             payload.cacheCreationInputTokens = usageForCost.cache_creation_input_tokens;
             payload.cacheReadInputTokens = usageForCost.cache_read_input_tokens;
+          }
+          if (costUsdStr !== undefined) {
             payload.costUsd = costUsdStr;
           }
 
@@ -3602,6 +3651,56 @@ export async function finalizeRequestStats(
   }
   const priorityServiceTierApplied = codexPriorityBillingDecision?.effectivePriority ?? false;
   if (!usageMetrics) {
+    const billablePerRequestUsage = await resolveBillableUsageMetricsForCost(
+      session,
+      provider,
+      null,
+      statusCode
+    );
+    let perRequestCostUsd: string | undefined;
+
+    if (billablePerRequestUsage) {
+      const costUpdateResult = await updateRequestCostFromUsage(
+        messageContext.id,
+        session,
+        billablePerRequestUsage,
+        provider,
+        provider.costMultiplier,
+        session.getContext1mApplied(),
+        priorityServiceTierApplied,
+        session.getGroupCostMultiplier()
+      );
+      if (costUpdateResult.resolvedPricing) {
+        ensurePricingResolutionSpecialSetting(session, costUpdateResult.resolvedPricing);
+      }
+      if (costUpdateResult.longContextPricingApplied) {
+        ensureLongContextPricingAudit(session, costUpdateResult.longContextPricing);
+      }
+
+      await trackCostToRedis(
+        session,
+        billablePerRequestUsage,
+        priorityServiceTierApplied,
+        costUpdateResult.resolvedPricing,
+        costUpdateResult.longContextPricing
+      );
+      perRequestCostUsd = costUpdateResult.costUsd ?? undefined;
+    }
+
+    if (
+      session.sessionId &&
+      perRequestCostUsd !== undefined &&
+      session.shouldTrackSessionObservability()
+    ) {
+      void SessionManager.updateSessionUsage(session.sessionId, {
+        costUsd: perRequestCostUsd,
+        status: statusCode >= 200 && statusCode < 300 ? "completed" : "error",
+        statusCode,
+      }).catch((error: unknown) => {
+        logger.error("[ResponseHandler] Failed to update session usage:", error);
+      });
+    }
+
     await updateMessageRequestDetails(messageContext.id, {
       statusCode: statusCode,
       ...(errorMessage ? { errorMessage } : {}),

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -438,7 +438,18 @@ async function resolveBillableUsageMetricsForCost(
     return null;
   }
 
-  const resolvedPricing = await session.getResolvedPricingByBillingSource(provider);
+  let resolvedPricing: Awaited<ReturnType<ProxySession["getResolvedPricingByBillingSource"]>>;
+  try {
+    resolvedPricing = await session.getResolvedPricingByBillingSource(provider);
+  } catch (error) {
+    logger.error("[CostCalculation] Failed to resolve per-request pricing, skipping billing", {
+      error: error instanceof Error ? error.message : String(error),
+      originalModel: session.getOriginalModel(),
+      redirectedModel: session.getCurrentModel(),
+    });
+    return null;
+  }
+
   if (!resolvedPricing?.priceData || !hasBillableInputCostPerRequest(resolvedPricing.priceData)) {
     return null;
   }

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -3696,6 +3696,7 @@ export async function finalizeRequestStats(
         costUsd: perRequestCostUsd,
         status: statusCode >= 200 && statusCode < 300 ? "completed" : "error",
         statusCode,
+        ...(errorMessage ? { errorMessage } : {}),
       }).catch((error: unknown) => {
         logger.error("[ResponseHandler] Failed to update session usage:", error);
       });

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -424,7 +424,8 @@ async function resolveBillableUsageMetricsForCost(
   session: ProxySession,
   provider: Provider | null,
   usageMetrics: UsageMetrics | null,
-  statusCode: number
+  statusCode: number,
+  responseText?: string | null
 ): Promise<UsageMetrics | null> {
   if (isNonBillingUsageEndpoint(session)) {
     return null;
@@ -452,6 +453,21 @@ async function resolveBillableUsageMetricsForCost(
 
   if (!resolvedPricing?.priceData || !hasBillableInputCostPerRequest(resolvedPricing.priceData)) {
     return null;
+  }
+
+  if (responseText !== undefined && responseText !== null) {
+    const detected = detectUpstreamErrorFromSseOrJsonText(responseText, {
+      maxJsonCharsForMessageCheck: 0,
+    });
+    if (detected.isError) {
+      logger.warn("[CostCalculation] Skipping per-request billing for fake-200 error payload", {
+        code: detected.code,
+        detail: detected.detail,
+        originalModel: session.getOriginalModel(),
+        redirectedModel: session.getCurrentModel(),
+      });
+      return null;
+    }
   }
 
   // 成功响应可能没有 token usage（例如 OpenAI Images），但本地价格表仍可配置按次价格。
@@ -1222,7 +1238,8 @@ export class ProxyResponseHandler {
           session,
           provider,
           usageMetrics,
-          statusCode
+          statusCode,
+          responseText
         );
 
         if (billableUsageMetrics) {
@@ -2394,7 +2411,8 @@ export class ProxyResponseHandler {
           session,
           provider,
           usageForCost,
-          effectiveStatusCode
+          effectiveStatusCode,
+          allContent
         );
 
         const costUpdateResult = await updateRequestCostFromUsage(
@@ -3666,7 +3684,8 @@ export async function finalizeRequestStats(
       session,
       provider,
       null,
-      statusCode
+      statusCode,
+      responseText
     );
     let perRequestCostUsd: string | undefined;
 

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -416,7 +416,7 @@ function hasBillableInputCostPerRequest(priceData: { input_cost_per_request?: un
   return (
     typeof inputCostPerRequest === "number" &&
     Number.isFinite(inputCostPerRequest) &&
-    inputCostPerRequest >= 0
+    inputCostPerRequest > 0
   );
 }
 

--- a/tests/integration/billing-model-source.test.ts
+++ b/tests/integration/billing-model-source.test.ts
@@ -1182,6 +1182,54 @@ describe("模型重定向后的图片按次计费", () => {
     expect(RateLimitService.trackCost).not.toHaveBeenCalled();
   });
 
+  it("价格查询失败时跳过按次计费且不影响成功响应", async () => {
+    invalidateSystemSettingsCache();
+
+    const originalModel = "gpt-image-2";
+    const redirectedModel = "gpt-image-2-all";
+
+    vi.mocked(getSystemSettings).mockResolvedValue(makeSystemSettings("original"));
+    vi.mocked(findLatestPriceByModel).mockImplementation(async () => {
+      throw new Error("pricing db unavailable");
+    });
+
+    vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestDuration).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.storeSessionResponse).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackUserDailyCost).mockResolvedValue(undefined);
+    vi.mocked(SessionTracker.refreshSession).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.updateSessionUsage).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackCost).mockResolvedValue(undefined);
+
+    const session = createSession({
+      originalModel,
+      redirectedModel,
+      sessionId: "sess-image-edit-pricing-error",
+      messageId: 4004,
+      requestPath: "/v1/images/edits",
+      providerOverrides: {
+        providerType: "openai",
+        url: "https://api.openai.com/v1",
+      },
+    });
+
+    const clientResponse = await ProxyResponseHandler.dispatch(
+      session,
+      createImageEditResponseWithoutUsage()
+    );
+    const responseText = await clientResponse.text();
+    await drainAsyncTasks();
+
+    expect(clientResponse.status).toBe(200);
+    expect(JSON.parse(responseText)).toMatchObject({
+      data: [{ b64_json: "test-image-bytes" }],
+    });
+    expect(updateMessageRequestCostWithBreakdown).not.toHaveBeenCalled();
+    expect(SessionManager.updateSessionUsage).not.toHaveBeenCalled();
+    expect(RateLimitService.trackCost).not.toHaveBeenCalled();
+  });
+
   it("finalizeRequestStats 的按次计费 session usage 保留 errorMessage", async () => {
     invalidateSystemSettingsCache();
 

--- a/tests/integration/billing-model-source.test.ts
+++ b/tests/integration/billing-model-source.test.ts
@@ -1137,6 +1137,50 @@ describe("模型重定向后的图片按次计费", () => {
       total: "0.12",
     });
   });
+
+  it("按次价格为 0 时不进入空 usage 计费写入路径", async () => {
+    invalidateSystemSettingsCache();
+
+    const originalModel = "gpt-image-2";
+    const redirectedModel = "gpt-image-2-all";
+
+    vi.mocked(getSystemSettings).mockResolvedValue(makeSystemSettings("original"));
+    vi.mocked(findLatestPriceByModel).mockImplementation(async (modelName: string) => {
+      return makePriceRecord(modelName, { input_cost_per_request: 0 }, "manual");
+    });
+
+    vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestDuration).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.storeSessionResponse).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackUserDailyCost).mockResolvedValue(undefined);
+    vi.mocked(SessionTracker.refreshSession).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.updateSessionUsage).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackCost).mockResolvedValue(undefined);
+
+    const session = createSession({
+      originalModel,
+      redirectedModel,
+      sessionId: "sess-image-edit-zero-per-request",
+      messageId: 4002,
+      requestPath: "/v1/images/edits",
+      providerOverrides: {
+        providerType: "openai",
+        url: "https://api.openai.com/v1",
+      },
+    });
+
+    const clientResponse = await ProxyResponseHandler.dispatch(
+      session,
+      createImageEditResponseWithoutUsage()
+    );
+    await clientResponse.text();
+    await drainAsyncTasks();
+
+    expect(updateMessageRequestCostWithBreakdown).not.toHaveBeenCalled();
+    expect(SessionManager.updateSessionUsage).not.toHaveBeenCalled();
+    expect(RateLimitService.trackCost).not.toHaveBeenCalled();
+  });
 });
 
 describe("价格表缺失/查询失败：不计费放行", () => {

--- a/tests/integration/billing-model-source.test.ts
+++ b/tests/integration/billing-model-source.test.ts
@@ -139,12 +139,17 @@ function makeSystemSettings(
   };
 }
 
-function makePriceRecord(modelName: string, priceData: ModelPriceData): ModelPrice {
+function makePriceRecord(
+  modelName: string,
+  priceData: ModelPriceData,
+  source: ModelPrice["source"] = "litellm"
+): ModelPrice {
   const now = new Date();
   return {
     id: 1,
     modelName,
     priceData,
+    source,
     createdAt: now,
     updatedAt: now,
   };
@@ -158,6 +163,8 @@ function createSession({
   enableHighConcurrencyMode = false,
   providerOverrides,
   requestMessage,
+  requestPath = "/v1/messages",
+  groupCostMultiplier,
 }: {
   originalModel: string;
   redirectedModel: string;
@@ -166,6 +173,8 @@ function createSession({
   enableHighConcurrencyMode?: boolean;
   providerOverrides?: Record<string, unknown>;
   requestMessage?: Record<string, unknown>;
+  requestPath?: string;
+  groupCostMultiplier?: number;
 }): ProxySession {
   const session = new (
     ProxySession as unknown as {
@@ -184,7 +193,7 @@ function createSession({
   )({
     startTime: Date.now(),
     method: "POST",
-    requestUrl: new URL("http://localhost/v1/messages"),
+    requestUrl: new URL(`http://localhost${requestPath}`),
     headers: new Headers(),
     headerLog: "",
     request: { message: requestMessage ?? {}, log: "(test)", model: redirectedModel },
@@ -196,6 +205,9 @@ function createSession({
   session.setOriginalModel(originalModel);
   session.setSessionId(sessionId);
   session.setHighConcurrencyModeEnabled(enableHighConcurrencyMode);
+  if (groupCostMultiplier !== undefined) {
+    session.setGroupCostMultiplier(groupCostMultiplier);
+  }
 
   const provider = {
     id: 99,
@@ -248,6 +260,19 @@ function createNonStreamResponse(
       type: "message",
       usage,
       ...(extras ?? {}),
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }
+  );
+}
+
+function createImageEditResponseWithoutUsage(): Response {
+  return new Response(
+    JSON.stringify({
+      created: 1_776_729_600,
+      data: [{ b64_json: "test-image-bytes" }],
     }),
     {
       status: 200,
@@ -993,6 +1018,124 @@ describe("Billing model source - Redis session cost vs DB cost", () => {
 
     expect(dbCosts[0]).toBe("32");
     expect(rateLimitCosts[0]).toBe(32);
+  });
+});
+
+describe("模型重定向后的图片按次计费", () => {
+  async function runImageEditPerRequestScenario(
+    billingModelSource: SystemSettings["billingModelSource"]
+  ): Promise<{
+    dbCostUsd: string;
+    storedBreakdown: Record<string, unknown> | undefined;
+    sessionCostUsd: string;
+    rateLimitCost: number;
+  }> {
+    invalidateSystemSettingsCache();
+
+    const originalModel = "gpt-image-2";
+    const redirectedModel = "gpt-image-2-all";
+    const providerMultiplier = 2;
+    const groupCostMultiplier = 3;
+
+    vi.mocked(getSystemSettings).mockResolvedValue(makeSystemSettings(billingModelSource));
+    vi.mocked(findLatestPriceByModel).mockImplementation(async (modelName: string) => {
+      if (modelName === originalModel) {
+        return makePriceRecord(modelName, { input_cost_per_request: 0.01 }, "manual");
+      }
+      if (modelName === redirectedModel) {
+        return makePriceRecord(modelName, { input_cost_per_request: 0.02 }, "manual");
+      }
+      return null;
+    });
+
+    vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestDuration).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.storeSessionResponse).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackUserDailyCost).mockResolvedValue(undefined);
+    vi.mocked(SessionTracker.refreshSession).mockResolvedValue(undefined);
+
+    const dbCosts: string[] = [];
+    let storedBreakdown: Record<string, unknown> | undefined;
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
+      async (_id: number, costUsd: unknown, breakdown?: Record<string, unknown>) => {
+        dbCosts.push(String(costUsd));
+        storedBreakdown = breakdown;
+      }
+    );
+
+    const sessionCosts: string[] = [];
+    vi.mocked(SessionManager.updateSessionUsage).mockImplementation(
+      async (_sessionId: string, payload: Record<string, unknown>) => {
+        if (typeof payload.costUsd === "string") {
+          sessionCosts.push(payload.costUsd);
+        }
+      }
+    );
+
+    const rateLimitCosts: number[] = [];
+    vi.mocked(RateLimitService.trackCost).mockImplementation(
+      async (_keyId: number, _providerId: number, _sessionId: string, costUsd: number) => {
+        rateLimitCosts.push(costUsd);
+      }
+    );
+
+    const session = createSession({
+      originalModel,
+      redirectedModel,
+      sessionId: `sess-image-edit-${billingModelSource}`,
+      messageId: billingModelSource === "original" ? 4000 : 4001,
+      requestPath: "/v1/images/edits",
+      providerOverrides: {
+        providerType: "openai",
+        url: "https://api.openai.com/v1",
+        costMultiplier: providerMultiplier,
+      },
+      groupCostMultiplier,
+    });
+
+    const clientResponse = await ProxyResponseHandler.dispatch(
+      session,
+      createImageEditResponseWithoutUsage()
+    );
+    await clientResponse.text();
+    await drainAsyncTasks();
+
+    return {
+      dbCostUsd: dbCosts[0] ?? "",
+      storedBreakdown,
+      sessionCostUsd: sessionCosts[0] ?? "",
+      rateLimitCost: rateLimitCosts[0] ?? Number.NaN,
+    };
+  }
+
+  it("配置 = original 时命中重定向前模型的本地按次价格并应用倍率", async () => {
+    const result = await runImageEditPerRequestScenario("original");
+
+    expect(result.dbCostUsd).toBe("0.06");
+    expect(result.sessionCostUsd).toBe("0.06");
+    expect(result.rateLimitCost).toBe(0.06);
+    expect(result.storedBreakdown).toMatchObject({
+      input: "0.01",
+      base_total: "0.01",
+      provider_multiplier: 2,
+      group_multiplier: 3,
+      total: "0.06",
+    });
+  });
+
+  it("配置 = redirected 时命中重定向后模型的本地按次价格并应用倍率", async () => {
+    const result = await runImageEditPerRequestScenario("redirected");
+
+    expect(result.dbCostUsd).toBe("0.12");
+    expect(result.sessionCostUsd).toBe("0.12");
+    expect(result.rateLimitCost).toBe(0.12);
+    expect(result.storedBreakdown).toMatchObject({
+      input: "0.02",
+      base_total: "0.02",
+      provider_multiplier: 2,
+      group_multiplier: 3,
+      total: "0.12",
+    });
   });
 });
 

--- a/tests/integration/billing-model-source.test.ts
+++ b/tests/integration/billing-model-source.test.ts
@@ -281,6 +281,20 @@ function createImageEditResponseWithoutUsage(): Response {
   );
 }
 
+function createFake200ErrorResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: "invalid api key",
+      },
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }
+  );
+}
+
 function createStreamResponse(usage: { input_tokens: number; output_tokens: number }): Response {
   const sseText = `event: message_delta\ndata: ${JSON.stringify({ usage })}\n\n`;
   const encoder = new TextEncoder();
@@ -1224,6 +1238,54 @@ describe("模型重定向后的图片按次计费", () => {
     expect(clientResponse.status).toBe(200);
     expect(JSON.parse(responseText)).toMatchObject({
       data: [{ b64_json: "test-image-bytes" }],
+    });
+    expect(updateMessageRequestCostWithBreakdown).not.toHaveBeenCalled();
+    expect(SessionManager.updateSessionUsage).not.toHaveBeenCalled();
+    expect(RateLimitService.trackCost).not.toHaveBeenCalled();
+  });
+
+  it("上游假 200 错误 payload 不触发图片按次计费", async () => {
+    invalidateSystemSettingsCache();
+
+    const originalModel = "gpt-image-2";
+    const redirectedModel = "gpt-image-2-all";
+
+    vi.mocked(getSystemSettings).mockResolvedValue(makeSystemSettings("original"));
+    vi.mocked(findLatestPriceByModel).mockImplementation(async (modelName: string) => {
+      return makePriceRecord(modelName, { input_cost_per_request: 0.01 }, "manual");
+    });
+
+    vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestDuration).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.storeSessionResponse).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackUserDailyCost).mockResolvedValue(undefined);
+    vi.mocked(SessionTracker.refreshSession).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.updateSessionUsage).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackCost).mockResolvedValue(undefined);
+
+    const session = createSession({
+      originalModel,
+      redirectedModel,
+      sessionId: "sess-image-edit-fake-200-error",
+      messageId: 4005,
+      requestPath: "/v1/images/edits",
+      providerOverrides: {
+        providerType: "openai",
+        url: "https://api.openai.com/v1",
+      },
+    });
+
+    const clientResponse = await ProxyResponseHandler.dispatch(
+      session,
+      createFake200ErrorResponse()
+    );
+    const responseText = await clientResponse.text();
+    await drainAsyncTasks();
+
+    expect(clientResponse.status).toBe(200);
+    expect(JSON.parse(responseText)).toMatchObject({
+      error: { message: "invalid api key" },
     });
     expect(updateMessageRequestCostWithBreakdown).not.toHaveBeenCalled();
     expect(SessionManager.updateSessionUsage).not.toHaveBeenCalled();

--- a/tests/integration/billing-model-source.test.ts
+++ b/tests/integration/billing-model-source.test.ts
@@ -77,7 +77,7 @@ vi.mock("@/lib/proxy-status-tracker", () => ({
   },
 }));
 
-import { ProxyResponseHandler } from "@/app/v1/_lib/proxy/response-handler";
+import { finalizeRequestStats, ProxyResponseHandler } from "@/app/v1/_lib/proxy/response-handler";
 import { ProxySession } from "@/app/v1/_lib/proxy/session";
 import { getCachedSystemSettings, invalidateSystemSettingsCache } from "@/lib/config";
 import { SessionManager } from "@/lib/session-manager";
@@ -1180,6 +1180,62 @@ describe("模型重定向后的图片按次计费", () => {
     expect(updateMessageRequestCostWithBreakdown).not.toHaveBeenCalled();
     expect(SessionManager.updateSessionUsage).not.toHaveBeenCalled();
     expect(RateLimitService.trackCost).not.toHaveBeenCalled();
+  });
+
+  it("finalizeRequestStats 的按次计费 session usage 保留 errorMessage", async () => {
+    invalidateSystemSettingsCache();
+
+    const originalModel = "gpt-image-2";
+    const redirectedModel = "gpt-image-2-all";
+    const errorMessage = "fake 200 upstream warning";
+
+    vi.mocked(getSystemSettings).mockResolvedValue(makeSystemSettings("original"));
+    vi.mocked(findLatestPriceByModel).mockImplementation(async (modelName: string) => {
+      return makePriceRecord(modelName, { input_cost_per_request: 0.01 }, "manual");
+    });
+
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackCost).mockResolvedValue(undefined);
+
+    let sessionUsagePayload: Record<string, unknown> | undefined;
+    vi.mocked(SessionManager.updateSessionUsage).mockImplementation(
+      async (_sessionId: string, payload: Record<string, unknown>) => {
+        sessionUsagePayload = payload;
+      }
+    );
+
+    const session = createSession({
+      originalModel,
+      redirectedModel,
+      sessionId: "sess-image-edit-finalize-error-message",
+      messageId: 4003,
+      requestPath: "/v1/images/edits",
+      providerOverrides: {
+        providerType: "openai",
+        url: "https://api.openai.com/v1",
+      },
+    });
+
+    await finalizeRequestStats(
+      session,
+      JSON.stringify({
+        created: 1_776_729_600,
+        data: [{ b64_json: "test-image-bytes" }],
+      }),
+      200,
+      42,
+      errorMessage,
+      99,
+      false
+    );
+
+    expect(sessionUsagePayload).toMatchObject({
+      costUsd: "0.01",
+      status: "completed",
+      statusCode: 200,
+      errorMessage,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes billing for redirected image requests when using per-request pricing (\`input_cost_per_request\`). Previously, successful image API responses without token usage data would bypass billing entirely when the resolved local price contained a per-request fee. This ensures proper cost tracking for OpenAI Images API and similar endpoints that don't return token usage.

## Problem
After the fix in #1118 for image requests without usage payload, a gap remained: when model redirects occur with \`billingModelSource\` set to \`original\` or \`redirected\`, successful responses without token usage (e.g., OpenAI Images API) were not being charged even when the local price table configured \`input_cost_per_request\`.

This caused:
- Missing billing records for redirected image generation requests with per-request pricing
- Zero-cost entries when providers didn't return usage payloads, despite local pricing having per-request fees
- Inconsistent billing behavior between regular chat completions and image API requests

**Related Issues:**
- Follow-up to #1118 - fixes remaining gap for model redirect scenarios with per-request pricing

## Solution
Introduced \`resolveBillableUsageMetricsForCost()\` to synthesize billable usage metrics when:
1. The response is successful (2xx status)
2. No token usage is present in the response
3. The resolved pricing (based on \`billingModelSource\`) contains a valid \`input_cost_per_request\`

This allows the existing billing pipeline (\`updateRequestCostFromUsage\`, \`trackCostToRedis\`) to process the request with the per-request fee from the correct model (either pre-redirect or post-redirect based on settings).

Key changes:
- Added \`hasBillableInputCostPerRequest()\` to validate per-request pricing availability
- Added \`resolveBillableUsageMetricsForCost()\` to generate empty usage objects that trigger per-request billing
- Unified the billing path in both streaming and non-streaming response handling
- Preserved existing model billing-source semantics: \`original\` charges pre-redirect model, \`redirected\` charges post-redirect model

## Changes

### Core Changes
- \`src/app/v1/_lib/proxy/response-handler.ts\`: Added \`resolveBillableUsageMetricsForCost()\` and integrated it into non-streaming, streaming, and request finalization paths

### Test Coverage
- \`tests/integration/billing-model-source.test.ts\`: Added regression tests for \`/v1/images/edits\` with \`gpt-image-2 -> gpt-image-2-all\` redirect scenarios, validating:
  - Provider multiplier application (2x)
  - Group multiplier application (3x)
  - DB cost recording with proper breakdown
  - Session cost tracking
  - Rate-limit cost tracking

## Testing

### Automated Tests
- [x] Integration tests added for redirected per-request image billing
- [x] Tests cover both \`original\` and \`redirected\` billing model sources
- [x] Tests verify provider multiplier, group multiplier, and cost breakdown accuracy

### Test Commands
\`\`\`bash
bunx vitest run tests/integration/billing-model-source.test.ts -t \"模型重定向后的图片按次计费\"
bunx vitest run tests/integration/billing-model-source.test.ts
\`\`\`

### Verification
\`\`\`bash
bun run build      # Production build (passes)
bun run lint       # Biome check (passes)
bun run lint:fix   # Auto-fix (passes)
bun run typecheck  # TypeScript check (passes)
bun run test       # All tests (passes)
\`\`\`

## Breaking Changes
None. This is a bug fix that enables previously non-functional billing paths. No existing billing behavior changes - only adds missing billing for the edge case.

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No documentation updates needed (behavioral fix, transparent to users)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a billing gap introduced after #1118: successful image API responses (e.g., `/v1/images/edits`) that carry no token-usage payload were not being charged when the resolved local pricing contained `input_cost_per_request` and a model redirect was in play. The fix introduces `resolveBillableUsageMetricsForCost()`, which synthesizes an empty `UsageMetrics` (`{}`) that routes through the existing billing pipeline (`updateRequestCostFromUsage`, `trackCostToRedis`, session observability) using the correct pre- or post-redirect model according to `billingModelSource` semantics. Test coverage is comprehensive across both billing model sources, provider/group multipliers, zero-cost guard, pricing-DB failure, fake-200 detection, and `finalizeRequestStats` error-message preservation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — focused billing bug fix with no regressions to existing token-based billing paths.

No P0/P1 issues found. The new `resolveBillableUsageMetricsForCost` guard correctly short-circuits for non-billing endpoints, non-2xx responses, zero/missing per-request prices, and fake-200 error payloads. The `usageRecord` removal is correct (it was redundant given the `billableUsageMetrics` guard). The session-observability condition change (`usageMetrics || costUsdStr !== undefined`) is an improvement for zero-token responses. All three billing paths (non-stream, SSE, `finalizeRequestStats`) are treated consistently, and the existing pricing cache prevents double resolution. Test coverage is thorough across all edge cases called out in the PR description.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/response-handler.ts | Adds `resolveBillableUsageMetricsForCost()` and integrates it into non-streaming, SSE, and `finalizeRequestStats` paths; removes the now-redundant `usageRecord` gate; corrects session-observability condition to trigger on `costUsdStr` for zero-token requests; SSE `costUsd` payload correctly split out of the `usageForCost` guard. |
| tests/integration/billing-model-source.test.ts | Adds six focused regression tests covering both `billingModelSource` values, zero per-request price, pricing-DB failure, fake-200 error payload, and `finalizeRequestStats` error-message propagation; extends `createSession` with `requestPath` and `groupCostMultiplier` parameters; adds `makePriceRecord` `source` field. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Response received] --> B{usageMetrics present?}
    B -- Yes --> C[normalizeUsageWithSwap]
    C --> D[resolveBillableUsageMetricsForCost returns usageMetrics]
    B -- No --> E[resolveBillableUsageMetricsForCost]
    E --> F{isNonBillingEndpoint?}
    F -- Yes --> G[return null - skip billing]
    F -- No --> H{statusCode 2xx?}
    H -- No --> G
    H -- Yes --> I[getResolvedPricingByBillingSource]
    I --> J{hasBillableInputCostPerRequest gt 0?}
    J -- No --> G
    J -- Yes --> K{responseText provided?}
    K -- Yes --> L{detectUpstreamError}
    L -- isError=true --> G
    L -- isError=false --> M[return empty UsageMetrics]
    K -- No --> M
    D --> N[updateRequestCostFromUsage + trackCostToRedis + updateSessionUsage]
    M --> N
    G --> O[skip billing]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(billing): skip per-request billing f..."](https://github.com/ding113/claude-code-hub/commit/8c69c56294dc5811868f8e78101877f661465c22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29830994)</sub>

<!-- /greptile_comment -->