### PR TITLE
release v0.7.4

### DIFF
--- a/messages/en/quota.json
+++ b/messages/en/quota.json
@@ -153,6 +153,9 @@
       "label": "Monthly Cost",
       "resetAt": "Resets at"
     },
+    "costTotal": {
+      "label": "Total Cost"
+    },
     "concurrentSessions": {
       "label": "Concurrent Sessions"
     },
@@ -183,6 +186,7 @@
       "costDaily": "Daily Quota",
       "costWeekly": "Weekly Quota",
       "costMonthly": "Monthly Quota",
+      "costTotal": "Total Quota",
       "concurrentSessions": "Concurrent Limit",
       "status": "Status",
       "actions": "Actions"
@@ -232,6 +236,11 @@
       },
       "costMonthly": {
         "label": "Monthly Quota (USD)",
+        "placeholder": "Unlimited",
+        "current": "Current usage: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "Total Quota (USD)",
         "placeholder": "Unlimited",
         "current": "Current usage: {currency}{current} / {currency}{limit}"
       },

--- a/messages/ja/quota.json
+++ b/messages/ja/quota.json
@@ -130,6 +130,9 @@
       "label": "月次コスト",
       "resetAt": "リセット時刻"
     },
+    "costTotal": {
+      "label": "総コスト"
+    },
     "concurrentSessions": {
       "label": "同時セッション"
     },
@@ -160,6 +163,7 @@
       "costDaily": "日次クォータ",
       "costWeekly": "週次クォータ",
       "costMonthly": "月次クォータ",
+      "costTotal": "総クォータ",
       "concurrentSessions": "同時制限",
       "status": "ステータス",
       "actions": "アクション"
@@ -209,6 +213,11 @@
       },
       "costMonthly": {
         "label": "月次クォータ (USD)",
+        "placeholder": "無制限",
+        "current": "現在使用: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "総クォータ (USD)",
         "placeholder": "無制限",
         "current": "現在使用: {currency}{current} / {currency}{limit}"
       },

--- a/messages/ru/quota.json
+++ b/messages/ru/quota.json
@@ -153,6 +153,9 @@
       "label": "Ежемесячные расходы",
       "resetAt": "Сброс в"
     },
+    "costTotal": {
+      "label": "Общие расходы"
+    },
     "concurrentSessions": {
       "label": "Параллельные сессии"
     },
@@ -183,6 +186,7 @@
       "costDaily": "Дневная квота",
       "costWeekly": "Еженедельная квота",
       "costMonthly": "Ежемесячная квота",
+      "costTotal": "Общая квота",
       "concurrentSessions": "Лимит параллельных",
       "status": "Статус",
       "actions": "Действия"
@@ -232,6 +236,11 @@
       },
       "costMonthly": {
         "label": "Ежемесячная квота (USD)",
+        "placeholder": "Неограниченно",
+        "current": "Использовано: {currency}{current} из {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "Общая квота (USD)",
         "placeholder": "Неограниченно",
         "current": "Использовано: {currency}{current} из {currency}{limit}"
       },

--- a/messages/zh-CN/quota.json
+++ b/messages/zh-CN/quota.json
@@ -153,6 +153,9 @@
       "label": "月消费",
       "resetAt": "重置于"
     },
+    "costTotal": {
+      "label": "总消费"
+    },
     "concurrentSessions": {
       "label": "并发 Session"
     },
@@ -183,6 +186,7 @@
       "costDaily": "每日限额",
       "costWeekly": "周限额",
       "costMonthly": "月限额",
+      "costTotal": "总限额",
       "concurrentSessions": "并发限制",
       "status": "状态",
       "actions": "操作"
@@ -232,6 +236,11 @@
       },
       "costMonthly": {
         "label": "月限额(USD)",
+        "placeholder": "不限制",
+        "current": "当前已用: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "总限额(USD)",
         "placeholder": "不限制",
         "current": "当前已用: {currency}{current} / {currency}{limit}"
       },

--- a/messages/zh-TW/quota.json
+++ b/messages/zh-TW/quota.json
@@ -128,6 +128,9 @@
       "label": "月消費",
       "resetAt": "重置於"
     },
+    "costTotal": {
+      "label": "總消費"
+    },
     "concurrentSessions": {
       "label": "並發 Session"
     },
@@ -158,6 +161,7 @@
       "costDaily": "每日限額",
       "costWeekly": "周限額",
       "costMonthly": "月限額",
+      "costTotal": "總限額",
       "concurrentSessions": "並發限制",
       "status": "狀態",
       "actions": "操作"
@@ -207,6 +211,11 @@
       },
       "costMonthly": {
         "label": "月限額 (USD)",
+        "placeholder": "不限制",
+        "current": "當前已用: {currency}{current} / {currency}{limit}"
+      },
+      "limitTotalUsd": {
+        "label": "總限額 (USD)",
         "placeholder": "不限制",
         "current": "當前已用: {currency}{current} / {currency}{limit}"
       },

--- a/src/actions/key-quota.ts
+++ b/src/actions/key-quota.ts
@@ -21,6 +21,7 @@ export interface KeyQuotaItem {
   limit: number | null;
   mode?: "fixed" | "rolling";
   time?: string;
+  resetAt?: Date;
 }
 
 export interface KeyQuotaUsageResult {
@@ -164,6 +165,7 @@ export async function getKeyQuotaUsage(keyId: number): Promise<ActionResult<KeyQ
         type: "limitTotal",
         current: totalCost,
         limit: parseNumericLimit(keyRow.limitTotalUsd),
+        resetAt: costResetAt ?? undefined,
       },
       {
         type: "limitSessions",

--- a/src/actions/keys.ts
+++ b/src/actions/keys.ts
@@ -837,7 +837,7 @@ export async function getKeyLimitUsage(keyId: number): Promise<
     costDaily: { current: number; limit: number | null; resetAt?: Date };
     costWeekly: { current: number; limit: number | null; resetAt?: Date };
     costMonthly: { current: number; limit: number | null; resetAt?: Date };
-    costTotal: { current: number; limit: number | null };
+    costTotal: { current: number; limit: number | null; resetAt?: Date };
     concurrentSessions: { current: number; limit: number };
   }>
 > {
@@ -958,6 +958,7 @@ export async function getKeyLimitUsage(keyId: number): Promise<
         costTotal: {
           current: totalCost,
           limit: key.limitTotalUsd ?? null,
+          resetAt: costResetAt ?? undefined,
         },
         concurrentSessions: {
           current: concurrentSessions,

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -1260,7 +1260,14 @@ export async function resetProviderTotalUsage(providerId: number): Promise<Actio
       return { ok: false, error: "供应商不存在" };
     }
 
-    await publishProviderCacheInvalidation();
+    try {
+      await publishProviderCacheInvalidation();
+    } catch (error) {
+      logger.warn("resetProviderTotalUsage:cache_invalidation_failed", {
+        providerId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
 
     return { ok: true };
   } catch (error) {

--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -327,6 +327,7 @@ export async function getProviders(): Promise<ProviderDisplay[]> {
         limitWeeklyUsd: provider.limitWeeklyUsd,
         limitMonthlyUsd: provider.limitMonthlyUsd,
         limitTotalUsd: provider.limitTotalUsd,
+        totalCostResetAt: provider.totalCostResetAt,
         limitConcurrentSessions: provider.limitConcurrentSessions,
         maxRetryAttempts: provider.maxRetryAttempts,
         circuitBreakerFailureThreshold: provider.circuitBreakerFailureThreshold,
@@ -1258,6 +1259,8 @@ export async function resetProviderTotalUsage(providerId: number): Promise<Actio
     if (!ok) {
       return { ok: false, error: "供应商不存在" };
     }
+
+    await publishProviderCacheInvalidation();
 
     return { ok: true };
   } catch (error) {
@@ -2690,6 +2693,7 @@ export async function getProviderLimitUsage(providerId: number): Promise<
     costDaily: { current: number; limit: number | null; resetAt?: Date };
     costWeekly: { current: number; limit: number | null; resetAt: Date };
     costMonthly: { current: number; limit: number | null; resetAt: Date };
+    limitTotalUsd: { current: number; limit: number | null; resetAt?: Date };
     concurrentSessions: { current: number; limit: number };
   }>
 > {
@@ -2713,7 +2717,9 @@ export async function getProviderLimitUsage(providerId: number): Promise<
       getTimeRangeForPeriodWithMode,
     } = await import("@/lib/rate-limit/time-utils");
     const { RateLimitService } = await import("@/lib/rate-limit");
-    const { sumProviderCostInTimeRange } = await import("@/repository/statistics");
+    const { sumProviderCostInTimeRange, sumProviderTotalCost } = await import(
+      "@/repository/statistics"
+    );
     const limit5hResetMode = provider.limit5hResetMode ?? "rolling";
 
     // 计算各周期的时间范围
@@ -2732,15 +2738,23 @@ export async function getProviderLimitUsage(providerId: number): Promise<
     ]);
 
     // 获取金额消费（直接查询数据库，确保配额显示与 DB 一致）
-    const [cost5h, costDaily, costWeekly, costMonthly, concurrentSessions] = await Promise.all([
-      limit5hResetMode === "fixed"
-        ? RateLimitService.getCurrentCost(providerId, "provider", "5h", undefined, limit5hResetMode)
-        : sumProviderCostInTimeRange(providerId, range5h.startTime, range5h.endTime),
-      sumProviderCostInTimeRange(providerId, rangeDaily.startTime, rangeDaily.endTime),
-      sumProviderCostInTimeRange(providerId, rangeWeekly.startTime, rangeWeekly.endTime),
-      sumProviderCostInTimeRange(providerId, rangeMonthly.startTime, rangeMonthly.endTime),
-      SessionTracker.getProviderSessionCount(providerId),
-    ]);
+    const [cost5h, costDaily, costWeekly, costMonthly, totalCost, concurrentSessions] =
+      await Promise.all([
+        limit5hResetMode === "fixed"
+          ? RateLimitService.getCurrentCost(
+              providerId,
+              "provider",
+              "5h",
+              undefined,
+              limit5hResetMode
+            )
+          : sumProviderCostInTimeRange(providerId, range5h.startTime, range5h.endTime),
+        sumProviderCostInTimeRange(providerId, rangeDaily.startTime, rangeDaily.endTime),
+        sumProviderCostInTimeRange(providerId, rangeWeekly.startTime, rangeWeekly.endTime),
+        sumProviderCostInTimeRange(providerId, rangeMonthly.startTime, rangeMonthly.endTime),
+        sumProviderTotalCost(providerId, provider.totalCostResetAt),
+        SessionTracker.getProviderSessionCount(providerId),
+      ]);
 
     // 获取重置时间信息
     const resetDaily = await getResetInfoWithMode(
@@ -2779,6 +2793,11 @@ export async function getProviderLimitUsage(providerId: number): Promise<
           limit: provider.limitMonthlyUsd,
           resetAt: resetMonthly.resetAt!,
         },
+        limitTotalUsd: {
+          current: totalCost,
+          limit: provider.limitTotalUsd ?? null,
+          resetAt: provider.totalCostResetAt ?? undefined,
+        },
         concurrentSessions: {
           current: concurrentSessions,
           limit: provider.limitConcurrentSessions || 0,
@@ -2800,6 +2819,7 @@ export type ProviderLimitUsageData = {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
+  limitTotalUsd: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 };
 
@@ -2820,6 +2840,8 @@ export async function getProviderLimitUsageBatch(
     limitDailyUsd?: number | null;
     limitWeeklyUsd?: number | null;
     limitMonthlyUsd?: number | null;
+    limitTotalUsd?: number | null;
+    totalCostResetAt?: Date | null;
     limitConcurrentSessions?: number | null;
   }>
 ): Promise<Map<number, ProviderLimitUsageData>> {
@@ -2845,7 +2867,9 @@ export async function getProviderLimitUsageBatch(
       getTimeRangeForPeriodWithMode,
     } = await import("@/lib/rate-limit/time-utils");
     const { RateLimitService } = await import("@/lib/rate-limit");
-    const { sumProviderCostInTimeRange } = await import("@/repository/statistics");
+    const { sumProviderCostInTimeRange, sumProviderTotalCost } = await import(
+      "@/repository/statistics"
+    );
 
     const providerIds = providers.map((p) => p.id);
 
@@ -2871,7 +2895,7 @@ export async function getProviderLimitUsageBatch(
       );
 
       // 并行查询该供应商的各周期消费（直接查询数据库）
-      const [cost5h, resetAt5h, costDaily, costWeekly, costMonthly] = await Promise.all([
+      const [cost5h, resetAt5h, costDaily, costWeekly, costMonthly, totalCost] = await Promise.all([
         limit5hResetMode === "fixed"
           ? RateLimitService.getCurrentCost(
               provider.id,
@@ -2887,6 +2911,7 @@ export async function getProviderLimitUsageBatch(
         sumProviderCostInTimeRange(provider.id, rangeDaily.startTime, rangeDaily.endTime),
         sumProviderCostInTimeRange(provider.id, rangeWeekly.startTime, rangeWeekly.endTime),
         sumProviderCostInTimeRange(provider.id, rangeMonthly.startTime, rangeMonthly.endTime),
+        sumProviderTotalCost(provider.id, provider.totalCostResetAt ?? null),
       ]);
 
       const sessionCount = sessionCountMap.get(provider.id) || 0;
@@ -2925,6 +2950,11 @@ export async function getProviderLimitUsageBatch(
           current: costMonthly,
           limit: provider.limitMonthlyUsd ?? null,
           resetAt: resetMonthly.resetAt!,
+        },
+        limitTotalUsd: {
+          current: totalCost,
+          limit: provider.limitTotalUsd ?? null,
+          resetAt: provider.totalCostResetAt ?? undefined,
         },
         concurrentSessions: {
           current: sessionCount,

--- a/src/app/[locale]/dashboard/_components/dashboard-header.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-header.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 import { VersionUpdateNotifier } from "@/components/customs/version-update-notifier";
 import { Button } from "@/components/ui/button";
 import { LanguageSwitcher } from "@/components/ui/language-switcher";
@@ -11,10 +11,11 @@ import { UserMenu } from "./user-menu";
 
 interface DashboardHeaderProps {
   session: AuthSession | null;
+  locale: string;
 }
 
-export function DashboardHeader({ session }: DashboardHeaderProps) {
-  const t = useTranslations("dashboard.nav");
+export async function DashboardHeader({ session, locale }: DashboardHeaderProps) {
+  const t = await getTranslations({ locale, namespace: "dashboard.nav" });
   const isAdmin = session?.user.role === "admin";
 
   const NAV_ITEMS: (DashboardNavItem & { adminOnly?: boolean })[] = [

--- a/src/app/[locale]/dashboard/_components/dashboard-sections.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-sections.tsx
@@ -32,7 +32,13 @@ export async function DashboardStatisticsSection() {
   );
 }
 
-export async function DashboardLeaderboardSection({ isAdmin }: { isAdmin: boolean }) {
+export async function DashboardLeaderboardSection({
+  isAdmin,
+  locale,
+}: {
+  isAdmin: boolean;
+  locale: string;
+}) {
   const systemSettings = await getCachedSystemSettings();
   const canViewLeaderboard = isAdmin || systemSettings.allowGlobalUsageView;
 
@@ -40,7 +46,7 @@ export async function DashboardLeaderboardSection({ isAdmin }: { isAdmin: boolea
     return null;
   }
 
-  const t = await getTranslations("dashboard");
+  const t = await getTranslations({ locale, namespace: "dashboard" });
 
   return (
     <div className="space-y-4">

--- a/src/app/[locale]/dashboard/_components/user/key-limit-usage.tsx
+++ b/src/app/[locale]/dashboard/_components/user/key-limit-usage.tsx
@@ -18,7 +18,7 @@ interface LimitUsageData {
   costDaily: { current: number; limit: number | null };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
-  costTotal: { current: number; limit: number | null };
+  costTotal: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/audit-logs/page.tsx
+++ b/src/app/[locale]/dashboard/audit-logs/page.tsx
@@ -17,7 +17,7 @@ export default async function AuditLogsPage({ params }: { params: Promise<{ loca
     return redirect({ href: "/dashboard", locale });
   }
 
-  const t = await getTranslations("auditLogs");
+  const t = await getTranslations({ locale, namespace: "auditLogs" });
 
   return (
     <div className="space-y-6">

--- a/src/app/[locale]/dashboard/availability/page.tsx
+++ b/src/app/[locale]/dashboard/availability/page.tsx
@@ -10,8 +10,13 @@ import { AvailabilityDashboardSkeleton } from "./_components/availability-skelet
 
 export const dynamic = "force-dynamic";
 
-export default async function AvailabilityPage() {
-  const t = await getTranslations("dashboard");
+export default async function AvailabilityPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "dashboard" });
   const session = await getSession();
 
   // Only admin can access availability monitoring

--- a/src/app/[locale]/dashboard/layout.tsx
+++ b/src/app/[locale]/dashboard/layout.tsx
@@ -28,7 +28,7 @@ export default async function DashboardLayout({
 
   return (
     <div className="min-h-[var(--cch-viewport-height,100vh)] bg-background">
-      <DashboardHeader session={session} />
+      <DashboardHeader session={session} locale={locale} />
       <DashboardMain>{children}</DashboardMain>
       <WebhookMigrationDialog />
     </div>

--- a/src/app/[locale]/dashboard/leaderboard/page.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/page.tsx
@@ -10,8 +10,9 @@ import { LeaderboardView } from "./_components/leaderboard-view";
 
 export const dynamic = "force-dynamic";
 
-export default async function LeaderboardPage() {
-  const t = await getTranslations("dashboard");
+export default async function LeaderboardPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "dashboard" });
   // 获取用户 session 和系统设置
   const session = await getSession();
   const systemSettings = await getSystemSettings();

--- a/src/app/[locale]/dashboard/my-quota/page.tsx
+++ b/src/app/[locale]/dashboard/my-quota/page.tsx
@@ -9,13 +9,13 @@ export const dynamic = "force-dynamic";
 
 export default async function MyQuotaPage({ params }: { params: Promise<{ locale: string }> }) {
   // Await params to ensure locale is available in the async context
-  await params;
+  const { locale } = await params;
 
   const [quotaResult, systemSettings, tNav, tCommon] = await Promise.all([
     getMyQuota(),
     getSystemSettings(),
-    getTranslations("dashboard.nav"),
-    getTranslations("common"),
+    getTranslations({ locale, namespace: "dashboard.nav" }),
+    getTranslations({ locale, namespace: "common" }),
   ]);
 
   // Handle error state

--- a/src/app/[locale]/dashboard/providers/page.tsx
+++ b/src/app/[locale]/dashboard/providers/page.tsx
@@ -30,7 +30,7 @@ export default async function DashboardProvidersPage({
   // TypeScript: session is guaranteed to be non-null after the redirect check
   const currentUser = session!.user;
 
-  const t = await getTranslations("settings");
+  const t = await getTranslations({ locale, namespace: "settings" });
   const providers = await getProviders();
 
   return (

--- a/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/edit-key-quota-dialog.tsx
@@ -32,6 +32,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
+  costTotal: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 }
 
@@ -79,6 +80,9 @@ export function EditKeyQuotaDialog({
   const [limitMonthly, setLimitMonthly] = useState<string>(
     currentQuota?.costMonthly.limit?.toString() ?? ""
   );
+  const [limitTotal, setLimitTotal] = useState<string>(
+    currentQuota?.costTotal.limit?.toString() ?? ""
+  );
   const [limitConcurrent, setLimitConcurrent] = useState<string>(
     currentQuota?.concurrentSessions.limit?.toString() ?? "0"
   );
@@ -98,6 +102,7 @@ export function EditKeyQuotaDialog({
           dailyResetTime: resetTime,
           limitWeeklyUsd: limitWeekly ? parseFloat(limitWeekly) : null,
           limitMonthlyUsd: limitMonthly ? parseFloat(limitMonthly) : null,
+          limitTotalUsd: limitTotal ? parseFloat(limitTotal) : null,
           limitConcurrentSessions: limitConcurrent ? parseInt(limitConcurrent, 10) : 0,
         });
 
@@ -127,6 +132,7 @@ export function EditKeyQuotaDialog({
           dailyResetTime: resetTime,
           limitWeeklyUsd: null,
           limitMonthlyUsd: null,
+          limitTotalUsd: null,
           limitConcurrentSessions: 0,
         });
 
@@ -330,6 +336,32 @@ export function EditKeyQuotaDialog({
                       currency: currencySymbol,
                       current: Number(currentQuota.costMonthly.current).toFixed(4),
                       limit: Number(currentQuota.costMonthly.limit).toFixed(2),
+                    })}
+                  </p>
+                )}
+              </div>
+
+              {/* 总限额 */}
+              <div className="grid gap-1.5">
+                <Label htmlFor="limitTotal" className="text-xs">
+                  {t("limitTotalUsd.label")}
+                </Label>
+                <Input
+                  id="limitTotal"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  placeholder={t("limitTotalUsd.placeholder")}
+                  value={limitTotal}
+                  onChange={(e) => setLimitTotal(e.target.value)}
+                  className="h-9"
+                />
+                {currentQuota?.costTotal.limit && (
+                  <p className="text-xs text-muted-foreground">
+                    {t("limitTotalUsd.current", {
+                      currency: currencySymbol,
+                      current: Number(currentQuota.costTotal.current).toFixed(4),
+                      limit: Number(currentQuota.costTotal.limit).toFixed(2),
                     })}
                   </p>
                 )}

--- a/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-client.tsx
@@ -35,6 +35,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt?: Date };
   costMonthly: { current: number; limit: number | null; resetAt?: Date };
+  costTotal: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 }
 
@@ -166,6 +167,7 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
                       <TableHead className="w-[150px]">{t("table.costDaily")}</TableHead>
                       <TableHead className="w-[150px]">{t("table.costWeekly")}</TableHead>
                       <TableHead className="w-[150px]">{t("table.costMonthly")}</TableHead>
+                      <TableHead className="w-[150px]">{t("table.costTotal")}</TableHead>
                       <TableHead className="w-[120px]">{t("table.concurrentSessions")}</TableHead>
                       <TableHead className="w-[100px]">{t("table.status")}</TableHead>
                       <TableHead className="w-[100px] text-right">{t("table.actions")}</TableHead>
@@ -379,6 +381,54 @@ export function KeysQuotaClient({ users, currencyCode = "USD" }: KeysQuotaClient
                                   {getUsageRate(
                                     key.quota.costMonthly.current,
                                     key.quota.costMonthly.limit
+                                  ).toFixed(1)}
+                                  %
+                                </div>
+                              </div>
+                            ) : (
+                              <span className="text-sm text-muted-foreground">-</span>
+                            )}
+                          </TableCell>
+
+                          {/* 总限额 */}
+                          <TableCell>
+                            {hasKeyQuota && key.quota && key.quota.costTotal.limit !== null ? (
+                              <div className="space-y-1">
+                                <div className="flex items-center justify-between mb-1">
+                                  <span className="text-xs text-muted-foreground">
+                                    {t("table.costTotal")}
+                                  </span>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  <span className="text-xs font-mono">
+                                    {formatCurrency(key.quota.costTotal.current, currencyCode)}/
+                                    <QuotaQuickEditPopover
+                                      currentLimit={key.quota.costTotal.limit}
+                                      label={t("table.costTotal")}
+                                      unit="currency"
+                                      currencyCode={currencyCode}
+                                      onSave={(v) =>
+                                        handleSaveLimit(key.id, key.name, "limitTotalUsd", v)
+                                      }
+                                    >
+                                      <button
+                                        type="button"
+                                        className="underline-offset-4 hover:underline cursor-pointer rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                      >
+                                        {formatCurrency(key.quota.costTotal.limit, currencyCode)}
+                                      </button>
+                                    </QuotaQuickEditPopover>
+                                  </span>
+                                </div>
+                                <QuotaProgress
+                                  current={key.quota.costTotal.current}
+                                  limit={key.quota.costTotal.limit}
+                                  className="h-1"
+                                />
+                                <div className="text-xs text-muted-foreground text-right">
+                                  {getUsageRate(
+                                    key.quota.costTotal.current,
+                                    key.quota.costTotal.limit
                                   ).toFixed(1)}
                                   %
                                 </div>

--- a/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-manager.tsx
+++ b/src/app/[locale]/dashboard/quotas/keys/_components/keys-quota-manager.tsx
@@ -20,6 +20,7 @@ interface KeyQuota {
   costDaily: { current: number; limit: number | null };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
+  costTotal: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/quotas/layout.tsx
+++ b/src/app/[locale]/dashboard/quotas/layout.tsx
@@ -2,8 +2,15 @@ import { getTranslations } from "next-intl/server";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Link } from "@/i18n/routing";
 
-export default async function QuotasLayout({ children }: { children: React.ReactNode }) {
-  const t = await getTranslations("quota.layout");
+export default async function QuotasLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "quota.layout" });
 
   return (
     <div className="space-y-6">

--- a/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/provider-quota-list-item.tsx
@@ -16,6 +16,7 @@ interface ProviderQuota {
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
   concurrentSessions: { current: number; limit: number };
+  limitTotalUsd: { current: number; limit: number | null; resetAt?: Date };
 }
 
 interface ProviderWithQuota {
@@ -215,6 +216,15 @@ export function ProviderQuotaListItem({
             provider.quota.costMonthly.current,
             provider.quota.costMonthly.limit,
             provider.quota.costMonthly.resetAt
+          )}
+
+        {/* 总限额 */}
+        {provider.quota.limitTotalUsd.limit &&
+          provider.quota.limitTotalUsd.limit > 0 &&
+          renderQuotaItem(
+            t("costTotal.label"),
+            provider.quota.limitTotalUsd.current,
+            provider.quota.limitTotalUsd.limit
           )}
 
         {/* 并发Session */}

--- a/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-client.tsx
@@ -15,6 +15,7 @@ interface ProviderQuota {
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
   concurrentSessions: { current: number; limit: number };
+  limitTotalUsd: { current: number; limit: number | null; resetAt?: Date };
 }
 
 interface ProviderWithQuota {
@@ -35,10 +36,12 @@ interface ProvidersQuotaClientProps {
   currencyCode?: CurrencyCode;
 }
 
-// 判断供应商是否设置了限额
+// 判断供应商是否设置了任意限额
 function hasQuotaLimit(quota: ProviderQuota | null): boolean {
   if (!quota) return false;
+
   return (
+    (quota.limitTotalUsd.limit !== null && quota.limitTotalUsd.limit > 0) ||
     (quota.cost5h.limit !== null && quota.cost5h.limit > 0) ||
     (quota.costDaily.limit !== null && quota.costDaily.limit > 0) ||
     (quota.costWeekly.limit !== null && quota.costWeekly.limit > 0) ||
@@ -69,6 +72,9 @@ function calculateMaxUsage(provider: ProviderWithQuota): number {
     usages.push(
       (provider.quota.concurrentSessions.current / provider.quota.concurrentSessions.limit) * 100
     );
+  }
+  if (provider.quota.limitTotalUsd.limit && provider.quota.limitTotalUsd.limit > 0) {
+    usages.push((provider.quota.limitTotalUsd.current / provider.quota.limitTotalUsd.limit) * 100);
   }
 
   return usages.length > 0 ? Math.max(...usages) : 0;

--- a/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-manager.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/_components/providers-quota-manager.tsx
@@ -16,6 +16,7 @@ interface ProviderQuota {
   costDaily: { current: number; limit: number | null; resetAt?: Date };
   costWeekly: { current: number; limit: number | null; resetAt: Date };
   costMonthly: { current: number; limit: number | null; resetAt: Date };
+  limitTotalUsd: { current: number; limit: number | null; resetAt?: Date };
   concurrentSessions: { current: number; limit: number };
 }
 

--- a/src/app/[locale]/dashboard/quotas/providers/page.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/page.tsx
@@ -53,7 +53,7 @@ export default async function ProvidersQuotaPage({
     redirect({ href: session ? "/dashboard/my-quota" : "/login", locale });
   }
 
-  const t = await getTranslations("quota.providers");
+  const t = await getTranslations({ locale, namespace: "quota.providers" });
 
   return (
     <div className="space-y-4">
@@ -64,18 +64,18 @@ export default async function ProvidersQuotaPage({
       </div>
 
       <Suspense fallback={<ProvidersQuotaSkeleton />}>
-        <ProvidersQuotaContent />
+        <ProvidersQuotaContent locale={locale} />
       </Suspense>
     </div>
   );
 }
 
-async function ProvidersQuotaContent() {
+async function ProvidersQuotaContent({ locale }: { locale: string }) {
   const [providers, systemSettings] = await Promise.all([
     getProvidersWithQuotas(),
     getSystemSettings(),
   ]);
-  const t = await getTranslations("quota.providers");
+  const t = await getTranslations({ locale, namespace: "quota.providers" });
 
   return (
     <div className="space-y-3">

--- a/src/app/[locale]/dashboard/quotas/providers/page.tsx
+++ b/src/app/[locale]/dashboard/quotas/providers/page.tsx
@@ -25,6 +25,8 @@ async function getProvidersWithQuotas() {
       limitDailyUsd: p.limitDailyUsd,
       limitWeeklyUsd: p.limitWeeklyUsd,
       limitMonthlyUsd: p.limitMonthlyUsd,
+      limitTotalUsd: p.limitTotalUsd,
+      totalCostResetAt: p.totalCostResetAt,
       limitConcurrentSessions: p.limitConcurrentSessions,
     }))
   );

--- a/src/app/[locale]/dashboard/quotas/users/page.tsx
+++ b/src/app/[locale]/dashboard/quotas/users/page.tsx
@@ -129,7 +129,7 @@ export default async function UsersQuotaPage({ params }: { params: Promise<{ loc
     return redirect({ href: session ? "/dashboard/my-quota" : "/login", locale });
   }
 
-  const t = await getTranslations("quota.users");
+  const t = await getTranslations({ locale, namespace: "quota.users" });
 
   return (
     <div className="space-y-4">
@@ -162,15 +162,15 @@ export default async function UsersQuotaPage({ params }: { params: Promise<{ loc
       />
 
       <Suspense fallback={<UsersQuotaSkeleton />}>
-        <UsersQuotaContent />
+        <UsersQuotaContent locale={locale} />
       </Suspense>
     </div>
   );
 }
 
-async function UsersQuotaContent() {
+async function UsersQuotaContent({ locale }: { locale: string }) {
   const [users, systemSettings] = await Promise.all([getUsersWithQuotas(), getSystemSettings()]);
-  const t = await getTranslations("quota.users");
+  const t = await getTranslations({ locale, namespace: "quota.users" });
 
   return (
     <div className="space-y-3">

--- a/src/app/[locale]/dashboard/rate-limits/page.tsx
+++ b/src/app/[locale]/dashboard/rate-limits/page.tsx
@@ -17,7 +17,7 @@ export default async function RateLimitsPage({ params }: { params: Promise<{ loc
     return redirect({ href: "/dashboard", locale });
   }
 
-  const t = await getTranslations("dashboard.rateLimits");
+  const t = await getTranslations({ locale, namespace: "dashboard.rateLimits" });
 
   return (
     <div className="space-y-6">

--- a/src/app/[locale]/settings/_lib/nav-items.ts
+++ b/src/app/[locale]/settings/_lib/nav-items.ts
@@ -108,8 +108,8 @@ export const SETTINGS_NAV_ITEMS: SettingsNavItem[] = [
 ];
 
 // Helper function to get translated nav items
-export async function getTranslatedNavItems(): Promise<SettingsNavItem[]> {
-  const t = await getTranslations("settings");
+export async function getTranslatedNavItems(locale: string): Promise<SettingsNavItem[]> {
+  const t = await getTranslations({ locale, namespace: "settings" });
   return SETTINGS_NAV_ITEMS.map((item) => ({
     ...item,
     label: item.labelKey ? t(item.labelKey) : item.label,

--- a/src/app/[locale]/settings/client-versions/page.tsx
+++ b/src/app/[locale]/settings/client-versions/page.tsx
@@ -21,7 +21,7 @@ export default async function ClientVersionsPage({
   // Await params to ensure locale is available in the async context
   const { locale } = await params;
 
-  const t = await getTranslations("settings");
+  const t = await getTranslations({ locale, namespace: "settings" });
   const session = await getSession();
 
   if (!session || session.user.role !== "admin") {
@@ -55,7 +55,7 @@ export default async function ClientVersionsPage({
         iconColor="text-[#E25706]"
       >
         <Suspense fallback={<ClientVersionsTableSkeleton />}>
-          <ClientVersionsStatsContent />
+          <ClientVersionsStatsContent locale={locale} />
         </Suspense>
       </SettingsSection>
     </div>
@@ -71,8 +71,8 @@ async function ClientVersionsSettingsContent() {
   return <ClientVersionToggle enabled={enableClientVersionCheck} />;
 }
 
-async function ClientVersionsStatsContent() {
-  const t = await getTranslations("settings");
+async function ClientVersionsStatsContent({ locale }: { locale: string }) {
+  const t = await getTranslations({ locale, namespace: "settings" });
   const statsResult = await fetchClientVersionStats();
   const stats = statsResult.ok ? statsResult.data : [];
 

--- a/src/app/[locale]/settings/config/page.tsx
+++ b/src/app/[locale]/settings/config/page.tsx
@@ -9,8 +9,13 @@ import { SystemSettingsForm } from "./_components/system-settings-form";
 
 export const dynamic = "force-dynamic";
 
-export default async function SettingsConfigPage() {
-  const t = await getTranslations("settings");
+export default async function SettingsConfigPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
 
   return (
     <>
@@ -20,14 +25,14 @@ export default async function SettingsConfigPage() {
         icon="settings"
       />
       <Suspense fallback={<SettingsConfigSkeleton />}>
-        <SettingsConfigContent />
+        <SettingsConfigContent locale={locale} />
       </Suspense>
     </>
   );
 }
 
-async function SettingsConfigContent() {
-  const t = await getTranslations("settings");
+async function SettingsConfigContent({ locale }: { locale: string }) {
+  const t = await getTranslations({ locale, namespace: "settings" });
   const settings = await getSystemSettings();
 
   return (

--- a/src/app/[locale]/settings/error-rules/page.tsx
+++ b/src/app/[locale]/settings/error-rules/page.tsx
@@ -12,8 +12,9 @@ import { RuleListTable } from "./_components/rule-list-table";
 
 export const dynamic = "force-dynamic";
 
-export default async function ErrorRulesPage() {
-  const t = await getTranslations("settings");
+export default async function ErrorRulesPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
 
   return (
     <>

--- a/src/app/[locale]/settings/layout.tsx
+++ b/src/app/[locale]/settings/layout.tsx
@@ -42,7 +42,7 @@ export default async function SettingsLayout({
               <SettingsNav items={translatedNavItems} />
             </aside>
             {/* Content area */}
-            <div className="space-y-6">
+            <div className="min-w-0 space-y-6">
               {/* Tablet: Horizontal nav shown above content */}
               <div className="lg:hidden">
                 <SettingsNav items={translatedNavItems} />

--- a/src/app/[locale]/settings/layout.tsx
+++ b/src/app/[locale]/settings/layout.tsx
@@ -28,11 +28,11 @@ export default async function SettingsLayout({
   }
 
   // Get translated navigation items
-  const translatedNavItems = await getTranslatedNavItems();
+  const translatedNavItems = await getTranslatedNavItems(locale);
 
   return (
     <div className="min-h-[var(--cch-viewport-height,100vh)] bg-background">
-      <DashboardHeader session={session} />
+      <DashboardHeader session={session} locale={locale} />
       <main className="mx-auto w-full max-w-7xl px-4 py-6 md:px-6 md:py-8 pb-24 md:pb-8">
         <div className="space-y-6">
           {/* Desktop: Grid layout with sidebar */}

--- a/src/app/[locale]/settings/logs/page.tsx
+++ b/src/app/[locale]/settings/logs/page.tsx
@@ -5,8 +5,13 @@ import { LogLevelForm } from "./_components/log-level-form";
 
 export const dynamic = "force-dynamic";
 
-export default async function SettingsLogsPage() {
-  const t = await getTranslations("settings");
+export default async function SettingsLogsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
 
   return (
     <>

--- a/src/app/[locale]/settings/prices/_components/price-list.tsx
+++ b/src/app/[locale]/settings/prices/_components/price-list.tsx
@@ -412,8 +412,8 @@ export function PriceList({
       </div>
 
       {/* 价格表格 */}
-      <div className="rounded-lg overflow-hidden border border-white/10 bg-white/[0.02]">
-        <table className="w-full table-fixed">
+      <div className="rounded-lg overflow-x-auto overflow-y-hidden border border-white/10 bg-white/[0.02]">
+        <table className="w-full min-w-[76rem] table-fixed">
           <thead>
             <tr className="border-b border-white/10">
               <th className="py-3 px-4 text-left text-xs font-semibold text-muted-foreground uppercase tracking-wide w-72">

--- a/src/app/[locale]/settings/prices/page.tsx
+++ b/src/app/[locale]/settings/prices/page.tsx
@@ -11,20 +11,29 @@ import { UploadPriceDialog } from "./_components/upload-price-dialog";
 
 export const dynamic = "force-dynamic";
 
+type SettingsPricesSearchParams = {
+  required?: string;
+  page?: string;
+  pageSize?: string;
+  size?: string;
+  search?: string;
+  source?: string;
+  litellmProvider?: string;
+};
+
 interface SettingsPricesPageProps {
-  searchParams: Promise<{
-    required?: string;
-    page?: string;
-    pageSize?: string;
-    size?: string;
-    search?: string;
-    source?: string;
-    litellmProvider?: string;
+  params: Promise<{
+    locale: string;
   }>;
+  searchParams: Promise<SettingsPricesSearchParams>;
 }
 
-export default async function SettingsPricesPage({ searchParams }: SettingsPricesPageProps) {
-  const t = await getTranslations("settings");
+export default async function SettingsPricesPage({
+  params,
+  searchParams,
+}: SettingsPricesPageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
 
   return (
     <>
@@ -34,14 +43,20 @@ export default async function SettingsPricesPage({ searchParams }: SettingsPrice
         icon="dollar-sign"
       />
       <Suspense fallback={<PricesSkeleton />}>
-        <SettingsPricesContent searchParams={searchParams} />
+        <SettingsPricesContent locale={locale} searchParams={searchParams} />
       </Suspense>
     </>
   );
 }
 
-async function SettingsPricesContent({ searchParams }: SettingsPricesPageProps) {
-  const t = await getTranslations("settings");
+async function SettingsPricesContent({
+  locale,
+  searchParams,
+}: {
+  locale: string;
+  searchParams: Promise<SettingsPricesSearchParams>;
+}) {
+  const t = await getTranslations({ locale, namespace: "settings" });
   const params = await searchParams;
 
   // 解析分页参数

--- a/src/app/[locale]/settings/providers/page.tsx
+++ b/src/app/[locale]/settings/providers/page.tsx
@@ -14,8 +14,13 @@ import { SchedulingRulesDialog } from "./_components/scheduling-rules-dialog";
 
 export const dynamic = "force-dynamic";
 
-export default async function SettingsProvidersPage() {
-  const t = await getTranslations("settings");
+export default async function SettingsProvidersPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
   const session = await getSession();
   const providers = await getProviders();
 

--- a/src/app/[locale]/settings/request-filters/page.tsx
+++ b/src/app/[locale]/settings/request-filters/page.tsx
@@ -9,8 +9,13 @@ import { RequestFiltersTableSkeleton } from "./_components/request-filters-skele
 
 export const dynamic = "force-dynamic";
 
-export default async function RequestFiltersPage() {
-  const t = await getTranslations("settings.requestFilters");
+export default async function RequestFiltersPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings.requestFilters" });
 
   return (
     <>

--- a/src/app/[locale]/settings/sensitive-words/page.tsx
+++ b/src/app/[locale]/settings/sensitive-words/page.tsx
@@ -11,8 +11,13 @@ import { WordListTable } from "./_components/word-list-table";
 
 export const dynamic = "force-dynamic";
 
-export default async function SensitiveWordsPage() {
-  const t = await getTranslations("settings");
+export default async function SensitiveWordsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
 
   return (
     <>

--- a/src/app/[locale]/settings/status-page/page.tsx
+++ b/src/app/[locale]/settings/status-page/page.tsx
@@ -5,8 +5,13 @@ import { loadStatusPageSettings } from "./loader";
 
 export const dynamic = "force-dynamic";
 
-export default async function StatusPageSettingsPage() {
-  const t = await getTranslations("settings");
+export default async function StatusPageSettingsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "settings" });
   const settings = await loadStatusPageSettings();
 
   return (

--- a/src/app/[locale]/status/[slug]/page.tsx
+++ b/src/app/[locale]/status/[slug]/page.tsx
@@ -34,7 +34,7 @@ export default async function PublicStatusGroupPage({
   params: Promise<{ locale: string; slug: string }>;
 }) {
   const { locale, slug } = await params;
-  const t = await getTranslations("settings");
+  const t = await getTranslations({ locale, namespace: "settings" });
   const {
     followServerDefaults,
     initialPayload,

--- a/src/app/[locale]/usage-doc/layout.tsx
+++ b/src/app/[locale]/usage-doc/layout.tsx
@@ -45,7 +45,7 @@ export default async function UsageDocLayout({
     <div className="min-h-[var(--cch-viewport-height,100vh)] bg-background">
       {/* 条件渲染头部：已登录显示 DashboardHeader，未登录显示简化版头部 */}
       {session ? (
-        <DashboardHeader session={session} />
+        <DashboardHeader session={session} locale={locale} />
       ) : (
         <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
           <div className="container flex h-14 items-center justify-between px-6">

--- a/src/app/v1/_lib/proxy/combine-abort-signals.ts
+++ b/src/app/v1/_lib/proxy/combine-abort-signals.ts
@@ -1,0 +1,55 @@
+/**
+ * 组合多个 AbortSignal 为单个信号，并返回显式 cleanup。
+ *
+ * 优先使用原生 `AbortSignal.any`（Node.js 20.3+ / V8 内部管理 listener）。
+ * 仅在原生不可用（例如 Next.js standalone 覆盖全局 AbortSignal）时使用 polyfill。
+ *
+ * Polyfill 路径必须由调用方在请求生命周期结束时调用 cleanup，否则源信号上的 abort
+ * listener 会一直持有闭包（包含 combinedController、cleanups 数组及源信号引用），
+ * 导致 session/请求体无法被 GC——和 #1113 修复的 client abort listener 是同一类泄漏。
+ */
+export interface CombinedAbortSignal {
+  signal: AbortSignal;
+  cleanup: () => void;
+}
+
+const NOOP_CLEANUP = () => {};
+
+export function combineAbortSignals(signals: AbortSignal[]): CombinedAbortSignal {
+  if ("any" in AbortSignal && typeof AbortSignal.any === "function") {
+    return { signal: AbortSignal.any(signals), cleanup: NOOP_CLEANUP };
+  }
+
+  const combinedController = new AbortController();
+  const detachers: Array<() => void> = [];
+  let cleaned = false;
+
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    for (const detach of detachers) {
+      detach();
+    }
+    detachers.length = 0;
+  };
+
+  for (const signal of signals) {
+    if (signal.aborted) {
+      combinedController.abort();
+      cleanup();
+      break;
+    }
+
+    const abortHandler = () => {
+      combinedController.abort();
+      cleanup();
+    };
+
+    signal.addEventListener("abort", abortHandler, { once: true });
+    detachers.push(() => {
+      signal.removeEventListener("abort", abortHandler);
+    });
+  }
+
+  return { signal: combinedController.signal, cleanup };
+}

--- a/src/app/v1/_lib/proxy/error-handler.ts
+++ b/src/app/v1/_lib/proxy/error-handler.ts
@@ -249,14 +249,30 @@ export class ProxyErrorHandler {
       }
     }
 
-    ProxyErrorHandler.emitErrorTrace(session, {
-      error,
-      errorMessage: logErrorMessage,
-      statusCode,
-    });
-
-    // 记录错误到数据库（始终记录详细错误消息，包含供应商名称）
-    await ProxyErrorHandler.logErrorToDatabase(session, logErrorMessage, statusCode, null);
+    const finalizeErrorResponse = async (
+      response: Response,
+      traceErrorMessage: string,
+      options: { traceFinalResponseBody?: boolean } = {}
+    ) => {
+      const finalResponse = await attachSessionIdToErrorResponse(session.sessionId, response);
+      let responseText: string | undefined;
+      if (options.traceFinalResponseBody) {
+        try {
+          responseText = await finalResponse.clone().text();
+        } catch {
+          responseText = undefined;
+        }
+      }
+      ProxyErrorHandler.emitErrorTrace(session, {
+        error,
+        errorMessage: traceErrorMessage,
+        statusCode: finalResponse.status,
+        responseText,
+      });
+      // 先发出 trace，再写数据库，避免 DB 持久化失败吞掉本次错误诊断。
+      await ProxyErrorHandler.logErrorToDatabase(session, logErrorMessage, statusCode, null);
+      return finalResponse;
+    };
 
     // 检测是否有覆写配置（响应体或状态码）
     // 使用异步版本确保错误规则已加载
@@ -303,15 +319,16 @@ export class ProxyErrorHandler {
                 settings,
                 override: { response: null, statusCode: override.statusCode },
               });
-              return await attachSessionIdToErrorResponse(
-                session.sessionId,
+              return await finalizeErrorResponse(
                 ProxyResponses.buildError(
                   responseStatusCode,
                   finalClientErrorMessage,
                   undefined,
                   undefined,
                   safeRequestId
-                )
+                ),
+                finalClientErrorMessage,
+                { traceFinalResponseBody: true }
               );
             }
             // 两者都无效，返回原始错误（但仍透传 request_id，因为有覆写意图）
@@ -321,15 +338,16 @@ export class ProxyErrorHandler {
               settings,
               override: { response: null, statusCode: null },
             });
-            return await attachSessionIdToErrorResponse(
-              session.sessionId,
+            return await finalizeErrorResponse(
               ProxyResponses.buildError(
                 statusCode,
                 finalClientErrorMessage,
                 undefined,
                 undefined,
                 safeRequestId
-              )
+              ),
+              finalClientErrorMessage,
+              { traceFinalResponseBody: true }
             );
           }
 
@@ -378,12 +396,13 @@ export class ProxyErrorHandler {
             overridden: true,
           });
 
-          return await attachSessionIdToErrorResponse(
-            session.sessionId,
+          return await finalizeErrorResponse(
             new Response(JSON.stringify(responseBody), {
               status: responseStatusCode,
               headers: { "Content-Type": "application/json" },
-            })
+            }),
+            String(responseBody.error.message),
+            { traceFinalResponseBody: true }
           );
         }
 
@@ -408,15 +427,16 @@ export class ProxyErrorHandler {
           override: { response: null, statusCode: override.statusCode },
         });
 
-        return await attachSessionIdToErrorResponse(
-          session.sessionId,
+        return await finalizeErrorResponse(
           ProxyResponses.buildError(
             responseStatusCode,
             finalClientErrorMessage,
             undefined,
             undefined,
             safeRequestId
-          )
+          ),
+          finalClientErrorMessage,
+          { traceFinalResponseBody: true }
         );
       }
     }
@@ -495,15 +515,15 @@ export class ProxyErrorHandler {
       override: null,
     });
 
-    return await attachSessionIdToErrorResponse(
-      session.sessionId,
+    return await finalizeErrorResponse(
       ProxyResponses.buildError(
         statusCode,
         finalClientErrorMessage,
         undefined,
         details,
         safeRequestId
-      )
+      ),
+      logErrorMessage
     );
   }
 
@@ -624,13 +644,13 @@ export class ProxyErrorHandler {
 
   private static emitErrorTrace(
     session: ProxySession,
-    data: { error: unknown; errorMessage: string; statusCode: number }
+    data: { error: unknown; errorMessage: string; statusCode: number; responseText?: string }
   ): void {
     const isStreaming = isRequestStreaming(session);
 
     emitProxyLangfuseTrace(session, {
       responseHeaders: new Headers(),
-      responseText: getErrorResponseText(data.error),
+      responseText: data.responseText ?? getErrorResponseText(data.error),
       usageMetrics: null,
       costUsd: undefined,
       statusCode: data.statusCode,

--- a/src/app/v1/_lib/proxy/error-handler.ts
+++ b/src/app/v1/_lib/proxy/error-handler.ts
@@ -270,7 +270,12 @@ export class ProxyErrorHandler {
         responseText,
       });
       // 先发出 trace，再写数据库，避免 DB 持久化失败吞掉本次错误诊断。
-      await ProxyErrorHandler.logErrorToDatabase(session, logErrorMessage, statusCode, null);
+      await ProxyErrorHandler.logErrorToDatabase(
+        session,
+        logErrorMessage,
+        finalResponse.status,
+        null
+      );
       return finalResponse;
     };
 

--- a/src/app/v1/_lib/proxy/error-handler.ts
+++ b/src/app/v1/_lib/proxy/error-handler.ts
@@ -5,6 +5,7 @@ import {
   isOpenAIErrorFormat,
   isValidErrorOverrideResponse,
 } from "@/lib/error-override-validator";
+import { emitProxyLangfuseTrace } from "@/lib/langfuse/emit-proxy-trace";
 import { logger } from "@/lib/logger";
 import { ProxyStatusTracker } from "@/lib/proxy-status-tracker";
 import { sanitizeErrorTextForDetail } from "@/lib/utils/upstream-error-detection";
@@ -32,6 +33,25 @@ type ErrorOverrideForMessageResolver = { response?: unknown; statusCode?: number
 
 function stripUpstreamDetailSuffix(message: string): string {
   return message.replace(/\s+Upstream detail:\s*[\s\S]*$/u, "").trim() || message;
+}
+
+function getErrorResponseText(error: unknown): string {
+  if (!(error instanceof ProxyError)) {
+    return "";
+  }
+
+  // Langfuse trace 用于排查上游故障，按产品预期保留原始上游错误主体。
+  return error.upstreamError?.rawBody ?? error.upstreamError?.body ?? "";
+}
+
+function isRequestStreaming(session: ProxySession): boolean {
+  const requestUrl = session.requestUrl;
+
+  return (
+    session.request?.message?.stream === true ||
+    requestUrl?.pathname.includes("streamGenerateContent") ||
+    requestUrl?.searchParams.get("alt") === "sse"
+  );
 }
 
 function getGenericProxyErrorFallbackMessage(
@@ -184,6 +204,12 @@ export class ProxyErrorHandler {
       // 构建详细的 402 响应
       const response = ProxyErrorHandler.buildRateLimitResponse(error);
 
+      ProxyErrorHandler.emitErrorTrace(session, {
+        error,
+        errorMessage: logErrorMessage,
+        statusCode,
+      });
+
       // 记录错误到数据库（包含 rate_limit 元数据）
       await ProxyErrorHandler.logErrorToDatabase(
         session,
@@ -222,6 +248,12 @@ export class ProxyErrorHandler {
         statusCode = lastRequestStatusCode;
       }
     }
+
+    ProxyErrorHandler.emitErrorTrace(session, {
+      error,
+      errorMessage: logErrorMessage,
+      statusCode,
+    });
 
     // 记录错误到数据库（始终记录详细错误消息，包含供应商名称）
     await ProxyErrorHandler.logErrorToDatabase(session, logErrorMessage, statusCode, null);
@@ -588,6 +620,25 @@ export class ProxyErrorHandler {
     // 记录请求结束
     const tracker = ProxyStatusTracker.getInstance();
     tracker.endRequest(session.messageContext.user.id, session.messageContext.id);
+  }
+
+  private static emitErrorTrace(
+    session: ProxySession,
+    data: { error: unknown; errorMessage: string; statusCode: number }
+  ): void {
+    const isStreaming = isRequestStreaming(session);
+
+    emitProxyLangfuseTrace(session, {
+      responseHeaders: new Headers(),
+      responseText: getErrorResponseText(data.error),
+      usageMetrics: null,
+      costUsd: undefined,
+      statusCode: data.statusCode,
+      durationMs: Math.max(0, Date.now() - session.startTime),
+      isStreaming,
+      sseEventCount: isStreaming ? 0 : undefined,
+      errorMessage: data.errorMessage,
+    });
   }
 
   /**

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -3418,9 +3418,11 @@ export class ProxyForwarder {
 
     const releaseAttemptAgent = (attempt: StreamingHedgeAttempt) => {
       if (attempt.agentReleased) return;
+      const releaseAgent = attempt.releaseAgent;
+      if (!releaseAgent) return;
       attempt.agentReleased = true;
       try {
-        attempt.releaseAgent?.();
+        releaseAgent();
       } catch (releaseError) {
         logger.debug("ProxyForwarder: hedge attempt releaseAgent failed", {
           error: releaseError instanceof Error ? releaseError.message : String(releaseError),

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -52,6 +52,7 @@ import { buildProxyUrl } from "../url";
 import { rectifyBillingHeader } from "./billing-header-rectifier";
 import { bindClientAbortListener } from "./client-abort-listener";
 import { deriveClientSafeUpstreamErrorMessage } from "./client-error-message";
+import { combineAbortSignals } from "./combine-abort-signals";
 import { isStandardProxyEndpointPath } from "./endpoint-family-catalog";
 import { resolveEndpointPolicy, shouldEnforceStrictEndpointPoolPolicy } from "./endpoint-policy";
 import {
@@ -2706,56 +2707,18 @@ export class ProxyForwarder {
     }
 
     // 2. 组合双路信号：response + client
-    let combinedSignal: AbortSignal | undefined;
     const signals = [responseController.signal];
     if (session.clientAbortSignal) {
       signals.push(session.clientAbortSignal);
     }
 
-    // ⭐ AbortSignal.any 实现（兼容所有环境）
-    // 原因：Next.js standalone 可能覆盖全局 AbortSignal，导致原生 any 方法不可用
-    if ("any" in AbortSignal && typeof AbortSignal.any === "function") {
-      // 优先使用原生实现（Node.js 20.3+）
-      combinedSignal = AbortSignal.any(signals);
-      logger.debug("ProxyForwarder: Using native AbortSignal.any", {
-        signalCount: signals.length,
-      });
-    } else {
-      // Polyfill: 手动实现多信号组合逻辑
-      logger.debug("ProxyForwarder: Using AbortSignal.any polyfill", {
-        signalCount: signals.length,
-        reason: "Native AbortSignal.any not available",
-      });
-
-      const combinedController = new AbortController();
-      const cleanupHandlers: Array<() => void> = [];
-
-      // 为每个信号添加监听器
-      for (const signal of signals) {
-        // 如果已经有信号中断，立即中断组合信号
-        if (signal.aborted) {
-          combinedController.abort();
-          break;
-        }
-
-        // 监听信号中断事件
-        const abortHandler = () => {
-          // 中断组合信号
-          combinedController.abort();
-          // 清理所有监听器（避免内存泄漏）
-          cleanupHandlers.forEach((cleanup) => cleanup());
-        };
-
-        signal.addEventListener("abort", abortHandler, { once: true });
-
-        // 记录清理函数
-        cleanupHandlers.push(() => {
-          signal.removeEventListener("abort", abortHandler);
-        });
-      }
-
-      combinedSignal = combinedController.signal;
-    }
+    // 优先 Node 20.3+ 原生 AbortSignal.any（V8 内部管理 listener，无需手动 cleanup）；
+    // Next.js standalone 覆盖全局时 fallback 到 polyfill，由调用方在请求结束时调用
+    // cleanupCombinedSignal 解绑源信号上的 listener，避免持有 session/请求体闭包。
+    const { signal: combinedSignal, cleanup: cleanupCombinedSignal } = combineAbortSignals(signals);
+    logger.debug("ProxyForwarder: Combined abort signals", {
+      signalCount: signals.length,
+    });
 
     const init: UndiciFetchOptions = {
       method: session.method,
@@ -2848,6 +2811,9 @@ export class ProxyForwarder {
       if (responseTimeoutId) {
         clearTimeout(responseTimeoutId);
       }
+
+      // Polyfill 路径上需要主动解绑源信号的 abort listener（response-handler 不会执行）。
+      cleanupCombinedSignal();
 
       // Release agent ref count on fetch failure (request never started streaming)
       const releaseKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
@@ -3281,6 +3247,8 @@ export class ProxyForwarder {
         if (errorReleaseKey && errorReleaseDispatcherId) {
           getGlobalAgentPool().releaseAgent(errorReleaseKey, errorReleaseDispatcherId);
         }
+        // 同上：response-handler 不会跑，polyfill 路径上的源信号 listener 必须在此解绑。
+        cleanupCombinedSignal();
       }
     }
 
@@ -3308,14 +3276,19 @@ export class ProxyForwarder {
 
     // Attach agent release callback for in-flight reference counting.
     // response-handler must call this in its finally block after the stream is fully consumed.
+    // 同时复用此回调作为 combineAbortSignals polyfill 的 cleanup 入口：response-handler 已经
+    // 保证在请求结束时（成功/异常）幂等地调用 releaseAgent，把 cleanup 合并到这里就不必再
+    // 改造 response-handler 的所有 finally 调用点。两个动作互不影响，cleanup 内部自带 cleaned
+    // 标志，重复调用安全。
     const agentCacheKeyToRelease = proxyConfig?.cacheKey ?? directConnectionCacheKey;
     const agentDispatcherIdToRelease = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
-    if (agentCacheKeyToRelease && agentDispatcherIdToRelease) {
-      const pool = getGlobalAgentPool();
-      sessionWithTimeout.releaseAgent = () => {
+    const pool = agentCacheKeyToRelease && agentDispatcherIdToRelease ? getGlobalAgentPool() : null;
+    sessionWithTimeout.releaseAgent = () => {
+      if (pool && agentCacheKeyToRelease && agentDispatcherIdToRelease) {
         pool.releaseAgent(agentCacheKeyToRelease, agentDispatcherIdToRelease);
-      };
-    }
+      }
+      cleanupCombinedSignal();
+    };
 
     return response;
   }

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -123,6 +123,8 @@ type StreamingHedgeAttempt = {
   thresholdTimer: NodeJS.Timeout | null;
   reader: ReadableStreamDefaultReader<Uint8Array> | null;
   response: Response | null;
+  releaseAgent: (() => void) | null;
+  agentReleased: boolean;
 };
 
 type ReactiveRectifierRetryState = {
@@ -3414,6 +3416,21 @@ export class ProxyForwarder {
       return attempt.modelRedirect;
     };
 
+    const releaseAttemptAgent = (attempt: StreamingHedgeAttempt) => {
+      if (attempt.agentReleased) return;
+      attempt.agentReleased = true;
+      try {
+        attempt.releaseAgent?.();
+      } catch (releaseError) {
+        logger.debug("ProxyForwarder: hedge attempt releaseAgent failed", {
+          error: releaseError instanceof Error ? releaseError.message : String(releaseError),
+          sessionId: attempt.session.sessionId ?? null,
+          providerId: attempt.provider.id,
+          providerName: attempt.provider.name,
+        });
+      }
+    };
+
     const abortAttempt = (attempt: StreamingHedgeAttempt, reason: string) => {
       if (attempt.settled) return;
       attempt.settled = true;
@@ -3452,6 +3469,7 @@ export class ProxyForwarder {
           providerName: attempt.provider.name,
         });
       });
+      releaseAttemptAgent(attempt);
     };
 
     const armAttemptThreshold = (attempt: StreamingHedgeAttempt) => {
@@ -3556,6 +3574,7 @@ export class ProxyForwarder {
         .then(async (response) => {
           if (settled || winnerCommitted || attempt.settled) {
             const attemptRuntime = attempt.session as ProxySessionWithAttemptRuntime;
+            attempt.releaseAgent = attemptRuntime.releaseAgent ?? attempt.releaseAgent;
             try {
               attemptRuntime.responseController?.abort(new Error("hedge_loser"));
             } catch (abortError) {
@@ -3575,12 +3594,14 @@ export class ProxyForwarder {
                 providerName: attempt.provider.name,
               });
             });
+            releaseAttemptAgent(attempt);
             return;
           }
 
           const attemptRuntime = attempt.session as ProxySessionWithAttemptRuntime;
           attempt.responseController = attemptRuntime.responseController ?? null;
           attempt.clearResponseTimeout = attemptRuntime.clearResponseTimeout ?? null;
+          attempt.releaseAgent = attemptRuntime.releaseAgent ?? null;
           attempt.clearResponseTimeout?.();
           attempt.response = response;
 
@@ -3985,6 +4006,8 @@ export class ProxyForwarder {
         thresholdTimer: null,
         reader: null,
         response: null,
+        releaseAgent: null,
+        agentReleased: false,
       };
 
       attempts.add(attempt);

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -103,6 +103,7 @@ type CacheTtlOption = CacheTtlPreference | null | undefined;
 type ProxySessionWithAttemptRuntime = ProxySession & {
   clearResponseTimeout?: () => void;
   responseController?: AbortController;
+  releaseAgent?: () => void;
 };
 
 type StreamingHedgeAttempt = {
@@ -2812,8 +2813,8 @@ export class ProxyForwarder {
         clearTimeout(responseTimeoutId);
       }
 
-      // Polyfill 路径上需要主动解绑源信号的 abort listener（response-handler 不会执行）。
-      cleanupCombinedSignal();
+      // fetch 失败后可能继续尝试 HTTP/1.1 / 直连 fallback。
+      // 这些 fallback 请求仍需响应客户端中断和响应超时，所以 cleanup 只能在最终失败时执行。
 
       // Release agent ref count on fetch failure (request never started streaming)
       const releaseKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
@@ -2864,6 +2865,7 @@ export class ProxyForwarder {
 
         // 抛出 ProxyError 并设置特殊状态码 524（Cloudflare: A Timeout Occurred）
         // 这样会被归类为 PROVIDER_ERROR，计入熔断器并直接切换供应商
+        cleanupCombinedSignal();
         throw new ProxyError(
           `${responseTimeoutType === "streaming_first_byte" ? "供应商首字节响应超时" : "供应商响应超时"}: ${responseTimeoutMs}ms 内未收到数据`,
           524, // 524 = A Timeout Occurred (Cloudflare standard)
@@ -2909,6 +2911,7 @@ export class ProxyForwarder {
         );
 
         // 抛出 ProxyError（归类为 PROVIDER_ERROR）
+        cleanupCombinedSignal();
         throw new ProxyError(
           `供应商流式响应静默超时: ${provider.streamingIdleTimeoutMs}ms 内未收到新数据`,
           524, // 524 = A Timeout Occurred
@@ -2945,6 +2948,7 @@ export class ProxyForwarder {
         });
 
         // 客户端中断不应计入熔断器，也不重试，直接抛出错误
+        cleanupCombinedSignal();
         throw new ProxyError(
           err.name === "ResponseAborted"
             ? "Response transmission aborted"
@@ -3066,6 +3070,7 @@ export class ProxyForwarder {
           });
 
           // 抛出 HTTP/1.1 错误，让正常的错误处理流程处理
+          cleanupCombinedSignal();
           throw http1Error;
         }
       } else if (proxyConfig) {
@@ -3140,10 +3145,12 @@ export class ProxyForwarder {
                 providerId: provider.id,
                 error: directError,
               });
+              cleanupCombinedSignal();
               throw fetchError; // 抛出原始代理错误
             }
           } else {
             // 不降级，直接抛出代理错误
+            cleanupCombinedSignal();
             throw new ProxyError("Service temporarily unavailable", 503);
           }
         } else {
@@ -3181,6 +3188,7 @@ export class ProxyForwarder {
             bodySize: requestBody ? JSON.stringify(requestBody).length : 0,
           });
 
+          cleanupCombinedSignal();
           throw fetchError;
         }
       } else {
@@ -3219,6 +3227,7 @@ export class ProxyForwarder {
           bodySize: requestBody ? JSON.stringify(requestBody).length : 0,
         });
 
+        cleanupCombinedSignal();
         throw fetchError;
       }
     }
@@ -4219,6 +4228,7 @@ export class ProxyForwarder {
       } | null;
       clearResponseTimeout?: () => void;
       responseController?: AbortController;
+      releaseAgent?: () => void;
     };
     const sourceRuntime = source as ProxySessionWithAttemptRuntime;
 
@@ -4255,6 +4265,7 @@ export class ProxyForwarder {
       : null;
     targetState.clearResponseTimeout = sourceRuntime.clearResponseTimeout;
     targetState.responseController = sourceRuntime.responseController;
+    targetState.releaseAgent = sourceRuntime.releaseAgent;
   }
 
   private static async clearSessionProviderBinding(session: ProxySession): Promise<void> {

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -389,12 +389,27 @@ async function resolveBillableUsageMetricsForCost(
     return null;
   }
 
-  if (usageMetrics) {
-    return usageMetrics;
-  }
-
   if (statusCode < 200 || statusCode >= 300) {
     return null;
+  }
+
+  if (responseText !== undefined && responseText !== null) {
+    const detected = detectUpstreamErrorFromSseOrJsonText(responseText, {
+      maxJsonCharsForMessageCheck: 0,
+    });
+    if (detected.isError) {
+      logger.warn("[CostCalculation] Skipping billing for fake-200 error payload", {
+        code: detected.code,
+        detail: detected.detail,
+        originalModel: session.getOriginalModel(),
+        redirectedModel: session.getCurrentModel(),
+      });
+      return null;
+    }
+  }
+
+  if (usageMetrics) {
+    return usageMetrics;
   }
 
   let resolvedPricing: Awaited<ReturnType<ProxySession["getResolvedPricingByBillingSource"]>>;
@@ -413,24 +428,9 @@ async function resolveBillableUsageMetricsForCost(
     return null;
   }
 
-  if (responseText !== undefined && responseText !== null) {
-    const detected = detectUpstreamErrorFromSseOrJsonText(responseText, {
-      maxJsonCharsForMessageCheck: 0,
-    });
-    if (detected.isError) {
-      logger.warn("[CostCalculation] Skipping per-request billing for fake-200 error payload", {
-        code: detected.code,
-        detail: detected.detail,
-        originalModel: session.getOriginalModel(),
-        redirectedModel: session.getCurrentModel(),
-      });
-      return null;
-    }
-  }
-
   // 成功响应可能没有 token usage（例如 OpenAI Images），但本地价格表仍可配置按次价格。
-  // 这里用空 usage 只承载 input_cost_per_request，不新增按图、按 token 等语义。
-  return {};
+  // 这里用显式零 token sentinel 只承载 input_cost_per_request，不新增按图、按 token 等语义。
+  return { input_tokens: 0, output_tokens: 0 };
 }
 
 type FinalizeDeferredStreamingResult = {

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -1,6 +1,7 @@
 import { ResponseFixer } from "@/app/v1/_lib/proxy/response-fixer";
 import { AsyncTaskManager } from "@/lib/async-task-manager";
 import { getEnvConfig } from "@/lib/config/env.schema";
+import { emitProxyLangfuseTrace } from "@/lib/langfuse/emit-proxy-trace";
 import { logger } from "@/lib/logger";
 import { requestCloudPriceTableSync } from "@/lib/price-sync/cloud-price-updater";
 import { ProxyStatusTracker } from "@/lib/proxy-status-tracker";
@@ -124,49 +125,6 @@ function maybeSetCodexContext1m(
   ) {
     session.setContext1mApplied(true);
   }
-}
-
-/**
- * Fire Langfuse trace asynchronously. Non-blocking, error-tolerant.
- */
-function emitLangfuseTrace(
-  session: ProxySession,
-  data: {
-    responseHeaders: Headers;
-    responseText: string;
-    usageMetrics: UsageMetrics | null;
-    costUsd: string | undefined;
-    costBreakdown?: CostBreakdown;
-    statusCode: number;
-    durationMs: number;
-    isStreaming: boolean;
-    sseEventCount?: number;
-    errorMessage?: string;
-  }
-): void {
-  if (!process.env.LANGFUSE_PUBLIC_KEY || !process.env.LANGFUSE_SECRET_KEY) return;
-
-  void import("@/lib/langfuse/trace-proxy-request")
-    .then(({ traceProxyRequest }) => {
-      void traceProxyRequest({
-        session,
-        responseHeaders: data.responseHeaders,
-        durationMs: data.durationMs,
-        statusCode: data.statusCode,
-        isStreaming: data.isStreaming,
-        responseText: data.responseText,
-        usageMetrics: data.usageMetrics,
-        costUsd: data.costUsd,
-        costBreakdown: data.costBreakdown,
-        sseEventCount: data.sseEventCount,
-        errorMessage: data.errorMessage,
-      });
-    })
-    .catch((err) => {
-      logger.warn("[ResponseHandler] Langfuse trace failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
 }
 
 /**
@@ -1048,7 +1006,7 @@ export class ProxyResponseHandler {
               false // Gemini 非流式透传
             );
 
-            emitLangfuseTrace(session, {
+            emitProxyLangfuseTrace(session, {
               responseHeaders: response.headers,
               responseText,
               usageMetrics: finalizedUsage,
@@ -1467,7 +1425,7 @@ export class ProxyResponseHandler {
           statusCode,
         });
 
-        emitLangfuseTrace(session, {
+        emitProxyLangfuseTrace(session, {
           responseHeaders: response.headers,
           responseText,
           usageMetrics,
@@ -1954,7 +1912,7 @@ export class ProxyResponseHandler {
               true // Gemini 流式透传(NDJSON 无 data:/event: 前缀,必须显式告知)
             );
 
-            emitLangfuseTrace(session, {
+            emitProxyLangfuseTrace(session, {
               responseHeaders: response.headers,
               responseText: allContent,
               usageMetrics: finalizedUsage,
@@ -2558,7 +2516,7 @@ export class ProxyResponseHandler {
           specialSettings: session.getSpecialSettings() ?? undefined,
         });
 
-        emitLangfuseTrace(session, {
+        emitProxyLangfuseTrace(session, {
           responseHeaders: response.headers,
           responseText: allContent,
           usageMetrics: usageForCost,
@@ -4118,7 +4076,7 @@ async function persistRequestFailure(options: {
   }
 
   // Emit Langfuse trace for error/abort paths
-  emitLangfuseTrace(session, {
+  emitProxyLangfuseTrace(session, {
     responseHeaders: new Headers(),
     responseText: "",
     usageMetrics: null,
@@ -4126,6 +4084,7 @@ async function persistRequestFailure(options: {
     statusCode,
     durationMs: duration,
     isStreaming: phase === "stream",
+    sseEventCount: phase === "stream" ? 0 : undefined,
     errorMessage,
   });
 }

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -411,6 +411,70 @@ function isNonBillingUsageEndpoint(session: ProxySession): boolean {
   return isNonBillingEndpoint(session.getEndpoint());
 }
 
+function hasBillableInputCostPerRequest(priceData: { input_cost_per_request?: unknown }): boolean {
+  const inputCostPerRequest = priceData.input_cost_per_request;
+  return (
+    typeof inputCostPerRequest === "number" &&
+    Number.isFinite(inputCostPerRequest) &&
+    inputCostPerRequest > 0
+  );
+}
+
+async function resolveBillableUsageMetricsForCost(
+  session: ProxySession,
+  provider: Provider | null,
+  usageMetrics: UsageMetrics | null,
+  statusCode: number,
+  responseText?: string | null
+): Promise<UsageMetrics | null> {
+  if (isNonBillingUsageEndpoint(session)) {
+    return null;
+  }
+
+  if (usageMetrics) {
+    return usageMetrics;
+  }
+
+  if (statusCode < 200 || statusCode >= 300) {
+    return null;
+  }
+
+  let resolvedPricing: Awaited<ReturnType<ProxySession["getResolvedPricingByBillingSource"]>>;
+  try {
+    resolvedPricing = await session.getResolvedPricingByBillingSource(provider);
+  } catch (error) {
+    logger.error("[CostCalculation] Failed to resolve per-request pricing, skipping billing", {
+      error: error instanceof Error ? error.message : String(error),
+      originalModel: session.getOriginalModel(),
+      redirectedModel: session.getCurrentModel(),
+    });
+    return null;
+  }
+
+  if (!resolvedPricing?.priceData || !hasBillableInputCostPerRequest(resolvedPricing.priceData)) {
+    return null;
+  }
+
+  if (responseText !== undefined && responseText !== null) {
+    const detected = detectUpstreamErrorFromSseOrJsonText(responseText, {
+      maxJsonCharsForMessageCheck: 0,
+    });
+    if (detected.isError) {
+      logger.warn("[CostCalculation] Skipping per-request billing for fake-200 error payload", {
+        code: detected.code,
+        detail: detected.detail,
+        originalModel: session.getOriginalModel(),
+        redirectedModel: session.getCurrentModel(),
+      });
+      return null;
+    }
+  }
+
+  // 成功响应可能没有 token usage（例如 OpenAI Images），但本地价格表仍可配置按次价格。
+  // 这里用空 usage 只承载 input_cost_per_request，不新增按图、按 token 等语义。
+  return {};
+}
+
 type FinalizeDeferredStreamingResult = {
   /**
    * “内部结算用”的状态码。
@@ -1145,11 +1209,9 @@ export class ProxyResponseHandler {
         if (sessionWithCleanup.clearResponseTimeout) {
           sessionWithCleanup.clearResponseTimeout();
         }
-        let usageRecord: Record<string, unknown> | null = null;
         let usageMetrics: UsageMetrics | null = null;
 
         const usageResult = parseUsageFromResponseText(responseText, provider.providerType);
-        usageRecord = usageResult.usageRecord;
         usageMetrics = usageResult.usageMetrics;
         const actualServiceTier = parseServiceTierFromResponseText(responseText);
         const codexPriorityBillingDecision = await resolveCodexPriorityBillingDecision(
@@ -1172,8 +1234,13 @@ export class ProxyResponseHandler {
         // 关键：必须在 normalizeUsageWithSwap 之后再快照 billable 视图，
         // 否则 updateRequestCostFromUsage / trackCostToRedis 会用未归一化的旧值，
         // 导致缓存 TTL swap、bucket 归一化等场景下的账单与限流统计错位。
-        const billableUsageMetrics =
-          usageMetrics && !isNonBillingUsageEndpoint(session) ? usageMetrics : null;
+        const billableUsageMetrics = await resolveBillableUsageMetricsForCost(
+          session,
+          provider,
+          usageMetrics,
+          statusCode,
+          responseText
+        );
 
         if (billableUsageMetrics) {
           maybeSetCodexContext1m(session, provider, billableUsageMetrics.input_tokens);
@@ -1221,7 +1288,7 @@ export class ProxyResponseHandler {
           });
         }
 
-        if (usageRecord && billableUsageMetrics && messageContext) {
+        if (billableUsageMetrics && messageContext) {
           const costUpdateResult = await updateRequestCostFromUsage(
             messageContext.id,
             session,
@@ -1315,12 +1382,16 @@ export class ProxyResponseHandler {
         }
 
         // 更新 session 使用量到 Redis（用于实时监控）
-        if (session.sessionId && usageMetrics && session.shouldTrackSessionObservability()) {
+        if (
+          session.sessionId &&
+          (usageMetrics || costUsdStr !== undefined) &&
+          session.shouldTrackSessionObservability()
+        ) {
           void SessionManager.updateSessionUsage(session.sessionId, {
-            inputTokens: usageMetrics.input_tokens,
-            outputTokens: usageMetrics.output_tokens,
-            cacheCreationInputTokens: usageMetrics.cache_creation_input_tokens,
-            cacheReadInputTokens: usageMetrics.cache_read_input_tokens,
+            inputTokens: usageMetrics?.input_tokens,
+            outputTokens: usageMetrics?.output_tokens,
+            cacheCreationInputTokens: usageMetrics?.cache_creation_input_tokens,
+            cacheReadInputTokens: usageMetrics?.cache_read_input_tokens,
             costUsd: costUsdStr,
             status: statusCode >= 200 && statusCode < 300 ? "completed" : "error",
             statusCode: statusCode,
@@ -2336,8 +2407,13 @@ export class ProxyResponseHandler {
           }
         }
 
-        const billableUsageForCost =
-          usageForCost && !isNonBillingUsageEndpoint(session) ? usageForCost : null;
+        const billableUsageForCost = await resolveBillableUsageMetricsForCost(
+          session,
+          provider,
+          usageForCost,
+          effectiveStatusCode,
+          allContent
+        );
 
         const costUpdateResult = await updateRequestCostFromUsage(
           messageContext.id,
@@ -2443,6 +2519,8 @@ export class ProxyResponseHandler {
             payload.outputTokens = usageForCost.output_tokens;
             payload.cacheCreationInputTokens = usageForCost.cache_creation_input_tokens;
             payload.cacheReadInputTokens = usageForCost.cache_read_input_tokens;
+          }
+          if (costUsdStr !== undefined) {
             payload.costUsd = costUsdStr;
           }
 
@@ -3602,6 +3680,58 @@ export async function finalizeRequestStats(
   }
   const priorityServiceTierApplied = codexPriorityBillingDecision?.effectivePriority ?? false;
   if (!usageMetrics) {
+    const billablePerRequestUsage = await resolveBillableUsageMetricsForCost(
+      session,
+      provider,
+      null,
+      statusCode,
+      responseText
+    );
+    let perRequestCostUsd: string | undefined;
+
+    if (billablePerRequestUsage) {
+      const costUpdateResult = await updateRequestCostFromUsage(
+        messageContext.id,
+        session,
+        billablePerRequestUsage,
+        provider,
+        provider.costMultiplier,
+        session.getContext1mApplied(),
+        priorityServiceTierApplied,
+        session.getGroupCostMultiplier()
+      );
+      if (costUpdateResult.resolvedPricing) {
+        ensurePricingResolutionSpecialSetting(session, costUpdateResult.resolvedPricing);
+      }
+      if (costUpdateResult.longContextPricingApplied) {
+        ensureLongContextPricingAudit(session, costUpdateResult.longContextPricing);
+      }
+
+      await trackCostToRedis(
+        session,
+        billablePerRequestUsage,
+        priorityServiceTierApplied,
+        costUpdateResult.resolvedPricing,
+        costUpdateResult.longContextPricing
+      );
+      perRequestCostUsd = costUpdateResult.costUsd ?? undefined;
+    }
+
+    if (
+      session.sessionId &&
+      perRequestCostUsd !== undefined &&
+      session.shouldTrackSessionObservability()
+    ) {
+      void SessionManager.updateSessionUsage(session.sessionId, {
+        costUsd: perRequestCostUsd,
+        status: statusCode >= 200 && statusCode < 300 ? "completed" : "error",
+        statusCode,
+        ...(errorMessage ? { errorMessage } : {}),
+      }).catch((error: unknown) => {
+        logger.error("[ResponseHandler] Failed to update session usage:", error);
+      });
+    }
+
     await updateMessageRequestDetails(messageContext.id, {
       statusCode: statusCode,
       ...(errorMessage ? { errorMessage } : {}),

--- a/src/components/ui/__tests__/language-switcher.test.tsx
+++ b/src/components/ui/__tests__/language-switcher.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { LanguageSwitcher } from "@/components/ui/language-switcher";
+import type { Locale } from "@/i18n/config";
+
+const testState = vi.hoisted(() => ({
+  currentLocale: "zh-CN" as Locale,
+  pathname: "/zh-CN/settings/config",
+  router: {
+    push: vi.fn(),
+    refresh: vi.fn(),
+  },
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => testState.currentLocale,
+}));
+
+vi.mock("@/i18n/routing", () => ({
+  usePathname: () => testState.pathname,
+  useRouter: () => testState.router,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+function render(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(node);
+  });
+
+  return {
+    container,
+    rerender: (nextNode: ReactNode) => {
+      act(() => {
+        root.render(nextNode);
+      });
+    },
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function click(element: Element) {
+  act(() => {
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("LanguageSwitcher", () => {
+  let view: ReturnType<typeof render> | null = null;
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    testState.currentLocale = "zh-CN";
+    testState.pathname = "/zh-CN/settings/config";
+    testState.router.push.mockReset();
+    testState.router.refresh.mockReset();
+  });
+
+  afterEach(() => {
+    view?.unmount();
+    view = null;
+  });
+
+  test("refreshes the current route after the locale provider catches up", () => {
+    view = render(<LanguageSwitcher />);
+
+    const englishOption = Array.from(view.container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("English")
+    );
+
+    expect(englishOption).toBeTruthy();
+    click(englishOption!);
+
+    expect(testState.router.push).toHaveBeenCalledWith("/settings/config", { locale: "en" });
+    expect(testState.router.refresh).not.toHaveBeenCalled();
+
+    testState.currentLocale = "en";
+    view.rerender(<LanguageSwitcher />);
+
+    expect(testState.router.refresh).toHaveBeenCalledTimes(1);
+    const trigger = view.container.querySelector<HTMLButtonElement>(
+      "button[aria-label='Select language']"
+    );
+    expect(trigger?.disabled).toBe(false);
+  });
+
+  test("restores the pending refresh after the switcher remounts during navigation", () => {
+    view = render(<LanguageSwitcher />);
+
+    const englishOption = Array.from(view.container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("English")
+    );
+
+    expect(englishOption).toBeTruthy();
+    click(englishOption!);
+
+    expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBe("en");
+
+    view.unmount();
+    view = null;
+
+    testState.currentLocale = "en";
+    view = render(<LanguageSwitcher />);
+
+    expect(testState.router.refresh).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBeNull();
+  });
+});

--- a/src/components/ui/__tests__/language-switcher.test.tsx
+++ b/src/components/ui/__tests__/language-switcher.test.tsx
@@ -164,13 +164,13 @@ describe("LanguageSwitcher", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  test("does not refresh from a stale stored locale marker on mount", () => {
+  test("restores a pending refresh from sessionStorage after remount", () => {
     window.sessionStorage.setItem("cch.pendingLocaleRefresh", "en");
     testState.currentLocale = "en";
 
     view = render(<LanguageSwitcher />);
 
-    expect(testState.router.refresh).not.toHaveBeenCalled();
-    expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBe("en");
+    expect(testState.router.refresh).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBeNull();
   });
 });

--- a/src/components/ui/__tests__/language-switcher.test.tsx
+++ b/src/components/ui/__tests__/language-switcher.test.tsx
@@ -11,7 +11,7 @@ import type { Locale } from "@/i18n/config";
 
 const testState = vi.hoisted(() => ({
   currentLocale: "zh-CN" as Locale,
-  pathname: "/zh-CN/settings/config",
+  pathname: "/settings/config",
   router: {
     push: vi.fn(),
     refresh: vi.fn(),
@@ -75,7 +75,7 @@ describe("LanguageSwitcher", () => {
   beforeEach(() => {
     window.sessionStorage.clear();
     testState.currentLocale = "zh-CN";
-    testState.pathname = "/zh-CN/settings/config";
+    testState.pathname = "/settings/config";
     testState.router.push.mockReset();
     testState.router.refresh.mockReset();
   });
@@ -128,5 +128,15 @@ describe("LanguageSwitcher", () => {
 
     expect(testState.router.refresh).toHaveBeenCalledTimes(1);
     expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBeNull();
+  });
+
+  test("does not refresh from a stale stored locale marker on mount", () => {
+    window.sessionStorage.setItem("cch.pendingLocaleRefresh", "en");
+    testState.currentLocale = "en";
+
+    view = render(<LanguageSwitcher />);
+
+    expect(testState.router.refresh).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBe("en");
   });
 });

--- a/src/components/ui/__tests__/language-switcher.test.tsx
+++ b/src/components/ui/__tests__/language-switcher.test.tsx
@@ -130,6 +130,40 @@ describe("LanguageSwitcher", () => {
     expect(window.sessionStorage.getItem("cch.pendingLocaleRefresh")).toBeNull();
   });
 
+  test("keeps the pending refresh after remount when sessionStorage is blocked", () => {
+    const setItemSpy = vi.spyOn(window.sessionStorage, "setItem").mockImplementation(() => {
+      throw new Error("blocked storage");
+    });
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    view = render(<LanguageSwitcher />);
+
+    const englishOption = Array.from(view.container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("English")
+    );
+
+    expect(englishOption).toBeTruthy();
+    click(englishOption!);
+
+    expect(testState.router.push).toHaveBeenCalledWith("/settings/config", { locale: "en" });
+    expect(testState.router.refresh).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to persist pending locale refresh target:",
+      expect.any(Error)
+    );
+
+    view.unmount();
+    view = null;
+    setItemSpy.mockRestore();
+
+    testState.currentLocale = "en";
+    view = render(<LanguageSwitcher />);
+
+    expect(testState.router.refresh).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
+  });
+
   test("does not refresh from a stale stored locale marker on mount", () => {
     window.sessionStorage.setItem("cch.pendingLocaleRefresh", "en");
     testState.currentLocale = "en";

--- a/src/components/ui/language-switcher.tsx
+++ b/src/components/ui/language-switcher.tsx
@@ -15,9 +15,48 @@ import { normalizePathnameForLocaleNavigation } from "@/i18n/pathname";
 import { usePathname, useRouter } from "@/i18n/routing";
 import { cn } from "@/lib/utils/index";
 
+const pendingLocaleRefreshKey = "cch.pendingLocaleRefresh";
+
 interface LanguageSwitcherProps {
   className?: string;
   size?: "sm" | "default";
+}
+
+function getPendingLocaleRefreshTarget(): Locale | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const value = window.sessionStorage.getItem(pendingLocaleRefreshKey);
+    return locales.some((locale) => locale === value) ? (value as Locale) : null;
+  } catch {
+    return null;
+  }
+}
+
+function setPendingLocaleRefreshTarget(locale: Locale) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(pendingLocaleRefreshKey, locale);
+  } catch {
+    // 存储失败不影响路由切换，只会跳过额外的 RSC 刷新兜底。
+  }
+}
+
+function clearPendingLocaleRefreshTarget() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.sessionStorage.removeItem(pendingLocaleRefreshKey);
+  } catch {
+    // 清理失败可忽略，下一次读取会重新校验 locale 是否有效。
+  }
 }
 
 /**
@@ -31,6 +70,21 @@ export function LanguageSwitcher({ className, size = "sm" }: LanguageSwitcherPro
   const router = useRouter();
   const pathname = usePathname();
   const [isTransitioning, setIsTransitioning] = React.useState(false);
+  const [pendingLocale, setPendingLocale] = React.useState<Locale | null>(null);
+
+  React.useEffect(() => {
+    const refreshTarget = pendingLocale ?? getPendingLocaleRefreshTarget();
+
+    if (refreshTarget !== currentLocale) {
+      return;
+    }
+
+    // Locale route 已切换后刷新当前 RSC 树，避免布局与服务端标题继续显示旧语言。
+    router.refresh();
+    clearPendingLocaleRefreshTarget();
+    setPendingLocale(null);
+    setIsTransitioning(false);
+  }, [currentLocale, pendingLocale, router]);
 
   const handleLocaleChange = React.useCallback(
     (newLocale: Locale) => {
@@ -39,11 +93,15 @@ export function LanguageSwitcher({ className, size = "sm" }: LanguageSwitcherPro
       }
 
       setIsTransitioning(true);
+      setPendingLocale(newLocale);
+      setPendingLocaleRefreshTarget(newLocale);
 
       try {
         router.push(normalizePathnameForLocaleNavigation(pathname), { locale: newLocale });
       } catch (error) {
         console.error("Failed to switch locale:", error);
+        clearPendingLocaleRefreshTarget();
+        setPendingLocale(null);
         setIsTransitioning(false);
       }
     },

--- a/src/components/ui/language-switcher.tsx
+++ b/src/components/ui/language-switcher.tsx
@@ -79,8 +79,7 @@ export function LanguageSwitcher({ className, size = "sm" }: LanguageSwitcherPro
   const [pendingLocale, setPendingLocale] = React.useState<Locale | null>(null);
 
   React.useEffect(() => {
-    const storedRefreshTarget =
-      activePendingLocaleRefreshTarget === null ? null : getPendingLocaleRefreshTarget();
+    const storedRefreshTarget = getPendingLocaleRefreshTarget();
     const refreshTarget = pendingLocale ?? activePendingLocaleRefreshTarget ?? storedRefreshTarget;
 
     if (refreshTarget !== currentLocale) {

--- a/src/components/ui/language-switcher.tsx
+++ b/src/components/ui/language-switcher.tsx
@@ -31,7 +31,8 @@ function getPendingLocaleRefreshTarget(): Locale | null {
   try {
     const value = window.sessionStorage.getItem(pendingLocaleRefreshKey);
     return locales.some((locale) => locale === value) ? (value as Locale) : null;
-  } catch {
+  } catch (error) {
+    console.error("Failed to read pending locale refresh target:", error);
     return null;
   }
 }
@@ -45,8 +46,8 @@ function setPendingLocaleRefreshTarget(locale: Locale) {
 
   try {
     window.sessionStorage.setItem(pendingLocaleRefreshKey, locale);
-  } catch {
-    // 存储失败不影响路由切换，只会跳过额外的 RSC 刷新兜底。
+  } catch (error) {
+    console.error("Failed to persist pending locale refresh target:", error);
   }
 }
 
@@ -59,8 +60,8 @@ function clearPendingLocaleRefreshTarget() {
 
   try {
     window.sessionStorage.removeItem(pendingLocaleRefreshKey);
-  } catch {
-    // 清理失败可忽略，下一次读取会重新校验 locale 是否有效。
+  } catch (error) {
+    console.error("Failed to clear pending locale refresh target:", error);
   }
 }
 
@@ -79,10 +80,8 @@ export function LanguageSwitcher({ className, size = "sm" }: LanguageSwitcherPro
 
   React.useEffect(() => {
     const storedRefreshTarget =
-      pendingLocale !== null || activePendingLocaleRefreshTarget !== null
-        ? getPendingLocaleRefreshTarget()
-        : null;
-    const refreshTarget = pendingLocale ?? storedRefreshTarget;
+      activePendingLocaleRefreshTarget === null ? null : getPendingLocaleRefreshTarget();
+    const refreshTarget = pendingLocale ?? activePendingLocaleRefreshTarget ?? storedRefreshTarget;
 
     if (refreshTarget !== currentLocale) {
       return;

--- a/src/components/ui/language-switcher.tsx
+++ b/src/components/ui/language-switcher.tsx
@@ -16,6 +16,7 @@ import { usePathname, useRouter } from "@/i18n/routing";
 import { cn } from "@/lib/utils/index";
 
 const pendingLocaleRefreshKey = "cch.pendingLocaleRefresh";
+let activePendingLocaleRefreshTarget: Locale | null = null;
 
 interface LanguageSwitcherProps {
   className?: string;
@@ -36,6 +37,8 @@ function getPendingLocaleRefreshTarget(): Locale | null {
 }
 
 function setPendingLocaleRefreshTarget(locale: Locale) {
+  activePendingLocaleRefreshTarget = locale;
+
   if (typeof window === "undefined") {
     return;
   }
@@ -48,6 +51,8 @@ function setPendingLocaleRefreshTarget(locale: Locale) {
 }
 
 function clearPendingLocaleRefreshTarget() {
+  activePendingLocaleRefreshTarget = null;
+
   if (typeof window === "undefined") {
     return;
   }
@@ -73,7 +78,11 @@ export function LanguageSwitcher({ className, size = "sm" }: LanguageSwitcherPro
   const [pendingLocale, setPendingLocale] = React.useState<Locale | null>(null);
 
   React.useEffect(() => {
-    const refreshTarget = pendingLocale ?? getPendingLocaleRefreshTarget();
+    const storedRefreshTarget =
+      pendingLocale !== null || activePendingLocaleRefreshTarget !== null
+        ? getPendingLocaleRefreshTarget()
+        : null;
+    const refreshTarget = pendingLocale ?? storedRefreshTarget;
 
     if (refreshTarget !== currentLocale) {
       return;

--- a/src/lib/langfuse/emit-proxy-trace.ts
+++ b/src/lib/langfuse/emit-proxy-trace.ts
@@ -1,0 +1,51 @@
+import type { UsageMetrics } from "@/app/v1/_lib/proxy/response-handler";
+import type { ProxySession } from "@/app/v1/_lib/proxy/session";
+import { logger } from "@/lib/logger";
+import type { CostBreakdown } from "@/lib/utils/cost-calculation";
+
+export interface EmitProxyLangfuseTraceData {
+  responseHeaders: Headers;
+  responseText: string;
+  usageMetrics: UsageMetrics | null;
+  costUsd: string | undefined;
+  costBreakdown?: CostBreakdown;
+  statusCode: number;
+  durationMs: number;
+  isStreaming: boolean;
+  sseEventCount?: number;
+  errorMessage?: string;
+}
+
+/**
+ * 异步发送代理请求的 Langfuse trace。
+ *
+ * 这里保持 fire-and-forget，避免观测系统故障影响代理响应。
+ */
+export function emitProxyLangfuseTrace(
+  session: ProxySession,
+  data: EmitProxyLangfuseTraceData
+): void {
+  if (!process.env.LANGFUSE_PUBLIC_KEY || !process.env.LANGFUSE_SECRET_KEY) return;
+
+  void import("@/lib/langfuse/trace-proxy-request")
+    .then(({ traceProxyRequest }) => {
+      void traceProxyRequest({
+        session,
+        responseHeaders: data.responseHeaders,
+        durationMs: data.durationMs,
+        statusCode: data.statusCode,
+        isStreaming: data.isStreaming,
+        responseText: data.responseText,
+        usageMetrics: data.usageMetrics,
+        costUsd: data.costUsd,
+        costBreakdown: data.costBreakdown,
+        sseEventCount: data.sseEventCount,
+        errorMessage: data.errorMessage,
+      });
+    })
+    .catch((err) => {
+      logger.warn("[Langfuse] Proxy trace failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+}

--- a/src/lib/langfuse/trace-proxy-request.ts
+++ b/src/lib/langfuse/trace-proxy-request.ts
@@ -82,6 +82,50 @@ export interface TraceContext {
   costBreakdown?: CostBreakdown;
 }
 
+function hasRequestInput(ctx: TraceContext): boolean {
+  if (
+    typeof ctx.session.forwardedRequestBody === "string" &&
+    ctx.session.forwardedRequestBody.trim().length > 0
+  ) {
+    return true;
+  }
+
+  return Object.keys(ctx.session.request.message ?? {}).length > 0;
+}
+
+function isResponseMissing(ctx: TraceContext): boolean {
+  if (ctx.responseText) return false;
+  if (ctx.errorMessage) return true;
+  if (!hasRequestInput(ctx)) return false;
+  if (ctx.isStreaming) return ctx.sseEventCount === 0;
+
+  return true;
+}
+
+function buildResponseOutput(ctx: TraceContext): unknown {
+  if (ctx.responseText) {
+    return tryParseJsonSafe(ctx.responseText);
+  }
+
+  const responseMissing = isResponseMissing(ctx);
+  const output: Record<string, unknown> = ctx.isStreaming
+    ? { streaming: true, sseEventCount: ctx.sseEventCount }
+    : { statusCode: ctx.statusCode };
+
+  if (responseMissing) {
+    output.responseMissing = true;
+  }
+
+  if (ctx.errorMessage) {
+    if (ctx.isStreaming) {
+      output.statusCode = ctx.statusCode;
+    }
+    output.errorMessage = ctx.errorMessage;
+  }
+
+  return output;
+}
+
 /**
  * Send a trace to Langfuse for a completed proxy request.
  * Fully async and non-blocking. Errors are caught and logged.
@@ -138,11 +182,8 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
       : session.request.message;
 
     // Actual response body - no truncation
-    const actualResponseBody = ctx.responseText
-      ? tryParseJsonSafe(ctx.responseText)
-      : isStreaming
-        ? { streaming: true, sseEventCount: ctx.sseEventCount }
-        : { statusCode };
+    const actualResponseBody = buildResponseOutput(ctx);
+    const responseMissing = isResponseMissing(ctx);
 
     // Root span metadata (former input/output summaries moved here)
     const rootSpanMetadata: Record<string, unknown> = {
@@ -153,6 +194,8 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
       providerName: provider?.name,
       statusCode,
       durationMs,
+      errorMessage: ctx.errorMessage,
+      responseMissing,
       hasUsage: !!ctx.usageMetrics,
       costUsd: ctx.costUsd,
       timingBreakdown,
@@ -336,11 +379,7 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
 
         // Generation input/output = raw payload, no truncation
         const generationInput = actualRequestBody;
-        const generationOutput = ctx.responseText
-          ? tryParseJsonSafe(ctx.responseText)
-          : isStreaming
-            ? { streaming: true, sseEventCount: ctx.sseEventCount }
-            : { statusCode };
+        const generationOutput = buildResponseOutput(ctx);
 
         // Create the LLM generation observation
         const generation = rootSpan.startObservation(

--- a/src/lib/utils/quota-helpers.ts
+++ b/src/lib/utils/quota-helpers.ts
@@ -10,6 +10,7 @@ export type KeyQuota = {
   costDaily: { current: number; limit: number | null };
   costWeekly: { current: number; limit: number | null };
   costMonthly: { current: number; limit: number | null };
+  costTotal?: { current: number; limit: number | null };
   concurrentSessions: { current: number; limit: number };
 } | null;
 
@@ -22,7 +23,7 @@ export type UserQuota = {
  * 判断密钥是否设置了限额
  *
  * @param quota - 密钥限额数据
- * @returns 是否设置了任意限额（5h/周/月/并发）
+ * @returns 是否设置了任意限额（5h/日/周/月/总额/并发）
  */
 export function hasKeyQuotaSet(quota: KeyQuota): boolean {
   if (!quota) return false;
@@ -32,6 +33,7 @@ export function hasKeyQuotaSet(quota: KeyQuota): boolean {
     quota.costDaily.limit ||
     quota.costWeekly.limit ||
     quota.costMonthly.limit ||
+    quota.costTotal?.limit ||
     (quota.concurrentSessions.limit && quota.concurrentSessions.limit > 0)
   );
 }
@@ -86,6 +88,9 @@ export function getMaxUsageRate(quota: KeyQuota): number {
   }
   if (quota.costMonthly.limit) {
     rates.push(getUsageRate(quota.costMonthly.current, quota.costMonthly.limit));
+  }
+  if (quota.costTotal?.limit) {
+    rates.push(getUsageRate(quota.costTotal.current, quota.costTotal.limit));
   }
   if (quota.concurrentSessions.limit > 0) {
     rates.push(getUsageRate(quota.concurrentSessions.current, quota.concurrentSessions.limit));

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -364,7 +364,7 @@ async function findLeaderboardWithTimezone(
     .innerJoin(users, and(sql`${usageLedger.userId} = ${users.id}`, isNull(users.deletedAt)))
     .where(and(...whereConditions))
     .groupBy(usageLedger.userId, users.name)
-    .orderBy(desc(sql`sum(${usageLedger.costUsd})`));
+    .orderBy(desc(sql`COALESCE(sum(${usageLedger.costUsd}), 0)`));
 
   const baseEntries: LeaderboardEntry[] = rankings.map((entry) => ({
     userId: entry.userId,
@@ -404,7 +404,7 @@ async function findLeaderboardWithTimezone(
     .innerJoin(users, and(sql`${usageLedger.userId} = ${users.id}`, isNull(users.deletedAt)))
     .where(and(...whereConditions))
     .groupBy(usageLedger.userId, modelField)
-    .orderBy(desc(sql`sum(${usageLedger.costUsd})`));
+    .orderBy(desc(sql`COALESCE(sum(${usageLedger.costUsd}), 0)`));
 
   const modelStatsByUser = new Map<number, UserModelStat[]>();
   for (const row of modelRows) {
@@ -696,7 +696,7 @@ async function findProviderLeaderboardWithTimezone(
       and(...whereConditions.filter((c): c is NonNullable<(typeof whereConditions)[number]> => !!c))
     )
     .groupBy(usageLedger.finalProviderId, providers.name)
-    .orderBy(desc(sql`sum(${usageLedger.costUsd})`));
+    .orderBy(desc(sql`COALESCE(sum(${usageLedger.costUsd}), 0)`));
 
   const baseEntries: ProviderLeaderboardEntry[] = rankings.map((entry) => {
     const totalCost = parseFloat(entry.totalCost);
@@ -747,7 +747,7 @@ async function findProviderLeaderboardWithTimezone(
       and(...whereConditions.filter((c): c is NonNullable<(typeof whereConditions)[number]> => !!c))
     )
     .groupBy(usageLedger.finalProviderId, modelField)
-    .orderBy(desc(sql`sum(${usageLedger.costUsd})`), desc(sql`count(*)`));
+    .orderBy(desc(sql`COALESCE(sum(${usageLedger.costUsd}), 0)`), desc(sql`count(*)`));
 
   const modelStatsByProvider = new Map<number, ModelProviderStat[]>();
   for (const row of modelRows) {
@@ -1153,7 +1153,7 @@ async function findModelLeaderboardWithTimezone(
     .from(usageLedger)
     .where(and(LEDGER_BILLING_CONDITION, buildDateCondition(period, timezone, dateRange)))
     .groupBy(modelField)
-    .orderBy(desc(sql`sum(${usageLedger.costUsd})`), desc(sql`count(*)`));
+    .orderBy(desc(sql`COALESCE(sum(${usageLedger.costUsd}), 0)`), desc(sql`count(*)`));
 
   return rankings
     .filter((entry) => entry.model !== null && entry.model !== "")

--- a/src/repository/leaderboard.ts
+++ b/src/repository/leaderboard.ts
@@ -1153,7 +1153,7 @@ async function findModelLeaderboardWithTimezone(
     .from(usageLedger)
     .where(and(LEDGER_BILLING_CONDITION, buildDateCondition(period, timezone, dateRange)))
     .groupBy(modelField)
-    .orderBy(desc(sql`count(*)`)); // 按请求数排序
+    .orderBy(desc(sql`sum(${usageLedger.costUsd})`), desc(sql`count(*)`));
 
   return rankings
     .filter((entry) => entry.model !== null && entry.model !== "")

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -464,6 +464,7 @@ export interface ProviderDisplay {
   limitWeeklyUsd: number | null;
   limitMonthlyUsd: number | null;
   limitTotalUsd: number | null;
+  totalCostResetAt?: Date | null;
   limitConcurrentSessions: number;
   // 熔断器配置
   maxRetryAttempts: number | null;

--- a/tests/integration/billing-model-source.test.ts
+++ b/tests/integration/billing-model-source.test.ts
@@ -334,7 +334,14 @@ async function runScenario({
   billingModelSource: SystemSettings["billingModelSource"];
   isStream: boolean;
   enableHighConcurrencyMode?: boolean;
-}): Promise<{ dbCostUsd: string; sessionCostUsd: string; rateLimitCost: number }> {
+}): Promise<{
+  dbCostCalls: number;
+  dbCostUsd: string;
+  rateLimitCalls: number;
+  rateLimitCost: number;
+  sessionCostCalls: number;
+  sessionCostUsd: string;
+}> {
   invalidateSystemSettingsCache();
 
   const usage = { input_tokens: 2, output_tokens: 3 };
@@ -406,11 +413,14 @@ async function runScenario({
 
   await drainAsyncTasks();
 
-  const dbCostUsd = dbCosts[0] ?? "";
-  const sessionCostUsd = sessionCosts[0] ?? "";
-  const rateLimitCost = rateLimitCosts[0] ?? Number.NaN;
-
-  return { dbCostUsd, sessionCostUsd, rateLimitCost };
+  return {
+    dbCostCalls: dbCosts.length,
+    dbCostUsd: dbCosts[0] ?? "",
+    rateLimitCalls: rateLimitCosts.length,
+    rateLimitCost: rateLimitCosts[0] ?? Number.NaN,
+    sessionCostCalls: sessionCosts.length,
+    sessionCostUsd: sessionCosts[0] ?? "",
+  };
 }
 
 describe("Billing model source - Redis session cost vs DB cost", () => {
@@ -1039,10 +1049,13 @@ describe("模型重定向后的图片按次计费", () => {
   async function runImageEditPerRequestScenario(
     billingModelSource: SystemSettings["billingModelSource"]
   ): Promise<{
+    dbCostCalls: number;
     dbCostUsd: string;
-    storedBreakdown: Record<string, unknown> | undefined;
-    sessionCostUsd: string;
+    rateLimitCalls: number;
     rateLimitCost: number;
+    sessionCostCalls: number;
+    sessionCostUsd: string;
+    storedBreakdown: Record<string, unknown> | undefined;
   }> {
     invalidateSystemSettingsCache();
 
@@ -1115,10 +1128,13 @@ describe("模型重定向后的图片按次计费", () => {
     await drainAsyncTasks();
 
     return {
+      dbCostCalls: dbCosts.length,
       dbCostUsd: dbCosts[0] ?? "",
-      storedBreakdown,
-      sessionCostUsd: sessionCosts[0] ?? "",
+      rateLimitCalls: rateLimitCosts.length,
       rateLimitCost: rateLimitCosts[0] ?? Number.NaN,
+      sessionCostCalls: sessionCosts.length,
+      sessionCostUsd: sessionCosts[0] ?? "",
+      storedBreakdown,
     };
   }
 
@@ -1128,6 +1144,9 @@ describe("模型重定向后的图片按次计费", () => {
     expect(result.dbCostUsd).toBe("0.06");
     expect(result.sessionCostUsd).toBe("0.06");
     expect(result.rateLimitCost).toBe(0.06);
+    expect(result.dbCostCalls).toBe(1);
+    expect(result.sessionCostCalls).toBe(1);
+    expect(result.rateLimitCalls).toBe(1);
     expect(result.storedBreakdown).toMatchObject({
       input: "0.01",
       base_total: "0.01",
@@ -1143,6 +1162,9 @@ describe("模型重定向后的图片按次计费", () => {
     expect(result.dbCostUsd).toBe("0.12");
     expect(result.sessionCostUsd).toBe("0.12");
     expect(result.rateLimitCost).toBe(0.12);
+    expect(result.dbCostCalls).toBe(1);
+    expect(result.sessionCostCalls).toBe(1);
+    expect(result.rateLimitCalls).toBe(1);
     expect(result.storedBreakdown).toMatchObject({
       input: "0.02",
       base_total: "0.02",

--- a/tests/integration/billing-model-source.test.ts
+++ b/tests/integration/billing-model-source.test.ts
@@ -77,7 +77,7 @@ vi.mock("@/lib/proxy-status-tracker", () => ({
   },
 }));
 
-import { ProxyResponseHandler } from "@/app/v1/_lib/proxy/response-handler";
+import { finalizeRequestStats, ProxyResponseHandler } from "@/app/v1/_lib/proxy/response-handler";
 import { ProxySession } from "@/app/v1/_lib/proxy/session";
 import { getCachedSystemSettings, invalidateSystemSettingsCache } from "@/lib/config";
 import { SessionManager } from "@/lib/session-manager";
@@ -139,12 +139,17 @@ function makeSystemSettings(
   };
 }
 
-function makePriceRecord(modelName: string, priceData: ModelPriceData): ModelPrice {
+function makePriceRecord(
+  modelName: string,
+  priceData: ModelPriceData,
+  source: ModelPrice["source"] = "litellm"
+): ModelPrice {
   const now = new Date();
   return {
     id: 1,
     modelName,
     priceData,
+    source,
     createdAt: now,
     updatedAt: now,
   };
@@ -158,6 +163,8 @@ function createSession({
   enableHighConcurrencyMode = false,
   providerOverrides,
   requestMessage,
+  requestPath = "/v1/messages",
+  groupCostMultiplier,
 }: {
   originalModel: string;
   redirectedModel: string;
@@ -166,6 +173,8 @@ function createSession({
   enableHighConcurrencyMode?: boolean;
   providerOverrides?: Record<string, unknown>;
   requestMessage?: Record<string, unknown>;
+  requestPath?: string;
+  groupCostMultiplier?: number;
 }): ProxySession {
   const session = new (
     ProxySession as unknown as {
@@ -184,7 +193,7 @@ function createSession({
   )({
     startTime: Date.now(),
     method: "POST",
-    requestUrl: new URL("http://localhost/v1/messages"),
+    requestUrl: new URL(`http://localhost${requestPath}`),
     headers: new Headers(),
     headerLog: "",
     request: { message: requestMessage ?? {}, log: "(test)", model: redirectedModel },
@@ -196,6 +205,9 @@ function createSession({
   session.setOriginalModel(originalModel);
   session.setSessionId(sessionId);
   session.setHighConcurrencyModeEnabled(enableHighConcurrencyMode);
+  if (groupCostMultiplier !== undefined) {
+    session.setGroupCostMultiplier(groupCostMultiplier);
+  }
 
   const provider = {
     id: 99,
@@ -248,6 +260,33 @@ function createNonStreamResponse(
       type: "message",
       usage,
       ...(extras ?? {}),
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }
+  );
+}
+
+function createImageEditResponseWithoutUsage(): Response {
+  return new Response(
+    JSON.stringify({
+      created: 1_776_729_600,
+      data: [{ b64_json: "test-image-bytes" }],
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }
+  );
+}
+
+function createFake200ErrorResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: "invalid api key",
+      },
     }),
     {
       status: 200,
@@ -993,6 +1032,320 @@ describe("Billing model source - Redis session cost vs DB cost", () => {
 
     expect(dbCosts[0]).toBe("32");
     expect(rateLimitCosts[0]).toBe(32);
+  });
+});
+
+describe("模型重定向后的图片按次计费", () => {
+  async function runImageEditPerRequestScenario(
+    billingModelSource: SystemSettings["billingModelSource"]
+  ): Promise<{
+    dbCostUsd: string;
+    storedBreakdown: Record<string, unknown> | undefined;
+    sessionCostUsd: string;
+    rateLimitCost: number;
+  }> {
+    invalidateSystemSettingsCache();
+
+    const originalModel = "gpt-image-2";
+    const redirectedModel = "gpt-image-2-all";
+    const providerMultiplier = 2;
+    const groupCostMultiplier = 3;
+
+    vi.mocked(getSystemSettings).mockResolvedValue(makeSystemSettings(billingModelSource));
+    vi.mocked(findLatestPriceByModel).mockImplementation(async (modelName: string) => {
+      if (modelName === originalModel) {
+        return makePriceRecord(modelName, { input_cost_per_request: 0.01 }, "manual");
+      }
+      if (modelName === redirectedModel) {
+        return makePriceRecord(modelName, { input_cost_per_request: 0.02 }, "manual");
+      }
+      return null;
+    });
+
+    vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestDuration).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.storeSessionResponse).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackUserDailyCost).mockResolvedValue(undefined);
+    vi.mocked(SessionTracker.refreshSession).mockResolvedValue(undefined);
+
+    const dbCosts: string[] = [];
+    let storedBreakdown: Record<string, unknown> | undefined;
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockImplementation(
+      async (_id: number, costUsd: unknown, breakdown?: Record<string, unknown>) => {
+        dbCosts.push(String(costUsd));
+        storedBreakdown = breakdown;
+      }
+    );
+
+    const sessionCosts: string[] = [];
+    vi.mocked(SessionManager.updateSessionUsage).mockImplementation(
+      async (_sessionId: string, payload: Record<string, unknown>) => {
+        if (typeof payload.costUsd === "string") {
+          sessionCosts.push(payload.costUsd);
+        }
+      }
+    );
+
+    const rateLimitCosts: number[] = [];
+    vi.mocked(RateLimitService.trackCost).mockImplementation(
+      async (_keyId: number, _providerId: number, _sessionId: string, costUsd: number) => {
+        rateLimitCosts.push(costUsd);
+      }
+    );
+
+    const session = createSession({
+      originalModel,
+      redirectedModel,
+      sessionId: `sess-image-edit-${billingModelSource}`,
+      messageId: billingModelSource === "original" ? 4000 : 4001,
+      requestPath: "/v1/images/edits",
+      providerOverrides: {
+        providerType: "openai",
+        url: "https://api.openai.com/v1",
+        costMultiplier: providerMultiplier,
+      },
+      groupCostMultiplier,
+    });
+
+    const clientResponse = await ProxyResponseHandler.dispatch(
+      session,
+      createImageEditResponseWithoutUsage()
+    );
+    await clientResponse.text();
+    await drainAsyncTasks();
+
+    return {
+      dbCostUsd: dbCosts[0] ?? "",
+      storedBreakdown,
+      sessionCostUsd: sessionCosts[0] ?? "",
+      rateLimitCost: rateLimitCosts[0] ?? Number.NaN,
+    };
+  }
+
+  it("配置 = original 时命中重定向前模型的本地按次价格并应用倍率", async () => {
+    const result = await runImageEditPerRequestScenario("original");
+
+    expect(result.dbCostUsd).toBe("0.06");
+    expect(result.sessionCostUsd).toBe("0.06");
+    expect(result.rateLimitCost).toBe(0.06);
+    expect(result.storedBreakdown).toMatchObject({
+      input: "0.01",
+      base_total: "0.01",
+      provider_multiplier: 2,
+      group_multiplier: 3,
+      total: "0.06",
+    });
+  });
+
+  it("配置 = redirected 时命中重定向后模型的本地按次价格并应用倍率", async () => {
+    const result = await runImageEditPerRequestScenario("redirected");
+
+    expect(result.dbCostUsd).toBe("0.12");
+    expect(result.sessionCostUsd).toBe("0.12");
+    expect(result.rateLimitCost).toBe(0.12);
+    expect(result.storedBreakdown).toMatchObject({
+      input: "0.02",
+      base_total: "0.02",
+      provider_multiplier: 2,
+      group_multiplier: 3,
+      total: "0.12",
+    });
+  });
+
+  it("按次价格为 0 时不进入空 usage 计费写入路径", async () => {
+    invalidateSystemSettingsCache();
+
+    const originalModel = "gpt-image-2";
+    const redirectedModel = "gpt-image-2-all";
+
+    vi.mocked(getSystemSettings).mockResolvedValue(makeSystemSettings("original"));
+    vi.mocked(findLatestPriceByModel).mockImplementation(async (modelName: string) => {
+      return makePriceRecord(modelName, { input_cost_per_request: 0 }, "manual");
+    });
+
+    vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestDuration).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.storeSessionResponse).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackUserDailyCost).mockResolvedValue(undefined);
+    vi.mocked(SessionTracker.refreshSession).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.updateSessionUsage).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackCost).mockResolvedValue(undefined);
+
+    const session = createSession({
+      originalModel,
+      redirectedModel,
+      sessionId: "sess-image-edit-zero-per-request",
+      messageId: 4002,
+      requestPath: "/v1/images/edits",
+      providerOverrides: {
+        providerType: "openai",
+        url: "https://api.openai.com/v1",
+      },
+    });
+
+    const clientResponse = await ProxyResponseHandler.dispatch(
+      session,
+      createImageEditResponseWithoutUsage()
+    );
+    await clientResponse.text();
+    await drainAsyncTasks();
+
+    expect(updateMessageRequestCostWithBreakdown).not.toHaveBeenCalled();
+    expect(SessionManager.updateSessionUsage).not.toHaveBeenCalled();
+    expect(RateLimitService.trackCost).not.toHaveBeenCalled();
+  });
+
+  it("价格查询失败时跳过按次计费且不影响成功响应", async () => {
+    invalidateSystemSettingsCache();
+
+    const originalModel = "gpt-image-2";
+    const redirectedModel = "gpt-image-2-all";
+
+    vi.mocked(getSystemSettings).mockResolvedValue(makeSystemSettings("original"));
+    vi.mocked(findLatestPriceByModel).mockImplementation(async () => {
+      throw new Error("pricing db unavailable");
+    });
+
+    vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestDuration).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.storeSessionResponse).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackUserDailyCost).mockResolvedValue(undefined);
+    vi.mocked(SessionTracker.refreshSession).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.updateSessionUsage).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackCost).mockResolvedValue(undefined);
+
+    const session = createSession({
+      originalModel,
+      redirectedModel,
+      sessionId: "sess-image-edit-pricing-error",
+      messageId: 4004,
+      requestPath: "/v1/images/edits",
+      providerOverrides: {
+        providerType: "openai",
+        url: "https://api.openai.com/v1",
+      },
+    });
+
+    const clientResponse = await ProxyResponseHandler.dispatch(
+      session,
+      createImageEditResponseWithoutUsage()
+    );
+    const responseText = await clientResponse.text();
+    await drainAsyncTasks();
+
+    expect(clientResponse.status).toBe(200);
+    expect(JSON.parse(responseText)).toMatchObject({
+      data: [{ b64_json: "test-image-bytes" }],
+    });
+    expect(updateMessageRequestCostWithBreakdown).not.toHaveBeenCalled();
+    expect(SessionManager.updateSessionUsage).not.toHaveBeenCalled();
+    expect(RateLimitService.trackCost).not.toHaveBeenCalled();
+  });
+
+  it("上游假 200 错误 payload 不触发图片按次计费", async () => {
+    invalidateSystemSettingsCache();
+
+    const originalModel = "gpt-image-2";
+    const redirectedModel = "gpt-image-2-all";
+
+    vi.mocked(getSystemSettings).mockResolvedValue(makeSystemSettings("original"));
+    vi.mocked(findLatestPriceByModel).mockImplementation(async (modelName: string) => {
+      return makePriceRecord(modelName, { input_cost_per_request: 0.01 }, "manual");
+    });
+
+    vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestDuration).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.storeSessionResponse).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackUserDailyCost).mockResolvedValue(undefined);
+    vi.mocked(SessionTracker.refreshSession).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockResolvedValue(undefined);
+    vi.mocked(SessionManager.updateSessionUsage).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackCost).mockResolvedValue(undefined);
+
+    const session = createSession({
+      originalModel,
+      redirectedModel,
+      sessionId: "sess-image-edit-fake-200-error",
+      messageId: 4005,
+      requestPath: "/v1/images/edits",
+      providerOverrides: {
+        providerType: "openai",
+        url: "https://api.openai.com/v1",
+      },
+    });
+
+    const clientResponse = await ProxyResponseHandler.dispatch(
+      session,
+      createFake200ErrorResponse()
+    );
+    const responseText = await clientResponse.text();
+    await drainAsyncTasks();
+
+    expect(clientResponse.status).toBe(200);
+    expect(JSON.parse(responseText)).toMatchObject({
+      error: { message: "invalid api key" },
+    });
+    expect(updateMessageRequestCostWithBreakdown).not.toHaveBeenCalled();
+    expect(SessionManager.updateSessionUsage).not.toHaveBeenCalled();
+    expect(RateLimitService.trackCost).not.toHaveBeenCalled();
+  });
+
+  it("finalizeRequestStats 的按次计费 session usage 保留 errorMessage", async () => {
+    invalidateSystemSettingsCache();
+
+    const originalModel = "gpt-image-2";
+    const redirectedModel = "gpt-image-2-all";
+    const errorMessage = "fake 200 upstream warning";
+
+    vi.mocked(getSystemSettings).mockResolvedValue(makeSystemSettings("original"));
+    vi.mocked(findLatestPriceByModel).mockImplementation(async (modelName: string) => {
+      return makePriceRecord(modelName, { input_cost_per_request: 0.01 }, "manual");
+    });
+
+    vi.mocked(updateMessageRequestCostWithBreakdown).mockResolvedValue(undefined);
+    vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
+    vi.mocked(RateLimitService.trackCost).mockResolvedValue(undefined);
+
+    let sessionUsagePayload: Record<string, unknown> | undefined;
+    vi.mocked(SessionManager.updateSessionUsage).mockImplementation(
+      async (_sessionId: string, payload: Record<string, unknown>) => {
+        sessionUsagePayload = payload;
+      }
+    );
+
+    const session = createSession({
+      originalModel,
+      redirectedModel,
+      sessionId: "sess-image-edit-finalize-error-message",
+      messageId: 4003,
+      requestPath: "/v1/images/edits",
+      providerOverrides: {
+        providerType: "openai",
+        url: "https://api.openai.com/v1",
+      },
+    });
+
+    await finalizeRequestStats(
+      session,
+      JSON.stringify({
+        created: 1_776_729_600,
+        data: [{ b64_json: "test-image-bytes" }],
+      }),
+      200,
+      42,
+      errorMessage,
+      99,
+      false
+    );
+
+    expect(sessionUsagePayload).toMatchObject({
+      costUsd: "0.01",
+      status: "completed",
+      statusCode: 200,
+      errorMessage,
+    });
   });
 });
 

--- a/tests/unit/actions/providers-usage.test.ts
+++ b/tests/unit/actions/providers-usage.test.ts
@@ -17,6 +17,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const getSessionMock = vi.fn();
 const findProviderByIdMock = vi.fn();
 const sumProviderCostInTimeRangeMock = vi.fn();
+const sumProviderTotalCostMock = vi.fn();
 const getProviderSessionCountMock = vi.fn();
 const getProviderSessionCountBatchMock = vi.fn();
 const getTimeRangeForPeriodMock = vi.fn();
@@ -37,6 +38,7 @@ vi.mock("@/repository/provider", () => ({
 vi.mock("@/repository/statistics", () => ({
   sumProviderCostInTimeRange: (providerId: number, startTime: Date, endTime: Date) =>
     sumProviderCostInTimeRangeMock(providerId, startTime, endTime),
+  sumProviderTotalCost: (providerId: number) => sumProviderTotalCostMock(providerId),
 }));
 
 vi.mock("@/lib/session-tracker", () => ({
@@ -166,6 +168,7 @@ describe("getProviderLimitUsage", () => {
 
     // Default DB costs
     sumProviderCostInTimeRangeMock.mockResolvedValue(5.5);
+    sumProviderTotalCostMock.mockResolvedValue(0);
   });
 
   afterEach(() => {
@@ -403,6 +406,7 @@ describe("getProviderLimitUsageBatch", () => {
     get5hWindowResetAtMock.mockResolvedValue(null);
 
     sumProviderCostInTimeRangeMock.mockResolvedValue(5.5);
+    sumProviderTotalCostMock.mockResolvedValue(0);
   });
 
   afterEach(() => {

--- a/tests/unit/actions/providers-usage.test.ts
+++ b/tests/unit/actions/providers-usage.test.ts
@@ -38,7 +38,8 @@ vi.mock("@/repository/provider", () => ({
 vi.mock("@/repository/statistics", () => ({
   sumProviderCostInTimeRange: (providerId: number, startTime: Date, endTime: Date) =>
     sumProviderCostInTimeRangeMock(providerId, startTime, endTime),
-  sumProviderTotalCost: (providerId: number) => sumProviderTotalCostMock(providerId),
+  sumProviderTotalCost: (providerId: number, resetAt?: Date | null) =>
+    sumProviderTotalCostMock(providerId, resetAt),
 }));
 
 vi.mock("@/lib/session-tracker", () => ({
@@ -99,6 +100,8 @@ describe("getProviderLimitUsage", () => {
     limitDailyUsd: 50,
     limitWeeklyUsd: 200,
     limitMonthlyUsd: 500,
+    limitTotalUsd: 1000,
+    totalCostResetAt: new Date(nowMs - 3 * 60 * 60 * 1000),
     limitConcurrentSessions: 5,
   };
 
@@ -198,6 +201,14 @@ describe("getProviderLimitUsage", () => {
     expect(getTimeRangeForPeriodMock).toHaveBeenCalledWith("5h", undefined);
     expect(getTimeRangeForPeriodMock).toHaveBeenCalledWith("weekly", undefined);
     expect(getTimeRangeForPeriodMock).toHaveBeenCalledWith("monthly", undefined);
+  });
+
+  it("should pass total cost reset time to sumProviderTotalCost", async () => {
+    const { getProviderLimitUsage } = await import("@/actions/providers");
+
+    await getProviderLimitUsage(1);
+
+    expect(sumProviderTotalCostMock).toHaveBeenCalledWith(1, mockProvider.totalCostResetAt);
   });
 
   it("should call getTimeRangeForPeriodWithMode for daily with provider config", async () => {
@@ -326,6 +337,8 @@ describe("getProviderLimitUsageBatch", () => {
       limitDailyUsd: 50,
       limitWeeklyUsd: 200,
       limitMonthlyUsd: 500,
+      limitTotalUsd: 1000,
+      totalCostResetAt: new Date(nowMs - 3 * 60 * 60 * 1000),
       limitConcurrentSessions: 5,
     },
     {
@@ -337,6 +350,8 @@ describe("getProviderLimitUsageBatch", () => {
       limitDailyUsd: 100,
       limitWeeklyUsd: 400,
       limitMonthlyUsd: 1000,
+      limitTotalUsd: 2000,
+      totalCostResetAt: new Date(nowMs - 6 * 60 * 60 * 1000),
       limitConcurrentSessions: 10,
     },
   ];
@@ -435,6 +450,15 @@ describe("getProviderLimitUsageBatch", () => {
 
     // Provider 2: rolling mode
     expect(getTimeRangeForPeriodWithModeMock).toHaveBeenCalledWith("daily", "18:00", "rolling");
+  });
+
+  it("should pass each provider total reset time to sumProviderTotalCost", async () => {
+    const { getProviderLimitUsageBatch } = await import("@/actions/providers");
+
+    await getProviderLimitUsageBatch(mockProviders);
+
+    expect(sumProviderTotalCostMock).toHaveBeenCalledWith(1, mockProviders[0].totalCostResetAt);
+    expect(sumProviderTotalCostMock).toHaveBeenCalledWith(2, mockProviders[1].totalCostResetAt);
   });
 
   it("should return empty map for empty providers array", async () => {

--- a/tests/unit/i18n/locale-server-translations.test.ts
+++ b/tests/unit/i18n/locale-server-translations.test.ts
@@ -1,0 +1,41 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return walk(fullPath);
+    }
+    return /\.(ts|tsx)$/.test(entry.name) ? [fullPath] : [];
+  });
+}
+
+function isRouteOrServerChromeFile(filePath: string): boolean {
+  const fileName = basename(filePath);
+
+  return (
+    fileName === "page.tsx" ||
+    fileName === "layout.tsx" ||
+    filePath.endsWith("dashboard-header.tsx") ||
+    filePath.endsWith("dashboard-sections.tsx") ||
+    filePath.endsWith("settings/_lib/nav-items.ts")
+  );
+}
+
+describe("locale server translations", () => {
+  test("route pages and server chrome pass locale explicitly to getTranslations", () => {
+    const files = walk("src/app/[locale]").filter(isRouteOrServerChromeFile);
+    const violations = files.flatMap((file) => {
+      const content = readFileSync(file, "utf8");
+      return content
+        .split("\n")
+        .map((line, index) => ({ line, lineNumber: index + 1 }))
+        .filter(({ line }) => /getTranslations\(\s*["']/.test(line))
+        .map(({ line, lineNumber }) => `${file}:${lineNumber}: ${line.trim()}`);
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/i18n/locale-server-translations.test.ts
+++ b/tests/unit/i18n/locale-server-translations.test.ts
@@ -29,11 +29,13 @@ describe("locale server translations", () => {
     const files = walk("src/app/[locale]").filter(isRouteOrServerChromeFile);
     const violations = files.flatMap((file) => {
       const content = readFileSync(file, "utf8");
-      return content
-        .split("\n")
-        .map((line, index) => ({ line, lineNumber: index + 1 }))
-        .filter(({ line }) => /getTranslations\(\s*["']/.test(line))
-        .map(({ line, lineNumber }) => `${file}:${lineNumber}: ${line.trim()}`);
+      const lines = content.split("\n");
+      return [...content.matchAll(/getTranslations\(\s*["']/g)].map((match) => {
+        const offset = match.index ?? 0;
+        const lineNumber = content.slice(0, offset).split("\n").length;
+        const line = lines[lineNumber - 1] ?? "";
+        return `${file}:${lineNumber}: ${line.trim()}`;
+      });
     });
 
     expect(violations).toEqual([]);

--- a/tests/unit/langfuse/langfuse-trace.test.ts
+++ b/tests/unit/langfuse/langfuse-trace.test.ts
@@ -513,6 +513,75 @@ describe("traceProxyRequest", () => {
     });
   });
 
+  test("should mark missing non-stream output for error traces", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+
+    await traceProxyRequest({
+      session: createMockSession(),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 502,
+      isStreaming: false,
+      errorMessage: "fetch failed",
+    });
+
+    const expectedOutput = {
+      statusCode: 502,
+      errorMessage: "fetch failed",
+      responseMissing: true,
+    };
+    const rootCall = mockStartObservation.mock.calls[0];
+    expect(rootCall[1].output).toEqual(expectedOutput);
+
+    const llmCall = mockRootSpan.startObservation.mock.calls.find(
+      (c: unknown[]) => c[0] === "llm-call"
+    );
+    expect(llmCall[1].output).toEqual(expectedOutput);
+    expect(mockRootSpan.updateTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: expectedOutput,
+      })
+    );
+  });
+
+  test("should mark missing non-stream output when request input exists", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+
+    await traceProxyRequest({
+      session: createMockSession({
+        request: {
+          message: {
+            model: "claude-sonnet-4-20250514",
+            messages: [{ role: "user", content: "Hello" }],
+            stream: false,
+          },
+          model: "claude-sonnet-4-20250514",
+        },
+      }),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 204,
+      isStreaming: false,
+    });
+
+    const expectedOutput = {
+      statusCode: 204,
+      responseMissing: true,
+    };
+    const rootCall = mockStartObservation.mock.calls[0];
+    expect(rootCall[1].output).toEqual(expectedOutput);
+
+    const llmCall = mockRootSpan.startObservation.mock.calls.find(
+      (c: unknown[]) => c[0] === "llm-call"
+    );
+    expect(llmCall[1].output).toEqual(expectedOutput);
+    expect(mockRootSpan.updateTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: expectedOutput,
+      })
+    );
+  });
+
   test("should include costUsd in root span metadata", async () => {
     const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
 

--- a/tests/unit/proxy/combine-abort-signals.test.ts
+++ b/tests/unit/proxy/combine-abort-signals.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { combineAbortSignals } from "@/app/v1/_lib/proxy/combine-abort-signals";
+
+type MutableAbortSignal = { any?: unknown };
+
+describe("combineAbortSignals", () => {
+  describe("native AbortSignal.any path", () => {
+    it("delegates to AbortSignal.any when available and cleanup is noop", () => {
+      const c1 = new AbortController();
+      const c2 = new AbortController();
+
+      const { signal, cleanup } = combineAbortSignals([c1.signal, c2.signal]);
+
+      expect(signal.aborted).toBe(false);
+      c1.abort();
+      expect(signal.aborted).toBe(true);
+
+      // cleanup should be safe to call (noop) — no listeners owned by us.
+      expect(() => cleanup()).not.toThrow();
+    });
+  });
+
+  describe("polyfill path (AbortSignal.any unavailable)", () => {
+    let originalAny: unknown;
+
+    beforeEach(() => {
+      originalAny = (AbortSignal as MutableAbortSignal).any;
+      // 赋 undefined 让 helper 的 `typeof ... === "function"` check 走 polyfill；
+      // delete 在部分 V8 版本上对 static 不生效，赋值更可靠。
+      (AbortSignal as MutableAbortSignal).any = undefined;
+    });
+
+    afterEach(() => {
+      (AbortSignal as MutableAbortSignal).any = originalAny;
+    });
+
+    it("aborts combined signal when any source aborts", () => {
+      const c1 = new AbortController();
+      const c2 = new AbortController();
+
+      const { signal } = combineAbortSignals([c1.signal, c2.signal]);
+      expect(signal.aborted).toBe(false);
+      c2.abort();
+      expect(signal.aborted).toBe(true);
+    });
+
+    it("source-side abort listeners are detached after cleanup is invoked", () => {
+      const c1 = new AbortController();
+      const c2 = new AbortController();
+
+      const { signal, cleanup } = combineAbortSignals([c1.signal, c2.signal]);
+      expect(signal.aborted).toBe(false);
+
+      // 模拟请求正常完成：调用方在 finally 中触发 cleanup。
+      cleanup();
+
+      // 源信号此后再 abort，不应再传播到组合信号（listener 已解绑）。
+      c1.abort();
+      c2.abort();
+      expect(signal.aborted).toBe(false);
+    });
+
+    it("auto-cleans listeners when a source aborts (does not require explicit cleanup)", () => {
+      const c1 = new AbortController();
+      const c2 = new AbortController();
+
+      const { signal, cleanup } = combineAbortSignals([c1.signal, c2.signal]);
+      c1.abort();
+      expect(signal.aborted).toBe(true);
+
+      // 二次 cleanup 必须幂等（请求结束的 finally 仍会调）。
+      expect(() => cleanup()).not.toThrow();
+      expect(() => cleanup()).not.toThrow();
+    });
+
+    it("immediately aborts and cleans up when a source signal is already aborted", () => {
+      const c1 = new AbortController();
+      c1.abort();
+      const c2 = new AbortController();
+
+      const { signal, cleanup } = combineAbortSignals([c1.signal, c2.signal]);
+      expect(signal.aborted).toBe(true);
+
+      // 后到的源 abort 不应再触发任何路径（已 cleanup）。
+      c2.abort();
+      expect(signal.aborted).toBe(true);
+      expect(() => cleanup()).not.toThrow();
+    });
+  });
+});

--- a/tests/unit/proxy/error-handler-langfuse-trace.test.ts
+++ b/tests/unit/proxy/error-handler-langfuse-trace.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  emitProxyLangfuseTrace: vi.fn(),
+  getCachedSystemSettings: vi.fn(async () => ({
+    verboseProviderError: false,
+    passThroughUpstreamErrorMessage: false,
+  })),
+  getErrorOverrideAsync: vi.fn(async () => undefined),
+  updateMessageRequestDetails: vi.fn(async () => undefined),
+  updateMessageRequestDuration: vi.fn(async () => undefined),
+  endRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/langfuse/emit-proxy-trace", () => ({
+  emitProxyLangfuseTrace: mocks.emitProxyLangfuseTrace,
+}));
+
+vi.mock("@/lib/config/system-settings-cache", () => ({
+  getCachedSystemSettings: mocks.getCachedSystemSettings,
+}));
+
+vi.mock("@/repository/message", () => ({
+  updateMessageRequestDetails: mocks.updateMessageRequestDetails,
+  updateMessageRequestDuration: mocks.updateMessageRequestDuration,
+}));
+
+vi.mock("@/lib/proxy-status-tracker", () => ({
+  ProxyStatusTracker: {
+    getInstance: () => ({
+      endRequest: mocks.endRequest,
+    }),
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    trace: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+vi.mock("@/app/v1/_lib/proxy/errors", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/v1/_lib/proxy/errors")>();
+  return {
+    ...actual,
+    getErrorOverrideAsync: mocks.getErrorOverrideAsync,
+  };
+});
+
+import { ProxyErrorHandler } from "@/app/v1/_lib/proxy/error-handler";
+import { ProxyError, RateLimitError } from "@/app/v1/_lib/proxy/errors";
+
+function createSession(overrides: Record<string, unknown> = {}): any {
+  const requestMessage = {
+    model: "claude-sonnet-4-20250514",
+    messages: [{ role: "user", content: "hello" }],
+  };
+
+  return {
+    sessionId: "s_langfuse_error",
+    messageContext: {
+      id: "msg_langfuse_error",
+      user: { id: 42, name: "test-user" },
+      key: { name: "test-key" },
+    },
+    startTime: Date.now() - 25,
+    method: "POST",
+    originalFormat: "claude",
+    request: {
+      message: requestMessage,
+      model: requestMessage.model,
+      log: JSON.stringify(requestMessage),
+    },
+    headers: new Headers({ "user-agent": "vitest" }),
+    provider: {
+      id: 7,
+      name: "provider-a",
+      providerType: "claude",
+      swapCacheTtlBilling: false,
+    },
+    getProviderChain: () => [],
+    getCurrentModel: () => requestMessage.model,
+    getContext1mApplied: () => false,
+    getGroupCostMultiplier: () => 1,
+    getSpecialSettings: () => null,
+    getEndpoint: () => "/v1/messages",
+    getRequestSequence: () => 1,
+    ...overrides,
+  };
+}
+
+describe("ProxyErrorHandler.handle - Langfuse error traces", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getCachedSystemSettings.mockResolvedValue({
+      verboseProviderError: false,
+      passThroughUpstreamErrorMessage: false,
+    });
+    mocks.getErrorOverrideAsync.mockResolvedValue(undefined);
+  });
+
+  test("emits trace for local request errors without upstream output", async () => {
+    const session = createSession();
+
+    await ProxyErrorHandler.handle(session, new ProxyError("Invalid request: missing model", 400));
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseHeaders: expect.any(Headers),
+        responseText: "",
+        usageMetrics: null,
+        costUsd: undefined,
+        statusCode: 400,
+        isStreaming: false,
+        errorMessage: "Invalid request: missing model",
+      })
+    );
+    expect(mocks.emitProxyLangfuseTrace.mock.calls[0][1].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("emits trace for thrown network errors without upstream output", async () => {
+    const session = createSession();
+
+    await ProxyErrorHandler.handle(session, new Error("fetch failed"));
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "",
+        statusCode: 500,
+        isStreaming: false,
+        errorMessage: "fetch failed",
+      })
+    );
+  });
+
+  test("emits trace before database persistence failures can abort handling", async () => {
+    const session = createSession();
+    mocks.updateMessageRequestDuration.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(ProxyErrorHandler.handle(session, new Error("fetch failed"))).rejects.toThrow(
+      "db down"
+    );
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "",
+        statusCode: 500,
+        errorMessage: "fetch failed",
+      })
+    );
+  });
+
+  test("uses upstream raw body as trace output when available", async () => {
+    const session = createSession();
+    const error = new ProxyError("Upstream failed", 502, {
+      body: "sanitized upstream body",
+      rawBody: '{"error":{"message":"raw upstream failure"}}',
+      rawBodyTruncated: false,
+      providerId: 7,
+      providerName: "provider-a",
+    });
+
+    await ProxyErrorHandler.handle(session, error);
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: '{"error":{"message":"raw upstream failure"}}',
+        statusCode: 502,
+        errorMessage: expect.stringContaining("Upstream failed"),
+      })
+    );
+  });
+
+  test("falls back to upstream body when raw body is missing", async () => {
+    const session = createSession();
+    const error = new ProxyError("Upstream failed", 502, {
+      body: "sanitized upstream body",
+      rawBodyTruncated: false,
+      providerId: 7,
+      providerName: "provider-a",
+    });
+
+    await ProxyErrorHandler.handle(session, error);
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "sanitized upstream body",
+        statusCode: 502,
+        errorMessage: expect.stringContaining("Upstream failed"),
+      })
+    );
+  });
+
+  test("preserves streaming request context for early error traces", async () => {
+    const requestMessage = {
+      model: "claude-sonnet-4-20250514",
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+    };
+    const session = createSession({
+      request: {
+        message: requestMessage,
+        model: requestMessage.model,
+        log: JSON.stringify(requestMessage),
+      },
+    });
+
+    await ProxyErrorHandler.handle(session, new Error("fetch failed"));
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "",
+        statusCode: 500,
+        isStreaming: true,
+        sseEventCount: 0,
+        errorMessage: "fetch failed",
+      })
+    );
+  });
+
+  test("detects Gemini SSE URLs as streaming for early error traces", async () => {
+    const session = createSession({
+      requestUrl: new URL(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:streamGenerateContent?alt=sse"
+      ),
+    });
+
+    await ProxyErrorHandler.handle(session, new Error("fetch failed"));
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "",
+        statusCode: 500,
+        isStreaming: true,
+        sseEventCount: 0,
+        errorMessage: "fetch failed",
+      })
+    );
+  });
+
+  test("emits trace for rate limit early returns", async () => {
+    const session = createSession();
+
+    await ProxyErrorHandler.handle(
+      session,
+      new RateLimitError("rate_limit_error", "limit exceeded", "daily_quota", 12, 20, null)
+    );
+
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: "",
+        statusCode: 402,
+        isStreaming: false,
+        errorMessage: "limit exceeded",
+      })
+    );
+  });
+});

--- a/tests/unit/proxy/error-handler-langfuse-trace.test.ts
+++ b/tests/unit/proxy/error-handler-langfuse-trace.test.ts
@@ -213,6 +213,12 @@ describe("ProxyErrorHandler.handle - Langfuse error traces", () => {
     expect(mocks.emitProxyLangfuseTrace.mock.calls[0][1].responseText).not.toContain(
       "raw upstream failure"
     );
+    expect(mocks.updateMessageRequestDetails).toHaveBeenCalledWith(
+      session.messageContext.id,
+      expect.objectContaining({
+        statusCode: 429,
+      })
+    );
   });
 
   test("falls back to upstream body when raw body is missing", async () => {

--- a/tests/unit/proxy/error-handler-langfuse-trace.test.ts
+++ b/tests/unit/proxy/error-handler-langfuse-trace.test.ts
@@ -180,6 +180,41 @@ describe("ProxyErrorHandler.handle - Langfuse error traces", () => {
     );
   });
 
+  test("emits final override response and status after error override is applied", async () => {
+    const session = createSession();
+    mocks.getErrorOverrideAsync.mockResolvedValueOnce({
+      statusCode: 429,
+      response: {
+        error: {
+          message: "masked quota message",
+          type: "rate_limit_error",
+        },
+      },
+    });
+
+    const response = await ProxyErrorHandler.handle(
+      session,
+      new ProxyError("Upstream failed", 502, {
+        rawBody: '{"error":{"message":"raw upstream failure"}}',
+        providerId: 7,
+        providerName: "provider-a",
+      })
+    );
+
+    expect(response.status).toBe(429);
+    expect(mocks.emitProxyLangfuseTrace).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({
+        responseText: expect.stringContaining("masked quota message"),
+        statusCode: 429,
+        errorMessage: "masked quota message",
+      })
+    );
+    expect(mocks.emitProxyLangfuseTrace.mock.calls[0][1].responseText).not.toContain(
+      "raw upstream failure"
+    );
+  });
+
   test("falls back to upstream body when raw body is missing", async () => {
     const session = createSession();
     const error = new ProxyError("Upstream failed", 502, {

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -127,6 +127,7 @@ import type { Provider } from "@/types/provider";
 type AttemptRuntime = {
   clearResponseTimeout?: () => void;
   responseController?: AbortController;
+  releaseAgent?: () => void;
 };
 
 function createProvider(overrides: Partial<Provider> = {}): Provider {
@@ -545,11 +546,14 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
 
       const controller1 = new AbortController();
       const controller2 = new AbortController();
+      const releaseInitialAgent = vi.fn();
+      const releaseLoserAgent = vi.fn();
 
       doForward.mockImplementationOnce(async (attemptSession, providerForRequest) => {
         const runtime = attemptSession as ProxySession & AttemptRuntime;
         runtime.responseController = controller1;
         runtime.clearResponseTimeout = vi.fn();
+        runtime.releaseAgent = releaseInitialAgent;
         expect(
           ModelRedirector.apply(attemptSession as ProxySession, providerForRequest as Provider)
         ).toBe(true);
@@ -564,6 +568,7 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
         const runtime = attemptSession as ProxySession & AttemptRuntime;
         runtime.responseController = controller2;
         runtime.clearResponseTimeout = vi.fn();
+        runtime.releaseAgent = releaseLoserAgent;
         expect(
           ModelRedirector.apply(attemptSession as ProxySession, providerForRequest as Provider)
         ).toBe(true);
@@ -601,6 +606,8 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
         billingModel: requestedModel,
       });
       expect(mocks.releaseProviderSession).toHaveBeenCalledWith(fireworks.id, "sess-hedge");
+      expect(releaseInitialAgent).toHaveBeenCalledTimes(1);
+      expect(releaseLoserAgent).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -613,6 +613,75 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
     }
   });
 
+  test("hedge loser 在 releaseAgent 晚到时仍会释放 agent cleanup", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const slow = createProvider({ id: 383, name: "slow", firstByteTimeoutStreamingMs: 100 });
+      const fast = createProvider({ id: 206, name: "fast", firstByteTimeoutStreamingMs: 100 });
+      const session = createSession();
+      setProviderWithSessionRef(session, slow);
+      session.addProviderToChain(slow, { reason: "initial_selection" });
+
+      mocks.pickRandomProviderWithExclusion.mockResolvedValueOnce(fast);
+
+      const doForward = vi.spyOn(
+        ProxyForwarder as unknown as {
+          doForward: (...args: unknown[]) => Promise<Response>;
+        },
+        "doForward"
+      );
+
+      const slowController = new AbortController();
+      const fastController = new AbortController();
+      const releaseSlowAgent = vi.fn();
+      const releaseFastAgent = vi.fn();
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        await new Promise<void>((resolve) => setTimeout(resolve, 180));
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = slowController;
+        runtime.clearResponseTimeout = vi.fn();
+        runtime.releaseAgent = releaseSlowAgent;
+        return createStreamingResponse({
+          label: "slow",
+          firstChunkDelayMs: 0,
+          controller: slowController,
+        });
+      });
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = fastController;
+        runtime.clearResponseTimeout = vi.fn();
+        runtime.releaseAgent = releaseFastAgent;
+        return createStreamingResponse({
+          label: "fast",
+          firstChunkDelayMs: 20,
+          controller: fastController,
+        });
+      });
+
+      const responsePromise = ProxyForwarder.send(session);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(doForward).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(50);
+      const response = await responsePromise;
+      expect(await response.text()).toContain('"provider":"fast"');
+      expect(releaseSlowAgent).not.toHaveBeenCalled();
+      expect(releaseFastAgent).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(150);
+
+      expect(releaseSlowAgent).toHaveBeenCalledTimes(1);
+      expect(releaseFastAgent).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("public hedge path should retain redirect on shadow retry_failed entries", async () => {
     vi.useFakeTimers();
 

--- a/tests/unit/proxy/proxy-forwarder-provider-session-release.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-provider-session-release.test.ts
@@ -109,4 +109,61 @@ describe("ProxyForwarder provider failure session release", () => {
     expect(failedProviderIds).toEqual([42]);
     expect(mocks.releaseProviderSession).not.toHaveBeenCalled();
   });
+
+  it("同步 hedge 胜出 shadow session 时保留 releaseAgent cleanup 回调", async () => {
+    const { ProxyForwarder } = await import("@/app/v1/_lib/proxy/forwarder");
+    const forwarderInternals = ProxyForwarder as unknown as {
+      syncWinningAttemptSession: (target: ProxySession, source: ProxySession) => void;
+    };
+    const clearResponseTimeout = vi.fn();
+    const releaseAgent = vi.fn();
+    const responseController = new AbortController();
+    const setTargetCacheTtlResolved = vi.fn();
+    const setTargetContext1mApplied = vi.fn();
+    const target = {
+      request: { message: null, buffer: null, log: null, note: null },
+      requestUrl: new URL("https://example.com/v1/messages"),
+      forwardedRequestBody: null,
+      providerChain: [],
+      specialSettings: [],
+      originalModelName: null,
+      originalUrlPathname: null,
+      currentModelRedirect: null,
+      getCacheTtlResolved: vi.fn(() => null),
+      setCacheTtlResolved: setTargetCacheTtlResolved,
+      getContext1mApplied: vi.fn(() => false),
+      setContext1mApplied: setTargetContext1mApplied,
+    } as unknown as ProxySession;
+    const source = {
+      request: { message: "winner", buffer: null, log: null, note: null },
+      requestUrl: new URL("https://shadow.example.com/v1/messages"),
+      forwardedRequestBody: '{"model":"winner"}',
+      providerChain: [],
+      specialSettings: [],
+      originalModelName: "winner-model",
+      originalUrlPathname: "/v1/messages",
+      currentModelRedirect: null,
+      getCacheTtlResolved: vi.fn(() => "5m"),
+      setCacheTtlResolved: vi.fn(),
+      getContext1mApplied: vi.fn(() => true),
+      setContext1mApplied: vi.fn(),
+      clearResponseTimeout,
+      responseController,
+      releaseAgent,
+    } as unknown as ProxySession;
+
+    forwarderInternals.syncWinningAttemptSession(target, source);
+
+    expect(
+      (target as ProxySession & { clearResponseTimeout?: () => void }).clearResponseTimeout
+    ).toBe(clearResponseTimeout);
+    expect(
+      (target as ProxySession & { responseController?: AbortController }).responseController
+    ).toBe(responseController);
+    expect((target as ProxySession & { releaseAgent?: () => void }).releaseAgent).toBe(
+      releaseAgent
+    );
+    expect(setTargetCacheTtlResolved).toHaveBeenCalledWith("5m");
+    expect(setTargetContext1mApplied).toHaveBeenCalledWith(true);
+  });
 });

--- a/tests/unit/repository/leaderboard-provider-metrics.test.ts
+++ b/tests/unit/repository/leaderboard-provider-metrics.test.ts
@@ -691,3 +691,52 @@ describe("Model Leaderboard basis handling", () => {
     });
   });
 });
+
+describe("Model Leaderboard sort order", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    selectCallIndex = 0;
+    chainMocks = [];
+    mockSelect.mockClear();
+    mocks.resolveSystemTimezone.mockResolvedValue("UTC");
+    mocks.getSystemSettings.mockResolvedValue({ billingModelSource: "redirected" });
+  });
+
+  it("orders by total cost descending with request count as tiebreaker", async () => {
+    chainMocks = [
+      createChainMock([
+        {
+          model: "expensive-low-volume",
+          totalRequests: 5,
+          totalCost: "50.0",
+          totalTokens: 1000,
+          successRate: 1.0,
+        },
+        {
+          model: "cheap-high-volume",
+          totalRequests: 200,
+          totalCost: "1.0",
+          totalTokens: 100000,
+          successRate: 1.0,
+        },
+      ]),
+    ];
+
+    const { findDailyModelLeaderboard } = await import("@/repository/leaderboard");
+    const result = await findDailyModelLeaderboard();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].model).toBe("expensive-low-volume");
+    expect(result[0].totalCost).toBe(50);
+    expect(result[1].model).toBe("cheap-high-volume");
+    expect(result[1].totalCost).toBe(1);
+
+    const orderByMock = chainMocks[0].orderBy;
+    expect(orderByMock).toHaveBeenCalledTimes(1);
+
+    const args = orderByMock.mock.calls[0];
+    expect(args).toHaveLength(2);
+    expect(JSON.stringify(args[0])).toContain("sum");
+    expect(JSON.stringify(args[1])).toContain("count");
+  });
+});

--- a/tests/unit/settings/prices-layout.test.ts
+++ b/tests/unit/settings/prices-layout.test.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+function readProjectFile(...segments: string[]) {
+  return fs.readFileSync(path.join(process.cwd(), ...segments), "utf8");
+}
+
+describe("settings prices layout constraints", () => {
+  test("settings content column can shrink inside the centered page container", () => {
+    const source = readProjectFile("src/app/[locale]/settings/layout.tsx");
+
+    expect(source).toContain('className="mx-auto w-full max-w-7xl');
+    expect(source).toContain('className="min-w-0 space-y-6"');
+  });
+
+  test("price table scrolls horizontally inside its settings section", () => {
+    const source = readProjectFile("src/app/[locale]/settings/prices/_components/price-list.tsx");
+
+    expect(source).toMatch(/<div className="[^"]*overflow-x-auto[^"]*overflow-y-hidden[^"]*"/);
+    expect(source).toMatch(/<table className="[^"]*min-w-\[[^\]]+\][^"]*table-fixed[^"]*"/);
+  });
+});


### PR DESCRIPTION
## Summary
Release v0.7.4 - A maintenance release containing 8 bug fixes and improvements across i18n, billing, proxy stability, quota management, and dashboard accuracy.

## Included PRs

### 1. fix(i18n): refresh server chrome on locale switch (#1116)
**Problem:** After switching locale, server-rendered navigation headings and descriptions could display stale translations while client components updated correctly.

**Solution:** Pass `[locale]` route param explicitly to all server-side `getTranslations` calls and add a locale-switch refresh guard in `LanguageSwitcher` to re-fetch the RSC tree after locale navigation.

**Files:** `language-switcher.tsx`, `dashboard-header.tsx`, `settings/layout.tsx`, and 18 other route pages

---

### 2. fix(billing): charge redirected per-request image responses (#1119)
**Problem:** Image API requests (OpenAI Images API) without token usage data were bypassing billing when model redirects occurred with per-request pricing configured.

**Solution:** Introduced `resolveBillableUsageMetricsForCost()` to synthesize billable usage metrics for successful responses without token usage when `input_cost_per_request` is configured.

**Files:** `response-handler.ts`, `billing-model-source.test.ts`

---

### 3. fix: trace proxy errors in Langfuse (#1120)
**Problem:** Proxy errors (rate limits, network errors, upstream errors) were not being traced in Langfuse, making debugging difficult.

**Solution:** Extracted shared `emitProxyLangfuseTrace` helper and wired it into `ProxyErrorHandler` to emit traces for all error paths before database persistence.

**Files:** `emit-proxy-trace.ts`, `error-handler.ts`, `response-handler.ts`, `error-handler-langfuse-trace.test.ts`

---

### 4. fix(dashboard): order model leaderboard by total cost (#1127)
**Problem:** Model leaderboard was sorting by request count instead of cost, causing expensive low-volume models to rank below cheap high-volume ones.

**Solution:** Changed `ORDER BY` from `count(*)` to `sum(cost_usd) DESC` with `count(*)` as tiebreaker.

**Files:** `leaderboard.ts`, `leaderboard-provider-metrics.test.ts`

---

### 5. fix total quota (#1126)
**Problem:** The quota system lacked a lifetime/total cost limit, preventing administrators from setting hard budget caps.

**Solution:** Added `limitTotalUsd` (total cost limit) support for both providers and API keys, with UI components and i18n translations for all 5 languages.

**Files:** `providers.ts`, `quota-helpers.ts`, `provider-quota-list-item.tsx`, `keys-quota-client.tsx`, `edit-key-quota-dialog.tsx`, `messages/*/quota.json`

---

### 6. fix(proxy): clean up combined abort signal listeners (#1121)
**Problem:** Memory leak in `AbortSignal.any` polyfill where abort listeners were never detached on normal request completion, preventing GC of session and request body.

**Solution:** Extracted `combine-abort-signals.ts` helper returning explicit `{ signal, cleanup }` pair; integrated cleanup into all exit paths.

**Files:** `combine-abort-signals.ts`, `forwarder.ts`, `combine-abort-signals.test.ts`

---

### 7. fix(leaderboard): ORDER BY 添加 COALESCE 以统一 NULL 排序行为 (#1128)
**Problem:** Leaderboard queries used `COALESCE(sum(costUsd), 0)` in SELECT but bare `sum(costUsd)` in ORDER BY, causing NULL groups to sort first in PostgreSQL DESC.

**Solution:** Added `COALESCE(sum(costUsd), 0)` to all 5 leaderboard ORDER BY clauses for consistent NULL handling.

**Files:** `leaderboard.ts`

---

### 8. fix(settings): constrain pricing table layout (#1129)
**Problem:** Wide pricing tables could overflow the centered max-width container, breaking horizontal layout on smaller screens.

**Solution:** Added `min-w-0` to content area and enabled horizontal scrolling on pricing table with `overflow-x-auto`.

**Files:** `settings/layout.tsx`, `price-list.tsx`, `prices-layout.test.ts`

## Breaking Changes
None. All changes are backward-compatible bug fixes.

## Testing
- All 8 PRs have passed:
  - `bun run build` - Production build
  - `bun run lint` - Biome linting
  - `bun run typecheck` - TypeScript type checking
  - `bun run test` - Unit and integration tests (5222+ tests)

## Migration
No migration required. Deploy and restart services.

---
*Release PR for v0.7.4*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This release bundles 8 targeted bug fixes: an AbortSignal listener memory leak in the proxy, per-request image billing for redirect scenarios, Langfuse tracing for error paths, leaderboard sort-order corrections (cost vs. count, COALESCE NULL handling), a lifetime quota (`limitTotalUsd`) for providers and API keys, an i18n stale-RSC refresh guard, and a pricing-table layout overflow fix. All changes are backward-compatible and covered by new unit/integration tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all changes are backward-compatible bug fixes with thorough test coverage. The single finding is a Langfuse observability gap that does not affect billing correctness.

Only P2 findings present (incomplete costUsd in one Langfuse trace within finalizeRequestStats). Billing DB writes, quota enforcement, leaderboard ordering, and the memory-leak fix are all correct. 5000+ tests pass.

src/app/v1/_lib/proxy/response-handler.ts — the perRequestCostUsd computed in finalizeRequestStats is not forwarded to the existing emitProxyLangfuseTrace at the end of the function.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/combine-abort-signals.ts | New helper that wraps AbortSignal.any with an explicit cleanup pair; polyfill path uses { once: true } listeners and a cleaned-flag guard to prevent double-cleanup. Correct and well-tested. |
| src/app/v1/_lib/proxy/forwarder.ts | Adopts combineAbortSignals and calls cleanupCombinedSignal in every early-exit throw path; success path merges cleanup into releaseAgent which response-handler already calls idempotently. Memory-leak fix is comprehensive. |
| src/app/v1/_lib/proxy/response-handler.ts | Adds resolveBillableUsageMetricsForCost() for per-request image billing and wires emitProxyLangfuseTrace into both redirect paths; perRequestCostUsd in finalizeRequestStats is not forwarded to the existing trace at the function's end. |
| src/app/v1/_lib/proxy/error-handler.ts | Extracts finalizeErrorResponse closure to emit Langfuse traces before DB persistence in all non-rate-limit error paths; rate-limit path uses a direct emitErrorTrace call. Logic is sound. |
| src/lib/langfuse/emit-proxy-trace.ts | Clean extraction of the fire-and-forget Langfuse trace helper from response-handler.ts; shared by both response and error handlers. |
| src/repository/leaderboard.ts | All five ORDER BY clauses updated from bare sum(costUsd) to COALESCE(sum(costUsd), 0); model leaderboard sort changed from count(*) to cost. Both fixes are correct. |
| src/actions/providers.ts | Adds limitTotalUsd tracking to both single-provider and batch provider usage queries; adds missing cache invalidation call after resetProviderTotalUsage. |
| src/lib/utils/quota-helpers.ts | Adds optional costTotal field with correct optional-chaining guards in hasKeyQuotaSet and getMaxUsageRate. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Proxy Request] --> B{Response Type}
    B -->|SSE / Streaming| C[processStreamingResponse]
    B -->|Non-Streaming| D[processNonStreamingResponse]
    B -->|Gemini Passthrough| E[Gemini passthrough handler]

    C --> F[finalizeDeferredStreamingFinalization]
    D --> G[resolveBillableUsageMetricsForCost]
    E --> G
    F --> G

    G -->|has token usage| H[return usageMetrics]
    G -->|no token usage + per-request price| I[return sentinel 0,0]
    G -->|no token usage + no price config| J[return null - no billing]

    H --> K[updateRequestCostFromUsage]
    I --> K
    J --> L[skip billing]

    K --> M[trackCostToRedis]
    M --> N[emitProxyLangfuseTrace]

    B -->|Error path| O[ProxyErrorHandler]
    O --> P[emitErrorTrace via emitProxyLangfuseTrace]
    P --> Q[logErrorToDatabase]

    A --> R[combineAbortSignals]
    R -->|native AbortSignal.any| S[NOOP cleanup]
    R -->|polyfill| T[explicit cleanup via releaseAgent]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/response-handler.ts
Line: 4079-4089

Comment:
**Per-request cost missing from `finalizeRequestStats` Langfuse trace**

The new `perRequestCostUsd` computed in the `if (!usageMetrics)` block (lines ~3648–3700) is never forwarded to the `emitProxyLangfuseTrace` call at the end of the function. That trace always emits `costUsd: undefined`, so any redirect + per-request-priced image response that flows through `finalizeRequestStats` will appear cost-free in Langfuse even though the DB entry is correct. Consider capturing `perRequestCostUsd` in a wider scope and passing it here:

```typescript
// Hoist before the if (!usageMetrics) block:
let perRequestCostUsd: string | undefined;

// ... existing billing logic sets perRequestCostUsd ...

emitProxyLangfuseTrace(session, {
  responseHeaders: new Headers(),
  responseText: "",
  usageMetrics: null,
  costUsd: perRequestCostUsd,   // was: undefined
  statusCode,
  durationMs: duration,
  isStreaming: phase === "stream",
  sseEventCount: phase === "stream" ? 0 : undefined,
  errorMessage,
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(proxy): release late hedge loser age..."](https://github.com/ding113/claude-code-hub/commit/955dab3f08bab2772331527c42fa4ef16a0113be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29973780)</sub>

<!-- /greptile_comment -->