### PR TITLE
fix: harden proxy stream lifecycle to avoid SIGSEGV under load (#1147)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,11 @@ COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/drizzle ./drizzle
 COPY --from=builder /app/VERSION ./VERSION
 
-CMD ["node", "server.js"]
+# Node 诊断报告输出目录（issue #1147）
+# 容器外通过 docker-compose volume 挂载到 ./data/reports 持久化
+RUN mkdir -p /app/reports
+
+# --report-on-fatalerror / --report-uncaught-exception：在 native 段错误或
+# 未捕获异常时写出 JSON 诊断报告（包含原生堆栈、libuv 句柄、JS 堆等）
+# --report-directory：指向 /app/reports 以便挂卷持久化
+CMD ["node", "--report-on-fatalerror", "--report-uncaught-exception", "--report-directory=/app/reports", "server.js"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,6 +70,10 @@ services:
       TZ: Asia/Shanghai
     ports:
       - "${APP_PORT:-23000}:3000"
+    volumes:
+      # Node 诊断报告（report.*.json）持久化到宿主机，便于事后排查 SIGSEGV 等
+      # native 崩溃。配合 Dockerfile 中 --report-* 启动参数生效（issue #1147）
+      - ./data/reports:/app/reports
     restart: unless-stopped
     healthcheck:
       test:

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -4798,11 +4798,13 @@ export class ProxyForwarder {
     rawBody.on("error", (err) => {
       const code = (err as NodeJS.ErrnoException).code;
       // 客户端/上游断连是高频路径事件，降级为 debug 以减少噪音
+      // 集合需与下方 streamPipeline 回调中的 isExpectedDisconnect 保持一致
       const isExpectedDisconnect =
         code === "ECONNRESET" ||
         code === "UND_ERR_SOCKET" ||
         code === "UND_ERR_ABORTED" ||
-        code === "ABORT_ERR";
+        code === "ABORT_ERR" ||
+        code === "ERR_STREAM_PREMATURE_CLOSE";
       const log = isExpectedDisconnect ? logger.debug : logger.warn;
       log("ProxyForwarder: undici body stream error (caught early)", {
         providerId,

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -1,5 +1,6 @@
 import { STATUS_CODES } from "node:http";
 import type { Readable } from "node:stream";
+import { pipeline as streamPipeline } from "node:stream";
 import { createGunzip, constants as zlibConstants } from "node:zlib";
 import type { Dispatcher } from "undici";
 import { request as undiciRequest } from "undici";
@@ -74,6 +75,7 @@ import {
   sanitizeUrl,
 } from "./errors";
 import { ModelRedirector } from "./model-redirector";
+import { nodeStreamToWebStreamSafe } from "./node-stream-to-web";
 import {
   cloneOpenAIImageRequestMetadata,
   sanitizeGenerationsRequestForProvider,
@@ -4794,11 +4796,19 @@ export class ProxyForwarder {
     // 必须在任何其他操作之前设置，否则 ECONNRESET 等错误会导致 uncaughtException
     const rawBody = undiciRes.body as Readable;
     rawBody.on("error", (err) => {
-      logger.warn("ProxyForwarder: undici body stream error (caught early)", {
+      const code = (err as NodeJS.ErrnoException).code;
+      // 客户端/上游断连是高频路径事件，降级为 debug 以减少噪音
+      const isExpectedDisconnect =
+        code === "ECONNRESET" ||
+        code === "UND_ERR_SOCKET" ||
+        code === "UND_ERR_ABORTED" ||
+        code === "ABORT_ERR";
+      const log = isExpectedDisconnect ? logger.debug : logger.warn;
+      log("ProxyForwarder: undici body stream error (caught early)", {
         providerId,
         providerName,
         error: err.message,
-        errorCode: (err as NodeJS.ErrnoException).code,
+        errorCode: code,
       });
     });
 
@@ -4862,28 +4872,47 @@ export class ProxyForwarder {
         finishFlush: zlibConstants.Z_SYNC_FLUSH,
       });
 
-      // 捕获 Gunzip 错误但不抛出（容错处理）
+      // 捕获 Gunzip 错误：使用 destroy(err) 而非 end()，避免与下游 cancel() 调用
+      // destroy(reason) 之间出现状态竞争，导致 native zlib 段错误（issue #1147）
       gunzip.on("error", (err) => {
-        logger.warn("ProxyForwarder: Gunzip decompression error (ignored)", {
+        logger.warn("ProxyForwarder: Gunzip decompression error", {
           providerId,
           providerName,
           error: err.message,
-          note: "Partial data may be returned, but no crash",
+          note: "Stream destroyed; partial data may already have been forwarded",
         });
-        // 尝试结束流，避免挂起
-        try {
-          gunzip.end();
-        } catch {
-          // ignore
+        if (!gunzip.destroyed) {
+          try {
+            gunzip.destroy(err);
+          } catch {
+            // ignore
+          }
         }
       });
 
-      // 将 undici body (Node Readable) pipe 到 Gunzip
-      // 注意：使用前面已添加错误处理器的 rawBody
-      rawBody.pipe(gunzip);
+      // 使用 stream.pipeline() 替代 .pipe()，确保任一端出错时双向 destroy
+      // 原子完成，消除 .pipe() 在错误路径上残留的清理竞争窗口
+      streamPipeline(rawBody, gunzip, (err) => {
+        if (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          const isExpectedDisconnect =
+            code === "ECONNRESET" ||
+            code === "UND_ERR_SOCKET" ||
+            code === "UND_ERR_ABORTED" ||
+            code === "ABORT_ERR" ||
+            code === "ERR_STREAM_PREMATURE_CLOSE";
+          const log = isExpectedDisconnect ? logger.debug : logger.warn;
+          log("ProxyForwarder: rawBody->gunzip pipeline ended with error", {
+            providerId,
+            providerName,
+            error: err.message,
+            errorCode: code,
+          });
+        }
+      });
 
       // 将 Gunzip 流转换为 Web 流（容错版本）
-      bodyStream = ProxyForwarder.nodeStreamToWebStreamSafe(gunzip, providerId, providerName);
+      bodyStream = nodeStreamToWebStreamSafe(gunzip, providerId, providerName);
 
       // 移除 content-encoding 和 content-length（避免下游再解压或使用错误长度）
       responseHeaders.delete("content-encoding");
@@ -4896,7 +4925,7 @@ export class ProxyForwarder {
         contentEncoding: encoding || "(none)",
       });
       // 注意：使用前面已添加错误处理器的 rawBody
-      bodyStream = ProxyForwarder.nodeStreamToWebStreamSafe(rawBody, providerId, providerName);
+      bodyStream = nodeStreamToWebStreamSafe(rawBody, providerId, providerName);
     }
 
     logger.debug("ProxyForwarder: undici.request completed, returning wrapped response", {
@@ -4911,93 +4940,6 @@ export class ProxyForwarder {
       // 未知/非标准状态码不应兜底为 OK（避免误导客户端日志与调试）
       statusText: STATUS_CODES[undiciRes.statusCode] ?? "",
       headers: responseHeaders,
-    });
-  }
-
-  /**
-   * 将 Node.js Readable 流转换为 Web ReadableStream（容错版本）
-   *
-   * 关键特性：吞掉上游流的错误事件，避免 "terminated" 错误冒泡到调用者
-   */
-  private static nodeStreamToWebStreamSafe(
-    nodeStream: Readable,
-    providerId: number,
-    providerName: string
-  ): ReadableStream<Uint8Array> {
-    let chunkCount = 0;
-    let totalBytes = 0;
-
-    return new ReadableStream<Uint8Array>({
-      start(controller) {
-        logger.debug("ProxyForwarder: Starting Node-to-Web stream conversion", {
-          providerId,
-          providerName,
-        });
-
-        nodeStream.on("data", (chunk: Buffer | Uint8Array) => {
-          chunkCount++;
-          totalBytes += chunk.length;
-          try {
-            const buf = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
-            controller.enqueue(buf);
-          } catch {
-            // 如果 controller 已关闭，忽略
-          }
-        });
-
-        nodeStream.on("end", () => {
-          logger.debug("ProxyForwarder: Node stream ended normally", {
-            providerId,
-            providerName,
-            chunkCount,
-            totalBytes,
-          });
-          try {
-            controller.close();
-          } catch {
-            // 如果已关闭，忽略
-          }
-        });
-
-        nodeStream.on("close", () => {
-          logger.debug("ProxyForwarder: Node stream closed", {
-            providerId,
-            providerName,
-            chunkCount,
-            totalBytes,
-          });
-          try {
-            controller.close();
-          } catch {
-            // 如果已关闭，忽略
-          }
-        });
-
-        // ⭐ 关键：将上游流错误传播到下游 reader，确保 ResponseHandler 能检测到截断
-        nodeStream.on("error", (err) => {
-          logger.warn("ProxyForwarder: Upstream stream error (signaling downstream)", {
-            providerId,
-            providerName,
-            error: err.message,
-            errorName: err.name,
-          });
-          try {
-            controller.error(err);
-          } catch {
-            // 如果已关闭或已出错，忽略
-          }
-        });
-      },
-
-      cancel(reason) {
-        try {
-          nodeStream.destroy(
-            reason instanceof Error ? reason : reason ? new Error(String(reason)) : undefined
-          );
-        } catch {
-          // ignore
-        }
-      },
     });
   }
 }

--- a/src/app/v1/_lib/proxy/node-stream-to-web.test.ts
+++ b/src/app/v1/_lib/proxy/node-stream-to-web.test.ts
@@ -1,0 +1,138 @@
+import { Readable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { nodeStreamToWebStreamSafe } from "./node-stream-to-web";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+async function readAll(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<Uint8Array[]> {
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) return chunks;
+    if (value) chunks.push(value);
+  }
+}
+
+describe("nodeStreamToWebStreamSafe", () => {
+  it("forwards chunks then closes when the source ends normally", async () => {
+    const node = Readable.from([Buffer.from("hello "), Buffer.from("world")]);
+
+    const web = nodeStreamToWebStreamSafe(node, 1, "test");
+    const reader = web.getReader();
+    const chunks = await readAll(reader);
+
+    const decoded = Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf8");
+    expect(decoded).toBe("hello world");
+
+    // Listeners must be detached after end
+    expect(node.listenerCount("data")).toBe(0);
+    expect(node.listenerCount("end")).toBe(0);
+    expect(node.listenerCount("close")).toBe(0);
+    expect(node.listenerCount("error")).toBe(0);
+  });
+
+  it("propagates source errors as a stream error to the reader", async () => {
+    // Pause the readable so we have time to emit error after attaching listeners
+    const node = new Readable({
+      read() {
+        // no-op, push manually
+      },
+    });
+
+    const web = nodeStreamToWebStreamSafe(node, 1, "test");
+    const reader = web.getReader();
+
+    const boom = new Error("boom");
+    queueMicrotask(() => node.emit("error", boom));
+
+    await expect(reader.read()).rejects.toThrow("boom");
+    // After error settles, listeners must be detached
+    expect(node.listenerCount("data")).toBe(0);
+    expect(node.listenerCount("end")).toBe(0);
+    expect(node.listenerCount("close")).toBe(0);
+    expect(node.listenerCount("error")).toBe(0);
+  });
+
+  it("destroys the source and detaches listeners on cancel(), and ignores subsequent events", async () => {
+    const node = new Readable({
+      read() {
+        // no-op
+      },
+    });
+    // Spy on destroy to confirm we call it exactly once
+    const destroySpy = vi.spyOn(node, "destroy");
+
+    const web = nodeStreamToWebStreamSafe(node, 1, "test");
+    const reader = web.getReader();
+    // Consume nothing — cancel mid-stream
+    await reader.cancel(new Error("client gone"));
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+    // Wrapper-registered data/end/close listeners are detached. A swallowing
+    // error listener is intentionally attached just before destroy(reason) so
+    // Node's emit("error", reason) does not become an uncaughtException.
+    expect(node.listenerCount("data")).toBe(0);
+    expect(node.listenerCount("end")).toBe(0);
+    expect(node.listenerCount("close")).toBe(0);
+
+    // Late events from the (now-destroyed) source must not reach the controller —
+    // because listeners were detached, emitting these is a no-op for our wrapper.
+    // (We assert no throw escapes; the reader is already closed.)
+    expect(() => node.emit("data", Buffer.from("late"))).not.toThrow();
+    expect(() => node.emit("close")).not.toThrow();
+  });
+
+  it("does not call destroy() twice when cancel() is invoked on an already-destroyed source", async () => {
+    const node = new Readable({
+      read() {
+        // no-op
+      },
+    });
+    node.destroy();
+    const destroySpy = vi.spyOn(node, "destroy");
+
+    const web = nodeStreamToWebStreamSafe(node, 1, "test");
+    const reader = web.getReader();
+    await reader.cancel("client gone");
+
+    // Wrapper must short-circuit when nodeStream.destroyed is true
+    expect(destroySpy).not.toHaveBeenCalled();
+  });
+
+  it("treats back-to-back end + close as a single close on the web stream", async () => {
+    const node = new Readable({
+      read() {
+        // no-op
+      },
+    });
+
+    const web = nodeStreamToWebStreamSafe(node, 1, "test");
+    const reader = web.getReader();
+
+    // Push one chunk, then emit both end and close synchronously
+    queueMicrotask(() => {
+      node.emit("data", Buffer.from("chunk"));
+      node.emit("end");
+      node.emit("close");
+    });
+
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    expect(Buffer.from(first.value as Uint8Array).toString("utf8")).toBe("chunk");
+
+    const second = await reader.read();
+    expect(second.done).toBe(true);
+    // No throw, reader closed exactly once. Listeners detached.
+    expect(node.listenerCount("end")).toBe(0);
+    expect(node.listenerCount("close")).toBe(0);
+  });
+});

--- a/src/app/v1/_lib/proxy/node-stream-to-web.test.ts
+++ b/src/app/v1/_lib/proxy/node-stream-to-web.test.ts
@@ -77,18 +77,59 @@ describe("nodeStreamToWebStreamSafe", () => {
     await reader.cancel(new Error("client gone"));
 
     expect(destroySpy).toHaveBeenCalledTimes(1);
+    // Wait for the destroy "close" event to fire so the cleanup once-listener
+    // can run and remove the swallowing error handler.
+    await new Promise((resolve) => setImmediate(resolve));
     // Wrapper-registered data/end/close listeners are detached. A swallowing
     // error listener is intentionally attached just before destroy(reason) so
-    // Node's emit("error", reason) does not become an uncaughtException.
+    // Node's emit("error", reason) does not become an uncaughtException;
+    // the close-listener cleanup removes it once destroy completes.
     expect(node.listenerCount("data")).toBe(0);
     expect(node.listenerCount("end")).toBe(0);
     expect(node.listenerCount("close")).toBe(0);
+    expect(node.listenerCount("error")).toBe(0);
 
     // Late events from the (now-destroyed) source must not reach the controller —
     // because listeners were detached, emitting these is a no-op for our wrapper.
     // (We assert no throw escapes; the reader is already closed.)
     expect(() => node.emit("data", Buffer.from("late"))).not.toThrow();
     expect(() => node.emit("close")).not.toThrow();
+  });
+
+  it("does not leak an error listener when cancel() is called without a reason", async () => {
+    const node = new Readable({
+      read() {
+        // no-op
+      },
+    });
+
+    const web = nodeStreamToWebStreamSafe(node, 1, "test");
+    const reader = web.getReader();
+    // No reason -> destroy() will not re-emit "error", so the swallow listener
+    // must be cleaned up via the close-listener fallback.
+    await reader.cancel();
+
+    // Wait one tick so the destroy "close" event fires and removes swallow
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(node.listenerCount("error")).toBe(0);
+    expect(node.listenerCount("close")).toBe(0);
+  });
+
+  it("is a no-op when cancel() is called twice", async () => {
+    const node = new Readable({
+      read() {
+        // no-op
+      },
+    });
+    const destroySpy = vi.spyOn(node, "destroy");
+
+    const web = nodeStreamToWebStreamSafe(node, 1, "test");
+    const reader = web.getReader();
+    await reader.cancel("first");
+    // Second cancel should be a no-op — no extra destroy, no extra swallow listener
+    await reader.cancel("second");
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
   });
 
   it("does not call destroy() twice when cancel() is invoked on an already-destroyed source", async () => {

--- a/src/app/v1/_lib/proxy/node-stream-to-web.ts
+++ b/src/app/v1/_lib/proxy/node-stream-to-web.ts
@@ -1,0 +1,134 @@
+import type { Readable } from "node:stream";
+import { logger } from "@/lib/logger";
+
+/**
+ * 将 Node.js Readable 流转换为 Web ReadableStream（容错版本）
+ *
+ * 关键不变量（issue #1147 修复）：
+ * - close()/error() 在 Web 流侧最多触发一次（settled 单触发标志）
+ * - 任一终态触发后立即移除 nodeStream 上的所有监听器，确保 destroy() 引发的
+ *   后续事件不会再访问 controller，从而消除"半释放 native 流上的回调"导致的
+ *   段错误窗口
+ * - cancel() 在调用 destroy() 之前先 detach 监听器，再检查 destroyed 防止
+ *   重复 destroy
+ */
+export function nodeStreamToWebStreamSafe(
+  nodeStream: Readable,
+  providerId: number,
+  providerName: string
+): ReadableStream<Uint8Array> {
+  let chunkCount = 0;
+  let totalBytes = 0;
+  let settled = false;
+
+  let onData: ((chunk: Buffer | Uint8Array) => void) | null = null;
+  let onEnd: (() => void) | null = null;
+  let onClose: (() => void) | null = null;
+  let onError: ((err: Error) => void) | null = null;
+
+  const detach = (stream: Readable) => {
+    if (onData) stream.removeListener("data", onData);
+    if (onEnd) stream.removeListener("end", onEnd);
+    if (onClose) stream.removeListener("close", onClose);
+    if (onError) stream.removeListener("error", onError);
+    onData = null;
+    onEnd = null;
+    onClose = null;
+    onError = null;
+  };
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      logger.debug("ProxyForwarder: Starting Node-to-Web stream conversion", {
+        providerId,
+        providerName,
+      });
+
+      onData = (chunk: Buffer | Uint8Array) => {
+        if (settled) return;
+        chunkCount++;
+        totalBytes += chunk.length;
+        try {
+          const buf = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+          controller.enqueue(buf);
+        } catch {
+          // controller 已关闭/出错时忽略
+        }
+      };
+      nodeStream.on("data", onData);
+
+      onEnd = () => {
+        if (settled) return;
+        settled = true;
+        logger.debug("ProxyForwarder: Node stream ended normally", {
+          providerId,
+          providerName,
+          chunkCount,
+          totalBytes,
+        });
+        detach(nodeStream);
+        try {
+          controller.close();
+        } catch {
+          // ignore
+        }
+      };
+      nodeStream.on("end", onEnd);
+
+      onClose = () => {
+        if (settled) return;
+        settled = true;
+        logger.debug("ProxyForwarder: Node stream closed", {
+          providerId,
+          providerName,
+          chunkCount,
+          totalBytes,
+        });
+        detach(nodeStream);
+        try {
+          controller.close();
+        } catch {
+          // ignore
+        }
+      };
+      nodeStream.on("close", onClose);
+
+      onError = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        logger.warn("ProxyForwarder: Upstream stream error (signaling downstream)", {
+          providerId,
+          providerName,
+          error: err.message,
+          errorName: err.name,
+        });
+        detach(nodeStream);
+        try {
+          controller.error(err);
+        } catch {
+          // ignore
+        }
+      };
+      nodeStream.on("error", onError);
+    },
+
+    cancel(reason) {
+      settled = true;
+      detach(nodeStream);
+      if (!nodeStream.destroyed) {
+        // destroy(reason) 会 re-emit "error"，而我们已经 detach 了错误监听。
+        // 留一个 no-op 监听吞掉它，避免 native EventEmitter 触发 uncaughtException。
+        nodeStream.once("error", () => {
+          // ignore: web 流已 cancel，下游没有 reader 关心了
+        });
+        try {
+          nodeStream.destroy(
+            reason instanceof Error ? reason : reason ? new Error(String(reason)) : undefined
+          );
+        } catch {
+          // ignore
+        }
+      }
+    },
+  });
+}

--- a/src/app/v1/_lib/proxy/node-stream-to-web.ts
+++ b/src/app/v1/_lib/proxy/node-stream-to-web.ts
@@ -113,21 +113,30 @@ export function nodeStreamToWebStreamSafe(
     },
 
     cancel(reason) {
+      // 重复 cancel 应是 no-op：避免重复 detach、重复注册 swallow 监听
+      if (settled) return;
       settled = true;
       detach(nodeStream);
-      if (!nodeStream.destroyed) {
-        // destroy(reason) 会 re-emit "error"，而我们已经 detach 了错误监听。
-        // 留一个 no-op 监听吞掉它，避免 native EventEmitter 触发 uncaughtException。
-        nodeStream.once("error", () => {
-          // ignore: web 流已 cancel，下游没有 reader 关心了
-        });
-        try {
-          nodeStream.destroy(
-            reason instanceof Error ? reason : reason ? new Error(String(reason)) : undefined
-          );
-        } catch {
-          // ignore
-        }
+      if (nodeStream.destroyed) return;
+
+      // destroy(reason) 在 reason 为 Error 时会 re-emit "error"，而我们已经
+      // detach 了错误监听。注册一次 swallow 监听吞掉它，避免触发 uncaughtException。
+      // 但 destroy() 不带 reason / 带非 Error reason 时 不会 emit error，此时
+      // once("error") 会成为常驻泄露 —— 用 once("close") 兜底清理。
+      const swallow = () => {
+        // ignore: web 流已 cancel，下游没有 reader 关心了
+      };
+      nodeStream.once("error", swallow);
+      nodeStream.once("close", () => {
+        nodeStream.removeListener("error", swallow);
+      });
+
+      try {
+        nodeStream.destroy(
+          reason instanceof Error ? reason : reason ? new Error(String(reason)) : undefined
+        );
+      } catch {
+        // ignore
       }
     },
   });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -19,7 +19,81 @@ const instrumentationState = globalThis as unknown as {
   __CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__?: ReturnType<typeof setInterval>;
   __CCH_API_KEY_VF_SYNC_STARTED__?: boolean;
   __CCH_API_KEY_VF_SYNC_CLEANUP__?: (() => void) | null;
+  __CCH_LIFECYCLE_MARKERS_LOGGED__?: boolean;
+  __CCH_CRASH_HANDLERS_REGISTERED__?: boolean;
+  __CCH_PROCESS_STARTED_AT__?: number;
 };
+
+/**
+ * 进程级崩溃诊断
+ *
+ * 背景：生产环境曾出现 exitCode=139 (SIGSEGV) 重启（issue #1147），但日志中
+ * 未捕获到任何 JS 异常。本函数注册 uncaughtException / unhandledRejection 兜底
+ * 处理器，并在崩溃时尝试写入 Node 诊断报告（report.*.json）。
+ *
+ * 必要的 node 启动参数（在 Dockerfile 中配置）：
+ *   --report-on-fatalerror --report-uncaught-exception --report-directory=/app/reports
+ *
+ * 这两个 process.on(...) 不会与现有的 SIGTERM / SIGINT 处理器冲突。
+ */
+function registerCrashDiagnostics(): void {
+  if (instrumentationState.__CCH_CRASH_HANDLERS_REGISTERED__) {
+    return;
+  }
+  instrumentationState.__CCH_CRASH_HANDLERS_REGISTERED__ = true;
+
+  const writeReport = (trigger: string, err: unknown): string | undefined => {
+    try {
+      const report = (
+        process as NodeJS.Process & {
+          report?: { writeReport: (filename?: string, err?: unknown) => string };
+        }
+      ).report;
+      if (report?.writeReport) {
+        return report.writeReport(`report.${trigger}.${Date.now()}.json`, err as Error);
+      }
+    } catch {
+      // 写入诊断报告失败不应再抛出
+    }
+    return undefined;
+  };
+
+  process.on("uncaughtException", (err: Error) => {
+    const reportPath = writeReport("uncaughtException", err);
+    logger.fatal("[Lifecycle] uncaughtException", {
+      error: err.message,
+      errorName: err.name,
+      stack: err.stack,
+      reportPath,
+    });
+    // 与 Node 默认行为一致：捕获后退出，避免后续运行在不一致状态
+    process.exit(1);
+  });
+
+  process.on("unhandledRejection", (reason: unknown) => {
+    const err = reason instanceof Error ? reason : new Error(String(reason));
+    logger.error("[Lifecycle] unhandledRejection", {
+      error: err.message,
+      errorName: err.name,
+      stack: err.stack,
+    });
+    // 不退出：保留与当前 Node 默认（warning 级别）一致的行为，避免引发回归
+  });
+}
+
+function logStartupMarker(): void {
+  if (instrumentationState.__CCH_LIFECYCLE_MARKERS_LOGGED__) {
+    return;
+  }
+  instrumentationState.__CCH_LIFECYCLE_MARKERS_LOGGED__ = true;
+  instrumentationState.__CCH_PROCESS_STARTED_AT__ = Date.now();
+  logger.info("[Lifecycle] Process started", {
+    pid: process.pid,
+    nodeVersion: process.version,
+    execArgv: process.execArgv,
+    nodeOptions: process.env.NODE_OPTIONS ?? null,
+  });
+}
 
 /**
  * 同步错误规则并初始化检测器
@@ -140,6 +214,12 @@ function warmupApiKeyVacuumFilter(): void {
 export async function register() {
   // 仅在服务器端执行
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // 生命周期与崩溃诊断（issue #1147）
+    // - startup marker：让运维能从日志中区分 "正常启动" 与 "Docker 异常重启后立即恢复"
+    // - crash handlers：兜底 uncaughtException / unhandledRejection，并触发 Node 诊断报告
+    logStartupMarker();
+    registerCrashDiagnostics();
+
     // Initialize Langfuse observability (no-op if env vars not set)
     try {
       const { initLangfuse } = await import("@/lib/langfuse");
@@ -174,6 +254,14 @@ export async function register() {
         }
         instrumentationState.__CCH_SHUTDOWN_IN_PROGRESS__ = true;
 
+        const startedAt = instrumentationState.__CCH_PROCESS_STARTED_AT__;
+        const uptimeSeconds =
+          startedAt !== undefined ? Math.round((Date.now() - startedAt) / 1000) : null;
+        logger.info("[Lifecycle] Process exiting", {
+          pid: process.pid,
+          signal,
+          uptimeSeconds,
+        });
         logger.info(`[Instrumentation] Received ${signal}, cleaning up...`);
 
         try {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -58,8 +58,30 @@ function registerCrashDiagnostics(): void {
     return undefined;
   };
 
+  // pino 在生产环境是同步直写 stdout（无 transport），但 dev 用 pino-pretty
+  // worker 是异步的；fatal 路径下 process.exit() 可能抢在 worker 写出之前。
+  // 用一行 JSON 直接同步写 stderr 作为兜底，确保至少日志层面留下痕迹。
+  const writeFatalStderr = (trigger: string, err: Error, reportPath?: string): void => {
+    try {
+      const line = JSON.stringify({
+        time: new Date().toISOString(),
+        level: "fatal",
+        msg: `[Lifecycle] ${trigger}`,
+        pid: process.pid,
+        error: err.message,
+        errorName: err.name,
+        stack: err.stack,
+        reportPath,
+      });
+      process.stderr.write(`${line}\n`);
+    } catch {
+      // ignore: 兜底写失败时已无更上游
+    }
+  };
+
   process.on("uncaughtException", (err: Error) => {
     const reportPath = writeReport("uncaughtException", err);
+    writeFatalStderr("uncaughtException", err, reportPath);
     logger.fatal("[Lifecycle] uncaughtException", {
       error: err.message,
       errorName: err.name,
@@ -70,14 +92,21 @@ function registerCrashDiagnostics(): void {
     process.exit(1);
   });
 
+  // Node 20 默认 --unhandled-rejections=throw：未注册处理器时直接 fail-fast。
+  // 注册了处理器就会变成 "继续运行"，相当于回归到旧行为。我们仍要求 fail-fast，
+  // 否则一个未捕获的 promise 会让进程留在未定义状态、绕过 supervisor 重启。
+  // 因此：写诊断报告 + 同步落盘日志 + 主动 exit(1) 复现默认语义。
   process.on("unhandledRejection", (reason: unknown) => {
     const err = reason instanceof Error ? reason : new Error(String(reason));
-    logger.error("[Lifecycle] unhandledRejection", {
+    const reportPath = writeReport("unhandledRejection", err);
+    writeFatalStderr("unhandledRejection", err, reportPath);
+    logger.fatal("[Lifecycle] unhandledRejection", {
       error: err.message,
       errorName: err.name,
       stack: err.stack,
+      reportPath,
     });
-    // 不退出：保留与当前 Node 默认（warning 级别）一致的行为，避免引发回归
+    process.exit(1);
   });
 }
 


### PR DESCRIPTION
Closes #1147.

## Summary
- Eliminate the destroy/end race in `ProxyForwarder` between `gunzip` error
  cleanup, the `rawBody->gunzip` pipe, and the Web stream `cancel()` path —
  the most likely trigger for the production `exitCode=139` (SIGSEGV) crashes
  observed under heavy proxy load on 2026-04-30.
- Wire process-level forensics so any future native crash leaves a
  `report.*.json` plus `[Lifecycle]` startup/shutdown markers in the logs.

## What changed
**Stream lifecycle (root-cause fix)**
- Extract `nodeStreamToWebStreamSafe` into `src/app/v1/_lib/proxy/node-stream-to-web.ts`.
  Add a single-fire `settled` flag, detach all source listeners on
  `end`/`close`/`error`/`cancel`, and skip `destroy()` when the source is
  already destroyed. Closes the post-destroy callback window that can corrupt
  native zlib state.
- `gunzip.on('error', ...)` now calls `gunzip.destroy(err)` instead of
  `gunzip.end()` to avoid the end/destroy state race.
- `rawBody.pipe(gunzip)` -> `stream.pipeline(rawBody, gunzip, cb)` so both
  ends are destroyed atomically on error.
- Lower log level on expected disconnect codes
  (`ECONNRESET` / `UND_ERR_SOCKET` / `UND_ERR_ABORTED` / `ABORT_ERR` /
  `ERR_STREAM_PREMATURE_CLOSE`) to cut noise.

**Forensic trail**
- Register `process.on('uncaughtException')` (writes a Node diagnostic
  report, then exits) and `process.on('unhandledRejection')` (logs only),
  guarded by an existing `globalThis` flag so they are registered exactly
  once. Reuses the existing logger.
- Add `[Lifecycle] Process started` (pid, node version, execArgv,
  NODE_OPTIONS) at instrumentation startup and `[Lifecycle] Process exiting`
  (signal, uptime) inside the shutdown handler. This lets ops distinguish a
  clean restart from a native crash restart in the logs.
- `Dockerfile`: launch node with
  `--report-on-fatalerror --report-uncaught-exception --report-directory=/app/reports`,
  and `mkdir -p /app/reports`.
- `docker-compose.yaml`: mount `./data/reports:/app/reports` so reports
  survive container restarts.

**Tests**
- 5 new vitest cases in `src/app/v1/_lib/proxy/node-stream-to-web.test.ts`
  covering: normal end, source error, cancel mid-stream
  (no post-destroy callbacks, single destroy), double-cancel against an
  already-destroyed source, and back-to-back `end`+`close` (single web-stream
  close).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (5839 passed, 13 skipped)
- [x] `bun run build`
- [x] `bunx vitest run src/app/v1/_lib/proxy/node-stream-to-web.test.ts` (5/5 pass)
- [ ] Post-deploy: verify `[Lifecycle] Process started` line appears on container
  start, and that `./data/reports/` is writable.
- [ ] Post-deploy: monitor for `exitCode=139` over the next week. If it
  recurs, the corresponding `report.*.json` will tell us whether the trigger
  is the same gunzip path or something else (AgentPool, see follow-up note
  below).

## Notes
- Out of scope: AgentPool destroy semantics in
  `src/lib/proxy-agent/agent-pool.ts` were flagged during exploration as a
  potential amplifier (force-destroy of the dispatcher mid-stream). Deferred
  to a follow-up — the diagnostic-report change in this PR will tell us if
  that path is actually involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the proxy stream lifecycle to close the destroy/end race on `gunzip` + `rawBody` that was the likely root cause of SIGSEGV crashes under load (#1147). The core fix extracts `nodeStreamToWebStreamSafe` into its own module with a `settled` single-fire flag and full listener detachment, replaces `.pipe()` with `stream.pipeline()` for atomic cleanup, and switches `gunzip.end()` to `gunzip.destroy(err)`. A companion forensics layer adds `uncaughtException`/`unhandledRejection` handlers, lifecycle log markers, and Node diagnostic report generation wired through Dockerfile and docker-compose.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all findings are P2; the core lifecycle fix and forensics are correct.

No P0 or P1 issues found. The settled flag, listener detachment, pipeline migration, and crash handler logic are all correctly implemented and backed by 7 test cases. The only finding is a P2 duplicate-logging noise issue caused by retaining gunzip.on("error") alongside the streamPipeline callback.

src/app/v1/_lib/proxy/forwarder.ts — gunzip standalone error handler produces duplicate warn logs alongside the pipeline callback.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/node-stream-to-web.ts | New file implementing the hardened Node→Web stream adapter with a `settled` flag, full listener detachment, and safe cancel() using a swallow error listener. Logic is correct. |
| src/app/v1/_lib/proxy/node-stream-to-web.test.ts | 7 test cases covering normal end, error propagation, cancel, double-cancel, pre-destroyed source, and back-to-back end+close — comprehensive coverage of the new invariants. |
| src/app/v1/_lib/proxy/forwarder.ts | Migrates to stream.pipeline() and gunzip.destroy(err), lowers log level for expected disconnects, and removes the inlined nodeStreamToWebStreamSafe. A standalone gunzip.on("error") handler is retained alongside the pipeline callback, producing duplicate warn logs for the same error event. |
| src/instrumentation.ts | Adds process-level crash diagnostics (uncaughtException + unhandledRejection both write a report and exit(1)), lifecycle start/exit markers, and globalThis guards to ensure single registration. |
| Dockerfile | Adds --report-on-fatalerror --report-uncaught-exception --report-directory=/app/reports to the CMD and creates the /app/reports directory. |
| docker-compose.yaml | Mounts ./data/reports:/app/reports so Node diagnostic reports survive container restarts. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant rawBody as rawBody (Readable)
    participant pipeline as stream.pipeline()
    participant gunzip as Gunzip (Transform)
    participant adapter as nodeStreamToWebStreamSafe
    participant web as Web ReadableStream
    participant reader as Response Reader

    rawBody->>pipeline: data chunks
    pipeline->>gunzip: pipe data
    gunzip->>adapter: decompressed chunks (onData)
    adapter->>web: controller.enqueue(chunk)
    web->>reader: { value, done: false }

    alt Normal end
        gunzip->>adapter: emit "end"
        adapter->>adapter: settled=true, detach()
        adapter->>web: controller.close()
        web->>reader: { done: true }
    else Source error
        gunzip->>adapter: emit "error"
        adapter->>adapter: settled=true, detach()
        adapter->>web: controller.error(err)
        pipeline->>rawBody: destroy(err)
    else Client cancel
        reader->>web: cancel(reason)
        web->>adapter: cancel(reason)
        adapter->>adapter: settled=true, detach(), register swallow listener
        adapter->>gunzip: destroy(reason)
        gunzip->>adapter: emit "error" (swallowed)
        gunzip->>adapter: emit "close" (removes swallow)
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/app/v1/_lib/proxy/forwarder.ts:4879-4913
**Triple-warn for a single gunzip decompression error**

When `gunzip` emits an error, three separate log entries are produced: (1) `gunzip.on("error", …)` logs "Gunzip decompression error", (2) `stream.pipeline` propagates the error by calling `rawBody.destroy(err)`, which causes `rawBody` to re-emit "error" — caught by the `rawBody.on("error", …)` handler at warn level (the decompression error code is not in the `isExpectedDisconnect` set), and (3) the pipeline callback logs "rawBody->gunzip pipeline ended with error". Under load, a single bad compressed response produces three warn-level lines that all reference the same root cause. Consider removing the standalone `gunzip.on("error", …)` handler and relying solely on the pipeline callback (which already logs at the appropriate level with `isExpectedDisconnect`).

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address PR #1152 review feedback"](https://github.com/ding113/claude-code-hub/commit/e15e293fa3e365d42c30106d3743076d39074c26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30591906)</sub>

<!-- /greptile_comment -->