### PR TITLE
fix(settings): constrain pricing table layout

### DIFF
--- a/src/app/[locale]/settings/layout.tsx
+++ b/src/app/[locale]/settings/layout.tsx
@@ -42,7 +42,7 @@ export default async function SettingsLayout({
               <SettingsNav items={translatedNavItems} />
             </aside>
             {/* Content area */}
-            <div className="space-y-6">
+            <div className="min-w-0 space-y-6">
               {/* Tablet: Horizontal nav shown above content */}
               <div className="lg:hidden">
                 <SettingsNav items={translatedNavItems} />

--- a/src/app/[locale]/settings/prices/_components/price-list.tsx
+++ b/src/app/[locale]/settings/prices/_components/price-list.tsx
@@ -412,8 +412,8 @@ export function PriceList({
       </div>
 
       {/* 价格表格 */}
-      <div className="rounded-lg overflow-hidden border border-white/10 bg-white/[0.02]">
-        <table className="w-full table-fixed">
+      <div className="rounded-lg overflow-x-auto overflow-y-hidden border border-white/10 bg-white/[0.02]">
+        <table className="w-full min-w-[76rem] table-fixed">
           <thead>
             <tr className="border-b border-white/10">
               <th className="py-3 px-4 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wide w-72">

--- a/tests/unit/settings/prices-layout.test.ts
+++ b/tests/unit/settings/prices-layout.test.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+function readProjectFile(...segments: string[]) {
+  return fs.readFileSync(path.join(process.cwd(), ...segments), "utf8");
+}
+
+describe("settings prices layout constraints", () => {
+  test("settings content column can shrink inside the centered page container", () => {
+    const source = readProjectFile("src/app/[locale]/settings/layout.tsx");
+
+    expect(source).toContain('className="mx-auto w-full max-w-7xl');
+    expect(source).toContain('className="min-w-0 space-y-6"');
+  });
+
+  test("price table scrolls horizontally inside its settings section", () => {
+    const source = readProjectFile("src/app/[locale]/settings/prices/_components/price-list.tsx");
+
+    expect(source).toMatch(/<div className="[^"]*overflow-x-auto[^"]*overflow-y-hidden[^"]*"/);
+    expect(source).toMatch(/<table className="[^"]*min-w-\[[^\]]+\][^"]*table-fixed[^"]*"/);
+  });
+});


### PR DESCRIPTION
## Summary
Fix layout overflow issue in the settings pricing table where wide content could expand beyond the centered max-width container, causing horizontal layout breakage.

## Problem
The pricing table in Settings > Prices contains many columns with fixed-width cells that can exceed the available viewport width. Without proper constraints:
- The content area could expand beyond the `max-w-7xl` container
- The pricing table would overflow its container on smaller screens
- Layout would break horizontally, requiring page-level scrolling

## Solution
Apply CSS containment strategies to constrain the layout at two levels:

1. **Content Column (`layout.tsx`)**: Add `min-w-0` to the content area to allow flex items to shrink below their intrinsic size, preventing expansion beyond the centered container.

2. **Pricing Table (`price-list.tsx`)**: Enable horizontal scrolling within the table card:
   - Change `overflow-hidden` to `overflow-x-auto overflow-y-hidden` on the container
   - Add `min-w-[76rem]` to the table to maintain readability while scrolling

## Changes

### Core Changes
| File | Change | Purpose |
|------|--------|---------|
| `src/app/[locale]/settings/layout.tsx` | Added `min-w-0` to content area | Prevent flex child from expanding beyond container |
| `src/app/[locale]/settings/prices/_components/price-list.tsx` | Added `overflow-x-auto overflow-y-hidden` and `min-w-[76rem]` | Enable horizontal scroll for wide tables |

### Supporting Changes
| File | Change | Purpose |
|------|--------|---------|
| `tests/unit/settings/prices-layout.test.ts` | New regression test | Verify layout constraints are in place |

## Testing

### Automated Tests
- [x] Unit test added: `tests/unit/settings/prices-layout.test.ts`
  - Verifies settings content column has `min-w-0` constraint
  - Verifies price table has horizontal scroll capability with minimum width

### Manual Testing
1. Navigate to Settings > Prices
2. Resize browser window to < 1280px width
3. Verify the pricing table scrolls horizontally within its card
4. Verify the overall page layout does not break/overflow

### Build Verification
- [x] `bun run test -- tests/unit/settings/prices-layout.test.ts`
- [x] `bun run typecheck`
- [x] `bunx biome check` passes for modified files

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No documentation updates needed (UI behavior fix)
- [x] No breaking changes (pure CSS layout fix)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a layout overflow bug in the settings pricing page by adding `min-w-0` to the CSS grid content column (preventing it from expanding beyond the `max-w-7xl` container) and enabling horizontal scrolling on the pricing table wrapper with a `min-w-[76rem]` floor on the table itself. A regression test is included, though its class-order-sensitive regexes are slightly fragile.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the layout fix is correct and the only concern is a minor test fragility.

All three changes are straightforward and correct. The sole finding is a P2 style issue in the test file where order-sensitive regexes could produce false negatives on class reordering, but this does not affect runtime behaviour.

tests/unit/settings/prices-layout.test.ts — regex patterns should match classes independently rather than in a fixed order.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/settings/layout.tsx | Adds `min-w-0` to the grid content column so it can shrink below its intrinsic content width — a standard CSS grid fix, no issues. |
| src/app/[locale]/settings/prices/_components/price-list.tsx | Replaces `overflow-hidden` with `overflow-x-auto overflow-y-hidden` on the table wrapper and adds `min-w-[76rem]` to the table for horizontal scroll; correct approach. |
| tests/unit/settings/prices-layout.test.ts | New regression tests read source files directly; the combined-order regex patterns for class names are fragile and may fail on innocuous class reordering. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["max-w-7xl container\n(mx-auto w-full max-w-7xl)"] --> B["Grid\n(lg:grid-cols-[220px_1fr])"]
    B --> C["Sidebar\n(aside, hidden on mobile)"]
    B --> D["Content column\n(min-w-0 space-y-6) ✦ NEW"]
    D --> E["PageTransition → children"]
    E --> F["PriceList component"]
    F --> G["Table wrapper\n(overflow-x-auto overflow-y-hidden) ✦ CHANGED"]
    G --> H["table\n(min-w-[76rem] table-fixed) ✦ CHANGED"]
    H --> I["Wide table columns\n(w-72 + w-40 + w-48 + …)"]

    style D fill:#2d4a2d,color:#fff
    style G fill:#2d4a2d,color:#fff
    style H fill:#2d4a2d,color:#fff
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/unit/settings/prices-layout.test.ts
Line: 19-21

Comment:
**Order-sensitive regex may produce false negatives**

Both regexes assert that `overflow-x-auto` precedes `overflow-y-hidden` and that `min-w-[...]` precedes `table-fixed` in the class string. Tailwind class order is arbitrary — a formatter or future edit could reorder them and the tests would fail even though the rendered behaviour is identical. Consider matching each class independently or using `toContain` per class.

```suggestion
    expect(source).toContain('overflow-x-auto');
    expect(source).toContain('overflow-y-hidden');
    expect(source).toMatch(/<table className="[^"]*table-fixed[^"]*"/);
    expect(source).toMatch(/min-w-\[[^\]]+\]/);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(settings): constrain pricing table l..."](https://github.com/ding113/claude-code-hub/commit/fef5ccff5c4125e56f71cd0536082b6434113aab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29958784)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->