### PR TITLE
fix(leaderboard): ORDER BY 添加 COALESCE 以统一 NULL 排序行为

### DIFF
--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -364,7 +364,7 @@ async function findLeaderboardWithTimezone(
     .innerJoin(users, and(sql`${usageLedger.userId} = ${users.id}`, isNull(users.deletedAt)))
     .where(and(...whereConditions))
     .groupBy(usageLedger.userId, users.name)
-    .orderBy(desc(sql`sum(${usageLedger.costUsd})`));
+    .orderBy(desc(sql`COALESCE(sum(${usageLedger.costUsd}), 0)`));
 
   const baseEntries: LeaderboardEntry[] = rankings.map((entry) => ({
     userId: entry.userId,
@@ -404,7 +404,7 @@ async function findLeaderboardWithTimezone(
     .innerJoin(users, and(sql`${usageLedger.userId} = ${users.id}`, isNull(users.deletedAt)))
     .where(and(...whereConditions))
     .groupBy(usageLedger.userId, modelField)
-    .orderBy(desc(sql`sum(${usageLedger.costUsd})`));
+    .orderBy(desc(sql`COALESCE(sum(${usageLedger.costUsd}), 0)`));
 
   const modelStatsByUser = new Map<number, UserModelStat[]>();
   for (const row of modelRows) {
@@ -696,7 +696,7 @@ async function findProviderLeaderboardWithTimezone(
       and(...whereConditions.filter((c): c is NonNullable<(typeof whereConditions)[number]> => !!c))
     )
     .groupBy(usageLedger.finalProviderId, providers.name)
-    .orderBy(desc(sql`sum(${usageLedger.costUsd})`));
+    .orderBy(desc(sql`COALESCE(sum(${usageLedger.costUsd}), 0)`));
 
   const baseEntries: ProviderLeaderboardEntry[] = rankings.map((entry) => {
     const totalCost = parseFloat(entry.totalCost);
@@ -747,7 +747,7 @@ async function findProviderLeaderboardWithTimezone(
       and(...whereConditions.filter((c): c is NonNullable<(typeof whereConditions)[number]> => !!c))
     )
     .groupBy(usageLedger.finalProviderId, modelField)
-    .orderBy(desc(sql`sum(${usageLedger.costUsd})`), desc(sql`count(*)`));
+    .orderBy(desc(sql`COALESCE(sum(${usageLedger.costUsd}), 0)`), desc(sql`count(*)`));
 
   const modelStatsByProvider = new Map<number, ModelProviderStat[]>();
   for (const row of modelRows) {
@@ -1153,7 +1153,7 @@ async function findModelLeaderboardWithTimezone(
     .from(usageLedger)
     .where(and(LEDGER_BILLING_CONDITION, buildDateCondition(period, timezone, dateRange)))
     .groupBy(modelField)
-    .orderBy(desc(sql`sum(${usageLedger.costUsd})`), desc(sql`count(*)`));
+    .orderBy(desc(sql`COALESCE(sum(${usageLedger.costUsd}), 0)`), desc(sql`count(*)`));
 
   return rankings
     .filter((entry) => entry.model !== null && entry.model !== "")


### PR DESCRIPTION
## Summary

Fix NULL sorting inconsistency in all 5 leaderboard ORDER BY clauses by adding COALESCE to match the SELECT expressions, ensuring groups with no billing data sort consistently with their returned `totalCost` value.

## Problem

All 5 leaderboard queries in `src/repository/leaderboard.ts` use `COALESCE(sum(costUsd), 0)` in their SELECT clause (so `totalCost` is always a number), but the ORDER BY used bare `sum(costUsd)`. In PostgreSQL, `NULL` sorts first under `DESC`, causing groups with no billing data (NULL sum) to rank above groups with explicit `$0.00` cost, even though both return `totalCost = 0` to the caller.

**Discovered during review of #1127** — Greptile and multiple reviewers flagged the NULL handling inconsistency at the model leaderboard ORDER BY.

**Related PRs:**
- Follow-up to #1127 — this PR addresses the COALESCE inconsistency flagged in review comments on that PR
- Depends on #1127 — must be merged after #1127

## Solution

Add `COALESCE(sum(costUsd), 0)` to all 5 ORDER BY clauses so the sort expression matches the SELECT expression, making NULL and explicit-zero groups sort identically.

## Changes

### Core Changes (`src/repository/leaderboard.ts`, +5/-5)
| Line | Query | Change |
|------|-------|--------|
| 367 | User leaderboard | `orderBy` now uses `COALESCE(sum(...), 0)` |
| 407 | User model detail | `orderBy` now uses `COALESCE(sum(...), 0)` |
| 699 | Provider leaderboard | `orderBy` now uses `COALESCE(sum(...), 0)` |
| 750 | Provider model detail | `orderBy` now uses `COALESCE(sum(...), 0)` |
| 1156 | Model leaderboard | `orderBy` now uses `COALESCE(sum(...), 0)` with `count(*)` tiebreaker |

### Tests (`tests/unit/repository/leaderboard-provider-metrics.test.ts`, +49)
- New test suite "Model Leaderboard sort order" verifying cost-based ordering
- Tests that expensive-low-volume models rank above cheap-high-volume models
- Validates ORDER BY arguments contain `sum` (primary) and `count` (tiebreaker)

## Testing

- [x] Unit tests added — verifies cost-first sort order with request count as tiebreaker
- [x] Pre-commit checklist: `bun run lint`, `bun run typecheck`, `bun run test`, `bun run build`

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes NULL-sort inconsistency across all 5 leaderboard `ORDER BY` clauses in `src/repository/leaderboard.ts` by wrapping `sum(costUsd)` with `COALESCE(..., 0)` to match the existing `SELECT` expressions. The change is minimal, targeted, and correctly resolves the PostgreSQL NULL-first-in-DESC behaviour for groups with no billing data.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — change is a correct, minimal fix with no functional regressions.

All 5 ORDER BY changes are consistent, correct, and match the existing SELECT COALESCE patterns. Only finding is a P2 test-assertion weakness that does not affect correctness of the fix.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/repository/leaderboard.ts | All 5 ORDER BY clauses updated from bare `sum(costUsd)` to `COALESCE(sum(costUsd), 0)`, aligning sort expressions with SELECT expressions and eliminating NULL-first DESC behaviour for groups with no billing data. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Leaderboard Query] --> B{Groups with billing data?}
    B -->|Yes| C["sum(costUsd) returns a value"]
    B -->|No| D["sum(costUsd) returns NULL"]
    subgraph Before["Before this PR"]
        C --> E["ORDER BY desc(sum) ranks by cost"]
        D --> F["ORDER BY desc(NULL) ranks FIRST in PostgreSQL DESC"]
        F --> G["Groups with no cost rank above paid groups"]
    end
    subgraph After["After this PR"]
        C --> H["ORDER BY desc(COALESCE(sum, 0)) ranks by cost"]
        D --> I["ORDER BY desc(COALESCE(NULL, 0)) = desc(0) ranks at bottom"]
        I --> J["Groups with no cost sort consistently with zero-cost groups"]
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/unit/repository/leaderboard-provider-metrics.test.ts
Line: 739-740

Comment:
**Test doesn't verify COALESCE is present in ORDER BY**

The assertions at lines 739–740 only check that the first sort argument contains `"sum"` and the second contains `"count"`. This was already true before this PR (the old `sum(costUsd)` also contains "sum"), so the test doesn't actually verify that the `COALESCE` wrapper introduced by this fix is present in the ORDER BY expression. Consider adding `expect(JSON.stringify(args[0])).toContain("COALESCE")` to make the test actually guard against regression.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(leaderboard): add COALESCE to ORDER ..."](https://github.com/ding113/claude-code-hub/commit/5740b97cbb6f9aead35e89f252903f418d59ff4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29900610)</sub>

<!-- /greptile_comment -->