### PR TITLE
total quota fix

### DIFF
--- a/messages/en/quota.json
+++ b/messages/en/quota.json
@@ -153,6 +153,9 @@
       "label": "Monthly Cost",
       "resetAt": "Resets at"
     },
+    "costTotal": {
+      "label": "Total Cost"
+    },
     "concurrentSessions": {
       "label": "Concurrent Sessions"
     },

--- a/messages/en/quota.json
+++ b/messages/en/quota.json
@@ -186,6 +186,7 @@
       "costDaily": "Daily Quota",
       "costWeekly": "Weekly Quota",
       "costMonthly": "Monthly Quota",
+      "costTotal": "Total Quota",
       "concurrentSessions": "Concurrent Limit",
       "status": "Status",
       "actions": "Actions"
@@ -235,6 +236,11 @@
       },
       "costMonthly": {
         "label": "Monthly Quota (USD)",
+        "placeholder": "Unlimited",
+        "current": "Current usage: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "Total Quota (USD)",
         "placeholder": "Unlimited",
         "current": "Current usage: {currency}{current} / {currency}{limit}"
       },

--- a/messages/ja/quota.json
+++ b/messages/ja/quota.json
@@ -130,6 +130,9 @@
       "label": "月次コスト",
       "resetAt": "リセット時刻"
     },
+    "costTotal": {
+      "label": "総コスト"
+    },
     "concurrentSessions": {
       "label": "同時セッション"
     },

--- a/messages/ja/quota.json
+++ b/messages/ja/quota.json
@@ -163,6 +163,7 @@
       "costDaily": "日次クォータ",
       "costWeekly": "週次クォータ",
       "costMonthly": "月次クォータ",
+      "costTotal": "総クォータ",
       "concurrentSessions": "同時制限",
       "status": "ステータス",
       "actions": "アクション"
@@ -212,6 +213,11 @@
       },
       "costMonthly": {
         "label": "月次クォータ (USD)",
+        "placeholder": "無制限",
+        "current": "現在使用: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "総クォータ (USD)",
         "placeholder": "無制限",
         "current": "現在使用: {currency}{current} / {currency}{limit}"
       },

--- a/messages/ru/quota.json
+++ b/messages/ru/quota.json
@@ -153,6 +153,9 @@
       "label": "Ежемесячные расходы",
       "resetAt": "Сброс в"
     },
+    "costTotal": {
+      "label": "Общие расходы"
+    },
     "concurrentSessions": {
       "label": "Параллельные сессии"
     },

--- a/messages/ru/quota.json
+++ b/messages/ru/quota.json
@@ -186,6 +186,7 @@
       "costDaily": "Дневная квота",
       "costWeekly": "Еженедельная квота",
       "costMonthly": "Ежемесячная квота",
+      "costTotal": "Общая квота",
       "concurrentSessions": "Лимит параллельных",
       "status": "Статус",
       "actions": "Действия"
@@ -235,6 +236,11 @@
       },
       "costMonthly": {
         "label": "Ежемесячная квота (USD)",
+        "placeholder": "Неограниченно",
+        "current": "Использовано: {currency}{current} из {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "Общая квота (USD)",
         "placeholder": "Неограниченно",
         "current": "Использовано: {currency}{current} из {currency}{limit}"
       },

--- a/messages/zh-CN/quota.json
+++ b/messages/zh-CN/quota.json
@@ -153,6 +153,9 @@
       "label": "月消费",
       "resetAt": "重置于"
     },
+    "costTotal": {
+      "label": "总消费"
+    },
     "concurrentSessions": {
       "label": "并发 Session"
     },

--- a/messages/zh-CN/quota.json
+++ b/messages/zh-CN/quota.json
@@ -186,6 +186,7 @@
       "costDaily": "每日限额",
       "costWeekly": "周限额",
       "costMonthly": "月限额",
+      "costTotal": "总限额",
       "concurrentSessions": "并发限制",
       "status": "状态",
       "actions": "操作"
@@ -235,6 +236,11 @@
       },
       "costMonthly": {
         "label": "月限额(USD)",
+        "placeholder": "不限制",
+        "current": "当前已用: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "总限额(USD)",
         "placeholder": "不限制",
         "current": "当前已用: {currency}{current} / {currency}{limit}"
       },

--- a/messages/zh-TW/quota.json
+++ b/messages/zh-TW/quota.json
@@ -128,6 +128,9 @@
       "label": "月消費",
       "resetAt": "重置於"
     },
+    "costTotal": {
+      "label": "總消費"
+    },
     "concurrentSessions": {
       "label": "並發 Session"
     },

--- a/messages/zh-TW/quota.json
+++ b/messages/zh-TW/quota.json
@@ -161,6 +161,7 @@
       "costDaily": "每日限額",
       "costWeekly": "周限額",
       "costMonthly": "月限額",
+      "costTotal": "總限額",
       "concurrentSessions": "並發限制",
       "status": "狀態",
       "actions": "操作"
@@ -210,6 +211,11 @@
       },
       "costMonthly": {
         "label": "月限額 (USD)",
+        "placeholder": "不限制",
+        "current": "當前已用: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "總限額 (USD)",
         "placeholder": "不限制",
         "current": "當前已用: {currency}{current} / {currency}{limit}"
       },

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -2690,6 +2690,7 @@ export async function getProviderLimitUsage(providerId: number): Promise<
     costDaily: { current: number; limit: number | null; resetAt?: Date };
     costWeekly: { current: number; limit: number | null; resetAt: Date };
     costMonthly: { current: number; limit: number | null; resetAt: Date };
+    limitTotalUsd: { current: number; limit: number | null };
     concurrentSessions: { current: number; limit: number };
   }>
 > {
@@ -2713,7 +2714,9 @@ export async function getProviderLimitUsage(providerId: number): Promise<
       getTimeRangeForPeriodWithMode,
     } = await import("@/lib/rate-limit/time-utils");
     const { RateLimitService } = await import("@/lib/rate-limit");
-    const { sumProviderCostInTimeRange } = await import("@/repository/statistics");
+    const { sumProviderCostInTimeRange, sumProviderTotalCost } = await import(
+      "@/repository/statistics"
+    );
     const limit5hResetMode = provider.limit5hResetMode ?? "rolling";
 
     // 计算各周期的时间范围
@@ -2732,13 +2735,15 @@ export async function getProviderLimitUsage(providerId: number): Promise<
     ]);
 
     // 获取金额消费（直接查询数据库，确保配额显示与 DB 一致）
-    const [cost5h, costDaily, costWeekly, costMonthly, concurrentSessions] = await Promise.all([
+    const [cost5h, costDaily, costWeekly, costMonthly, totalCost, concurrentSessions] =
+      await Promise.all([
       limit5hResetMode === "fixed"
         ? RateLimitService.getCurrentCost(providerId, "provider", "5h", undefined, limit5hResetMode)
         : sumProviderCostInTimeRange(providerId, range5h.startTime, range5h.endTime),
       sumProviderCostInTimeRange(providerId, rangeDaily.startTime, rangeDaily.endTime),
       sumProviderCostInTimeRange(providerId, rangeWeekly.startTime, rangeWeekly.endTime),
       sumProviderCostInTimeRange(providerId, rangeMonthly.startTime, rangeMonthly.endTime),
+      sumProviderTotalCost(providerId),
       SessionTracker.getProviderSessionCount(providerId),
     ]);
 
@@ -2779,6 +2784,10 @@ export async function getProviderLimitUsage(providerId: number): Promise<
           limit: provider.limitMonthlyUsd,
           resetAt: resetMonthly.resetAt!,
         },
+        limitTotalUsd: {
+          current: totalCost,
+          limit: provider.limitTotalUsd ?? null,
+        },
         concurrentSessions: {
           current: concurrentSessions,
           limit: provider.limitConcurrentSessions || 0,
@@ -2800,6 +2809,7 @@ export type ProviderLimitUsageData = {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
+  limitTotalUsd: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 };
 
@@ -2820,6 +2830,7 @@ export async function getProviderLimitUsageBatch(
     limitDailyUsd?: number | null;
     limitWeeklyUsd?: number | null;
     limitMonthlyUsd?: number | null;
+    limitTotalUsd?: number | null;
     limitConcurrentSessions?: number | null;
   }>
 ): Promise<Map<number, ProviderLimitUsageData>> {
@@ -2845,7 +2856,9 @@ export async function getProviderLimitUsageBatch(
       getTimeRangeForPeriodWithMode,
     } = await import("@/lib/rate-limit/time-utils");
     const { RateLimitService } = await import("@/lib/rate-limit");
-    const { sumProviderCostInTimeRange } = await import("@/repository/statistics");
+    const { sumProviderCostInTimeRange, sumProviderTotalCost } = await import(
+      "@/repository/statistics"
+    );
 
     const providerIds = providers.map((p) => p.id);
 
@@ -2871,7 +2884,8 @@ export async function getProviderLimitUsageBatch(
       );
 
       // 并行查询该供应商的各周期消费（直接查询数据库）
-      const [cost5h, resetAt5h, costDaily, costWeekly, costMonthly] = await Promise.all([
+      const [cost5h, resetAt5h, costDaily, costWeekly, costMonthly, totalCost] =
+        await Promise.all([
         limit5hResetMode === "fixed"
           ? RateLimitService.getCurrentCost(
               provider.id,
@@ -2887,6 +2901,7 @@ export async function getProviderLimitUsageBatch(
         sumProviderCostInTimeRange(provider.id, rangeDaily.startTime, rangeDaily.endTime),
         sumProviderCostInTimeRange(provider.id, rangeWeekly.startTime, rangeWeekly.endTime),
         sumProviderCostInTimeRange(provider.id, rangeMonthly.startTime, rangeMonthly.endTime),
+        sumProviderTotalCost(provider.id),
       ]);
 
       const sessionCount = sessionCountMap.get(provider.id) || 0;
@@ -2925,6 +2940,10 @@ export async function getProviderLimitUsageBatch(
           current: costMonthly,
           limit: provider.limitMonthlyUsd ?? null,
           resetAt: resetMonthly.resetAt!,
+        },
+        limitTotalUsd: {
+          current: totalCost,
+          limit: provider.limitTotalUsd ?? null,
         },
         concurrentSessions: {
           current: sessionCount,

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -2737,15 +2737,21 @@ export async function getProviderLimitUsage(providerId: number): Promise<
     // 获取金额消费（直接查询数据库，确保配额显示与 DB 一致）
     const [cost5h, costDaily, costWeekly, costMonthly, totalCost, concurrentSessions] =
       await Promise.all([
-      limit5hResetMode === "fixed"
-        ? RateLimitService.getCurrentCost(providerId, "provider", "5h", undefined, limit5hResetMode)
-        : sumProviderCostInTimeRange(providerId, range5h.startTime, range5h.endTime),
-      sumProviderCostInTimeRange(providerId, rangeDaily.startTime, rangeDaily.endTime),
-      sumProviderCostInTimeRange(providerId, rangeWeekly.startTime, rangeWeekly.endTime),
-      sumProviderCostInTimeRange(providerId, rangeMonthly.startTime, rangeMonthly.endTime),
-      sumProviderTotalCost(providerId),
-      SessionTracker.getProviderSessionCount(providerId),
-    ]);
+        limit5hResetMode === "fixed"
+          ? RateLimitService.getCurrentCost(
+              providerId,
+              "provider",
+              "5h",
+              undefined,
+              limit5hResetMode
+            )
+          : sumProviderCostInTimeRange(providerId, range5h.startTime, range5h.endTime),
+        sumProviderCostInTimeRange(providerId, rangeDaily.startTime, rangeDaily.endTime),
+        sumProviderCostInTimeRange(providerId, rangeWeekly.startTime, rangeWeekly.endTime),
+        sumProviderCostInTimeRange(providerId, rangeMonthly.startTime, rangeMonthly.endTime),
+        sumProviderTotalCost(providerId),
+        SessionTracker.getProviderSessionCount(providerId),
+      ]);
 
     // 获取重置时间信息
     const resetDaily = await getResetInfoWithMode(
@@ -2884,8 +2890,7 @@ export async function getProviderLimitUsageBatch(
       );
 
       // 并行查询该供应商的各周期消费（直接查询数据库）
-      const [cost5h, resetAt5h, costDaily, costWeekly, costMonthly, totalCost] =
-        await Promise.all([
+      const [cost5h, resetAt5h, costDaily, costWeekly, costMonthly, totalCost] = await Promise.all([
         limit5hResetMode === "fixed"
           ? RateLimitService.getCurrentCost(
               provider.id,

--- a/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
@@ -32,6 +32,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
+  costTotal: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 }
 
@@ -79,6 +80,7 @@ export function EditKeyQuotaDialog({
   const [limitMonthly, setLimitMonthly] = useState<string>(
     currentQuota?.costMonthly.limit?.toString() ?? ""
   );
+  const [limitTotal, setLimitTotal] = useState<string>(currentQuota?.costTotal.limit?.toString() ?? "");
   const [limitConcurrent, setLimitConcurrent] = useState<string>(
     currentQuota?.concurrentSessions.limit?.toString() ?? "0"
   );
@@ -98,6 +100,7 @@ export function EditKeyQuotaDialog({
           dailyResetTime: resetTime,
           limitWeeklyUsd: limitWeekly ? parseFloat(limitWeekly) : null,
           limitMonthlyUsd: limitMonthly ? parseFloat(limitMonthly) : null,
+          limitTotalUsd: limitTotal ? parseFloat(limitTotal) : null,
           limitConcurrentSessions: limitConcurrent ? parseInt(limitConcurrent, 10) : 0,
         });
 
@@ -127,6 +130,7 @@ export function EditKeyQuotaDialog({
           dailyResetTime: resetTime,
           limitWeeklyUsd: null,
           limitMonthlyUsd: null,
+          limitTotalUsd: null,
           limitConcurrentSessions: 0,
         });
 
@@ -330,6 +334,32 @@ export function EditKeyQuotaDialog({
                       currency: currencySymbol,
                       current: Number(currentQuota.costMonthly.current).toFixed(4),
                       limit: Number(currentQuota.costMonthly.limit).toFixed(2),
+                    })}
+                  </p>
+                )}
+              </div>
+
+              {/* 总限额 */}
+              <div className="grid gap-1.5">
+                <Label htmlFor="limitTotal" className="text-xs">
+                  {t("limitTotalUsd.label")}
+                </Label>
+                <Input
+                  id="limitTotal"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  placeholder={t("limitTotalUsd.placeholder")}
+                  value={limitTotal}
+                  onChange={(e) => setLimitTotal(e.target.value)}
+                  className="h-9"
+                />
+                {currentQuota?.costTotal.limit && (
+                  <p className="text-xs text-muted-foreground">
+                    {t("limitTotalUsd.current", {
+                      currency: currencySymbol,
+                      current: Number(currentQuota.costTotal.current).toFixed(4),
+                      limit: Number(currentQuota.costTotal.limit).toFixed(2),
                     })}
                   </p>
                 )}

--- a/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
@@ -80,7 +80,9 @@ export function EditKeyQuotaDialog({
   const [limitMonthly, setLimitMonthly] = useState<string>(
     currentQuota?.costMonthly.limit?.toString() ?? ""
   );
-  const [limitTotal, setLimitTotal] = useState<string>(currentQuota?.costTotal.limit?.toString() ?? "");
+  const [limitTotal, setLimitTotal] = useState<string>(
+    currentQuota?.costTotal.limit?.toString() ?? ""
+  );
   const [limitConcurrent, setLimitConcurrent] = useState<string>(
     currentQuota?.concurrentSessions.limit?.toString() ?? "0"
   );

--- a/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
@@ -35,6 +35,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt?: Date };
   costMonthly: { current: number; limit: number | null; resetAt?: Date };
+  costTotal: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 }
 
@@ -166,6 +167,7 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
                       <TableHead className="w-[150px]">{t("table.costDaily")}</TableHead>
                       <TableHead className="w-[150px]">{t("table.costWeekly")}</TableHead>
                       <TableHead className="w-[150px]">{t("table.costMonthly")}</TableHead>
+                      <TableHead className="w-[150px]">{t("table.costTotal")}</TableHead>
                       <TableHead className="w-[120px]">{t("table.concurrentSessions")}</TableHead>
                       <TableHead className="w-[100px]">{t("table.status")}</TableHead>
                       <TableHead className="w-[100px] text-right">{t("table.actions")}</TableHead>
@@ -379,6 +381,54 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
                                   {getUsageRate(
                                     key.quota.costMonthly.current,
                                     key.quota.costMonthly.limit
+                                  ).toFixed(1)}
+                                  %
+                                </div>
+                              </div>
+                            ) : (
+                              <span className="text-sm text-muted-foreground">-</span>
+                            )}
+                          </TableCell>
+
+                          {/* 总限额 */}
+                          <TableCell>
+                            {hasKeyQuota && key.quota && key.quota.costTotal.limit !== null ? (
+                              <div className="space-y-1">
+                                <div className="flex items-center justify-between mb-1">
+                                  <span className="text-xs text-muted-foreground">
+                                    {t("table.costTotal")}
+                                  </span>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  <span className="text-xs font-mono">
+                                    {formatCurrency(key.quota.costTotal.current, currencyCode)}/
+                                    <QuotaQuickEditPopover
+                                      currentLimit={key.quota.costTotal.limit}
+                                      label={t("table.costTotal")}
+                                      unit="currency"
+                                      currencyCode={currencyCode}
+                                      onSave={(v) =>
+                                        handleSaveLimit(key.id, key.name, "limitTotalUsd", v)
+                                      }
+                                    >
+                                      <button
+                                        type="button"
+                                        className="underline-offset-4 hover:underline cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                      >
+                                        {formatCurrency(key.quota.costTotal.limit, currencyCode)}
+                                      </button>
+                                    </QuotaQuickEditPopover>
+                                  </span>
+                                </div>
+                                <QuotaProgress
+                                  current={key.quota.costTotal.current}
+                                  limit={key.quota.costTotal.limit}
+                                  className="h-1"
+                                />
+                                <div className="text-xs text-muted-foreground text-right">
+                                  {getUsageRate(
+                                    key.quota.costTotal.current,
+                                    key.quota.costTotal.limit
                                   ).toFixed(1)}
                                   %
                                 </div>

--- a/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-manager.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-manager.tsx
@@ -20,6 +20,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
+  costTotal: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
@@ -219,7 +219,8 @@ export function ProviderQuotaListItem({
           )}
 
         {/* 总限额 */}
-        {provider.quota.limitTotalUsd.limit && provider.quota.limitTotalUsd.limit > 0 &&
+        {provider.quota.limitTotalUsd.limit &&
+          provider.quota.limitTotalUsd.limit > 0 &&
           renderQuotaItem(
             t("costTotal.label"),
             provider.quota.limitTotalUsd.current,

--- a/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
@@ -16,6 +16,7 @@ interface ProviderQuota {
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
   concurrentSessions: { current: number; limit: number };
+  limitTotalUsd: { current: number; limit: number | null };
 }
 
 interface ProviderWithQuota {
@@ -215,6 +216,14 @@ export function ProviderQuotaListItem({
             provider.quota.costMonthly.current,
             provider.quota.costMonthly.limit,
             provider.quota.costMonthly.resetAt
+          )}
+
+        {/* 总限额 */}
+        {provider.quota.limitTotalUsd.limit && provider.quota.limitTotalUsd.limit > 0 &&
+          renderQuotaItem(
+            t("costTotal.label"),
+            provider.quota.limitTotalUsd.current,
+            provider.quota.limitTotalUsd.limit
           )}
 
         {/* 并发Session */}

--- a/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
@@ -15,6 +15,7 @@ interface ProviderQuota {
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
   concurrentSessions: { current: number; limit: number };
+  limitTotalUsd: { current: number; limit: number | null };
 }
 
 interface ProviderWithQuota {
@@ -35,10 +36,12 @@ interface ProvidersQuotaClientProps {
   currencyCode?: CurrencyCode;
 }
 
-// 判断供应商是否设置了限额
+// 判断供应商是否设置了任意限额
 function hasQuotaLimit(quota: ProviderQuota | null): boolean {
   if (!quota) return false;
+
   return (
+    (quota.limitTotalUsd.limit !== null && quota.limitTotalUsd.limit > 0) ||
     (quota.cost5h.limit !== null && quota.cost5h.limit > 0) ||
     (quota.costDaily.limit !== null && quota.costDaily.limit > 0) ||
     (quota.costWeekly.limit !== null && quota.costWeekly.limit > 0) ||
@@ -68,6 +71,11 @@ function calculateMaxUsage(provider: ProviderWithQuota): number {
   if (provider.quota.concurrentSessions.limit > 0) {
     usages.push(
       (provider.quota.concurrentSessions.current / provider.quota.concurrentSessions.limit) * 100
+    );
+  }
+  if (provider.quota.limitTotalUsd.limit && provider.quota.limitTotalUsd.limit > 0) {
+    usages.push(
+      (provider.quota.limitTotalUsd.current / provider.quota.limitTotalUsd.limit) * 100
     );
   }
 

--- a/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
@@ -74,9 +74,7 @@ function calculateMaxUsage(provider: ProviderWithQuota): number {
     );
   }
   if (provider.quota.limitTotalUsd.limit && provider.quota.limitTotalUsd.limit > 0) {
-    usages.push(
-      (provider.quota.limitTotalUsd.current / provider.quota.limitTotalUsd.limit) * 100
-    );
+    usages.push((provider.quota.limitTotalUsd.current / provider.quota.limitTotalUsd.limit) * 100);
   }
 
   return usages.length > 0 ? Math.max(...usages) : 0;

--- a/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-manager.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-manager.tsx
@@ -16,6 +16,7 @@ interface ProviderQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
+  limitTotalUsd: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/quotas/providers/page.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/page.tsx
@@ -25,6 +25,7 @@ async function getProvidersWithQuotas() {
       limitDailyUsd: p.limitDailyUsd,
       limitWeeklyUsd: p.limitWeeklyUsd,
       limitMonthlyUsd: p.limitMonthlyUsd,
+      limitTotalUsd: p.limitTotalUsd,
       limitConcurrentSessions: p.limitConcurrentSessions,
     }))
   );

--- a/src/lib/utils/quota-helpers.ts
+++ b/src/lib/utils/quota-helpers.ts
@@ -10,6 +10,7 @@ export type KeyQuota = {
   costDaily: { current: number; limit: number | null };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
+  costTotal?: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 } | null;
 
@@ -22,7 +23,7 @@ export type UserQuota = {
  * 判断密钥是否设置了限额
  *
  * @param quota - 密钥限额数据
- * @returns 是否设置了任意限额（5h/周/月/并发）
+ * @returns 是否设置了任意限额（5h/日/周/月/总额/并发）
  */
 export function hasKeyQuotaSet(quota: KeyQuota): boolean {
   if (!quota) return false;
@@ -32,6 +33,7 @@ export function hasKeyQuotaSet(quota: KeyQuota): boolean {
     quota.costDaily.limit ||
     quota.costWeekly.limit ||
     quota.costMonthly.limit ||
+    quota.costTotal?.limit ||
     (quota.concurrentSessions.limit && quota.concurrentSessions.limit > 0)
   );
 }
@@ -86,6 +88,9 @@ export function getMaxUsageRate(quota: KeyQuota): number {
   }
   if (quota.costMonthly.limit) {
     rates.push(getUsageRate(quota.costMonthly.current, quota.costMonthly.limit));
+  }
+  if (quota.costTotal?.limit) {
+    rates.push(getUsageRate(quota.costTotal.current, quota.costTotal.limit));
   }
   if (quota.concurrentSessions.limit > 0) {
     rates.push(getUsageRate(quota.concurrentSessions.current, quota.concurrentSessions.limit));

--- a/tests/unit/actions/providers-usage.test.ts
+++ b/tests/unit/actions/providers-usage.test.ts
@@ -17,6 +17,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const getSessionMock = vi.fn();
 const findProviderByIdMock = vi.fn();
 const sumProviderCostInTimeRangeMock = vi.fn();
+const sumProviderTotalCostMock = vi.fn();
 const getProviderSessionCountMock = vi.fn();
 const getProviderSessionCountBatchMock = vi.fn();
 const getTimeRangeForPeriodMock = vi.fn();
@@ -37,6 +38,7 @@ vi.mock("@/repository/provider", () => ({
 vi.mock("@/repository/statistics", () => ({
   sumProviderCostInTimeRange: (providerId: number, startTime: Date, endTime: Date) =>
     sumProviderCostInTimeRangeMock(providerId, startTime, endTime),
+  sumProviderTotalCost: (providerId: number) => sumProviderTotalCostMock(providerId),
 }));
 
 vi.mock("@/lib/session-tracker", () => ({
@@ -166,6 +168,7 @@ describe("getProviderLimitUsage", () => {
 
     // Default DB costs
     sumProviderCostInTimeRangeMock.mockResolvedValue(5.5);
+    sumProviderTotalCostMock.mockResolvedValue(0);
   });
 
   afterEach(() => {
@@ -403,6 +406,7 @@ describe("getProviderLimitUsageBatch", () => {
     get5hWindowResetAtMock.mockResolvedValue(null);
 
     sumProviderCostInTimeRangeMock.mockResolvedValue(5.5);
+    sumProviderTotalCostMock.mockResolvedValue(0);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Adds **total cost limit** (`limitTotalUsd`) to provider and key quotas, enabling administrators to set absolute spending caps that never auto-reset. This complements the existing time-based quotas (5h, daily, weekly, monthly) with a permanent lifetime limit.

## Related PRs

- Related to #1111 - Exposes total quota data through self-service `getMyQuota` API
- Related to #1112 - User-to-key sync can now propagate total limits from users to their keys

## Problem

Previously, quota management only supported time-windowed limits (5h, daily, weekly, monthly). For long-term budget control and hard spending caps, administrators needed a **total/lifetime cost limit** that accumulates indefinitely until manually reset.

## Solution

### 1. Total Cost Limit Implementation

Added new `limitTotalUsd` field support across the quota system:

| Component | Changes |
|-----------|---------|
| Repository Layer | Added `sumProviderTotalCost()` in `src/repository/statistics.ts` - aggregates all historical costs for a provider with optional reset date |
| Provider Actions | Updated `getProviderLimitUsage()` and `getProviderLimitUsageBatch()` in `src/actions/providers.ts` to include total cost data |
| Key Quota UI | Added total quota display and edit controls in key quota management dialogs |
| Provider Quota UI | Added total quota visualization in provider quota list and client components |

### 2. Key Features

- **Non-resetting accumulation**: Total cost is calculated from `resetAt` (if set) or from the earliest ledger record
- **No 365-day truncation**: Unlike other windows, total quota intentionally never auto-expires to enforce hard caps
- **Cross-provider consistency**: Same limit field works for both provider-level and key-level quotas
- **Full i18n support**: Added translations in all 5 languages (en, ja, ru, zh-CN, zh-TW)

## Changes

### Core Changes
- `src/repository/statistics.ts` (+27 lines) - New `sumProviderTotalCost()` function
- `src/actions/providers.ts` (+19/-4 lines) - Include `limitTotalUsd` in provider limit usage queries

### Dashboard UI Changes
- `src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx` (+30 lines) - Total quota input field
- `src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx` (+50 lines) - Total quota column with progress bar
- `src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-manager.tsx` (+1 line) - Type definition update
- `src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx` (+9 lines) - Total quota display
- `src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx` (+9/-1 lines) - Total limit check in quota calculation
- `src/app/[locale]/dashboard/quotas/providers/page.tsx` (+1 line) - Type update

### i18n Changes (5 Languages)
- `messages/en/quota.json` (+9 lines) - English translations
- `messages/ja/quota.json` (+9 lines) - Japanese translations
- `messages/ru/quota.json` (+9 lines) - Russian translations
- `messages/zh-CN/quota.json` (+9 lines) - Simplified Chinese translations
- `messages/zh-TW/quota.json` (+9 lines) - Traditional Chinese translations

## Breaking Changes

None. All changes are additive:
- New quota field in existing data structures - consumers without total limit will see `null` (unlimited)
- New UI elements only appear when total limit is configured

## Testing

### Verification Steps
1. Navigate to Provider Quotas page - verify total quota displays correctly
2. Edit a provider's key quotas - verify total quota field appears and saves
3. Set a total limit on a key - verify progress bar shows usage percentage
4. Create usage records - verify total cost accumulates correctly without auto-reset

### Database Query Verification
The new `sumProviderTotalCost()` function uses the existing `usageLedger` table with proper billing condition filtering.

## Checklist
- [x] Code follows project conventions (named exports, Biome formatting)
- [x] i18n strings added for all 5 languages
- [x] Type definitions updated consistently
- [x] No breaking changes introduced
- [x] UI components tested manually

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a permanent `limitTotalUsd` spending cap to both provider and key quotas — complementing the existing time-windowed limits (5h, daily, weekly, monthly) with a lifetime accumulator that never auto-resets. The implementation is additive: `null` means unlimited, and all UI elements are guarded accordingly. The shared `KeyQuota` helper type in `quota-helpers.ts` is correctly updated with an optional `costTotal` field, and `hasKeyQuotaSet` / `getMaxUsageRate` (and transitively `isWarning` / `isExceeded`) now include it.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are additive, no breaking changes, and the shared helper types are updated correctly.

Only P2 findings: missing test assertions on the new `limitTotalUsd` output field, and a minor redundant condition in the provider list item. No P0 or P1 issues found; the previously flagged P1 (`costTotal` absent from quota-helpers) is addressed in this PR.

`tests/unit/actions/providers-usage.test.ts` — consider adding assertions to verify `limitTotalUsd` is present and correct in both `getProviderLimitUsage` and `getProviderLimitUsageBatch` output.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/repository/statistics.ts | Adds `sumProviderTotalCost()` — queries `usageLedger` with no time truncation, correctly respecting an optional `resetAt`. Implementation is consistent with the analogous `sumUserTotalCost` / `sumKeyTotalCost` patterns. |
| src/actions/providers.ts | Adds `totalCost` to both `getProviderLimitUsage` and `getProviderLimitUsageBatch` Promise.all arrays and exposes it as `limitTotalUsd`; `resetAt` is not passed to `sumProviderTotalCost` because providers have no such field yet — intentional per PR design. |
| src/lib/utils/quota-helpers.ts | Adds optional `costTotal` field to `KeyQuota` type and updates `hasKeyQuotaSet` and `getMaxUsageRate` — `isWarning`/`isExceeded` are covered transitively through `getMaxUsageRate`. |
| src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx | Adds total-limit input and current-usage tooltip; the `costTotal.limit` truthiness guard (falsy at 0) for the tooltip was flagged in a previous review thread. |
| src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx | Includes `limitTotalUsd` in both `hasQuotaLimit` (explicit `!== null && > 0`) and `calculateMaxUsage`; consistent with existing quota field treatment. |
| tests/unit/actions/providers-usage.test.ts | Wires `sumProviderTotalCostMock` into existing setup but adds no assertions on the `limitTotalUsd` output field in either test suite. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Dashboard UI
    participant PA as providers.ts (action)
    participant ST as statistics.ts (repo)
    participant DB as usageLedger (DB)

    UI->>PA: getProviderLimitUsage(providerId)
    PA->>ST: sumProviderCostInTimeRange() x4
    PA->>ST: sumProviderTotalCost(providerId)
    ST->>DB: SELECT SUM(cost_usd) WHERE finalProviderId = ? [no time cutoff]
    DB-->>ST: totalCost
    ST-->>PA: totalCost
    PA-->>UI: { ..., limitTotalUsd: { current, limit } }

    UI->>PA: getProviderLimitUsageBatch(providers[])
    loop per provider
        PA->>ST: sumProviderTotalCost(provider.id)
        ST->>DB: SELECT SUM(cost_usd) WHERE finalProviderId = ?
        DB-->>ST: totalCost
        ST-->>PA: totalCost
    end
    PA-->>UI: Map<providerId, ProviderLimitUsageData>
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/utils/quota-helpers.ts`, line 8-14 ([link](https://github.com/ding113/claude-code-hub/blob/e6a0151b4ca5766a3f7efd3f97d44da3c9ef1861/src/lib/utils/quota-helpers.ts#L8-L14)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`costTotal` missing from shared `KeyQuota` type and helper functions**

   The PR adds `costTotal` to every component-level `KeyQuota` interface, but the canonical `KeyQuota` type in `quota-helpers.ts` is not updated. As a result, `hasKeyQuotaSet`, `getMaxUsageRate`, `isWarning`, and `isExceeded` all silently ignore `costTotal`. A key whose only limit is `limitTotalUsd` will be treated as having no quota at all — filter tabs ("key-quota", "warning", "exceeded") in `keys-quota-manager.tsx` will misclassify it, and the per-key status badge will show "正常" even after the total budget is exhausted.

   Add `costTotal` to the type and include it in the helper functions:

   ```ts
   // quota-helpers.ts
   export type KeyQuota = {
     cost5h: { current: number; limit: number | null };
     costDaily: { current: number; limit: number | null };
     costWeekly: { current: number; limit: number | null };
     costMonthly: { current: number; limit: number | null };
     costTotal: { current: number; limit: number | null };   // add
     concurrentSessions: { current: number; limit: number };
   } | null;
   ```

   And in `hasKeyQuotaSet`:
   ```ts
   quota.costTotal?.limit ||
   ```

   And in `getMaxUsageRate`:
   ```ts
   if (quota.costTotal?.limit) {
     rates.push(getUsageRate(quota.costTotal.current, quota.costTotal.limit));
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/utils/quota-helpers.ts
   Line: 8-14

   Comment:
   **`costTotal` missing from shared `KeyQuota` type and helper functions**

   The PR adds `costTotal` to every component-level `KeyQuota` interface, but the canonical `KeyQuota` type in `quota-helpers.ts` is not updated. As a result, `hasKeyQuotaSet`, `getMaxUsageRate`, `isWarning`, and `isExceeded` all silently ignore `costTotal`. A key whose only limit is `limitTotalUsd` will be treated as having no quota at all — filter tabs ("key-quota", "warning", "exceeded") in `keys-quota-manager.tsx` will misclassify it, and the per-key status badge will show "正常" even after the total budget is exhausted.

   Add `costTotal` to the type and include it in the helper functions:

   ```ts
   // quota-helpers.ts
   export type KeyQuota = {
     cost5h: { current: number; limit: number | null };
     costDaily: { current: number; limit: number | null };
     costWeekly: { current: number; limit: number | null };
     costMonthly: { current: number; limit: number | null };
     costTotal: { current: number; limit: number | null };   // add
     concurrentSessions: { current: number; limit: number };
   } | null;
   ```

   And in `hasKeyQuotaSet`:
   ```ts
   quota.costTotal?.limit ||
   ```

   And in `getMaxUsageRate`:
   ```ts
   if (quota.costTotal?.limit) {
     rates.push(getUsageRate(quota.costTotal.current, quota.costTotal.limit));
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/unit/actions/providers-usage.test.ts
Line: 168-169

Comment:
**No assertions on `limitTotalUsd` output shape**

The mock is wired up and returns `0`, but no test case checks that `getProviderLimitUsage` or `getProviderLimitUsageBatch` actually include `limitTotalUsd: { current: 0, limit: <value> }` in the returned data. A future refactor that accidentally drops the field would go undetected.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
Line: 221-223

Comment:
**Redundant double-check on `limit`**

`limit && limit > 0` is redundant: if `limit` is truthy (non-null, non-zero) it is already `> 0` for positive values. More importantly, this differs from the `!== null && > 0` pattern used in `hasQuotaLimit` in `providers-quota-client.tsx`. Prefer the explicit pattern for consistency.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(quota): repair total quota compile i..."](https://github.com/ding113/claude-code-hub/commit/0d64074a6d1a98258537feaace8b243e7bb19b0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29856989)</sub>

<!-- /greptile_comment -->