### PR TITLE
fix total quota

### DIFF
--- a/messages/en/quota.json
+++ b/messages/en/quota.json
@@ -153,6 +153,9 @@
       "label": "Monthly Cost",
       "resetAt": "Resets at"
     },
+    "costTotal": {
+      "label": "Total Cost"
+    },
     "concurrentSessions": {
       "label": "Concurrent Sessions"
     },

--- a/messages/en/quota.json
+++ b/messages/en/quota.json
@@ -186,6 +186,7 @@
       "costDaily": "Daily Quota",
       "costWeekly": "Weekly Quota",
       "costMonthly": "Monthly Quota",
+      "costTotal": "Total Quota",
       "concurrentSessions": "Concurrent Limit",
       "status": "Status",
       "actions": "Actions"
@@ -235,6 +236,11 @@
       },
       "costMonthly": {
         "label": "Monthly Quota (USD)",
+        "placeholder": "Unlimited",
+        "current": "Current usage: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "Total Quota (USD)",
         "placeholder": "Unlimited",
         "current": "Current usage: {currency}{current} / {currency}{limit}"
       },

--- a/messages/ja/quota.json
+++ b/messages/ja/quota.json
@@ -130,6 +130,9 @@
       "label": "月次コスト",
       "resetAt": "リセット時刻"
     },
+    "costTotal": {
+      "label": "総コスト"
+    },
     "concurrentSessions": {
       "label": "同時セッション"
     },

--- a/messages/ja/quota.json
+++ b/messages/ja/quota.json
@@ -163,6 +163,7 @@
       "costDaily": "日次クォータ",
       "costWeekly": "週次クォータ",
       "costMonthly": "月次クォータ",
+      "costTotal": "総クォータ",
       "concurrentSessions": "同時制限",
       "status": "ステータス",
       "actions": "アクション"
@@ -212,6 +213,11 @@
       },
       "costMonthly": {
         "label": "月次クォータ (USD)",
+        "placeholder": "無制限",
+        "current": "現在使用: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "総クォータ (USD)",
         "placeholder": "無制限",
         "current": "現在使用: {currency}{current} / {currency}{limit}"
       },

--- a/messages/ru/quota.json
+++ b/messages/ru/quota.json
@@ -153,6 +153,9 @@
       "label": "Ежемесячные расходы",
       "resetAt": "Сброс в"
     },
+    "costTotal": {
+      "label": "Общие расходы"
+    },
     "concurrentSessions": {
       "label": "Параллельные сессии"
     },

--- a/messages/ru/quota.json
+++ b/messages/ru/quota.json
@@ -186,6 +186,7 @@
       "costDaily": "Дневная квота",
       "costWeekly": "Еженедельная квота",
       "costMonthly": "Ежемесячная квота",
+      "costTotal": "Общая квота",
       "concurrentSessions": "Лимит параллельных",
       "status": "Статус",
       "actions": "Действия"
@@ -235,6 +236,11 @@
       },
       "costMonthly": {
         "label": "Ежемесячная квота (USD)",
+        "placeholder": "Неограниченно",
+        "current": "Использовано: {currency}{current} из {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "Общая квота (USD)",
         "placeholder": "Неограниченно",
         "current": "Использовано: {currency}{current} из {currency}{limit}"
       },

--- a/messages/zh-CN/quota.json
+++ b/messages/zh-CN/quota.json
@@ -153,6 +153,9 @@
       "label": "月消费",
       "resetAt": "重置于"
     },
+    "costTotal": {
+      "label": "总消费"
+    },
     "concurrentSessions": {
       "label": "并发 Session"
     },

--- a/messages/zh-CN/quota.json
+++ b/messages/zh-CN/quota.json
@@ -186,6 +186,7 @@
       "costDaily": "每日限额",
       "costWeekly": "周限额",
       "costMonthly": "月限额",
+      "costTotal": "总限额",
       "concurrentSessions": "并发限制",
       "status": "状态",
       "actions": "操作"
@@ -235,6 +236,11 @@
       },
       "costMonthly": {
         "label": "月限额(USD)",
+        "placeholder": "不限制",
+        "current": "当前已用: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "总限额(USD)",
         "placeholder": "不限制",
         "current": "当前已用: {currency}{current} / {currency}{limit}"
       },

--- a/messages/zh-TW/quota.json
+++ b/messages/zh-TW/quota.json
@@ -128,6 +128,9 @@
       "label": "月消費",
       "resetAt": "重置於"
     },
+    "costTotal": {
+      "label": "總消費"
+    },
     "concurrentSessions": {
       "label": "並發 Session"
     },

--- a/messages/zh-TW/quota.json
+++ b/messages/zh-TW/quota.json
@@ -161,6 +161,7 @@
       "costDaily": "每日限額",
       "costWeekly": "周限額",
       "costMonthly": "月限額",
+      "costTotal": "總限額",
       "concurrentSessions": "並發限制",
       "status": "狀態",
       "actions": "操作"
@@ -210,6 +211,11 @@
       },
       "costMonthly": {
         "label": "月限額 (USD)",
+        "placeholder": "不限制",
+        "current": "當前已用: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "總限額 (USD)",
         "placeholder": "不限制",
         "current": "當前已用: {currency}{current} / {currency}{limit}"
       },

--- a/src/actions/key-quota.ts
+++ b/src/actions/key-quota.ts
@@ -21,6 +21,7 @@ export interface KeyQuotaItem {
   limit: number | null;
   mode?: "fixed" | "rolling";
   time?: string;
+  resetAt?: Date;
 }
 
 export interface KeyQuotaUsageResult {
@@ -164,6 +165,7 @@ export async function getKeyQuotaUsage(keyId: number): Promise<ActionResult<KeyQ
         type: "limitTotal",
         current: totalCost,
         limit: parseNumericLimit(keyRow.limitTotalUsd),
+        resetAt: costResetAt ?? undefined,
       },
       {
         type: "limitSessions",

--- a/src/actions/keys.ts
+++ b/src/actions/keys.ts
@@ -837,7 +837,7 @@ export async function getKeyLimitUsage(keyId: number): Promise<
     costDaily: { current: number; limit: number | null; resetAt?: Date };
     costWeekly: { current: number; limit: number | null; resetAt?: Date };
     costMonthly: { current: number; limit: number | null; resetAt?: Date };
-    costTotal: { current: number; limit: number | null };
+    costTotal: { current: number; limit: number | null; resetAt?: Date };
     concurrentSessions: { current: number; limit: number };
   }>
 > {
@@ -958,6 +958,7 @@ export async function getKeyLimitUsage(keyId: number): Promise<
         costTotal: {
           current: totalCost,
           limit: key.limitTotalUsd ?? null,
+          resetAt: costResetAt ?? undefined,
         },
         concurrentSessions: {
           current: concurrentSessions,

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -2690,6 +2690,7 @@ export async function getProviderLimitUsage(providerId: number): Promise<
     costDaily: { current: number; limit: number | null; resetAt?: Date };
     costWeekly: { current: number; limit: number | null; resetAt: Date };
     costMonthly: { current: number; limit: number | null; resetAt: Date };
+    limitTotalUsd: { current: number; limit: number | null };
     concurrentSessions: { current: number; limit: number };
   }>
 > {
@@ -2713,7 +2714,9 @@ export async function getProviderLimitUsage(providerId: number): Promise<
       getTimeRangeForPeriodWithMode,
     } = await import("@/lib/rate-limit/time-utils");
     const { RateLimitService } = await import("@/lib/rate-limit");
-    const { sumProviderCostInTimeRange } = await import("@/repository/statistics");
+    const { sumProviderCostInTimeRange, sumProviderTotalCost } = await import(
+      "@/repository/statistics"
+    );
     const limit5hResetMode = provider.limit5hResetMode ?? "rolling";
 
     // 计算各周期的时间范围
@@ -2732,13 +2735,15 @@ export async function getProviderLimitUsage(providerId: number): Promise<
     ]);
 
     // 获取金额消费（直接查询数据库，确保配额显示与 DB 一致）
-    const [cost5h, costDaily, costWeekly, costMonthly, concurrentSessions] = await Promise.all([
+    const [cost5h, costDaily, costWeekly, costMonthly, totalCost, concurrentSessions] =
+      await Promise.all([
       limit5hResetMode === "fixed"
         ? RateLimitService.getCurrentCost(providerId, "provider", "5h", undefined, limit5hResetMode)
         : sumProviderCostInTimeRange(providerId, range5h.startTime, range5h.endTime),
       sumProviderCostInTimeRange(providerId, rangeDaily.startTime, rangeDaily.endTime),
       sumProviderCostInTimeRange(providerId, rangeWeekly.startTime, rangeWeekly.endTime),
       sumProviderCostInTimeRange(providerId, rangeMonthly.startTime, rangeMonthly.endTime),
+      sumProviderTotalCost(providerId),
       SessionTracker.getProviderSessionCount(providerId),
     ]);
 
@@ -2779,6 +2784,10 @@ export async function getProviderLimitUsage(providerId: number): Promise<
           limit: provider.limitMonthlyUsd,
           resetAt: resetMonthly.resetAt!,
         },
+        limitTotalUsd: {
+          current: totalCost,
+          limit: provider.limitTotalUsd ?? null,
+        },
         concurrentSessions: {
           current: concurrentSessions,
           limit: provider.limitConcurrentSessions || 0,
@@ -2800,6 +2809,7 @@ export type ProviderLimitUsageData = {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
+  limitTotalUsd: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 };
 
@@ -2820,6 +2830,7 @@ export async function getProviderLimitUsageBatch(
     limitDailyUsd?: number | null;
     limitWeeklyUsd?: number | null;
     limitMonthlyUsd?: number | null;
+    limitTotalUsd?: number | null;
     limitConcurrentSessions?: number | null;
   }>
 ): Promise<Map<number, ProviderLimitUsageData>> {
@@ -2845,7 +2856,9 @@ export async function getProviderLimitUsageBatch(
       getTimeRangeForPeriodWithMode,
     } = await import("@/lib/rate-limit/time-utils");
     const { RateLimitService } = await import("@/lib/rate-limit");
-    const { sumProviderCostInTimeRange } = await import("@/repository/statistics");
+    const { sumProviderCostInTimeRange, sumProviderTotalCost } = await import(
+      "@/repository/statistics"
+    );
 
     const providerIds = providers.map((p) => p.id);
 
@@ -2871,7 +2884,8 @@ export async function getProviderLimitUsageBatch(
       );
 
       // 并行查询该供应商的各周期消费（直接查询数据库）
-      const [cost5h, resetAt5h, costDaily, costWeekly, costMonthly] = await Promise.all([
+      const [cost5h, resetAt5h, costDaily, costWeekly, costMonthly, totalCost] =
+        await Promise.all([
         limit5hResetMode === "fixed"
           ? RateLimitService.getCurrentCost(
               provider.id,
@@ -2887,6 +2901,7 @@ export async function getProviderLimitUsageBatch(
         sumProviderCostInTimeRange(provider.id, rangeDaily.startTime, rangeDaily.endTime),
         sumProviderCostInTimeRange(provider.id, rangeWeekly.startTime, rangeWeekly.endTime),
         sumProviderCostInTimeRange(provider.id, rangeMonthly.startTime, rangeMonthly.endTime),
+        sumProviderTotalCost(provider.id),
       ]);
 
       const sessionCount = sessionCountMap.get(provider.id) || 0;
@@ -2925,6 +2940,10 @@ export async function getProviderLimitUsageBatch(
           current: costMonthly,
           limit: provider.limitMonthlyUsd ?? null,
           resetAt: resetMonthly.resetAt!,
+        },
+        limitTotalUsd: {
+          current: totalCost,
+          limit: provider.limitTotalUsd ?? null,
         },
         concurrentSessions: {
           current: sessionCount,

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -327,6 +327,7 @@ export async function getProviders(): Promise<ProviderDisplay[]> {
         limitWeeklyUsd: provider.limitWeeklyUsd,
         limitMonthlyUsd: provider.limitMonthlyUsd,
         limitTotalUsd: provider.limitTotalUsd,
+        totalCostResetAt: provider.totalCostResetAt,
         limitConcurrentSessions: provider.limitConcurrentSessions,
         maxRetryAttempts: provider.maxRetryAttempts,
         circuitBreakerFailureThreshold: provider.circuitBreakerFailureThreshold,
@@ -1258,6 +1259,8 @@ export async function resetProviderTotalUsage(providerId: number): Promise<Actio
     if (!ok) {
       return { ok: false, error: "供应商不存在" };
     }
+
+    await publishProviderCacheInvalidation();
 
     return { ok: true };
   } catch (error) {
@@ -2690,7 +2693,7 @@ export async function getProviderLimitUsage(providerId: number): Promise<
     costDaily: { current: number; limit: number | null; resetAt?: Date };
     costWeekly: { current: number; limit: number | null; resetAt: Date };
     costMonthly: { current: number; limit: number | null; resetAt: Date };
-    limitTotalUsd: { current: number; limit: number | null };
+    limitTotalUsd: { current: number; limit: number | null; resetAt?: Date };
     concurrentSessions: { current: number; limit: number };
   }>
 > {
@@ -2749,7 +2752,7 @@ export async function getProviderLimitUsage(providerId: number): Promise<
         sumProviderCostInTimeRange(providerId, rangeDaily.startTime, rangeDaily.endTime),
         sumProviderCostInTimeRange(providerId, rangeWeekly.startTime, rangeWeekly.endTime),
         sumProviderCostInTimeRange(providerId, rangeMonthly.startTime, rangeMonthly.endTime),
-        sumProviderTotalCost(providerId),
+        sumProviderTotalCost(providerId, provider.totalCostResetAt),
         SessionTracker.getProviderSessionCount(providerId),
       ]);
 
@@ -2793,6 +2796,7 @@ export async function getProviderLimitUsage(providerId: number): Promise<
         limitTotalUsd: {
           current: totalCost,
           limit: provider.limitTotalUsd ?? null,
+          resetAt: provider.totalCostResetAt ?? undefined,
         },
         concurrentSessions: {
           current: concurrentSessions,
@@ -2815,7 +2819,7 @@ export type ProviderLimitUsageData = {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
-  limitTotalUsd: { current: number; limit: number | null };
+  limitTotalUsd: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 };
 
@@ -2837,6 +2841,7 @@ export async function getProviderLimitUsageBatch(
     limitWeeklyUsd?: number | null;
     limitMonthlyUsd?: number | null;
     limitTotalUsd?: number | null;
+    totalCostResetAt?: Date | null;
     limitConcurrentSessions?: number | null;
   }>
 ): Promise<Map<number, ProviderLimitUsageData>> {
@@ -2906,7 +2911,7 @@ export async function getProviderLimitUsageBatch(
         sumProviderCostInTimeRange(provider.id, rangeDaily.startTime, rangeDaily.endTime),
         sumProviderCostInTimeRange(provider.id, rangeWeekly.startTime, rangeWeekly.endTime),
         sumProviderCostInTimeRange(provider.id, rangeMonthly.startTime, rangeMonthly.endTime),
-        sumProviderTotalCost(provider.id),
+        sumProviderTotalCost(provider.id, provider.totalCostResetAt ?? null),
       ]);
 
       const sessionCount = sessionCountMap.get(provider.id) || 0;
@@ -2949,6 +2954,7 @@ export async function getProviderLimitUsageBatch(
         limitTotalUsd: {
           current: totalCost,
           limit: provider.limitTotalUsd ?? null,
+          resetAt: provider.totalCostResetAt ?? undefined,
         },
         concurrentSessions: {
           current: sessionCount,

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -2737,15 +2737,21 @@ export async function getProviderLimitUsage(providerId: number): Promise<
     // 获取金额消费（直接查询数据库，确保配额显示与 DB 一致）
     const [cost5h, costDaily, costWeekly, costMonthly, totalCost, concurrentSessions] =
       await Promise.all([
-      limit5hResetMode === "fixed"
-        ? RateLimitService.getCurrentCost(providerId, "provider", "5h", undefined, limit5hResetMode)
-        : sumProviderCostInTimeRange(providerId, range5h.startTime, range5h.endTime),
-      sumProviderCostInTimeRange(providerId, rangeDaily.startTime, rangeDaily.endTime),
-      sumProviderCostInTimeRange(providerId, rangeWeekly.startTime, rangeWeekly.endTime),
-      sumProviderCostInTimeRange(providerId, rangeMonthly.startTime, rangeMonthly.endTime),
-      sumProviderTotalCost(providerId),
-      SessionTracker.getProviderSessionCount(providerId),
-    ]);
+        limit5hResetMode === "fixed"
+          ? RateLimitService.getCurrentCost(
+              providerId,
+              "provider",
+              "5h",
+              undefined,
+              limit5hResetMode
+            )
+          : sumProviderCostInTimeRange(providerId, range5h.startTime, range5h.endTime),
+        sumProviderCostInTimeRange(providerId, rangeDaily.startTime, rangeDaily.endTime),
+        sumProviderCostInTimeRange(providerId, rangeWeekly.startTime, rangeWeekly.endTime),
+        sumProviderCostInTimeRange(providerId, rangeMonthly.startTime, rangeMonthly.endTime),
+        sumProviderTotalCost(providerId),
+        SessionTracker.getProviderSessionCount(providerId),
+      ]);
 
     // 获取重置时间信息
     const resetDaily = await getResetInfoWithMode(
@@ -2884,8 +2890,7 @@ export async function getProviderLimitUsageBatch(
       );
 
       // 并行查询该供应商的各周期消费（直接查询数据库）
-      const [cost5h, resetAt5h, costDaily, costWeekly, costMonthly, totalCost] =
-        await Promise.all([
+      const [cost5h, resetAt5h, costDaily, costWeekly, costMonthly, totalCost] = await Promise.all([
         limit5hResetMode === "fixed"
           ? RateLimitService.getCurrentCost(
               provider.id,

--- a/src/app/[locale]/dashboard/_components/user/key-limit-usage.tsx
+++ b/src/app/[locale]/dashboard/_components/user/key-limit-usage.tsx
@@ -18,7 +18,7 @@ interface LimitUsageData {
   costDaily: { current: number; limit: number | null };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
-  costTotal: { current: number; limit: number | null };
+  costTotal: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
@@ -32,6 +32,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
+  costTotal: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 }
 
@@ -79,6 +80,7 @@ export function EditKeyQuotaDialog({
   const [limitMonthly, setLimitMonthly] = useState<string>(
     currentQuota?.costMonthly.limit?.toString() ?? ""
   );
+  const [limitTotal, setLimitTotal] = useState<string>(currentQuota?.costTotal.limit?.toString() ?? "");
   const [limitConcurrent, setLimitConcurrent] = useState<string>(
     currentQuota?.concurrentSessions.limit?.toString() ?? "0"
   );
@@ -98,6 +100,7 @@ export function EditKeyQuotaDialog({
           dailyResetTime: resetTime,
           limitWeeklyUsd: limitWeekly ? parseFloat(limitWeekly) : null,
           limitMonthlyUsd: limitMonthly ? parseFloat(limitMonthly) : null,
+          limitTotalUsd: limitTotal ? parseFloat(limitTotal) : null,
           limitConcurrentSessions: limitConcurrent ? parseInt(limitConcurrent, 10) : 0,
         });
 
@@ -127,6 +130,7 @@ export function EditKeyQuotaDialog({
           dailyResetTime: resetTime,
           limitWeeklyUsd: null,
           limitMonthlyUsd: null,
+          limitTotalUsd: null,
           limitConcurrentSessions: 0,
         });
 
@@ -330,6 +334,32 @@ export function EditKeyQuotaDialog({
                       currency: currencySymbol,
                       current: Number(currentQuota.costMonthly.current).toFixed(4),
                       limit: Number(currentQuota.costMonthly.limit).toFixed(2),
+                    })}
+                  </p>
+                )}
+              </div>
+
+              {/* 总限额 */}
+              <div className="grid gap-1.5">
+                <Label htmlFor="limitTotal" className="text-xs">
+                  {t("limitTotalUsd.label")}
+                </Label>
+                <Input
+                  id="limitTotal"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  placeholder={t("limitTotalUsd.placeholder")}
+                  value={limitTotal}
+                  onChange={(e) => setLimitTotal(e.target.value)}
+                  className="h-9"
+                />
+                {currentQuota?.costTotal.limit && (
+                  <p className="text-xs text-muted-foreground">
+                    {t("limitTotalUsd.current", {
+                      currency: currencySymbol,
+                      current: Number(currentQuota.costTotal.current).toFixed(4),
+                      limit: Number(currentQuota.costTotal.limit).toFixed(2),
                     })}
                   </p>
                 )}

--- a/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
@@ -80,7 +80,9 @@ export function EditKeyQuotaDialog({
   const [limitMonthly, setLimitMonthly] = useState<string>(
     currentQuota?.costMonthly.limit?.toString() ?? ""
   );
-  const [limitTotal, setLimitTotal] = useState<string>(currentQuota?.costTotal.limit?.toString() ?? "");
+  const [limitTotal, setLimitTotal] = useState<string>(
+    currentQuota?.costTotal.limit?.toString() ?? ""
+  );
   const [limitConcurrent, setLimitConcurrent] = useState<string>(
     currentQuota?.concurrentSessions.limit?.toString() ?? "0"
   );

--- a/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
@@ -32,7 +32,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
-  costTotal: { current: number; limit: number | null };
+  costTotal: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
@@ -35,6 +35,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt?: Date };
   costMonthly: { current: number; limit: number | null; resetAt?: Date };
+  costTotal: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 }
 
@@ -166,6 +167,7 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
                       <TableHead className="w-[150px]">{t("table.costDaily")}</TableHead>
                       <TableHead className="w-[150px]">{t("table.costWeekly")}</TableHead>
                       <TableHead className="w-[150px]">{t("table.costMonthly")}</TableHead>
+                      <TableHead className="w-[150px]">{t("table.costTotal")}</TableHead>
                       <TableHead className="w-[120px]">{t("table.concurrentSessions")}</TableHead>
                       <TableHead className="w-[100px]">{t("table.status")}</TableHead>
                       <TableHead className="w-[100px] text-right">{t("table.actions")}</TableHead>
@@ -379,6 +381,54 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
                                   {getUsageRate(
                                     key.quota.costMonthly.current,
                                     key.quota.costMonthly.limit
+                                  ).toFixed(1)}
+                                  %
+                                </div>
+                              </div>
+                            ) : (
+                              <span className="text-sm text-muted-foreground">-</span>
+                            )}
+                          </TableCell>
+
+                          {/* 总限额 */}
+                          <TableCell>
+                            {hasKeyQuota && key.quota && key.quota.costTotal.limit !== null ? (
+                              <div className="space-y-1">
+                                <div className="flex items-center justify-between mb-1">
+                                  <span className="text-xs text-muted-foreground">
+                                    {t("table.costTotal")}
+                                  </span>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  <span className="text-xs font-mono">
+                                    {formatCurrency(key.quota.costTotal.current, currencyCode)}/
+                                    <QuotaQuickEditPopover
+                                      currentLimit={key.quota.costTotal.limit}
+                                      label={t("table.costTotal")}
+                                      unit="currency"
+                                      currencyCode={currencyCode}
+                                      onSave={(v) =>
+                                        handleSaveLimit(key.id, key.name, "limitTotalUsd", v)
+                                      }
+                                    >
+                                      <button
+                                        type="button"
+                                        className="underline-offset-4 hover:underline cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                      >
+                                        {formatCurrency(key.quota.costTotal.limit, currencyCode)}
+                                      </button>
+                                    </QuotaQuickEditPopover>
+                                  </span>
+                                </div>
+                                <QuotaProgress
+                                  current={key.quota.costTotal.current}
+                                  limit={key.quota.costTotal.limit}
+                                  className="h-1"
+                                />
+                                <div className="text-xs text-muted-foreground text-right">
+                                  {getUsageRate(
+                                    key.quota.costTotal.current,
+                                    key.quota.costTotal.limit
                                   ).toFixed(1)}
                                   %
                                 </div>

--- a/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
@@ -35,7 +35,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt?: Date };
   costMonthly: { current: number; limit: number | null; resetAt?: Date };
-  costTotal: { current: number; limit: number | null };
+  costTotal: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-manager.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-manager.tsx
@@ -20,6 +20,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
+  costTotal: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-manager.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-manager.tsx
@@ -20,7 +20,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
-  costTotal: { current: number; limit: number | null };
+  costTotal: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
@@ -219,7 +219,8 @@ export function ProviderQuotaListItem({
           )}
 
         {/* 总限额 */}
-        {provider.quota.limitTotalUsd.limit && provider.quota.limitTotalUsd.limit > 0 &&
+        {provider.quota.limitTotalUsd.limit &&
+          provider.quota.limitTotalUsd.limit > 0 &&
           renderQuotaItem(
             t("costTotal.label"),
             provider.quota.limitTotalUsd.current,

--- a/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
@@ -16,7 +16,7 @@ interface ProviderQuota {
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
   concurrentSessions: { current: number; limit: number };
-  limitTotalUsd: { current: number; limit: number | null };
+  limitTotalUsd: { current: number; limit: number | null; resetAt?: Date };
 }
 
 interface ProviderWithQuota {

--- a/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
@@ -16,6 +16,7 @@ interface ProviderQuota {
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
   concurrentSessions: { current: number; limit: number };
+  limitTotalUsd: { current: number; limit: number | null };
 }
 
 interface ProviderWithQuota {
@@ -215,6 +216,14 @@ export function ProviderQuotaListItem({
             provider.quota.costMonthly.current,
             provider.quota.costMonthly.limit,
             provider.quota.costMonthly.resetAt
+          )}
+
+        {/* 总限额 */}
+        {provider.quota.limitTotalUsd.limit && provider.quota.limitTotalUsd.limit > 0 &&
+          renderQuotaItem(
+            t("costTotal.label"),
+            provider.quota.limitTotalUsd.current,
+            provider.quota.limitTotalUsd.limit
           )}
 
         {/* 并发Session */}

--- a/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
@@ -15,6 +15,7 @@ interface ProviderQuota {
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
   concurrentSessions: { current: number; limit: number };
+  limitTotalUsd: { current: number; limit: number | null };
 }
 
 interface ProviderWithQuota {
@@ -35,10 +36,12 @@ interface ProvidersQuotaClientProps {
   currencyCode?: CurrencyCode;
 }
 
-// 判断供应商是否设置了限额
+// 判断供应商是否设置了任意限额
 function hasQuotaLimit(quota: ProviderQuota | null): boolean {
   if (!quota) return false;
+
   return (
+    (quota.limitTotalUsd.limit !== null && quota.limitTotalUsd.limit > 0) ||
     (quota.cost5h.limit !== null && quota.cost5h.limit > 0) ||
     (quota.costDaily.limit !== null && quota.costDaily.limit > 0) ||
     (quota.costWeekly.limit !== null && quota.costWeekly.limit > 0) ||
@@ -68,6 +71,11 @@ function calculateMaxUsage(provider: ProviderWithQuota): number {
   if (provider.quota.concurrentSessions.limit > 0) {
     usages.push(
       (provider.quota.concurrentSessions.current / provider.quota.concurrentSessions.limit) * 100
+    );
+  }
+  if (provider.quota.limitTotalUsd.limit && provider.quota.limitTotalUsd.limit > 0) {
+    usages.push(
+      (provider.quota.limitTotalUsd.current / provider.quota.limitTotalUsd.limit) * 100
     );
   }
 

--- a/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
@@ -74,9 +74,7 @@ function calculateMaxUsage(provider: ProviderWithQuota): number {
     );
   }
   if (provider.quota.limitTotalUsd.limit && provider.quota.limitTotalUsd.limit > 0) {
-    usages.push(
-      (provider.quota.limitTotalUsd.current / provider.quota.limitTotalUsd.limit) * 100
-    );
+    usages.push((provider.quota.limitTotalUsd.current / provider.quota.limitTotalUsd.limit) * 100);
   }
 
   return usages.length > 0 ? Math.max(...usages) : 0;

--- a/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
@@ -15,7 +15,7 @@ interface ProviderQuota {
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
   concurrentSessions: { current: number; limit: number };
-  limitTotalUsd: { current: number; limit: number | null };
+  limitTotalUsd: { current: number; limit: number | null; resetAt?: Date };
 }
 
 interface ProviderWithQuota {

--- a/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-manager.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-manager.tsx
@@ -16,6 +16,7 @@ interface ProviderQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
+  limitTotalUsd: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-manager.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-manager.tsx
@@ -16,7 +16,7 @@ interface ProviderQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
-  limitTotalUsd: { current: number; limit: number | null };
+  limitTotalUsd: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/quotas/providers/page.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/page.tsx
@@ -26,6 +26,7 @@ async function getProvidersWithQuotas() {
       limitWeeklyUsd: p.limitWeeklyUsd,
       limitMonthlyUsd: p.limitMonthlyUsd,
       limitTotalUsd: p.limitTotalUsd,
+      totalCostResetAt: p.totalCostResetAt,
       limitConcurrentSessions: p.limitConcurrentSessions,
     }))
   );

--- a/src/app/[locale]/dashboard/quotas/providers/page.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/page.tsx
@@ -25,6 +25,7 @@ async function getProvidersWithQuotas() {
       limitDailyUsd: p.limitDailyUsd,
       limitWeeklyUsd: p.limitWeeklyUsd,
       limitMonthlyUsd: p.limitMonthlyUsd,
+      limitTotalUsd: p.limitTotalUsd,
       limitConcurrentSessions: p.limitConcurrentSessions,
     }))
   );

--- a/src/lib/utils/quota-helpers.ts
+++ b/src/lib/utils/quota-helpers.ts
@@ -10,6 +10,7 @@ export type KeyQuota = {
   costDaily: { current: number; limit: number | null };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
+  costTotal?: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 } | null;
 
@@ -22,7 +23,7 @@ export type UserQuota = {
  * 判断密钥是否设置了限额
  *
  * @param quota - 密钥限额数据
- * @returns 是否设置了任意限额（5h/周/月/并发）
+ * @returns 是否设置了任意限额（5h/日/周/月/总额/并发）
  */
 export function hasKeyQuotaSet(quota: KeyQuota): boolean {
   if (!quota) return false;
@@ -32,6 +33,7 @@ export function hasKeyQuotaSet(quota: KeyQuota): boolean {
     quota.costDaily.limit ||
     quota.costWeekly.limit ||
     quota.costMonthly.limit ||
+    quota.costTotal?.limit ||
     (quota.concurrentSessions.limit && quota.concurrentSessions.limit > 0)
   );
 }
@@ -86,6 +88,9 @@ export function getMaxUsageRate(quota: KeyQuota): number {
   }
   if (quota.costMonthly.limit) {
     rates.push(getUsageRate(quota.costMonthly.current, quota.costMonthly.limit));
+  }
+  if (quota.costTotal?.limit) {
+    rates.push(getUsageRate(quota.costTotal.current, quota.costTotal.limit));
   }
   if (quota.concurrentSessions.limit > 0) {
     rates.push(getUsageRate(quota.concurrentSessions.current, quota.concurrentSessions.limit));

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -464,6 +464,7 @@ export interface ProviderDisplay {
   limitWeeklyUsd: number | null;
   limitMonthlyUsd: number | null;
   limitTotalUsd: number | null;
+  totalCostResetAt?: Date | null;
   limitConcurrentSessions: number;
   // 熔断器配置
   maxRetryAttempts: number | null;

--- a/tests/unit/actions/providers-usage.test.ts
+++ b/tests/unit/actions/providers-usage.test.ts
@@ -17,6 +17,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const getSessionMock = vi.fn();
 const findProviderByIdMock = vi.fn();
 const sumProviderCostInTimeRangeMock = vi.fn();
+const sumProviderTotalCostMock = vi.fn();
 const getProviderSessionCountMock = vi.fn();
 const getProviderSessionCountBatchMock = vi.fn();
 const getTimeRangeForPeriodMock = vi.fn();
@@ -37,6 +38,7 @@ vi.mock("@/repository/provider", () => ({
 vi.mock("@/repository/statistics", () => ({
   sumProviderCostInTimeRange: (providerId: number, startTime: Date, endTime: Date) =>
     sumProviderCostInTimeRangeMock(providerId, startTime, endTime),
+  sumProviderTotalCost: (providerId: number) => sumProviderTotalCostMock(providerId),
 }));
 
 vi.mock("@/lib/session-tracker", () => ({
@@ -166,6 +168,7 @@ describe("getProviderLimitUsage", () => {
 
     // Default DB costs
     sumProviderCostInTimeRangeMock.mockResolvedValue(5.5);
+    sumProviderTotalCostMock.mockResolvedValue(0);
   });
 
   afterEach(() => {
@@ -403,6 +406,7 @@ describe("getProviderLimitUsageBatch", () => {
     get5hWindowResetAtMock.mockResolvedValue(null);
 
     sumProviderCostInTimeRangeMock.mockResolvedValue(5.5);
+    sumProviderTotalCostMock.mockResolvedValue(0);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
Adds total cost quota (\`limitTotalUsd\`) support to provider and API key quota management, completing the quota system alongside existing 5h, daily, weekly, and monthly quotas.

## Problem
The quota system previously supported time-windowed limits (5h, daily, weekly, monthly) but lacked a lifetime/total cost limit. This prevented administrators from setting a hard cap on total spend for providers or keys, which is essential for budget control and preventing runaway costs.

## Solution
Extends the quota system to support \`limitTotalUsd\` (total cost limit) for both providers and API keys:
- Added total cost tracking using \`sumProviderTotalCost()\` repository function
- Updated UI components to display and edit total quotas
- Added i18n translations for all 5 supported languages (EN, JA, RU, ZH-CN, ZH-TW)
- Updated quota helper functions to include total cost in usage calculations

## Changes

### Core Changes
- \`src/actions/providers.ts\`: Added \`limitTotalUsd\` to \`getProviderLimitUsage()\` and \`getProviderLimitUsageBatch()\` functions
- \`src/lib/utils/quota-helpers.ts\`: Updated \`hasKeyQuotaSet()\` and \`getMaxUsageRate()\` to consider total cost quota
- \`src/repository/statistics.ts\`: Uses \`sumProviderTotalCost()\` for calculating lifetime spend

### UI Changes
- \`src/app/[locale]/dashboard/quotas/providers/_components/\`: Added total quota display and editing in provider quota list and client components
- \`src/app/[locale]/dashboard/quotas/keys/_components/\`: Added total quota column to keys quota table and edit dialog

### i18n Updates
- \`messages/*/quota.json\`: Added translations for "Total Cost" labels across all 5 languages

### Test Updates
- \`tests/unit/actions/providers-usage.test.ts\`: Added mock for \`sumProviderTotalCost\`

## Testing

### Automated Tests
- [x] Unit tests updated (\`providers-usage.test.ts\`)

### Manual Testing
1. Navigate to Provider Quotas page
2. Verify total quota appears in provider list items
3. Edit a key quota and verify total quota field is present
4. Check that quota progress bars display correctly for total limits

## Related PRs
- Related to #1124 - Previous closed attempt at this feature

## Checklist
- [x] i18n strings added for all supported languages (per CLAUDE.md requirements)
- [x] Unit tests updated
- [x] No breaking changes to existing quota APIs
- [x] UI components properly display total quota status

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR completes the quota system by adding `limitTotalUsd` (lifetime total cost limit) support for both providers and API keys, covering data fetching, UI display, quick-edit, and i18n across all five supported languages. The core logic is sound: `sumProviderTotalCost` correctly receives `totalCostResetAt` in both the single and batch paths, and `publishProviderCacheInvalidation` is now properly called after `resetProviderTotalUsage`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; only P2 style/test quality issues found.

All core logic (quota enforcement, `resetAt` forwarding, cache invalidation) is correct. Two P2 findings: the test mock drops the `resetAt` argument, and the list item omits `resetAt` when calling `renderQuotaItem`, suppressing the countdown timer for total quota after a manual reset. Neither causes incorrect quota enforcement or data loss.

`provider-quota-list-item.tsx` (missing `resetAt` in `renderQuotaItem`) and `providers-usage.test.ts` (mock drops `resetAt` arg).
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/actions/providers.ts | Adds `limitTotalUsd` tracking to both single and batch provider usage functions; `sumProviderTotalCost` now correctly receives `totalCostResetAt` in both paths. Also adds a `publishProviderCacheInvalidation` call to `resetProviderTotalUsage`. |
| src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx | Renders total quota item via `renderQuotaItem` but omits `resetAt`, so the countdown timer is never shown after a manual reset. |
| tests/unit/actions/providers-usage.test.ts | Adds `sumProviderTotalCostMock` but the mock wrapper silently drops the `resetAt` argument, preventing future assertions on argument correctness. |
| src/lib/utils/quota-helpers.ts | Extends `hasKeyQuotaSet` and `getMaxUsageRate` to include `costTotal`; uses optional chaining since the field is optional in `KeyQuota`, consistent with surrounding patterns. |
| src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx | Adds `limitTotal` state and input field for the total quota in the key edit dialog; wired to `limitTotalUsd` on save. |
| src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx | Adds a Total Quota column to the keys quota table with progress bar, quick-edit popover, and usage rate display. |
| src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx | Updates `hasQuotaLimit` and `calculateMaxUsage` to include `limitTotalUsd`; null/zero checks are correct and consistent. |
| src/types/provider.ts | Adds `totalCostResetAt?: Date | null` to `ProviderDisplay` interface to support the new total-cost-reset feature. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getProviderLimitUsage / getProviderLimitUsageBatch] --> B[sumProviderTotalCost\nproviderId, totalCostResetAt]
    A --> C[sumProviderCostInTimeRange\n5h / daily / weekly / monthly]
    B --> D[limitTotalUsd result\ncurrent, limit, resetAt]
    C --> E[cost5h / costDaily / costWeekly / costMonthly]
    D --> F[ProviderLimitUsageData]
    E --> F
    F --> G[UI: providers-quota-client\nhasQuotaLimit / calculateMaxUsage]
    F --> H[UI: provider-quota-list-item\nrenderQuotaItem — resetAt missing]
    F --> I[UI: keys-quota-client\nTotal Quota column]

    J[quota-helpers.ts\nhasKeyQuotaSet / getMaxUsageRate] --> K[includes costTotal?.limit]
    L[edit-key-quota-dialog\nlimitTotal state] --> M[updateKeyQuota\nlimitTotalUsd field]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/unit/actions/providers-usage.test.ts
Line: 41

Comment:
**Mock drops the `resetAt` argument**

The mock signature only captures `providerId`, silently dropping the second `resetAt` argument. The real call in `providers.ts` passes `provider.totalCostResetAt` (single path) and `provider.totalCostResetAt ?? null` (batch path). Any future assertion that verifies the correct `resetAt` is forwarded will always receive `undefined` instead.

```suggestion
  sumProviderTotalCost: (providerId: number, resetAt?: Date | null) =>
    sumProviderTotalCostMock(providerId, resetAt),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
Line: 222-228

Comment:
**`resetAt` not forwarded — countdown timer never shown for total quota**

Every other quota item (daily, weekly, monthly) passes its `resetAt` to `renderQuotaItem`, which conditionally renders a `CountdownTimer`. The total quota call omits `provider.quota.limitTotalUsd.resetAt`, so after an admin triggers a manual reset via `resetProviderTotalUsage`, the list item will never display the reset timestamp, unlike all sibling items.

```suggestion
        {provider.quota.limitTotalUsd.limit &&
          provider.quota.limitTotalUsd.limit > 0 &&
          renderQuotaItem(
            t("costTotal.label"),
            provider.quota.limitTotalUsd.current,
            provider.quota.limitTotalUsd.limit,
            provider.quota.limitTotalUsd.resetAt
          )}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(quota): honor total reset markers"](https://github.com/ding113/claude-code-hub/commit/024fcce0e97f56443dbe560e6c6835a1de3af443) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29870764)</sub>

<!-- /greptile_comment -->