### PR TITLE
fix(proxy): avoid openai-compatible cache token double counting

### DIFF
--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -3344,11 +3344,17 @@ export function parseUsageFromResponseText(
   return { usageRecord, usageMetrics };
 }
 
+// Provider types whose upstream APIs report cached tokens as a subset of
+// input_tokens (OpenAI semantics) rather than as a disjoint bucket (Anthropic
+// semantics). For these, subtract cache_read_input_tokens from input_tokens
+// before persistence so internal cost buckets are not double-counted.
+const PROVIDERS_WITH_CACHE_SUBSET_USAGE = new Set<string>(["codex", "openai-compatible"]);
+
 function adjustUsageForProviderType(
   usage: UsageMetrics,
   providerType: string | null | undefined
 ): UsageMetrics {
-  if (providerType !== "codex") {
+  if (!providerType || !PROVIDERS_WITH_CACHE_SUBSET_USAGE.has(providerType)) {
     return usage;
   }
 
@@ -3364,7 +3370,7 @@ function adjustUsageForProviderType(
     return usage;
   }
 
-  logger.debug("[UsageMetrics] Adjusted codex input tokens to exclude cached tokens", {
+  logger.debug("[UsageMetrics] Adjusted input tokens to exclude cached tokens", {
     providerType,
     originalInputTokens: inputTokens,
     cachedTokens,

--- a/tests/unit/proxy/extract-usage-metrics.test.ts
+++ b/tests/unit/proxy/extract-usage-metrics.test.ts
@@ -822,4 +822,96 @@ describe("extractUsageMetrics", () => {
       expect(result.usageMetrics?.output_tokens).toBe(57);
     });
   });
+
+  describe("openai-compatible cached_tokens subset normalization", () => {
+    it("should subtract Chat Completions cached_tokens from input_tokens (non-stream)", () => {
+      const response = JSON.stringify({
+        usage: {
+          prompt_tokens: 2006,
+          completion_tokens: 300,
+          total_tokens: 2306,
+          prompt_tokens_details: {
+            cached_tokens: 1920,
+          },
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "openai-compatible");
+
+      expect(result.usageMetrics).not.toBeNull();
+      expect(result.usageMetrics?.input_tokens).toBe(86);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(1920);
+      expect(result.usageMetrics?.output_tokens).toBe(300);
+    });
+
+    it("should subtract Responses input_tokens_details.cached_tokens from input_tokens (non-stream)", () => {
+      const response = JSON.stringify({
+        usage: {
+          input_tokens: 2322,
+          output_tokens: 1158,
+          input_tokens_details: {
+            cached_tokens: 2176,
+          },
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "openai-compatible");
+
+      expect(result.usageMetrics).not.toBeNull();
+      expect(result.usageMetrics?.input_tokens).toBe(146);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(2176);
+      expect(result.usageMetrics?.output_tokens).toBe(1158);
+    });
+
+    it("should subtract cached_tokens from input_tokens in SSE final usage chunk", () => {
+      const sse = [
+        'data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}',
+        "",
+        'data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":2006,"completion_tokens":300,"total_tokens":2306,"prompt_tokens_details":{"cached_tokens":1920}}}',
+        "",
+        "data: [DONE]",
+      ].join("\n");
+
+      const result = parseUsageFromResponseText(sse, "openai-compatible");
+
+      expect(result.usageMetrics).not.toBeNull();
+      expect(result.usageMetrics?.input_tokens).toBe(86);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(1920);
+      expect(result.usageMetrics?.output_tokens).toBe(300);
+    });
+
+    it("should clamp input_tokens at zero when cached_tokens exceed prompt_tokens", () => {
+      const response = JSON.stringify({
+        usage: {
+          prompt_tokens: 1500,
+          completion_tokens: 100,
+          prompt_tokens_details: {
+            cached_tokens: 2000,
+          },
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "openai-compatible");
+
+      expect(result.usageMetrics?.input_tokens).toBe(0);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(2000);
+      expect(result.usageMetrics?.output_tokens).toBe(100);
+    });
+
+    it("should leave Claude usage with disjoint cache_read_input_tokens unchanged", () => {
+      const response = JSON.stringify({
+        usage: {
+          input_tokens: 700,
+          output_tokens: 200,
+          cache_read_input_tokens: 300,
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "claude");
+
+      expect(result.usageMetrics?.input_tokens).toBe(700);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(300);
+      expect(result.usageMetrics?.output_tokens).toBe(200);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- OpenAI Chat Completions and Responses report \`cached_tokens\` as a subset of \`prompt_tokens\`/\`input_tokens\`, but this codebase's internal cost buckets treat \`input_tokens\` and \`cache_read_input_tokens\` as disjoint. Without subtraction, openai-compatible upstreams billed cached tokens twice (once at full input rate, once at cache-read rate).
- The fix extends the existing codex-only adjustment in \`adjustUsageForProviderType()\` to also cover \`openai-compatible\`, via a shared \`Set<string>\`. Same \`Math.max(input - cached, 0)\` formula. Internal accounting only — upstream response bodies forwarded to clients are untouched.

### Related Issues
- Fixes #1075 - Token calculation inaccuracy where cached tokens were double-counted for OpenAI-compatible providers

### Behavior matrix after the fix

| providerType | Cached subtraction? | Notes |
|---|---|---|
| \`codex\` | yes | unchanged |
| \`openai-compatible\` | yes (new) | covers OpenAI Chat Completions, Responses, and SSE |
| \`claude\`, \`claude-auth\` | no | disjoint bucket semantics |
| \`gemini\`, \`gemini-cli\` | no | already handled inside \`extractUsageMetrics()\` |
| null/undefined/other | no | unchanged |

## Test plan
- [x] Add 5 regression cases in \`tests/unit/proxy/extract-usage-metrics.test.ts\` (TDD: 4 RED before fix, all GREEN after):
  - Chat Completions non-stream: \`prompt_tokens=2006, cached=1920\` → \`input=86, cache_read=1920\`
  - Responses non-stream: \`input_tokens=2322, cached=2176\` → \`input=146, cache_read=2176\`
  - SSE final usage chunk: same Chat shape, same normalization
  - Clamp: \`cached > prompt\` → \`input=0\`, \`cache_read\` preserved
  - Claude reverse-protection guard: disjoint buckets unchanged
- [x] \`bunx vitest run tests/unit/proxy/extract-usage-metrics.test.ts\` — 53/53 pass
- [x] \`bunx vitest run tests/unit/proxy/\` — 1057/1057 pass across 82 files
- [x] \`bun run typecheck\` — only pre-existing \`maplibre-gl\` errors in \`src/components/ui/map.tsx\` (verified by stashing); zero new errors
- [x] \`bun run lint\` — zero issues in changed files
- [x] \`bun run test\` — only pre-existing UI failures (map, language-switcher, dashboard logs); verified by stashing

## Out of scope
- No changes to \`src/lib/utils/cost-calculation.ts\` — formulas already correct under the disjoint-bucket model
- No schema or migration changes
- No mutation of upstream response bodies
- No \`cache_creation_input_tokens\` inference for OpenAI (the API does not report it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a double-counting bug in the proxy's internal usage accounting: for `openai-compatible` providers, OpenAI reports `cached_tokens` as a **subset** of `prompt_tokens`/`input_tokens`, but the codebase's cost buckets treat the two as disjoint. The fix adds `"openai-compatible"` alongside `"codex"` in a new `PROVIDERS_WITH_CACHE_SUBSET_USAGE` set and applies the same `Math.max(input - cached, 0)` adjustment already used for Codex. Test coverage is thorough (Chat Completions, Responses API, SSE, clamp, and Claude guard), and upstream response bodies are untouched.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the P2 observation is a pre-existing SSE edge case and does not affect the correctness of the new subtraction path under normal conditions.

Only P2 findings. The core logic is correct, tests are comprehensive, and the change is well-scoped to avoid side effects on other provider types.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/response-handler.ts | Extends adjustUsageForProviderType to cover openai-compatible via a Set; the subtraction logic is correct and tests pass, though SSE first-wins semantics could surface an edge case for proxy-injected partial usage chunks. |
| tests/unit/proxy/extract-usage-metrics.test.ts | Adds 5 well-scoped regression tests covering Chat Completions, Responses API, SSE, clamping, and Claude disjoint-bucket guard; all scenarios are correct and complete. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parseUsageFromResponseText] --> B{SSE or JSON?}
    B -->|JSON| C[applyUsageValue → extractUsageMetrics]
    B -->|SSE| D{Claude event type?}
    D -->|message_start/delta| E[mergedClaudeUsage]
    D -->|other| F[applyUsageValue → extractUsageMetrics]
    C --> G[adjustUsageForProviderType]
    E --> G
    F --> G
    G --> H{providerType in PROVIDERS_WITH_CACHE_SUBSET_USAGE?}
    H -->|codex or openai-compatible NEW| I["input_tokens = max(input - cache_read, 0)"]
    H -->|claude, gemini, others| J[return usage unchanged]
    I --> K[UsageMetrics persisted to DB]
    J --> K
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/v1/_lib/proxy/response-handler.ts`, line 3283-3285 ([link](https://github.com/ding113/claude-code-hub/blob/d15c8b2c2a50b54494aca2482f6fb779450ecf93/src/app/v1/_lib/proxy/response-handler.ts#L3283-L3285)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **First-wins SSE semantics may silently drop the final usage chunk**

   `applyUsageValue` uses first-wins semantics (it returns immediately when `usageMetrics` is already set). For OpenAI-compatible SSE, usage data appears in the **final** chunk (with `stream_options: {include_usage: true}`). If any earlier chunk in the stream includes a non-null `usage` field (e.g. a relay or proxy that injects partial counts), that incomplete value will be used and the terminal, complete usage chunk will be silently ignored — meaning the `adjustUsageForProviderType` subtraction runs on stale data.

   This pre-exists this PR, but the PR's new path makes it observable for `openai-compatible`, where the stakes are higher (billing correction). Worth documenting at minimum, or flipping to last-wins for non-Claude/Gemini SSE paths to match how the OpenAI SSE protocol actually delivers final usage.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/v1/_lib/proxy/response-handler.ts
   Line: 3283-3285

   Comment:
   **First-wins SSE semantics may silently drop the final usage chunk**

   `applyUsageValue` uses first-wins semantics (it returns immediately when `usageMetrics` is already set). For OpenAI-compatible SSE, usage data appears in the **final** chunk (with `stream_options: {include_usage: true}`). If any earlier chunk in the stream includes a non-null `usage` field (e.g. a relay or proxy that injects partial counts), that incomplete value will be used and the terminal, complete usage chunk will be silently ignored — meaning the `adjustUsageForProviderType` subtraction runs on stale data.

   This pre-exists this PR, but the PR's new path makes it observable for `openai-compatible`, where the stakes are higher (billing correction). Worth documenting at minimum, or flipping to last-wins for non-Claude/Gemini SSE paths to match how the OpenAI SSE protocol actually delivers final usage.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/v1/_lib/proxy/response-handler.ts
Line: 3283-3285

Comment:
**First-wins SSE semantics may silently drop the final usage chunk**

`applyUsageValue` uses first-wins semantics (it returns immediately when `usageMetrics` is already set). For OpenAI-compatible SSE, usage data appears in the **final** chunk (with `stream_options: {include_usage: true}`). If any earlier chunk in the stream includes a non-null `usage` field (e.g. a relay or proxy that injects partial counts), that incomplete value will be used and the terminal, complete usage chunk will be silently ignored — meaning the `adjustUsageForProviderType` subtraction runs on stale data.

This pre-exists this PR, but the PR's new path makes it observable for `openai-compatible`, where the stakes are higher (billing correction). Worth documenting at minimum, or flipping to last-wins for non-Claude/Gemini SSE paths to match how the OpenAI SSE protocol actually delivers final usage.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(proxy): avoid openai-compatible cach..."](https://github.com/ding113/claude-code-hub/commit/d15c8b2c2a50b54494aca2482f6fb779450ecf93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29992718)</sub>

<!-- /greptile_comment -->