### PR TITLE
feat(proxy): add fake streaming whitelist

### DIFF
--- a/drizzle/0099_equal_expediter.sql
+++ b/drizzle/0099_equal_expediter.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "system_settings" ADD COLUMN "fake_streaming_whitelist" jsonb;

--- a/drizzle/meta/0099_snapshot.json
+++ b/drizzle/meta/0099_snapshot.json
@@ -1,0 +1,4477 @@
+{
+  "id": "0121f242-24bd-4fb5-b4c4-1889677099c5",
+  "prevId": "6014bb32-638d-4ca1-bb4b-16d9f3fe0e01",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action_category": {
+          "name": "action_category",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_value": {
+          "name": "before_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_value": {
+          "name": "after_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_user_id": {
+          "name": "operator_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_user_name": {
+          "name": "operator_user_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_key_id": {
+          "name": "operator_key_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_key_name": {
+          "name": "operator_key_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_ip": {
+          "name": "operator_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_category_created_at": {
+          "name": "idx_audit_log_category_created_at",
+          "columns": [
+            {
+              "expression": "action_category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_operator_user_created_at": {
+          "name": "idx_audit_log_operator_user_created_at",
+          "columns": [
+            {
+              "expression": "operator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"operator_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_operator_ip_created_at": {
+          "name": "idx_audit_log_operator_ip_created_at",
+          "columns": [
+            {
+              "expression": "operator_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"operator_ip\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_target": {
+          "name": "idx_audit_log_target",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"audit_log\".\"target_type\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_created_at_id": {
+          "name": "idx_audit_log_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_rules": {
+      "name": "error_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regex'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_response": {
+          "name": "override_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "override_status_code": {
+          "name": "override_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_error_rules_enabled": {
+          "name": "idx_error_rules_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_pattern": {
+          "name": "unique_pattern",
+          "columns": [
+            {
+              "expression": "pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_category": {
+          "name": "idx_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_match_type": {
+          "name": "idx_match_type",
+          "columns": [
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_login_web_ui": {
+          "name": "can_login_web_ui",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_reset_mode": {
+          "name": "limit_5h_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rolling'"
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_reset_at": {
+          "name": "cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_keys_user_id": {
+          "name": "idx_keys_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_key": {
+          "name": "idx_keys_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_created_at": {
+          "name": "idx_keys_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_keys_deleted_at": {
+          "name": "idx_keys_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_request": {
+      "name": "message_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_cost_multiplier": {
+          "name": "group_cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_breakdown": {
+          "name": "cost_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "provider_chain": {
+          "name": "provider_chain",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_response_model": {
+          "name": "actual_response_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "swap_cache_ttl_applied": {
+          "name": "swap_cache_ttl_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "special_settings": {
+          "name": "special_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_cause": {
+          "name": "error_cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages_count": {
+          "name": "messages_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_message_request_user_date_cost": {
+          "name": "idx_message_request_user_date_cost",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_created_at_cost_stats": {
+          "name": "idx_message_request_user_created_at_cost_stats",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_query": {
+          "name": "idx_message_request_user_query",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_created_at_active": {
+          "name": "idx_message_request_provider_created_at_active",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_created_at_finalized_active": {
+          "name": "idx_message_request_provider_created_at_finalized_active",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"status_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_id": {
+          "name": "idx_message_request_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_id_prefix": {
+          "name": "idx_message_request_session_id_prefix",
+          "columns": [
+            {
+              "expression": "\"session_id\" varchar_pattern_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_seq": {
+          "name": "idx_message_request_session_seq",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_endpoint": {
+          "name": "idx_message_request_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_blocked_by": {
+          "name": "idx_message_request_blocked_by",
+          "columns": [
+            {
+              "expression": "blocked_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_provider_id": {
+          "name": "idx_message_request_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_user_id": {
+          "name": "idx_message_request_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key": {
+          "name": "idx_message_request_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_created_at_id": {
+          "name": "idx_message_request_key_created_at_id",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_model_active": {
+          "name": "idx_message_request_key_model_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"model\" IS NOT NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_endpoint_active": {
+          "name": "idx_message_request_key_endpoint_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"endpoint\" IS NOT NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_created_at_id_active": {
+          "name": "idx_message_request_created_at_id_active",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_model_active": {
+          "name": "idx_message_request_model_active",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"model\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_status_code_active": {
+          "name": "idx_message_request_status_code_active",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"status_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_created_at": {
+          "name": "idx_message_request_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_deleted_at": {
+          "name": "idx_message_request_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_last_active": {
+          "name": "idx_message_request_key_last_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_key_cost_active": {
+          "name": "idx_message_request_key_cost_active",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND (\"message_request\".\"blocked_by\" IS NULL OR \"message_request\".\"blocked_by\" <> 'warmup')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_session_user_info": {
+          "name": "idx_message_request_session_user_info",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_message_request_client_ip_created_at": {
+          "name": "idx_message_request_client_ip_created_at",
+          "columns": [
+            {
+              "expression": "client_ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_request\".\"deleted_at\" IS NULL AND \"message_request\".\"client_ip\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_prices": {
+      "name": "model_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_data": {
+          "name": "price_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'litellm'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_prices_latest": {
+          "name": "idx_model_prices_latest",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_model_name": {
+          "name": "idx_model_prices_model_name",
+          "columns": [
+            {
+              "expression": "model_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_created_at": {
+          "name": "idx_model_prices_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_prices_source": {
+          "name": "idx_model_prices_source",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_settings": {
+      "name": "notification_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_legacy_mode": {
+          "name": "use_legacy_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_enabled": {
+          "name": "circuit_breaker_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "circuit_breaker_webhook": {
+          "name": "circuit_breaker_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_enabled": {
+          "name": "daily_leaderboard_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "daily_leaderboard_webhook": {
+          "name": "daily_leaderboard_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_leaderboard_time": {
+          "name": "daily_leaderboard_time",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'09:00'"
+        },
+        "daily_leaderboard_top_n": {
+          "name": "daily_leaderboard_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cost_alert_enabled": {
+          "name": "cost_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cost_alert_webhook": {
+          "name": "cost_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_alert_threshold": {
+          "name": "cost_alert_threshold",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.80'"
+        },
+        "cost_alert_check_interval": {
+          "name": "cost_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "cache_hit_rate_alert_enabled": {
+          "name": "cache_hit_rate_alert_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cache_hit_rate_alert_webhook": {
+          "name": "cache_hit_rate_alert_webhook",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit_rate_alert_window_mode": {
+          "name": "cache_hit_rate_alert_window_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "cache_hit_rate_alert_check_interval": {
+          "name": "cache_hit_rate_alert_check_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "cache_hit_rate_alert_historical_lookback_days": {
+          "name": "cache_hit_rate_alert_historical_lookback_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 7
+        },
+        "cache_hit_rate_alert_min_eligible_requests": {
+          "name": "cache_hit_rate_alert_min_eligible_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 20
+        },
+        "cache_hit_rate_alert_min_eligible_tokens": {
+          "name": "cache_hit_rate_alert_min_eligible_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cache_hit_rate_alert_abs_min": {
+          "name": "cache_hit_rate_alert_abs_min",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "cache_hit_rate_alert_drop_rel": {
+          "name": "cache_hit_rate_alert_drop_rel",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.3'"
+        },
+        "cache_hit_rate_alert_drop_abs": {
+          "name": "cache_hit_rate_alert_drop_abs",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.1'"
+        },
+        "cache_hit_rate_alert_cooldown_minutes": {
+          "name": "cache_hit_rate_alert_cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cache_hit_rate_alert_top_n": {
+          "name": "cache_hit_rate_alert_top_n",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_target_bindings": {
+      "name": "notification_target_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule_cron": {
+          "name": "schedule_cron",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_timezone": {
+          "name": "schedule_timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_override": {
+          "name": "template_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_notification_target_binding": {
+          "name": "unique_notification_target_binding",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_type": {
+          "name": "idx_notification_bindings_type",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_bindings_target": {
+          "name": "idx_notification_bindings_target",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_target_bindings_target_id_webhook_targets_id_fk": {
+          "name": "notification_target_bindings_target_id_webhook_targets_id_fk",
+          "tableFrom": "notification_target_bindings",
+          "tableTo": "webhook_targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoint_probe_logs": {
+      "name": "provider_endpoint_probe_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_endpoint_probe_logs_endpoint_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_endpoint_created_at",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoint_probe_logs_created_at": {
+          "name": "idx_provider_endpoint_probe_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk": {
+          "name": "provider_endpoint_probe_logs_endpoint_id_provider_endpoints_id_fk",
+          "tableFrom": "provider_endpoint_probe_logs",
+          "tableTo": "provider_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_endpoints": {
+      "name": "provider_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_probed_at": {
+          "name": "last_probed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_ok": {
+          "name": "last_probe_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_status_code": {
+          "name": "last_probe_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_latency_ms": {
+          "name": "last_probe_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_type": {
+          "name": "last_probe_error_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_error_message": {
+          "name": "last_probe_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uniq_provider_endpoints_vendor_type_url": {
+          "name": "uniq_provider_endpoints_vendor_type_url",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_vendor_type": {
+          "name": "idx_provider_endpoints_vendor_type",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_enabled": {
+          "name": "idx_provider_endpoints_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_pick_enabled": {
+          "name": "idx_provider_endpoints_pick_enabled",
+          "columns": [
+            {
+              "expression": "vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provider_endpoints\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_created_at": {
+          "name": "idx_provider_endpoints_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_endpoints_deleted_at": {
+          "name": "idx_provider_endpoints_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_endpoints_vendor_id_provider_vendors_id_fk": {
+          "name": "provider_endpoints_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "provider_endpoints",
+          "tableTo": "provider_vendors",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_groups": {
+      "name": "provider_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_groups_name_unique": {
+          "name": "provider_groups_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_vendors": {
+      "name": "provider_vendors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "website_domain": {
+          "name": "website_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uniq_provider_vendors_website_domain": {
+          "name": "uniq_provider_vendors_website_domain",
+          "columns": [
+            {
+              "expression": "website_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_vendors_created_at": {
+          "name": "idx_provider_vendors_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_vendor_id": {
+          "name": "provider_vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "group_priorities": {
+          "name": "group_priorities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.0'"
+        },
+        "group_tag": {
+          "name": "group_tag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude'"
+        },
+        "preserve_client_ip": {
+          "name": "preserve_client_ip",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "disable_session_reuse": {
+          "name": "disable_session_reuse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "model_redirects": {
+          "name": "model_redirects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_clients": {
+          "name": "blocked_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "active_time_start": {
+          "name": "active_time_start",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_end": {
+          "name": "active_time_end",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_instructions_strategy": {
+          "name": "codex_instructions_strategy",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'auto'"
+        },
+        "mcp_passthrough_type": {
+          "name": "mcp_passthrough_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "mcp_passthrough_url": {
+          "name": "mcp_passthrough_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_reset_mode": {
+          "name": "limit_5h_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rolling'"
+        },
+        "limit_daily_usd": {
+          "name": "limit_daily_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_cost_reset_at": {
+          "name": "total_cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "max_retry_attempts": {
+          "name": "max_retry_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "circuit_breaker_failure_threshold": {
+          "name": "circuit_breaker_failure_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "circuit_breaker_open_duration": {
+          "name": "circuit_breaker_open_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1800000
+        },
+        "circuit_breaker_half_open_success_threshold": {
+          "name": "circuit_breaker_half_open_success_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "first_byte_timeout_streaming_ms": {
+          "name": "first_byte_timeout_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "streaming_idle_timeout_ms": {
+          "name": "streaming_idle_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_timeout_non_streaming_ms": {
+          "name": "request_timeout_non_streaming_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_preference": {
+          "name": "cache_ttl_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swap_cache_ttl_billing": {
+          "name": "swap_cache_ttl_billing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "context_1m_preference": {
+          "name": "context_1m_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_effort_preference": {
+          "name": "codex_reasoning_effort_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_reasoning_summary_preference": {
+          "name": "codex_reasoning_summary_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_text_verbosity_preference": {
+          "name": "codex_text_verbosity_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_parallel_tool_calls_preference": {
+          "name": "codex_parallel_tool_calls_preference",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_service_tier_preference": {
+          "name": "codex_service_tier_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_max_tokens_preference": {
+          "name": "anthropic_max_tokens_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_thinking_budget_preference": {
+          "name": "anthropic_thinking_budget_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anthropic_adaptive_thinking": {
+          "name": "anthropic_adaptive_thinking",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'null'::jsonb"
+        },
+        "gemini_google_search_preference": {
+          "name": "gemini_google_search_preference",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tpm": {
+          "name": "tpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpm": {
+          "name": "rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rpd": {
+          "name": "rpd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cc": {
+          "name": "cc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_providers_enabled_priority": {
+          "name": "idx_providers_enabled_priority",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_group": {
+          "name": "idx_providers_group",
+          "columns": [
+            {
+              "expression": "group_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_vendor_type_url_active": {
+          "name": "idx_providers_vendor_type_url_active",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_created_at": {
+          "name": "idx_providers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_deleted_at": {
+          "name": "idx_providers_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_vendor_type": {
+          "name": "idx_providers_vendor_type",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_providers_enabled_vendor_type": {
+          "name": "idx_providers_enabled_vendor_type",
+          "columns": [
+            {
+              "expression": "provider_vendor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"providers\".\"deleted_at\" IS NULL AND \"providers\".\"is_enabled\" = true AND \"providers\".\"provider_vendor_id\" IS NOT NULL AND \"providers\".\"provider_vendor_id\" > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "providers_provider_vendor_id_provider_vendors_id_fk": {
+          "name": "providers_provider_vendor_id_provider_vendors_id_fk",
+          "tableFrom": "providers",
+          "tableTo": "provider_vendors",
+          "columnsFrom": [
+            "provider_vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_filters": {
+      "name": "request_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement": {
+          "name": "replacement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'global'"
+        },
+        "provider_ids": {
+          "name": "provider_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_tags": {
+          "name": "group_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rule_mode": {
+          "name": "rule_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'simple'"
+        },
+        "execution_phase": {
+          "name": "execution_phase",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'guard'"
+        },
+        "operations": {
+          "name": "operations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_request_filters_enabled": {
+          "name": "idx_request_filters_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_scope": {
+          "name": "idx_request_filters_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_action": {
+          "name": "idx_request_filters_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_binding": {
+          "name": "idx_request_filters_binding",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_request_filters_phase": {
+          "name": "idx_request_filters_phase",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "execution_phase",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sensitive_words": {
+      "name": "sensitive_words",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "word": {
+          "name": "word",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'contains'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sensitive_words_enabled": {
+          "name": "idx_sensitive_words_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sensitive_words_created_at": {
+          "name": "idx_sensitive_words_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "site_title": {
+          "name": "site_title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Claude Code Hub'"
+        },
+        "allow_global_usage_view": {
+          "name": "allow_global_usage_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "currency_display": {
+          "name": "currency_display",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "billing_model_source": {
+          "name": "billing_model_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'original'"
+        },
+        "codex_priority_billing_source": {
+          "name": "codex_priority_billing_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_auto_cleanup": {
+          "name": "enable_auto_cleanup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cleanup_retention_days": {
+          "name": "cleanup_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "cleanup_schedule": {
+          "name": "cleanup_schedule",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0 2 * * *'"
+        },
+        "cleanup_batch_size": {
+          "name": "cleanup_batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10000
+        },
+        "enable_client_version_check": {
+          "name": "enable_client_version_check",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verbose_provider_error": {
+          "name": "verbose_provider_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pass_through_upstream_error_message": {
+          "name": "pass_through_upstream_error_message",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_http2": {
+          "name": "enable_http2",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_high_concurrency_mode": {
+          "name": "enable_high_concurrency_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "intercept_anthropic_warmup_requests": {
+          "name": "intercept_anthropic_warmup_requests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enable_thinking_signature_rectifier": {
+          "name": "enable_thinking_signature_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_thinking_budget_rectifier": {
+          "name": "enable_thinking_budget_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_billing_header_rectifier": {
+          "name": "enable_billing_header_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_response_input_rectifier": {
+          "name": "enable_response_input_rectifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allow_non_conversation_endpoint_provider_fallback": {
+          "name": "allow_non_conversation_endpoint_provider_fallback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fake_streaming_whitelist": {
+          "name": "fake_streaming_whitelist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_codex_session_id_completion": {
+          "name": "enable_codex_session_id_completion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_claude_metadata_user_id_injection": {
+          "name": "enable_claude_metadata_user_id_injection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enable_response_fixer": {
+          "name": "enable_response_fixer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "response_fixer_config": {
+          "name": "response_fixer_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"fixTruncatedJson\":true,\"fixSseFormat\":true,\"fixEncoding\":true,\"maxJsonDepth\":200,\"maxFixSize\":1048576}'::jsonb"
+        },
+        "quota_db_refresh_interval_seconds": {
+          "name": "quota_db_refresh_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "quota_lease_percent_5h": {
+          "name": "quota_lease_percent_5h",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_daily": {
+          "name": "quota_lease_percent_daily",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_weekly": {
+          "name": "quota_lease_percent_weekly",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_percent_monthly": {
+          "name": "quota_lease_percent_monthly",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0.05'"
+        },
+        "quota_lease_cap_usd": {
+          "name": "quota_lease_cap_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_extraction_config": {
+          "name": "ip_extraction_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_geo_lookup_enabled": {
+          "name": "ip_geo_lookup_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_status_window_hours": {
+          "name": "public_status_window_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "public_status_aggregation_interval_minutes": {
+          "name": "public_status_aggregation_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_ledger": {
+      "name": "usage_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_provider_id": {
+          "name": "final_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_model": {
+          "name": "original_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_response_model": {
+          "name": "actual_response_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_type": {
+          "name": "api_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_success": {
+          "name": "is_success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "success_rate_outcome": {
+          "name": "success_rate_outcome",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_by": {
+          "name": "blocked_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(21, 15)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "cost_multiplier": {
+          "name": "cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_cost_multiplier": {
+          "name": "group_cost_multiplier",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_5m_input_tokens": {
+          "name": "cache_creation_5m_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_creation_1h_input_tokens": {
+          "name": "cache_creation_1h_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_ttl_applied": {
+          "name": "cache_ttl_applied",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_1m_applied": {
+          "name": "context_1m_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "swap_cache_ttl_applied": {
+          "name": "swap_cache_ttl_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ttfb_ms": {
+          "name": "ttfb_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_ledger_request_id": {
+          "name": "idx_usage_ledger_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_user_created_at": {
+          "name": "idx_usage_ledger_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_key_created_at": {
+          "name": "idx_usage_ledger_key_created_at",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_provider_created_at": {
+          "name": "idx_usage_ledger_provider_created_at",
+          "columns": [
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_created_at_minute": {
+          "name": "idx_usage_ledger_created_at_minute",
+          "columns": [
+            {
+              "expression": "date_trunc('minute', \"created_at\" AT TIME ZONE 'UTC')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_created_at_desc_id": {
+          "name": "idx_usage_ledger_created_at_desc_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_session_id": {
+          "name": "idx_usage_ledger_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"session_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_model": {
+          "name": "idx_usage_ledger_model",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"model\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_key_cost": {
+          "name": "idx_usage_ledger_key_cost",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_user_cost_cover": {
+          "name": "idx_usage_ledger_user_cost_cover",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_provider_cost_cover": {
+          "name": "idx_usage_ledger_provider_cost_cover",
+          "columns": [
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cost_usd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_ledger_key_created_at_desc_cover": {
+          "name": "idx_usage_ledger_key_created_at_desc_cover",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC NULLS LAST",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "final_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"usage_ledger\".\"blocked_by\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "rpm_limit": {
+          "name": "rpm_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_limit_usd": {
+          "name": "daily_limit_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_group": {
+          "name": "provider_group",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "limit_5h_usd": {
+          "name": "limit_5h_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_reset_mode": {
+          "name": "limit_5h_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rolling'"
+        },
+        "limit_weekly_usd": {
+          "name": "limit_weekly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_monthly_usd": {
+          "name": "limit_monthly_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_total_usd": {
+          "name": "limit_total_usd",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_reset_at": {
+          "name": "cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_5h_cost_reset_at": {
+          "name": "limit_5h_cost_reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "limit_concurrent_sessions": {
+          "name": "limit_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_reset_mode": {
+          "name": "daily_reset_mode",
+          "type": "daily_reset_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fixed'"
+        },
+        "daily_reset_time": {
+          "name": "daily_reset_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'00:00'"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_clients": {
+          "name": "allowed_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "allowed_models": {
+          "name": "allowed_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "blocked_clients": {
+          "name": "blocked_clients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_active_role_sort": {
+          "name": "idx_users_active_role_sort",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_enabled_expires_at": {
+          "name": "idx_users_enabled_expires_at",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_tags_gin": {
+          "name": "idx_users_tags_gin",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_users_created_at": {
+          "name": "idx_users_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_deleted_at": {
+          "name": "idx_users_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_targets": {
+      "name": "webhook_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "webhook_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_bot_token": {
+          "name": "telegram_bot_token",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram_chat_id": {
+          "name": "telegram_chat_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dingtalk_secret": {
+          "name": "dingtalk_secret",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_template": {
+          "name": "custom_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_headers": {
+          "name": "custom_headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_fallback_to_direct": {
+          "name": "proxy_fallback_to_direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_test_at": {
+          "name": "last_test_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_result": {
+          "name": "last_test_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.daily_reset_mode": {
+      "name": "daily_reset_mode",
+      "schema": "public",
+      "values": [
+        "fixed",
+        "rolling"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "circuit_breaker",
+        "daily_leaderboard",
+        "cost_alert",
+        "cache_hit_rate_alert"
+      ]
+    },
+    "public.webhook_provider_type": {
+      "name": "webhook_provider_type",
+      "schema": "public",
+      "values": [
+        "wechat",
+        "feishu",
+        "dingtalk",
+        "telegram",
+        "custom"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -694,6 +694,13 @@
       "when": 1776965161943,
       "tag": "0098_equal_selene",
       "breakpoints": true
+    },
+    {
+      "idx": 99,
+      "version": "7",
+      "when": 1777362451734,
+      "tag": "0099_equal_expediter",
+      "breakpoints": true
     }
   ]
 }

--- a/messages/en/settings/config.json
+++ b/messages/en/settings/config.json
@@ -70,6 +70,17 @@
     "enableResponseInputRectifierDesc": "Automatically normalizes non-array input (string shortcut or single message object) in /v1/responses requests to standard array format before processing (enabled by default).",
     "allowNonConversationEndpointProviderFallback": "Allow cross-provider fallback for non-conversation endpoints",
     "allowNonConversationEndpointProviderFallbackDesc": "Controls whether /v1/messages/count_tokens and /v1/responses/compact may reuse the existing decision chain to switch to a compatible provider after the current provider fails. Enabled by default while preserving raw passthrough and non-billing semantics.",
+    "fakeStreaming": {
+      "title": "Fake streaming whitelist",
+      "description": "For long-running synchronous generations (image / video) that exceed Cloudflare's 120s no-body timeout, CCH keeps the SSE connection alive with safe heartbeat pings while it serially calls upstream providers internally and only emits a final, non-empty result. Listed models are auto-enabled; an empty list disables fake streaming entirely.",
+      "modelLabel": "Model",
+      "modelPlaceholder": "exact client-requested model name",
+      "groupsLabel": "Groups",
+      "allGroupsHint": "No groups selected — applies to all provider groups.",
+      "addModel": "Add model",
+      "remove": "Remove",
+      "emptyState": "No models configured. Fake streaming is disabled — use \"Add model\" to enable it for specific models."
+    },
     "enableCodexSessionIdCompletion": "Enable Codex Session ID Completion",
     "enableCodexSessionIdCompletionDesc": "When Codex requests provide only one of session_id (header) or prompt_cache_key (body), automatically completes the other. If both are missing, generates a UUID v7 session id and reuses it stably within the same conversation.",
     "enableClaudeMetadataUserIdInjection": "Enable Claude metadata.user_id Injection",

--- a/messages/ja/settings/config.json
+++ b/messages/ja/settings/config.json
@@ -70,6 +70,17 @@
     "enableResponseInputRectifierDesc": "/v1/responses リクエストの非配列 input（文字列ショートカットまたは role/type 付き単一メッセージオブジェクト）を処理前に標準の配列形式に自動正規化します（既定で有効）。",
     "allowNonConversationEndpointProviderFallback": "非会話エンドポイントのクロスプロバイダ fallback を許可",
     "allowNonConversationEndpointProviderFallbackDesc": "/v1/messages/count_tokens と /v1/responses/compact で現在のプロバイダが失敗した際に、既存の決定チェーンを使って互換プロバイダへ切り替えて再試行するかを制御します。既定で有効で、raw passthrough と非課金の意味論は維持されます。",
+    "fakeStreaming": {
+      "title": "Fake ストリーミング出力ホワイトリスト",
+      "description": "画像 / 動画など Cloudflare の 120 秒ノーボディタイムアウトを超えやすい長時間同期生成では、CCH が SSE ハートビートで接続を維持しつつ内部で上流プロバイダを直列に呼び出し、最終的な非空結果のみをクライアントへ返します。リスト掲載モデルは自動的に有効化、空リストは完全に無効化を意味します。",
+      "modelLabel": "モデル",
+      "modelPlaceholder": "クライアント要求の正確なモデル名",
+      "groupsLabel": "プロバイダグループ",
+      "allGroupsHint": "グループ未選択 → すべてのプロバイダグループに適用されます。",
+      "addModel": "モデル追加",
+      "remove": "削除",
+      "emptyState": "モデル未設定 — fake streaming は無効です。「モデル追加」で対象モデルを設定すると有効化されます。"
+    },
     "enableCodexSessionIdCompletion": "Codex セッションID補完を有効化",
     "enableCodexSessionIdCompletionDesc": "Codex リクエストで session_id（ヘッダー）または prompt_cache_key（ボディ）のどちらか一方しか提供されない場合に、欠けている方を自動補完します。両方ない場合は UUID v7 のセッションIDを生成し、同一対話内で安定して再利用します。",
     "enableClaudeMetadataUserIdInjection": "Claude metadata.user_id 注入を有効化",

--- a/messages/ru/settings/config.json
+++ b/messages/ru/settings/config.json
@@ -70,6 +70,17 @@
     "enableResponseInputRectifierDesc": "Автоматически нормализует не-массивные input (строковые сокращения или одиночные объекты сообщений с role/type) в запросах /v1/responses в стандартный формат массива перед обработкой (включено по умолчанию).",
     "allowNonConversationEndpointProviderFallback": "Разрешить cross-provider fallback для не-диалоговых endpoint",
     "allowNonConversationEndpointProviderFallbackDesc": "Управляет тем, могут ли /v1/messages/count_tokens и /v1/responses/compact при ошибке текущего провайдера использовать существующую decision chain для переключения на совместимый провайдер. По умолчанию включено и сохраняет raw passthrough и non-billing семантику.",
+    "fakeStreaming": {
+      "title": "Список «фейковой» потоковой выдачи",
+      "description": "Для длительных синхронных генераций (изображения / видео), которые могут превысить 120-секундный no-body таймаут Cloudflare, CCH удерживает SSE-соединение безопасными heartbeat-пингами, последовательно опрашивает upstream-провайдеров во внутреннем цикле и отправляет клиенту только финальный непустой результат. Модели в списке включаются автоматически; пустой список полностью отключает функцию.",
+      "modelLabel": "Модель",
+      "modelPlaceholder": "точное имя модели из запроса клиента",
+      "groupsLabel": "Группы провайдеров",
+      "allGroupsHint": "Группы не выбраны — применяется ко всем группам провайдеров.",
+      "addModel": "Добавить модель",
+      "remove": "Удалить",
+      "emptyState": "Модели не настроены — fake streaming отключён. Нажмите «Добавить модель», чтобы включить его для конкретных моделей."
+    },
     "enableCodexSessionIdCompletion": "Включить дополнение Session ID для Codex",
     "enableCodexSessionIdCompletionDesc": "Если в Codex-запросе присутствует только session_id (в заголовках) или prompt_cache_key (в теле), автоматически дополняет отсутствующее поле. Если оба отсутствуют, генерирует UUID v7 и стабильно переиспользует его в рамках одного диалога.",
     "enableClaudeMetadataUserIdInjection": "Включить инъекцию Claude metadata.user_id",

--- a/messages/zh-CN/settings/config.json
+++ b/messages/zh-CN/settings/config.json
@@ -62,6 +62,17 @@
     "enableResponseInputRectifierDesc": "自动将 /v1/responses 请求中的非数组 input（字符串简写或带 role/type 的单消息对象）规范化为标准数组格式后再处理（默认开启）。",
     "allowNonConversationEndpointProviderFallback": "允许非对话端点跨供应商 fallback",
     "allowNonConversationEndpointProviderFallbackDesc": "控制 /v1/messages/count_tokens 与 /v1/responses/compact 在当前供应商失败时，是否沿用现有决策链切换到兼容供应商重试。默认开启，并继续保持 raw passthrough 与非计费语义。",
+    "fakeStreaming": {
+      "title": "Fake 流式输出白名单",
+      "description": "针对图像 / 视频等长耗时同步生成场景（容易超过 Cloudflare 120 秒无响应体超时），CCH 会先返回 SSE 心跳保活，并在内部串行调用上游供应商，仅在最终拿到非空结果时回写最终响应。命中白名单的模型会启用 fake streaming；列表为空表示完全禁用。",
+      "modelLabel": "模型",
+      "modelPlaceholder": "客户端请求中的精确模型名",
+      "groupsLabel": "供应商分组",
+      "allGroupsHint": "未选择分组 → 适用于所有供应商分组。",
+      "addModel": "添加模型",
+      "remove": "删除",
+      "emptyState": "尚未配置任何模型，fake streaming 处于关闭状态。点击 \"添加模型\" 即可为指定模型启用。"
+    },
     "enableCodexSessionIdCompletion": "启用 Codex Session ID 补全",
     "enableCodexSessionIdCompletionDesc": "当 Codex 请求仅提供 session_id（请求头）或 prompt_cache_key（请求体）之一时，自动补全另一个；若两者均缺失，则生成 UUID v7 会话 ID，并在同一对话内稳定复用。",
     "enableClaudeMetadataUserIdInjection": "启用 Claude metadata.user_id 注入",

--- a/messages/zh-TW/settings/config.json
+++ b/messages/zh-TW/settings/config.json
@@ -70,6 +70,17 @@
     "enableResponseInputRectifierDesc": "自動將 /v1/responses 請求中的非陣列 input（字串簡寫或帶 role/type 的單訊息物件）規範化為標準陣列格式後再處理（預設開啟）。",
     "allowNonConversationEndpointProviderFallback": "允許非對話端點跨供應商 fallback",
     "allowNonConversationEndpointProviderFallbackDesc": "控制 /v1/messages/count_tokens 與 /v1/responses/compact 在目前供應商失敗時，是否沿用既有決策鏈切換到相容供應商重試。預設開啟，並持續保持 raw passthrough 與非計費語義。",
+    "fakeStreaming": {
+      "title": "Fake 串流輸出白名單",
+      "description": "針對圖像 / 影片等長耗時同步生成場景（容易超過 Cloudflare 120 秒無回應主體逾時），CCH 會先回傳 SSE 心跳保持連線，在內部串行呼叫上游供應商，僅在最終取得非空結果時才回寫最終回應。命中白名單的模型會啟用 fake streaming；列表為空表示完全停用。",
+      "modelLabel": "模型",
+      "modelPlaceholder": "客戶端請求中的精確模型名稱",
+      "groupsLabel": "供應商分組",
+      "allGroupsHint": "未選擇分組 → 套用於所有供應商分組。",
+      "addModel": "新增模型",
+      "remove": "刪除",
+      "emptyState": "尚未設定任何模型，fake streaming 已關閉。點擊「新增模型」即可為指定模型啟用。"
+    },
     "enableCodexSessionIdCompletion": "啟用 Codex Session ID 補全",
     "enableCodexSessionIdCompletionDesc": "當 Codex 請求僅提供 session_id（請求頭）或 prompt_cache_key（請求體）之一時，自動補全另一個；若兩者皆缺失，則產生 UUID v7 會話 ID，並在同一對話內穩定複用。",
     "enableClaudeMetadataUserIdInjection": "啟用 Claude metadata.user_id 注入",

--- a/src/actions/system-config.ts
+++ b/src/actions/system-config.ts
@@ -14,6 +14,7 @@ import { getSystemSettings, updateSystemSettings } from "@/repository/system-con
 import type { IpExtractionConfig } from "@/types/ip-extraction";
 import type {
   CodexPriorityBillingSource,
+  FakeStreamingWhitelistEntry,
   ResponseFixerConfig,
   SystemSettings,
 } from "@/types/system-config";
@@ -72,6 +73,7 @@ export async function saveSystemSettings(formData: {
   enableBillingHeaderRectifier?: boolean;
   enableResponseInputRectifier?: boolean;
   allowNonConversationEndpointProviderFallback?: boolean;
+  fakeStreamingWhitelist?: FakeStreamingWhitelistEntry[];
   enableCodexSessionIdCompletion?: boolean;
   enableClaudeMetadataUserIdInjection?: boolean;
   enableResponseFixer?: boolean;
@@ -121,6 +123,7 @@ export async function saveSystemSettings(formData: {
       enableResponseInputRectifier: validated.enableResponseInputRectifier,
       allowNonConversationEndpointProviderFallback:
         validated.allowNonConversationEndpointProviderFallback,
+      fakeStreamingWhitelist: validated.fakeStreamingWhitelist,
       enableCodexSessionIdCompletion: validated.enableCodexSessionIdCompletion,
       enableClaudeMetadataUserIdInjection: validated.enableClaudeMetadataUserIdInjection,
       enableResponseFixer: validated.enableResponseFixer,

--- a/src/app/[locale]/settings/config/_components/system-settings-form.tsx
+++ b/src/app/[locale]/settings/config/_components/system-settings-form.tsx
@@ -252,17 +252,28 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
       // (deduped, trimmed) instead of silently dropping later entries. The
       // server-side schema rejects duplicates, so this aggregates client
       // intent before submission.
+      //
+      // Empty groupTags means "all groups" — that is strictly broader than any
+      // explicit tag set, so once any entry for a model selects "all groups"
+      // the merged result must remain empty (do not narrow it by unioning in
+      // explicit tags from sibling rows).
       const merged = new Map<string, Set<string>>();
+      const allGroupsModels = new Set<string>();
       const order: string[] = [];
       for (const entry of fakeStreamingWhitelist) {
         const model = entry.model.trim();
         if (!model) continue;
-        let groups = merged.get(model);
-        if (!groups) {
-          groups = new Set<string>();
-          merged.set(model, groups);
+        if (!merged.has(model)) {
+          merged.set(model, new Set<string>());
           order.push(model);
         }
+        if (entry.groupTags.length === 0) {
+          allGroupsModels.add(model);
+          continue;
+        }
+        if (allGroupsModels.has(model)) continue;
+        const groups = merged.get(model);
+        if (!groups) continue;
         for (const tag of entry.groupTags) {
           const trimmed = tag.trim();
           if (trimmed) groups.add(trimmed);
@@ -270,7 +281,9 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
       }
       return order.map((model) => ({
         model,
-        groupTags: Array.from(merged.get(model) ?? new Set<string>()),
+        groupTags: allGroupsModels.has(model)
+          ? []
+          : Array.from(merged.get(model) ?? new Set<string>()),
       }));
     })();
 

--- a/src/app/[locale]/settings/config/_components/system-settings-form.tsx
+++ b/src/app/[locale]/settings/config/_components/system-settings-form.tsx
@@ -247,24 +247,32 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
       ipExtractionConfigToSave = parsed as IpExtractionConfig;
     }
 
-    const sanitizedFakeStreamingWhitelist: FakeStreamingWhitelistEntry[] = [];
-    {
-      const seenModels = new Set<string>();
+    const sanitizedFakeStreamingWhitelist: FakeStreamingWhitelistEntry[] = (() => {
+      // If the same model is listed multiple times, merge their groupTags
+      // (deduped, trimmed) instead of silently dropping later entries. The
+      // server-side schema rejects duplicates, so this aggregates client
+      // intent before submission.
+      const merged = new Map<string, Set<string>>();
+      const order: string[] = [];
       for (const entry of fakeStreamingWhitelist) {
         const model = entry.model.trim();
-        if (!model || seenModels.has(model)) continue;
-        seenModels.add(model);
-        const groupSeen = new Set<string>();
-        const groupTags: string[] = [];
+        if (!model) continue;
+        let groups = merged.get(model);
+        if (!groups) {
+          groups = new Set<string>();
+          merged.set(model, groups);
+          order.push(model);
+        }
         for (const tag of entry.groupTags) {
           const trimmed = tag.trim();
-          if (!trimmed || groupSeen.has(trimmed)) continue;
-          groupSeen.add(trimmed);
-          groupTags.push(trimmed);
+          if (trimmed) groups.add(trimmed);
         }
-        sanitizedFakeStreamingWhitelist.push({ model, groupTags });
       }
-    }
+      return order.map((model) => ({
+        model,
+        groupTags: Array.from(merged.get(model) ?? new Set<string>()),
+      }));
+    })();
 
     startTransition(async () => {
       const result = await saveSystemSettings({

--- a/src/app/[locale]/settings/config/_components/system-settings-form.tsx
+++ b/src/app/[locale]/settings/config/_components/system-settings-form.tsx
@@ -11,8 +11,11 @@ import {
   MapPin,
   Network,
   Pencil,
+  Plus,
+  Radio,
   Terminal,
   Thermometer,
+  Trash2,
   Wrench,
   Zap,
 } from "lucide-react";
@@ -21,6 +24,7 @@ import { useTranslations } from "next-intl";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { saveSystemSettings } from "@/actions/system-config";
+import { GroupMultiSelect } from "@/app/[locale]/settings/request-filters/_components/group-multi-select";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { InlineWarning } from "@/components/ui/inline-warning";
@@ -49,6 +53,7 @@ import { DEFAULT_IP_EXTRACTION_CONFIG, type IpExtractionConfig } from "@/types/i
 import type {
   BillingModelSource,
   CodexPriorityBillingSource,
+  FakeStreamingWhitelistEntry,
   SystemSettings,
 } from "@/types/system-config";
 
@@ -71,6 +76,7 @@ interface SystemSettingsFormProps {
     | "enableResponseInputRectifier"
     | "enableThinkingBudgetRectifier"
     | "allowNonConversationEndpointProviderFallback"
+    | "fakeStreamingWhitelist"
     | "enableCodexSessionIdCompletion"
     | "enableClaudeMetadataUserIdInjection"
     | "enableResponseFixer"
@@ -144,6 +150,14 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
     allowNonConversationEndpointProviderFallback,
     setAllowNonConversationEndpointProviderFallback,
   ] = useState(initialSettings.allowNonConversationEndpointProviderFallback);
+  const [fakeStreamingWhitelist, setFakeStreamingWhitelist] = useState<
+    FakeStreamingWhitelistEntry[]
+  >(() =>
+    (initialSettings.fakeStreamingWhitelist ?? []).map((entry) => ({
+      model: entry.model,
+      groupTags: [...entry.groupTags],
+    }))
+  );
   const [enableThinkingBudgetRectifier, setEnableThinkingBudgetRectifier] = useState(
     initialSettings.enableThinkingBudgetRectifier
   );
@@ -233,6 +247,25 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
       ipExtractionConfigToSave = parsed as IpExtractionConfig;
     }
 
+    const sanitizedFakeStreamingWhitelist: FakeStreamingWhitelistEntry[] = [];
+    {
+      const seenModels = new Set<string>();
+      for (const entry of fakeStreamingWhitelist) {
+        const model = entry.model.trim();
+        if (!model || seenModels.has(model)) continue;
+        seenModels.add(model);
+        const groupSeen = new Set<string>();
+        const groupTags: string[] = [];
+        for (const tag of entry.groupTags) {
+          const trimmed = tag.trim();
+          if (!trimmed || groupSeen.has(trimmed)) continue;
+          groupSeen.add(trimmed);
+          groupTags.push(trimmed);
+        }
+        sanitizedFakeStreamingWhitelist.push({ model, groupTags });
+      }
+    }
+
     startTransition(async () => {
       const result = await saveSystemSettings({
         siteTitle,
@@ -250,6 +283,7 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
         enableBillingHeaderRectifier,
         enableResponseInputRectifier,
         allowNonConversationEndpointProviderFallback,
+        fakeStreamingWhitelist: sanitizedFakeStreamingWhitelist,
         enableThinkingBudgetRectifier,
         enableCodexSessionIdCompletion,
         enableClaudeMetadataUserIdInjection,
@@ -287,6 +321,12 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
         setEnableResponseInputRectifier(result.data.enableResponseInputRectifier);
         setAllowNonConversationEndpointProviderFallback(
           result.data.allowNonConversationEndpointProviderFallback
+        );
+        setFakeStreamingWhitelist(
+          (result.data.fakeStreamingWhitelist ?? []).map((entry) => ({
+            model: entry.model,
+            groupTags: [...entry.groupTags],
+          }))
         );
         setEnableThinkingBudgetRectifier(result.data.enableThinkingBudgetRectifier);
         setEnableCodexSessionIdCompletion(result.data.enableCodexSessionIdCompletion);
@@ -712,6 +752,109 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
             onCheckedChange={(checked) => setAllowNonConversationEndpointProviderFallback(checked)}
             disabled={isPending}
           />
+        </div>
+
+        {/* Fake Streaming Whitelist */}
+        <div className="p-4 rounded-xl bg-white/[0.02] border border-white/5 space-y-3">
+          <div className="flex items-start gap-3">
+            <div className="w-8 h-8 flex items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-400 shrink-0">
+              <Radio className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-foreground">{t("fakeStreaming.title")}</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {t("fakeStreaming.description")}
+              </p>
+            </div>
+          </div>
+
+          {fakeStreamingWhitelist.length === 0 ? (
+            <p className="text-xs text-muted-foreground italic px-1">
+              {t("fakeStreaming.emptyState")}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {fakeStreamingWhitelist.map((entry, index) => (
+                <div
+                  key={index}
+                  className="rounded-lg border border-border bg-muted/30 p-3 space-y-2"
+                >
+                  <div className="flex items-center gap-2">
+                    <Label
+                      htmlFor={`fake-streaming-model-${index}`}
+                      className="text-xs font-medium text-muted-foreground w-20 shrink-0"
+                    >
+                      {t("fakeStreaming.modelLabel")}
+                    </Label>
+                    <Input
+                      id={`fake-streaming-model-${index}`}
+                      data-testid={`fake-streaming-model-${index}`}
+                      value={entry.model}
+                      onChange={(event) => {
+                        const next = event.target.value;
+                        setFakeStreamingWhitelist((prev) =>
+                          prev.map((item, i) => (i === index ? { ...item, model: next } : item))
+                        );
+                      }}
+                      placeholder={t("fakeStreaming.modelPlaceholder")}
+                      disabled={isPending}
+                      className={inputClassName}
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      data-testid={`fake-streaming-remove-${index}`}
+                      onClick={() => {
+                        setFakeStreamingWhitelist((prev) => prev.filter((_, i) => i !== index));
+                      }}
+                      disabled={isPending}
+                      aria-label={t("fakeStreaming.remove")}
+                      className="shrink-0 text-destructive hover:text-destructive"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <Label className="text-xs font-medium text-muted-foreground w-20 shrink-0 pt-2">
+                      {t("fakeStreaming.groupsLabel")}
+                    </Label>
+                    <div className="flex-1 space-y-1">
+                      <GroupMultiSelect
+                        selectedGroupTags={entry.groupTags}
+                        onChange={(groupTags) => {
+                          setFakeStreamingWhitelist((prev) =>
+                            prev.map((item, i) => (i === index ? { ...item, groupTags } : item))
+                          );
+                        }}
+                        disabled={isPending}
+                      />
+                      {entry.groupTags.length === 0 ? (
+                        <p className="text-[11px] text-muted-foreground">
+                          {t("fakeStreaming.allGroupsHint")}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid="fake-streaming-add"
+            onClick={() => {
+              setFakeStreamingWhitelist((prev) => [...prev, { model: "", groupTags: [] }]);
+            }}
+            disabled={isPending}
+            className="w-full"
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            {t("fakeStreaming.addModel")}
+          </Button>
         </div>
 
         {/* Enable Codex Session ID Completion */}

--- a/src/app/[locale]/settings/config/page.tsx
+++ b/src/app/[locale]/settings/config/page.tsx
@@ -62,6 +62,7 @@ async function SettingsConfigContent({ locale }: { locale: string }) {
             enableResponseInputRectifier: settings.enableResponseInputRectifier,
             allowNonConversationEndpointProviderFallback:
               settings.allowNonConversationEndpointProviderFallback,
+            fakeStreamingWhitelist: settings.fakeStreamingWhitelist,
             enableCodexSessionIdCompletion: settings.enableCodexSessionIdCompletion,
             enableClaudeMetadataUserIdInjection: settings.enableClaudeMetadataUserIdInjection,
             enableResponseFixer: settings.enableResponseFixer,

--- a/src/app/v1/_lib/proxy-handler.ts
+++ b/src/app/v1/_lib/proxy-handler.ts
@@ -107,16 +107,17 @@ export async function handleProxyRequest(c: Context): Promise<Response> {
     // current provider group, hand off to the fake-streaming runner which
     // keeps the SSE connection alive with heartbeats while it serially calls
     // upstream and validates the buffered response before emitting it.
-    try {
-      const fakeStreamingSettings = await getCachedSystemSettings();
-      const fakeStreamingResponse = await tryFakeStreamingPath(session, fakeStreamingSettings);
-      if (fakeStreamingResponse) {
-        return await attachSessionIdToErrorResponse(session.sessionId, fakeStreamingResponse);
-      }
-    } catch (fakeStreamingError) {
-      logger.warn("[ProxyHandler] fake streaming path threw; falling back to normal flow", {
-        error: fakeStreamingError,
-      });
+    //
+    // We do NOT swallow exceptions: `tryFakeStreamingPath` mutates the session
+    // (request body, URL) before the forwarder runs. Falling back to the
+    // normal flow with a mutated session would either double-hit the upstream
+    // (duplicating cost / message context) or leave the request in an
+    // inconsistent state. Let the outer error handler turn the failure into a
+    // protocol error response instead.
+    const fakeStreamingSettings = await getCachedSystemSettings();
+    const fakeStreamingResponse = await tryFakeStreamingPath(session, fakeStreamingSettings);
+    if (fakeStreamingResponse) {
+      return await attachSessionIdToErrorResponse(session.sessionId, fakeStreamingResponse);
     }
 
     const response = await ProxyForwarder.send(session);

--- a/src/app/v1/_lib/proxy-handler.ts
+++ b/src/app/v1/_lib/proxy-handler.ts
@@ -6,6 +6,7 @@ import { SessionTracker } from "@/lib/session-tracker";
 import { ProxyErrorHandler } from "./proxy/error-handler";
 import { attachSessionIdToErrorResponse } from "./proxy/error-session-id";
 import { ProxyError } from "./proxy/errors";
+import { tryFakeStreamingPath } from "./proxy/fake-streaming/proxy-integration";
 import { detectClientFormat, detectFormatByEndpoint } from "./proxy/format-mapper";
 import { ProxyForwarder } from "./proxy/forwarder";
 import { GuardPipelineBuilder } from "./proxy/guard-pipeline";
@@ -101,6 +102,23 @@ export async function handleProxyRequest(c: Context): Promise<Response> {
     }
 
     session.recordForwardStart();
+
+    // Fake streaming: if the client-requested model is whitelisted for the
+    // current provider group, hand off to the fake-streaming runner which
+    // keeps the SSE connection alive with heartbeats while it serially calls
+    // upstream and validates the buffered response before emitting it.
+    try {
+      const fakeStreamingSettings = await getCachedSystemSettings();
+      const fakeStreamingResponse = await tryFakeStreamingPath(session, fakeStreamingSettings);
+      if (fakeStreamingResponse) {
+        return await attachSessionIdToErrorResponse(session.sessionId, fakeStreamingResponse);
+      }
+    } catch (fakeStreamingError) {
+      logger.warn("[ProxyHandler] fake streaming path threw; falling back to normal flow", {
+        error: fakeStreamingError,
+      });
+    }
+
     const response = await ProxyForwarder.send(session);
     const handled = await ProxyResponseHandler.dispatch(session, response);
     const finalResponse = await attachSessionIdToErrorResponse(session.sessionId, handled);

--- a/src/app/v1/_lib/proxy-handler.ts
+++ b/src/app/v1/_lib/proxy-handler.ts
@@ -17,13 +17,16 @@ import { ProxySession } from "./proxy/session";
 
 export async function handleProxyRequest(c: Context): Promise<Response> {
   let session: ProxySession | null = null;
+  let cachedSystemSettings: Awaited<ReturnType<typeof getCachedSystemSettings>> | null = null;
   try {
     session = await ProxySession.fromContext(c);
     try {
-      const systemSettings = await getCachedSystemSettings();
-      session.setHighConcurrencyModeEnabled(systemSettings.enableHighConcurrencyMode ?? false);
+      cachedSystemSettings = await getCachedSystemSettings();
+      session.setHighConcurrencyModeEnabled(
+        cachedSystemSettings.enableHighConcurrencyMode ?? false
+      );
       session.setRawCrossProviderFallbackEnabled(
-        systemSettings.allowNonConversationEndpointProviderFallback ?? true
+        cachedSystemSettings.allowNonConversationEndpointProviderFallback ?? true
       );
     } catch (settingsError) {
       logger.warn(
@@ -114,10 +117,15 @@ export async function handleProxyRequest(c: Context): Promise<Response> {
     // (duplicating cost / message context) or leave the request in an
     // inconsistent state. Let the outer error handler turn the failure into a
     // protocol error response instead.
-    const fakeStreamingSettings = await getCachedSystemSettings();
-    const fakeStreamingResponse = await tryFakeStreamingPath(session, fakeStreamingSettings);
-    if (fakeStreamingResponse) {
-      return await attachSessionIdToErrorResponse(session.sessionId, fakeStreamingResponse);
+    //
+    // Reuse the system settings already loaded above (with its fallback path)
+    // instead of re-reading the cache. A transient cache miss must not turn an
+    // otherwise-routable request into an error response.
+    if (cachedSystemSettings) {
+      const fakeStreamingResponse = await tryFakeStreamingPath(session, cachedSystemSettings);
+      if (fakeStreamingResponse) {
+        return await attachSessionIdToErrorResponse(session.sessionId, fakeStreamingResponse);
+      }
     }
 
     const response = await ProxyForwarder.send(session);

--- a/src/app/v1/_lib/proxy/fake-streaming/eligibility.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/eligibility.ts
@@ -1,0 +1,41 @@
+import { PROVIDER_GROUP } from "@/lib/constants/provider.constants";
+import type { FakeStreamingWhitelistEntry } from "@/types/system-config";
+
+/**
+ * Pure helper: decide whether a request is eligible for fake streaming
+ * orchestration based on the configured whitelist.
+ *
+ * Rules:
+ * - Trim model and group inputs.
+ * - Empty / whitespace-only model => false.
+ * - Match whitelist entries by EXACT trimmed model (no prefix / glob / regex).
+ * - For the matching entry, an empty groupTags array means "all provider groups".
+ * - For non-empty groupTags, the trimmed providerGroupTag must match one of the
+ *   trimmed configured tags.
+ * - A null / undefined / empty providerGroupTag is treated as PROVIDER_GROUP.DEFAULT
+ *   for non-empty groupTags matching, mirroring resolveProviderGroupsWithDefault.
+ */
+export function isFakeStreamingEligible(
+  clientRequestedModel: string,
+  providerGroupTag: string | null | undefined,
+  whitelist: ReadonlyArray<FakeStreamingWhitelistEntry>
+): boolean {
+  if (whitelist.length === 0) return false;
+
+  const model = clientRequestedModel.trim();
+  if (model.length === 0) return false;
+
+  const entry = whitelist.find((candidate) => candidate.model.trim() === model);
+  if (!entry) return false;
+
+  const trimmedGroups = entry.groupTags.map((tag) => tag.trim()).filter((tag) => tag.length > 0);
+
+  if (trimmedGroups.length === 0) return true;
+
+  const requestGroup =
+    typeof providerGroupTag === "string" && providerGroupTag.trim().length > 0
+      ? providerGroupTag.trim()
+      : PROVIDER_GROUP.DEFAULT;
+
+  return trimmedGroups.includes(requestGroup);
+}

--- a/src/app/v1/_lib/proxy/fake-streaming/eligibility.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/eligibility.ts
@@ -18,9 +18,9 @@ import type { FakeStreamingWhitelistEntry } from "@/types/system-config";
 export function isFakeStreamingEligible(
   clientRequestedModel: string,
   providerGroupTag: string | null | undefined,
-  whitelist: ReadonlyArray<FakeStreamingWhitelistEntry>
+  whitelist: ReadonlyArray<FakeStreamingWhitelistEntry> | null | undefined
 ): boolean {
-  if (whitelist.length === 0) return false;
+  if (!whitelist || whitelist.length === 0) return false;
 
   const model = clientRequestedModel.trim();
   if (model.length === 0) return false;

--- a/src/app/v1/_lib/proxy/fake-streaming/emitters.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/emitters.ts
@@ -105,7 +105,7 @@ function emitAnthropicStream(parsed: unknown): string {
   for (let i = 0; i < blocks.length; i += 1) {
     const block = blocks[i];
     if (!block || typeof block !== "object") continue;
-    const typed = block as { type?: unknown; text?: unknown };
+    const typed = block as { type?: unknown; text?: unknown; input?: unknown };
     if (typed.type === "text" && typeof typed.text === "string") {
       parts.push(
         formatSseEvent("content_block_start", {
@@ -124,7 +124,39 @@ function emitAnthropicStream(parsed: unknown): string {
       parts.push(formatSseEvent("content_block_stop", { type: "content_block_stop", index: i }));
       continue;
     }
-    // Non-text block: emit content_block_start with the full block, then stop.
+    if (typed.type === "tool_use") {
+      // Anthropic SDKs only populate tool_use input from input_json_delta
+      // events; fields embedded in content_block_start are ignored. To stay
+      // protocol-compatible we open with an empty `input: {}`, stream the
+      // serialized input as a single partial_json delta, then close.
+      const startBlock: Record<string, unknown> = {
+        type: "tool_use",
+        id: (block as { id?: unknown }).id,
+        name: (block as { name?: unknown }).name,
+        input: {},
+      };
+      parts.push(
+        formatSseEvent("content_block_start", {
+          type: "content_block_start",
+          index: i,
+          content_block: startBlock,
+        })
+      );
+      const inputJson =
+        typed.input !== undefined && typed.input !== null ? JSON.stringify(typed.input) : "{}";
+      parts.push(
+        formatSseEvent("content_block_delta", {
+          type: "content_block_delta",
+          index: i,
+          delta: { type: "input_json_delta", partial_json: inputJson },
+        })
+      );
+      parts.push(formatSseEvent("content_block_stop", { type: "content_block_stop", index: i }));
+      continue;
+    }
+    // Other non-text blocks (thinking / image / etc.): emit content_block_start
+    // with the full block, then stop. These shapes don't have an SDK-side
+    // accumulator that requires deltas.
     parts.push(
       formatSseEvent("content_block_start", {
         type: "content_block_start",
@@ -325,8 +357,17 @@ function emitGeminiStream(_parsed: unknown, finalBody: string): string {
   // bundle. Since the upstream validation guaranteed the body is a complete
   // candidates payload, emit the whole thing as a single SSE event.
   // Re-stringifying through JSON.parse/stringify would lose key ordering /
-  // numerical precision; just trim and emit the original bytes.
-  return formatRawSse(`data: ${finalBody.trim()}\n\n`);
+  // numerical precision; just emit the original bytes line-by-line.
+  //
+  // Per SSE spec, every line of a multi-line `data:` field requires its own
+  // `data:` prefix. Pretty-printed upstream JSON would otherwise be silently
+  // truncated by SSE consumers after the first newline.
+  const trimmed = finalBody.trim();
+  const framed = trimmed
+    .split(/\r?\n/)
+    .map((line) => `data: ${line}`)
+    .join("\n");
+  return formatRawSse(`${framed}\n\n`);
 }
 
 function formatSseEvent(eventName: string, payload: unknown): string {

--- a/src/app/v1/_lib/proxy/fake-streaming/emitters.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/emitters.ts
@@ -1,0 +1,352 @@
+import type { ProtocolFamily } from "./response-validator";
+
+export interface NonStreamEmitInput {
+  family: ProtocolFamily;
+  finalBody: string;
+}
+
+export interface StreamEmitInput {
+  family: ProtocolFamily;
+  finalBody: string;
+}
+
+export interface StreamErrorEmitInput {
+  family: ProtocolFamily;
+  errorMessage: string;
+  errorCode?: string;
+}
+
+/**
+ * Non-stream emitter is a passthrough: the validator already guaranteed the
+ * body is non-empty and protocol-compatible, so the orchestrator simply forwards
+ * the upstream body bytes verbatim.
+ */
+export function emitFinalNonStream(input: NonStreamEmitInput): string {
+  return input.finalBody;
+}
+
+/**
+ * Stream emitter. Given a fully buffered, validated upstream JSON body, return
+ * a protocol-compatible SSE byte string that downstream clients can decode as
+ * if it were a regular streaming response.
+ */
+export function emitFinalStream(input: StreamEmitInput): string {
+  const parsed = parseJsonOrThrow(input.finalBody);
+  switch (input.family) {
+    case "anthropic":
+      return emitAnthropicStream(parsed);
+    case "openai-chat":
+      return emitOpenAIChatStream(parsed);
+    case "openai-responses":
+      return emitOpenAIResponsesStream(parsed);
+    case "gemini":
+      return emitGeminiStream(parsed, input.finalBody);
+  }
+}
+
+/**
+ * Stream error emitter. Used after heartbeats have already been sent and the
+ * orchestrator decides every upstream attempt failed. The output must be
+ * protocol-compatible, must NOT contain a success terminator, and is the
+ * caller's responsibility to flush before closing the response stream.
+ */
+export function emitStreamError(input: StreamErrorEmitInput): string {
+  const code = input.errorCode ?? "upstream_failure";
+  switch (input.family) {
+    case "anthropic":
+      return formatSseEvent("error", {
+        type: "error",
+        error: { type: code, message: input.errorMessage },
+      });
+    case "openai-chat":
+      return formatSseData({
+        error: { code, message: input.errorMessage },
+      });
+    case "openai-responses":
+      return formatSseEvent("response.error", {
+        type: "response.error",
+        error: { code, message: input.errorMessage },
+      });
+    case "gemini":
+      return formatSseData({
+        error: { code, message: input.errorMessage, status: code },
+      });
+  }
+}
+
+interface AnthropicMessage {
+  id?: unknown;
+  type?: unknown;
+  role?: unknown;
+  model?: unknown;
+  content?: unknown;
+  stop_reason?: unknown;
+  stop_sequence?: unknown;
+  usage?: unknown;
+}
+
+function emitAnthropicStream(parsed: unknown): string {
+  const msg = (parsed ?? {}) as AnthropicMessage;
+  const blocks = Array.isArray(msg.content) ? (msg.content as unknown[]) : [];
+  const baseMessage = {
+    id: msg.id ?? "msg_fake_streaming",
+    type: "message",
+    role: msg.role ?? "assistant",
+    model: msg.model ?? null,
+    content: [] as unknown[],
+    stop_reason: null,
+    stop_sequence: null,
+    usage: msg.usage ?? null,
+  };
+
+  const parts: string[] = [];
+  parts.push(formatSseEvent("message_start", { type: "message_start", message: baseMessage }));
+
+  for (let i = 0; i < blocks.length; i += 1) {
+    const block = blocks[i];
+    if (!block || typeof block !== "object") continue;
+    const typed = block as { type?: unknown; text?: unknown };
+    if (typed.type === "text" && typeof typed.text === "string") {
+      parts.push(
+        formatSseEvent("content_block_start", {
+          type: "content_block_start",
+          index: i,
+          content_block: { type: "text", text: "" },
+        })
+      );
+      parts.push(
+        formatSseEvent("content_block_delta", {
+          type: "content_block_delta",
+          index: i,
+          delta: { type: "text_delta", text: typed.text },
+        })
+      );
+      parts.push(formatSseEvent("content_block_stop", { type: "content_block_stop", index: i }));
+      continue;
+    }
+    // Non-text block: emit content_block_start with the full block, then stop.
+    parts.push(
+      formatSseEvent("content_block_start", {
+        type: "content_block_start",
+        index: i,
+        content_block: block,
+      })
+    );
+    parts.push(formatSseEvent("content_block_stop", { type: "content_block_stop", index: i }));
+  }
+
+  parts.push(
+    formatSseEvent("message_delta", {
+      type: "message_delta",
+      delta: {
+        stop_reason: msg.stop_reason ?? null,
+        stop_sequence: msg.stop_sequence ?? null,
+      },
+      usage: msg.usage ?? undefined,
+    })
+  );
+  parts.push(formatSseEvent("message_stop", { type: "message_stop" }));
+  return parts.join("");
+}
+
+interface ChatChoice {
+  index?: unknown;
+  message?: unknown;
+  finish_reason?: unknown;
+  logprobs?: unknown;
+}
+
+interface ChatCompletion {
+  id?: unknown;
+  object?: unknown;
+  created?: unknown;
+  model?: unknown;
+  choices?: unknown;
+  usage?: unknown;
+  system_fingerprint?: unknown;
+}
+
+function emitOpenAIChatStream(parsed: unknown): string {
+  const completion = (parsed ?? {}) as ChatCompletion;
+  const choices = Array.isArray(completion.choices) ? (completion.choices as ChatChoice[]) : [];
+  const baseChunk = {
+    id: completion.id ?? "chatcmpl_fake_streaming",
+    object: "chat.completion.chunk",
+    created: completion.created ?? Math.floor(Date.now() / 1000),
+    model: completion.model ?? null,
+    system_fingerprint: completion.system_fingerprint ?? null,
+  };
+
+  const parts: string[] = [];
+
+  // First, emit a "role" delta chunk per choice — initialises the assistant turn.
+  parts.push(
+    formatSseData({
+      ...baseChunk,
+      choices: choices.map((choice, index) => ({
+        index: typeof choice.index === "number" ? choice.index : index,
+        delta: { role: messageRole(choice.message) ?? "assistant" },
+        finish_reason: null,
+        logprobs: null,
+      })),
+    })
+  );
+
+  // Then emit content / tool_calls deltas. We bundle each choice's full content
+  // into one chunk to minimise SSE noise; downstream clients accept a single
+  // delta the same as multiple smaller ones.
+  parts.push(
+    formatSseData({
+      ...baseChunk,
+      choices: choices.map((choice, index) => {
+        const message = (choice.message ?? {}) as Record<string, unknown>;
+        const delta: Record<string, unknown> = {};
+        if (typeof message.content === "string") {
+          delta.content = message.content;
+        } else if (Array.isArray(message.content)) {
+          delta.content = message.content;
+        }
+        if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+          delta.tool_calls = message.tool_calls;
+        }
+        if (message.function_call && typeof message.function_call === "object") {
+          delta.function_call = message.function_call;
+        }
+        return {
+          index: typeof choice.index === "number" ? choice.index : index,
+          delta,
+          finish_reason: null,
+          logprobs: choice.logprobs ?? null,
+        };
+      }),
+    })
+  );
+
+  // Finish reason chunk per choice.
+  parts.push(
+    formatSseData({
+      ...baseChunk,
+      choices: choices.map((choice, index) => ({
+        index: typeof choice.index === "number" ? choice.index : index,
+        delta: {},
+        finish_reason: choice.finish_reason ?? "stop",
+        logprobs: null,
+      })),
+      usage: completion.usage ?? undefined,
+    })
+  );
+
+  parts.push(formatRawSse("data: [DONE]\n\n"));
+  return parts.join("");
+}
+
+function messageRole(message: unknown): string | null {
+  if (!message || typeof message !== "object") return null;
+  const role = (message as { role?: unknown }).role;
+  return typeof role === "string" ? role : null;
+}
+
+interface OpenAIResponsesEnvelope {
+  id?: unknown;
+  object?: unknown;
+  output?: unknown;
+}
+
+function emitOpenAIResponsesStream(parsed: unknown): string {
+  const envelope = (parsed ?? {}) as OpenAIResponsesEnvelope;
+  const parts: string[] = [];
+
+  // response.created mirrors the final response shape but with empty output for
+  // clients that build state incrementally.
+  const createdResponse = { ...((parsed as object) ?? {}), output: [] };
+  parts.push(
+    formatSseEvent("response.created", { type: "response.created", response: createdResponse })
+  );
+
+  const output = Array.isArray(envelope.output) ? (envelope.output as unknown[]) : [];
+  for (let i = 0; i < output.length; i += 1) {
+    const item = output[i];
+    parts.push(
+      formatSseEvent("response.output_item.added", {
+        type: "response.output_item.added",
+        output_index: i,
+        item,
+      })
+    );
+
+    if (item && typeof item === "object" && (item as { type?: unknown }).type === "message") {
+      const content = ((item as { content?: unknown }).content as unknown[]) ?? [];
+      for (let p = 0; p < content.length; p += 1) {
+        const part = content[p];
+        if (
+          part &&
+          typeof part === "object" &&
+          (part as { type?: unknown }).type === "output_text" &&
+          typeof (part as { text?: unknown }).text === "string"
+        ) {
+          const text = (part as { text: string }).text;
+          parts.push(
+            formatSseEvent("response.output_text.delta", {
+              type: "response.output_text.delta",
+              output_index: i,
+              content_index: p,
+              delta: text,
+            })
+          );
+          parts.push(
+            formatSseEvent("response.output_text.done", {
+              type: "response.output_text.done",
+              output_index: i,
+              content_index: p,
+              text,
+            })
+          );
+        }
+      }
+    }
+
+    parts.push(
+      formatSseEvent("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: i,
+        item,
+      })
+    );
+  }
+
+  parts.push(
+    formatSseEvent("response.completed", { type: "response.completed", response: parsed })
+  );
+  return parts.join("");
+}
+
+function emitGeminiStream(_parsed: unknown, finalBody: string): string {
+  // Gemini stream framing is `data: <full JSON>\n\n` per response candidate
+  // bundle. Since the upstream validation guaranteed the body is a complete
+  // candidates payload, emit the whole thing as a single SSE event.
+  // Re-stringifying through JSON.parse/stringify would lose key ordering /
+  // numerical precision; just trim and emit the original bytes.
+  return formatRawSse(`data: ${finalBody.trim()}\n\n`);
+}
+
+function formatSseEvent(eventName: string, payload: unknown): string {
+  return `event: ${eventName}\ndata: ${JSON.stringify(payload)}\n\n`;
+}
+
+function formatSseData(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+function formatRawSse(text: string): string {
+  return text;
+}
+
+function parseJsonOrThrow(body: string): unknown {
+  try {
+    return JSON.parse(body);
+  } catch (error) {
+    throw new Error(
+      `fake streaming emitter received invalid JSON body (${(error as Error).message})`
+    );
+  }
+}

--- a/src/app/v1/_lib/proxy/fake-streaming/orchestrator.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/orchestrator.ts
@@ -1,0 +1,153 @@
+import {
+  type ProtocolFamily,
+  type ValidationResult,
+  validateUpstreamResponse,
+} from "./response-validator";
+
+export interface FakeStreamingAttemptOutcome {
+  status: number;
+  body: string;
+  providerId: string;
+}
+
+export type AttemptPerformer = (
+  attemptIndex: number,
+  abortSignal: AbortSignal
+) => Promise<FakeStreamingAttemptOutcome | null>;
+
+export interface FakeStreamingAttemptRecord {
+  providerId: string;
+  status: number;
+  validation: ValidationResult;
+}
+
+export type FakeStreamingErrorCode =
+  | "upstream_all_attempts_failed"
+  | "client_abort"
+  | "no_providers";
+
+export interface OrchestrateInput {
+  family: ProtocolFamily;
+  performAttempt: AttemptPerformer;
+  abortSignal: AbortSignal;
+  maxAttempts: number;
+  isStream?: boolean; // default true: orchestrator runs while client expects a stream
+}
+
+export interface OrchestrateResult {
+  ok: boolean;
+  finalBody?: string;
+  finalProviderId?: string;
+  attempts: FakeStreamingAttemptRecord[];
+  errorCode?: FakeStreamingErrorCode;
+  errorMessage?: string;
+}
+
+/**
+ * Run upstream attempts strictly serially. Each attempt is a complete buffered
+ * upstream fetch (the caller is responsible for converting stream upstream into
+ * a buffered body). The validator decides whether the buffered body is
+ * deliverable; on failure, we move on to the next provider.
+ *
+ * The function exits as soon as:
+ * - validator returns ok (success), or
+ * - performAttempt returns null (no more providers / loop exhausted), or
+ * - the abort signal fires (client disconnected — no further fallback), or
+ * - maxAttempts is reached.
+ */
+export async function orchestrateFakeStreamingAttempts(
+  input: OrchestrateInput
+): Promise<OrchestrateResult> {
+  const attempts: FakeStreamingAttemptRecord[] = [];
+  // The validator default is "stream === false" semantics, but for fake
+  // streaming we always buffer upstream as non-stream and rely on the
+  // protocol-family validation rules. Allow callers to override.
+  const validateAsStream = input.isStream === true ? true : false;
+
+  for (let attemptIndex = 0; attemptIndex < input.maxAttempts; attemptIndex += 1) {
+    if (input.abortSignal.aborted) {
+      return {
+        ok: false,
+        attempts,
+        errorCode: "client_abort",
+        errorMessage: "client disconnected",
+      };
+    }
+
+    const attemptAbort = new AbortController();
+    const onParentAbort = () => attemptAbort.abort();
+    input.abortSignal.addEventListener("abort", onParentAbort, { once: true });
+
+    let outcome: FakeStreamingAttemptOutcome | null;
+    try {
+      outcome = await input.performAttempt(attemptIndex, attemptAbort.signal);
+    } catch (error) {
+      input.abortSignal.removeEventListener("abort", onParentAbort);
+      if (input.abortSignal.aborted || isAbortError(error)) {
+        return {
+          ok: false,
+          attempts,
+          errorCode: "client_abort",
+          errorMessage: error instanceof Error ? error.message : "client disconnected",
+        };
+      }
+      // Re-throw non-abort errors so the caller can decide what to do.
+      throw error;
+    } finally {
+      input.abortSignal.removeEventListener("abort", onParentAbort);
+    }
+
+    if (outcome === null) {
+      if (attempts.length === 0) {
+        return {
+          ok: false,
+          attempts,
+          errorCode: "no_providers",
+          errorMessage: "no providers available",
+        };
+      }
+      return {
+        ok: false,
+        attempts,
+        errorCode: "upstream_all_attempts_failed",
+        errorMessage: "all upstream attempts failed and no more providers",
+      };
+    }
+
+    const validation = validateUpstreamResponse({
+      family: input.family,
+      status: outcome.status,
+      body: outcome.body,
+      isStream: validateAsStream,
+    });
+
+    attempts.push({
+      providerId: outcome.providerId,
+      status: outcome.status,
+      validation,
+    });
+
+    if (validation.ok) {
+      return {
+        ok: true,
+        finalBody: outcome.body,
+        finalProviderId: outcome.providerId,
+        attempts,
+      };
+    }
+  }
+
+  return {
+    ok: false,
+    attempts,
+    errorCode: "upstream_all_attempts_failed",
+    errorMessage: "all upstream attempts failed",
+  };
+}
+
+function isAbortError(error: unknown): boolean {
+  if (!error) return false;
+  const name = (error as { name?: unknown }).name;
+  if (typeof name === "string" && name === "AbortError") return true;
+  return false;
+}

--- a/src/app/v1/_lib/proxy/fake-streaming/orchestrator.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/orchestrator.ts
@@ -31,7 +31,11 @@ export interface OrchestrateInput {
   performAttempt: AttemptPerformer;
   abortSignal: AbortSignal;
   maxAttempts: number;
-  isStream?: boolean; // default true: orchestrator runs while client expects a stream
+  // The orchestrator buffers each upstream attempt fully before validation, so
+  // by default it asks the validator to apply non-stream rules. Set `true`
+  // explicitly when the buffered body is itself an SSE byte stream and you
+  // want stream-specific event-shape checks.
+  isStream?: boolean;
 }
 
 export interface OrchestrateResult {
@@ -62,7 +66,7 @@ export async function orchestrateFakeStreamingAttempts(
   // The validator default is "stream === false" semantics, but for fake
   // streaming we always buffer upstream as non-stream and rely on the
   // protocol-family validation rules. Allow callers to override.
-  const validateAsStream = input.isStream === true ? true : false;
+  const validateAsStream = input.isStream === true;
 
   for (let attemptIndex = 0; attemptIndex < input.maxAttempts; attemptIndex += 1) {
     if (input.abortSignal.aborted) {
@@ -77,6 +81,19 @@ export async function orchestrateFakeStreamingAttempts(
     const attemptAbort = new AbortController();
     const onParentAbort = () => attemptAbort.abort();
     input.abortSignal.addEventListener("abort", onParentAbort, { once: true });
+    // AbortSignal.addEventListener does NOT retroactively fire for a signal
+    // that is already aborted, so we must re-check after wiring the listener
+    // to close the race window between the loop-top check and this binding.
+    if (input.abortSignal.aborted) {
+      attemptAbort.abort();
+      input.abortSignal.removeEventListener("abort", onParentAbort);
+      return {
+        ok: false,
+        attempts,
+        errorCode: "client_abort",
+        errorMessage: "client disconnected",
+      };
+    }
 
     let outcome: FakeStreamingAttemptOutcome | null;
     try {

--- a/src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts
@@ -71,6 +71,14 @@ export async function tryFakeStreamingPath(
   applyNonStreamMutation(session);
 
   const performAttempt = buildAttemptPerformer(session);
+  if (session.clientAbortSignal === null) {
+    // No client abort signal means heartbeat / orchestrator can't observe
+    // client disconnect — surface the silent degradation in the log so it's
+    // not invisible in edge-middleware / test environments where this happens.
+    logger.warn("[FakeStreaming] session.clientAbortSignal is null; abort propagation disabled", {
+      model: clientModel,
+    });
+  }
   const abortSignal = session.clientAbortSignal ?? new AbortController().signal;
 
   if (isStream) {
@@ -134,11 +142,39 @@ function buildAttemptPerformer(session: ProxySession): AttemptPerformer {
       throw Object.assign(new Error("aborted"), { name: "AbortError" });
     }
     const response = await ProxyForwarder.send(session);
-    const body = await response.text();
-    return {
-      status: response.status,
-      body,
-      providerId: session.provider?.id != null ? String(session.provider.id) : "unknown",
-    };
+    try {
+      const body = await response.text();
+      return {
+        status: response.status,
+        body,
+        providerId: session.provider?.id != null ? String(session.provider.id) : "unknown",
+      };
+    } finally {
+      // ProxyForwarder.send hangs cleanup callbacks on the session that
+      // ProxyResponseHandler.dispatch is normally responsible for invoking.
+      // Since fake streaming consumes the response body itself, we must run
+      // them here or the response timeout timer + agent-pool reservation will
+      // leak.
+      releaseForwarderResources(session);
+    }
   };
+}
+
+function releaseForwarderResources(session: ProxySession): void {
+  const augmented = session as ProxySession & {
+    clearResponseTimeout?: (() => void) | null;
+    releaseAgent?: (() => void) | null;
+  };
+  try {
+    augmented.clearResponseTimeout?.();
+  } catch {
+    /* swallow cleanup errors */
+  }
+  augmented.clearResponseTimeout = null;
+  try {
+    augmented.releaseAgent?.();
+  } catch {
+    /* swallow cleanup errors */
+  }
+  augmented.releaseAgent = null;
 }

--- a/src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts
@@ -1,0 +1,144 @@
+import { logger } from "@/lib/logger";
+import type { SystemSettings } from "@/types/system-config";
+import type { ClientFormat } from "../format-mapper";
+import { ProxyForwarder } from "../forwarder";
+import type { ProxySession } from "../session";
+import { isFakeStreamingEligible } from "./eligibility";
+import type { ProtocolFamily } from "./response-validator";
+import {
+  type AttemptPerformer,
+  buildFakeStreamingNonStreamResponse,
+  buildFakeStreamingResponse,
+} from "./runner";
+import { cloneRequestForInternalNonStreamAttempt, detectClientStreamIntent } from "./stream-intent";
+
+const HEARTBEAT_INTERVAL_MS = 5000;
+// The underlying ProxyForwarder runs its own multi-provider loop with fake-200
+// detection and serial fallback. We only allow ONE invocation of that loop
+// per fake-streaming request to avoid double-counting message context, cost,
+// and provider chain. Edge cases that slip past the forwarder's fake-200
+// detection (e.g., empty content array, comment-only SSE) end as 502 here
+// instead of triggering a second forwarder pass.
+const MAX_ATTEMPTS = 1;
+
+function familyFromFormat(format: ClientFormat): ProtocolFamily | null {
+  switch (format) {
+    case "claude":
+      return "anthropic";
+    case "openai":
+      return "openai-chat";
+    case "response":
+      return "openai-responses";
+    case "gemini":
+    case "gemini-cli":
+      return "gemini";
+    default:
+      return null;
+  }
+}
+
+/**
+ * If the request is eligible for fake streaming, run the fake streaming flow
+ * and return its Response. Otherwise return null so the caller can fall back
+ * to the regular ProxyForwarder + ProxyResponseHandler path.
+ */
+export async function tryFakeStreamingPath(
+  session: ProxySession,
+  systemSettings: SystemSettings
+): Promise<Response | null> {
+  const clientModel = (session.request.model ?? "").toString();
+  const providerGroup = session.provider?.groupTag ?? null;
+  const eligible = isFakeStreamingEligible(
+    clientModel,
+    providerGroup,
+    systemSettings.fakeStreamingWhitelist
+  );
+  if (!eligible) return null;
+
+  const family = familyFromFormat(session.originalFormat);
+  if (!family) return null;
+
+  const isStream = detectClientStreamIntent({
+    format: session.originalFormat,
+    pathname: session.requestUrl.pathname,
+    search: session.requestUrl.search,
+    body: session.request.message,
+  });
+
+  // Convert the session request to a non-stream upstream attempt before the
+  // forwarder runs. We never let upstream open a streaming response because
+  // we need to fully buffer + validate before emitting anything.
+  applyNonStreamMutation(session);
+
+  const performAttempt = buildAttemptPerformer(session);
+  const abortSignal = session.clientAbortSignal ?? new AbortController().signal;
+
+  if (isStream) {
+    logger.debug("[FakeStreaming] taking stream path", {
+      model: clientModel,
+      providerGroup,
+      family,
+    });
+    return buildFakeStreamingResponse({
+      family,
+      isStream: true,
+      performAttempt,
+      abortSignal,
+      maxAttempts: MAX_ATTEMPTS,
+      heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+    });
+  }
+
+  logger.debug("[FakeStreaming] taking non-stream path", {
+    model: clientModel,
+    providerGroup,
+    family,
+  });
+  return await buildFakeStreamingNonStreamResponse({
+    family,
+    performAttempt,
+    abortSignal,
+    maxAttempts: MAX_ATTEMPTS,
+  });
+}
+
+function applyNonStreamMutation(session: ProxySession): void {
+  const cloned = cloneRequestForInternalNonStreamAttempt({
+    format: session.originalFormat,
+    pathname: session.requestUrl.pathname,
+    search: session.requestUrl.search,
+    body: session.request.message,
+  });
+  if (cloned.body) {
+    // Mutate in place so downstream forwarder uses the non-stream body.
+    for (const key of Object.keys(session.request.message)) {
+      delete (session.request.message as Record<string, unknown>)[key];
+    }
+    Object.assign(session.request.message, cloned.body);
+  }
+
+  if (
+    cloned.pathname !== session.requestUrl.pathname ||
+    cloned.search !== session.requestUrl.search
+  ) {
+    const next = new URL(session.requestUrl.toString());
+    next.pathname = cloned.pathname;
+    next.search = cloned.search;
+    session.requestUrl = next;
+  }
+}
+
+function buildAttemptPerformer(session: ProxySession): AttemptPerformer {
+  return async (_attemptIndex, abortSignal) => {
+    if (abortSignal.aborted) {
+      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+    }
+    const response = await ProxyForwarder.send(session);
+    const body = await response.text();
+    return {
+      status: response.status,
+      body,
+      providerId: session.provider?.id != null ? String(session.provider.id) : "unknown",
+    };
+  };
+}

--- a/src/app/v1/_lib/proxy/fake-streaming/response-validator.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/response-validator.ts
@@ -347,10 +347,9 @@ function collectSseEvents(body: string): SseEvent[] {
     }
     if (line.startsWith("data:")) {
       dataLines.push(line.slice(5).replace(/^\s/, ""));
-      continue;
     }
-    if (line.startsWith("id:") || line.startsWith("retry:")) {
-    }
+    // `id:` / `retry:` are valid SSE fields that don't carry deliverable data,
+    // so we intentionally skip them without bumping any state.
   }
   flush();
   return events;

--- a/src/app/v1/_lib/proxy/fake-streaming/response-validator.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/response-validator.ts
@@ -280,9 +280,9 @@ function eventCarriesDeliverable(
         if (Array.isArray(output) && output.length > 0) return true;
       }
     }
-    if (typed.type === "response.created" && eventName !== "response.created") {
-      return true;
-    }
+    // response.created is purely a metadata envelope; do not treat it as
+    // deliverable, otherwise streams that contain only metadata events with
+    // no output would falsely pass validation.
     return false;
   }
 

--- a/src/app/v1/_lib/proxy/fake-streaming/response-validator.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/response-validator.ts
@@ -1,0 +1,373 @@
+export type ProtocolFamily = "anthropic" | "openai-chat" | "openai-responses" | "gemini";
+
+export type ValidationFailureCode =
+  | "non_2xx_status"
+  | "empty_body"
+  | "invalid_json"
+  | "stream_no_events"
+  | "stream_done_only"
+  | "stream_error_event"
+  | "stream_no_deliverable"
+  | "missing_required_field"
+  | "no_deliverable_content";
+
+export interface ValidationResult {
+  ok: boolean;
+  code?: ValidationFailureCode;
+  reason?: string;
+}
+
+export interface ValidateInput {
+  family: ProtocolFamily;
+  status: number;
+  body: string;
+  isStream: boolean;
+}
+
+const SUCCESS: ValidationResult = { ok: true };
+
+export function validateUpstreamResponse(input: ValidateInput): ValidationResult {
+  if (input.status < 200 || input.status >= 300) {
+    return fail("non_2xx_status", `upstream status=${input.status}`);
+  }
+
+  const trimmed = input.body.trim();
+  if (trimmed.length === 0) {
+    return fail("empty_body", "body is empty / whitespace only");
+  }
+
+  if (input.isStream) {
+    return validateStream(input.family, input.body);
+  }
+
+  return validateNonStream(input.family, input.body);
+}
+
+function validateNonStream(family: ProtocolFamily, body: string): ValidationResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return fail("invalid_json", "non-stream body is not valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return fail("invalid_json", "non-stream body did not parse to an object");
+  }
+
+  switch (family) {
+    case "anthropic":
+      return validateAnthropicMessage(parsed);
+    case "openai-chat":
+      return validateOpenAIChatCompletion(parsed);
+    case "openai-responses":
+      return validateOpenAIResponses(parsed);
+    case "gemini":
+      return validateGeminiNonStream(parsed);
+  }
+}
+
+function validateAnthropicMessage(parsed: unknown): ValidationResult {
+  const obj = parsed as { content?: unknown };
+  if (!Array.isArray(obj.content)) {
+    return fail("missing_required_field", "anthropic response missing content array");
+  }
+  if (obj.content.length === 0) {
+    return fail("no_deliverable_content", "anthropic content array is empty");
+  }
+  for (const block of obj.content) {
+    if (!block || typeof block !== "object") continue;
+    const typedBlock = block as { type?: unknown; text?: unknown; input?: unknown };
+    if (typedBlock.type === "text" && isNonEmptyString(typedBlock.text)) return SUCCESS;
+    if (typedBlock.type === "tool_use") return SUCCESS;
+    if (typedBlock.type === "thinking") {
+      // thinking by itself is not deliverable; keep scanning
+      continue;
+    }
+    if (typeof typedBlock.type === "string" && typedBlock.type.length > 0) {
+      // Unknown but typed block: accept as deliverable.
+      return SUCCESS;
+    }
+  }
+  return fail("no_deliverable_content", "anthropic content has no deliverable block");
+}
+
+function validateOpenAIChatCompletion(parsed: unknown): ValidationResult {
+  const obj = parsed as { choices?: unknown };
+  if (!Array.isArray(obj.choices)) {
+    return fail("missing_required_field", "openai-chat response missing choices");
+  }
+  if (obj.choices.length === 0) {
+    return fail("no_deliverable_content", "openai-chat choices array is empty");
+  }
+  for (const choice of obj.choices) {
+    if (!choice || typeof choice !== "object") continue;
+    const message = (choice as { message?: unknown }).message;
+    if (!message || typeof message !== "object") continue;
+    if (chatMessageHasDeliverable(message)) return SUCCESS;
+  }
+  return fail("no_deliverable_content", "openai-chat choices have no deliverable message");
+}
+
+function chatMessageHasDeliverable(message: unknown): boolean {
+  if (!message || typeof message !== "object") return false;
+  const typed = message as {
+    content?: unknown;
+    tool_calls?: unknown;
+    function_call?: unknown;
+    refusal?: unknown;
+  };
+  if (isNonEmptyString(typed.content)) return true;
+  if (Array.isArray(typed.content) && typed.content.length > 0) return true;
+  if (Array.isArray(typed.tool_calls) && typed.tool_calls.length > 0) return true;
+  if (typed.function_call && typeof typed.function_call === "object") return true;
+  return false;
+}
+
+function validateOpenAIResponses(parsed: unknown): ValidationResult {
+  const obj = parsed as { output?: unknown };
+  if (!Array.isArray(obj.output)) {
+    return fail("missing_required_field", "openai-responses missing output array");
+  }
+  if (obj.output.length === 0) {
+    return fail("no_deliverable_content", "openai-responses output array is empty");
+  }
+  for (const item of obj.output) {
+    if (!item || typeof item !== "object") continue;
+    const typedItem = item as { type?: unknown; content?: unknown };
+    if (typedItem.type === "message" && Array.isArray(typedItem.content)) {
+      for (const part of typedItem.content) {
+        if (!part || typeof part !== "object") continue;
+        const partTyped = part as { type?: unknown; text?: unknown };
+        if (partTyped.type === "output_text" && isNonEmptyString(partTyped.text)) return SUCCESS;
+        if (typeof partTyped.type === "string" && partTyped.type.length > 0) return SUCCESS;
+      }
+    }
+    if (typeof typedItem.type === "string" && typedItem.type !== "message") {
+      // function_call, custom_tool_call_output, reasoning, etc. — all deliverable.
+      return SUCCESS;
+    }
+  }
+  return fail("no_deliverable_content", "openai-responses output has no deliverable item");
+}
+
+function validateGeminiNonStream(parsed: unknown): ValidationResult {
+  const obj = parsed as { candidates?: unknown };
+  if (!Array.isArray(obj.candidates)) {
+    return fail("missing_required_field", "gemini response missing candidates array");
+  }
+  if (obj.candidates.length === 0) {
+    return fail("no_deliverable_content", "gemini candidates array is empty");
+  }
+  for (const candidate of obj.candidates) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const content = (candidate as { content?: unknown }).content;
+    if (!content || typeof content !== "object") continue;
+    const parts = (content as { parts?: unknown }).parts;
+    if (!Array.isArray(parts) || parts.length === 0) continue;
+    for (const part of parts) {
+      if (!part || typeof part !== "object") continue;
+      const typed = part as Record<string, unknown>;
+      if (isNonEmptyString(typed.text)) return SUCCESS;
+      if (typed.inlineData && typeof typed.inlineData === "object") return SUCCESS;
+      if (typed.fileData && typeof typed.fileData === "object") return SUCCESS;
+      if (typed.functionCall && typeof typed.functionCall === "object") return SUCCESS;
+      if (typed.functionResponse && typeof typed.functionResponse === "object") return SUCCESS;
+      if (typed.executableCode && typeof typed.executableCode === "object") return SUCCESS;
+      if (typed.codeExecutionResult && typeof typed.codeExecutionResult === "object")
+        return SUCCESS;
+    }
+  }
+  return fail("no_deliverable_content", "gemini candidates have no deliverable part");
+}
+
+function validateStream(family: ProtocolFamily, body: string): ValidationResult {
+  const events = collectSseEvents(body);
+  if (events.length === 0) {
+    return fail("stream_no_events", "stream contained no events (comments / blanks only)");
+  }
+
+  let sawDone = false;
+  let sawError = false;
+  let sawDeliverable = false;
+
+  for (const event of events) {
+    if (event.kind === "done") {
+      sawDone = true;
+      continue;
+    }
+    if (event.kind === "error") {
+      sawError = true;
+      continue;
+    }
+    if (event.eventName === "error") {
+      sawError = true;
+      continue;
+    }
+    const json = parseJsonSafe(event.data);
+    if (!json || typeof json !== "object") continue;
+    if (eventCarriesDeliverable(family, event.eventName, json)) {
+      sawDeliverable = true;
+    }
+  }
+
+  if (sawDeliverable) return SUCCESS;
+  if (sawError) return fail("stream_error_event", "stream contained an error event");
+  if (sawDone) return fail("stream_done_only", "stream contained only [DONE]");
+  return fail("stream_no_deliverable", "stream had no deliverable events");
+}
+
+function eventCarriesDeliverable(
+  family: ProtocolFamily,
+  eventName: string | null,
+  json: object
+): boolean {
+  if (family === "anthropic") {
+    const typed = json as { type?: unknown; delta?: unknown; content_block?: unknown };
+    if (typed.type === "error") return false;
+    if (typed.type === "content_block_delta") {
+      const delta = typed.delta as { type?: unknown; text?: unknown } | undefined;
+      if (
+        delta &&
+        (isNonEmptyString(delta.text) ||
+          isNonEmptyString((delta as { partial_json?: unknown }).partial_json))
+      ) {
+        return true;
+      }
+    }
+    if (typed.type === "content_block_start") {
+      const block = typed.content_block as { type?: unknown; text?: unknown } | undefined;
+      if (block && typeof block.type === "string" && block.type.length > 0) {
+        if (block.type !== "text" || isNonEmptyString(block.text)) {
+          // Non-text blocks (tool_use etc.) count immediately; text blocks need delta to confirm content.
+          if (block.type !== "text") return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  if (family === "openai-chat") {
+    const choices = (json as { choices?: unknown }).choices;
+    if (!Array.isArray(choices)) return false;
+    for (const choice of choices) {
+      if (!choice || typeof choice !== "object") continue;
+      const delta = (choice as { delta?: unknown }).delta;
+      if (!delta || typeof delta !== "object") continue;
+      const typed = delta as { content?: unknown; tool_calls?: unknown; function_call?: unknown };
+      if (isNonEmptyString(typed.content)) return true;
+      if (Array.isArray(typed.content) && typed.content.length > 0) return true;
+      if (Array.isArray(typed.tool_calls) && typed.tool_calls.length > 0) return true;
+      if (typed.function_call && typeof typed.function_call === "object") return true;
+    }
+    return false;
+  }
+
+  if (family === "openai-responses") {
+    const typed = json as { type?: unknown };
+    if (typeof typed.type !== "string") return false;
+    if (typed.type === "response.error") return false;
+    if (typed.type === "response.output_text.delta") {
+      const delta = (json as { delta?: unknown }).delta;
+      if (isNonEmptyString(delta)) return true;
+    }
+    if (typed.type === "response.output_item.added" || typed.type === "response.output_item.done") {
+      return true;
+    }
+    if (typed.type === "response.completed") {
+      const response = (json as { response?: unknown }).response;
+      if (response && typeof response === "object") {
+        const output = (response as { output?: unknown }).output;
+        if (Array.isArray(output) && output.length > 0) return true;
+      }
+    }
+    if (typed.type === "response.created" && eventName !== "response.created") {
+      return true;
+    }
+    return false;
+  }
+
+  if (family === "gemini") {
+    const candidates = (json as { candidates?: unknown }).candidates;
+    if (!Array.isArray(candidates) || candidates.length === 0) return false;
+    for (const candidate of candidates) {
+      if (!candidate || typeof candidate !== "object") continue;
+      const content = (candidate as { content?: unknown }).content;
+      if (!content || typeof content !== "object") continue;
+      const parts = (content as { parts?: unknown }).parts;
+      if (Array.isArray(parts) && parts.length > 0) return true;
+    }
+    return false;
+  }
+
+  return false;
+}
+
+interface SseEvent {
+  kind: "data" | "done" | "error";
+  eventName: string | null;
+  data: string;
+}
+
+function collectSseEvents(body: string): SseEvent[] {
+  const events: SseEvent[] = [];
+  const dataLines: string[] = [];
+  let currentEvent: string | null = null;
+
+  const flush = () => {
+    if (dataLines.length === 0) {
+      currentEvent = null;
+      return;
+    }
+    const payload = dataLines.join("\n").trim();
+    dataLines.length = 0;
+    const event = currentEvent;
+    currentEvent = null;
+    if (!payload) return;
+    if (payload === "[DONE]") {
+      events.push({ kind: "done", eventName: event, data: payload });
+      return;
+    }
+    if (event === "error") {
+      events.push({ kind: "error", eventName: event, data: payload });
+      return;
+    }
+    events.push({ kind: "data", eventName: event, data: payload });
+  };
+
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine;
+    if (line.length === 0) {
+      flush();
+      continue;
+    }
+    if (line.startsWith(":")) continue; // SSE comment
+    if (line.startsWith("event:")) {
+      currentEvent = line.slice(6).trim();
+      continue;
+    }
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).replace(/^\s/, ""));
+      continue;
+    }
+    if (line.startsWith("id:") || line.startsWith("retry:")) {
+    }
+  }
+  flush();
+  return events;
+}
+
+function parseJsonSafe(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function fail(code: ValidationFailureCode, reason: string): ValidationResult {
+  return { ok: false, code, reason };
+}

--- a/src/app/v1/_lib/proxy/fake-streaming/runner.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/runner.ts
@@ -19,17 +19,20 @@ export interface FakeStreamingRunInput {
  * Synchronous entry for the stream client path: returns a Response immediately
  * so the SSE heartbeat can flush before the orchestrator finishes.
  *
- * For non-stream clients, callers should use `buildFakeStreamingNonStreamResponse`
- * which awaits the orchestrator and returns an accurate HTTP status code.
+ * For non-stream clients, use `buildFakeStreamingNonStreamResponse` directly —
+ * it awaits the orchestrator and returns an accurate HTTP status code (200 /
+ * 502 / 499). Calling this synchronous entry with `isStream: false` cannot
+ * surface a non-200 status (Response status is locked at construction), so we
+ * fail fast rather than silently report 200 on upstream failure.
  */
 export function buildFakeStreamingResponse(input: FakeStreamingRunInput): Response {
-  if (input.isStream) {
-    return buildStreamResponse(input);
+  if (!input.isStream) {
+    throw new Error(
+      "buildFakeStreamingResponse requires isStream=true. " +
+        "Use buildFakeStreamingNonStreamResponse for non-stream clients."
+    );
   }
-  // Tests / callers that pass `isStream: false` here get a placeholder 200
-  // response whose body resolves once the orchestrator settles; for accurate
-  // HTTP status, prefer `buildFakeStreamingNonStreamResponse`.
-  return buildLegacyNonStreamPlaceholder(input);
+  return buildStreamResponse(input);
 }
 
 function buildStreamResponse(input: FakeStreamingRunInput): Response {
@@ -76,6 +79,7 @@ function buildStreamResponse(input: FakeStreamingRunInput): Response {
         performAttempt: input.performAttempt,
         abortSignal: input.abortSignal,
         maxAttempts: input.maxAttempts,
+        isStream: false,
       })
         .then((result) => {
           cleanupHeartbeat();
@@ -135,40 +139,6 @@ function buildStreamResponse(input: FakeStreamingRunInput): Response {
       Connection: "keep-alive",
       "X-Accel-Buffering": "no",
     },
-  });
-}
-
-/**
- * Placeholder for the synchronous `isStream: false` path. Status is fixed at
- * 200; callers that need accurate HTTP status should use
- * `buildFakeStreamingNonStreamResponse`.
- */
-function buildLegacyNonStreamPlaceholder(input: FakeStreamingRunInput): Response {
-  const encoder = new TextEncoder();
-  const stream = new ReadableStream<Uint8Array>({
-    async start(controller) {
-      const result = await orchestrateFakeStreamingAttempts({
-        family: input.family,
-        performAttempt: input.performAttempt,
-        abortSignal: input.abortSignal,
-        maxAttempts: input.maxAttempts,
-      });
-      const body =
-        result.ok && typeof result.finalBody === "string"
-          ? emitFinalNonStream({ family: input.family, finalBody: result.finalBody })
-          : JSON.stringify({
-              error: {
-                code: result.errorCode ?? "upstream_all_attempts_failed",
-                message: result.errorMessage ?? "all upstream attempts failed",
-              },
-            });
-      controller.enqueue(encoder.encode(body));
-      controller.close();
-    },
-  });
-  return new Response(stream, {
-    status: 200,
-    headers: { "Content-Type": "application/json; charset=utf-8" },
   });
 }
 

--- a/src/app/v1/_lib/proxy/fake-streaming/runner.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/runner.ts
@@ -149,12 +149,32 @@ function buildStreamResponse(input: FakeStreamingRunInput): Response {
 export async function buildFakeStreamingNonStreamResponse(
   input: Omit<FakeStreamingRunInput, "isStream" | "heartbeatIntervalMs">
 ): Promise<Response> {
-  const result = await orchestrateFakeStreamingAttempts({
-    family: input.family,
-    performAttempt: input.performAttempt,
-    abortSignal: input.abortSignal,
-    maxAttempts: input.maxAttempts,
-  });
+  let result: Awaited<ReturnType<typeof orchestrateFakeStreamingAttempts>>;
+  try {
+    result = await orchestrateFakeStreamingAttempts({
+      family: input.family,
+      performAttempt: input.performAttempt,
+      abortSignal: input.abortSignal,
+      maxAttempts: input.maxAttempts,
+    });
+  } catch (error) {
+    // Orchestrator only re-throws non-abort exceptions (e.g., transport
+    // failures). Surface a structured 502 here so non-stream clients get the
+    // same JSON contract they would for "all attempts failed", instead of the
+    // outer ProxyErrorHandler turning this into a different shape.
+    return new Response(
+      JSON.stringify({
+        error: {
+          code: "runner_error",
+          message: error instanceof Error ? error.message : "fake streaming runner failed",
+        },
+      }),
+      {
+        status: 502,
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+      }
+    );
+  }
 
   if (result.ok && typeof result.finalBody === "string") {
     return new Response(emitFinalNonStream({ family: input.family, finalBody: result.finalBody }), {

--- a/src/app/v1/_lib/proxy/fake-streaming/runner.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/runner.ts
@@ -1,0 +1,225 @@
+import { emitFinalNonStream, emitFinalStream, emitStreamError } from "./emitters";
+import { type AttemptPerformer, orchestrateFakeStreamingAttempts } from "./orchestrator";
+import type { ProtocolFamily } from "./response-validator";
+
+export type { AttemptPerformer } from "./orchestrator";
+
+const HEARTBEAT_FRAME = ": ping\n\n";
+
+export interface FakeStreamingRunInput {
+  family: ProtocolFamily;
+  isStream: boolean;
+  performAttempt: AttemptPerformer;
+  abortSignal: AbortSignal;
+  maxAttempts: number;
+  heartbeatIntervalMs: number;
+}
+
+/**
+ * Synchronous entry for the stream client path: returns a Response immediately
+ * so the SSE heartbeat can flush before the orchestrator finishes.
+ *
+ * For non-stream clients, callers should use `buildFakeStreamingNonStreamResponse`
+ * which awaits the orchestrator and returns an accurate HTTP status code.
+ */
+export function buildFakeStreamingResponse(input: FakeStreamingRunInput): Response {
+  if (input.isStream) {
+    return buildStreamResponse(input);
+  }
+  // Tests / callers that pass `isStream: false` here get a placeholder 200
+  // response whose body resolves once the orchestrator settles; for accurate
+  // HTTP status, prefer `buildFakeStreamingNonStreamResponse`.
+  return buildLegacyNonStreamPlaceholder(input);
+}
+
+function buildStreamResponse(input: FakeStreamingRunInput): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let closed = false;
+      const safeEnqueue = (chunk: string) => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(chunk));
+        } catch {
+          closed = true;
+        }
+      };
+      const safeClose = () => {
+        if (closed) return;
+        closed = true;
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+      };
+
+      // First heartbeat goes out immediately so consumers see something on the
+      // wire right away.
+      safeEnqueue(HEARTBEAT_FRAME);
+
+      const heartbeatTimer = setInterval(() => {
+        safeEnqueue(HEARTBEAT_FRAME);
+      }, input.heartbeatIntervalMs);
+
+      const cleanupHeartbeat = () => clearInterval(heartbeatTimer);
+
+      const onAbort = () => {
+        cleanupHeartbeat();
+        safeClose();
+      };
+      input.abortSignal.addEventListener("abort", onAbort, { once: true });
+
+      void orchestrateFakeStreamingAttempts({
+        family: input.family,
+        performAttempt: input.performAttempt,
+        abortSignal: input.abortSignal,
+        maxAttempts: input.maxAttempts,
+      })
+        .then((result) => {
+          cleanupHeartbeat();
+          input.abortSignal.removeEventListener("abort", onAbort);
+          if (input.abortSignal.aborted) {
+            safeClose();
+            return;
+          }
+          if (result.ok && typeof result.finalBody === "string") {
+            try {
+              safeEnqueue(emitFinalStream({ family: input.family, finalBody: result.finalBody }));
+            } catch {
+              safeEnqueue(
+                emitStreamError({
+                  family: input.family,
+                  errorMessage: "fake streaming emitter failed",
+                  errorCode: "emitter_error",
+                })
+              );
+            }
+          } else if (result.errorCode === "client_abort") {
+            // Already handled by abort listener; nothing to emit.
+          } else {
+            safeEnqueue(
+              emitStreamError({
+                family: input.family,
+                errorMessage: result.errorMessage ?? "all upstream attempts failed",
+                errorCode: result.errorCode ?? "upstream_all_attempts_failed",
+              })
+            );
+          }
+          safeClose();
+        })
+        .catch((error: unknown) => {
+          cleanupHeartbeat();
+          input.abortSignal.removeEventListener("abort", onAbort);
+          if (!input.abortSignal.aborted) {
+            safeEnqueue(
+              emitStreamError({
+                family: input.family,
+                errorMessage:
+                  error instanceof Error ? error.message : "fake streaming runner failed",
+                errorCode: "runner_error",
+              })
+            );
+          }
+          safeClose();
+        });
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
+/**
+ * Placeholder for the synchronous `isStream: false` path. Status is fixed at
+ * 200; callers that need accurate HTTP status should use
+ * `buildFakeStreamingNonStreamResponse`.
+ */
+function buildLegacyNonStreamPlaceholder(input: FakeStreamingRunInput): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const result = await orchestrateFakeStreamingAttempts({
+        family: input.family,
+        performAttempt: input.performAttempt,
+        abortSignal: input.abortSignal,
+        maxAttempts: input.maxAttempts,
+      });
+      const body =
+        result.ok && typeof result.finalBody === "string"
+          ? emitFinalNonStream({ family: input.family, finalBody: result.finalBody })
+          : JSON.stringify({
+              error: {
+                code: result.errorCode ?? "upstream_all_attempts_failed",
+                message: result.errorMessage ?? "all upstream attempts failed",
+              },
+            });
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+}
+
+/**
+ * Strict Promise<Response> variant for non-stream path. Always resolves with
+ * an accurate HTTP status code (200 success / 502 all-failed / 499 abort).
+ */
+export async function buildFakeStreamingNonStreamResponse(
+  input: Omit<FakeStreamingRunInput, "isStream" | "heartbeatIntervalMs">
+): Promise<Response> {
+  const result = await orchestrateFakeStreamingAttempts({
+    family: input.family,
+    performAttempt: input.performAttempt,
+    abortSignal: input.abortSignal,
+    maxAttempts: input.maxAttempts,
+  });
+
+  if (result.ok && typeof result.finalBody === "string") {
+    return new Response(emitFinalNonStream({ family: input.family, finalBody: result.finalBody }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+      },
+    });
+  }
+
+  if (result.errorCode === "client_abort") {
+    return new Response(
+      JSON.stringify({
+        error: {
+          code: "client_abort",
+          message: result.errorMessage ?? "client disconnected",
+        },
+      }),
+      {
+        status: 499,
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+      }
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: result.errorCode ?? "upstream_all_attempts_failed",
+        message: result.errorMessage ?? "all upstream attempts failed",
+      },
+    }),
+    {
+      status: 502,
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+    }
+  );
+}

--- a/src/app/v1/_lib/proxy/fake-streaming/stream-intent.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/stream-intent.ts
@@ -1,0 +1,110 @@
+import type { ClientFormat } from "../format-mapper";
+
+export interface StreamIntentInputs {
+  format: ClientFormat;
+  pathname: string;
+  search: string;
+  body: Record<string, unknown> | null;
+}
+
+const GEMINI_FORMATS: ReadonlyArray<ClientFormat> = ["gemini", "gemini-cli"];
+
+function isGeminiFamily(format: ClientFormat): boolean {
+  return GEMINI_FORMATS.includes(format);
+}
+
+function bodyStreamFlag(body: Record<string, unknown> | null): boolean {
+  return body !== null && body.stream === true;
+}
+
+/**
+ * Detect whether the client requested a streaming response.
+ *
+ * Standard formats (claude / openai / response): only `body.stream === true`
+ * counts. Path / query are ignored.
+ *
+ * Gemini family (gemini / gemini-cli): any of `:streamGenerateContent` in
+ * pathname, `alt=sse` query, or `body.stream === true` counts.
+ *
+ * Inputs come from already-parsed request state — this helper does not consume
+ * request body streams.
+ */
+export function detectClientStreamIntent(input: StreamIntentInputs): boolean {
+  if (isGeminiFamily(input.format)) {
+    if (input.pathname.includes(":streamGenerateContent")) return true;
+    if (hasAltSse(input.search)) return true;
+    return bodyStreamFlag(input.body);
+  }
+  return bodyStreamFlag(input.body);
+}
+
+function hasAltSse(search: string): boolean {
+  if (!search) return false;
+  // search may or may not include leading "?"; URLSearchParams handles both.
+  const normalized = search.startsWith("?") ? search.slice(1) : search;
+  if (!normalized) return false;
+  try {
+    const params = new URLSearchParams(normalized);
+    return params.get("alt") === "sse";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Produce a non-stream variant of the request inputs without mutating the
+ * originals. Used when the client wants a stream but fake streaming wants to
+ * call upstream with a buffered, non-stream attempt.
+ */
+export function cloneRequestForInternalNonStreamAttempt(
+  input: StreamIntentInputs
+): StreamIntentInputs {
+  if (isGeminiFamily(input.format)) {
+    const newPath = input.pathname.replace(":streamGenerateContent", ":generateContent");
+    const newSearch = stripAltSse(input.search);
+    const newBody = cloneBodyWithoutStreamFlag(input.body);
+    return { format: input.format, pathname: newPath, search: newSearch, body: newBody };
+  }
+
+  return {
+    format: input.format,
+    pathname: input.pathname,
+    search: input.search,
+    body: cloneBodyWithStreamFalse(input.body),
+  };
+}
+
+function stripAltSse(search: string): string {
+  if (!search) return "";
+  const hasLeadingQuestion = search.startsWith("?");
+  const raw = hasLeadingQuestion ? search.slice(1) : search;
+  if (!raw) return "";
+  try {
+    const params = new URLSearchParams(raw);
+    if (params.get("alt") === "sse") {
+      params.delete("alt");
+    }
+    const remaining = params.toString();
+    if (!remaining) return "";
+    return hasLeadingQuestion ? `?${remaining}` : remaining;
+  } catch {
+    return search;
+  }
+}
+
+function cloneBodyWithStreamFalse(
+  body: Record<string, unknown> | null
+): Record<string, unknown> | null {
+  if (body === null) return null;
+  return { ...body, stream: false };
+}
+
+function cloneBodyWithoutStreamFlag(
+  body: Record<string, unknown> | null
+): Record<string, unknown> | null {
+  if (body === null) return null;
+  if (!("stream" in body)) {
+    return { ...body };
+  }
+  return { ...body, stream: false };
+}

--- a/src/app/v1/_lib/proxy/fake-streaming/stream-intent.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/stream-intent.ts
@@ -45,7 +45,10 @@ function hasAltSse(search: string): boolean {
   if (!normalized) return false;
   try {
     const params = new URLSearchParams(normalized);
-    return params.get("alt") === "sse";
+    // `alt` may legally appear multiple times (e.g. ?alt=json&alt=sse). Only
+    // looking at the first value would misclassify such requests as
+    // non-streaming.
+    return params.getAll("alt").includes("sse");
   } catch {
     return false;
   }
@@ -81,8 +84,13 @@ function stripAltSse(search: string): string {
   if (!raw) return "";
   try {
     const params = new URLSearchParams(raw);
-    if (params.get("alt") === "sse") {
+    const altValues = params.getAll("alt");
+    if (altValues.includes("sse")) {
+      // Drop only the sse occurrences; preserve any other `alt` values.
       params.delete("alt");
+      for (const value of altValues) {
+        if (value !== "sse") params.append("alt", value);
+      }
     }
     const remaining = params.toString();
     if (!remaining) return "";

--- a/src/drizzle/schema.ts
+++ b/src/drizzle/schema.ts
@@ -799,6 +799,12 @@ export const systemSettings = pgTable('system_settings', {
     .notNull()
     .default(true),
 
+  // Fake 流式输出白名单（缺省 NULL → transformer 落 DEFAULT_FAKE_STREAMING_WHITELIST；
+  // 显式 [] → 表示禁用 fake streaming）
+  fakeStreamingWhitelist: jsonb('fake_streaming_whitelist').$type<
+    Array<{ model: string; groupTags: string[] }>
+  >(),
+
   // Codex Session ID 补全（默认开启）
   // 开启后：当 Codex 请求缺少 session_id / prompt_cache_key 时，自动补全或生成稳定的会话标识
   enableCodexSessionIdCompletion: boolean('enable_codex_session_id_completion')

--- a/src/lib/config/system-settings-cache.ts
+++ b/src/lib/config/system-settings-cache.ts
@@ -43,6 +43,7 @@ const DEFAULT_SETTINGS: Pick<
   | "enableBillingHeaderRectifier"
   | "enableResponseInputRectifier"
   | "allowNonConversationEndpointProviderFallback"
+  | "fakeStreamingWhitelist"
   | "enableCodexSessionIdCompletion"
   | "enableClaudeMetadataUserIdInjection"
   | "enableResponseFixer"
@@ -61,6 +62,9 @@ const DEFAULT_SETTINGS: Pick<
   enableResponseInputRectifier: true,
   // 安全敏感开关：冷缓存 / DB 读取失败时 fail-closed，避免意外重新开启跨供应商 raw fallback。
   allowNonConversationEndpointProviderFallback: false,
+  // Fake streaming 在 DB 完全不可达时 fail-closed（空白名单 → 走原有直传路径），
+  // 避免在不确定状态下劫持流式。Transformer / createFallbackSettings 仍走 4 个默认模型。
+  fakeStreamingWhitelist: [],
   enableCodexSessionIdCompletion: true,
   enableClaudeMetadataUserIdInjection: true,
   enableResponseFixer: true,
@@ -143,6 +147,7 @@ export async function getCachedSystemSettings(): Promise<SystemSettings> {
       enableResponseInputRectifier: DEFAULT_SETTINGS.enableResponseInputRectifier,
       allowNonConversationEndpointProviderFallback:
         DEFAULT_SETTINGS.allowNonConversationEndpointProviderFallback,
+      fakeStreamingWhitelist: DEFAULT_SETTINGS.fakeStreamingWhitelist,
       enableCodexSessionIdCompletion: DEFAULT_SETTINGS.enableCodexSessionIdCompletion,
       enableClaudeMetadataUserIdInjection: DEFAULT_SETTINGS.enableClaudeMetadataUserIdInjection,
       enableResponseFixer: DEFAULT_SETTINGS.enableResponseFixer,

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -974,6 +974,43 @@ export const UpdateSystemSettingsSchema = z.object({
   enableResponseInputRectifier: z.boolean().optional(),
   // 非对话端点跨供应商 fallback（可选）
   allowNonConversationEndpointProviderFallback: z.boolean().optional(),
+  // Fake 流式输出白名单（可选）。空数组表示显式禁用；缺省 → 使用默认四个图像生成模型。
+  fakeStreamingWhitelist: z
+    .array(
+      z.object({
+        model: z
+          .string()
+          .min(1, "model 不能为空")
+          .max(200, "model 不能超过 200 个字符")
+          .transform((value) => value.trim())
+          .refine((value) => value.length > 0, { message: "model 不能为空" }),
+        groupTags: z
+          .array(
+            z
+              .string()
+              .min(1)
+              .transform((value) => value.trim())
+              .refine((value) => value.length > 0, { message: "groupTag 不能为空" })
+          )
+          .default([])
+          .transform((tags) => Array.from(new Set(tags))),
+      })
+    )
+    .superRefine((entries, ctx) => {
+      const seen = new Set<string>();
+      for (let index = 0; index < entries.length; index += 1) {
+        const model = entries[index].model;
+        if (seen.has(model)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `fakeStreamingWhitelist 模型重复: ${model}`,
+            path: [index, "model"],
+          });
+        }
+        seen.add(model);
+      }
+    })
+    .optional(),
   // Codex Session ID 补全（可选）
   enableCodexSessionIdCompletion: z.boolean().optional(),
   // Claude metadata.user_id 注入（可选）

--- a/src/repository/_shared/transformers.ts
+++ b/src/repository/_shared/transformers.ts
@@ -195,13 +195,9 @@ export function toModelPrice(dbPrice: any): ModelPrice {
 }
 
 function normalizeFakeStreamingWhitelist(value: unknown): FakeStreamingWhitelistEntry[] {
-  // null / undefined → use legacy default; persisted [] is preserved as opt-out.
-  if (value === undefined || value === null) {
-    return DEFAULT_FAKE_STREAMING_WHITELIST.map((entry) => ({
-      model: entry.model,
-      groupTags: [...entry.groupTags],
-    }));
-  }
+  // null / undefined / non-array (legacy schemas) → fall back to the default
+  // image-model list. A persisted empty array is preserved as explicit
+  // opt-out and bypasses this branch.
   if (!Array.isArray(value)) {
     return DEFAULT_FAKE_STREAMING_WHITELIST.map((entry) => ({
       model: entry.model,

--- a/src/repository/_shared/transformers.ts
+++ b/src/repository/_shared/transformers.ts
@@ -5,7 +5,12 @@ import type { Key } from "@/types/key";
 import type { MessageRequest } from "@/types/message";
 import type { ModelPrice } from "@/types/model-price";
 import type { Provider } from "@/types/provider";
-import type { ResponseFixerConfig, SystemSettings } from "@/types/system-config";
+import {
+  DEFAULT_FAKE_STREAMING_WHITELIST,
+  type FakeStreamingWhitelistEntry,
+  type ResponseFixerConfig,
+  type SystemSettings,
+} from "@/types/system-config";
 import type { User } from "@/types/user";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -189,6 +194,44 @@ export function toModelPrice(dbPrice: any): ModelPrice {
   };
 }
 
+function normalizeFakeStreamingWhitelist(value: unknown): FakeStreamingWhitelistEntry[] {
+  // null / undefined → use legacy default; persisted [] is preserved as opt-out.
+  if (value === undefined || value === null) {
+    return DEFAULT_FAKE_STREAMING_WHITELIST.map((entry) => ({
+      model: entry.model,
+      groupTags: [...entry.groupTags],
+    }));
+  }
+  if (!Array.isArray(value)) {
+    return DEFAULT_FAKE_STREAMING_WHITELIST.map((entry) => ({
+      model: entry.model,
+      groupTags: [...entry.groupTags],
+    }));
+  }
+  const seen = new Set<string>();
+  const result: FakeStreamingWhitelistEntry[] = [];
+  for (const raw of value) {
+    if (!raw || typeof raw !== "object") continue;
+    const candidate = raw as { model?: unknown; groupTags?: unknown };
+    const model = typeof candidate.model === "string" ? candidate.model.trim() : "";
+    if (model.length === 0 || seen.has(model)) continue;
+    seen.add(model);
+    const groupTags: string[] = [];
+    if (Array.isArray(candidate.groupTags)) {
+      const groupSeen = new Set<string>();
+      for (const tag of candidate.groupTags) {
+        if (typeof tag !== "string") continue;
+        const trimmed = tag.trim();
+        if (trimmed.length === 0 || groupSeen.has(trimmed)) continue;
+        groupSeen.add(trimmed);
+        groupTags.push(trimmed);
+      }
+    }
+    result.push({ model, groupTags });
+  }
+  return result;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function toSystemSettings(dbSettings: any): SystemSettings {
   const defaultResponseFixerConfig: ResponseFixerConfig = {
@@ -227,6 +270,7 @@ export function toSystemSettings(dbSettings: any): SystemSettings {
     enableResponseInputRectifier: dbSettings?.enableResponseInputRectifier ?? true,
     allowNonConversationEndpointProviderFallback:
       dbSettings?.allowNonConversationEndpointProviderFallback ?? true,
+    fakeStreamingWhitelist: normalizeFakeStreamingWhitelist(dbSettings?.fakeStreamingWhitelist),
     enableCodexSessionIdCompletion: dbSettings?.enableCodexSessionIdCompletion ?? true,
     enableClaudeMetadataUserIdInjection: dbSettings?.enableClaudeMetadataUserIdInjection ?? true,
     enableResponseFixer: dbSettings?.enableResponseFixer ?? true,

--- a/src/repository/system-config.ts
+++ b/src/repository/system-config.ts
@@ -5,7 +5,11 @@ import { db } from "@/drizzle/db";
 import { systemSettings } from "@/drizzle/schema";
 import { logger } from "@/lib/logger";
 import { DEFAULT_SITE_TITLE } from "@/lib/site-title";
-import type { SystemSettings, UpdateSystemSettingsInput } from "@/types/system-config";
+import {
+  DEFAULT_FAKE_STREAMING_WHITELIST,
+  type SystemSettings,
+  type UpdateSystemSettingsInput,
+} from "@/types/system-config";
 import { toSystemSettings } from "./_shared/transformers";
 
 type TransactionExecutor = Parameters<Parameters<typeof db.transaction>[0]>[0];
@@ -159,6 +163,10 @@ function createFallbackSettings(): SystemSettings {
     enableBillingHeaderRectifier: true,
     enableResponseInputRectifier: true,
     allowNonConversationEndpointProviderFallback: true,
+    fakeStreamingWhitelist: DEFAULT_FAKE_STREAMING_WHITELIST.map((entry) => ({
+      model: entry.model,
+      groupTags: [...entry.groupTags],
+    })),
     enableCodexSessionIdCompletion: true,
     enableClaudeMetadataUserIdInjection: true,
     enableResponseFixer: true,
@@ -270,6 +278,7 @@ export async function getSystemSettings(): Promise<SystemSettings> {
     };
     const fullSelection = {
       passThroughUpstreamErrorMessage: systemSettings.passThroughUpstreamErrorMessage,
+      fakeStreamingWhitelist: systemSettings.fakeStreamingWhitelist,
       ...selectionWithoutPassThrough,
     };
 
@@ -287,12 +296,36 @@ export async function getSystemSettings(): Promise<SystemSettings> {
           error,
         });
 
-        // 第一层降级：仅移除本次新增的 allowNonConversationEndpointProviderFallback 列，
+        // 第一层降级：仅移除本次新增的 fakeStreamingWhitelist 列，
         // 其它已迁移的现代字段保留，避免只缺该列时其它设置被连带默认化。
+        const {
+          fakeStreamingWhitelist: _omitFakeStreamingWhitelist,
+          ...selectionWithoutFakeStreamingWhitelist
+        } = fullSelection;
+
+        try {
+          const [row] = await db
+            .select(selectionWithoutFakeStreamingWhitelist)
+            .from(systemSettings)
+            .orderBy(asc(systemSettings.id))
+            .limit(1);
+          return row ?? null;
+        } catch (fakeStreamingFallbackError) {
+          if (!isUndefinedColumnError(fakeStreamingFallbackError)) {
+            throw fakeStreamingFallbackError;
+          }
+
+          logger.warn(
+            "system_settings 表除 fakeStreamingWhitelist 外仍有列缺失，继续回退到上一代字段集。",
+            { error: fakeStreamingFallbackError }
+          );
+        }
+
+        // 第二层降级：再移除 allowNonConversationEndpointProviderFallback 列。
         const {
           allowNonConversationEndpointProviderFallback: _omitNonConversationFallback,
           ...selectionWithoutNonConversationFallback
-        } = fullSelection;
+        } = selectionWithoutFakeStreamingWhitelist;
 
         try {
           const [row] = await db
@@ -533,6 +566,7 @@ export async function updateSystemSettings(
   };
   const fullReturning = {
     passThroughUpstreamErrorMessage: systemSettings.passThroughUpstreamErrorMessage,
+    fakeStreamingWhitelist: systemSettings.fakeStreamingWhitelist,
     ...returningWithoutPassThrough,
   };
 
@@ -698,6 +732,11 @@ export async function updateSystemSettings(
       updates.ipGeoLookupEnabled = payload.ipGeoLookupEnabled;
     }
 
+    // Fake 流式输出白名单（如果提供；空数组表示显式禁用，null 留待 transformer 落默认）
+    if (payload.fakeStreamingWhitelist !== undefined) {
+      updates.fakeStreamingWhitelist = payload.fakeStreamingWhitelist;
+    }
+
     let updated;
     try {
       [updated] = await executor
@@ -714,87 +753,116 @@ export async function updateSystemSettings(
         error,
       });
 
-      // 第一层降级：仅移除本次新增的 allowNonConversationEndpointProviderFallback 列，
-      // 其它字段继续原值更新 / 返回，避免只缺该列时连带丢失 codex/highConcurrency 等更新。
+      // 第一层降级：仅移除本次新增的 fakeStreamingWhitelist 列，
+      // 其它字段继续原值更新 / 返回。
       const {
-        allowNonConversationEndpointProviderFallback: _omitUpdate,
-        ...updatesWithoutNonConversationFallback
+        fakeStreamingWhitelist: _omitUpdateFakeStreaming,
+        ...updatesWithoutFakeStreamingWhitelist
       } = updates;
       const {
-        allowNonConversationEndpointProviderFallback: _omitReturning,
-        ...returningWithoutNonConversationFallback
+        fakeStreamingWhitelist: _omitReturningFakeStreaming,
+        ...returningWithoutFakeStreamingWhitelist
       } = fullReturning;
 
       try {
         [updated] = await executor
           .update(systemSettings)
-          .set(updatesWithoutNonConversationFallback)
+          .set(updatesWithoutFakeStreamingWhitelist)
           .where(eq(systemSettings.id, current.id))
-          .returning(returningWithoutNonConversationFallback);
-      } catch (nonConversationFallbackError) {
-        if (!isUndefinedColumnError(nonConversationFallbackError)) {
-          throw nonConversationFallbackError;
+          .returning(returningWithoutFakeStreamingWhitelist);
+      } catch (fakeStreamingFallbackError) {
+        if (!isUndefinedColumnError(fakeStreamingFallbackError)) {
+          throw fakeStreamingFallbackError;
         }
 
         logger.warn(
-          "system_settings 表除新增列外仍有列缺失，继续回退到 passThrough / highConcurrency 字段集更新。",
-          { error: nonConversationFallbackError }
+          "system_settings 表除 fakeStreamingWhitelist 外仍有列缺失，继续回退到 allowNonConversationEndpointProviderFallback 之外的字段集。",
+          { error: fakeStreamingFallbackError }
         );
+      }
 
+      // 第二层降级：再移除 allowNonConversationEndpointProviderFallback 列。
+      const {
+        allowNonConversationEndpointProviderFallback: _omitUpdate,
+        ...updatesWithoutNonConversationFallback
+      } = updatesWithoutFakeStreamingWhitelist;
+      const {
+        allowNonConversationEndpointProviderFallback: _omitReturning,
+        ...returningWithoutNonConversationFallback
+      } = returningWithoutFakeStreamingWhitelist;
+
+      if (!updated) {
         try {
-          const withoutPassThroughUpdates = { ...updates };
-          delete withoutPassThroughUpdates.passThroughUpstreamErrorMessage;
           [updated] = await executor
             .update(systemSettings)
-            .set(withoutPassThroughUpdates)
+            .set(updatesWithoutNonConversationFallback)
             .where(eq(systemSettings.id, current.id))
-            .returning(returningWithoutPassThrough);
-        } catch (passThroughFallbackError) {
-          if (!isUndefinedColumnError(passThroughFallbackError)) {
-            throw passThroughFallbackError;
+            .returning(returningWithoutNonConversationFallback);
+        } catch (nonConversationFallbackError) {
+          if (!isUndefinedColumnError(nonConversationFallbackError)) {
+            throw nonConversationFallbackError;
           }
 
-          const downgradedUpdates = { ...updates };
-          delete downgradedUpdates.passThroughUpstreamErrorMessage;
-          delete downgradedUpdates.enableHighConcurrencyMode;
-          delete downgradedUpdates.publicStatusWindowHours;
-          delete downgradedUpdates.publicStatusAggregationIntervalMinutes;
-          delete downgradedUpdates.ipExtractionConfig;
-          delete downgradedUpdates.ipGeoLookupEnabled;
-
-          const legacyUpdates = { ...downgradedUpdates };
-          delete legacyUpdates.codexPriorityBillingSource;
-          delete legacyUpdates.allowNonConversationEndpointProviderFallback;
+          logger.warn(
+            "system_settings 表除新增列外仍有列缺失，继续回退到 passThrough / highConcurrency 字段集更新。",
+            { error: nonConversationFallbackError }
+          );
 
           try {
+            const withoutPassThroughUpdates = { ...updates };
+            delete withoutPassThroughUpdates.passThroughUpstreamErrorMessage;
             [updated] = await executor
               .update(systemSettings)
-              .set(downgradedUpdates)
+              .set(withoutPassThroughUpdates)
               .where(eq(systemSettings.id, current.id))
-              .returning(returningWithoutHighConcurrencyMode);
-          } catch (downgradedFallbackError) {
-            if (!isUndefinedColumnError(downgradedFallbackError)) {
-              throw downgradedFallbackError;
+              .returning(returningWithoutPassThrough);
+          } catch (passThroughFallbackError) {
+            if (!isUndefinedColumnError(passThroughFallbackError)) {
+              throw passThroughFallbackError;
             }
 
-            logger.warn(
-              "system_settings 表缺少 codexPriorityBillingSource 之外的新列，继续降级重试。",
-              { error: downgradedFallbackError }
-            );
+            const downgradedUpdates = { ...updates };
+            delete downgradedUpdates.passThroughUpstreamErrorMessage;
+            delete downgradedUpdates.enableHighConcurrencyMode;
+            delete downgradedUpdates.publicStatusWindowHours;
+            delete downgradedUpdates.publicStatusAggregationIntervalMinutes;
+            delete downgradedUpdates.ipExtractionConfig;
+            delete downgradedUpdates.ipGeoLookupEnabled;
 
-            [updated] = await executor
-              .update(systemSettings)
-              .set(legacyUpdates)
-              .where(eq(systemSettings.id, current.id))
-              .returning(returningWithoutCodexAndHighConcurrency);
-          }
+            const legacyUpdates = { ...downgradedUpdates };
+            delete legacyUpdates.codexPriorityBillingSource;
+            delete legacyUpdates.allowNonConversationEndpointProviderFallback;
 
-          if (!updated) {
-            [updated] = await executor
-              .update(systemSettings)
-              .set(legacyUpdates)
-              .where(eq(systemSettings.id, current.id))
-              .returning(returningWithoutCodexAndHighConcurrency);
+            try {
+              [updated] = await executor
+                .update(systemSettings)
+                .set(downgradedUpdates)
+                .where(eq(systemSettings.id, current.id))
+                .returning(returningWithoutHighConcurrencyMode);
+            } catch (downgradedFallbackError) {
+              if (!isUndefinedColumnError(downgradedFallbackError)) {
+                throw downgradedFallbackError;
+              }
+
+              logger.warn(
+                "system_settings 表缺少 codexPriorityBillingSource 之外的新列，继续降级重试。",
+                { error: downgradedFallbackError }
+              );
+
+              [updated] = await executor
+                .update(systemSettings)
+                .set(legacyUpdates)
+                .where(eq(systemSettings.id, current.id))
+                .returning(returningWithoutCodexAndHighConcurrency);
+            }
+
+            if (!updated) {
+              [updated] = await executor
+                .update(systemSettings)
+                .set(legacyUpdates)
+                .where(eq(systemSettings.id, current.id))
+                .returning(returningWithoutCodexAndHighConcurrency);
+            }
           }
         }
       }

--- a/src/repository/system-config.ts
+++ b/src/repository/system-config.ts
@@ -809,7 +809,10 @@ export async function updateSystemSettings(
           );
 
           try {
-            const withoutPassThroughUpdates = { ...updates };
+            // Continue pruning from the already-reduced object, otherwise the
+            // freshly removed `fakeStreamingWhitelist` (and any other newer
+            // columns) would be reintroduced and fail again on legacy schemas.
+            const withoutPassThroughUpdates = { ...updatesWithoutNonConversationFallback };
             delete withoutPassThroughUpdates.passThroughUpstreamErrorMessage;
             [updated] = await executor
               .update(systemSettings)
@@ -821,7 +824,9 @@ export async function updateSystemSettings(
               throw passThroughFallbackError;
             }
 
-            const downgradedUpdates = { ...updates };
+            // Same rationale: clone from the already-pruned object to avoid
+            // re-introducing newer columns the legacy schema can't handle.
+            const downgradedUpdates = { ...updatesWithoutNonConversationFallback };
             delete downgradedUpdates.passThroughUpstreamErrorMessage;
             delete downgradedUpdates.enableHighConcurrencyMode;
             delete downgradedUpdates.publicStatusWindowHours;
@@ -829,9 +834,12 @@ export async function updateSystemSettings(
             delete downgradedUpdates.ipExtractionConfig;
             delete downgradedUpdates.ipGeoLookupEnabled;
 
+            // legacyUpdates already inherits the pruning from
+            // updatesWithoutNonConversationFallback (which dropped
+            // allowNonConversationEndpointProviderFallback), so we only need
+            // to additionally remove codexPriorityBillingSource here.
             const legacyUpdates = { ...downgradedUpdates };
             delete legacyUpdates.codexPriorityBillingSource;
-            delete legacyUpdates.allowNonConversationEndpointProviderFallback;
 
             try {
               [updated] = await executor

--- a/src/types/system-config.ts
+++ b/src/types/system-config.ts
@@ -13,6 +13,22 @@ export interface ResponseFixerConfig {
   maxFixSize: number;
 }
 
+// Fake streaming whitelist entry: pairs an exact client-requested model name
+// with optional provider group tags. Empty groupTags means "all groups".
+export interface FakeStreamingWhitelistEntry {
+  model: string;
+  groupTags: string[];
+}
+
+// Default whitelist used when system_settings has no persisted value (legacy
+// upgrade path). A persisted empty array is preserved as explicit opt-out.
+export const DEFAULT_FAKE_STREAMING_WHITELIST: ReadonlyArray<FakeStreamingWhitelistEntry> = [
+  { model: "gpt-image-2", groupTags: [] },
+  { model: "gpt-image-1.5", groupTags: [] },
+  { model: "gemini-3.1-flash-image-preview", groupTags: [] },
+  { model: "gemini-3-pro-image-preview", groupTags: [] },
+];
+
 export interface SystemSettings {
   id: number;
   siteTitle: string;
@@ -78,6 +94,9 @@ export interface SystemSettings {
   // 非对话端点跨供应商 fallback（默认开启）
   // 当前仅作用于 count_tokens / compact 这两个 raw endpoint
   allowNonConversationEndpointProviderFallback: boolean;
+
+  // Fake 流式输出白名单（缺省时使用 DEFAULT_FAKE_STREAMING_WHITELIST，持久化空数组表示显式禁用）
+  fakeStreamingWhitelist: FakeStreamingWhitelistEntry[];
 
   // Codex Session ID 补全（默认开启）
   // 目标：当 Codex 请求缺少 session_id / prompt_cache_key 时，自动补全或生成稳定的会话标识
@@ -166,6 +185,9 @@ export interface UpdateSystemSettingsInput {
 
   // 非对话端点跨供应商 fallback（可选）
   allowNonConversationEndpointProviderFallback?: boolean;
+
+  // Fake 流式输出白名单（可选）
+  fakeStreamingWhitelist?: FakeStreamingWhitelistEntry[];
 
   // Codex Session ID 补全（可选）
   enableCodexSessionIdCompletion?: boolean;

--- a/tests/unit/actions/system-config-fake-streaming-setting.test.ts
+++ b/tests/unit/actions/system-config-fake-streaming-setting.test.ts
@@ -1,0 +1,341 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const getSystemSettingsMock = vi.fn();
+const loggerWarnMock = vi.fn();
+const invalidateSystemSettingsCacheMock = vi.fn();
+const updateSystemSettingsMock = vi.fn();
+const getSessionMock = vi.fn();
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/repository/system-config", () => ({
+  getSystemSettings: () => getSystemSettingsMock(),
+  updateSystemSettings: (...args: unknown[]) => updateSystemSettingsMock(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: loggerWarnMock,
+    error: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSession: () => getSessionMock(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/config")>();
+  return {
+    ...actual,
+    invalidateSystemSettingsCache: () => invalidateSystemSettingsCacheMock(),
+  };
+});
+
+vi.mock("@/lib/public-status/config-publisher", () => ({
+  publishCurrentPublicStatusConfigProjection: vi.fn(async () => ({
+    configVersion: "cfg-1",
+    key: "public-status:v1:config:cfg-1",
+    written: true,
+    groupCount: 0,
+  })),
+}));
+
+vi.mock("@/lib/public-status/rebuild-hints", () => ({
+  schedulePublicStatusRebuild: vi.fn(async () => ({
+    accepted: true,
+    rebuildState: "rebuilding",
+  })),
+}));
+
+vi.mock("@/lib/utils/timezone", () => ({
+  resolveSystemTimezone: vi.fn(async () => "UTC"),
+  isValidIANATimezone: vi.fn(() => true),
+}));
+
+const DEFAULT_FAKE_STREAMING_MODELS = [
+  { model: "gpt-image-2", groupTags: [] },
+  { model: "gpt-image-1.5", groupTags: [] },
+  { model: "gemini-3.1-flash-image-preview", groupTags: [] },
+  { model: "gemini-3-pro-image-preview", groupTags: [] },
+];
+
+function createSettings(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    siteTitle: "Claude Code Hub",
+    allowGlobalUsageView: false,
+    currencyDisplay: "USD",
+    billingModelSource: "original",
+    codexPriorityBillingSource: "requested",
+    timezone: null,
+    enableAutoCleanup: false,
+    cleanupRetentionDays: 30,
+    cleanupSchedule: "0 2 * * *",
+    cleanupBatchSize: 10000,
+    enableClientVersionCheck: false,
+    verboseProviderError: false,
+    passThroughUpstreamErrorMessage: true,
+    enableHttp2: false,
+    enableHighConcurrencyMode: false,
+    interceptAnthropicWarmupRequests: false,
+    enableThinkingSignatureRectifier: true,
+    enableThinkingBudgetRectifier: true,
+    enableBillingHeaderRectifier: true,
+    enableResponseInputRectifier: true,
+    enableCodexSessionIdCompletion: true,
+    enableClaudeMetadataUserIdInjection: true,
+    enableResponseFixer: true,
+    allowNonConversationEndpointProviderFallback: true,
+    fakeStreamingWhitelist: DEFAULT_FAKE_STREAMING_MODELS,
+    responseFixerConfig: {
+      fixTruncatedJson: true,
+      fixSseFormat: true,
+      fixEncoding: true,
+      maxJsonDepth: 200,
+      maxFixSize: 1024 * 1024,
+    },
+    quotaDbRefreshIntervalSeconds: 10,
+    quotaLeasePercent5h: 0.05,
+    quotaLeasePercentDaily: 0.05,
+    quotaLeasePercentWeekly: 0.05,
+    quotaLeasePercentMonthly: 0.05,
+    quotaLeaseCapUsd: null,
+    publicStatusWindowHours: 24,
+    publicStatusAggregationIntervalMinutes: 5,
+    ipExtractionConfig: null,
+    ipGeoLookupEnabled: true,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("fake streaming whitelist system setting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
+    updateSystemSettingsMock.mockResolvedValue(createSettings());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("transformer defaults", () => {
+    test("defaults missing fake streaming config to requested image models", async () => {
+      const { toSystemSettings } = await import("@/repository/_shared/transformers");
+
+      const fromUndefined = toSystemSettings(undefined);
+      expect(fromUndefined.fakeStreamingWhitelist).toEqual(DEFAULT_FAKE_STREAMING_MODELS);
+
+      const fromNullField = toSystemSettings({
+        id: 1,
+        siteTitle: "Claude Code Hub",
+        fakeStreamingWhitelist: null,
+      });
+      expect(fromNullField.fakeStreamingWhitelist).toEqual(DEFAULT_FAKE_STREAMING_MODELS);
+
+      const fromMissingField = toSystemSettings({
+        id: 1,
+        siteTitle: "Claude Code Hub",
+      });
+      expect(fromMissingField.fakeStreamingWhitelist).toEqual(DEFAULT_FAKE_STREAMING_MODELS);
+    });
+
+    test("preserves empty fake streaming whitelist as explicit opt out", async () => {
+      const { toSystemSettings } = await import("@/repository/_shared/transformers");
+
+      const result = toSystemSettings({
+        id: 1,
+        siteTitle: "Claude Code Hub",
+        fakeStreamingWhitelist: [],
+      });
+
+      expect(result.fakeStreamingWhitelist).toEqual([]);
+    });
+
+    test("preserves persisted non-empty fake streaming whitelist", async () => {
+      const { toSystemSettings } = await import("@/repository/_shared/transformers");
+
+      const persisted = [
+        { model: "custom-model-a", groupTags: [] },
+        { model: "custom-model-b", groupTags: ["group-a"] },
+      ];
+
+      const result = toSystemSettings({
+        id: 1,
+        siteTitle: "Claude Code Hub",
+        fakeStreamingWhitelist: persisted,
+      });
+
+      expect(result.fakeStreamingWhitelist).toEqual(persisted);
+    });
+
+    test("repository fallback (table missing) defaults to image models", async () => {
+      vi.resetModules();
+      vi.doUnmock("@/repository/system-config");
+      vi.doMock("@/drizzle/db", () => ({
+        db: {
+          select: vi.fn(() => {
+            const query: Record<string, unknown> = {};
+            query.from = vi.fn(() => query);
+            query.orderBy = vi.fn(() => query);
+            query.limit = vi.fn(() => Promise.reject({ code: "42P01" }));
+            return query;
+          }),
+          update: vi.fn(),
+          insert: vi.fn(),
+          execute: vi.fn(async () => ({ count: 0 })),
+        },
+      }));
+
+      const { getSystemSettings } = await import("@/repository/system-config");
+      const fallbackSettings = await getSystemSettings();
+      expect(fallbackSettings.fakeStreamingWhitelist).toEqual(DEFAULT_FAKE_STREAMING_MODELS);
+
+      // Restore the mock for subsequent tests in this file.
+      vi.resetModules();
+      vi.doMock("@/repository/system-config", () => ({
+        getSystemSettings: () => getSystemSettingsMock(),
+        updateSystemSettings: (...args: unknown[]) => updateSystemSettingsMock(...args),
+      }));
+    });
+  });
+
+  describe("validation schema", () => {
+    test("rejects duplicate fake streaming models", async () => {
+      const { UpdateSystemSettingsSchema } = await import("@/lib/validation/schemas");
+
+      expect(() =>
+        UpdateSystemSettingsSchema.parse({
+          fakeStreamingWhitelist: [
+            { model: "gpt-image-2", groupTags: [] },
+            { model: "gpt-image-2", groupTags: ["group-a"] },
+          ],
+        })
+      ).toThrow();
+    });
+
+    test("rejects duplicate models after trimming", async () => {
+      const { UpdateSystemSettingsSchema } = await import("@/lib/validation/schemas");
+
+      expect(() =>
+        UpdateSystemSettingsSchema.parse({
+          fakeStreamingWhitelist: [
+            { model: "gpt-image-2", groupTags: [] },
+            { model: "  gpt-image-2  ", groupTags: [] },
+          ],
+        })
+      ).toThrow();
+    });
+
+    test("trims model and groupTags entries", async () => {
+      const { UpdateSystemSettingsSchema } = await import("@/lib/validation/schemas");
+
+      const parsed = UpdateSystemSettingsSchema.parse({
+        fakeStreamingWhitelist: [
+          { model: "  gpt-image-2  ", groupTags: ["  group-a  ", " group-b "] },
+        ],
+      });
+
+      expect(parsed.fakeStreamingWhitelist).toEqual([
+        { model: "gpt-image-2", groupTags: ["group-a", "group-b"] },
+      ]);
+    });
+
+    test("accepts empty groupTags as all-groups semantic", async () => {
+      const { UpdateSystemSettingsSchema } = await import("@/lib/validation/schemas");
+
+      const parsed = UpdateSystemSettingsSchema.parse({
+        fakeStreamingWhitelist: [{ model: "gpt-image-2", groupTags: [] }],
+      });
+
+      expect(parsed.fakeStreamingWhitelist).toEqual([{ model: "gpt-image-2", groupTags: [] }]);
+    });
+
+    test("accepts empty whitelist (explicit disable)", async () => {
+      const { UpdateSystemSettingsSchema } = await import("@/lib/validation/schemas");
+
+      const parsed = UpdateSystemSettingsSchema.parse({
+        fakeStreamingWhitelist: [],
+      });
+
+      expect(parsed.fakeStreamingWhitelist).toEqual([]);
+    });
+
+    test("rejects empty model string", async () => {
+      const { UpdateSystemSettingsSchema } = await import("@/lib/validation/schemas");
+
+      expect(() =>
+        UpdateSystemSettingsSchema.parse({
+          fakeStreamingWhitelist: [{ model: "", groupTags: [] }],
+        })
+      ).toThrow();
+
+      expect(() =>
+        UpdateSystemSettingsSchema.parse({
+          fakeStreamingWhitelist: [{ model: "   ", groupTags: [] }],
+        })
+      ).toThrow();
+    });
+  });
+
+  describe("save action", () => {
+    test("saves fake streaming whitelist entry for all groups and invalidates cache", async () => {
+      const persisted = [
+        { model: "gpt-image-2", groupTags: [] },
+        { model: "gpt-image-1.5", groupTags: ["group-a", "group-b"] },
+      ];
+
+      updateSystemSettingsMock.mockResolvedValueOnce(
+        createSettings({ fakeStreamingWhitelist: persisted })
+      );
+
+      const { saveSystemSettings } = await import("@/actions/system-config");
+      const result = await saveSystemSettings({
+        fakeStreamingWhitelist: persisted,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(updateSystemSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fakeStreamingWhitelist: persisted,
+        })
+      );
+      expect(invalidateSystemSettingsCacheMock).toHaveBeenCalledTimes(1);
+      if (result.ok) {
+        expect(result.data.fakeStreamingWhitelist).toEqual(persisted);
+      }
+    });
+
+    test("preserves empty fake streaming whitelist as explicit opt out", async () => {
+      updateSystemSettingsMock.mockResolvedValueOnce(
+        createSettings({ fakeStreamingWhitelist: [] })
+      );
+
+      const { saveSystemSettings } = await import("@/actions/system-config");
+      const result = await saveSystemSettings({
+        fakeStreamingWhitelist: [],
+      });
+
+      expect(result.ok).toBe(true);
+      expect(updateSystemSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fakeStreamingWhitelist: [],
+        })
+      );
+      if (result.ok) {
+        expect(result.data.fakeStreamingWhitelist).toEqual([]);
+      }
+    });
+  });
+});

--- a/tests/unit/proxy/fake-streaming-eligibility.test.ts
+++ b/tests/unit/proxy/fake-streaming-eligibility.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "vitest";
+import { isFakeStreamingEligible } from "@/app/v1/_lib/proxy/fake-streaming/eligibility";
+import { PROVIDER_GROUP } from "@/lib/constants/provider.constants";
+import type { FakeStreamingWhitelistEntry } from "@/types/system-config";
+
+describe("isFakeStreamingEligible", () => {
+  test("matches exact model for all groups when groupTags is empty", () => {
+    const whitelist: FakeStreamingWhitelistEntry[] = [{ model: "gpt-image-2", groupTags: [] }];
+
+    expect(isFakeStreamingEligible("gpt-image-2", "any-group", whitelist)).toBe(true);
+    expect(isFakeStreamingEligible("gpt-image-2", "default", whitelist)).toBe(true);
+    expect(isFakeStreamingEligible("gpt-image-2", null, whitelist)).toBe(true);
+    expect(isFakeStreamingEligible("gpt-image-2", undefined, whitelist)).toBe(true);
+  });
+
+  test("rejects model not in whitelist", () => {
+    const whitelist: FakeStreamingWhitelistEntry[] = [{ model: "gpt-image-2", groupTags: [] }];
+
+    expect(isFakeStreamingEligible("claude-3-5-sonnet-latest", "default", whitelist)).toBe(false);
+    expect(isFakeStreamingEligible("gpt-image", "default", whitelist)).toBe(false);
+    expect(isFakeStreamingEligible("gpt-image-2-turbo", "default", whitelist)).toBe(false);
+  });
+
+  test("does not match by prefix or substring", () => {
+    const whitelist: FakeStreamingWhitelistEntry[] = [{ model: "claude-3", groupTags: [] }];
+
+    expect(isFakeStreamingEligible("claude-3", "default", whitelist)).toBe(true);
+    expect(isFakeStreamingEligible("claude-3-5-sonnet-latest", "default", whitelist)).toBe(false);
+    expect(isFakeStreamingEligible("anthropic/claude-3", "default", whitelist)).toBe(false);
+  });
+
+  test("matches only configured provider groups when groupTags is non-empty", () => {
+    const whitelist: FakeStreamingWhitelistEntry[] = [
+      { model: "gpt-image-2", groupTags: ["group-a", "group-b"] },
+    ];
+
+    expect(isFakeStreamingEligible("gpt-image-2", "group-a", whitelist)).toBe(true);
+    expect(isFakeStreamingEligible("gpt-image-2", "group-b", whitelist)).toBe(true);
+    expect(isFakeStreamingEligible("gpt-image-2", "group-c", whitelist)).toBe(false);
+  });
+
+  test("missing group resolves via default group constant", () => {
+    const whitelistAll: FakeStreamingWhitelistEntry[] = [{ model: "gpt-image-2", groupTags: [] }];
+    expect(isFakeStreamingEligible("gpt-image-2", null, whitelistAll)).toBe(true);
+
+    const whitelistDefault: FakeStreamingWhitelistEntry[] = [
+      { model: "gpt-image-2", groupTags: [PROVIDER_GROUP.DEFAULT] },
+    ];
+    expect(isFakeStreamingEligible("gpt-image-2", null, whitelistDefault)).toBe(true);
+    expect(isFakeStreamingEligible("gpt-image-2", undefined, whitelistDefault)).toBe(true);
+    expect(isFakeStreamingEligible("gpt-image-2", "", whitelistDefault)).toBe(true);
+
+    const whitelistOther: FakeStreamingWhitelistEntry[] = [
+      { model: "gpt-image-2", groupTags: ["group-a"] },
+    ];
+    expect(isFakeStreamingEligible("gpt-image-2", null, whitelistOther)).toBe(false);
+  });
+
+  test("returns false when whitelist is empty (explicit opt out)", () => {
+    expect(isFakeStreamingEligible("gpt-image-2", "default", [])).toBe(false);
+    expect(isFakeStreamingEligible("any-model", null, [])).toBe(false);
+  });
+
+  test("trims whitespace from inputs and whitelist values", () => {
+    const whitelist: FakeStreamingWhitelistEntry[] = [
+      { model: "gpt-image-2", groupTags: ["group-a"] },
+    ];
+
+    expect(isFakeStreamingEligible("  gpt-image-2  ", "  group-a  ", whitelist)).toBe(true);
+    expect(isFakeStreamingEligible("gpt-image-2", " group-a ", whitelist)).toBe(true);
+  });
+
+  test("rejects empty model string", () => {
+    const whitelist: FakeStreamingWhitelistEntry[] = [{ model: "gpt-image-2", groupTags: [] }];
+
+    expect(isFakeStreamingEligible("", "default", whitelist)).toBe(false);
+    expect(isFakeStreamingEligible("   ", "default", whitelist)).toBe(false);
+  });
+
+  test("default image-generation models match when whitelist contains them with empty groups", () => {
+    const whitelist: FakeStreamingWhitelistEntry[] = [
+      { model: "gpt-image-2", groupTags: [] },
+      { model: "gpt-image-1.5", groupTags: [] },
+      { model: "gemini-3.1-flash-image-preview", groupTags: [] },
+      { model: "gemini-3-pro-image-preview", groupTags: [] },
+    ];
+
+    for (const model of [
+      "gpt-image-2",
+      "gpt-image-1.5",
+      "gemini-3.1-flash-image-preview",
+      "gemini-3-pro-image-preview",
+    ]) {
+      expect(isFakeStreamingEligible(model, "default", whitelist)).toBe(true);
+      expect(isFakeStreamingEligible(model, "any-group", whitelist)).toBe(true);
+    }
+  });
+
+  test("ignores duplicate model entries (deterministic first match)", () => {
+    const whitelist: FakeStreamingWhitelistEntry[] = [
+      { model: "gpt-image-2", groupTags: [] },
+      { model: "gpt-image-2", groupTags: ["group-x"] },
+    ];
+
+    // Even if a duplicate slipped through (validation should prevent), the first
+    // entry's "all groups" semantics should win, so any group matches.
+    expect(isFakeStreamingEligible("gpt-image-2", "group-y", whitelist)).toBe(true);
+  });
+});

--- a/tests/unit/proxy/fake-streaming-orchestrator.test.ts
+++ b/tests/unit/proxy/fake-streaming-orchestrator.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  orchestrateFakeStreamingAttempts,
+  type FakeStreamingAttemptOutcome,
+} from "@/app/v1/_lib/proxy/fake-streaming/orchestrator";
+
+const validBody = JSON.stringify({
+  id: "msg",
+  type: "message",
+  content: [{ type: "text", text: "ok" }],
+});
+
+const emptyBody = "";
+
+function makeAttempt(outcome: {
+  status: number;
+  body: string;
+  providerId: string;
+}): FakeStreamingAttemptOutcome {
+  return outcome;
+}
+
+describe("orchestrateFakeStreamingAttempts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("returns success on first valid attempt", async () => {
+    const performAttempt = vi.fn(async (_index: number) =>
+      makeAttempt({ status: 200, body: validBody, providerId: "p1" })
+    );
+
+    const result = await orchestrateFakeStreamingAttempts({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 5,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.finalBody).toBe(validBody);
+    expect(result.attempts).toHaveLength(1);
+    expect(result.attempts[0].providerId).toBe("p1");
+    expect(performAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  test("never runs more than one upstream attempt at once (no race)", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const performAttempt = vi.fn(async (index: number) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        if (index === 0) {
+          return makeAttempt({ status: 200, body: emptyBody, providerId: "p1" });
+        }
+        return makeAttempt({ status: 200, body: validBody, providerId: "p2" });
+      } finally {
+        inFlight -= 1;
+      }
+    });
+
+    const promise = orchestrateFakeStreamingAttempts({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 5,
+    });
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toHaveLength(2);
+    expect(result.attempts[0].validation.ok).toBe(false);
+    expect(result.attempts[1].validation.ok).toBe(true);
+    expect(maxInFlight).toBe(1);
+    expect(performAttempt).toHaveBeenCalledTimes(2);
+  });
+
+  test("retries on empty upstream until success or providers exhaust", async () => {
+    const performAttempt = vi.fn(
+      async (index: number): Promise<FakeStreamingAttemptOutcome | null> => {
+        if (index === 0) return makeAttempt({ status: 200, body: emptyBody, providerId: "p1" });
+        if (index === 1) return makeAttempt({ status: 200, body: "  ", providerId: "p2" });
+        if (index === 2) return makeAttempt({ status: 200, body: validBody, providerId: "p3" });
+        return null;
+      }
+    );
+
+    const result = await orchestrateFakeStreamingAttempts({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 5,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toHaveLength(3);
+    expect(result.finalBody).toBe(validBody);
+  });
+
+  test("returns failure when all providers fail", async () => {
+    let calls = 0;
+    const performAttempt = vi.fn(async (): Promise<FakeStreamingAttemptOutcome | null> => {
+      calls += 1;
+      if (calls > 3) return null;
+      return makeAttempt({ status: 200, body: emptyBody, providerId: `p${calls}` });
+    });
+
+    const result = await orchestrateFakeStreamingAttempts({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 10,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCode).toBe("upstream_all_attempts_failed");
+    expect(result.attempts).toHaveLength(3);
+    expect(result.attempts.every((a) => !a.validation.ok)).toBe(true);
+  });
+
+  test("aborts current attempt and stops fallback on client disconnect", async () => {
+    const abortController = new AbortController();
+    const seenAborts: AbortSignal[] = [];
+
+    const performAttempt = vi.fn(async (index: number, signal: AbortSignal) => {
+      seenAborts.push(signal);
+      if (index === 0) {
+        return await new Promise<FakeStreamingAttemptOutcome>((_, reject) => {
+          signal.addEventListener("abort", () => {
+            reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+          });
+        });
+      }
+      return makeAttempt({ status: 200, body: validBody, providerId: "p2" });
+    });
+
+    const promise = orchestrateFakeStreamingAttempts({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: abortController.signal,
+      maxAttempts: 5,
+    });
+
+    // Abort while first attempt is pending
+    await Promise.resolve();
+    abortController.abort();
+
+    const result = await promise;
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCode).toBe("client_abort");
+    expect(performAttempt).toHaveBeenCalledTimes(1);
+    expect(seenAborts.length).toBe(1);
+    expect(seenAborts[0].aborted).toBe(true);
+  });
+
+  test("maxAttempts caps the loop even if more providers are available", async () => {
+    const performAttempt = vi.fn(async (index: number) =>
+      makeAttempt({ status: 200, body: emptyBody, providerId: `p${index}` })
+    );
+
+    const result = await orchestrateFakeStreamingAttempts({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 2,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCode).toBe("upstream_all_attempts_failed");
+    expect(result.attempts).toHaveLength(2);
+    expect(performAttempt).toHaveBeenCalledTimes(2);
+  });
+
+  test("preserves attempt metadata across attempts", async () => {
+    const performAttempt = vi.fn(async (index: number) => {
+      if (index === 0) {
+        return makeAttempt({ status: 502, body: "bad gateway", providerId: "p1" });
+      }
+      return makeAttempt({ status: 200, body: validBody, providerId: "p2" });
+    });
+
+    const result = await orchestrateFakeStreamingAttempts({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 5,
+    });
+
+    expect(result.attempts[0].providerId).toBe("p1");
+    expect(result.attempts[0].status).toBe(502);
+    expect(result.attempts[0].validation.ok).toBe(false);
+    expect(result.attempts[0].validation.code).toBe("non_2xx_status");
+
+    expect(result.attempts[1].providerId).toBe("p2");
+    expect(result.attempts[1].status).toBe(200);
+    expect(result.attempts[1].validation.ok).toBe(true);
+  });
+
+  test("returns no_providers when first call returns null", async () => {
+    const performAttempt = vi.fn(async () => null);
+
+    const result = await orchestrateFakeStreamingAttempts({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 5,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCode).toBe("no_providers");
+    expect(result.attempts).toHaveLength(0);
+  });
+
+  test("client abort signal flows into in-flight perform attempts", async () => {
+    const abortController = new AbortController();
+    let observedSignalDuringAttempt: AbortSignal | null = null;
+    const performAttempt = vi.fn(async (_index: number, signal: AbortSignal) => {
+      observedSignalDuringAttempt = signal;
+      // While the attempt is in flight, parent abort should propagate.
+      await Promise.resolve();
+      abortController.abort();
+      expect(signal.aborted).toBe(true);
+      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+    });
+
+    const result = await orchestrateFakeStreamingAttempts({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: abortController.signal,
+      maxAttempts: 5,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errorCode).toBe("client_abort");
+    expect(observedSignalDuringAttempt).not.toBeNull();
+  });
+});

--- a/tests/unit/proxy/fake-streaming-response-validator.test.ts
+++ b/tests/unit/proxy/fake-streaming-response-validator.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, test } from "vitest";
+import {
+  validateUpstreamResponse,
+  type ProtocolFamily,
+} from "@/app/v1/_lib/proxy/fake-streaming/response-validator";
+
+function failure(family: ProtocolFamily, body: string, isStream: boolean, status = 200) {
+  return validateUpstreamResponse({
+    family,
+    status,
+    body,
+    isStream,
+  });
+}
+
+describe("validateUpstreamResponse", () => {
+  describe("status code handling", () => {
+    test.each<ProtocolFamily>([
+      "anthropic",
+      "openai-chat",
+      "openai-responses",
+      "gemini",
+    ])("%s: non-2xx is failure regardless of body", (family) => {
+      const valid = `{"id":"ok","model":"m","content":[{"type":"text","text":"hi"}]}`;
+      expect(failure(family, valid, false, 500).ok).toBe(false);
+      expect(failure(family, valid, false, 502).ok).toBe(false);
+      expect(failure(family, valid, false, 429).ok).toBe(false);
+      expect(failure(family, valid, false, 401).ok).toBe(false);
+    });
+  });
+
+  describe("empty / whitespace bodies", () => {
+    test.each<ProtocolFamily>([
+      "anthropic",
+      "openai-chat",
+      "openai-responses",
+      "gemini",
+    ])("%s: empty body fails (non-stream)", (family) => {
+      expect(failure(family, "", false).ok).toBe(false);
+      expect(failure(family, "   ", false).ok).toBe(false);
+      expect(failure(family, "\n\n  \t\n", false).ok).toBe(false);
+    });
+
+    test.each<ProtocolFamily>([
+      "anthropic",
+      "openai-chat",
+      "openai-responses",
+      "gemini",
+    ])("%s: empty body fails (stream)", (family) => {
+      expect(failure(family, "", true).ok).toBe(false);
+      expect(failure(family, "   ", true).ok).toBe(false);
+    });
+  });
+
+  describe("invalid JSON for non-stream", () => {
+    test.each<ProtocolFamily>([
+      "anthropic",
+      "openai-chat",
+      "openai-responses",
+      "gemini",
+    ])("%s: invalid JSON fails non-stream", (family) => {
+      expect(failure(family, "not-json", false).ok).toBe(false);
+      expect(failure(family, "{ truncated", false).ok).toBe(false);
+    });
+  });
+
+  describe("SSE failure cases", () => {
+    test.each<ProtocolFamily>([
+      "anthropic",
+      "openai-chat",
+      "openai-responses",
+      "gemini",
+    ])("%s: comment-only SSE fails", (family) => {
+      expect(failure(family, ": ping\n\n: ping\n\n", true).ok).toBe(false);
+    });
+
+    test("openai-chat: [DONE]-only SSE fails", () => {
+      expect(failure("openai-chat", "data: [DONE]\n\n", true).ok).toBe(false);
+    });
+
+    test("openai-chat: error SSE fails", () => {
+      const errEvent = `event: error\ndata: {"error":{"message":"upstream"}}\n\n`;
+      expect(failure("openai-chat", errEvent, true).ok).toBe(false);
+    });
+
+    test("anthropic: error SSE fails", () => {
+      const errEvent = `event: error\ndata: {"type":"error","error":{"type":"overloaded_error"}}\n\n`;
+      expect(failure("anthropic", errEvent, true).ok).toBe(false);
+    });
+
+    test("openai-chat: usage-only chunk fails (no delta content / tool_calls)", () => {
+      const usageOnly = `data: {"id":"x","object":"chat.completion.chunk","choices":[{"delta":{},"index":0}],"usage":{"completion_tokens":3}}\n\ndata: [DONE]\n\n`;
+      expect(failure("openai-chat", usageOnly, true).ok).toBe(false);
+    });
+  });
+
+  describe("non-stream success cases", () => {
+    test("anthropic: text content_block accepted", () => {
+      const body = JSON.stringify({
+        id: "msg",
+        type: "message",
+        role: "assistant",
+        model: "claude-3",
+        content: [{ type: "text", text: "hello" }],
+      });
+      expect(failure("anthropic", body, false).ok).toBe(true);
+    });
+
+    test("anthropic: tool_use block accepted (no text)", () => {
+      const body = JSON.stringify({
+        id: "msg",
+        type: "message",
+        role: "assistant",
+        model: "claude-3",
+        content: [{ type: "tool_use", id: "tu_1", name: "foo", input: { x: 1 } }],
+      });
+      expect(failure("anthropic", body, false).ok).toBe(true);
+    });
+
+    test("openai-chat: text choice accepted", () => {
+      const body = JSON.stringify({
+        id: "x",
+        object: "chat.completion",
+        choices: [{ message: { content: "hi" }, index: 0, finish_reason: "stop" }],
+      });
+      expect(failure("openai-chat", body, false).ok).toBe(true);
+    });
+
+    test("openai-chat: function_call accepted (no text)", () => {
+      const body = JSON.stringify({
+        id: "x",
+        object: "chat.completion",
+        choices: [
+          {
+            message: {
+              tool_calls: [{ id: "t", type: "function", function: { name: "f", arguments: "{}" } }],
+            },
+            index: 0,
+            finish_reason: "tool_calls",
+          },
+        ],
+      });
+      expect(failure("openai-chat", body, false).ok).toBe(true);
+    });
+
+    test("openai-responses: text output_item accepted", () => {
+      const body = JSON.stringify({
+        id: "resp_1",
+        object: "response",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "hi" }],
+          },
+        ],
+      });
+      expect(failure("openai-responses", body, false).ok).toBe(true);
+    });
+
+    test("openai-responses: structured output accepted", () => {
+      const body = JSON.stringify({
+        id: "resp_1",
+        object: "response",
+        output: [
+          {
+            type: "function_call",
+            name: "foo",
+            arguments: "{}",
+          },
+        ],
+      });
+      expect(failure("openai-responses", body, false).ok).toBe(true);
+    });
+
+    test("gemini: candidates accepted", () => {
+      const body = JSON.stringify({
+        candidates: [
+          {
+            content: { parts: [{ text: "hi" }] },
+            finishReason: "STOP",
+          },
+        ],
+      });
+      expect(failure("gemini", body, false).ok).toBe(true);
+    });
+
+    test("gemini: candidates with image bytes only also accepted (no text)", () => {
+      const body = JSON.stringify({
+        candidates: [
+          {
+            content: {
+              parts: [{ inlineData: { mimeType: "image/png", data: "AAAA" } }],
+            },
+            finishReason: "STOP",
+          },
+        ],
+      });
+      expect(failure("gemini", body, false).ok).toBe(true);
+    });
+  });
+
+  describe("non-stream failure cases", () => {
+    test("anthropic: empty content array fails", () => {
+      const body = JSON.stringify({
+        id: "msg",
+        type: "message",
+        content: [],
+      });
+      expect(failure("anthropic", body, false).ok).toBe(false);
+    });
+
+    test("openai-chat: empty choices array fails", () => {
+      const body = JSON.stringify({
+        id: "x",
+        object: "chat.completion",
+        choices: [],
+      });
+      expect(failure("openai-chat", body, false).ok).toBe(false);
+    });
+
+    test("openai-chat: choice with empty message content + no tool_calls fails", () => {
+      const body = JSON.stringify({
+        id: "x",
+        object: "chat.completion",
+        choices: [{ message: { content: "" }, index: 0, finish_reason: "stop" }],
+      });
+      expect(failure("openai-chat", body, false).ok).toBe(false);
+    });
+
+    test("openai-responses: empty output array fails", () => {
+      const body = JSON.stringify({
+        id: "resp_1",
+        object: "response",
+        output: [],
+      });
+      expect(failure("openai-responses", body, false).ok).toBe(false);
+    });
+
+    test("gemini: empty candidates array fails", () => {
+      const body = JSON.stringify({ candidates: [] });
+      expect(failure("gemini", body, false).ok).toBe(false);
+    });
+
+    test("gemini: candidate with no content parts fails", () => {
+      const body = JSON.stringify({
+        candidates: [{ finishReason: "STOP" }],
+      });
+      expect(failure("gemini", body, false).ok).toBe(false);
+    });
+  });
+
+  describe("stream success cases", () => {
+    test("anthropic: message_start + content_block_delta accepted", () => {
+      const sse =
+        `event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"claude-3","content":[]}}\n\n` +
+        `event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n` +
+        `event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}\n\n` +
+        `event: message_stop\ndata: {"type":"message_stop"}\n\n`;
+      expect(failure("anthropic", sse, true).ok).toBe(true);
+    });
+
+    test("openai-chat: chunks with delta content + [DONE] accepted", () => {
+      const sse =
+        `data: {"id":"x","object":"chat.completion.chunk","choices":[{"delta":{"content":"hi"},"index":0}]}\n\n` +
+        `data: [DONE]\n\n`;
+      expect(failure("openai-chat", sse, true).ok).toBe(true);
+    });
+
+    test("openai-chat: tool_calls delta accepted", () => {
+      const sse =
+        `data: {"id":"x","object":"chat.completion.chunk","choices":[{"delta":{"tool_calls":[{"index":0,"id":"t","type":"function","function":{"name":"f","arguments":"{}"}}]},"index":0}]}\n\n` +
+        `data: [DONE]\n\n`;
+      expect(failure("openai-chat", sse, true).ok).toBe(true);
+    });
+
+    test("openai-responses: response.created + completed accepted", () => {
+      const sse =
+        `event: response.created\ndata: {"type":"response.created","response":{"id":"resp_1","object":"response","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}]}}\n\n` +
+        `event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1","object":"response","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}]}}\n\n`;
+      expect(failure("openai-responses", sse, true).ok).toBe(true);
+    });
+
+    test("gemini: data event with candidates accepted", () => {
+      const sse = `data: ${JSON.stringify({
+        candidates: [{ content: { parts: [{ text: "hi" }] }, finishReason: "STOP" }],
+      })}\n\n`;
+      expect(failure("gemini", sse, true).ok).toBe(true);
+    });
+  });
+});

--- a/tests/unit/proxy/fake-streaming-response.test.ts
+++ b/tests/unit/proxy/fake-streaming-response.test.ts
@@ -83,7 +83,7 @@ describe("emitFinalStream — anthropic", () => {
     }
   });
 
-  test("emits content_block_start with full block for non-text content (tool_use)", () => {
+  test("emits tool_use as start(empty input) + input_json_delta + stop", () => {
     const finalBody = JSON.stringify({
       id: "msg_1",
       type: "message",
@@ -103,12 +103,27 @@ describe("emitFinalStream — anthropic", () => {
 
     const sse = emitFinalStream({ family: "anthropic", finalBody });
     const events = parseSseEvents(sse);
+
+    // The Anthropic SDK only populates tool_use input from input_json_delta
+    // events; data inlined into content_block_start is silently ignored.
     const blockStart = events.find((e) => e.event === "content_block_start");
     expect(blockStart).toBeTruthy();
     if (blockStart) {
       const parsed = JSON.parse(blockStart.data);
       expect(parsed.content_block.type).toBe("tool_use");
-      expect(parsed.content_block.input).toEqual({ query: "x" });
+      expect(parsed.content_block.id).toBe("tu_1");
+      expect(parsed.content_block.name).toBe("search");
+      expect(parsed.content_block.input).toEqual({});
+    }
+
+    const inputJsonDelta = events.find(
+      (e) =>
+        e.event === "content_block_delta" && JSON.parse(e.data).delta?.type === "input_json_delta"
+    );
+    expect(inputJsonDelta).toBeTruthy();
+    if (inputJsonDelta) {
+      const parsed = JSON.parse(inputJsonDelta.data);
+      expect(parsed.delta.partial_json).toBe(JSON.stringify({ query: "x" }));
     }
 
     // No text delta for tool_use
@@ -116,6 +131,31 @@ describe("emitFinalStream — anthropic", () => {
       (e) => e.event === "content_block_delta" && JSON.parse(e.data).delta?.type === "text_delta"
     );
     expect(textDeltas.length).toBe(0);
+
+    const blockStop = events.find((e) => e.event === "content_block_stop");
+    expect(blockStop).toBeTruthy();
+  });
+
+  test("tool_use with missing/null input still emits a delta with empty object JSON", () => {
+    const finalBody = JSON.stringify({
+      id: "msg_2",
+      type: "message",
+      role: "assistant",
+      model: "claude-3-5",
+      content: [{ type: "tool_use", id: "tu_2", name: "noop" }],
+      stop_reason: "tool_use",
+    });
+    const sse = emitFinalStream({ family: "anthropic", finalBody });
+    const events = parseSseEvents(sse);
+    const inputJsonDelta = events.find(
+      (e) =>
+        e.event === "content_block_delta" && JSON.parse(e.data).delta?.type === "input_json_delta"
+    );
+    expect(inputJsonDelta).toBeTruthy();
+    if (inputJsonDelta) {
+      const parsed = JSON.parse(inputJsonDelta.data);
+      expect(parsed.delta.partial_json).toBe("{}");
+    }
   });
 });
 
@@ -221,6 +261,26 @@ describe("emitFinalStream — gemini", () => {
     expect(events.length).toBe(1);
     const parsed = JSON.parse(events[0].data);
     expect(parsed).toEqual(finalObj);
+  });
+
+  test("preserves multi-line (pretty-printed) JSON across SSE data lines", () => {
+    const finalObj = {
+      candidates: [{ content: { parts: [{ text: "multi\nline" }] }, finishReason: "STOP" }],
+      modelVersion: "gemini-3-pro",
+    };
+    // Pretty-print with 2-space indent so the body contains real newlines.
+    const finalBody = JSON.stringify(finalObj, null, 2);
+    const sse = emitFinalStream({ family: "gemini", finalBody });
+
+    // Every non-blank line in the framed payload must carry the `data:` prefix
+    // — otherwise SSE consumers drop the trailing JSON lines.
+    const framedLines = sse.split(/\r?\n/).filter((line) => line.length > 0);
+    expect(framedLines.every((line) => line.startsWith("data: "))).toBe(true);
+
+    // And after parsing, the recovered object must round-trip exactly.
+    const events = parseSseEvents(sse);
+    expect(events.length).toBe(1);
+    expect(JSON.parse(events[0].data)).toEqual(finalObj);
   });
 });
 

--- a/tests/unit/proxy/fake-streaming-response.test.ts
+++ b/tests/unit/proxy/fake-streaming-response.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test } from "vitest";
+import {
+  emitFinalNonStream,
+  emitFinalStream,
+  emitStreamError,
+} from "@/app/v1/_lib/proxy/fake-streaming/emitters";
+import type { ProtocolFamily } from "@/app/v1/_lib/proxy/fake-streaming/response-validator";
+
+function parseSseEvents(body: string): Array<{ event: string | null; data: string }> {
+  const events: Array<{ event: string | null; data: string }> = [];
+  const dataLines: string[] = [];
+  let currentEvent: string | null = null;
+
+  const flush = () => {
+    if (dataLines.length === 0) {
+      currentEvent = null;
+      return;
+    }
+    events.push({ event: currentEvent, data: dataLines.join("\n") });
+    dataLines.length = 0;
+    currentEvent = null;
+  };
+
+  for (const line of body.split(/\r?\n/)) {
+    if (line.length === 0) {
+      flush();
+      continue;
+    }
+    if (line.startsWith(":")) continue;
+    if (line.startsWith("event:")) {
+      currentEvent = line.slice(6).trim();
+      continue;
+    }
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).replace(/^\s/, ""));
+    }
+  }
+  flush();
+  return events;
+}
+
+describe("emitFinalNonStream", () => {
+  test.each<ProtocolFamily>([
+    "anthropic",
+    "openai-chat",
+    "openai-responses",
+    "gemini",
+  ])("%s: returns the validated final body verbatim", (family) => {
+    const body = JSON.stringify({ id: "x", model: "m", content: [{ type: "text", text: "hi" }] });
+    expect(emitFinalNonStream({ family, finalBody: body })).toBe(body);
+  });
+});
+
+describe("emitFinalStream — anthropic", () => {
+  test("emits message_start, content_block_*, message_delta, message_stop for text content", () => {
+    const finalBody = JSON.stringify({
+      id: "msg_1",
+      type: "message",
+      role: "assistant",
+      model: "claude-3-5-sonnet-latest",
+      content: [{ type: "text", text: "hello world" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+
+    const sse = emitFinalStream({ family: "anthropic", finalBody });
+    const events = parseSseEvents(sse);
+    const eventNames = events.map((e) => e.event).filter((name) => name !== null);
+
+    expect(eventNames[0]).toBe("message_start");
+    expect(eventNames).toContain("content_block_start");
+    expect(eventNames).toContain("content_block_delta");
+    expect(eventNames).toContain("content_block_stop");
+    expect(eventNames).toContain("message_delta");
+    expect(eventNames[eventNames.length - 1]).toBe("message_stop");
+
+    // Find the text delta and verify it contains the full text
+    const textDelta = events.find((e) => e.event === "content_block_delta");
+    expect(textDelta).toBeTruthy();
+    if (textDelta) {
+      const parsed = JSON.parse(textDelta.data);
+      expect(parsed.delta.text).toBe("hello world");
+    }
+  });
+
+  test("emits content_block_start with full block for non-text content (tool_use)", () => {
+    const finalBody = JSON.stringify({
+      id: "msg_1",
+      type: "message",
+      role: "assistant",
+      model: "claude-3-5",
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_1",
+          name: "search",
+          input: { query: "x" },
+        },
+      ],
+      stop_reason: "tool_use",
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+
+    const sse = emitFinalStream({ family: "anthropic", finalBody });
+    const events = parseSseEvents(sse);
+    const blockStart = events.find((e) => e.event === "content_block_start");
+    expect(blockStart).toBeTruthy();
+    if (blockStart) {
+      const parsed = JSON.parse(blockStart.data);
+      expect(parsed.content_block.type).toBe("tool_use");
+      expect(parsed.content_block.input).toEqual({ query: "x" });
+    }
+
+    // No text delta for tool_use
+    const textDeltas = events.filter(
+      (e) => e.event === "content_block_delta" && JSON.parse(e.data).delta?.type === "text_delta"
+    );
+    expect(textDeltas.length).toBe(0);
+  });
+});
+
+describe("emitFinalStream — openai-chat", () => {
+  test("emits chat.completion.chunk delta, finish_reason, [DONE]", () => {
+    const finalBody = JSON.stringify({
+      id: "chatcmpl_1",
+      object: "chat.completion",
+      created: 1700000000,
+      model: "gpt-4o-mini",
+      choices: [
+        {
+          message: { role: "assistant", content: "hi there" },
+          index: 0,
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+    });
+
+    const sse = emitFinalStream({ family: "openai-chat", finalBody });
+    const events = parseSseEvents(sse);
+
+    expect(events.length).toBeGreaterThan(0);
+
+    // First event must be a chunk with role
+    const firstChunk = JSON.parse(events[0].data);
+    expect(firstChunk.object).toBe("chat.completion.chunk");
+    expect(firstChunk.choices[0].delta.role).toBe("assistant");
+
+    // There must be a chunk with delta.content carrying the text
+    const textChunkEvents = events
+      .filter((e) => e.data !== "[DONE]")
+      .map((e) => JSON.parse(e.data));
+    const textJoined = textChunkEvents
+      .flatMap(
+        (c) =>
+          c.choices?.flatMap((ch: { delta?: { content?: string } }) => ch.delta?.content ?? "") ??
+          []
+      )
+      .join("");
+    expect(textJoined).toContain("hi there");
+
+    // Finish reason chunk
+    const finishChunk = textChunkEvents.find((c) =>
+      c.choices?.some((ch: { finish_reason?: string }) => ch.finish_reason === "stop")
+    );
+    expect(finishChunk).toBeTruthy();
+
+    // Final [DONE]
+    expect(events[events.length - 1].data).toBe("[DONE]");
+  });
+});
+
+describe("emitFinalStream — openai-responses", () => {
+  test("emits response.created and response.completed events", () => {
+    const finalBody = JSON.stringify({
+      id: "resp_1",
+      object: "response",
+      created: 1700000000,
+      model: "gpt-4o-mini",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "hi" }],
+        },
+      ],
+    });
+
+    const sse = emitFinalStream({ family: "openai-responses", finalBody });
+    const events = parseSseEvents(sse);
+    const eventNames = events.map((e) => e.event).filter((name) => name !== null);
+
+    expect(eventNames[0]).toBe("response.created");
+    expect(eventNames).toContain("response.completed");
+
+    const completed = events.find((e) => e.event === "response.completed");
+    expect(completed).toBeTruthy();
+    if (completed) {
+      const parsed = JSON.parse(completed.data);
+      expect(parsed.response.output[0].content[0].text).toBe("hi");
+    }
+  });
+});
+
+describe("emitFinalStream — gemini", () => {
+  test("emits a single data frame containing the full candidates body", () => {
+    const finalObj = {
+      candidates: [
+        {
+          content: { parts: [{ text: "hi" }] },
+          finishReason: "STOP",
+          index: 0,
+        },
+      ],
+      usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2 },
+      modelVersion: "gemini-3-pro",
+    };
+    const sse = emitFinalStream({ family: "gemini", finalBody: JSON.stringify(finalObj) });
+    const events = parseSseEvents(sse);
+
+    expect(events.length).toBe(1);
+    const parsed = JSON.parse(events[0].data);
+    expect(parsed).toEqual(finalObj);
+  });
+});
+
+describe("emitStreamError", () => {
+  test("anthropic emits event: error with type=error", () => {
+    const sse = emitStreamError({
+      family: "anthropic",
+      errorMessage: "all upstream attempts failed",
+      errorCode: "upstream_all_attempts_failed",
+    });
+    const events = parseSseEvents(sse);
+    const errEvent = events.find((e) => e.event === "error");
+    expect(errEvent).toBeTruthy();
+    if (errEvent) {
+      const parsed = JSON.parse(errEvent.data);
+      expect(parsed.type).toBe("error");
+      expect(parsed.error.type).toBe("upstream_all_attempts_failed");
+    }
+
+    // Must NOT include any success terminator
+    expect(events.some((e) => e.event === "message_stop")).toBe(false);
+  });
+
+  test("openai-chat emits a JSON error frame and no [DONE] success terminator", () => {
+    const sse = emitStreamError({
+      family: "openai-chat",
+      errorMessage: "all upstream attempts failed",
+      errorCode: "upstream_all_attempts_failed",
+    });
+    const events = parseSseEvents(sse);
+
+    expect(events.length).toBeGreaterThan(0);
+    const last = events[events.length - 1];
+    expect(last.data).not.toBe("[DONE]");
+
+    const errPayload = JSON.parse(events[0].data);
+    expect(errPayload.error).toBeTruthy();
+    expect(errPayload.error.code ?? errPayload.error.type).toBe("upstream_all_attempts_failed");
+  });
+
+  test("openai-responses emits response.error and no response.completed", () => {
+    const sse = emitStreamError({
+      family: "openai-responses",
+      errorMessage: "all upstream attempts failed",
+      errorCode: "upstream_all_attempts_failed",
+    });
+    const events = parseSseEvents(sse);
+    const errEvent = events.find((e) => e.event === "response.error");
+    expect(errEvent).toBeTruthy();
+    expect(events.some((e) => e.event === "response.completed")).toBe(false);
+  });
+
+  test("gemini emits an error data frame", () => {
+    const sse = emitStreamError({
+      family: "gemini",
+      errorMessage: "all upstream attempts failed",
+      errorCode: "upstream_all_attempts_failed",
+    });
+    const events = parseSseEvents(sse);
+    expect(events.length).toBe(1);
+    const parsed = JSON.parse(events[0].data);
+    expect(parsed.error).toBeTruthy();
+  });
+});

--- a/tests/unit/proxy/fake-streaming-stream-intent.test.ts
+++ b/tests/unit/proxy/fake-streaming-stream-intent.test.ts
@@ -239,4 +239,21 @@ describe("cloneRequestForInternalNonStreamAttempt", () => {
     expect(clone.pathname).toBe("/v1beta/models/gemini-1.5-pro:generateContent");
     expect(clone.search).toBe("");
   });
+
+  test("multi-valued alt: detects sse even when not first, and only strips sse occurrences", () => {
+    const original = {
+      format: "gemini" as ClientFormat,
+      pathname: "/v1beta/models/gemini-1.5-pro:generateContent",
+      search: "?alt=json&alt=sse&key=abc",
+      body: {} as Record<string, unknown>,
+    };
+    const intent = detectClientStreamIntent(original);
+    expect(intent).toBe(true);
+
+    const clone = cloneRequestForInternalNonStreamAttempt(original);
+    // Only `alt=sse` should be removed; `alt=json` and `key` are preserved.
+    const params = new URLSearchParams(clone.search.replace(/^\?/, ""));
+    expect(params.getAll("alt")).toEqual(["json"]);
+    expect(params.get("key")).toBe("abc");
+  });
 });

--- a/tests/unit/proxy/fake-streaming-stream-intent.test.ts
+++ b/tests/unit/proxy/fake-streaming-stream-intent.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from "vitest";
+import {
+  cloneRequestForInternalNonStreamAttempt,
+  detectClientStreamIntent,
+} from "@/app/v1/_lib/proxy/fake-streaming/stream-intent";
+import type { ClientFormat } from "@/app/v1/_lib/proxy/format-mapper";
+
+function inputs({
+  format,
+  pathname,
+  search,
+  body,
+}: {
+  format: ClientFormat;
+  pathname: string;
+  search?: string;
+  body?: Record<string, unknown> | null;
+}) {
+  return {
+    format,
+    pathname,
+    search: search ?? "",
+    body: body ?? null,
+  };
+}
+
+describe("detectClientStreamIntent", () => {
+  describe("standard formats (claude / openai / response)", () => {
+    test.each<ClientFormat>([
+      "claude",
+      "openai",
+      "response",
+    ])("%s: body.stream === true => stream", (format) => {
+      expect(
+        detectClientStreamIntent(
+          inputs({ format, pathname: "/v1/messages", body: { stream: true } })
+        )
+      ).toBe(true);
+    });
+
+    test.each<ClientFormat>([
+      "claude",
+      "openai",
+      "response",
+    ])("%s: body.stream missing or false => non-stream", (format) => {
+      expect(
+        detectClientStreamIntent(
+          inputs({ format, pathname: "/v1/messages", body: { stream: false } })
+        )
+      ).toBe(false);
+      expect(detectClientStreamIntent(inputs({ format, pathname: "/v1/messages", body: {} }))).toBe(
+        false
+      );
+      expect(detectClientStreamIntent(inputs({ format, pathname: "/v1/messages" }))).toBe(false);
+    });
+
+    test("standard formats ignore path / query for stream intent", () => {
+      expect(
+        detectClientStreamIntent(
+          inputs({
+            format: "openai",
+            pathname: "/v1/chat/completions",
+            search: "?alt=sse",
+            body: { stream: false },
+          })
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("gemini family", () => {
+    test.each<ClientFormat>([
+      "gemini",
+      "gemini-cli",
+    ])("%s: streamGenerateContent in path => stream", (format) => {
+      expect(
+        detectClientStreamIntent(
+          inputs({
+            format,
+            pathname: "/v1beta/models/gemini-1.5-pro:streamGenerateContent",
+            body: {},
+          })
+        )
+      ).toBe(true);
+    });
+
+    test.each<ClientFormat>(["gemini", "gemini-cli"])("%s: alt=sse query => stream", (format) => {
+      expect(
+        detectClientStreamIntent(
+          inputs({
+            format,
+            pathname: "/v1beta/models/gemini-1.5-pro:generateContent",
+            search: "?alt=sse",
+            body: {},
+          })
+        )
+      ).toBe(true);
+    });
+
+    test.each<ClientFormat>([
+      "gemini",
+      "gemini-cli",
+    ])("%s: body.stream === true => stream", (format) => {
+      expect(
+        detectClientStreamIntent(
+          inputs({
+            format,
+            pathname: "/v1beta/models/gemini-1.5-pro:generateContent",
+            body: { stream: true },
+          })
+        )
+      ).toBe(true);
+    });
+
+    test.each<ClientFormat>([
+      "gemini",
+      "gemini-cli",
+    ])("%s: no streaming signal => non-stream", (format) => {
+      expect(
+        detectClientStreamIntent(
+          inputs({
+            format,
+            pathname: "/v1beta/models/gemini-1.5-pro:generateContent",
+            body: { stream: false },
+          })
+        )
+      ).toBe(false);
+      expect(
+        detectClientStreamIntent(
+          inputs({
+            format,
+            pathname: "/v1beta/models/gemini-1.5-pro:generateContent",
+          })
+        )
+      ).toBe(false);
+    });
+
+    test("gemini search supports object form", () => {
+      expect(
+        detectClientStreamIntent(
+          inputs({
+            format: "gemini",
+            pathname: "/v1beta/models/gemini-1.5-pro:generateContent",
+            search: "?alt=json",
+            body: {},
+          })
+        )
+      ).toBe(false);
+    });
+  });
+});
+
+describe("cloneRequestForInternalNonStreamAttempt", () => {
+  test("standard format clones body with stream: false without mutating original", () => {
+    const original = {
+      format: "openai" as ClientFormat,
+      pathname: "/v1/chat/completions",
+      search: "",
+      body: { stream: true, model: "gpt-4o-mini", messages: [] } as Record<string, unknown>,
+    };
+
+    const clone = cloneRequestForInternalNonStreamAttempt(original);
+
+    expect(clone.pathname).toBe("/v1/chat/completions");
+    expect(clone.search).toBe("");
+    expect(clone.body).toEqual({ stream: false, model: "gpt-4o-mini", messages: [] });
+    // Original must not have been mutated
+    expect(original.body).toEqual({ stream: true, model: "gpt-4o-mini", messages: [] });
+    expect(clone.body).not.toBe(original.body);
+  });
+
+  test("standard format adds stream: false even when missing", () => {
+    const original = {
+      format: "claude" as ClientFormat,
+      pathname: "/v1/messages",
+      search: "",
+      body: { model: "claude-3-5", messages: [] } as Record<string, unknown>,
+    };
+
+    const clone = cloneRequestForInternalNonStreamAttempt(original);
+    expect(clone.body).toEqual({ model: "claude-3-5", messages: [], stream: false });
+  });
+
+  test("gemini path rewrites streamGenerateContent to generateContent", () => {
+    const original = {
+      format: "gemini" as ClientFormat,
+      pathname: "/v1beta/models/gemini-3-pro-image-preview:streamGenerateContent",
+      search: "?alt=sse&key=abc",
+      body: { contents: [] } as Record<string, unknown>,
+    };
+
+    const clone = cloneRequestForInternalNonStreamAttempt(original);
+    expect(clone.pathname).toBe("/v1beta/models/gemini-3-pro-image-preview:generateContent");
+    expect(clone.search.includes("alt=sse")).toBe(false);
+    expect(clone.search.includes("key=abc")).toBe(true);
+    // Original is not mutated
+    expect(original.pathname).toBe(
+      "/v1beta/models/gemini-3-pro-image-preview:streamGenerateContent"
+    );
+    expect(original.search).toBe("?alt=sse&key=abc");
+  });
+
+  test("gemini drops alt=sse but keeps other query params", () => {
+    const original = {
+      format: "gemini-cli" as ClientFormat,
+      pathname: "/v1internal/models/gemini-3-pro-image-preview:generateContent",
+      search: "?alt=sse&clientName=cli",
+      body: {} as Record<string, unknown>,
+    };
+
+    const clone = cloneRequestForInternalNonStreamAttempt(original);
+    expect(clone.pathname).toBe("/v1internal/models/gemini-3-pro-image-preview:generateContent");
+    expect(clone.search).toBe("?clientName=cli");
+  });
+
+  test("gemini sets body.stream=false when present", () => {
+    const original = {
+      format: "gemini" as ClientFormat,
+      pathname: "/v1beta/models/gemini-1.5-pro:generateContent",
+      search: "",
+      body: { stream: true, contents: [] } as Record<string, unknown>,
+    };
+
+    const clone = cloneRequestForInternalNonStreamAttempt(original);
+    expect(clone.body).toEqual({ stream: false, contents: [] });
+    expect(original.body).toEqual({ stream: true, contents: [] });
+  });
+
+  test("preserves null body for gemini without body", () => {
+    const original = {
+      format: "gemini" as ClientFormat,
+      pathname: "/v1beta/models/gemini-1.5-pro:streamGenerateContent",
+      search: "?alt=sse",
+      body: null as Record<string, unknown> | null,
+    };
+
+    const clone = cloneRequestForInternalNonStreamAttempt(original);
+    expect(clone.body).toBeNull();
+    expect(clone.pathname).toBe("/v1beta/models/gemini-1.5-pro:generateContent");
+    expect(clone.search).toBe("");
+  });
+});

--- a/tests/unit/proxy/response-handler-fake-streaming.test.ts
+++ b/tests/unit/proxy/response-handler-fake-streaming.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  buildFakeStreamingNonStreamResponse,
+  buildFakeStreamingResponse,
+  type AttemptPerformer,
+} from "@/app/v1/_lib/proxy/fake-streaming/runner";
+
+const validBody = JSON.stringify({
+  id: "msg",
+  type: "message",
+  content: [{ type: "text", text: "hello" }],
+  model: "claude-3",
+});
+
+const emptyBody = "";
+
+async function consumeStream(stream: ReadableStream<Uint8Array> | null): Promise<string> {
+  if (!stream) return "";
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let result = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    result += decoder.decode(value, { stream: true });
+  }
+  result += decoder.decode();
+  return result;
+}
+
+async function readUntilFirstChunk(
+  stream: ReadableStream<Uint8Array> | null
+): Promise<{ text: string; reader: ReadableStreamDefaultReader<Uint8Array> }> {
+  if (!stream) throw new Error("stream is null");
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const { value } = await reader.read();
+  return {
+    text: value ? decoder.decode(value, { stream: true }) : "",
+    reader,
+  };
+}
+
+describe("buildFakeStreamingResponse — stream path", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("emits SSE heartbeat immediately and final emission after success", async () => {
+    const performAttempt = vi.fn(async () => ({
+      status: 200,
+      body: validBody,
+      providerId: "p1",
+    }));
+
+    const response = buildFakeStreamingResponse({
+      family: "anthropic",
+      isStream: true,
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 5,
+      heartbeatIntervalMs: 5000,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+    await vi.runAllTimersAsync();
+    const body = await consumeStream(response.body);
+
+    expect(body.startsWith(": ping\n\n")).toBe(true);
+    expect(body).toContain("event: message_start");
+    expect(body).toContain("event: message_stop");
+    expect(performAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries on empty upstream and only emits provider B final data", async () => {
+    const performAttempt = vi.fn(async (index: number) => {
+      if (index === 0) return { status: 200, body: emptyBody, providerId: "p1" };
+      return { status: 200, body: validBody, providerId: "p2" };
+    });
+
+    const response = buildFakeStreamingResponse({
+      family: "anthropic",
+      isStream: true,
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 5,
+      heartbeatIntervalMs: 5000,
+    });
+
+    await vi.runAllTimersAsync();
+    const body = await consumeStream(response.body);
+
+    expect(body).toContain("event: message_start");
+    expect(body).toContain("event: message_stop");
+    // Provider A's empty body must not leak into the stream
+    expect(body).not.toContain("p1-data");
+    expect(performAttempt).toHaveBeenCalledTimes(2);
+  });
+
+  test("emits protocol-compatible error on terminal failure (no success terminator)", async () => {
+    const performAttempt = vi.fn(
+      async (
+        index: number
+      ): Promise<{ status: number; body: string; providerId: string } | null> => {
+        if (index < 3) return { status: 200, body: emptyBody, providerId: `p${index}` };
+        return null;
+      }
+    );
+
+    const response = buildFakeStreamingResponse({
+      family: "anthropic",
+      isStream: true,
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 5,
+      heartbeatIntervalMs: 5000,
+    });
+
+    await vi.runAllTimersAsync();
+    const body = await consumeStream(response.body);
+
+    expect(body).toContain("event: error");
+    expect(body).not.toContain("event: message_stop");
+  });
+
+  test("repeats heartbeat at the configured interval while attempts pend", async () => {
+    let releaseAttempt: (() => void) | null = null;
+    const performAttempt = vi.fn(
+      async () =>
+        new Promise<{ status: number; body: string; providerId: string }>((resolve) => {
+          releaseAttempt = () => resolve({ status: 200, body: validBody, providerId: "p1" });
+        })
+    );
+
+    const response = buildFakeStreamingResponse({
+      family: "anthropic",
+      isStream: true,
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 1,
+      heartbeatIntervalMs: 5000,
+    });
+
+    expect(response.body).not.toBeNull();
+    if (!response.body) throw new Error("body must not be null");
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+
+    const initial = await reader.read();
+    expect(initial.value).toBeTruthy();
+    expect(decoder.decode(initial.value, { stream: true }).startsWith(": ping\n\n")).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    const second = await reader.read();
+    expect(decoder.decode(second.value, { stream: true })).toContain(": ping\n\n");
+
+    await vi.advanceTimersByTimeAsync(5000);
+    const third = await reader.read();
+    expect(decoder.decode(third.value, { stream: true })).toContain(": ping\n\n");
+
+    if (releaseAttempt) releaseAttempt();
+    await vi.runAllTimersAsync();
+
+    let finalBuffer = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      finalBuffer += decoder.decode(value, { stream: true });
+    }
+    expect(finalBuffer).toContain("event: message_stop");
+  });
+
+  test("client abort closes the response without emitting success terminator", async () => {
+    const abortController = new AbortController();
+
+    let abortFired = false;
+    const performAttempt = vi.fn(async (_index: number, signal: AbortSignal) => {
+      return new Promise<never>((_, reject) => {
+        signal.addEventListener("abort", () => {
+          abortFired = true;
+          reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+        });
+      });
+    });
+
+    const response = buildFakeStreamingResponse({
+      family: "anthropic",
+      isStream: true,
+      performAttempt,
+      abortSignal: abortController.signal,
+      maxAttempts: 5,
+      heartbeatIntervalMs: 5000,
+    });
+
+    const { reader, text } = await readUntilFirstChunk(response.body);
+    expect(text.startsWith(": ping\n\n")).toBe(true);
+
+    abortController.abort();
+    await vi.runAllTimersAsync();
+
+    let buffer = "";
+    const decoder = new TextDecoder();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    expect(abortFired).toBe(true);
+    expect(buffer).not.toContain("event: message_stop");
+  });
+});
+
+describe("buildFakeStreamingNonStreamResponse — non-stream path", () => {
+  test("returns final JSON body verbatim without heartbeat for non-stream client", async () => {
+    const performAttempt: AttemptPerformer = async () => ({
+      status: 200,
+      body: validBody,
+      providerId: "p1",
+    });
+
+    const response = await buildFakeStreamingNonStreamResponse({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 5,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    const body = await response.text();
+    expect(body).toBe(validBody);
+  });
+
+  test("returns 502 JSON error when all attempts fail", async () => {
+    const performAttempt: AttemptPerformer = async () => ({
+      status: 200,
+      body: emptyBody,
+      providerId: "p1",
+    });
+
+    const response = await buildFakeStreamingNonStreamResponse({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 2,
+    });
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    const body = await response.json();
+    expect(body.error).toBeTruthy();
+    expect(body.error.code).toBe("upstream_all_attempts_failed");
+  });
+});

--- a/tests/unit/settings/system-settings-form-fake-streaming.test.tsx
+++ b/tests/unit/settings/system-settings-form-fake-streaming.test.tsx
@@ -271,6 +271,50 @@ describe("SystemSettingsForm fake streaming whitelist", () => {
     unmount();
   });
 
+  test("merges duplicate model entries and keeps 'all groups' as the broader scope", async () => {
+    // Two entries for the same model: one explicit `["group-a"]`, one empty
+    // (meaning "all groups"). Empty is strictly broader, so the merge result
+    // must keep groupTags=[] instead of narrowing to ["group-a"].
+    const initial = {
+      ...baseSettings,
+      fakeStreamingWhitelist: [
+        { model: "gpt-image-2", groupTags: ["group-a"] },
+        { model: "gpt-image-2", groupTags: [] },
+        { model: "gemini-3.1-flash-image-preview", groupTags: ["group-a"] },
+        { model: "gemini-3.1-flash-image-preview", groupTags: ["group-b"] },
+      ],
+    } satisfies typeof baseSettings;
+
+    const { unmount } = render(<SystemSettingsForm initialSettings={initial} />);
+
+    await submitForm();
+
+    const lastCall =
+      systemConfigActionMocks.saveSystemSettings.mock.calls[
+        systemConfigActionMocks.saveSystemSettings.mock.calls.length - 1
+      ];
+    const sentList = (lastCall?.[0] as { fakeStreamingWhitelist?: unknown })
+      ?.fakeStreamingWhitelist as Array<{ model: string; groupTags: string[] }>;
+
+    const imageEntry = sentList.find((e) => e.model === "gpt-image-2");
+    expect(imageEntry).toBeTruthy();
+    expect(imageEntry?.groupTags).toEqual([]);
+
+    // For models with only explicit tags across rows, union deduped tags.
+    const geminiEntry = sentList.find((e) => e.model === "gemini-3.1-flash-image-preview");
+    expect(geminiEntry).toBeTruthy();
+    expect(geminiEntry?.groupTags?.sort()).toEqual(["group-a", "group-b"].sort());
+
+    // Each model should appear exactly once after the merge.
+    const counts = new Map<string, number>();
+    for (const entry of sentList) {
+      counts.set(entry.model, (counts.get(entry.model) ?? 0) + 1);
+    }
+    for (const [, count] of counts) expect(count).toBe(1);
+
+    unmount();
+  });
+
   test("all locales define fake streaming labels", () => {
     const locales = ["zh-CN", "zh-TW", "en", "ja", "ru"] as const;
 

--- a/tests/unit/settings/system-settings-form-fake-streaming.test.tsx
+++ b/tests/unit/settings/system-settings-form-fake-streaming.test.tsx
@@ -1,0 +1,292 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { SystemSettingsForm } from "@/app/[locale]/settings/config/_components/system-settings-form";
+import type { SystemSettings } from "@/types/system-config";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+const systemConfigActionMocks = vi.hoisted(() => ({
+  saveSystemSettings: vi.fn(async () => ({ ok: true })),
+}));
+vi.mock("@/actions/system-config", () => systemConfigActionMocks);
+
+const requestFiltersActionMocks = vi.hoisted(() => ({
+  getDistinctProviderGroupsAction: vi.fn(async () => ({ ok: true, data: ["group-a", "group-b"] })),
+}));
+vi.mock("@/actions/request-filters", () => requestFiltersActionMocks);
+
+const sonnerMocks = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+vi.mock("sonner", () => sonnerMocks);
+
+const baseSettings = {
+  siteTitle: "Claude Code Hub",
+  allowGlobalUsageView: true,
+  currencyDisplay: "USD",
+  billingModelSource: "original",
+  codexPriorityBillingSource: "requested",
+  timezone: "UTC",
+  verboseProviderError: false,
+  passThroughUpstreamErrorMessage: true,
+  enableHttp2: true,
+  enableHighConcurrencyMode: false,
+  interceptAnthropicWarmupRequests: false,
+  enableThinkingSignatureRectifier: true,
+  enableThinkingBudgetRectifier: true,
+  enableBillingHeaderRectifier: true,
+  enableResponseInputRectifier: true,
+  enableCodexSessionIdCompletion: true,
+  enableClaudeMetadataUserIdInjection: true,
+  enableResponseFixer: true,
+  allowNonConversationEndpointProviderFallback: true,
+  fakeStreamingWhitelist: [
+    { model: "gpt-image-2", groupTags: [] },
+    { model: "gemini-3.1-flash-image-preview", groupTags: [] },
+  ],
+  responseFixerConfig: {
+    fixEncoding: true,
+    fixSseFormat: true,
+    fixTruncatedJson: true,
+  },
+  quotaDbRefreshIntervalSeconds: 10,
+  quotaLeasePercent5h: 0.05,
+  quotaLeasePercentDaily: 0.05,
+  quotaLeasePercentWeekly: 0.05,
+  quotaLeasePercentMonthly: 0.05,
+  quotaLeaseCapUsd: null,
+  ipGeoLookupEnabled: true,
+  ipExtractionConfig: null,
+} satisfies Pick<
+  SystemSettings,
+  | "siteTitle"
+  | "allowGlobalUsageView"
+  | "currencyDisplay"
+  | "billingModelSource"
+  | "codexPriorityBillingSource"
+  | "timezone"
+  | "verboseProviderError"
+  | "passThroughUpstreamErrorMessage"
+  | "enableHttp2"
+  | "enableHighConcurrencyMode"
+  | "interceptAnthropicWarmupRequests"
+  | "enableThinkingSignatureRectifier"
+  | "enableThinkingBudgetRectifier"
+  | "enableBillingHeaderRectifier"
+  | "enableResponseInputRectifier"
+  | "enableCodexSessionIdCompletion"
+  | "enableClaudeMetadataUserIdInjection"
+  | "enableResponseFixer"
+  | "allowNonConversationEndpointProviderFallback"
+  | "fakeStreamingWhitelist"
+  | "responseFixerConfig"
+  | "quotaDbRefreshIntervalSeconds"
+  | "quotaLeasePercent5h"
+  | "quotaLeasePercentDaily"
+  | "quotaLeasePercentWeekly"
+  | "quotaLeasePercentMonthly"
+  | "quotaLeaseCapUsd"
+  | "ipGeoLookupEnabled"
+  | "ipExtractionConfig"
+>;
+
+function loadMessages(locale: string) {
+  const base = path.join(process.cwd(), `messages/${locale}/settings`);
+  const read = (name: string) => JSON.parse(fs.readFileSync(path.join(base, name), "utf8"));
+
+  return {
+    settings: {
+      common: read("common.json"),
+      config: read("config.json"),
+      requestFilters: read("requestFilters.json"),
+    },
+  };
+}
+
+function render(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <NextIntlClientProvider locale="en" messages={loadMessages("en")} timeZone="UTC">
+        {node}
+      </NextIntlClientProvider>
+    );
+  });
+
+  return {
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+async function submitForm() {
+  const form = document.body.querySelector("form");
+  if (!form) throw new Error("未找到系统设置表单");
+
+  await act(async () => {
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function findRemoveButtons(): HTMLButtonElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLButtonElement>('button[data-testid^="fake-streaming-remove-"]')
+  );
+}
+
+function findAddButton(): HTMLButtonElement | null {
+  return document.querySelector<HTMLButtonElement>('button[data-testid="fake-streaming-add"]');
+}
+
+function findModelInputs(): HTMLInputElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLInputElement>('input[data-testid^="fake-streaming-model-"]')
+  );
+}
+
+describe("SystemSettingsForm fake streaming whitelist", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  test("submits initial whitelist on save", async () => {
+    const { unmount } = render(<SystemSettingsForm initialSettings={baseSettings} />);
+
+    await submitForm();
+
+    expect(systemConfigActionMocks.saveSystemSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fakeStreamingWhitelist: [
+          { model: "gpt-image-2", groupTags: [] },
+          { model: "gemini-3.1-flash-image-preview", groupTags: [] },
+        ],
+      })
+    );
+
+    unmount();
+  });
+
+  test("user can add a new model entry and saves it for all groups", async () => {
+    const { unmount } = render(<SystemSettingsForm initialSettings={baseSettings} />);
+
+    const addBtn = findAddButton();
+    if (!addBtn) throw new Error("未找到 fake-streaming 添加按钮");
+
+    act(() => {
+      addBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const inputs = findModelInputs();
+    expect(inputs.length).toBe(3);
+    const newRow = inputs[2];
+
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(newRow, "custom-model-x");
+      newRow.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    await submitForm();
+
+    expect(systemConfigActionMocks.saveSystemSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fakeStreamingWhitelist: [
+          { model: "gpt-image-2", groupTags: [] },
+          { model: "gemini-3.1-flash-image-preview", groupTags: [] },
+          { model: "custom-model-x", groupTags: [] },
+        ],
+      })
+    );
+
+    unmount();
+  });
+
+  test("user can remove a model entry and the empty whitelist is preserved as opt-out", async () => {
+    const singleEntry = {
+      ...baseSettings,
+      fakeStreamingWhitelist: [{ model: "gpt-image-2", groupTags: [] }],
+    } satisfies typeof baseSettings;
+
+    const { unmount } = render(<SystemSettingsForm initialSettings={singleEntry} />);
+
+    const removeBtns = findRemoveButtons();
+    expect(removeBtns.length).toBe(1);
+
+    act(() => {
+      removeBtns[0].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await submitForm();
+
+    expect(systemConfigActionMocks.saveSystemSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fakeStreamingWhitelist: [],
+      })
+    );
+
+    unmount();
+  });
+
+  test("trims whitespace and drops empty model entries before submitting", async () => {
+    const { unmount } = render(<SystemSettingsForm initialSettings={baseSettings} />);
+
+    const inputs = findModelInputs();
+    expect(inputs.length).toBe(2);
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+
+    act(() => {
+      setter?.call(inputs[0], "  custom-image-model  ");
+      inputs[0].dispatchEvent(new Event("input", { bubbles: true }));
+      setter?.call(inputs[1], "   ");
+      inputs[1].dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    await submitForm();
+
+    expect(systemConfigActionMocks.saveSystemSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fakeStreamingWhitelist: [{ model: "custom-image-model", groupTags: [] }],
+      })
+    );
+
+    unmount();
+  });
+
+  test("all locales define fake streaming labels", () => {
+    const locales = ["zh-CN", "zh-TW", "en", "ja", "ru"] as const;
+
+    for (const locale of locales) {
+      const config = loadMessages(locale).settings.config;
+      const section = config.form.fakeStreaming;
+      expect(section, `missing fakeStreaming section in ${locale}`).toBeTruthy();
+      expect(section.title).toBeTruthy();
+      expect(section.description).toBeTruthy();
+      expect(section.modelLabel).toBeTruthy();
+      expect(section.groupsLabel).toBeTruthy();
+      expect(section.allGroupsHint).toBeTruthy();
+      expect(section.addModel).toBeTruthy();
+      expect(section.remove).toBeTruthy();
+      expect(section.modelPlaceholder).toBeTruthy();
+      expect(section.emptyState).toBeTruthy();
+    }
+  });
+});

--- a/tests/unit/settings/system-settings-form-ip-extraction.test.tsx
+++ b/tests/unit/settings/system-settings-form-ip-extraction.test.tsx
@@ -57,6 +57,7 @@ const baseSettings = {
   enableCodexSessionIdCompletion: true,
   enableClaudeMetadataUserIdInjection: true,
   enableResponseFixer: true,
+  fakeStreamingWhitelist: [],
   responseFixerConfig: {
     fixEncoding: true,
     fixSseFormat: true,

--- a/tests/unit/settings/system-settings-form-non-chat-fallback.test.tsx
+++ b/tests/unit/settings/system-settings-form-non-chat-fallback.test.tsx
@@ -45,6 +45,7 @@ const baseSettings = {
   enableClaudeMetadataUserIdInjection: true,
   enableResponseFixer: true,
   allowNonConversationEndpointProviderFallback: true,
+  fakeStreamingWhitelist: [],
   responseFixerConfig: {
     fixEncoding: true,
     fixSseFormat: true,
@@ -78,6 +79,7 @@ const baseSettings = {
   | "enableClaudeMetadataUserIdInjection"
   | "enableResponseFixer"
   | "allowNonConversationEndpointProviderFallback"
+  | "fakeStreamingWhitelist"
   | "responseFixerConfig"
   | "quotaDbRefreshIntervalSeconds"
   | "quotaLeasePercent5h"


### PR DESCRIPTION
## Summary
- Adds a system-configured fake-streaming whitelist that keeps long synchronous generation requests (image / video) alive past Cloudflare's 120s no-body timeout. Eligible **stream** clients receive an immediate SSE comment heartbeat (`: ping\n\n`) plus 5-second pings while CCH serially calls upstream providers, validates the buffered response is non-empty, and only then emits a final protocol-compatible stream (or a protocol-compatible error event on terminal failure). Eligible **non-stream** clients follow the same buffer + validate semantics without heartbeat — final 200 JSON on success, 502 JSON on failure.
- Default whitelist (auto-enabled when `system_settings` has no persisted value): `gpt-image-2`, `gpt-image-1.5`, `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview`. Persisted empty array is preserved as explicit opt-out. Per-model provider-group restriction supported; empty `groupTags` = all groups.
- Architecture: new module `src/app/v1/_lib/proxy/fake-streaming/` (eligibility / stream-intent / validator / emitters / orchestrator / runner / integration). Hot-path branch in `src/app/v1/_lib/proxy-handler.ts` after guards — non-whitelisted requests are byte-identical to today. Reuses `ProxyForwarder`'s existing multi-provider loop and fake-200 detection for fallback; the validator catches additional cases (empty content array, comment-only SSE, etc.) and returns 502 if undeliverable. `MAX_ATTEMPTS = 1` per fake-streaming request to avoid double-counting accounting.

## Problem
Image and video generation models (like `gpt-image-2`, `gemini-3-pro-image-preview`) often take longer than 120 seconds to complete. Cloudflare's timeout kills requests with no response body after 120s, causing failed generations and poor user experience. This is a platform-level limitation that affects all long-running synchronous API calls.

## Solution
Fake streaming sends SSE heartbeat comments (`: ping`) every 5 seconds to keep the connection alive while buffering upstream responses. This works for both streaming and non-streaming client requests:

- **Streaming clients**: Receive immediate SSE heartbeat, then final response when ready
- **Non-streaming clients**: Connection stays alive, receive final 200 JSON or 502 error

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/fake-streaming/` - New module with 7 components:
  - `eligibility.ts` - Model whitelist matching with group tag support
  - `stream-intent.ts` - Detect streaming vs non-streaming requests
  - `response-validator.ts` - Validate upstream responses are deliverable
  - `emitters.ts` - Protocol-specific SSE emitters (Anthropic/OpenAI/Gemini)
  - `orchestrator.ts` - Serial provider attempt orchestration
  - `runner.ts` - Heartbeat timing and response streaming
  - `proxy-integration.ts` - Integration with existing proxy pipeline
- `src/app/v1/_lib/proxy-handler.ts` - Hot-path branch after guards
- `src/drizzle/schema.ts` - Add `fake_streaming_whitelist` JSONB column
- `src/repository/system-config.ts` - Backwards-compatible transformer for missing column
- `src/actions/system-config.ts` - Server action for settings update

### Supporting Changes
- `src/app/[locale]/settings/config/_components/system-settings-form.tsx` - UI for whitelist management
- `src/lib/config/system-settings-cache.ts` - Cache invalidation for whitelist
- `src/lib/validation/schemas.ts` - Validation schemas for whitelist entries
- `src/types/system-config.ts` - Type definitions
- `messages/*/settings/config.json` - i18n for 5 locales (zh-CN, zh-TW, en, ja, ru)
- `drizzle/0099_equal_expediter.sql` - Database migration

### Test Coverage
8 new test files, 121 unit tests:
- `tests/unit/proxy/fake-streaming-*.test.ts` (6 files) - Core module tests
- `tests/unit/settings/system-settings-form-fake-streaming.test.tsx` - UI tests
- `tests/unit/actions/system-config-fake-streaming-setting.test.ts` - Action tests

## Verification

```bash
$ bunx vitest run \\
    tests/unit/proxy/fake-streaming-response.test.ts \\
    tests/unit/proxy/fake-streaming-eligibility.test.ts \\
    tests/unit/proxy/fake-streaming-stream-intent.test.ts \\
    tests/unit/proxy/fake-streaming-response-validator.test.ts \\
    tests/unit/proxy/fake-streaming-orchestrator.test.ts \\
    tests/unit/proxy/response-handler-fake-streaming.test.ts \\
    tests/unit/settings/system-settings-form-fake-streaming.test.tsx \\
    tests/unit/actions/system-config-fake-streaming-setting.test.ts

Test Files  8 passed (8)
     Tests  121 passed (121)
```

- `bun run lint` / `bun run lint:fix` — clean (only pre-existing warnings).
- `bun run typecheck` — clean for fake-streaming code (only pre-existing `map.tsx` errors).
- `bunx vitest run tests/unit/proxy/` — 1156/1156 proxy tests pass (no regressions).
- Full `bun run test` shows 8 unrelated test files failing on baseline branch (verified via `git stash` + rerun); all are pre-existing and unrelated to this branch.

## Related Issues

This PR addresses the general class of timeout issues affecting long-running synchronous generation requests. While not a direct fix for these specific issues, it shares conceptual overlap:

- **#938** - Related: Codex stream disconnection issues (different root cause but related to streaming reliability)
- **#916** - Related: SocketError during streaming (improved error handling in the same code area)

## Notes
- Provider attempts are strictly serial — no race / hedge.
- Empty / whitespace / comment-only / done-only / error-only SSE / missing required fields all classified retryable; tool / function / structured / Gemini-candidate outputs accepted as deliverable.
- Client abort clears heartbeat timer, aborts the current attempt, and stops fallback (not counted as a provider failure).
- All five locales (zh-CN, zh-TW, en, ja, ru) have new `form.fakeStreaming.*` keys.
- Generated migration `drizzle/0099_equal_expediter.sql` adds `fake_streaming_whitelist` JSONB column with backwards-compatible cascade fallback in repository.

## Test Plan
- [ ] Run `bun run db:migrate` on a clean DB — settings page should show the four default models pre-populated.
- [ ] Run on an upgraded DB (with existing `system_settings` row) — settings page should still show the four default models (transformer fills missing column).
- [ ] Save an empty whitelist via UI — fake streaming disabled (verify by hitting `gpt-image-2` and confirming normal passthrough).
- [ ] Issue a streaming `/v1/messages` request with model=`gpt-image-2` against a slow upstream — verify SSE heartbeat at 0s/5s/10s and final `message_stop` after upstream resolves.
- [ ] Same as above but kill the client mid-flight — verify upstream attempt aborts and no further attempts occur.

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a fake-streaming module that keeps long-running image/video generation requests alive past Cloudflare's 120 s no-body timeout by sending SSE heartbeat comments while buffering and validating the upstream response before emitting a final protocol-compatible stream or JSON reply.

- **Cross-format validation mismatch (P1):** `familyFromFormat(session.originalFormat)` selects validator and emitter rules from the *client* API format, but `ProxyForwarder.send` returns the raw upstream response in the *provider's* native format (format translation is done by `ProxyResponseHandler`, which is bypassed). For any cross-format routing (Anthropic-format client → OpenAI provider, or OpenAI-format client → Gemini provider), the validator always applies the wrong schema and returns 502/stream-error, silently disabling the feature for those requests.
- **Per-attempt abort signal unused (P2):** `buildAttemptPerformer` accepts the orchestrator's per-attempt `abortSignal` but never forwards it to `ProxyForwarder.send`; the forwarder uses `session.clientAbortSignal` directly, so the orchestrator's per-attempt isolation has no HTTP-layer effect.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge for same-format requests; cross-format routes degrade silently to 502 rather than crashing, but the feature would be ineffective for those cases.

One P1 finding: the validator family is derived from the client format while the upstream response is in the provider native format, causing systematic validation failures for cross-format routing. Score held to 3 rather than 4 because the P1 affects the primary use case of CCH users routing Claude-format requests to OpenAI image providers.

src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts — familyFromFormat selection; src/repository/system-config.ts — four-level fallback cascade.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts | Core integration layer — contains P1 concern: familyFromFormat(session.originalFormat) selects validator/emitter family from the client format rather than the upstream response format, causing systematic validation failures for cross-format routing scenarios. |
| src/app/v1/_lib/proxy/fake-streaming/orchestrator.ts | Serial attempt orchestration with correct abort-signal propagation, double-removeEventListener guard, and structured error codes; logic is sound. |
| src/app/v1/_lib/proxy/fake-streaming/runner.ts | Heartbeat timer management, safe stream enqueue/close guards, and non-stream path all correctly structured; synchronous entry point correctly rejects isStream=false calls. |
| src/app/v1/_lib/proxy/fake-streaming/response-validator.ts | Thorough per-family validators covering empty arrays, thinking-only content, tool-use, function calls, inlineData etc.; stream-event collection correctly handles done/error/deliverable classification. |
| src/app/v1/_lib/proxy/fake-streaming/emitters.ts | Protocol-specific SSE emitters for all four families; Gemini multi-line framing correctly applies per-line data: prefixes; OpenAI chat emitter bundles role/content/finish_reason as separate chunks per spec. |
| src/app/v1/_lib/proxy-handler.ts | Hot-path integration looks correct: cachedSystemSettings reuse avoids double-fetch, fake streaming response routed through attachSessionIdToErrorResponse which safely short-circuits on status 200 SSE responses. |
| src/repository/system-config.ts | Backwards-compatible cascade fallback correctly extended; fakeStreamingWhitelist added to fullSelection/fullReturning; fallback nesting is now four levels deep raising maintainability concerns. |
| src/app/v1/_lib/proxy/fake-streaming/eligibility.ts | Pure eligibility check with correct trim/empty-model guards, empty-groupTags=all-groups semantics, and null-providerGroup defaulting to PROVIDER_GROUP.DEFAULT. |
| src/app/v1/_lib/proxy/fake-streaming/stream-intent.ts | Stream detection and non-stream mutation helpers correctly handle Gemini :streamGenerateContent path, alt=sse query stripping, and body.stream flag; no mutation of original inputs. |
| drizzle/0099_equal_expediter.sql | Single nullable JSONB column addition; backwards-compatible (no DEFAULT clause); transformer handles NULL to default whitelist correctly. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant PH as proxy-handler.ts
    participant PI as proxy-integration.ts
    participant O as orchestrator.ts
    participant R as runner.ts
    participant PF as ProxyForwarder
    participant U as Upstream API

    C->>PH: HTTP Request (stream or non-stream)
    PH->>PH: load cachedSystemSettings
    PH->>PI: tryFakeStreamingPath(session, settings)
    PI->>PI: isFakeStreamingEligible(model, group, whitelist)
    PI->>PI: applyNonStreamMutation(session)

    alt Streaming client
        PI->>R: buildFakeStreamingResponse(...)
        R-->>C: Response(200, SSE) immediately
        Note over R,C: heartbeat at t=0
        R->>O: orchestrateFakeStreamingAttempts() async
        loop Every 5s until done
            R-->>C: ping heartbeat
        end
        O->>PF: ProxyForwarder.send(session)
        PF->>U: HTTP request non-stream
        U-->>PF: JSON response
        PF-->>O: Response body text
        O->>O: validateUpstreamResponse(family, body)
        alt Validation OK
            O-->>R: OrchestrateResult ok finalBody
            R->>R: emitFinalStream(family, finalBody)
            R-->>C: SSE events message_start to message_stop
        else Validation failed
            O-->>R: OrchestrateResult errorCode
            R-->>C: SSE error event
        end
    else Non-streaming client
        PI->>R: buildFakeStreamingNonStreamResponse await
        R->>O: orchestrateFakeStreamingAttempts()
        O->>PF: ProxyForwarder.send(session)
        PF->>U: HTTP request non-stream
        U-->>PF: JSON response
        PF-->>O: Response body text
        O->>O: validateUpstreamResponse(family, body)
        alt Validation OK
            R-->>PI: Response 200 JSON
        else All attempts failed
            R-->>PI: Response 502 JSON error
        end
        PI-->>PH: Response
        PH-->>C: Final HTTP response
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts
Line: 54-56

Comment:
**Validator family derived from client format, not provider response format**

`familyFromFormat(session.originalFormat)` maps the *client-facing* API format to a protocol family, but `ProxyForwarder.send` returns the raw upstream response in the *provider's* native format (format translation is done by `ProxyResponseHandler.dispatch`, which is intentionally bypassed here). For any cross-format routing (e.g., a Claude-format client at `/v1/messages` mapped to an OpenAI-backed model, or an OpenAI-format client mapped to a Gemini provider), the validator will apply the wrong schema rules and always return a validation failure, causing every eligible request to produce a 502 or stream-error.

For the four default whitelist models (`gpt-image-2`, `gpt-image-1.5`, `gemini-*`) the upstream response format is fixed by the provider. If a user accesses these via a mismatched client format, the feature silently degrades to a 502 rather than a pass-through.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts
Line: 138-149

Comment:
**Per-attempt `abortSignal` is checked but never forwarded to `ProxyForwarder.send`**

The orchestrator creates a child `AbortController` per attempt and passes its `.signal` as the `abortSignal` parameter to `performAttempt`. Inside `buildAttemptPerformer`, that signal is only checked once at the very start (pre-flight guard). The actual HTTP call — `ProxyForwarder.send(session)` — uses `session.clientAbortSignal` internally, which is the *parent* signal.

In the common case this still works because `session.clientAbortSignal` is the same signal that the orchestrator derives from. But the per-attempt abort isolation the orchestrator is designed to provide has no effect at the HTTP layer. If `MAX_ATTEMPTS` is ever raised above 1, only the first provider chain will be cancellable via client disconnect; subsequent attempts would share the same parent signal state.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/repository/system-config.ts
Line: 296-380

Comment:
**Cascade fallback pyramid is now four levels deep**

Each migration adds another nested try/catch layer that re-derives `updates` / `fullReturning` by destructuring the previous level's already-pruned objects. The `updateSystemSettings` function now has four levels of nested `try` blocks for column-not-found fallback. The logic is currently correct, but each new migration must correctly thread through all previous pruning levels (which the compiler cannot enforce), and the deepest path is only reachable on schemas multiple migrations behind.

Consider extracting the fallback chain into a table-driven retry loop over an ordered list of `{updates, returning}` column sets, so each new migration adds one entry to the array rather than another nesting level.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(proxy): address fake streaming PR re..."](https://github.com/ding113/claude-code-hub/commit/e9cd93c96fead37bb8cdda48094bb12e9a21cd6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29986940)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->