### PR TITLE
fix: restore dashboard API compatibility

### DIFF
--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -951,11 +951,14 @@ function toActionTransportUserDisplay(user: UserDisplay): UserDisplay {
 }
 
 function toActionTransportDate(value: Date | null | undefined): Date | null {
-  return value ? (value.toISOString() as unknown as Date) : null;
+  if (!value) return null;
+  const timestamp = value.getTime();
+  return (Number.isFinite(timestamp) ? value.toISOString() : null) as unknown as Date;
 }
 
 function toRequiredActionTransportDate(value: Date): Date {
-  return value.toISOString() as unknown as Date;
+  const timestamp = value.getTime();
+  return (Number.isFinite(timestamp) ? value.toISOString() : null) as unknown as Date;
 }
 
 /**

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -922,12 +922,40 @@ export async function getUsersBatchCore(
       };
     });
 
-    return { ok: true, data: { users: userDisplays, nextCursor, hasMore } };
+    return {
+      ok: true,
+      data: {
+        users: userDisplays.map(toActionTransportUserDisplay),
+        nextCursor,
+        hasMore,
+      },
+    };
   } catch (error) {
     logger.error("Failed to fetch user batch core data:", error);
     const message = error instanceof Error ? error.message : "Failed to fetch user batch core data";
     return { ok: false, error: message, errorCode: ERROR_CODES.INTERNAL_ERROR };
   }
+}
+
+function toActionTransportUserDisplay(user: UserDisplay): UserDisplay {
+  return {
+    ...user,
+    costResetAt: toActionTransportDate(user.costResetAt),
+    expiresAt: toActionTransportDate(user.expiresAt),
+    keys: user.keys.map((key) => ({
+      ...key,
+      createdAt: toRequiredActionTransportDate(key.createdAt),
+      lastUsedAt: toActionTransportDate(key.lastUsedAt),
+    })),
+  };
+}
+
+function toActionTransportDate(value: Date | null | undefined): Date | null {
+  return value ? (value.toISOString() as unknown as Date) : null;
+}
+
+function toRequiredActionTransportDate(value: Date): Date {
+  return value.toISOString() as unknown as Date;
 }
 
 /**

--- a/src/app/api/v1/resources/provider-endpoints/handlers.ts
+++ b/src/app/api/v1/resources/provider-endpoints/handlers.ts
@@ -2,7 +2,12 @@ import type { Context } from "hono";
 import { z } from "zod";
 import type { ActionResult } from "@/actions/types";
 import { callAction } from "@/lib/api/v1/_shared/action-bridge";
-import { DASHBOARD_COMPAT_HEADER, HIDDEN_PROVIDER_TYPES } from "@/lib/api/v1/_shared/constants";
+import type { ResolvedAuth } from "@/lib/api/v1/_shared/auth-middleware";
+import {
+  DASHBOARD_COMPAT_HEADER,
+  HIDDEN_PROVIDER_TYPES,
+  INTERNAL_PROVIDER_TYPE_VALUES,
+} from "@/lib/api/v1/_shared/constants";
 import {
   createProblemResponse,
   fromZodError,
@@ -28,15 +33,6 @@ import {
   VendorTypeManualOpenSchema,
   VendorTypeQuerySchema,
 } from "@/lib/api/v1/schemas/provider-endpoints";
-
-const INTERNAL_PROVIDER_TYPE_VALUES = [
-  "claude",
-  "claude-auth",
-  "codex",
-  "gemini",
-  "gemini-cli",
-  "openai-compatible",
-] as const;
 
 const InternalProviderTypeSchema = z.enum(INTERNAL_PROVIDER_TYPE_VALUES);
 const InternalProviderEndpointListQuerySchema = ProviderEndpointListQuerySchema.extend({
@@ -508,5 +504,6 @@ function isHiddenProviderType(providerType: unknown): boolean {
 }
 
 function isDashboardCompatRequest(c: Context): boolean {
-  return c.req.header(DASHBOARD_COMPAT_HEADER) === "1";
+  const auth = c.get("auth") as ResolvedAuth | undefined;
+  return c.req.header(DASHBOARD_COMPAT_HEADER) === "1" && auth?.session?.user.role === "admin";
 }

--- a/src/app/api/v1/resources/provider-endpoints/handlers.ts
+++ b/src/app/api/v1/resources/provider-endpoints/handlers.ts
@@ -83,7 +83,8 @@ export async function getProviderVendor(c: Context): Promise<Response> {
   if (!result.ok) return actionError(c, result);
   if (!result.data)
     return notFound(c, "provider_vendor.not_found", "Provider vendor was not found.");
-  return jsonResponse(sanitizeProviderEndpointData(result.data));
+  const data = isDashboardCompatRequest(c) ? result.data : filterVisibleProviderTypes(result.data);
+  return jsonResponse(sanitizeProviderEndpointData(data));
 }
 
 export async function updateProviderVendor(c: Context): Promise<Response> {

--- a/src/app/api/v1/resources/provider-endpoints/handlers.ts
+++ b/src/app/api/v1/resources/provider-endpoints/handlers.ts
@@ -1,7 +1,8 @@
 import type { Context } from "hono";
+import { z } from "zod";
 import type { ActionResult } from "@/actions/types";
 import { callAction } from "@/lib/api/v1/_shared/action-bridge";
-import { HIDDEN_PROVIDER_TYPES } from "@/lib/api/v1/_shared/constants";
+import { DASHBOARD_COMPAT_HEADER, HIDDEN_PROVIDER_TYPES } from "@/lib/api/v1/_shared/constants";
 import {
   createProblemResponse,
   fromZodError,
@@ -28,6 +29,35 @@ import {
   VendorTypeQuerySchema,
 } from "@/lib/api/v1/schemas/provider-endpoints";
 
+const INTERNAL_PROVIDER_TYPE_VALUES = [
+  "claude",
+  "claude-auth",
+  "codex",
+  "gemini",
+  "gemini-cli",
+  "openai-compatible",
+] as const;
+
+const InternalProviderTypeSchema = z.enum(INTERNAL_PROVIDER_TYPE_VALUES);
+const InternalProviderEndpointListQuerySchema = ProviderEndpointListQuerySchema.extend({
+  providerType: InternalProviderTypeSchema.optional(),
+});
+const InternalProviderEndpointCreateSchema = ProviderEndpointCreateSchema.extend({
+  providerType: InternalProviderTypeSchema,
+});
+const InternalBatchVendorEndpointStatsSchema = BatchVendorEndpointStatsSchema.extend({
+  providerType: InternalProviderTypeSchema,
+});
+const InternalVendorTypeQuerySchema = VendorTypeQuerySchema.extend({
+  providerType: InternalProviderTypeSchema,
+});
+const InternalVendorTypeManualOpenSchema = VendorTypeManualOpenSchema.extend({
+  providerType: InternalProviderTypeSchema,
+});
+const InternalVendorTypeBodySchema = VendorTypeBodySchema.extend({
+  providerType: InternalProviderTypeSchema,
+});
+
 export async function listProviderVendors(c: Context): Promise<Response> {
   const query = ProviderVendorListQuerySchema.safeParse({ dashboard: c.req.query("dashboard") });
   if (!query.success) return fromZodError(query.error, new URL(c.req.url).pathname);
@@ -38,8 +68,9 @@ export async function listProviderVendors(c: Context): Promise<Response> {
     : actions.getProviderVendors;
   const result = await callAction(c, action, [], c.get("auth"));
   if (!result.ok) return actionError(c, result);
+  const data = isDashboardCompatRequest(c) ? result.data : filterVisibleProviderTypes(result.data);
   return jsonResponse({
-    items: sanitizeProviderEndpointData(filterVisibleProviderTypes(result.data)),
+    items: sanitizeProviderEndpointData(data),
   });
 }
 
@@ -93,7 +124,11 @@ export async function deleteProviderVendor(c: Context): Promise<Response> {
 export async function listProviderEndpoints(c: Context): Promise<Response> {
   const params = parseVendorParams(c);
   if (params instanceof Response) return params;
-  const query = ProviderEndpointListQuerySchema.safeParse({
+  const query = (
+    isDashboardCompatRequest(c)
+      ? InternalProviderEndpointListQuerySchema
+      : ProviderEndpointListQuerySchema
+  ).safeParse({
     providerType: c.req.query("providerType"),
     dashboard: c.req.query("dashboard"),
   });
@@ -114,15 +149,21 @@ export async function listProviderEndpoints(c: Context): Promise<Response> {
         c.get("auth")
       );
   if (!result.ok) return actionError(c, result);
+  const data = isDashboardCompatRequest(c) ? result.data : filterVisibleProviderTypes(result.data);
   return jsonResponse({
-    items: sanitizeProviderEndpointData(filterVisibleProviderTypes(result.data)),
+    items: sanitizeProviderEndpointData(data),
   });
 }
 
 export async function createProviderEndpoint(c: Context): Promise<Response> {
   const params = parseVendorParams(c);
   if (params instanceof Response) return params;
-  const body = await parseHonoJsonBody(c, ProviderEndpointCreateSchema);
+  const body = await parseHonoJsonBody(
+    c,
+    isDashboardCompatRequest(c)
+      ? InternalProviderEndpointCreateSchema
+      : ProviderEndpointCreateSchema
+  );
   if (!body.ok) return body.response;
   const actions = await import("@/actions/provider-endpoints");
   return sanitizedActionJson(
@@ -232,7 +273,12 @@ export async function batchGetProbeLogs(c: Context): Promise<Response> {
 }
 
 export async function batchGetVendorEndpointStats(c: Context): Promise<Response> {
-  const body = await parseHonoJsonBody(c, BatchVendorEndpointStatsSchema);
+  const body = await parseHonoJsonBody(
+    c,
+    isDashboardCompatRequest(c)
+      ? InternalBatchVendorEndpointStatsSchema
+      : BatchVendorEndpointStatsSchema
+  );
   if (!body.ok) return body.response;
   const actions = await import("@/actions/provider-endpoints");
   return sanitizedActionJson(
@@ -294,7 +340,9 @@ export async function resetEndpointCircuit(c: Context): Promise<Response> {
 export async function getVendorCircuit(c: Context): Promise<Response> {
   const params = parseVendorParams(c);
   if (params instanceof Response) return params;
-  const query = VendorTypeQuerySchema.safeParse({ providerType: c.req.query("providerType") });
+  const query = (
+    isDashboardCompatRequest(c) ? InternalVendorTypeQuerySchema : VendorTypeQuerySchema
+  ).safeParse({ providerType: c.req.query("providerType") });
   if (!query.success) return fromZodError(query.error, new URL(c.req.url).pathname);
   const actions = await import("@/actions/provider-endpoints");
   return sanitizedActionJson(
@@ -311,7 +359,10 @@ export async function getVendorCircuit(c: Context): Promise<Response> {
 export async function setVendorCircuitManualOpen(c: Context): Promise<Response> {
   const params = parseVendorParams(c);
   if (params instanceof Response) return params;
-  const body = await parseHonoJsonBody(c, VendorTypeManualOpenSchema);
+  const body = await parseHonoJsonBody(
+    c,
+    isDashboardCompatRequest(c) ? InternalVendorTypeManualOpenSchema : VendorTypeManualOpenSchema
+  );
   if (!body.ok) return body.response;
   const actions = await import("@/actions/provider-endpoints");
   const result = await callAction(
@@ -327,7 +378,10 @@ export async function setVendorCircuitManualOpen(c: Context): Promise<Response> 
 export async function resetVendorCircuit(c: Context): Promise<Response> {
   const params = parseVendorParams(c);
   if (params instanceof Response) return params;
-  const body = await parseHonoJsonBody(c, VendorTypeBodySchema);
+  const body = await parseHonoJsonBody(
+    c,
+    isDashboardCompatRequest(c) ? InternalVendorTypeBodySchema : VendorTypeBodySchema
+  );
   if (!body.ok) return body.response;
   const actions = await import("@/actions/provider-endpoints");
   const result = await callAction(
@@ -356,7 +410,7 @@ function parseEndpointParams(c: Context): { endpointId: number } | Response {
 async function ensureVisibleEndpoint(c: Context, endpointId: number): Promise<Response | null> {
   const { findProviderEndpointById } = await import("@/repository/provider-endpoints");
   const endpoint = await findProviderEndpointById(endpointId);
-  if (!endpoint || isHiddenProviderType(endpoint.providerType)) {
+  if (!endpoint || (!isDashboardCompatRequest(c) && isHiddenProviderType(endpoint.providerType))) {
     return notFound(c, "provider_endpoint.not_found", "Provider endpoint was not found.");
   }
   return null;
@@ -451,4 +505,8 @@ function sanitizeProviderEndpointData<T>(value: T): T {
 
 function isHiddenProviderType(providerType: unknown): boolean {
   return HIDDEN_PROVIDER_TYPES.some((hidden) => hidden === providerType);
+}
+
+function isDashboardCompatRequest(c: Context): boolean {
+  return c.req.header(DASHBOARD_COMPAT_HEADER) === "1";
 }

--- a/src/app/api/v1/resources/provider-endpoints/router.ts
+++ b/src/app/api/v1/resources/provider-endpoints/router.ts
@@ -1,5 +1,6 @@
-import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { requireAuth } from "@/lib/api/v1/_shared/auth-middleware";
+import { PUBLIC_PROVIDER_TYPE_VALUES } from "@/lib/api/v1/_shared/constants";
 import { fromZodError } from "@/lib/api/v1/_shared/error-envelope";
 import { ProblemJsonSchema } from "@/lib/api/v1/schemas/_common";
 import {
@@ -42,6 +43,32 @@ import {
   updateProviderEndpoint,
   updateProviderVendor,
 } from "./handlers";
+
+const DashboardCompatProviderTypeRouteSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .openapi({ enum: [...PUBLIC_PROVIDER_TYPE_VALUES] })
+  .describe("Provider type.");
+const ProviderEndpointListRouteQuerySchema = ProviderEndpointListQuerySchema.extend({
+  providerType: DashboardCompatProviderTypeRouteSchema.optional(),
+});
+const ProviderEndpointCreateRouteSchema = ProviderEndpointCreateSchema.extend({
+  providerType: DashboardCompatProviderTypeRouteSchema,
+});
+const BatchVendorEndpointStatsRouteSchema = BatchVendorEndpointStatsSchema.extend({
+  providerType: DashboardCompatProviderTypeRouteSchema,
+});
+const VendorTypeRouteQuerySchema = VendorTypeQuerySchema.extend({
+  providerType: DashboardCompatProviderTypeRouteSchema,
+});
+const VendorTypeManualOpenRouteSchema = VendorTypeManualOpenSchema.extend({
+  providerType: DashboardCompatProviderTypeRouteSchema,
+});
+const VendorTypeBodyRouteSchema = VendorTypeBodySchema.extend({
+  providerType: DashboardCompatProviderTypeRouteSchema,
+});
 
 export const providerEndpointsRouter = new OpenAPIHono({
   defaultHook: (result, c) => {
@@ -176,7 +203,7 @@ providerEndpointsRouter.openapi(
     description: "Lists endpoints for a vendor, optionally filtered by supported provider type.",
     "x-required-access": "admin",
     security,
-    request: { params: ProviderVendorIdParamSchema, query: ProviderEndpointListQuerySchema },
+    request: { params: ProviderVendorIdParamSchema, query: ProviderEndpointListRouteQuerySchema },
     responses: {
       200: {
         description: "Provider endpoints.",
@@ -202,7 +229,7 @@ providerEndpointsRouter.openapi(
       params: ProviderVendorIdParamSchema,
       body: {
         required: true,
-        content: { "application/json": { schema: ProviderEndpointCreateSchema } },
+        content: { "application/json": { schema: ProviderEndpointCreateRouteSchema } },
       },
     },
     responses: {
@@ -350,7 +377,7 @@ providerEndpointsRouter.openapi(
     request: {
       body: {
         required: true,
-        content: { "application/json": { schema: BatchVendorEndpointStatsSchema } },
+        content: { "application/json": { schema: BatchVendorEndpointStatsRouteSchema } },
       },
     },
     responses: {
@@ -439,7 +466,7 @@ providerEndpointsRouter.openapi(
     description: "Gets circuit breaker state for a vendor and provider type.",
     "x-required-access": "admin",
     security,
-    request: { params: ProviderVendorIdParamSchema, query: VendorTypeQuerySchema },
+    request: { params: ProviderVendorIdParamSchema, query: VendorTypeRouteQuerySchema },
     responses: {
       200: {
         description: "Vendor type circuit state.",
@@ -465,7 +492,7 @@ providerEndpointsRouter.openapi(
       params: ProviderVendorIdParamSchema,
       body: {
         required: true,
-        content: { "application/json": { schema: VendorTypeManualOpenSchema } },
+        content: { "application/json": { schema: VendorTypeManualOpenRouteSchema } },
       },
     },
     responses: { 204: { description: "Vendor type circuit updated." }, ...problemResponses },
@@ -485,7 +512,10 @@ providerEndpointsRouter.openapi(
     security,
     request: {
       params: ProviderVendorIdParamSchema,
-      body: { required: true, content: { "application/json": { schema: VendorTypeBodySchema } } },
+      body: {
+        required: true,
+        content: { "application/json": { schema: VendorTypeBodyRouteSchema } },
+      },
     },
     responses: { 204: { description: "Vendor type circuit reset." }, ...problemResponses },
   }),

--- a/src/app/api/v1/resources/providers/handlers.ts
+++ b/src/app/api/v1/resources/providers/handlers.ts
@@ -1,9 +1,11 @@
 import type { Context } from "hono";
 import type { ZodError } from "zod";
+import { z } from "zod";
 import type { ActionResult } from "@/actions/types";
 import { hasLegacyRedactedWritePlaceholders } from "@/lib/api/legacy-action-sanitizers";
 import { callAction } from "@/lib/api/v1/_shared/action-bridge";
 import { withNoStoreHeaders } from "@/lib/api/v1/_shared/cache-control";
+import { DASHBOARD_COMPAT_HEADER } from "@/lib/api/v1/_shared/constants";
 import {
   createProblemResponse,
   fromZodError,
@@ -27,7 +29,6 @@ import {
   ProviderFetchUpstreamModelsSchema,
   ProviderGroupsQuerySchema,
   ProviderIdsBodySchema,
-  type ProviderListQuery,
   ProviderListQuerySchema,
   ProviderModelSuggestionsQuerySchema,
   ProviderProxyTestSchema,
@@ -40,8 +41,39 @@ import {
 } from "@/lib/api/v1/schemas/providers";
 import type { ProviderDisplay } from "@/types/provider";
 
+const INTERNAL_PROVIDER_TYPE_VALUES = [
+  "claude",
+  "claude-auth",
+  "codex",
+  "gemini",
+  "gemini-cli",
+  "openai-compatible",
+] as const;
+
+const InternalProviderTypeSchema = z.enum(INTERNAL_PROVIDER_TYPE_VALUES);
+const InternalProviderListQuerySchema = ProviderListQuerySchema.extend({
+  providerType: InternalProviderTypeSchema.optional(),
+});
+const InternalProviderUpdateSchema = ProviderUpdateSchema.extend({
+  provider_type: InternalProviderTypeSchema.optional(),
+});
+type InternalProviderUpdateInput = z.infer<typeof InternalProviderUpdateSchema>;
+type ProviderUpdatePayload = ProviderUpdateInput | InternalProviderUpdateInput;
+const InternalProviderTypeQuerySchema = ProviderTypeQuerySchema.extend({
+  providerType: InternalProviderTypeSchema,
+});
+const InternalProviderUnifiedTestSchema = ProviderUnifiedTestSchema.extend({
+  providerType: InternalProviderTypeSchema,
+});
+const InternalProviderFetchUpstreamModelsSchema = ProviderFetchUpstreamModelsSchema.extend({
+  providerType: InternalProviderTypeSchema,
+});
+
 export async function listProviders(c: Context): Promise<Response> {
-  const query = ProviderListQuerySchema.safeParse({
+  const querySchema = isDashboardCompatRequest(c)
+    ? InternalProviderListQuerySchema
+    : ProviderListQuerySchema;
+  const query = querySchema.safeParse({
     q: c.req.query("q"),
     providerType: c.req.query("providerType"),
     include: c.req.query("include"),
@@ -98,7 +130,10 @@ export async function createProvider(c: Context): Promise<Response> {
 
 export async function updateProvider(c: Context): Promise<Response> {
   const id = Number(c.req.param("id"));
-  const body = await parseHonoJsonBody(c, ProviderUpdateSchema);
+  const body = await parseHonoJsonBody(
+    c,
+    isDashboardCompatRequest(c) ? InternalProviderUpdateSchema : ProviderUpdateSchema
+  );
   if (!body.ok) return body.response;
   const existing = await findVisibleProvider(c, id);
   if (existing instanceof Response) return existing;
@@ -373,7 +408,11 @@ export async function testProviderProxy(c: Context): Promise<Response> {
 }
 
 export async function testProviderUnified(c: Context): Promise<Response> {
-  return callProviderTest(c, ProviderUnifiedTestSchema, "testProviderUnified");
+  return callProviderTest(
+    c,
+    isDashboardCompatRequest(c) ? InternalProviderUnifiedTestSchema : ProviderUnifiedTestSchema,
+    "testProviderUnified"
+  );
 }
 
 export async function testProviderAnthropic(c: Context): Promise<Response> {
@@ -393,7 +432,9 @@ export async function testProviderGemini(c: Context): Promise<Response> {
 }
 
 export async function getProviderTestPresets(c: Context): Promise<Response> {
-  const query = ProviderTypeQuerySchema.safeParse({ providerType: c.req.query("providerType") });
+  const query = (
+    isDashboardCompatRequest(c) ? InternalProviderTypeQuerySchema : ProviderTypeQuerySchema
+  ).safeParse({ providerType: c.req.query("providerType") });
   if (!query.success) return fromZodError(query.error, new URL(c.req.url).pathname);
   const providerActions = await import("@/actions/providers");
   return actionJson(
@@ -408,7 +449,12 @@ export async function getProviderTestPresets(c: Context): Promise<Response> {
 }
 
 export async function fetchProviderUpstreamModels(c: Context): Promise<Response> {
-  const body = await parseJson(c, ProviderFetchUpstreamModelsSchema);
+  const body = await parseJson(
+    c,
+    isDashboardCompatRequest(c)
+      ? InternalProviderFetchUpstreamModelsSchema
+      : ProviderFetchUpstreamModelsSchema
+  );
   if (body instanceof Response) return body;
   const providerActions = await import("@/actions/providers");
   return actionJson(
@@ -448,9 +494,14 @@ async function loadVisibleProviders(c: Context): Promise<ProviderDisplay[] | Res
   const providerActions = await import("@/actions/providers");
   const result = await callAction(c, providerActions.getProviders, [], c.get("auth"));
   if (!result.ok) return actionError(c, result);
+  if (isDashboardCompatRequest(c)) return result.data;
   return result.data.filter(
     (provider) => !HIDDEN_PROVIDER_TYPES.has(provider.providerType as never)
   );
+}
+
+function isDashboardCompatRequest(c: Context): boolean {
+  return c.req.header(DASHBOARD_COMPAT_HEADER) === "1";
 }
 
 async function findVisibleProvider(
@@ -501,7 +552,7 @@ function undoMetadataHeaders(data: unknown): HeadersInit {
 
 function filterProviders(
   providers: ProviderDisplay[],
-  query: ProviderListQuery
+  query: { q?: string; providerType?: string; include?: "statistics" }
 ): ProviderDisplay[] {
   const normalizedQuery = query.q?.toLowerCase();
   return providers.filter((provider) => {
@@ -580,11 +631,11 @@ function sanitizeProvider(provider: ProviderDisplay): ProviderSummaryResponse {
   };
 }
 
-function preserveRedactedProviderUpdateFields(
-  input: ProviderUpdateInput,
+function preserveRedactedProviderUpdateFields<T extends ProviderUpdatePayload>(
+  input: T,
   existing: ProviderDisplay
-): ProviderUpdateInput {
-  const next: ProviderUpdateInput = { ...input };
+): T {
+  const next: T = { ...input };
   const urlFields = [
     ["url", "url"],
     ["proxy_url", "proxyUrl"],

--- a/src/app/api/v1/resources/providers/handlers.ts
+++ b/src/app/api/v1/resources/providers/handlers.ts
@@ -4,8 +4,12 @@ import { z } from "zod";
 import type { ActionResult } from "@/actions/types";
 import { hasLegacyRedactedWritePlaceholders } from "@/lib/api/legacy-action-sanitizers";
 import { callAction } from "@/lib/api/v1/_shared/action-bridge";
+import type { ResolvedAuth } from "@/lib/api/v1/_shared/auth-middleware";
 import { withNoStoreHeaders } from "@/lib/api/v1/_shared/cache-control";
-import { DASHBOARD_COMPAT_HEADER } from "@/lib/api/v1/_shared/constants";
+import {
+  DASHBOARD_COMPAT_HEADER,
+  INTERNAL_PROVIDER_TYPE_VALUES,
+} from "@/lib/api/v1/_shared/constants";
 import {
   createProblemResponse,
   fromZodError,
@@ -40,15 +44,6 @@ import {
   ProviderUpdateSchema,
 } from "@/lib/api/v1/schemas/providers";
 import type { ProviderDisplay } from "@/types/provider";
-
-const INTERNAL_PROVIDER_TYPE_VALUES = [
-  "claude",
-  "claude-auth",
-  "codex",
-  "gemini",
-  "gemini-cli",
-  "openai-compatible",
-] as const;
 
 const InternalProviderTypeSchema = z.enum(INTERNAL_PROVIDER_TYPE_VALUES);
 const InternalProviderListQuerySchema = ProviderListQuerySchema.extend({
@@ -501,7 +496,8 @@ async function loadVisibleProviders(c: Context): Promise<ProviderDisplay[] | Res
 }
 
 function isDashboardCompatRequest(c: Context): boolean {
-  return c.req.header(DASHBOARD_COMPAT_HEADER) === "1";
+  const auth = c.get("auth") as ResolvedAuth | undefined;
+  return c.req.header(DASHBOARD_COMPAT_HEADER) === "1" && auth?.session?.user.role === "admin";
 }
 
 async function findVisibleProvider(

--- a/src/app/api/v1/resources/providers/router.ts
+++ b/src/app/api/v1/resources/providers/router.ts
@@ -1,5 +1,6 @@
-import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { requireAuth } from "@/lib/api/v1/_shared/auth-middleware";
+import { PUBLIC_PROVIDER_TYPE_VALUES } from "@/lib/api/v1/_shared/constants";
 import { fromZodError } from "@/lib/api/v1/_shared/error-envelope";
 import { ProblemJsonSchema } from "@/lib/api/v1/schemas/_common";
 import {
@@ -59,6 +60,26 @@ import {
   updateProvider,
 } from "./handlers";
 
+const DashboardCompatProviderTypeRouteSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .openapi({ enum: [...PUBLIC_PROVIDER_TYPE_VALUES] })
+  .describe("Provider type.");
+const ProviderListRouteQuerySchema = ProviderListQuerySchema.extend({
+  providerType: DashboardCompatProviderTypeRouteSchema.optional(),
+});
+const ProviderUnifiedTestRouteSchema = ProviderUnifiedTestSchema.extend({
+  providerType: DashboardCompatProviderTypeRouteSchema,
+});
+const ProviderTypeRouteQuerySchema = ProviderTypeQuerySchema.extend({
+  providerType: DashboardCompatProviderTypeRouteSchema,
+});
+const ProviderFetchUpstreamModelsRouteSchema = ProviderFetchUpstreamModelsSchema.extend({
+  providerType: DashboardCompatProviderTypeRouteSchema,
+});
+
 export const providersRouter = new OpenAPIHono({
   defaultHook: (result, c) => {
     if (!result.success) {
@@ -114,7 +135,7 @@ providersRouter.openapi(
       "Lists visible providers with optional search. Hidden legacy provider types are omitted.",
     "x-required-access": "admin",
     security,
-    request: { query: ProviderListQuerySchema },
+    request: { query: ProviderListRouteQuerySchema },
     responses: {
       200: {
         description: "Provider list.",
@@ -622,7 +643,7 @@ providersRouter.openapi(
     request: {
       body: {
         required: true,
-        content: { "application/json": { schema: ProviderUnifiedTestSchema } },
+        content: { "application/json": { schema: ProviderUnifiedTestRouteSchema } },
       },
     },
     responses: {
@@ -742,7 +763,7 @@ providersRouter.openapi(
     description: "Returns provider test presets for a supported provider type.",
     "x-required-access": "admin",
     security,
-    request: { query: ProviderTypeQuerySchema },
+    request: { query: ProviderTypeRouteQuerySchema },
     responses: {
       200: {
         description: "Provider test presets.",
@@ -767,7 +788,7 @@ providersRouter.openapi(
     request: {
       body: {
         required: true,
-        content: { "application/json": { schema: ProviderFetchUpstreamModelsSchema } },
+        content: { "application/json": { schema: ProviderFetchUpstreamModelsRouteSchema } },
       },
     },
     responses: {

--- a/src/lib/api-client/v1/actions/_compat.ts
+++ b/src/lib/api-client/v1/actions/_compat.ts
@@ -77,8 +77,11 @@ export function legacyCursorQueryEntries(value: unknown): [string, string | numb
     : [];
 }
 
-export function apiGet<T = any>(path: string): Promise<T> {
-  return apiClient.get<T>(path);
+export function apiGet<T = any>(
+  path: string,
+  options?: Parameters<typeof apiClient.get>[1]
+): Promise<T> {
+  return options === undefined ? apiClient.get<T>(path) : apiClient.get<T>(path, options);
 }
 
 export function apiPost<T = any>(
@@ -93,33 +96,48 @@ export function apiPut<T = any>(path: string, body?: unknown): Promise<T> {
   return apiClient.put<T>(path, body);
 }
 
-export function apiPatch<T = any>(path: string, body?: unknown): Promise<T> {
-  return apiClient.patch<T>(path, body);
+export function apiPatch<T = any>(
+  path: string,
+  body?: unknown,
+  options?: Parameters<typeof apiClient.patch>[2]
+): Promise<T> {
+  return options === undefined
+    ? apiClient.patch<T>(path, body)
+    : apiClient.patch<T>(path, body, options);
 }
 
 export async function apiPatchWithHeaders<T = any>(
   path: string,
-  body?: unknown
+  body?: unknown,
+  options?: Parameters<typeof apiClient.patch>[2]
 ): Promise<{ body: T; headers: Headers }> {
   let responseHeaders = new Headers();
   const responseBody = await apiClient.patch<T>(path, body, {
+    ...options,
     onResponse: (response) => {
+      options?.onResponse?.(response);
       responseHeaders = response.headers;
     },
   });
   return { body: responseBody, headers: responseHeaders };
 }
 
-export function apiDelete<T = void>(path: string): Promise<T> {
-  return apiClient.delete<T>(path);
+export function apiDelete<T = void>(
+  path: string,
+  options?: Parameters<typeof apiClient.delete>[1]
+): Promise<T> {
+  return options === undefined ? apiClient.delete<T>(path) : apiClient.delete<T>(path, options);
 }
 
 export async function apiDeleteWithHeaders<T = void>(
-  path: string
+  path: string,
+  options?: Parameters<typeof apiClient.delete>[1]
 ): Promise<{ body: T; headers: Headers }> {
   let responseHeaders = new Headers();
   const body = await apiClient.delete<T>(path, {
+    ...options,
     onResponse: (response) => {
+      options?.onResponse?.(response);
       responseHeaders = response.headers;
     },
   });

--- a/src/lib/api-client/v1/actions/provider-endpoints.ts
+++ b/src/lib/api-client/v1/actions/provider-endpoints.ts
@@ -1,5 +1,5 @@
 import type { DashboardProviderVendor } from "@/actions/provider-endpoints";
-import { DASHBOARD_COMPAT_HEADER, HIDDEN_PROVIDER_TYPES } from "@/lib/api/v1/_shared/constants";
+import { DASHBOARD_COMPAT_HEADER } from "@/lib/api/v1/_shared/constants";
 import type { ProviderEndpoint, ProviderVendor } from "@/types/provider";
 import {
   apiDelete,
@@ -19,8 +19,6 @@ const dashboardCompatOptions = {
     [DASHBOARD_COMPAT_HEADER]: "1",
   },
 } as const;
-
-const hiddenProviderTypes = new Set<string>(HIDDEN_PROVIDER_TYPES);
 
 type VendorTypeEndpointStats = {
   vendorId: number;
@@ -70,12 +68,9 @@ export function getProviderEndpoints(input: {
   providerType?: string;
   dashboard?: boolean;
 }) {
-  const providerTypeQuery = hiddenProviderTypes.has(input.providerType ?? "")
-    ? undefined
-    : input.providerType;
   return apiGet<{ items?: ProviderEndpoint[] }>(
     `/api/v1/provider-vendors/${input.vendorId}/endpoints${searchParams({
-      providerType: providerTypeQuery,
+      providerType: input.providerType,
       dashboard: input.dashboard,
     })}`,
     dashboardCompatOptions
@@ -144,58 +139,12 @@ export function batchGetProviderEndpointProbeLogs(input: unknown) {
 }
 
 export function batchGetVendorTypeEndpointStats(input: unknown) {
-  const hiddenInput = parseHiddenVendorEndpointStatsInput(input);
-  if (hiddenInput) {
-    return toActionResult(loadHiddenVendorEndpointStats(hiddenInput));
-  }
-
   return toActionResult(
     apiPost<VendorTypeEndpointStats[]>(
       "/api/v1/provider-vendors/endpoint-stats:batch",
       input,
       dashboardCompatOptions
     )
-  );
-}
-
-function parseHiddenVendorEndpointStatsInput(
-  input: unknown
-): { vendorIds: number[]; providerType: string } | null {
-  if (!input || typeof input !== "object") return null;
-  const value = input as { vendorIds?: unknown; providerType?: unknown };
-  if (typeof value.providerType !== "string" || !hiddenProviderTypes.has(value.providerType)) {
-    return null;
-  }
-  if (!Array.isArray(value.vendorIds)) return null;
-
-  const vendorIds = value.vendorIds.filter(
-    (vendorId): vendorId is number => Number.isInteger(vendorId) && vendorId > 0
-  );
-  return { vendorIds: Array.from(new Set(vendorIds)), providerType: value.providerType };
-}
-
-async function loadHiddenVendorEndpointStats(input: {
-  vendorIds: number[];
-  providerType: string;
-}): Promise<VendorTypeEndpointStats[]> {
-  return Promise.all(
-    input.vendorIds.map(async (vendorId) => {
-      const endpoints = await getProviderEndpoints({
-        vendorId,
-        providerType: input.providerType,
-        dashboard: true,
-      });
-      const activeEndpoints = endpoints.filter((endpoint) => endpoint.deletedAt === null);
-      const enabledEndpoints = activeEndpoints.filter((endpoint) => endpoint.isEnabled === true);
-      return {
-        vendorId,
-        total: activeEndpoints.length,
-        enabled: enabledEndpoints.length,
-        healthy: enabledEndpoints.filter((endpoint) => endpoint.lastProbeOk === true).length,
-        unhealthy: enabledEndpoints.filter((endpoint) => endpoint.lastProbeOk === false).length,
-        unknown: enabledEndpoints.filter((endpoint) => endpoint.lastProbeOk == null).length,
-      };
-    })
   );
 }
 

--- a/src/lib/api-client/v1/actions/provider-endpoints.ts
+++ b/src/lib/api-client/v1/actions/provider-endpoints.ts
@@ -1,4 +1,5 @@
 import type { DashboardProviderVendor } from "@/actions/provider-endpoints";
+import { DASHBOARD_COMPAT_HEADER, HIDDEN_PROVIDER_TYPES } from "@/lib/api/v1/_shared/constants";
 import type { ProviderEndpoint, ProviderVendor } from "@/types/provider";
 import {
   apiDelete,
@@ -13,6 +14,14 @@ import {
 
 export type { DashboardProviderVendor } from "@/actions/provider-endpoints";
 
+const dashboardCompatOptions = {
+  headers: {
+    [DASHBOARD_COMPAT_HEADER]: "1",
+  },
+} as const;
+
+const hiddenProviderTypes = new Set<string>(HIDDEN_PROVIDER_TYPES);
+
 type VendorTypeEndpointStats = {
   vendorId: number;
   total: number;
@@ -23,26 +32,37 @@ type VendorTypeEndpointStats = {
 };
 
 export function getProviderVendors() {
-  return apiGet<{ items?: ProviderVendor[] }>("/api/v1/provider-vendors").then(unwrapItems);
+  return apiGet<{ items?: ProviderVendor[] }>(
+    "/api/v1/provider-vendors",
+    dashboardCompatOptions
+  ).then(unwrapItems);
 }
 
 export function getDashboardProviderVendors() {
   return apiGet<{ items?: DashboardProviderVendor[] }>(
-    "/api/v1/provider-vendors?dashboard=true"
+    "/api/v1/provider-vendors?dashboard=true",
+    dashboardCompatOptions
   ).then(unwrapItems);
 }
 
 export function getProviderVendorById(vendorId: number) {
-  return apiGet<ProviderVendor | null>(`/api/v1/provider-vendors/${vendorId}`);
+  return apiGet<ProviderVendor | null>(
+    `/api/v1/provider-vendors/${vendorId}`,
+    dashboardCompatOptions
+  );
 }
 
 export function editProviderVendor(input: { vendorId: number } & Record<string, unknown>) {
   const { vendorId, ...body } = input;
-  return toActionResult(apiPatch(`/api/v1/provider-vendors/${vendorId}`, body));
+  return toActionResult(
+    apiPatch(`/api/v1/provider-vendors/${vendorId}`, body, dashboardCompatOptions)
+  );
 }
 
 export function removeProviderVendor(input: { vendorId: number }) {
-  return toVoidActionResult(apiDelete(`/api/v1/provider-vendors/${input.vendorId}`));
+  return toVoidActionResult(
+    apiDelete(`/api/v1/provider-vendors/${input.vendorId}`, dashboardCompatOptions)
+  );
 }
 
 export function getProviderEndpoints(input: {
@@ -50,12 +70,20 @@ export function getProviderEndpoints(input: {
   providerType?: string;
   dashboard?: boolean;
 }) {
+  const providerTypeQuery = hiddenProviderTypes.has(input.providerType ?? "")
+    ? undefined
+    : input.providerType;
   return apiGet<{ items?: ProviderEndpoint[] }>(
     `/api/v1/provider-vendors/${input.vendorId}/endpoints${searchParams({
-      providerType: input.providerType,
+      providerType: providerTypeQuery,
       dashboard: input.dashboard,
-    })}`
-  ).then(unwrapItems);
+    })}`,
+    dashboardCompatOptions
+  )
+    .then(unwrapItems)
+    .then((items) =>
+      input.providerType ? items.filter((item) => item.providerType === input.providerType) : items
+    );
 }
 
 export function getDashboardProviderEndpoints(input: { vendorId: number; providerType?: string }) {
@@ -68,21 +96,29 @@ export function getProviderEndpointsByVendor(input: { vendorId: number }) {
 
 export function addProviderEndpoint(input: { vendorId: number } & Record<string, unknown>) {
   const { vendorId, ...body } = input;
-  return toActionResult(apiPost(`/api/v1/provider-vendors/${vendorId}/endpoints`, body));
+  return toActionResult(
+    apiPost(`/api/v1/provider-vendors/${vendorId}/endpoints`, body, dashboardCompatOptions)
+  );
 }
 
 export function editProviderEndpoint(input: { endpointId: number } & Record<string, unknown>) {
   const { endpointId, ...body } = input;
-  return toActionResult(apiPatch(`/api/v1/provider-endpoints/${endpointId}`, body));
+  return toActionResult(
+    apiPatch(`/api/v1/provider-endpoints/${endpointId}`, body, dashboardCompatOptions)
+  );
 }
 
 export function removeProviderEndpoint(input: { endpointId: number }) {
-  return toVoidActionResult(apiDelete(`/api/v1/provider-endpoints/${input.endpointId}`));
+  return toVoidActionResult(
+    apiDelete(`/api/v1/provider-endpoints/${input.endpointId}`, dashboardCompatOptions)
+  );
 }
 
 export function probeProviderEndpoint(input: { endpointId: number } & Record<string, unknown>) {
   const { endpointId, ...body } = input;
-  return toActionResult(apiPost(`/api/v1/provider-endpoints/${endpointId}:probe`, body));
+  return toActionResult(
+    apiPost(`/api/v1/provider-endpoints/${endpointId}:probe`, body, dashboardCompatOptions)
+  );
 }
 
 export function getProviderEndpointProbeLogs(input: {
@@ -95,32 +131,93 @@ export function getProviderEndpointProbeLogs(input: {
       `/api/v1/provider-endpoints/${input.endpointId}/probe-logs${searchParams({
         limit: input.limit,
         offset: input.offset,
-      })}`
+      })}`,
+      dashboardCompatOptions
     )
   );
 }
 
 export function batchGetProviderEndpointProbeLogs(input: unknown) {
-  return toActionResult(apiPost("/api/v1/provider-endpoints/probe-logs:batch", input));
+  return toActionResult(
+    apiPost("/api/v1/provider-endpoints/probe-logs:batch", input, dashboardCompatOptions)
+  );
 }
 
 export function batchGetVendorTypeEndpointStats(input: unknown) {
+  const hiddenInput = parseHiddenVendorEndpointStatsInput(input);
+  if (hiddenInput) {
+    return toActionResult(loadHiddenVendorEndpointStats(hiddenInput));
+  }
+
   return toActionResult(
-    apiPost<VendorTypeEndpointStats[]>("/api/v1/provider-vendors/endpoint-stats:batch", input)
+    apiPost<VendorTypeEndpointStats[]>(
+      "/api/v1/provider-vendors/endpoint-stats:batch",
+      input,
+      dashboardCompatOptions
+    )
+  );
+}
+
+function parseHiddenVendorEndpointStatsInput(
+  input: unknown
+): { vendorIds: number[]; providerType: string } | null {
+  if (!input || typeof input !== "object") return null;
+  const value = input as { vendorIds?: unknown; providerType?: unknown };
+  if (typeof value.providerType !== "string" || !hiddenProviderTypes.has(value.providerType)) {
+    return null;
+  }
+  if (!Array.isArray(value.vendorIds)) return null;
+
+  const vendorIds = value.vendorIds.filter(
+    (vendorId): vendorId is number => Number.isInteger(vendorId) && vendorId > 0
+  );
+  return { vendorIds: Array.from(new Set(vendorIds)), providerType: value.providerType };
+}
+
+async function loadHiddenVendorEndpointStats(input: {
+  vendorIds: number[];
+  providerType: string;
+}): Promise<VendorTypeEndpointStats[]> {
+  return Promise.all(
+    input.vendorIds.map(async (vendorId) => {
+      const endpoints = await getProviderEndpoints({
+        vendorId,
+        providerType: input.providerType,
+        dashboard: true,
+      });
+      const activeEndpoints = endpoints.filter((endpoint) => endpoint.deletedAt === null);
+      const enabledEndpoints = activeEndpoints.filter((endpoint) => endpoint.isEnabled === true);
+      return {
+        vendorId,
+        total: activeEndpoints.length,
+        enabled: enabledEndpoints.length,
+        healthy: enabledEndpoints.filter((endpoint) => endpoint.lastProbeOk === true).length,
+        unhealthy: enabledEndpoints.filter((endpoint) => endpoint.lastProbeOk === false).length,
+        unknown: enabledEndpoints.filter((endpoint) => endpoint.lastProbeOk == null).length,
+      };
+    })
   );
 }
 
 export function getEndpointCircuitInfo(input: { endpointId: number }) {
-  return toActionResult(apiGet(`/api/v1/provider-endpoints/${input.endpointId}/circuit`));
+  return toActionResult(
+    apiGet(`/api/v1/provider-endpoints/${input.endpointId}/circuit`, dashboardCompatOptions)
+  );
 }
 
 export function batchGetEndpointCircuitInfo(input: unknown) {
-  return toActionResult(apiPost("/api/v1/provider-endpoints/circuits:batch", input));
+  return toActionResult(
+    apiPost("/api/v1/provider-endpoints/circuits:batch", input, dashboardCompatOptions)
+  );
 }
 
 export function resetEndpointCircuit(input: { endpointId: number }) {
   return toVoidActionResult(
-    apiPost(`/api/v1/provider-endpoints/${input.endpointId}/circuit:reset`)
+    apiPost(
+      `/api/v1/provider-endpoints/${input.endpointId}/circuit:reset`,
+      undefined,
+      dashboardCompatOptions
+    )
   );
 }
 
@@ -129,7 +226,8 @@ export function getVendorTypeCircuitInfo(input: { vendorId: number; providerType
     apiGet(
       `/api/v1/provider-vendors/${input.vendorId}/circuit${searchParams({
         providerType: input.providerType,
-      })}`
+      })}`,
+      dashboardCompatOptions
     )
   );
 }
@@ -140,17 +238,25 @@ export function setVendorTypeCircuitManualOpen(input: {
   manualOpen: boolean;
 }) {
   return toVoidActionResult(
-    apiPost(`/api/v1/provider-vendors/${input.vendorId}/circuit:setManualOpen`, {
-      providerType: input.providerType,
-      manualOpen: input.manualOpen,
-    })
+    apiPost(
+      `/api/v1/provider-vendors/${input.vendorId}/circuit:setManualOpen`,
+      {
+        providerType: input.providerType,
+        manualOpen: input.manualOpen,
+      },
+      dashboardCompatOptions
+    )
   );
 }
 
 export function resetVendorTypeCircuit(input: { vendorId: number; providerType: string }) {
   return toVoidActionResult(
-    apiPost(`/api/v1/provider-vendors/${input.vendorId}/circuit:reset`, {
-      providerType: input.providerType,
-    })
+    apiPost(
+      `/api/v1/provider-vendors/${input.vendorId}/circuit:reset`,
+      {
+        providerType: input.providerType,
+      },
+      dashboardCompatOptions
+    )
   );
 }

--- a/src/lib/api-client/v1/actions/providers.ts
+++ b/src/lib/api-client/v1/actions/providers.ts
@@ -1,4 +1,5 @@
 import type { EditProviderResult, RemoveProviderResult } from "@/actions/providers";
+import { DASHBOARD_COMPAT_HEADER } from "@/lib/api/v1/_shared/constants";
 import type { ProviderDisplay, ProviderStatisticsMap } from "@/types/provider";
 import {
   apiDeleteWithHeaders,
@@ -20,12 +21,20 @@ export type {
 } from "@/actions/providers";
 export type { ProviderDisplay, ProviderStatisticsMap } from "@/types/provider";
 
+const dashboardCompatOptions = {
+  headers: {
+    [DASHBOARD_COMPAT_HEADER]: "1",
+  },
+} as const;
+
 export function getProviders(): Promise<ProviderDisplay[]> {
-  return apiGet<{ items?: ProviderDisplay[] }>("/api/v1/providers").then(unwrapItems);
+  return apiGet<{ items?: ProviderDisplay[] }>("/api/v1/providers", dashboardCompatOptions).then(
+    unwrapItems
+  );
 }
 
 export function getProviderStatisticsAsync(): Promise<ProviderStatisticsMap> {
-  return apiGet("/api/v1/providers?include=statistics").then((body) => {
+  return apiGet("/api/v1/providers?include=statistics", dashboardCompatOptions).then((body) => {
     const items = unwrapItems(
       body as { items?: Array<{ id: number; statistics?: ProviderStatisticsMap[number] }> }
     );
@@ -36,13 +45,14 @@ export function getProviderStatisticsAsync(): Promise<ProviderStatisticsMap> {
 }
 
 export function getAvailableProviderGroups(userId?: number): Promise<string[]> {
-  return apiGet<{ items?: string[] }>(`/api/v1/providers/groups${searchParams({ userId })}`).then(
-    unwrapItems
-  );
+  return apiGet<{ items?: string[] }>(
+    `/api/v1/providers/groups${searchParams({ userId })}`,
+    dashboardCompatOptions
+  ).then(unwrapItems);
 }
 
 export function getProviderGroupsWithCount() {
-  return apiGet(`/api/v1/providers/groups?include=count`);
+  return apiGet(`/api/v1/providers/groups?include=count`, dashboardCompatOptions);
 }
 
 export function addProvider(data: unknown) {
@@ -51,121 +61,163 @@ export function addProvider(data: unknown) {
 
 export function editProvider(providerId: number, data: unknown) {
   return toActionResult(
-    apiPatchWithHeaders(`/api/v1/providers/${providerId}`, data).then(({ headers }) => {
-      const undoToken = headers.get("X-CCH-Undo-Token") ?? undefined;
-      const operationId = headers.get("X-CCH-Operation-Id") ?? undefined;
-      return { undoToken, operationId } as EditProviderResult;
-    })
+    apiPatchWithHeaders(`/api/v1/providers/${providerId}`, data, dashboardCompatOptions).then(
+      ({ headers }) => {
+        const undoToken = headers.get("X-CCH-Undo-Token") ?? undefined;
+        const operationId = headers.get("X-CCH-Operation-Id") ?? undefined;
+        return { undoToken, operationId } as EditProviderResult;
+      }
+    )
   );
 }
 
 export function removeProvider(providerId: number, options?: unknown) {
   return toActionResult(
-    apiDeleteWithHeaders(`/api/v1/providers/${providerId}`).then(({ headers }) => {
-      const undoToken = headers.get("X-CCH-Undo-Token") ?? undefined;
-      const operationId = headers.get("X-CCH-Operation-Id") ?? undefined;
-      return (options ?? { undoToken, operationId }) as RemoveProviderResult;
-    })
+    apiDeleteWithHeaders(`/api/v1/providers/${providerId}`, dashboardCompatOptions).then(
+      ({ headers }) => {
+        const undoToken = headers.get("X-CCH-Undo-Token") ?? undefined;
+        const operationId = headers.get("X-CCH-Operation-Id") ?? undefined;
+        return (options ?? { undoToken, operationId }) as RemoveProviderResult;
+      }
+    )
   );
 }
 
 export function autoSortProviderPriority(args: unknown) {
-  return toActionResult(apiPost("/api/v1/providers:autoSortPriority", args));
+  return toActionResult(
+    apiPost("/api/v1/providers:autoSortPriority", args, dashboardCompatOptions)
+  );
 }
 
 export function getProvidersHealthStatus() {
-  return toActionResult(apiGet("/api/v1/providers/health"));
+  return toActionResult(apiGet("/api/v1/providers/health", dashboardCompatOptions));
 }
 
 export function resetProviderCircuit(providerId: number) {
-  return toActionResult(apiPost(`/api/v1/providers/${providerId}/circuit:reset`));
+  return toActionResult(
+    apiPost(`/api/v1/providers/${providerId}/circuit:reset`, undefined, dashboardCompatOptions)
+  );
 }
 
 export function resetProviderTotalUsage(providerId: number) {
-  return toActionResult(apiPost(`/api/v1/providers/${providerId}/usage:reset`));
+  return toActionResult(
+    apiPost(`/api/v1/providers/${providerId}/usage:reset`, undefined, dashboardCompatOptions)
+  );
 }
 
 export function previewProviderBatchPatch(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers:batchPatch:preview", data));
+  return toActionResult(
+    apiPost("/api/v1/providers:batchPatch:preview", data, dashboardCompatOptions)
+  );
 }
 
 export function applyProviderBatchPatch(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers:batchPatch:apply", data));
+  return toActionResult(
+    apiPost("/api/v1/providers:batchPatch:apply", data, dashboardCompatOptions)
+  );
 }
 
 export function undoProviderPatch(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers:undoPatch", data));
+  return toActionResult(apiPost("/api/v1/providers:undoPatch", data, dashboardCompatOptions));
 }
 
 export function batchUpdateProviders(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers:batchUpdate", data));
+  return toActionResult(apiPost("/api/v1/providers:batchUpdate", data, dashboardCompatOptions));
 }
 
 export function batchDeleteProviders(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers:batchDelete", data));
+  return toActionResult(apiPost("/api/v1/providers:batchDelete", data, dashboardCompatOptions));
 }
 
 export function undoProviderDelete(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers:undoDelete", data));
+  return toActionResult(apiPost("/api/v1/providers:undoDelete", data, dashboardCompatOptions));
 }
 
 export function batchResetProviderCircuits(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers/circuits:batchReset", data));
+  return toActionResult(
+    apiPost("/api/v1/providers/circuits:batchReset", data, dashboardCompatOptions)
+  );
 }
 
 export function getProviderLimitUsage(providerId: number) {
-  return toActionResult(apiGet(`/api/v1/providers/${providerId}/limit-usage`));
+  return toActionResult(
+    apiGet(`/api/v1/providers/${providerId}/limit-usage`, dashboardCompatOptions)
+  );
 }
 
 export function getProviderLimitUsageBatch(providerIds: number[] | { providerIds: number[] }) {
   const body = Array.isArray(providerIds) ? { providerIds } : providerIds;
-  return toActionResult(apiPost("/api/v1/providers/limit-usage:batch", body));
+  return toActionResult(
+    apiPost("/api/v1/providers/limit-usage:batch", body, dashboardCompatOptions)
+  );
 }
 
 export function testProviderProxy(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers/test:proxy", data));
+  return toActionResult(apiPost("/api/v1/providers/test:proxy", data, dashboardCompatOptions));
 }
 
 export function getUnmaskedProviderKey(providerId: number) {
-  return toActionResult(apiGet<{ key: string }>(`/api/v1/providers/${providerId}/key:reveal`));
+  return toActionResult(
+    apiGet<{ key: string }>(`/api/v1/providers/${providerId}/key:reveal`, dashboardCompatOptions)
+  );
 }
 
 export function testProviderAnthropicMessages(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers/test:anthropic-messages", data));
+  return toActionResult(
+    apiPost("/api/v1/providers/test:anthropic-messages", data, dashboardCompatOptions)
+  );
 }
 
 export function testProviderOpenAIChatCompletions(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers/test:openai-chat-completions", data));
+  return toActionResult(
+    apiPost("/api/v1/providers/test:openai-chat-completions", data, dashboardCompatOptions)
+  );
 }
 
 export function testProviderOpenAIResponses(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers/test:openai-responses", data));
+  return toActionResult(
+    apiPost("/api/v1/providers/test:openai-responses", data, dashboardCompatOptions)
+  );
 }
 
 export function testProviderGemini(data: unknown) {
-  return toActionResult(apiPost("/api/v1/providers/test:gemini", data));
+  return toActionResult(apiPost("/api/v1/providers/test:gemini", data, dashboardCompatOptions));
 }
 
 export function testProviderUnified(data: unknown) {
-  return apiPost("/api/v1/providers/test:unified", data);
+  return apiPost("/api/v1/providers/test:unified", data, dashboardCompatOptions);
 }
 
 export function getProviderTestPresets(providerType: string) {
-  return toActionResult(apiGet(`/api/v1/providers/test:presets${searchParams({ providerType })}`));
+  return toActionResult(
+    apiGet(
+      `/api/v1/providers/test:presets${searchParams({ providerType })}`,
+      dashboardCompatOptions
+    )
+  );
 }
 
 export function fetchUpstreamModels(data: unknown) {
   return toActionResult(
-    apiPost<{ models: string[] }>("/api/v1/providers/upstream-models:fetch", data)
+    apiPost<{ models: string[] }>(
+      "/api/v1/providers/upstream-models:fetch",
+      data,
+      dashboardCompatOptions
+    )
   );
 }
 
 export function getModelSuggestionsByProviderGroup(providerGroup?: string | null) {
-  return apiGet(`/api/v1/providers/model-suggestions${searchParams({ providerGroup })}`);
+  return apiGet(
+    `/api/v1/providers/model-suggestions${searchParams({ providerGroup })}`,
+    dashboardCompatOptions
+  );
 }
 
 export function reclusterProviderVendors(args: unknown) {
-  return toActionResult(apiPost("/api/v1/providers/vendors:recluster", args));
+  return toActionResult(
+    apiPost("/api/v1/providers/vendors:recluster", args, dashboardCompatOptions)
+  );
 }
 
 export { getAvailableModelCatalog } from "./model-prices";

--- a/src/lib/api-client/v1/actions/users.ts
+++ b/src/lib/api-client/v1/actions/users.ts
@@ -1,4 +1,5 @@
 import type { BatchUpdateUsersParams, GetUsersBatchParams } from "@/actions/users";
+import { DASHBOARD_COMPAT_HEADER } from "@/lib/api/v1/_shared/constants";
 import { ApiError } from "@/lib/api-client/v1/errors";
 import type { UserDisplay } from "@/types/user";
 import {
@@ -32,6 +33,12 @@ type V1UsersPage = {
   hasMore?: boolean;
 };
 
+const dashboardCompatOptions = {
+  headers: {
+    [DASHBOARD_COMPAT_HEADER]: "1",
+  },
+} as const;
+
 export function getUsers(params?: GetUsersBatchParams): Promise<UserDisplay[]> {
   return apiGet<V1UsersPage>(`/api/v1/users${toUserListQuery(params)}`)
     .catch((error: unknown) => {
@@ -40,7 +47,7 @@ export function getUsers(params?: GetUsersBatchParams): Promise<UserDisplay[]> {
       }
       throw error;
     })
-    .then((body) => body.items ?? body.users ?? []);
+    .then((body) => normalizeUsers(body.items ?? body.users ?? []));
 }
 
 export function getUsersBatchCore(params?: GetUsersBatchParams) {
@@ -51,10 +58,39 @@ export function getUsersBatchCore(params?: GetUsersBatchParams) {
 
 function toLegacyUsersPage(body: V1UsersPage): UsersPage {
   return {
-    users: body.users ?? body.items ?? [],
+    users: normalizeUsers(body.users ?? body.items ?? []),
     nextCursor: body.nextCursor ?? body.pageInfo?.nextCursor ?? null,
     hasMore: body.hasMore ?? body.pageInfo?.hasMore ?? false,
   };
+}
+
+function normalizeUsers(users: UserDisplay[]): UserDisplay[] {
+  return users.map((user) => {
+    const normalizedUser = { ...user } as UserDisplay;
+    if ("costResetAt" in normalizedUser) {
+      normalizedUser.costResetAt = normalizeDate(normalizedUser.costResetAt);
+    }
+    if ("expiresAt" in normalizedUser) {
+      normalizedUser.expiresAt = normalizeDate(normalizedUser.expiresAt);
+    }
+    if (Array.isArray(normalizedUser.keys)) {
+      normalizedUser.keys = normalizedUser.keys.map((key) => ({
+        ...key,
+        createdAt: normalizeDate(key.createdAt) ?? new Date(0),
+        lastUsedAt: normalizeDate(key.lastUsedAt),
+      }));
+    }
+    return normalizedUser;
+  });
+}
+
+function normalizeDate(value: unknown): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof value !== "string" && typeof value !== "number") return null;
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
 }
 
 export function getUsersUsageBatch(userIds: number[]) {
@@ -64,7 +100,8 @@ export function getUsersUsageBatch(userIds: number[]) {
 export function searchUsers(query?: string, limit?: number) {
   return toActionResult(
     apiGet<{ items?: Array<{ id: number; name: string }> }>(
-      `/api/v1/users:search${searchParams({ q: query, limit })}`
+      `/api/v1/users:search${searchParams({ q: query, limit })}`,
+      dashboardCompatOptions
     ).then((body) => unwrapItems(body))
   );
 }
@@ -72,7 +109,8 @@ export function searchUsers(query?: string, limit?: number) {
 export function searchUsersForFilter(query?: string, limit?: number) {
   return toActionResult(
     apiGet<{ items?: Array<{ id: number; name: string }> }>(
-      `/api/v1/users:filter-search${searchParams({ q: query, limit })}`
+      `/api/v1/users:filter-search${searchParams({ q: query, limit })}`,
+      dashboardCompatOptions
     ).then((body) => unwrapItems(body))
   );
 }

--- a/src/lib/api-client/v1/actions/users.ts
+++ b/src/lib/api-client/v1/actions/users.ts
@@ -85,7 +85,7 @@ function normalizeUsers(users: UserDisplay[]): UserDisplay[] {
 }
 
 function normalizeDate(value: unknown): Date | null {
-  if (!value) return null;
+  if (value === null || value === undefined || value === "") return null;
   if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
   if (typeof value !== "string" && typeof value !== "number") return null;
 

--- a/src/lib/api-client/v1/openapi-types.gen.ts
+++ b/src/lib/api-client/v1/openapi-types.gen.ts
@@ -4236,7 +4236,7 @@ export interface operations {
             query?: {
                 /** @description Case-insensitive provider search text. */
                 q?: string;
-                /** @description Filter by supported provider type. */
+                /** @description Provider type. */
                 providerType?: "claude" | "codex" | "gemini" | "openai-compatible";
                 /** @description Optional response expansion. Supported value: statistics. */
                 include?: "statistics";
@@ -8871,7 +8871,7 @@ export interface operations {
                     /** @description Request timeout in milliseconds. */
                     timeoutMs?: number;
                     /**
-                     * @description Provider type to test.
+                     * @description Provider type.
                      * @enum {string}
                      */
                     providerType: "claude" | "codex" | "gemini" | "openai-compatible";
@@ -24510,7 +24510,7 @@ export interface operations {
     getProviderVendorsByVendoridEndpoints: {
         parameters: {
             query?: {
-                /** @description Provider type filter. */
+                /** @description Provider type. */
                 providerType?: "claude" | "codex" | "gemini" | "openai-compatible";
                 /** @description Return dashboard-oriented endpoints. */
                 dashboard?: boolean | null;

--- a/src/lib/api/v1/_shared/constants.ts
+++ b/src/lib/api/v1/_shared/constants.ts
@@ -3,5 +3,6 @@ export const MANAGEMENT_API_BASE_PATH = "/api/v1";
 export const PROBLEM_JSON_CONTENT_TYPE = "application/problem+json";
 export const API_VERSION_HEADER = "X-API-Version";
 export const CSRF_HEADER = "X-CCH-CSRF";
+export const DASHBOARD_COMPAT_HEADER = "X-CCH-Dashboard-Compat";
 
 export const HIDDEN_PROVIDER_TYPES = ["claude-auth", "gemini-cli"] as const;

--- a/src/lib/api/v1/_shared/constants.ts
+++ b/src/lib/api/v1/_shared/constants.ts
@@ -5,4 +5,14 @@ export const API_VERSION_HEADER = "X-API-Version";
 export const CSRF_HEADER = "X-CCH-CSRF";
 export const DASHBOARD_COMPAT_HEADER = "X-CCH-Dashboard-Compat";
 
+export const PUBLIC_PROVIDER_TYPE_VALUES = [
+  "claude",
+  "codex",
+  "gemini",
+  "openai-compatible",
+] as const;
 export const HIDDEN_PROVIDER_TYPES = ["claude-auth", "gemini-cli"] as const;
+export const INTERNAL_PROVIDER_TYPE_VALUES = [
+  ...PUBLIC_PROVIDER_TYPE_VALUES,
+  ...HIDDEN_PROVIDER_TYPES,
+] as const;

--- a/src/lib/api/v1/_shared/serialization.ts
+++ b/src/lib/api/v1/_shared/serialization.ts
@@ -6,11 +6,36 @@ export function toIsoDateTime(value: Date | string | number | null | undefined):
 }
 
 export function serializeDates(value: unknown): unknown {
-  if (value instanceof Date) return value.toISOString();
+  if (isDateLike(value)) return dateToIsoString(value);
   if (Array.isArray(value)) return value.map((item) => serializeDates(item));
   if (!value || typeof value !== "object") return value;
+  if (hasJsonSerializer(value)) {
+    const jsonValue = value.toJSON();
+    if (jsonValue !== value) return serializeDates(jsonValue);
+  }
 
   return Object.fromEntries(
     Object.entries(value).map(([key, item]) => [key, serializeDates(item)])
   );
+}
+
+function isDateLike(value: unknown): value is Date {
+  return (
+    value instanceof Date ||
+    Object.prototype.toString.call(value) === "[object Date]" ||
+    (Boolean(value) &&
+      typeof value === "object" &&
+      typeof (value as Date).getTime === "function" &&
+      typeof (value as Date).toISOString === "function")
+  );
+}
+
+function dateToIsoString(date: Date): string | null {
+  const timestamp = date.getTime();
+  if (!Number.isFinite(timestamp)) return null;
+  return date.toISOString();
+}
+
+function hasJsonSerializer(value: object): value is { toJSON: () => unknown } {
+  return typeof (value as { toJSON?: unknown }).toJSON === "function";
 }

--- a/src/lib/api/v1/schemas/_common.ts
+++ b/src/lib/api/v1/schemas/_common.ts
@@ -1,4 +1,5 @@
 import { z } from "@hono/zod-openapi";
+import { PUBLIC_PROVIDER_TYPE_VALUES } from "@/lib/api/v1/_shared/constants";
 
 export const ApiVersionSchema = z.literal("1.0.0").describe("Management API version.");
 
@@ -69,7 +70,7 @@ export const CursorPageInfoSchema = z.object({
 });
 
 export const ProviderTypeSchema = z
-  .enum(["claude", "codex", "gemini", "openai-compatible"])
+  .enum(PUBLIC_PROVIDER_TYPE_VALUES)
   .describe("Supported provider type. Hidden legacy provider types are intentionally excluded.");
 
 export function createPageResponseSchema<T extends z.ZodType>(itemSchema: T) {

--- a/src/lib/api/v1/schemas/users.ts
+++ b/src/lib/api/v1/schemas/users.ts
@@ -95,7 +95,7 @@ export const UserListQuerySchema = z.object({
 
 export const UserFilterSearchQuerySchema = z.object({
   q: z.string().trim().optional().describe("Search text."),
-  limit: z.coerce.number().int().min(1).max(100).default(20).describe("Result limit."),
+  limit: z.coerce.number().int().min(1).max(5000).default(20).describe("Result limit."),
 });
 
 export const UserCreateSchema = z.object(UserMutationFieldsSchema).strict();

--- a/src/repository/statistics.ts
+++ b/src/repository/statistics.ts
@@ -1040,33 +1040,28 @@ export async function getRateLimitEventStats(
   const timezone = await resolveSystemTimezone();
   const { user_id, provider_id, limit_type, start_time, end_time, key_id } = filters;
 
-  // 构建 WHERE 条件
-  const conditions: string[] = [
-    `${messageRequest.errorMessage.name} LIKE '%rate_limit_metadata%'`,
-    `${messageRequest.deletedAt.name} IS NULL`,
+  const conditions: SQL[] = [
+    sql`${messageRequest.errorMessage} LIKE ${"%rate_limit_metadata%"}`,
+    isNull(messageRequest.deletedAt),
   ];
 
-  const params: (string | number | Date)[] = [];
-  let paramIndex = 1;
-
   if (user_id !== undefined) {
-    conditions.push(`${messageRequest.userId.name} = $${paramIndex++}`);
-    params.push(user_id);
+    conditions.push(eq(messageRequest.userId, user_id));
   }
 
   if (provider_id !== undefined) {
-    conditions.push(`${messageRequest.providerId.name} = $${paramIndex++}`);
-    params.push(provider_id);
+    conditions.push(eq(messageRequest.providerId, provider_id));
   }
 
-  if (start_time) {
-    conditions.push(`${messageRequest.createdAt.name} >= $${paramIndex++}`);
-    params.push(start_time);
+  const startIso = start_time?.toISOString();
+  const endIso = end_time?.toISOString();
+
+  if (startIso) {
+    conditions.push(sql`${messageRequest.createdAt} >= ${startIso}::timestamptz`);
   }
 
-  if (end_time) {
-    conditions.push(`${messageRequest.createdAt.name} <= $${paramIndex++}`);
-    params.push(end_time);
+  if (endIso) {
+    conditions.push(sql`${messageRequest.createdAt} <= ${endIso}::timestamptz`);
   }
 
   // Key ID 过滤需要先查询 key 字符串
@@ -1074,8 +1069,7 @@ export async function getRateLimitEventStats(
   if (key_id !== undefined) {
     keyString = await getKeyStringByIdCached(key_id);
     if (keyString) {
-      conditions.push(`${messageRequest.key.name} = $${paramIndex++}`);
-      params.push(keyString);
+      conditions.push(eq(messageRequest.key, keyString));
     } else {
       // Key 不存在，返回空统计
       return {
@@ -1098,7 +1092,7 @@ export async function getRateLimitEventStats(
       ${messageRequest.errorMessage},
       DATE_TRUNC('hour', ${messageRequest.createdAt} AT TIME ZONE ${timezone}) AS hour
     FROM ${messageRequest}
-    WHERE ${sql.raw(conditions.join(" AND "))}
+    WHERE ${and(...conditions)}
     ORDER BY ${messageRequest.createdAt}
   `;
 

--- a/tests/api/v1/dashboard/dashboard.test.ts
+++ b/tests/api/v1/dashboard/dashboard.test.ts
@@ -149,7 +149,7 @@ describe("v1 dashboard endpoints", () => {
     const rateLimit = await callV1Route({
       method: "GET",
       pathname:
-        "/api/v1/dashboard/rate-limit-stats?userId=1&providerId=2&keyId=3&limitType=rpm&startTime=2026-04-28T00:00:00.000Z",
+        "/api/v1/dashboard/rate-limit-stats?userId=1&providerId=2&keyId=3&limitType=rpm&startTime=2026-04-28T00:00:00.000Z&endTime=2026-04-30T00:00:00.000Z",
       headers,
     });
     expect(rateLimit.response.status).toBe(200);
@@ -159,7 +159,7 @@ describe("v1 dashboard endpoints", () => {
       key_id: 3,
       limit_type: "rpm",
       start_time: new Date("2026-04-28T00:00:00.000Z"),
-      end_time: undefined,
+      end_time: new Date("2026-04-30T00:00:00.000Z"),
     });
 
     const proxy = await callV1Route({

--- a/tests/api/v1/provider-endpoints/provider-endpoints.test.ts
+++ b/tests/api/v1/provider-endpoints/provider-endpoints.test.ts
@@ -238,6 +238,46 @@ describe("v1 provider endpoint REST endpoints", () => {
         expect.objectContaining({ id: 12, providerType: "claude-auth", label: "legacy" }),
       ]),
     });
+
+    const filteredEndpoints = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/provider-vendors/1/endpoints?providerType=gemini-cli",
+      headers: dashboardCompatHeaders,
+    });
+    expect(filteredEndpoints.response.status).toBe(200);
+    expect(getProviderEndpointsMock).toHaveBeenCalledWith({
+      vendorId: 1,
+      providerType: "gemini-cli",
+    });
+
+    const stats = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/provider-vendors/endpoint-stats:batch",
+      headers: dashboardCompatHeaders,
+      body: { vendorIds: [1], providerType: "claude-auth" },
+    });
+    expect(stats.response.status).toBe(200);
+    expect(batchGetVendorTypeEndpointStatsMock).toHaveBeenCalledWith({
+      vendorIds: [1],
+      providerType: "claude-auth",
+    });
+  });
+
+  test("rejects dashboard compatibility headers without an admin session", async () => {
+    validateAuthTokenMock.mockResolvedValueOnce({
+      ...adminSession,
+      user: { ...adminSession.user, role: "user" },
+    } as AuthSession);
+
+    const response = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/provider-vendors/1/endpoints?providerType=gemini-cli",
+      headers: dashboardCompatHeaders,
+    });
+
+    expect(response.response.status).toBe(403);
+    expect(response.json).toMatchObject({ errorCode: "auth.forbidden" });
+    expect(getProviderEndpointsMock).not.toHaveBeenCalled();
   });
 
   test("reads, updates, and deletes provider vendors", async () => {

--- a/tests/api/v1/provider-endpoints/provider-endpoints.test.ts
+++ b/tests/api/v1/provider-endpoints/provider-endpoints.test.ts
@@ -1,4 +1,5 @@
 import type { AuthSession } from "@/lib/auth";
+import { DASHBOARD_COMPAT_HEADER } from "@/lib/api/v1/_shared/constants";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const getProviderVendorsMock = vi.hoisted(() => vi.fn());
@@ -66,6 +67,7 @@ const adminSession = {
 } as AuthSession;
 
 const headers = { Authorization: "Bearer admin-token" };
+const dashboardCompatHeaders = { ...headers, [DASHBOARD_COMPAT_HEADER]: "1" };
 
 function vendor(overrides: Record<string, unknown> = {}) {
   return {
@@ -213,6 +215,29 @@ describe("v1 provider endpoint REST endpoints", () => {
     expect(JSON.stringify(dashboard.json)).not.toContain("gemini-cli");
     expect(JSON.stringify(dashboard.json)).not.toContain("web-pass");
     expect(JSON.stringify(dashboard.json)).toContain("REDACTED:REDACTED");
+  });
+
+  test("keeps hidden provider endpoint types for dashboard compatibility requests", async () => {
+    const vendors = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/provider-vendors?dashboard=true",
+      headers: dashboardCompatHeaders,
+    });
+    expect(vendors.response.status).toBe(200);
+    expect(JSON.stringify(vendors.json)).toContain("claude-auth");
+    expect(JSON.stringify(vendors.json)).toContain("gemini-cli");
+
+    const endpoints = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/provider-vendors/1/endpoints?dashboard=true",
+      headers: dashboardCompatHeaders,
+    });
+    expect(endpoints.response.status).toBe(200);
+    expect(endpoints.json).toMatchObject({
+      items: expect.arrayContaining([
+        expect.objectContaining({ id: 12, providerType: "claude-auth", label: "legacy" }),
+      ]),
+    });
   });
 
   test("reads, updates, and deletes provider vendors", async () => {

--- a/tests/api/v1/provider-endpoints/provider-endpoints.test.ts
+++ b/tests/api/v1/provider-endpoints/provider-endpoints.test.ts
@@ -263,6 +263,38 @@ describe("v1 provider endpoint REST endpoints", () => {
     });
   });
 
+  test("filters hidden vendor detail provider types unless dashboard compatibility is verified", async () => {
+    getProviderVendorByIdMock.mockResolvedValueOnce(
+      vendor({ providerTypes: ["claude", "claude-auth", "gemini-cli"] })
+    );
+
+    const visible = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/provider-vendors/1",
+      headers,
+    });
+
+    expect(visible.response.status).toBe(200);
+    expect(visible.json).toMatchObject({ providerTypes: ["claude"] });
+    expect(JSON.stringify(visible.json)).not.toContain("claude-auth");
+    expect(JSON.stringify(visible.json)).not.toContain("gemini-cli");
+
+    getProviderVendorByIdMock.mockResolvedValueOnce(
+      vendor({ providerTypes: ["claude", "claude-auth", "gemini-cli"] })
+    );
+
+    const compat = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/provider-vendors/1",
+      headers: dashboardCompatHeaders,
+    });
+
+    expect(compat.response.status).toBe(200);
+    expect(compat.json).toMatchObject({
+      providerTypes: ["claude", "claude-auth", "gemini-cli"],
+    });
+  });
+
   test("rejects dashboard compatibility headers without an admin session", async () => {
     validateAuthTokenMock.mockResolvedValueOnce({
       ...adminSession,

--- a/tests/api/v1/providers/providers.read.test.ts
+++ b/tests/api/v1/providers/providers.read.test.ts
@@ -1,4 +1,5 @@
 import type { AuthSession } from "@/lib/auth";
+import { DASHBOARD_COMPAT_HEADER } from "@/lib/api/v1/_shared/constants";
 import type { ProviderDisplay } from "@/types/provider";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -281,6 +282,38 @@ describe("v1 providers read endpoints", () => {
     });
     expect(JSON.stringify(json)).not.toContain("claude-auth");
     expect(JSON.stringify(json)).not.toContain("tpm");
+  });
+
+  test("keeps hidden provider types available for dashboard compatibility requests", async () => {
+    const hiddenList = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/providers?q=legacy",
+      headers: {
+        Authorization: "Bearer admin-token",
+        [DASHBOARD_COMPAT_HEADER]: "1",
+      },
+    });
+
+    expect(hiddenList.response.status).toBe(200);
+    expect(hiddenList.json).toMatchObject({
+      items: [{ id: 2, name: "Legacy hidden", providerType: "claude-auth" }],
+    });
+
+    const update = await callV1Route({
+      method: "PATCH",
+      pathname: "/api/v1/providers/2",
+      headers: {
+        Authorization: "Bearer admin-token",
+        [DASHBOARD_COMPAT_HEADER]: "1",
+      },
+      body: { name: "Legacy renamed", provider_type: "claude-auth" },
+    });
+
+    expect(update.response.status).toBe(200);
+    expect(editProviderMock).toHaveBeenCalledWith(
+      2,
+      expect.objectContaining({ name: "Legacy renamed", provider_type: "claude-auth" })
+    );
   });
 
   test("rejects bearer user API keys for admin routes when API key admin access is disabled", async () => {

--- a/tests/api/v1/providers/providers.read.test.ts
+++ b/tests/api/v1/providers/providers.read.test.ts
@@ -287,7 +287,7 @@ describe("v1 providers read endpoints", () => {
   test("keeps hidden provider types available for dashboard compatibility requests", async () => {
     const hiddenList = await callV1Route({
       method: "GET",
-      pathname: "/api/v1/providers?q=legacy",
+      pathname: "/api/v1/providers?q=legacy&providerType=claude-auth",
       headers: {
         Authorization: "Bearer admin-token",
         [DASHBOARD_COMPAT_HEADER]: "1",
@@ -314,6 +314,26 @@ describe("v1 providers read endpoints", () => {
       2,
       expect.objectContaining({ name: "Legacy renamed", provider_type: "claude-auth" })
     );
+  });
+
+  test("rejects provider dashboard compatibility headers without an admin session", async () => {
+    validateAuthTokenMock.mockResolvedValueOnce({
+      ...adminSession,
+      user: { ...adminSession.user, role: "user" },
+    } as AuthSession);
+
+    const { response, json } = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/providers?providerType=claude-auth",
+      headers: {
+        Authorization: "Bearer admin-token",
+        [DASHBOARD_COMPAT_HEADER]: "1",
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(json).toMatchObject({ errorCode: "auth.forbidden" });
+    expect(getProvidersMock).not.toHaveBeenCalled();
   });
 
   test("rejects bearer user API keys for admin routes when API key admin access is disabled", async () => {

--- a/tests/api/v1/users/users.test.ts
+++ b/tests/api/v1/users/users.test.ts
@@ -420,6 +420,14 @@ describe("v1 users endpoints", () => {
     expect(search.response.status).toBe(200);
     expect(searchUsersMock).toHaveBeenCalledWith("user", 10);
 
+    const largeSearch = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/users:search?limit=5000",
+      headers,
+    });
+    expect(largeSearch.response.status).toBe(200);
+    expect(searchUsersMock).toHaveBeenCalledWith("", 5000);
+
     const batch = await callV1Route({
       method: "POST",
       pathname: "/api/v1/users:batchUpdate",

--- a/tests/unit/api/v1/api-client-actions.test.ts
+++ b/tests/unit/api/v1/api-client-actions.test.ts
@@ -211,37 +211,48 @@ describe("v1 action compatibility client", () => {
     expect(result).toEqual({ ok: true, data: { logs: [] } });
   });
 
-  test("summarizes hidden provider endpoint stats without hitting the public batch schema", async () => {
+  test("passes hidden provider endpoint filters through the dashboard compatibility path", async () => {
     getMock.mockResolvedValue({
-      items: [
-        { id: 1, providerType: "claude-auth", isEnabled: true, deletedAt: null, lastProbeOk: true },
-        {
-          id: 2,
-          providerType: "claude-auth",
-          isEnabled: true,
-          deletedAt: null,
-          lastProbeOk: false,
-        },
-        {
-          id: 3,
-          providerType: "claude-auth",
-          isEnabled: false,
-          deletedAt: null,
-          lastProbeOk: null,
-        },
-        { id: 4, providerType: "claude", isEnabled: true, deletedAt: null, lastProbeOk: true },
-      ],
+      items: [{ id: 1, providerType: "claude-auth" }],
     });
+
+    await expect(
+      providerEndpoints.getProviderEndpoints({
+        vendorId: 2,
+        providerType: "claude-auth",
+        dashboard: true,
+      })
+    ).resolves.toEqual([{ id: 1, providerType: "claude-auth" }]);
+
+    expect(getMock).toHaveBeenCalledWith(
+      "/api/v1/provider-vendors/2/endpoints?providerType=claude-auth&dashboard=true",
+      { headers: { [DASHBOARD_COMPAT_HEADER]: "1" } }
+    );
+  });
+
+  test("requests hidden provider endpoint stats from the server batch endpoint", async () => {
+    postMock.mockResolvedValue([
+      {
+        vendorId: 2,
+        total: 3,
+        enabled: 2,
+        healthy: 1,
+        unhealthy: 1,
+        unknown: 0,
+      },
+    ]);
 
     const result = await providerEndpoints.batchGetVendorTypeEndpointStats({
       vendorIds: [2, 2],
       providerType: "claude-auth",
     });
 
-    expect(postMock).not.toHaveBeenCalled();
-    expect(getMock).toHaveBeenCalledWith("/api/v1/provider-vendors/2/endpoints?dashboard=true", {
-      headers: { [DASHBOARD_COMPAT_HEADER]: "1" },
-    });
+    expect(getMock).not.toHaveBeenCalled();
+    expect(postMock).toHaveBeenCalledWith(
+      "/api/v1/provider-vendors/endpoint-stats:batch",
+      { vendorIds: [2, 2], providerType: "claude-auth" },
+      { headers: { [DASHBOARD_COMPAT_HEADER]: "1" } }
+    );
     expect(result).toEqual({
       ok: true,
       data: [

--- a/tests/unit/api/v1/api-client-actions.test.ts
+++ b/tests/unit/api/v1/api-client-actions.test.ts
@@ -186,6 +186,31 @@ describe("v1 action compatibility client", () => {
     expect(user.keys[0]?.lastUsedAt).toBeInstanceOf(Date);
   });
 
+  test("revives numeric epoch timestamps instead of treating zero as empty", async () => {
+    getMock.mockResolvedValue({
+      items: [
+        {
+          id: 8,
+          name: "epoch user",
+          keys: [{ id: 12, createdAt: 0, lastUsedAt: 0 }],
+          costResetAt: 0,
+          expiresAt: 0,
+        },
+      ],
+      pageInfo: { nextCursor: null, hasMore: false, limit: 50 },
+    });
+
+    const result = await users.getUsersBatchCore({ limit: 50 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const [user] = result.data.users;
+    expect(user.expiresAt?.toISOString()).toBe("1970-01-01T00:00:00.000Z");
+    expect(user.costResetAt?.toISOString()).toBe("1970-01-01T00:00:00.000Z");
+    expect(user.keys[0]?.createdAt.toISOString()).toBe("1970-01-01T00:00:00.000Z");
+    expect(user.keys[0]?.lastUsedAt?.toISOString()).toBe("1970-01-01T00:00:00.000Z");
+  });
+
   test("marks dashboard user search as a compatibility request", async () => {
     getMock.mockResolvedValue({ items: [{ id: 1, name: "Admin" }] });
 

--- a/tests/unit/api/v1/api-client-actions.test.ts
+++ b/tests/unit/api/v1/api-client-actions.test.ts
@@ -1,14 +1,17 @@
 import { Buffer } from "node:buffer";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { DASHBOARD_COMPAT_HEADER } from "@/lib/api/v1/_shared/constants";
 import { ApiError } from "@/lib/api-client/v1/errors";
 
 const getMock = vi.hoisted(() => vi.fn());
 const patchMock = vi.hoisted(() => vi.fn());
+const postMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api-client/v1/client", () => ({
   apiClient: {
     get: getMock,
     patch: patchMock,
+    post: postMock,
   },
 }));
 
@@ -68,6 +71,20 @@ describe("v1 action compatibility client", () => {
         operationId: "op-123",
         undoToken: "undo-123",
       },
+    });
+  });
+
+  test("marks provider reads as dashboard compatibility requests", async () => {
+    getMock.mockResolvedValue({
+      items: [{ id: 2, name: "Legacy hidden", providerType: "claude-auth" }],
+    });
+
+    await expect(providers.getProviders()).resolves.toEqual([
+      { id: 2, name: "Legacy hidden", providerType: "claude-auth" },
+    ]);
+
+    expect(getMock).toHaveBeenCalledWith("/api/v1/providers", {
+      headers: { [DASHBOARD_COMPAT_HEADER]: "1" },
     });
   });
 
@@ -137,6 +154,49 @@ describe("v1 action compatibility client", () => {
     expect(getMock).toHaveBeenNthCalledWith(2, "/api/v1/users:self");
   });
 
+  test("revives v1 user list date strings for legacy dashboard components", async () => {
+    getMock.mockResolvedValue({
+      items: [
+        {
+          id: 7,
+          name: "dated user",
+          keys: [
+            {
+              id: 11,
+              createdAt: "2026-04-30T07:41:10.000Z",
+              lastUsedAt: "2026-04-30T08:00:00.000Z",
+            },
+          ],
+          costResetAt: "2026-04-30T00:00:00.000Z",
+          expiresAt: "2026-05-07T07:41:10.000Z",
+        },
+      ],
+      pageInfo: { nextCursor: null, hasMore: false, limit: 50 },
+    });
+
+    const result = await users.getUsersBatchCore({ limit: 50 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const [user] = result.data.users;
+    expect(user.expiresAt).toBeInstanceOf(Date);
+    expect(user.expiresAt?.toISOString()).toBe("2026-05-07T07:41:10.000Z");
+    expect(user.costResetAt).toBeInstanceOf(Date);
+    expect(user.keys[0]?.createdAt).toBeInstanceOf(Date);
+    expect(user.keys[0]?.lastUsedAt).toBeInstanceOf(Date);
+  });
+
+  test("marks dashboard user search as a compatibility request", async () => {
+    getMock.mockResolvedValue({ items: [{ id: 1, name: "Admin" }] });
+
+    const result = await users.searchUsers(undefined, 5000);
+
+    expect(getMock).toHaveBeenCalledWith("/api/v1/users:search?limit=5000", {
+      headers: { [DASHBOARD_COMPAT_HEADER]: "1" },
+    });
+    expect(result).toEqual({ ok: true, data: [{ id: 1, name: "Admin" }] });
+  });
+
   test("maps provider endpoint probe logs to the v1 resource endpoint", async () => {
     getMock.mockResolvedValue({ logs: [] });
 
@@ -145,8 +205,56 @@ describe("v1 action compatibility client", () => {
       limit: 50,
     });
 
-    expect(getMock).toHaveBeenCalledWith("/api/v1/provider-endpoints/12/probe-logs?limit=50");
+    expect(getMock).toHaveBeenCalledWith("/api/v1/provider-endpoints/12/probe-logs?limit=50", {
+      headers: { [DASHBOARD_COMPAT_HEADER]: "1" },
+    });
     expect(result).toEqual({ ok: true, data: { logs: [] } });
+  });
+
+  test("summarizes hidden provider endpoint stats without hitting the public batch schema", async () => {
+    getMock.mockResolvedValue({
+      items: [
+        { id: 1, providerType: "claude-auth", isEnabled: true, deletedAt: null, lastProbeOk: true },
+        {
+          id: 2,
+          providerType: "claude-auth",
+          isEnabled: true,
+          deletedAt: null,
+          lastProbeOk: false,
+        },
+        {
+          id: 3,
+          providerType: "claude-auth",
+          isEnabled: false,
+          deletedAt: null,
+          lastProbeOk: null,
+        },
+        { id: 4, providerType: "claude", isEnabled: true, deletedAt: null, lastProbeOk: true },
+      ],
+    });
+
+    const result = await providerEndpoints.batchGetVendorTypeEndpointStats({
+      vendorIds: [2, 2],
+      providerType: "claude-auth",
+    });
+
+    expect(postMock).not.toHaveBeenCalled();
+    expect(getMock).toHaveBeenCalledWith("/api/v1/provider-vendors/2/endpoints?dashboard=true", {
+      headers: { [DASHBOARD_COMPAT_HEADER]: "1" },
+    });
+    expect(result).toEqual({
+      ok: true,
+      data: [
+        {
+          vendorId: 2,
+          total: 3,
+          enabled: 2,
+          healthy: 1,
+          unhealthy: 1,
+          unknown: 0,
+        },
+      ],
+    });
   });
 
   test("decodes opaque usage-log cursors before returning the legacy page shape", async () => {

--- a/tests/unit/api/v1/schema-serialization.test.ts
+++ b/tests/unit/api/v1/schema-serialization.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from "node:vm";
 import { describe, expect, test } from "vitest";
 import { ProblemJsonSchema, ProviderTypeSchema } from "@/lib/api/v1/schemas/_common";
 import { serializeDates, toIsoDateTime } from "@/lib/api/v1/_shared/serialization";
@@ -10,6 +11,27 @@ describe("v1 schema serialization", () => {
     expect(serializeDates({ createdAt: date, nested: [date] })).toEqual({
       createdAt: "2026-04-28T00:00:00.000Z",
       nested: ["2026-04-28T00:00:00.000Z"],
+    });
+  });
+
+  test("serializes Date values from another VM context", () => {
+    const date = runInNewContext('new Date("2026-04-30T07:41:10.464Z")') as Date;
+
+    expect(date instanceof Date).toBe(false);
+    expect(serializeDates({ expiresAt: date, nested: { createdAt: date } })).toEqual({
+      expiresAt: "2026-04-30T07:41:10.464Z",
+      nested: { createdAt: "2026-04-30T07:41:10.464Z" },
+    });
+  });
+
+  test("serializes date-like objects through their JSON representation", () => {
+    const dateLike = {};
+    Object.defineProperty(dateLike, "toJSON", {
+      value: () => "2026-04-30T07:41:10.464Z",
+    });
+
+    expect(serializeDates({ expiresAt: dateLike })).toEqual({
+      expiresAt: "2026-04-30T07:41:10.464Z",
     });
   });
 

--- a/tests/unit/repository/rate-limit-stats-query.test.ts
+++ b/tests/unit/repository/rate-limit-stats-query.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const executeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/drizzle/db", () => ({
+  db: {
+    execute: executeMock,
+  },
+}));
+
+vi.mock("@/lib/utils/timezone", () => ({
+  resolveSystemTimezone: vi.fn(async () => "Asia/Shanghai"),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe("getRateLimitEventStats query", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("casts time filters as timestamptz ISO parameters", async () => {
+    const start = new Date("2026-04-23T08:28:28.258Z");
+    const end = new Date("2026-04-30T08:28:28.258Z");
+    let capturedQuery: unknown;
+
+    executeMock.mockImplementation(async (query: unknown) => {
+      capturedQuery = query;
+      return [
+        {
+          id: 1,
+          user_id: 2,
+          provider_id: 3,
+          error_message: 'rate_limit_metadata: {"limit_type":"rpm","current":95}',
+          hour: new Date("2026-04-30T08:00:00.000Z"),
+        },
+      ];
+    });
+
+    const { getRateLimitEventStats } = await import("@/repository/statistics");
+    const stats = await getRateLimitEventStats({ start_time: start, end_time: end });
+
+    expect(stats.total_events).toBe(1);
+    expect(executeMock).toHaveBeenCalledOnce();
+
+    const chunks = collectSqlChunks(capturedQuery);
+    expect(chunks.dates).toEqual([]);
+    expect(chunks.strings).toEqual(
+      expect.arrayContaining([start.toISOString(), end.toISOString()])
+    );
+    expect(chunks.strings.join(" ")).toContain("::timestamptz");
+    expect(chunks.strings.join(" ")).not.toContain("created_at >= $1");
+    expect(chunks.strings.join(" ")).not.toContain("created_at <= $2");
+  });
+});
+
+function collectSqlChunks(value: unknown): { strings: string[]; dates: Date[] } {
+  const strings: string[] = [];
+  const dates: Date[] = [];
+  const seen = new Set<object>();
+
+  const visit = (item: unknown) => {
+    if (typeof item === "string") {
+      strings.push(item);
+      return;
+    }
+    if (item instanceof Date) {
+      dates.push(item);
+      return;
+    }
+    if (Array.isArray(item)) {
+      item.forEach(visit);
+      return;
+    }
+    if (!item || typeof item !== "object" || seen.has(item)) return;
+
+    seen.add(item);
+    const record = item as { queryChunks?: unknown; value?: unknown };
+    if ("queryChunks" in record) visit(record.queryChunks);
+    if ("value" in record) visit(record.value);
+  };
+
+  visit(value);
+  return { strings, dates };
+}

--- a/tests/unit/users-action-get-users-compat.test.ts
+++ b/tests/unit/users-action-get-users-compat.test.ts
@@ -155,6 +155,56 @@ describe("getUsers compatibility", () => {
     expect(result[0]?.name).toBe("xiaolunanbei");
   });
 
+  test("getUsersBatchCore returns JSON-safe date fields for v1 API transport", async () => {
+    const user = makeUser(88, "dated-user");
+    user.expiresAt = new Date("2026-05-07T07:41:10.000Z");
+    user.costResetAt = new Date("2026-04-30T00:00:00.000Z");
+    findUserListBatchMock.mockResolvedValueOnce({
+      users: [user],
+      nextCursor: null,
+      hasMore: false,
+    });
+    findKeyListBatchMock.mockResolvedValueOnce(
+      new Map([
+        [
+          88,
+          [
+            {
+              id: 99,
+              name: "default",
+              key: "sk-test",
+              expiresAt: null,
+              isEnabled: true,
+              createdAt: new Date("2026-04-30T07:41:10.000Z"),
+              canLoginWebUi: true,
+              limit5hUsd: null,
+              limit5hResetMode: "rolling",
+              limitDailyUsd: null,
+              dailyResetMode: "fixed",
+              dailyResetTime: "00:00",
+              limitWeeklyUsd: null,
+              limitMonthlyUsd: null,
+              limitTotalUsd: null,
+              limitConcurrentSessions: 0,
+              costResetAt: null,
+              providerGroup: "default",
+            },
+          ],
+        ],
+      ])
+    );
+
+    const { getUsersBatchCore } = await import("@/actions/users");
+
+    const result = await getUsersBatchCore({ limit: 50 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.users[0]?.expiresAt).toBe("2026-05-07T07:41:10.000Z");
+    expect(result.data.users[0]?.costResetAt).toBe("2026-04-30T00:00:00.000Z");
+    expect(result.data.users[0]?.keys[0]?.createdAt).toBe("2026-04-30T07:41:10.000Z");
+  });
+
   test("falls back to legacy query when searchTerm is blank", async () => {
     findUserListBatchMock.mockResolvedValueOnce({
       users: [makeUser(77, "legacy-query-hit")],

--- a/tests/unit/users-action-get-users-compat.test.ts
+++ b/tests/unit/users-action-get-users-compat.test.ts
@@ -205,6 +205,56 @@ describe("getUsers compatibility", () => {
     expect(result.data.users[0]?.keys[0]?.createdAt).toBe("2026-04-30T07:41:10.000Z");
   });
 
+  test("getUsersBatchCore returns null for invalid date transport fields", async () => {
+    const user = makeUser(89, "invalid-date-user");
+    user.expiresAt = new Date("bad-date");
+    user.costResetAt = new Date("also-bad");
+    findUserListBatchMock.mockResolvedValueOnce({
+      users: [user],
+      nextCursor: null,
+      hasMore: false,
+    });
+    findKeyListBatchMock.mockResolvedValueOnce(
+      new Map([
+        [
+          89,
+          [
+            {
+              id: 100,
+              name: "default",
+              key: "sk-test",
+              expiresAt: null,
+              isEnabled: true,
+              createdAt: new Date("bad-key-date"),
+              canLoginWebUi: true,
+              limit5hUsd: null,
+              limit5hResetMode: "rolling",
+              limitDailyUsd: null,
+              dailyResetMode: "fixed",
+              dailyResetTime: "00:00",
+              limitWeeklyUsd: null,
+              limitMonthlyUsd: null,
+              limitTotalUsd: null,
+              limitConcurrentSessions: 0,
+              costResetAt: null,
+              providerGroup: "default",
+            },
+          ],
+        ],
+      ])
+    );
+
+    const { getUsersBatchCore } = await import("@/actions/users");
+
+    const result = await getUsersBatchCore({ limit: 50 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.users[0]?.expiresAt).toBeNull();
+    expect(result.data.users[0]?.costResetAt).toBeNull();
+    expect(result.data.users[0]?.keys[0]?.createdAt).toBeNull();
+  });
+
   test("falls back to legacy query when searchTerm is blank", async () => {
     findUserListBatchMock.mockResolvedValueOnce({
       users: [makeUser(77, "legacy-query-hit")],


### PR DESCRIPTION
## Summary

Fixes dashboard/API regressions introduced by the v1 REST management migration where multiple dashboard pages rendered empty, threw Date-related client errors, or hit v1 validation failures.

## Reproduced issues

- Users page crashed with `TypeError: S?.getTime is not a function` because v1 JSON transport returned date strings while legacy dashboard components expected `Date` instances.
- Provider dashboard/settings/status-page surfaces lost hidden legacy provider types (`claude-auth`, `gemini-cli`) after public v1 schemas filtered them out.
- Provider endpoint hidden-type stats hit public batch schemas and returned 400.
- Rate-limit dashboard returned 400 from `/api/v1/dashboard/rate-limit-stats` due Date values flowing through raw SQL parameters.
- Rate-limit dashboard also hit `/api/v1/users:search?limit=5000` 400 because the v1 user search limit was capped below the legacy action/repository contract.

## Fixes

- Revive dashboard user date fields in the v1 action client and keep action/v1 transport JSON-safe.
- Add dashboard compatibility handling for provider and provider-endpoint REST reads/writes while keeping hidden provider types out of public schemas.
- Avoid public batch endpoint validation for hidden provider endpoint stats by using compat endpoint reads and local aggregation.
- Convert rate-limit stats time filters to ISO strings with explicit `::timestamptz` casts.
- Restore `/api/v1/users:search` and filter-search limit support up to 5000.

## Agent Browser QA

Local target: `http://localhost:13500`

```text
dashboard errs 0 cErrs 0 http4+ 0
users errs 0 cErrs 0 http4+ 0
providers-dashboard errs 0 cErrs 0 http4+ 0
providers-settings errs 0 cErrs 0 http4+ 0
status-page-settings errs 0 cErrs 0 http4+ 0
availability errs 0 cErrs 0 http4+ 0
logs errs 0 cErrs 0 http4+ 0
rate-limits errs 0 cErrs 0 http4+ 0
quotas-providers errs 0 cErrs 0 http4+ 0
quotas-users errs 0 cErrs 0 http4+ 0
settings-prices errs 0 cErrs 0 http4+ 0
```

## Local verification

- `bunx vitest run tests/unit/users-action-get-users-compat.test.ts tests/unit/api/v1/schema-serialization.test.ts tests/unit/api/v1/api-client-actions.test.ts tests/api/v1/users/users.test.ts tests/api/v1/providers/providers.read.test.ts tests/api/v1/provider-endpoints/provider-endpoints.test.ts tests/api/v1/dashboard/dashboard.test.ts tests/unit/repository/rate-limit-stats-query.test.ts --reporter=verbose`
- `bun run build`
- `bun run lint`
- `bun run lint:fix`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

Note: `bun run build` still prints existing Next/Turbopack warnings about `node:net` imports in Edge runtime traces, but the build exits successfully.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a set of dashboard/API regressions introduced by the v1 REST management migration: user date fields crashing dashboard components, hidden provider types (`claude-auth`, `gemini-cli`) disappearing from provider/endpoint surfaces, rate-limit stats returning 400 due to raw `Date` SQL parameters, and user search limit caps blocking legacy callers. The core strategy is a `X-CCH-Dashboard-Compat: 1` request header (admin-only) that unlocks internal schemas server-side, while the client action layer adds the header automatically and revives ISO date strings back to `Date` instances.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all findings are P2 style/quality suggestions with no present runtime defects.

Only P2 findings: a type-lie in `toRequiredActionTransportDate` (no runtime crash because the client handles null) and the 5000-user search limit being wider than the dashboard-only intent. The compat-header approach is properly gated behind admin role checks, the Drizzle migration for stats queries is correct, and date normalization logic is well-covered by tests.

src/lib/api/v1/schemas/users.ts — limit increase affects both public search endpoints, not just the dashboard path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/actions/users.ts | Adds `toActionTransportUserDisplay` to serialize Date fields to ISO strings for JSON transport; `toRequiredActionTransportDate` lies about its `Date` return type and can actually return `null`. |
| src/app/api/v1/resources/provider-endpoints/handlers.ts | Adds `isDashboardCompatRequest` guard and internal schemas to allow hidden provider types through the compat header path; logic is consistent and admin-gated. |
| src/app/api/v1/resources/providers/handlers.ts | Mirrors compat-header approach from provider-endpoints; adds early return in `loadVisibleProviders` for dashboard requests; pre-existing `HIDDEN_PROVIDER_TYPES.has()` call is unchanged. |
| src/lib/api-client/v1/actions/users.ts | Adds `normalizeUsers`/`normalizeDate` to revive JSON date strings to `Date` instances on the client; handles null, string, and numeric epoch inputs correctly. |
| src/repository/statistics.ts | Migrates raw SQL string concatenation to Drizzle ORM DSL; ISO string + `::timestamptz` cast correctly avoids passing raw `Date` objects through the parameterized query layer. |
| src/lib/api/v1/schemas/users.ts | Raises `UserFilterSearchQuerySchema` limit from 100 to 5000 — shared by both `:search` and `:filter-search` endpoints, opening large unbounded fetches to any admin caller. |
| src/lib/api/v1/_shared/serialization.ts | Extends `serializeDates` to handle Date-like objects via duck typing and guard invalid dates in `dateToIsoString`; `toJSON` recursion guard (`jsonValue !== value`) prevents simple cycles. |
| src/lib/api/v1/_shared/constants.ts | Adds `DASHBOARD_COMPAT_HEADER`, `PUBLIC_PROVIDER_TYPE_VALUES`, and `INTERNAL_PROVIDER_TYPE_VALUES`; consolidates provider type enumeration cleanly. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dashboard as Dashboard (browser)
    participant ActionClient as API Client (v1 actions)
    participant Server as Hono Route Handler
    participant Action as Server Action
    participant DB as Database

    Dashboard->>ActionClient: getProviders() / getProviderEndpoints()
    ActionClient->>Server: GET /api/v1/providers<br/>X-CCH-Dashboard-Compat: 1
    Server->>Server: isDashboardCompatRequest(c)<br/>checks header + admin role
    alt compat + admin
        Server->>Action: getProviders() [all types]
        Action->>DB: SELECT providers
        DB-->>Action: rows (incl. claude-auth, gemini-cli)
        Action-->>Server: ProviderDisplay[]
        Server-->>ActionClient: {items: [...all types...]}
    else public
        Server->>Action: getProviders() [filtered]
        Action->>DB: SELECT providers
        DB-->>Action: rows
        Action-->>Server: ProviderDisplay[]
        Server->>Server: filterVisibleProviderTypes()
        Server-->>ActionClient: {items: [...public types only...]}
    end
    ActionClient-->>Dashboard: ProviderDisplay[]

    Dashboard->>ActionClient: getUsersBatchCore()
    ActionClient->>Server: GET /api/v1/users
    Server->>Action: getUsersBatchCore()
    Action->>Action: toActionTransportUserDisplay()<br/>(Date to ISO string for JSON)
    Action-->>Server: UserDisplay[] (dates as strings)
    Server-->>ActionClient: {users: [...]}
    ActionClient->>ActionClient: normalizeUsers()<br/>(ISO string to Date)
    ActionClient-->>Dashboard: UserDisplay[] (dates as Date objects)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/actions/users.ts:44-47
**`toRequiredActionTransportDate` return type is a type-lie**

`toRequiredActionTransportDate` is typed as `(value: Date): Date` but can actually return `null` (via the `as unknown as Date` cast) when the input date is invalid. If any call site (now or in the future) relies on the returned value being a real `Date` — e.g., calling `.getTime()` on it — it will throw `TypeError: null.getTime is not a function` at runtime. The client-side fallback `?? new Date(0)` is only present for `createdAt`; if the same server-side helper is ever reused in a context without that guard, silent `null`-as-`Date` values will propagate.

Consider making the type honest:

```suggestion
function toRequiredActionTransportDate(value: Date): string | null {
  const timestamp = value.getTime();
  return Number.isFinite(timestamp) ? value.toISOString() : null;
}
```

### Issue 2 of 2
src/lib/api/v1/schemas/users.ts:98
**Search limit raised to 5000 on both public endpoints**

`UserFilterSearchQuerySchema` is shared by both `/api/v1/users:search` and `/api/v1/users:filter-search`. Raising `max` from 100 → 5000 was intended to unblock the rate-limit dashboard (`limit=5000`), but it also opens the same ceiling to any admin calling either endpoint directly. A deployment with tens of thousands of users could produce a very large unstreamed JSON payload on each call. If the intent is only to allow the dashboard path to request more users, consider keeping the public schema capped at 100 and adding a separate dashboard-scoped schema (similar to the compat pattern applied to providers), or at minimum add a server-side timeout or row limit to protect the query.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: filter hidden provider types in ven..."](https://github.com/ding113/claude-code-hub/commit/e1a6463ce92d7d44ab3b279c72a4181bd34e75ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30300860)</sub>

<!-- /greptile_comment -->