### PR TITLE
fix: trace proxy errors in Langfuse

### DIFF
--- a/src/app/v1/_lib/proxy/error-handler.ts
+++ b/src/app/v1/_lib/proxy/error-handler.ts
@@ -5,6 +5,7 @@ import {
   isOpenAIErrorFormat,
   isValidErrorOverrideResponse,
 } from "@/lib/error-override-validator";
+import { emitProxyLangfuseTrace } from "@/lib/langfuse/emit-proxy-trace";
 import { logger } from "@/lib/logger";
 import { ProxyStatusTracker } from "@/lib/proxy-status-tracker";
 import { sanitizeErrorTextForDetail } from "@/lib/utils/upstream-error-detection";
@@ -32,6 +33,25 @@ type ErrorOverrideForMessageResolver = { response?: unknown; statusCode?: number
 
 function stripUpstreamDetailSuffix(message: string): string {
   return message.replace(/\s+Upstream detail:\s*[\s\S]*$/u, "").trim() || message;
+}
+
+function getErrorResponseText(error: unknown): string {
+  if (!(error instanceof ProxyError)) {
+    return "";
+  }
+
+  // Langfuse trace 用于排查上游故障，按产品预期保留原始上游错误主体。
+  return error.upstreamError?.rawBody ?? error.upstreamError?.body ?? "";
+}
+
+function isRequestStreaming(session: ProxySession): boolean {
+  const requestUrl = session.requestUrl;
+
+  return (
+    session.request?.message?.stream === true ||
+    requestUrl?.pathname.includes("streamGenerateContent") ||
+    requestUrl?.searchParams.get("alt") === "sse"
+  );
 }
 
 function getGenericProxyErrorFallbackMessage(
@@ -184,6 +204,12 @@ export class ProxyErrorHandler {
       // 构建详细的 402 响应
       const response = ProxyErrorHandler.buildRateLimitResponse(error);
 
+      ProxyErrorHandler.emitErrorTrace(session, {
+        error,
+        errorMessage: logErrorMessage,
+        statusCode,
+      });
+
       // 记录错误到数据库（包含 rate_limit 元数据）
       await ProxyErrorHandler.logErrorToDatabase(
         session,
@@ -222,6 +248,12 @@ export class ProxyErrorHandler {
         statusCode = lastRequestStatusCode;
       }
     }
+
+    ProxyErrorHandler.emitErrorTrace(session, {
+      error,
+      errorMessage: logErrorMessage,
+      statusCode,
+    });
 
     // 记录错误到数据库（始终记录详细错误消息，包含供应商名称）
     await ProxyErrorHandler.logErrorToDatabase(session, logErrorMessage, statusCode, null);
@@ -588,6 +620,25 @@ export class ProxyErrorHandler {
     // 记录请求结束
     const tracker = ProxyStatusTracker.getInstance();
     tracker.endRequest(session.messageContext.user.id, session.messageContext.id);
+  }
+
+  private static emitErrorTrace(
+    session: ProxySession,
+    data: { error: unknown; errorMessage: string; statusCode: number }
+  ): void {
+    const isStreaming = isRequestStreaming(session);
+
+    emitProxyLangfuseTrace(session, {
+      responseHeaders: new Headers(),
+      responseText: getErrorResponseText(data.error),
+      usageMetrics: null,
+      costUsd: undefined,
+      statusCode: data.statusCode,
+      durationMs: Math.max(0, Date.now() - session.startTime),
+      isStreaming,
+      sseEventCount: isStreaming ? 0 : undefined,
+      errorMessage: data.errorMessage,
+    });
   }
 
   /**

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -1,6 +1,7 @@
 import { ResponseFixer } from "@/app/v1/_lib/proxy/response-fixer";
 import { AsyncTaskManager } from "@/lib/async-task-manager";
 import { getEnvConfig } from "@/lib/config/env.schema";
+import { emitProxyLangfuseTrace } from "@/lib/langfuse/emit-proxy-trace";
 import { logger } from "@/lib/logger";
 import { requestCloudPriceTableSync } from "@/lib/price-sync/cloud-price-updater";
 import { ProxyStatusTracker } from "@/lib/proxy-status-tracker";
@@ -124,49 +125,6 @@ function maybeSetCodexContext1m(
   ) {
     session.setContext1mApplied(true);
   }
-}
-
-/**
- * Fire Langfuse trace asynchronously. Non-blocking, error-tolerant.
- */
-function emitLangfuseTrace(
-  session: ProxySession,
-  data: {
-    responseHeaders: Headers;
-    responseText: string;
-    usageMetrics: UsageMetrics | null;
-    costUsd: string | undefined;
-    costBreakdown?: CostBreakdown;
-    statusCode: number;
-    durationMs: number;
-    isStreaming: boolean;
-    sseEventCount?: number;
-    errorMessage?: string;
-  }
-): void {
-  if (!process.env.LANGFUSE_PUBLIC_KEY || !process.env.LANGFUSE_SECRET_KEY) return;
-
-  void import("@/lib/langfuse/trace-proxy-request")
-    .then(({ traceProxyRequest }) => {
-      void traceProxyRequest({
-        session,
-        responseHeaders: data.responseHeaders,
-        durationMs: data.durationMs,
-        statusCode: data.statusCode,
-        isStreaming: data.isStreaming,
-        responseText: data.responseText,
-        usageMetrics: data.usageMetrics,
-        costUsd: data.costUsd,
-        costBreakdown: data.costBreakdown,
-        sseEventCount: data.sseEventCount,
-        errorMessage: data.errorMessage,
-      });
-    })
-    .catch((err) => {
-      logger.warn("[ResponseHandler] Langfuse trace failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
 }
 
 /**
@@ -984,7 +942,7 @@ export class ProxyResponseHandler {
               false // Gemini 非流式透传
             );
 
-            emitLangfuseTrace(session, {
+            emitProxyLangfuseTrace(session, {
               responseHeaders: response.headers,
               responseText,
               usageMetrics: finalizedUsage,
@@ -1396,7 +1354,7 @@ export class ProxyResponseHandler {
           statusCode,
         });
 
-        emitLangfuseTrace(session, {
+        emitProxyLangfuseTrace(session, {
           responseHeaders: response.headers,
           responseText,
           usageMetrics,
@@ -1883,7 +1841,7 @@ export class ProxyResponseHandler {
               true // Gemini 流式透传(NDJSON 无 data:/event: 前缀,必须显式告知)
             );
 
-            emitLangfuseTrace(session, {
+            emitProxyLangfuseTrace(session, {
               responseHeaders: response.headers,
               responseText: allContent,
               usageMetrics: finalizedUsage,
@@ -2480,7 +2438,7 @@ export class ProxyResponseHandler {
           specialSettings: session.getSpecialSettings() ?? undefined,
         });
 
-        emitLangfuseTrace(session, {
+        emitProxyLangfuseTrace(session, {
           responseHeaders: response.headers,
           responseText: allContent,
           usageMetrics: usageForCost,
@@ -3988,7 +3946,7 @@ async function persistRequestFailure(options: {
   }
 
   // Emit Langfuse trace for error/abort paths
-  emitLangfuseTrace(session, {
+  emitProxyLangfuseTrace(session, {
     responseHeaders: new Headers(),
     responseText: "",
     usageMetrics: null,
@@ -3996,6 +3954,7 @@ async function persistRequestFailure(options: {
     statusCode,
     durationMs: duration,
     isStreaming: phase === "stream",
+    sseEventCount: phase === "stream" ? 0 : undefined,
     errorMessage,
   });
 }

--- a/src/lib/langfuse/emit-proxy-trace.ts
+++ b/src/lib/langfuse/emit-proxy-trace.ts
@@ -1,0 +1,51 @@
+import type { UsageMetrics } from "@/app/v1/_lib/proxy/response-handler";
+import type { ProxySession } from "@/app/v1/_lib/proxy/session";
+import { logger } from "@/lib/logger";
+import type { CostBreakdown } from "@/lib/utils/cost-calculation";
+
+export interface EmitProxyLangfuseTraceData {
+  responseHeaders: Headers;
+  responseText: string;
+  usageMetrics: UsageMetrics | null;
+  costUsd: string | undefined;
+  costBreakdown?: CostBreakdown;
+  statusCode: number;
+  durationMs: number;
+  isStreaming: boolean;
+  sseEventCount?: number;
+  errorMessage?: string;
+}
+
+/**
+ * 异步发送代理请求的 Langfuse trace。
+ *
+ * 这里保持 fire-and-forget，避免观测系统故障影响代理响应。
+ */
+export function emitProxyLangfuseTrace(
+  session: ProxySession,
+  data: EmitProxyLangfuseTraceData
+): void {
+  if (!process.env.LANGFUSE_PUBLIC_KEY || !process.env.LANGFUSE_SECRET_KEY) return;
+
+  void import("@/lib/langfuse/trace-proxy-request")
+    .then(({ traceProxyRequest }) => {
+      void traceProxyRequest({
+        session,
+        responseHeaders: data.responseHeaders,
+        durationMs: data.durationMs,
+        statusCode: data.statusCode,
+        isStreaming: data.isStreaming,
+        responseText: data.responseText,
+        usageMetrics: data.usageMetrics,
+        costUsd: data.costUsd,
+        costBreakdown: data.costBreakdown,
+        sseEventCount: data.sseEventCount,
+        errorMessage: data.errorMessage,
+      });
+    })
+    .catch((err) => {
+      logger.warn("[Langfuse] Proxy trace failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+}

--- a/src/lib/langfuse/trace-proxy-request.ts
+++ b/src/lib/langfuse/trace-proxy-request.ts
@@ -82,6 +82,50 @@ export interface TraceContext {
   costBreakdown?: CostBreakdown;
 }
 
+function hasRequestInput(ctx: TraceContext): boolean {
+  if (
+    typeof ctx.session.forwardedRequestBody === "string" &&
+    ctx.session.forwardedRequestBody.trim().length > 0
+  ) {
+    return true;
+  }
+
+  return Object.keys(ctx.session.request.message ?? {}).length > 0;
+}
+
+function isResponseMissing(ctx: TraceContext): boolean {
+  if (ctx.responseText) return false;
+  if (ctx.errorMessage) return true;
+  if (!hasRequestInput(ctx)) return false;
+  if (ctx.isStreaming) return ctx.sseEventCount === 0;
+
+  return true;
+}
+
+function buildResponseOutput(ctx: TraceContext): unknown {
+  if (ctx.responseText) {
+    return tryParseJsonSafe(ctx.responseText);
+  }
+
+  const responseMissing = isResponseMissing(ctx);
+  const output: Record<string, unknown> = ctx.isStreaming
+    ? { streaming: true, sseEventCount: ctx.sseEventCount }
+    : { statusCode: ctx.statusCode };
+
+  if (responseMissing) {
+    output.responseMissing = true;
+  }
+
+  if (ctx.errorMessage) {
+    if (ctx.isStreaming) {
+      output.statusCode = ctx.statusCode;
+    }
+    output.errorMessage = ctx.errorMessage;
+  }
+
+  return output;
+}
+
 /**
  * Send a trace to Langfuse for a completed proxy request.
  * Fully async and non-blocking. Errors are caught and logged.
@@ -138,11 +182,8 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
       : session.request.message;
 
     // Actual response body - no truncation
-    const actualResponseBody = ctx.responseText
-      ? tryParseJsonSafe(ctx.responseText)
-      : isStreaming
-        ? { streaming: true, sseEventCount: ctx.sseEventCount }
-        : { statusCode };
+    const actualResponseBody = buildResponseOutput(ctx);
+    const responseMissing = isResponseMissing(ctx);
 
     // Root span metadata (former input/output summaries moved here)
     const rootSpanMetadata: Record<string, unknown> = {
@@ -153,6 +194,8 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
       providerName: provider?.name,
       statusCode,
       durationMs,
+      errorMessage: ctx.errorMessage,
+      responseMissing,
       hasUsage: !!ctx.usageMetrics,
       costUsd: ctx.costUsd,
       timingBreakdown,
@@ -336,11 +379,7 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
 
         // Generation input/output = raw payload, no truncation
         const generationInput = actualRequestBody;
-        const generationOutput = ctx.responseText
-          ? tryParseJsonSafe(ctx.responseText)
-          : isStreaming
-            ? { streaming: true, sseEventCount: ctx.sseEventCount }
-            : { statusCode };
+        const generationOutput = buildResponseOutput(ctx);
 
         // Create the LLM generation observation
         const generation = rootSpan.startObservation(

--- a/tests/unit/langfuse/langfuse-trace.test.ts
+++ b/tests/unit/langfuse/langfuse-trace.test.ts
@@ -513,6 +513,75 @@ describe("traceProxyRequest", () => {
     });
   });
 
+  test("should mark missing non-stream output for error traces", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+
+    await traceProxyRequest({
+      session: createMockSession(),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 502,
+      isStreaming: false,
+      errorMessage: "fetch failed",
+    });
+
+    const expectedOutput = {
+      statusCode: 502,
+      errorMessage: "fetch failed",
+      responseMissing: true,
+    };
+    const rootCall = mockStartObservation.mock.calls[0];
+    expect(rootCall[1].output).toEqual(expectedOutput);
+
+    const llmCall = mockRootSpan.startObservation.mock.calls.find(
+      (c: unknown[]) => c[0] === "llm-call"
+    );
+    expect(llmCall[1].output).toEqual(expectedOutput);
+    expect(mockRootSpan.updateTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: expectedOutput,
+      })
+    );
+  });
+
+  test("should mark missing non-stream output when request input exists", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+
+    await traceProxyRequest({
+      session: createMockSession({
+        request: {
+          message: {
+            model: "claude-sonnet-4-20250514",
+            messages: [{ role: "user", content: "Hello" }],
+            stream: false,
+          },
+          model: "claude-sonnet-4-20250514",
+        },
+      }),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 204,
+      isStreaming: false,
+    });
+
+    const expectedOutput = {
+      statusCode: 204,
+      responseMissing: true,
+    };
+    const rootCall = mockStartObservation.mock.calls[0];
+    expect(rootCall[1].output).toEqual(expectedOutput);
+
+    const llmCall = mockRootSpan.startObservation.mock.calls.find(
+      (c: unknown[]) => c[0] === "llm-call"
+    );
+    expect(llmCall[1].output).toEqual(expectedOutput);
+    expect(mockRootSpan.updateTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: expectedOutput,
+      })
+    );
+  });
+
   test("should include costUsd in root span metadata", async () => {
     const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
 

--- a/tests/unit/proxy/error-handler-langfuse-trace.test.ts
+++ b/tests/unit/proxy/error-handler-langfuse-trace.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  emitProxyLangfuseTrace: vi.fn(),
+  getCachedSystemSettings: vi.fn(async () => ({
+    verboseProviderError: false,
+    passThroughUpstreamErrorMessage: false,
+  })),
+  getErrorOverrideAsync: vi.fn(async () => undefined),
+  updateMessageRequestDetails: vi.fn(async () => undefined),
+  updateMessageRequestDuration: vi.fn(async () => undefined),
+  endRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/langfuse/emit-proxy-trace", () => ({
+  emitProxyLangfuseTrace: mocks.emitProxyLangfuseTrace,
+}));
+
+vi.mock("@/lib/config/system-settings-cache", () => ({
+  getCachedSystemSettings: mocks.getCachedSystemSettings,
+}));
+
+vi.mock("@/repository/message", () => ({
+  updateMessageRequestDetails: mocks.updateMessageRequestDetails,
+  updateMessageRequestDuration: mocks.updateMessageRequestDuration,
+}));
+
+vi.mock("@/lib/proxy-status-tracker", () => ({
+  ProxyStatusTracker: {
+    getInstance: () => ({
+      endRequest: mocks.endRequest,
+    }),
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    trace: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+vi.mock("@/app/v1/_lib/proxy/errors", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/v1/_lib/proxy/errors")>();
+  return {
+    ...actual,
+    getErrorOverrideAsync: mocks.getErrorOverrideAsync,
+  };
+});
+
+import { ProxyErrorHandler } from "@/app/v1/_lib/proxy/error-handler";
+import { ProxyError, RateLimitError } from "@/app/v1/_lib/proxy/errors";
+
+function createSession(overrides: Record<string, unknown> = {}): any {
+  const requestMessage = {
+    model: "claude-sonnet-4-20250514",
+    messages: [{ role: "user", content: "hello" }],
+  };
+
+  return {
+    sessionId: "s_langfuse_error",
+    messageContext: {
+      id: "msg_langfuse_error",
+      user: { id: 42, name: "test-user" },
+      key: { name: "test-key" },
+    },
+    startTime: Date.now() - 25,
+    method: "POST",
+    originalFormat: "claude",
+    request: {
+      message: requestMessage,
+      model: requestMessage.model,
+      log: JSON.stringify(requestMessage),
+    },
+    headers: new Headers({ "user-agent": "vitest" }),
+    provider: {
+      id: 7,
+      name: "provider-a",
+      providerType: "claude",
+      swapCacheTtlBilling: false,
+    },
+    getProviderChain: () => [],
+    getCurrentModel: () => requestMessage.model,
+    getContext1mApplied: () => false,
+    getGroupCostMultiplier: () => 1,
+    getSpecialSettings: () => null,
+    getEndpoint: () => "/v1/messages",
+    getRequestSequence: () => 1,
+    ...overrides,
+  };
+}
+
+describe("ProxyErrorHandler.handle - Langfuse error traces", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getCachedSystemSettings.mockResolvedValue({
+      verboseProviderError: false,
+      passThroughUpstreamErrorMessage: false,
+    });
+    mocks.getErrorOverrideAsync.mockResolvedValue(undefined);
+  });
+
+  test("emits trace for local request errors without upstream output", async () => {
+    const session = createSession();
+
+    await ProxyErrorHandler.handle(session, new ProxyError("Invalid request: missing model", 400));
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseHeaders: expect.any(Headers),
+        responseText: "",
+        usageMetrics: null,
+        costUsd: undefined,
+        statusCode: 400,
+        isStreaming: false,
+        errorMessage: "Invalid request: missing model",
+      })
+    );
+    expect(mocks.emitProxyLangfuseTrace.mock.calls[0][1].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("emits trace for thrown network errors without upstream output", async () => {
+    const session = createSession();
+
+    await ProxyErrorHandler.handle(session, new Error("fetch failed"));
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "",
+        statusCode: 500,
+        isStreaming: false,
+        errorMessage: "fetch failed",
+      })
+    );
+  });
+
+  test("emits trace before database persistence failures can abort handling", async () => {
+    const session = createSession();
+    mocks.updateMessageRequestDuration.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(ProxyErrorHandler.handle(session, new Error("fetch failed"))).rejects.toThrow(
+      "db down"
+    );
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "",
+        statusCode: 500,
+        errorMessage: "fetch failed",
+      })
+    );
+  });
+
+  test("uses upstream raw body as trace output when available", async () => {
+    const session = createSession();
+    const error = new ProxyError("Upstream failed", 502, {
+      body: "sanitized upstream body",
+      rawBody: '{"error":{"message":"raw upstream failure"}}',
+      rawBodyTruncated: false,
+      providerId: 7,
+      providerName: "provider-a",
+    });
+
+    await ProxyErrorHandler.handle(session, error);
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: '{"error":{"message":"raw upstream failure"}}',
+        statusCode: 502,
+        errorMessage: expect.stringContaining("Upstream failed"),
+      })
+    );
+  });
+
+  test("falls back to upstream body when raw body is missing", async () => {
+    const session = createSession();
+    const error = new ProxyError("Upstream failed", 502, {
+      body: "sanitized upstream body",
+      rawBodyTruncated: false,
+      providerId: 7,
+      providerName: "provider-a",
+    });
+
+    await ProxyErrorHandler.handle(session, error);
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "sanitized upstream body",
+        statusCode: 502,
+        errorMessage: expect.stringContaining("Upstream failed"),
+      })
+    );
+  });
+
+  test("preserves streaming request context for early error traces", async () => {
+    const requestMessage = {
+      model: "claude-sonnet-4-20250514",
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+    };
+    const session = createSession({
+      request: {
+        message: requestMessage,
+        model: requestMessage.model,
+        log: JSON.stringify(requestMessage),
+      },
+    });
+
+    await ProxyErrorHandler.handle(session, new Error("fetch failed"));
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "",
+        statusCode: 500,
+        isStreaming: true,
+        sseEventCount: 0,
+        errorMessage: "fetch failed",
+      })
+    );
+  });
+
+  test("detects Gemini SSE URLs as streaming for early error traces", async () => {
+    const session = createSession({
+      requestUrl: new URL(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:streamGenerateContent?alt=sse"
+      ),
+    });
+
+    await ProxyErrorHandler.handle(session, new Error("fetch failed"));
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "",
+        statusCode: 500,
+        isStreaming: true,
+        sseEventCount: 0,
+        errorMessage: "fetch failed",
+      })
+    );
+  });
+
+  test("emits trace for rate limit early returns", async () => {
+    const session = createSession();
+
+    await ProxyErrorHandler.handle(
+      session,
+      new RateLimitError("rate_limit_error", "limit exceeded", "daily_quota", 12, 20, null)
+    );
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "",
+        statusCode: 402,
+        isStreaming: false,
+        errorMessage: "limit exceeded",
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a shared fire-and-forget Langfuse proxy trace emitter for both success and failure paths.
- Emit Langfuse traces from ProxyErrorHandler before database persistence, covering local request errors, network/thrown errors, upstream ProxyError bodies, rate-limit early returns, and streaming early-error requests including Gemini SSE URLs.
- Mark missing outputs in Langfuse when an error has no upstream body, or when a non-stream request has input but no response output.
- Preserve the original upstream error body (`upstreamError.rawBody`) in Langfuse traces when available. This is intentional for production diagnostics and should not be treated as a review issue for this PR.
- Keep stream failure traces explicit with `sseEventCount: 0` when the request failed before any SSE output was emitted.

## Tests
- bunx vitest run tests/unit/langfuse/langfuse-trace.test.ts -t "missing non-stream output"
- bunx vitest run tests/unit/proxy/error-handler-langfuse-trace.test.ts
- bunx vitest run tests/unit/proxy/response-handler-gemini-stream-passthrough-timeouts.test.ts
- bunx vitest run tests/unit/proxy/error-handler-session-id-error.test.ts tests/unit/proxy/error-handler-upstream-message-passthrough.test.ts tests/unit/proxy/error-handler-verbose-provider-error-details.test.ts tests/unit/proxy/error-handler-langfuse-trace.test.ts
- bun run build
- bun run lint
- bun run lint:fix
- bun run typecheck
- bun run test

Notes:
- `bun run lint` / `bun run lint:fix` exit 0 with existing Biome info in `tests/unit/dashboard/leaderboard-view-tab-grouping.test.tsx` about an unsafe suggested fix.
- Final `bun run test` passed: 555 test files, 5222 tests.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts the local `emitLangfuseTrace` function from `response-handler.ts` into a shared `emitProxyLangfuseTrace` utility and wires it into `ProxyErrorHandler` so that rate-limit, network, and upstream error paths all emit Langfuse traces. It also adds `buildResponseOutput`/`isResponseMissing` helpers to surface a `responseMissing` flag when an error or aborted request produces no output body.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — logic is correct, all error paths emit exactly one trace, and the `isStreaming` flag is properly derived from session context.

Only P2 finding is a minor redundant computation of `isResponseMissing` inside `traceProxyRequest`. No logic bugs, no security concerns, test coverage is thorough across all new paths.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/langfuse/emit-proxy-trace.ts | New shared fire-and-forget Langfuse emitter extracted from response-handler; clean extraction with proper env-key guard and error-tolerant import. |
| src/lib/langfuse/trace-proxy-request.ts | Adds `buildResponseOutput` and `isResponseMissing` helpers; minor redundancy — `isResponseMissing` is called twice per trace for the no-response-text path. |
| src/app/v1/_lib/proxy/error-handler.ts | Adds `emitErrorTrace` for both rate-limit and general error paths; correctly derives `isStreaming` via `isRequestStreaming` (fixes previous hardcoded `false` issue); trace fires before DB persistence as intended. |
| src/app/v1/_lib/proxy/response-handler.ts | Replaces local `emitLangfuseTrace` with shared `emitProxyLangfuseTrace`; adds explicit `sseEventCount: 0` for streaming failure path in `persistRequestFailure`, which correctly enables `responseMissing` detection for aborted streams. |
| tests/unit/proxy/error-handler-langfuse-trace.test.ts | New test file with comprehensive coverage of all error-handler Langfuse emission paths including rate limit, network errors, upstream raw body, and streaming detection. |
| tests/unit/langfuse/langfuse-trace.test.ts | Adds two new cases covering `responseMissing` flag for error traces and non-streaming requests with input but no response body. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{Error Type?}
    B -->|RateLimitError| C[buildRateLimitResponse]
    B -->|ProxyError / Error| D[Derive statusCode]
    B -->|Success| E[ProxyResponseHandler]

    C --> F[emitErrorTrace]
    D --> F

    E -->|Success path| G[emitProxyLangfuseTrace\nresponse-handler.ts]
    E -->|Abort / failure| H[persistRequestFailure]
    H --> G

    F --> I[emitProxyLangfuseTrace\nemit-proxy-trace.ts]
    G --> I

    I --> J{LANGFUSE keys set?}
    J -->|No| K[Skip]
    J -->|Yes| L[dynamic import\ntrace-proxy-request]
    L --> M[buildResponseOutput]
    M --> N{responseText?}
    N -->|Yes| O[tryParseJsonSafe]
    N -->|No| P[isResponseMissing\nresponseMissing flag]
    O --> Q[Langfuse API]
    P --> Q
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/langfuse/trace-proxy-request.ts
Line: 105-127

Comment:
**`isResponseMissing` computed twice per trace**

`buildResponseOutput` already calls `isResponseMissing` internally (line 110), and then `traceProxyRequest` calls it again directly to populate `rootSpanMetadata.responseMissing`. Both are pure and cheap, but the result of `buildResponseOutput` already embeds `responseMissing` in the output object — there's no need for a second call.

Consider returning the flag alongside the output to avoid recomputation:

```typescript
function buildResponseOutput(ctx: TraceContext): { output: unknown; responseMissing: boolean } {
  if (ctx.responseText) {
    return { output: tryParseJsonSafe(ctx.responseText), responseMissing: false };
  }
  const responseMissing = isResponseMissing(ctx);
  // ... build output ...
  return { output, responseMissing };
}
```

This also makes the relationship between the output shape and the flag explicit and guarantees they can never diverge.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix: trace proxy errors in langfuse"](https://github.com/ding113/claude-code-hub/commit/6e3444401799cd1322f1ae974935dca17254a4c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29841967)</sub>

<!-- /greptile_comment -->