### PR TITLE
feat: add custom service modules

### DIFF
--- a/src/actions/service/keys.ts
+++ b/src/actions/service/keys.ts
@@ -1,0 +1,164 @@
+import type { ActionResult } from "@/actions/types";
+import { logger } from "@/lib/logger";
+import { createKey, deleteKey, findActiveKeyByKeyString } from "@/repository/key";
+import { countLedgerRequestsInTimeRange, sumLedgerTotalCost } from "@/repository/usage-ledger";
+
+/**
+ * 创建临时 Key（Service API 专用）
+ * POST /api/service/keys/createTemp
+ */
+export async function createTempKey(params: {
+  name: string;
+  providerGroup: string;
+  userId?: number;
+  expiresAt?: string;
+}): Promise<
+  ActionResult<{
+    id: number;
+    key: string;
+    name: string;
+    providerGroup: string;
+    createdAt: string;
+  }>
+> {
+  try {
+    const { name, providerGroup, userId = 1, expiresAt } = params;
+
+    // 生成随机 Key
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const crypto = require("node:crypto");
+    const keyString = `sk-${crypto.randomBytes(16).toString("hex")}`;
+
+    // 调用 repository 创建 Key（使用 snake_case 字段）
+    const keyRecord = await createKey({
+      user_id: userId,
+      key: keyString,
+      name,
+      provider_group: providerGroup,
+      is_enabled: true,
+      expires_at: expiresAt ? new Date(expiresAt) : null,
+      can_login_web_ui: false,
+      limit_5h_usd: null,
+      limit_daily_usd: null,
+      limit_weekly_usd: null,
+      limit_monthly_usd: null,
+      limit_total_usd: null,
+      limit_concurrent_sessions: 10,
+      cache_ttl_preference: "inherit",
+    });
+
+    logger.info("[ServiceKeys] Created temp key", { keyId: keyRecord.id, name });
+
+    return {
+      ok: true,
+      data: {
+        id: keyRecord.id,
+        key: keyRecord.key,
+        name: keyRecord.name,
+        providerGroup: keyRecord.providerGroup ?? "",
+        createdAt: keyRecord.createdAt.toISOString(),
+      },
+    };
+  } catch (error) {
+    logger.error("[ServiceKeys] Failed to create temp key", { error });
+    return { ok: false, error: "Failed to create temp key" };
+  }
+}
+
+/**
+ * 软删除 Key（Service API 专用）
+ * POST /api/service/keys/revoke
+ */
+export async function revokeKey(params: {
+  keyId?: number;
+  key?: string;
+}): Promise<ActionResult<{ revoked: boolean }>> {
+  try {
+    const { keyId, key } = params;
+
+    if (!keyId && !key) {
+      return { ok: false, error: "keyId or key is required" };
+    }
+
+    let targetKeyId = keyId;
+
+    // 如果只提供了 key 字符串，先查询 ID
+    if (!targetKeyId && key) {
+      const keyRecord = await findActiveKeyByKeyString(key);
+      if (!keyRecord) {
+        return { ok: false, error: "Key not found" };
+      }
+      targetKeyId = keyRecord.id;
+    }
+
+    // 调用 repository 软删除
+    await deleteKey(targetKeyId!);
+
+    logger.info("[ServiceKeys] Revoked key", { keyId: targetKeyId });
+
+    return { ok: true, data: { revoked: true } };
+  } catch (error) {
+    logger.error("[ServiceKeys] Failed to revoke key", { error });
+    return { ok: false, error: "Failed to revoke key" };
+  }
+}
+
+/**
+ * 查询 Key 用量统计（Service API 专用）
+ * GET /api/service/keys/usage?key=sk-xxx
+ */
+export async function getKeyUsage(params: { key: string }): Promise<
+  ActionResult<{
+    key: string;
+    keyName: string;
+    providerGroup: string;
+    totalCostUsd: number;
+    totalRequests: number;
+    todayCostUsd: number;
+    todayRequests: number;
+  }>
+> {
+  try {
+    const { key } = params;
+
+    // 查询 Key 信息
+    const keyRecord = await findActiveKeyByKeyString(key);
+    if (!keyRecord) {
+      return { ok: false, error: "Key not found" };
+    }
+
+    // 计算总费用
+    const totalCost = await sumLedgerTotalCost("key", key);
+
+    // 计算今日费用
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const todayCost = await sumLedgerTotalCost("key", key, today);
+
+    // 计算请求数
+    const totalRequests = await countLedgerRequestsInTimeRange(
+      "key",
+      key,
+      new Date(0), // 从 epoch 开始
+      new Date()
+    );
+
+    const todayRequests = await countLedgerRequestsInTimeRange("key", key, today, new Date());
+
+    return {
+      ok: true,
+      data: {
+        key,
+        keyName: keyRecord.name,
+        providerGroup: keyRecord.providerGroup ?? "",
+        totalCostUsd: parseFloat(totalCost),
+        totalRequests,
+        todayCostUsd: parseFloat(todayCost),
+        todayRequests,
+      },
+    };
+  } catch (error) {
+    logger.error("[ServiceKeys] Failed to get key usage", { error });
+    return { ok: false, error: "Failed to get key usage" };
+  }
+}

--- a/src/actions/service/providers.ts
+++ b/src/actions/service/providers.ts
@@ -1,0 +1,176 @@
+import { isNull } from "drizzle-orm";
+import type { ActionResult } from "@/actions/types";
+import { db } from "@/drizzle/db";
+import { providers } from "@/drizzle/schema";
+import { logger } from "@/lib/logger";
+import { createProvider, deleteProvider, updateProvider } from "@/repository/provider";
+import { createProviderGroup, findProviderGroupByName } from "@/repository/provider-groups";
+
+/**
+ * 生成 Provider 组合唯一键
+ */
+function makeProviderKey(p: {
+  name: string;
+  url: string;
+  key: string;
+  providerType: string;
+}): string {
+  return `${p.name}|${p.url}|${p.key}|${p.providerType}`;
+}
+
+/**
+ * 批量同步 Providers（幂等）
+ * POST /api/service/providers/batchSync
+ *
+ * 对比输入列表与数据库，执行增删改操作：
+ * - 新增：列表有而数据库没有
+ * - 更新：列表和数据库同时有
+ * - 移除：列表没有数据库有（软删除）
+ *
+ * 唯一性判断：按 name + url + key + providerType 组合
+ */
+export async function batchSyncProviders(params: {
+  providers: Array<{
+    name: string;
+    url: string;
+    apiKey: string;
+    providerType: "claude" | "codex" | "gemini" | "openai-compatible";
+    providerGroup: string;
+    models?: string[];
+  }>;
+}): Promise<
+  ActionResult<{
+    created: number;
+    updated: number;
+    removed: number;
+  }>
+> {
+  try {
+    const { providers: inputProviders } = params;
+
+    // 1. 确保所有 providerGroup 存在
+    const uniqueGroups = [...new Set(inputProviders.map((p) => p.providerGroup))];
+    for (const groupName of uniqueGroups) {
+      const existingGroup = await findProviderGroupByName(groupName);
+      if (!existingGroup) {
+        await createProviderGroup({ name: groupName, costMultiplier: 1.0 });
+        logger.info("[ServiceProviders] Created provider group", { group: groupName });
+      }
+    }
+
+    // 2. 查询数据库中所有未删除的 providers
+    const dbProviders = await db.query.providers.findMany({
+      where: isNull(providers.deletedAt),
+    });
+
+    // 3. 构建组合键映射 (name + url + key + providerType)
+    const inputKeys = new Set(
+      inputProviders.map((p) =>
+        makeProviderKey({
+          name: p.name,
+          url: p.url,
+          key: p.apiKey,
+          providerType: p.providerType,
+        })
+      )
+    );
+
+    const dbProvidersMap = new Map(
+      dbProviders.map((p) => [
+        makeProviderKey({
+          name: p.name,
+          url: p.url,
+          key: p.key,
+          providerType: p.providerType,
+        }),
+        p,
+      ])
+    );
+
+    let createdCount = 0;
+    let updatedCount = 0;
+    let removedCount = 0;
+
+    // 4. 新增 & 更新
+    for (const input of inputProviders) {
+      const key = makeProviderKey({
+        name: input.name,
+        url: input.url,
+        key: input.apiKey,
+        providerType: input.providerType,
+      });
+      const existingProvider = dbProvidersMap.get(key);
+
+      if (existingProvider) {
+        // 更新已有 Provider
+        const updated = await updateProvider(existingProvider.id, {
+          name: input.name,
+          url: input.url,
+          key: input.apiKey,
+          provider_type: input.providerType,
+          group_tag: input.providerGroup,
+          allowed_models: input.models,
+        });
+
+        if (updated) {
+          updatedCount++;
+          logger.info("[ServiceProviders] Updated provider", { providerId: updated.id });
+        }
+      } else {
+        // 创建新 Provider
+        const created = await createProvider({
+          name: input.name,
+          url: input.url,
+          key: input.apiKey,
+          provider_type: input.providerType,
+          is_enabled: true,
+          group_tag: input.providerGroup,
+          allowed_models: input.models,
+          weight: 100,
+          priority: 0,
+          // 废弃字段，必须提供
+          tpm: null,
+          rpm: null,
+          rpd: null,
+          cc: null,
+        });
+
+        createdCount++;
+        logger.info("[ServiceProviders] Created provider", { providerId: created.id });
+      }
+    }
+
+    // 5. 移除（软删除）列表没有而数据库有的
+    for (const dbProvider of dbProviders) {
+      const key = makeProviderKey({
+        name: dbProvider.name,
+        url: dbProvider.url,
+        key: dbProvider.key,
+        providerType: dbProvider.providerType,
+      });
+      if (!inputKeys.has(key)) {
+        await deleteProvider(dbProvider.id);
+        removedCount++;
+        logger.info("[ServiceProviders] Removed provider", { providerId: dbProvider.id });
+      }
+    }
+
+    logger.info("[ServiceProviders] Batch sync completed", {
+      created: createdCount,
+      updated: updatedCount,
+      removed: removedCount,
+    });
+
+    return {
+      ok: true,
+      data: {
+        created: createdCount,
+        updated: updatedCount,
+        removed: removedCount,
+      },
+    };
+  } catch (error) {
+    logger.error("[ServiceProviders] Failed to batch sync providers", { error });
+    return { ok: false, error: "Failed to batch sync providers" };
+  }
+}

--- a/src/app/api/service/[...route]/route.ts
+++ b/src/app/api/service/[...route]/route.ts
@@ -1,0 +1,74 @@
+import type { NextRequest } from "next/server";
+import { createTempKey, getKeyUsage, revokeKey } from "@/actions/service/keys";
+import { batchSyncProviders } from "@/actions/service/providers";
+
+// 运行时配置
+export const runtime = "nodejs";
+
+// 路由映射表
+const ROUTE_HANDLERS: Record<
+  string,
+  {
+    POST?: (body: any) => Promise<Response>;
+    GET?: (params: Record<string, string>) => Promise<Response>;
+  }
+> = {
+  // Keys
+  "keys/createTemp": {
+    POST: async (body) => {
+      const result = await createTempKey(body);
+      return Response.json(result, { status: result.ok ? 200 : 400 });
+    },
+  },
+  "keys/revoke": {
+    POST: async (body) => {
+      const result = await revokeKey(body);
+      return Response.json(result, { status: result.ok ? 200 : 400 });
+    },
+  },
+  "keys/usage": {
+    GET: async (params) => {
+      const result = await getKeyUsage({ key: params.key });
+      return Response.json(result, { status: result.ok ? 200 : 400 });
+    },
+  },
+
+  // Providers
+  "providers/batchSync": {
+    POST: async (body) => {
+      const result = await batchSyncProviders(body);
+      return Response.json(result, { status: result.ok ? 200 : 400 });
+    },
+  },
+};
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const path = url.pathname.replace("/api/service/", "");
+
+  const handler = ROUTE_HANDLERS[path]?.GET;
+  if (!handler) {
+    return Response.json({ ok: false, error: "Not found" }, { status: 404 });
+  }
+
+  // 提取 URL 参数
+  const params: Record<string, string> = {};
+  url.searchParams.forEach((value, key) => {
+    params[key] = value;
+  });
+
+  return handler(params);
+}
+
+export async function POST(request: NextRequest) {
+  const url = new URL(request.url);
+  const path = url.pathname.replace("/api/service/", "");
+
+  const handler = ROUTE_HANDLERS[path]?.POST;
+  if (!handler) {
+    return Response.json({ ok: false, error: "Not found" }, { status: 404 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  return handler(body);
+}


### PR DESCRIPTION
## Summary

This PR introduces a new **Service API** (`/api/service/*`) that provides programmatic endpoints for external integrations to manage temporary API keys and synchronize provider configurations. This complements the existing v1 REST management API by offering specialized operations for service-to-service integration scenarios.

## Related Issues

- **Related to #1123** - Extends management API capabilities with service-oriented endpoints for provider synchronization and temporary key lifecycle management

## What This PR Adds

### 1. Service API Routes (`/api/service/*`)

A new API surface under `/api/service/[...route]/route.ts` exposing the following endpoints:

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/service/keys/createTemp` | POST | Create temporary API keys with optional expiration |
| `/api/service/keys/revoke` | POST | Revoke (soft-delete) an API key by ID or key string |
| `/api/service/keys/usage` | GET | Query usage statistics for a specific key |
| `/api/service/providers/batchSync` | POST | Idempotent batch synchronization of providers |

### 2. Key Management (`src/actions/service/keys.ts`)

- **`createTempKey`**: Creates temporary API keys for external service integration
  - Auto-generates `sk-{hex}` formatted keys using crypto.randomBytes
  - Supports optional expiration via `expiresAt` parameter
  - Assigns keys to specific provider groups
  - Returns key metadata including creation timestamp

- **`revokeKey`**: Soft-deletes API keys
  - Supports revocation by `keyId` or `key` string lookup
  - Validates key existence before revocation

- **`getKeyUsage`**: Retrieves usage statistics for monitoring
  - Total cost and request count (all time)
  - Daily cost and request count (current day)
  - Key metadata (name, provider group)

### 3. Provider Synchronization (`src/actions/service/providers.ts`)

- **`batchSyncProviders`**: Idempotent provider configuration sync
  - **Creates** new providers not present in database
  - **Updates** existing providers (matching by `name + url + key + providerType` composite key)
  - **Removes** (soft-deletes) providers not in input list
  - Auto-creates provider groups if they don't exist
  - Supports all provider types: `claude`, `codex`, `gemini`, `openai-compatible`

## API Response Format

All endpoints return a consistent `ActionResult<T>` structure:

```json
{ "ok": true, "data": { ... } }     // Success
{ "ok": false, "error": "..." }    // Error
```

## Use Cases

This Service API enables:

1. **Multi-tenant SaaS integrations** - Create temporary keys per customer
2. **CI/CD automation** - Programmatic key provisioning and cleanup
3. **Provider fleet management** - Sync provider configurations from infrastructure-as-code
4. **Usage monitoring** - Track key-level consumption for billing

## Files Added

| File | Lines | Purpose |
|------|-------|---------|
| `src/actions/service/keys.ts` | +164 | Key management actions (createTemp, revoke, getUsage) |
| `src/actions/service/providers.ts` | +176 | Provider batch sync action |
| `src/app/api/service/[...route]/route.ts` | +74 | HTTP route handlers for Service API |

## Testing

- [ ] Unit tests for key management actions
- [ ] Unit tests for provider sync action
- [ ] Integration tests for Service API endpoints
- [ ] Manual testing via curl/API client

## Checklist

- [ ] Code follows project conventions (Biome formatting)
- [ ] No hardcoded user-facing strings (i18n applied if needed)
- [ ] Error handling with proper logging
- [ ] Repository pattern used for database access
- [ ] No emoji in code/comments

---
*This PR was enhanced by Claude AI based on the original commit: "feat: add custom service modules"*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a service API module (`/api/service/[...route]`) that exposes key management and provider sync operations. The critical problem is that neither the `GET` nor `POST` handler applies any authentication or authorization check, leaving all four endpoints fully public — a significant departure from every other sensitive route in the codebase. There is also a P1 data-safety gap where calling `batchSyncProviders` with an empty list silently deletes all providers, and a `parseFloat(null)` bug in the usage query that produces `NaN` responses for keys with no ledger entries.
</details>

<details open><summary><h3>Confidence Score: 1/5</h3></summary>

Not safe to merge — publicly accessible endpoints allow unauthenticated key creation/revocation and mass provider deletion.

A P0 security finding (completely missing authentication on administrative endpoints) sets the ceiling at 2/5. Two additional P1 findings (empty-list wipes all providers, NaN in API responses) pull the score below the ceiling to 1/5.

`src/app/api/service/[...route]/route.ts` needs immediate attention for authentication; `src/actions/service/providers.ts` needs the empty-list guard; `src/actions/service/keys.ts` needs the null-safe parseFloat fix.
</details>

<details open><summary><h3>Security Review</h3></summary>

- **Unauthenticated access to all service endpoints** (`src/app/api/service/[...route]/route.ts`): No session or role guard is applied. Any anonymous caller can create API keys, revoke existing keys, read cost/usage data for arbitrary keys, and wipe all providers via an empty `batchSync` payload.
- **Mass provider deletion via empty payload** (`src/actions/service/providers.ts`): `batchSyncProviders({ providers: [] })` soft-deletes every provider with no safeguard, directly exploitable through the unauthenticated endpoint above.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/api/service/[...route]/route.ts | Catch-all service API router with no authentication — all four endpoints are publicly accessible without a session or admin-role check. |
| src/actions/service/providers.ts | Batch-sync action for providers: no guard against an empty input list that would silently soft-delete all providers; otherwise logic is sound. |
| src/actions/service/keys.ts | Key management actions: `parseFloat` on a potentially-null SQL SUM can return NaN; inline `require("node:crypto")` should be a top-level import. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTTP Request] --> B["Service API Router (no auth)"]
    B --> C{Route match?}
    C -->|No| D[404 Not Found]
    C -->|Yes| E{Method}
    E -->|GET keys/usage| F[getKeyUsage]
    E -->|POST keys/createTemp| G[createTempKey]
    E -->|POST keys/revoke| H[revokeKey]
    E -->|POST providers/batchSync| I[batchSyncProviders]
    F --> J[sumLedgerTotalCost]
    J --> K{Returns null?}
    K -->|Yes| L["parseFloat = NaN in response"]
    K -->|No| M[Valid number returned]
    I --> N{Input list empty?}
    N -->|Yes - no guard| O["Soft-delete ALL providers"]
    N -->|No| P[Diff and sync providers]
    style B fill:#d9534f,color:#fff
    style L fill:#f0ad4e,color:#fff
    style O fill:#d9534f,color:#fff
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/app/api/service/[...route]/route.ts:44-74
**No authentication on admin-level endpoints**

Every other sensitive route in this codebase (e.g., `src/app/api/admin/system-config/route.ts`, `src/app/api/internal/data-gen/route.ts`) guards access with `await getSession()` and a role check of `"admin"`. These new `/api/service/*` handlers have no such guard, making all four endpoints publicly accessible to unauthenticated callers. A malicious actor can mint new API keys, revoke any key by ID, enumerate cost/usage data for any key, or call `batchSyncProviders` with an empty providers list to soft-delete every provider in the database. Both `GET` and `POST` handlers need an auth guard before routing to a handler, matching the pattern used everywhere else in the codebase.

### Issue 2 of 4
src/actions/service/providers.ts:122-135
**Empty input silently deletes all providers**

The sync loop treats every DB provider whose composite key is absent from the input list as "to remove." Calling `batchSyncProviders({ providers: [] })` from a misconfigured client, a partial deploy, or an accidental empty payload will soft-delete every provider in the database with no warning. Add a guard to reject an empty list:

```typescript
if (inputProviders.length === 0) {
  return { ok: false, error: "providers list must not be empty" };
}
```

### Issue 3 of 4
src/actions/service/keys.ts:119-130
**`parseFloat` on a potentially-null sum returns `NaN`**

`sumLedgerTotalCost` is backed by a SQL `SUM` aggregate which returns `null` when there are no matching rows. `parseFloat(null)` evaluates to `NaN`, so callers with zero usage receive `{ totalCostUsd: NaN, todayCostUsd: NaN }` which JSON-serializes as `null`, silently breaking the response contract. Use a nullish fallback:

```typescript
totalCostUsd: parseFloat(totalCost ?? "0"),
todayCostUsd: parseFloat(todayCost ?? "0"),
```

### Issue 4 of 4
src/actions/service/keys.ts:27-29
**`require` inside function body — prefer a top-level import**

Since the route is already configured with `runtime = "nodejs"`, the Node.js `crypto` module is available unconditionally. A top-level ESM import is cleaner and resolved once at module load rather than on every call:

```typescript
import crypto from "node:crypto";
```

Then remove the inline `require` and the eslint-disable comment.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add custom service modules"](https://github.com/ding113/claude-code-hub/commit/c7a3330f1cfeff967a292a26c674112c6c698254) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30303138)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->