### PR TITLE
fix: 修复首页模型排行榜排序问题

### DIFF
--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -1153,7 +1153,7 @@ async function findModelLeaderboardWithTimezone(
     .from(usageLedger)
     .where(and(LEDGER_BILLING_CONDITION, buildDateCondition(period, timezone, dateRange)))
     .groupBy(modelField)
-    .orderBy(desc(sql`count(*)`)); // 按请求数排序
+    .orderBy(desc(sql`sum(${usageLedger.costUsd})`), desc(sql`count(*)`));
 
   return rankings
     .filter((entry) => entry.model !== null && entry.model !== "")

--- a/tests/unit/repository/leaderboard-provider-metrics.test.ts
+++ b/tests/unit/repository/leaderboard-provider-metrics.test.ts
@@ -691,3 +691,52 @@ describe("Model Leaderboard basis handling", () => {
     });
   });
 });
+
+describe("Model Leaderboard sort order", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    selectCallIndex = 0;
+    chainMocks = [];
+    mockSelect.mockClear();
+    mocks.resolveSystemTimezone.mockResolvedValue("UTC");
+    mocks.getSystemSettings.mockResolvedValue({ billingModelSource: "redirected" });
+  });
+
+  it("orders by total cost descending with request count as tiebreaker", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          model: "expensive-low-volume",
+          totalRequests: 5,
+          totalCost: "50.0",
+          totalTokens: 1000,
+          successRate: 1.0,
+        },
+        {
+          model: "cheap-high-volume",
+          totalRequests: 200,
+          totalCost: "1.0",
+          totalTokens: 100000,
+          successRate: 1.0,
+        },
+      ]),
+    ];
+
+    const { findDailyModelLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyModelLeaderboard();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].model).toBe("expensive-low-volume");
+    expect(result[0].totalCost).toBe(50);
+    expect(result[1].model).toBe("cheap-high-volume");
+    expect(result[1].totalCost).toBe(1);
+
+    const orderByMock = chainMocks[0].orderBy;
+    expect(orderByMock).toHaveBeenCalledTimes(1);
+
+    const args = orderByMock.mock.calls[0];
+    expect(args).toHaveLength(2);
+    expect(JSON.stringify(args[0])).toContain("sum");
+    expect(JSON.stringify(args[1])).toContain("count");
+  });
+});


### PR DESCRIPTION
## Summary

Fix the model leaderboard sort order to rank by total cost (descending) instead of request count, aligning it with the user and provider leaderboards.

## Problem

The model leaderboard query (`findModelLeaderboardWithTimezone`) was sorting by `count(*)` (request count) while all other leaderboard scopes (user at L367/L407, provider at L699) sort by `sum(cost_usd)`. This caused the "Cost Leaderboard" display to show models ordered by volume rather than cost, making expensive low-volume models appear below cheap high-volume ones.

## Solution

Switch the `ORDER BY` clause from:
```sql
ORDER BY count(*) DESC
```
to:
```sql
ORDER BY sum(cost_usd) DESC, count(*) DESC
```

This matches the provider model sub-rows pattern (L750) and is consistent with all other leaderboard scopes.

## Changes

- **`src/repository/leaderboard.ts`**: Change model leaderboard `orderBy` to `sum(cost_usd) DESC` with `count(*)` as tiebreaker
- **`tests/unit/repository/leaderboard-provider-metrics.test.ts`**: Add test verifying cost-based ordering with an expensive-low-volume model ranking above a cheap-high-volume model

## Testing

- [x] Unit test added: verifies models sort by total cost descending with request count as tiebreaker

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the homepage model leaderboard to sort by total cost (descending) with request count as a tiebreaker, replacing the previous sort by request count alone. It bundles several related improvements: explicit `locale` propagation to `getTranslations()` across all RSC pages (fixing potential locale-mismatch in server components), a `LanguageSwitcher` refresh fix that triggers `router.refresh()` after locale navigation, per-request billing support for image APIs without token usage, and extraction of the Langfuse trace helper into a shared module with error-path coverage.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; all changes are well-tested and the single finding is a minor ORDER BY NULL-handling inconsistency.

Only P2 findings present. The core leaderboard sort fix is correct and covered by a new unit test. The i18n, language-switcher, billing, and Langfuse changes all have matching tests. One minor inconsistency exists between COALESCE in SELECT vs bare sum() in ORDER BY, but practical impact is negligible.

src/repository/leaderboard.ts — minor COALESCE inconsistency between SELECT and ORDER BY for null costUsd rows.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/repository/leaderboard.ts | Core fix: changed model leaderboard sort from request count to cost (sum costUsd) with count as tiebreaker; minor NULL-vs-COALESCE inconsistency between SELECT and ORDER BY. |
| src/app/v1/_lib/proxy/response-handler.ts | Added per-request billing support for image/no-token-usage APIs; extracted emitLangfuseTrace to shared module; billable usage resolution now handles input_cost_per_request. |
| src/app/v1/_lib/proxy/error-handler.ts | Added Langfuse trace emission for both rate-limit and generic error paths; uses shared emitProxyLangfuseTrace helper. |
| src/components/ui/language-switcher.tsx | Added router.refresh() after locale change with dual-layer persistence (module-level var + sessionStorage) to correctly refresh RSC tree and unblock the disabled trigger button. |
| src/lib/langfuse/emit-proxy-trace.ts | New module extracting the fire-and-forget Langfuse trace helper previously inlined in response-handler.ts; no issues. |
| tests/integration/billing-model-source.test.ts | Comprehensive tests for per-request billing (image edit endpoints): multipliers, zero-cost guard, pricing DB failure, fake-200 error detection, session usage payload. |
| tests/unit/repository/leaderboard-provider-metrics.test.ts | Added test suite verifying cost-first sort order with request count as tiebreaker; tests ORDER BY argument structure and result ordering. |
| tests/unit/i18n/locale-server-translations.test.ts | New regression test ensuring all route pages and server chrome use explicit locale form of getTranslations rather than the implicit context-based form. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Model Leaderboard Query] --> B[GROUP BY modelField]
    B --> C{ORDER BY}
    C -->|Before PR| D["count(*) DESC\n(request count)"]
    C -->|After PR| E["sum(costUsd) DESC\nthen count(*) DESC"]
    E --> F[Return sorted rankings]
    D --> F
    F --> G[Filter null/empty models]
    G --> H[Map to ModelLeaderboardEntry]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/repository/leaderboard.ts
Line: 1156

Comment:
**NULL handling inconsistency in ORDER BY vs SELECT**

The SELECT clause uses `COALESCE(sum(${usageLedger.costUsd}), 0)` (so `totalCost` is always a number), but the ORDER BY uses `sum(${usageLedger.costUsd})` without COALESCE. In PostgreSQL, a group where all `costUsd` values are NULL produces `SUM = NULL`, which sorts **last** under `DESC` — below models with an explicit `$0.00` cost. Models with no billing data at all would rank below models billed at exactly zero, which is inconsistent with the `totalCost` value returned to the caller.

```suggestion
    .orderBy(desc(sql`COALESCE(sum(${usageLedger.costUsd}), 0)`), desc(sql`count(*)`));
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): order model leaderboard ..."](https://github.com/ding113/claude-code-hub/commit/94c8f930a9cdf7132361ed4d93a7a22b38d0a90e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29896899)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->