### PR TITLE
fix(responses-ws): send close frame after terminal event; raise WS payload cap (#1150)

### DIFF
--- a/docs/k8s-deployment.md
+++ b/docs/k8s-deployment.md
@@ -213,6 +213,45 @@ bash scripts/deploy-k8s.sh --replicas 3 --hpa-min 3 --hpa-max 10 -y
 默认模板保留 `replicas=2`,但 `AUTO_MIGRATE` 入口 `src/instrumentation.ts` 会先获取 PostgreSQL advisory lock,
 因此首次多副本启动时迁移会串行执行。如果你更关心首启速度,也可以先用 `--replicas 1` 部署,确认健康后再扩容。
 
+### Codex `/v1/responses` WebSocket 反代
+
+`/v1/responses` 端点对 Codex 客户端会走 **WebSocket 升级**(其余路径仍是 HTTP)。
+反代必须显式放行 Upgrade/Connection 头并放宽 idle timeout,否则会出现
+`stream disconnected before completion: WebSocket protocol error: Connection reset
+without closing handshake`(直连 CCH 正常,经反代失败时多半是这一项)。
+
+**Nginx**
+
+```nginx
+location /v1/responses {
+  proxy_pass         http://cch_upstream;
+  proxy_http_version 1.1;
+  proxy_set_header   Upgrade    $http_upgrade;
+  proxy_set_header   Connection "upgrade";
+  proxy_set_header   Host       $host;
+  proxy_read_timeout 600s;     # Codex 长 reasoning 流式响应时间
+  proxy_send_timeout 600s;
+  proxy_buffering    off;      # 关闭缓冲,SSE / WS 才能实时
+}
+```
+
+**ingress-nginx (Kubernetes)**
+
+`deploy/k8s/ingress/ingress.yaml` 已经默认带这两条注解;若你自定义 Ingress
+要保留:
+
+```yaml
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+```
+
+**Cloudflare / 其它 CDN**
+
+WebSocket 必须在 CDN 控制台显式开启;同时 `cache-everything` 一类规则会绕过
+WS,务必把 `/v1/responses` 排除在缓存规则之外。
+
 ### 客户端 IP 透传
 
 - 默认 k8s 部署保持 `main -> ghcr.io/ding113/claude-code-hub:latest`；只有显式传

--- a/server.js
+++ b/server.js
@@ -51,12 +51,14 @@ const RESERVED_INTERNAL_HEADER_PREFIX = "x-cch-";
 // Per-WebSocket-connection guardrails: cap the queue depth and total queued
 // bytes to make a misbehaving / malicious client a bounded-memory event.
 const MAX_PENDING_FRAMES = 64;
-const MAX_PENDING_BYTES = 4 * 1024 * 1024; // 4 MiB across all queued frames
+const MAX_PENDING_BYTES = 64 * 1024 * 1024; // 64 MiB across all queued frames
 
 // Maximum payload size for any single inbound WS frame. The default `ws`
-// limit is 100 MiB, far larger than a Responses create body needs to be and
-// dangerous for a public endpoint.
-const WS_MAX_PAYLOAD_BYTES = 1 * 1024 * 1024; // 1 MiB per frame
+// limit is 100 MiB. We pick 32 MiB to accommodate Codex requests that ship
+// large conversation history alongside the prompt — a tighter cap caused the
+// `ws` library to socket.destroy() (TCP RST) without sending a close frame,
+// surfacing on the client as "Connection reset without closing handshake".
+const WS_MAX_PAYLOAD_BYTES = 32 * 1024 * 1024; // 32 MiB per frame
 
 const TERMINAL_EVENT_TYPES = new Set([
   "response.completed",
@@ -97,6 +99,20 @@ function emitErrorEvent(ws, code, message) {
   });
 }
 
+// Initiate a WebSocket closing handshake on the client connection. Codex /
+// tungstenite-style clients treat a missing close frame as
+// "Connection reset without closing handshake" — this helper centralizes the
+// close so every request-response cycle ends with a proper close frame.
+function closeClient(ws, code, reason) {
+  if (!ws || ws.readyState >= 2 /* CLOSING | CLOSED */) return;
+  log("info", "ws_client_close_initiated", { code, reason });
+  try {
+    ws.close(code, reason);
+  } catch (err) {
+    log("warn", "ws_client_close_failed", { error: String(err) });
+  }
+}
+
 function sanitizedRequestPath(rawUrl) {
   if (typeof rawUrl !== "string" || rawUrl.length === 0) {
     return "/";
@@ -127,6 +143,7 @@ async function handleWebSocketConnection(ws, req) {
   let currentInternalReq = null;
 
   const finalize = () => {
+    if (closed) return;
     closed = true;
     if (currentInternalReq) {
       try {
@@ -135,6 +152,12 @@ async function handleWebSocketConnection(ws, req) {
         // ignore
       }
       currentInternalReq = null;
+    }
+    if (pending.length > 0) {
+      log("warn", "ws_pending_dropped_on_close", {
+        droppedFrames: pending.length,
+        droppedBytes: pendingBytes,
+      });
     }
     pending.length = 0;
     pendingBytes = 0;
@@ -194,6 +217,12 @@ async function handleWebSocketConnection(ws, req) {
     if (queryModel && (body.model === undefined || body.model === null || body.model === "")) {
       body.model = queryModel;
     }
+
+    log("info", "ws_request_started", {
+      model: typeof body.model === "string" ? body.model : null,
+      payloadBytes: Buffer.byteLength(raw, "utf8"),
+      hasPreviousResponseId: typeof body.previous_response_id === "string",
+    });
 
     await forwardToInternalHttp(ws, req, body, (clientReq) => {
       currentInternalReq = clientReq;
@@ -352,7 +381,8 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
             } catch {
               parsed = { raw: text };
             }
-            if (res.statusCode && res.statusCode >= 400) {
+            const isHttpError = !!(res.statusCode && res.statusCode >= 400);
+            if (isHttpError) {
               safeSend(ws, {
                 type: "error",
                 error:
@@ -360,11 +390,14 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
                     ? parsed.error
                     : { code: `http_${res.statusCode}`, message: text.slice(0, 512) },
               });
+              closeClient(ws, 1011, `http_${res.statusCode}`);
             } else {
               safeSend(ws, {
                 type: "response.completed",
                 response: parsed,
               });
+              log("info", "ws_terminal_event_sent", { type: "response.completed", source: "json" });
+              closeClient(ws, 1000, "response_completed");
             }
             resolve();
           });
@@ -374,6 +407,7 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
               "internal_response_error",
               String(err && err.message ? err.message : err)
             );
+            closeClient(ws, 1011, "internal_response_error");
             resolve();
           });
           return;
@@ -384,6 +418,7 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
         // upstreams in the wild emit either form.
         let buffer = "";
         let sawTerminal = false;
+        let terminalEventType = null;
         const EVENT_DELIMITER = /\r?\n\r?\n/;
 
         const flushEvents = () => {
@@ -423,6 +458,8 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
             safeSend(ws, event);
             if (event && typeof event.type === "string" && TERMINAL_EVENT_TYPES.has(event.type)) {
               sawTerminal = true;
+              terminalEventType = event.type;
+              log("info", "ws_terminal_event_sent", { type: event.type, source: "sse" });
             }
           }
         };
@@ -444,6 +481,17 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
               "stream_ended_without_terminal",
               "Upstream stream ended before emitting a terminal response event"
             );
+            closeClient(ws, 1011, "stream_ended_without_terminal");
+          } else {
+            // Use 1000 for normal terminal types and the synthesized [DONE]
+            // path; reserve 1011 for the explicit upstream "error" terminal
+            // so the client distinguishes a clean response from a failure.
+            const isErrorTerminal = terminalEventType === "error";
+            closeClient(
+              ws,
+              isErrorTerminal ? 1011 : 1000,
+              isErrorTerminal ? "upstream_error" : "response_completed"
+            );
           }
           resolve();
         });
@@ -453,6 +501,7 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
             "internal_response_error",
             String(err && err.message ? err.message : err)
           );
+          closeClient(ws, 1011, "internal_response_error");
           resolve();
         });
       }
@@ -469,6 +518,7 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
           "internal_request_error",
           String(err && err.message ? err.message : err)
         );
+        closeClient(ws, 1011, "internal_request_error");
       }
       resolve();
     });
@@ -581,7 +631,14 @@ async function main() {
 }
 
 // Exposed for tests; not part of the long-lived server entrypoint.
-module.exports = { sanitizedRequestPath };
+module.exports = {
+  sanitizedRequestPath,
+  handleWebSocketConnection,
+  forwardToInternalHttp,
+  closeClient,
+  WS_MAX_PAYLOAD_BYTES,
+  MAX_PENDING_BYTES,
+};
 
 if (require.main === module) {
   main().catch((err) => {

--- a/server.js
+++ b/server.js
@@ -99,20 +99,6 @@ function emitErrorEvent(ws, code, message) {
   });
 }
 
-// Initiate a WebSocket closing handshake on the client connection. Codex /
-// tungstenite-style clients treat a missing close frame as
-// "Connection reset without closing handshake" — this helper centralizes the
-// close so every request-response cycle ends with a proper close frame.
-function closeClient(ws, code, reason) {
-  if (!ws || ws.readyState >= 2 /* CLOSING | CLOSED */) return;
-  log("info", "ws_client_close_initiated", { code, reason });
-  try {
-    ws.close(code, reason);
-  } catch (err) {
-    log("warn", "ws_client_close_failed", { error: String(err) });
-  }
-}
-
 function sanitizedRequestPath(rawUrl) {
   if (typeof rawUrl !== "string" || rawUrl.length === 0) {
     return "/";
@@ -161,6 +147,35 @@ async function handleWebSocketConnection(ws, req) {
     }
     pending.length = 0;
     pendingBytes = 0;
+  };
+
+  // Synchronously mark the connection closed so any pipelined frame in
+  // `pending` is dropped *before* drain() can dispatch another upstream
+  // request. Without this the gap between ws.close() and the async
+  // ws.on("close") event is wide enough for `drain()` to pop the next frame
+  // and run `forwardToInternalHttp` against the upstream — work the client
+  // can never receive (safeSend would fail) but the provider would still bill.
+  const requestClose = (code, reason) => {
+    if (closed || (ws && ws.readyState >= 2) /* CLOSING | CLOSED */) {
+      // Already closing/closed; just make sure local state matches.
+      if (!closed) finalize();
+      return;
+    }
+    closed = true;
+    if (pending.length > 0) {
+      log("warn", "ws_pending_dropped_on_close", {
+        droppedFrames: pending.length,
+        droppedBytes: pendingBytes,
+      });
+    }
+    pending.length = 0;
+    pendingBytes = 0;
+    log("info", "ws_client_close_initiated", { code, reason });
+    try {
+      ws.close(code, reason);
+    } catch (err) {
+      log("warn", "ws_client_close_failed", { error: String(err) });
+    }
   };
 
   ws.on("close", finalize);
@@ -224,9 +239,15 @@ async function handleWebSocketConnection(ws, req) {
       hasPreviousResponseId: typeof body.previous_response_id === "string",
     });
 
-    await forwardToInternalHttp(ws, req, body, (clientReq) => {
-      currentInternalReq = clientReq;
-    });
+    await forwardToInternalHttp(
+      ws,
+      req,
+      body,
+      (clientReq) => {
+        currentInternalReq = clientReq;
+      },
+      requestClose
+    );
     if (!closed) {
       currentInternalReq = null;
     }
@@ -302,7 +323,22 @@ async function handleWebSocketConnection(ws, req) {
   });
 }
 
-async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq) {
+async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq, requestClose) {
+  // requestClose(code, reason) initiates the WebSocket closing handshake AND
+  // synchronously marks the client connection closed so the caller's pending
+  // queue stops dispatching follow-up frames against the upstream. Tests that
+  // exercise this function in isolation can pass a no-op fallback.
+  const initiateClose =
+    typeof requestClose === "function"
+      ? requestClose
+      : (code, reason) => {
+          log("info", "ws_client_close_initiated", { code, reason });
+          try {
+            ws.close(code, reason);
+          } catch (err) {
+            log("warn", "ws_client_close_failed", { error: String(err) });
+          }
+        };
   const internalHeaders = {};
   for (const [k, v] of Object.entries(originalReq.headers)) {
     const lower = k.toLowerCase();
@@ -390,14 +426,14 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
                     ? parsed.error
                     : { code: `http_${res.statusCode}`, message: text.slice(0, 512) },
               });
-              closeClient(ws, 1011, `http_${res.statusCode}`);
+              initiateClose(1011, `http_${res.statusCode}`);
             } else {
               safeSend(ws, {
                 type: "response.completed",
                 response: parsed,
               });
               log("info", "ws_terminal_event_sent", { type: "response.completed", source: "json" });
-              closeClient(ws, 1000, "response_completed");
+              initiateClose(1000, "response_completed");
             }
             resolve();
           });
@@ -407,7 +443,7 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
               "internal_response_error",
               String(err && err.message ? err.message : err)
             );
-            closeClient(ws, 1011, "internal_response_error");
+            initiateClose(1011, "internal_response_error");
             resolve();
           });
           return;
@@ -481,14 +517,13 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
               "stream_ended_without_terminal",
               "Upstream stream ended before emitting a terminal response event"
             );
-            closeClient(ws, 1011, "stream_ended_without_terminal");
+            initiateClose(1011, "stream_ended_without_terminal");
           } else {
             // Use 1000 for normal terminal types and the synthesized [DONE]
             // path; reserve 1011 for the explicit upstream "error" terminal
             // so the client distinguishes a clean response from a failure.
             const isErrorTerminal = terminalEventType === "error";
-            closeClient(
-              ws,
+            initiateClose(
               isErrorTerminal ? 1011 : 1000,
               isErrorTerminal ? "upstream_error" : "response_completed"
             );
@@ -501,7 +536,7 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
             "internal_response_error",
             String(err && err.message ? err.message : err)
           );
-          closeClient(ws, 1011, "internal_response_error");
+          initiateClose(1011, "internal_response_error");
           resolve();
         });
       }
@@ -518,7 +553,7 @@ async function forwardToInternalHttp(ws, originalReq, body, registerInternalReq)
           "internal_request_error",
           String(err && err.message ? err.message : err)
         );
-        closeClient(ws, 1011, "internal_request_error");
+        initiateClose(1011, "internal_request_error");
       }
       resolve();
     });
@@ -635,7 +670,6 @@ module.exports = {
   sanitizedRequestPath,
   handleWebSocketConnection,
   forwardToInternalHttp,
-  closeClient,
   WS_MAX_PAYLOAD_BYTES,
   MAX_PENDING_BYTES,
 };

--- a/src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts
+++ b/src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts
@@ -398,6 +398,80 @@ describe("tryResponsesWebsocketUpstream", () => {
     // The mid-stream failure must surface as an error event so the downstream
     // pipeline does not mistake the truncated stream for a clean success.
     expect(body).toContain('"type":"error"');
-    expect(body).toContain("upstream_ws_mid_stream_error");
+    // Either the network-level error path (`upstream_ws_mid_stream_error`)
+    // or the close-without-error path (`upstream_ws_closed_mid_stream`) is
+    // acceptable here — terminate() may surface as one or the other depending
+    // on platform timing.
+    expect(
+      body.includes("upstream_ws_mid_stream_error") ||
+        body.includes("upstream_ws_closed_mid_stream")
+    ).toBe(true);
+  });
+
+  it("synthesizes a mid-stream error when upstream closes cleanly without a terminal event", async () => {
+    // Some upstreams (or transient infra failures) close the WS with code 1000
+    // mid-stream — no `error` event is fired, only `close`. The adapter must
+    // still surface this as an error frame so a truncated response is never
+    // billed as a clean success.
+    server = await startMockServer((socket) => {
+      socket.on("message", () => {
+        socket.send(JSON.stringify({ type: "response.created", response: { id: "resp_2" } }));
+        setTimeout(() => {
+          try {
+            socket.close(1000, "early_close");
+          } catch {
+            // ignore
+          }
+        }, 5);
+      });
+    });
+
+    const result = await tryResponsesWebsocketUpstream({
+      provider: codexProvider(),
+      upstreamUrl: `http://127.0.0.1:${server.port}/v1/responses`,
+      upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+      body: { model: "gpt-5", input: "hi" },
+    });
+
+    expect("response" in result).toBe(true);
+    if (!("response" in result)) return;
+    const body = await collectSseBody(result.response);
+    expect(body).toContain('"type":"response.created"');
+    expect(body).toContain('"type":"error"');
+    expect(body).toContain("upstream_ws_closed_mid_stream");
+    expect(body).toContain("code=1000");
+  });
+
+  it("closes the upstream WS after delivering a terminal event", async () => {
+    let upstreamCloseCode: number | null = null;
+    let upstreamClosedResolve: (() => void) | null = null;
+    const upstreamClosed = new Promise<void>((resolve) => {
+      upstreamClosedResolve = resolve;
+    });
+    server = await startMockServer((socket) => {
+      socket.on("close", (code) => {
+        upstreamCloseCode = code;
+        upstreamClosedResolve?.();
+      });
+      socket.on("message", () => {
+        socket.send(JSON.stringify({ type: "response.created", response: { id: "resp_3" } }));
+        socket.send(JSON.stringify({ type: "response.completed", response: { id: "resp_3" } }));
+      });
+    });
+
+    const result = await tryResponsesWebsocketUpstream({
+      provider: codexProvider(),
+      upstreamUrl: `http://127.0.0.1:${server.port}/v1/responses`,
+      upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+      body: { model: "gpt-5", input: "hi" },
+    });
+
+    expect("response" in result).toBe(true);
+    if (!("response" in result)) return;
+    await collectSseBody(result.response);
+    await upstreamClosed;
+    // 1000 == normal closure. The adapter must initiate a close handshake to
+    // release the upstream socket once the terminal event is forwarded.
+    expect(upstreamCloseCode).toBe(1000);
   });
 });

--- a/src/app/v1/_lib/responses-ws/upstream-adapter.ts
+++ b/src/app/v1/_lib/responses-ws/upstream-adapter.ts
@@ -245,6 +245,13 @@ export async function tryResponsesWebsocketUpstream(options: {
   // The downstream pipeline must see this as an error rather than a clean
   // end-of-stream so it doesn't treat a half-streamed response as success.
   let midStreamError: { code: string; message?: string } | null = null;
+  // Hoisted twin of `sawTerminalEvent` (which is scoped inside the SSE
+  // ReadableStream's start()). The `ws.on("close")` handler runs in this
+  // outer scope and would otherwise have no way to tell whether a terminal
+  // event was already forwarded — without this flag a clean post-terminal
+  // close (e.g. our own `closeUpstream(1000)`) would be misclassified as a
+  // mid-stream error.
+  let terminalEventSeen = false;
   let firstEventTimer: ReturnType<typeof setTimeout> | null = null;
 
   ws.on("message", (data: Buffer | string) => {
@@ -323,17 +330,20 @@ export async function tryResponsesWebsocketUpstream(options: {
         // re-probe on the next request.
         cacheableAsUnsupported: false,
       });
-    } else if (!midStreamError) {
+    } else if (!midStreamError && !terminalEventSeen) {
       // Upstream closed after the first event but before a terminal event.
       // Record this as an error so the synthesized error frame downstream
       // carries the actual close code instead of a generic message — and so
       // the forwarder doesn't bill the truncated stream as a clean success.
-      const reasonText =
-        reason && (typeof reason === "string" ? reason.length : reason.length)
-          ? typeof reason === "string"
-            ? reason
-            : reason.toString("utf8")
-          : "";
+      // We must also gate on `terminalEventSeen` because our own clean
+      // closeUpstream(1000) after a terminal event triggers this same
+      // handler — without the flag we'd inject a spurious error frame after
+      // a successful response.
+      const reasonText = reason?.length
+        ? typeof reason === "string"
+          ? reason
+          : reason.toString("utf8")
+        : "";
       midStreamError = {
         code: "upstream_ws_closed_mid_stream",
         message: `upstream WebSocket closed (code=${code ?? "unknown"})${
@@ -411,6 +421,9 @@ export async function tryResponsesWebsocketUpstream(options: {
           const parsed = JSON.parse(text);
           if (parsed && typeof parsed.type === "string" && TERMINAL_EVENT_TYPES.has(parsed.type)) {
             sawTerminalEvent = true;
+            // Hoisted twin so the outer `ws.on("close")` handler can tell
+            // a clean post-terminal close apart from a real mid-stream drop.
+            terminalEventSeen = true;
             return true;
           }
         } catch {

--- a/src/app/v1/_lib/responses-ws/upstream-adapter.ts
+++ b/src/app/v1/_lib/responses-ws/upstream-adapter.ts
@@ -193,6 +193,17 @@ export async function tryResponsesWebsocketUpstream(options: {
     openPromiseResolve(result);
   };
 
+  // Idempotent close helper. Centralizes the try/catch wrapping so every exit
+  // path can call closeUpstream() without leaking an upstream socket. Calling
+  // close() on an already-CLOSING/CLOSED ws is a no-op in `ws`.
+  const closeUpstream = (code: number) => {
+    try {
+      ws.close(code);
+    } catch {
+      // ignore
+    }
+  };
+
   ws.on("open", () => {
     try {
       ws.send(JSON.stringify(frame));
@@ -204,11 +215,7 @@ export async function tryResponsesWebsocketUpstream(options: {
         // Local send failure (closed underlying socket, etc.) is transient.
         cacheableAsUnsupported: false,
       });
-      try {
-        ws.close(1011);
-      } catch {
-        // ignore
-      }
+      closeUpstream(1011);
     }
   });
 
@@ -226,11 +233,7 @@ export async function tryResponsesWebsocketUpstream(options: {
         // are cacheable. 401/403/5xx/etc. are auth or transient state.
         cacheableAsUnsupported: cacheable,
       });
-      try {
-        ws.close(1011);
-      } catch {
-        // ignore
-      }
+      closeUpstream(1011);
     }
   );
 
@@ -273,11 +276,7 @@ export async function tryResponsesWebsocketUpstream(options: {
         message: `buffered upstream payload exceeded ${MAX_BUFFERED_QUEUE_BYTES} bytes`,
       };
       closed = true;
-      try {
-        ws.close(1011);
-      } catch {
-        // ignore
-      }
+      closeUpstream(1011);
       return;
     }
     messageQueue.push(text);
@@ -312,7 +311,7 @@ export async function tryResponsesWebsocketUpstream(options: {
     }
   });
 
-  ws.on("close", () => {
+  ws.on("close", (code: number, reason: Buffer | string) => {
     closed = true;
     if (!firstEventSeen) {
       finishOpen({
@@ -324,6 +323,23 @@ export async function tryResponsesWebsocketUpstream(options: {
         // re-probe on the next request.
         cacheableAsUnsupported: false,
       });
+    } else if (!midStreamError) {
+      // Upstream closed after the first event but before a terminal event.
+      // Record this as an error so the synthesized error frame downstream
+      // carries the actual close code instead of a generic message — and so
+      // the forwarder doesn't bill the truncated stream as a clean success.
+      const reasonText =
+        reason && (typeof reason === "string" ? reason.length : reason.length)
+          ? typeof reason === "string"
+            ? reason
+            : reason.toString("utf8")
+          : "";
+      midStreamError = {
+        code: "upstream_ws_closed_mid_stream",
+        message: `upstream WebSocket closed (code=${code ?? "unknown"})${
+          reasonText ? `: ${reasonText}` : ""
+        }`,
+      };
     }
     if (queueResolver) {
       const resolve = queueResolver;
@@ -336,11 +352,7 @@ export async function tryResponsesWebsocketUpstream(options: {
     options.abortSignal.addEventListener(
       "abort",
       () => {
-        try {
-          ws.close(1000);
-        } catch {
-          // ignore
-        }
+        closeUpstream(1000);
       },
       { once: true }
     );
@@ -359,11 +371,7 @@ export async function tryResponsesWebsocketUpstream(options: {
       // next request should re-probe rather than skip the WS path.
       cacheableAsUnsupported: false,
     });
-    try {
-      ws.close(1011);
-    } catch {
-      // ignore
-    }
+    closeUpstream(1011);
   }, FIRST_EVENT_TIMEOUT_MS);
 
   const openResult = await openPromise;
@@ -426,11 +434,7 @@ export async function tryResponsesWebsocketUpstream(options: {
         if (msg === undefined) break;
         if (processText(msg)) {
           controller.close();
-          try {
-            ws.close(1000);
-          } catch {
-            // ignore
-          }
+          closeUpstream(1000);
           return;
         }
       }
@@ -446,11 +450,7 @@ export async function tryResponsesWebsocketUpstream(options: {
         if (next === null) break;
         if (processText(next)) {
           controller.close();
-          try {
-            ws.close(1000);
-          } catch {
-            // ignore
-          }
+          closeUpstream(1000);
           return;
         }
       }
@@ -462,6 +462,7 @@ export async function tryResponsesWebsocketUpstream(options: {
         if (msg === undefined) break;
         if (processText(msg)) {
           controller.close();
+          closeUpstream(1000);
           return;
         }
       }
@@ -483,13 +484,13 @@ export async function tryResponsesWebsocketUpstream(options: {
       }
 
       controller.close();
+      // Belt-and-suspenders: ensure the upstream socket is closed even if the
+      // earlier paths above didn't run (e.g. closed=true before we entered
+      // the loop). Idempotent.
+      closeUpstream(sawTerminalEvent ? 1000 : 1011);
     },
     cancel() {
-      try {
-        ws.close(1000);
-      } catch {
-        // ignore
-      }
+      closeUpstream(1000);
     },
   });
 

--- a/tests/unit/server-ws-close-handshake.test.ts
+++ b/tests/unit/server-ws-close-handshake.test.ts
@@ -259,4 +259,41 @@ describe("server.js WebSocket close-handshake (issue #1150)", () => {
     expect(close.code).toBe(1000);
     expect(close.reason).toBe("response_completed");
   }, 20000);
+
+  it("drops queued frames once a terminal close is initiated (no extra upstream calls)", async () => {
+    if (!harness) throw new Error("harness not initialized");
+    let upstreamCalls = 0;
+    harness.setSseHandler((_req, res) => {
+      upstreamCalls += 1;
+      res.statusCode = 200;
+      res.setHeader("content-type", "text/event-stream");
+      // Stagger the response so the second frame, if not dropped, has time
+      // to be dequeued and dispatched while we're closing the first.
+      setTimeout(() => {
+        res.write(
+          `data: ${JSON.stringify({
+            type: "response.completed",
+            response: { id: `r_${upstreamCalls}` },
+          })}\n\n`
+        );
+        res.end();
+      }, 20);
+    });
+
+    const client = connectClient(harness.port);
+    await client.opened;
+    // Pipeline two frames before the first response completes. With the race
+    // present, drain() pops the second after closeClient() initiates the
+    // close handshake but before ws.on("close") fires, hitting the upstream
+    // a second time and burning provider quota.
+    client.ws.send(JSON.stringify({ type: "response.create", model: "gpt-5", input: "first" }));
+    client.ws.send(JSON.stringify({ type: "response.create", model: "gpt-5", input: "second" }));
+
+    const close = await client.closeEvent;
+    expect(close.code).toBe(1000);
+    expect(close.reason).toBe("response_completed");
+    // Exactly one upstream call must have happened — the second frame is
+    // dropped synchronously when we initiate the close.
+    expect(upstreamCalls).toBe(1);
+  });
 });

--- a/tests/unit/server-ws-close-handshake.test.ts
+++ b/tests/unit/server-ws-close-handshake.test.ts
@@ -1,0 +1,262 @@
+/**
+ * server.js WebSocket close-handshake regression for issue #1150.
+ *
+ * Verifies that after the SSE→WS bridge delivers a terminal event (or runs
+ * into an error), the client WebSocket receives a proper close frame instead
+ * of being abruptly torn down — which clients like Codex (tungstenite-rs)
+ * surface as "Connection reset without closing handshake".
+ */
+
+import { createRequire } from "node:module";
+import http from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import WebSocket, { WebSocketServer } from "ws";
+
+const requireFromHere = createRequire(import.meta.url);
+
+type ServerHarness = {
+  port: number;
+  server: http.Server;
+  wss: WebSocketServer;
+  setSseHandler: (handler: (req: http.IncomingMessage, res: http.ServerResponse) => void) => void;
+  close: () => Promise<void>;
+};
+
+type ServerJsModule = {
+  handleWebSocketConnection: (ws: WebSocket, req: http.IncomingMessage) => Promise<void>;
+};
+
+let serverModule: ServerJsModule;
+let harness: ServerHarness | null = null;
+
+async function pickFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = http.createServer();
+    probe.listen(0, "127.0.0.1", () => {
+      const addr = probe.address();
+      if (typeof addr !== "object" || addr === null) {
+        probe.close();
+        reject(new Error("address() returned non-object"));
+        return;
+      }
+      const port = addr.port;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+async function startHarness(port: number): Promise<ServerHarness> {
+  let sseHandler: ((req: http.IncomingMessage, res: http.ServerResponse) => void) | null = null;
+
+  const server = http.createServer((req, res) => {
+    if (req.method === "POST" && req.url === "/v1/responses") {
+      // Drain the body before invoking the handler — otherwise some Node
+      // versions hold the request open waiting for the consumer.
+      const chunks: Buffer[] = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        if (sseHandler) sseHandler(req, res);
+        else {
+          res.statusCode = 503;
+          res.end("no handler set");
+        }
+      });
+      return;
+    }
+    res.statusCode = 404;
+    res.end("not found");
+  });
+
+  const wss = new WebSocketServer({ noServer: true });
+  server.on("upgrade", (req, socket, head) => {
+    if (req.url !== "/v1/responses") {
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      void serverModule.handleWebSocketConnection(ws as unknown as WebSocket, req);
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+
+  return {
+    port,
+    server,
+    wss,
+    setSseHandler: (handler) => {
+      sseHandler = handler;
+    },
+    close: () =>
+      new Promise<void>((resolve) => {
+        wss.close(() => {
+          server.close(() => resolve());
+        });
+      }),
+  };
+}
+
+function connectClient(port: number) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/responses`);
+  const closeEvent = new Promise<{ code: number; reason: string }>((resolve) => {
+    ws.once("close", (code, reason) => resolve({ code, reason: reason.toString("utf8") }));
+  });
+  const messages: unknown[] = [];
+  ws.on("message", (raw) => {
+    try {
+      messages.push(JSON.parse(raw.toString("utf8")));
+    } catch {
+      messages.push(raw.toString("utf8"));
+    }
+  });
+  const opened = new Promise<void>((resolve, reject) => {
+    ws.once("open", () => resolve());
+    ws.once("error", reject);
+  });
+  return { ws, opened, closeEvent, messages };
+}
+
+describe("server.js WebSocket close-handshake (issue #1150)", () => {
+  beforeAll(async () => {
+    const port = await pickFreePort();
+    process.env.PORT = String(port);
+    process.env.HOSTNAME = "127.0.0.1";
+    process.env.NODE_ENV = "test";
+    // Require server.js *after* env vars are set so its module-level `port`
+    // and INTERNAL_TUNNEL_HOST capture our values.
+    serverModule = requireFromHere("../../server.js") as ServerJsModule;
+    harness = await startHarness(port);
+  });
+
+  afterAll(async () => {
+    if (harness) {
+      await harness.close();
+      harness = null;
+    }
+  });
+
+  it("sends close(1000) after delivering response.completed", async () => {
+    if (!harness) throw new Error("harness not initialized");
+    harness.setSseHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "text/event-stream");
+      res.write(
+        `data: ${JSON.stringify({ type: "response.created", response: { id: "r_1" } })}\n\n`
+      );
+      res.write(
+        `data: ${JSON.stringify({
+          type: "response.completed",
+          response: { id: "r_1", usage: { input_tokens: 1, output_tokens: 1 } },
+        })}\n\n`
+      );
+      res.end();
+    });
+
+    const client = connectClient(harness.port);
+    await client.opened;
+    client.ws.send(JSON.stringify({ type: "response.create", model: "gpt-5", input: "hi" }));
+
+    const close = await client.closeEvent;
+    expect(close.code).toBe(1000);
+    expect(close.reason).toBe("response_completed");
+    const types = client.messages
+      .filter((m): m is { type: string } => typeof m === "object" && m !== null)
+      .map((m) => m.type);
+    expect(types).toContain("response.created");
+    expect(types).toContain("response.completed");
+  });
+
+  it("sends close(1011) when the upstream stream ends without a terminal event", async () => {
+    if (!harness) throw new Error("harness not initialized");
+    harness.setSseHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "text/event-stream");
+      res.write(
+        `data: ${JSON.stringify({ type: "response.created", response: { id: "r_2" } })}\n\n`
+      );
+      // End without a terminal event — Codex must still receive a close frame.
+      res.end();
+    });
+
+    const client = connectClient(harness.port);
+    await client.opened;
+    client.ws.send(JSON.stringify({ type: "response.create", model: "gpt-5", input: "hi" }));
+
+    const close = await client.closeEvent;
+    expect(close.code).toBe(1011);
+    expect(close.reason).toBe("stream_ended_without_terminal");
+    const errorEvent = client.messages.find(
+      (m): m is { type: string; error: { code: string } } =>
+        typeof m === "object" && m !== null && (m as { type?: unknown }).type === "error"
+    );
+    expect(errorEvent).toBeTruthy();
+    expect(errorEvent?.error.code).toBe("stream_ended_without_terminal");
+  });
+
+  it("sends close(1011) when the upstream returns a non-stream HTTP error", async () => {
+    if (!harness) throw new Error("harness not initialized");
+    harness.setSseHandler((_req, res) => {
+      res.statusCode = 502;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: { code: "bad_gateway", message: "upstream down" } }));
+    });
+
+    const client = connectClient(harness.port);
+    await client.opened;
+    client.ws.send(JSON.stringify({ type: "response.create", model: "gpt-5", input: "hi" }));
+
+    const close = await client.closeEvent;
+    expect(close.code).toBe(1011);
+    expect(close.reason).toBe("http_502");
+  });
+
+  it("sends close(1011) labelled upstream_error when terminal type is 'error'", async () => {
+    if (!harness) throw new Error("harness not initialized");
+    harness.setSseHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "text/event-stream");
+      res.write(
+        `data: ${JSON.stringify({
+          type: "error",
+          error: { code: "upstream_failure", message: "boom" },
+        })}\n\n`
+      );
+      res.end();
+    });
+
+    const client = connectClient(harness.port);
+    await client.opened;
+    client.ws.send(JSON.stringify({ type: "response.create", model: "gpt-5", input: "hi" }));
+
+    const close = await client.closeEvent;
+    expect(close.code).toBe(1011);
+    expect(close.reason).toBe("upstream_error");
+  });
+
+  it("accepts response.create bodies up to 4 MiB without a maxPayload teardown", async () => {
+    if (!harness) throw new Error("harness not initialized");
+    harness.setSseHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "text/event-stream");
+      res.write(
+        `data: ${JSON.stringify({
+          type: "response.completed",
+          response: { id: "r_big" },
+        })}\n\n`
+      );
+      res.end();
+    });
+
+    const client = connectClient(harness.port);
+    await client.opened;
+    // 4 MiB of repeated text — comfortably above the prior 1 MiB cap that
+    // caused tungstenite to surface "Connection reset without closing
+    // handshake".
+    const bigInput = "x".repeat(4 * 1024 * 1024);
+    client.ws.send(JSON.stringify({ type: "response.create", model: "gpt-5", input: bigInput }));
+
+    const close = await client.closeEvent;
+    expect(close.code).toBe(1000);
+    expect(close.reason).toBe("response_completed");
+  }, 20000);
+});


### PR DESCRIPTION
## Summary

Fixes #1150. Codex (tungstenite-rs) clients reported "WebSocket protocol error: Connection reset without closing handshake" against `/v1/responses` even though CCH logs `ws_client_connected`. Two compounding bugs:

- **`server.js` never sent a closing handshake** after delivering the terminal SSE event. The underlying socket was eventually torn down by lower layers (proxy idle timeout, OS timeout, GC) — no WS close frame ever reached the client. Now `forwardToInternalHttp` calls `ws.close(1000, "response_completed")` after a terminal event and `ws.close(1011, <reason>)` after errors / HTTP failures.
- **`WS_MAX_PAYLOAD_BYTES = 1 MiB` was too tight.** When `ws` rejects an oversized inbound frame it calls `socket.destroy()` (TCP RST) — exactly the symptom Codex reports. Raised to **32 MiB** to fit Codex requests with real conversation context; `MAX_PENDING_BYTES` raised to **64 MiB** to match.

Also tightens cleanup in `upstream-adapter.ts`: every exit path now closes the upstream socket via a small `closeUpstream()` helper, and a mid-stream upstream close (after the first event, no terminal) is recorded as `upstream_ws_closed_mid_stream` instead of being silently lost.

Adds nginx WebSocket reverse-proxy guidance to `docs/k8s-deployment.md` (Upgrade / Connection headers, `proxy_read_timeout`, `proxy_buffering off`).

## Related Issues

- **Fixes #1150** - WebSocket connection reset without closing handshake when using Codex with CPA upstream

## Changes

- `server.js`: new `closeClient()` helper; close client WS after every terminal/error in `forwardToInternalHttp`; raise WS payload caps; new diagnostic logs (`ws_request_started`, `ws_terminal_event_sent`, `ws_client_close_initiated`, `ws_pending_dropped_on_close`); export internals for testing.
- `src/app/v1/_lib/responses-ws/upstream-adapter.ts`: idempotent `closeUpstream()`; close upstream on every loop exit; mark mid-stream close as error.
- `src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts`: +2 cases (clean close without terminal, terminal triggers `close(1000)`).
- `tests/unit/server-ws-close-handshake.test.ts`: 5 new end-to-end cases driving server.js + a mock SSE upstream + a real WS client; covers terminal close(1000), no-terminal close(1011), HTTP error close(1011), terminal=error close(1011), 4 MiB payload.
- `docs/k8s-deployment.md`: new "Codex `/v1/responses` WebSocket 反代" section.

## Verification

- `bun run test` — 5841 passed (49 of those touch this code path).
- `bun run typecheck` — clean.
- `bun run lint` — clean (only pre-existing unrelated warnings).
- `bun run build` — clean.

## Test Plan

- [ ] Codex CLI against CCH with CPA upstream — short prompt completes and closes cleanly (no `Connection reset`).
- [ ] Codex CLI against CCH with CPA upstream — long-context prompt (>1 MiB body) succeeds.
- [ ] Force upstream interruption (e.g. point provider baseUrl at an unreachable port) — Codex receives an `error` event and a close frame, not a TCP RST.
- [ ] Behind nginx with the documented config — verify same end-to-end behavior.

---
*Enhanced description by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes two compounding bugs behind the Codex "Connection reset without closing handshake" report: `server.js` now sends a proper WS close frame after every terminal/error path via the new `requestClose` helper, and the `WS_MAX_PAYLOAD_BYTES` cap is raised from 1 MiB to 32 MiB so oversized Codex requests no longer trigger a silent `socket.destroy()`. `upstream-adapter.ts` adds an idempotent `closeUpstream()` helper and a hoisted `terminalEventSeen` flag to prevent spurious mid-stream error injection after a clean post-terminal upstream close.

Two small gaps remain in `server.js`:
- The `drain().catch()` error handler (line 274) still calls `ws.close()` directly rather than `requestClose`, leaving the pending-queue race window open on that (uncommon) path.
- `requestClose` sets `closed = true` and clears `pending` but does not destroy `currentInternalReq`; because `finalize`'s new early-return guard skips cleanup, the `ClientRequest` reference is held until GC rather than released immediately.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all findings are P2 edge cases on error/exception paths that don't affect the primary fix.

Only P2 findings are present. The core fix (close-frame handshake + payload cap) is correct and thoroughly tested with 5 new end-to-end cases. The two gaps identified are in an uncommon drain-failure path and a minor resource-management concern, neither of which affects the reported bug or the happy path.

server.js — `drain().catch()` handler and `requestClose` cleanup path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| server.js | Adds `requestClose` helper (sync `closed=true` + pending flush + `ws.close()`), raises payload caps, and wires close handshakes after every terminal/error path; `drain().catch()` still calls `ws.close()` directly (bypassing the new helper) and `requestClose` doesn't clean up `currentInternalReq`. |
| src/app/v1/_lib/responses-ws/upstream-adapter.ts | Introduces `closeUpstream()` helper for idempotent upstream close and hoists `terminalEventSeen` flag to prevent spurious mid-stream error injection after a clean post-terminal close; the `reasonText` ternary redundancy and potential spurious `midStreamError` were flagged in prior review threads. |
| tests/unit/server-ws-close-handshake.test.ts | New end-to-end test file covering close(1000) after terminal event, close(1011) for no-terminal/HTTP-error/upstream-error paths, 4 MiB payload acceptance, and pipelined-frame drop; good regression coverage for the reported issue. |
| src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts | Adds two new cases: upstream closes cleanly without a terminal event (expects `upstream_ws_closed_mid_stream` error) and upstream closes after a terminal event (expects close code 1000); broadens existing mid-stream error assertion to accept either error code. |
| docs/k8s-deployment.md | Adds a new section documenting nginx WebSocket reverse-proxy configuration (Upgrade/Connection headers, 600 s timeouts, `proxy_buffering off`) for the `/v1/responses` endpoint; purely additive and accurate. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Codex Client (WS)
    participant S as server.js
    participant U as upstream-adapter.ts
    participant P as Provider (WS/SSE)

    C->>S: WS connect + response.create frame
    S->>U: tryResponsesWebsocketUpstream()
    U->>P: WS upgrade + send frame

    alt Streaming SSE path (normal)
        P-->>U: SSE events (response.created, ...)
        U-->>S: ReadableStream of SSE
        S-->>C: Forward SSE events as WS messages
        P-->>U: terminal event (response.completed)
        U->>U: terminalEventSeen = true
        U->>P: closeUpstream(1000)
        S->>S: requestClose(1000, response_completed)
        Note over S: closed=true, pending cleared
        S->>C: WS close(1000, response_completed)
    else Upstream closes mid-stream (no terminal)
        P-->>U: WS close(1000) without terminal
        U->>U: midStreamError = upstream_ws_closed_mid_stream
        U-->>S: SSE error frame
        S->>S: requestClose(1011, stream_ended_without_terminal)
        S->>C: WS close(1011)
    else HTTP error response
        P-->>S: HTTP 4xx/5xx body
        S-->>C: error event
        S->>S: requestClose(1011, http_NNN)
        S->>C: WS close(1011, http_NNN)
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
server.js:268-278
**`drain().catch()` bypasses `requestClose`, leaving the same race open**

The entire motivation for `requestClose` is to synchronously set `closed = true` and drain `pending` *before* calling `ws.close()`, so no further frames can be dispatched while awaiting the async `close` event. The error handler in `drain().catch()` (line 274) still calls `ws.close()` directly, skipping both steps. If a nested `drain()` throws, `closed` stays `false` and `pending` stays populated — the `ws.on("message")` handler can still enqueue frames, and the next `ws.on("close")` → `finalize()` path is the only thing that cleans up. On a slow event-loop tick that's exactly the window the PR description says must be closed.

```suggestion
        void drain().catch((err) => {
          log("error", "ws_drain_failed", {
            error: String(err && err.message ? err.message : err),
          });
          emitErrorEvent(ws, "internal_error", "Failed to process queued request");
          requestClose(1011, "internal_error");
        });
```

### Issue 2 of 2
server.js:158-179
**`requestClose` skips `currentInternalReq` cleanup that `finalize` normally does**

`requestClose` sets `closed = true` and clears `pending`, but does not touch `currentInternalReq`. Because `finalize` now has an early-return guard (`if (closed) return`), the `ws.on("close")` callback will never reach the `currentInternalReq.destroy()` block. Meanwhile the `processFrame` caller skips its own cleanup:

```js
if (!closed) {
  currentInternalReq = null;   // skipped because closed = true
}
```

In practice `requestClose` is only called once the SSE stream has fully resolved, so the in-flight request is already done and `destroy()` would be a no-op — but the stale reference still holds the `ClientRequest` object in memory for the lifetime of the WebSocket connection. Adding `currentInternalReq?.destroy(); currentInternalReq = null;` to `requestClose` (after clearing `pending`) would make the invariant explicit and close the gap defensively.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(responses-ws): address PR review — d..."](https://github.com/ding113/claude-code-hub/commit/e3575272ccbb52c15ed409026b70286195f5fd57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30591977)</sub>

<!-- /greptile_comment -->