### PR TITLE
fix(keys): register :reveal/:enable/:renew before generic CRUD

### DIFF
--- a/src/app/api/v1/resources/keys/router.ts
+++ b/src/app/api/v1/resources/keys/router.ts
@@ -111,69 +111,10 @@ keysRouter.openapi(
   createUserKey as never
 );
 
-keysRouter.openapi(
-  createRoute({
-    method: "get",
-    path: "/keys/{keyId}",
-    middleware: requireAuth("admin"),
-    tags: ["Keys"],
-    summary: "Get key",
-    description: "Gets one key view through the existing key limit usage guard.",
-    "x-required-access": "admin",
-    security,
-    request: { params: KeyIdParamSchema },
-    responses: {
-      200: {
-        description: "Key detail.",
-        content: { "application/json": { schema: GenericKeyResponseSchema } },
-      },
-      ...problemResponses,
-    },
-  }),
-  getKey as never
-);
-
-keysRouter.openapi(
-  createRoute({
-    method: "patch",
-    path: "/keys/{keyId}",
-    middleware: requireAuth("admin"),
-    tags: ["Keys"],
-    summary: "Update key",
-    description: "Updates one key.",
-    "x-required-access": "admin",
-    security,
-    request: {
-      params: KeyIdParamSchema,
-      body: { required: true, content: { "application/json": { schema: KeyUpdateSchema } } },
-    },
-    responses: {
-      200: {
-        description: "Update result.",
-        content: { "application/json": { schema: GenericKeyResponseSchema } },
-      },
-      ...problemResponses,
-    },
-  }),
-  updateKey as never
-);
-
-keysRouter.openapi(
-  createRoute({
-    method: "delete",
-    path: "/keys/{keyId}",
-    middleware: requireAuth("admin"),
-    tags: ["Keys"],
-    summary: "Delete key",
-    description: "Deletes one key.",
-    "x-required-access": "admin",
-    security,
-    request: { params: KeyIdParamSchema },
-    responses: { 204: { description: "Key deleted." }, ...problemResponses },
-  }),
-  deleteKey as never
-);
-
+// Custom-method routes (`/keys/{id}:reveal` etc.) must register before the
+// generic `/keys/{keyId}` CRUD routes — Hono's RegExpRouter resolves
+// overlapping matches in registration order, and the generic GET would
+// otherwise capture `keyId="155:reveal"` and fail Zod coercion as NaN.
 const enableKeyRoute = createRoute({
   method: "post",
   path: "/keys/{keyId}:enable",
@@ -245,6 +186,69 @@ keysRouter.openAPIRegistry.registerPath(revealKeyRoute);
 // Auth tier is "read" so the action's per-request ownership check can
 // apply (admin OR key owner). Non-owners are rejected at the action layer.
 keysRouter.get("/keys/:keyId{[0-9]+:reveal}", requireAuth("read"), revealKey);
+
+keysRouter.openapi(
+  createRoute({
+    method: "get",
+    path: "/keys/{keyId}",
+    middleware: requireAuth("admin"),
+    tags: ["Keys"],
+    summary: "Get key",
+    description: "Gets one key view through the existing key limit usage guard.",
+    "x-required-access": "admin",
+    security,
+    request: { params: KeyIdParamSchema },
+    responses: {
+      200: {
+        description: "Key detail.",
+        content: { "application/json": { schema: GenericKeyResponseSchema } },
+      },
+      ...problemResponses,
+    },
+  }),
+  getKey as never
+);
+
+keysRouter.openapi(
+  createRoute({
+    method: "patch",
+    path: "/keys/{keyId}",
+    middleware: requireAuth("admin"),
+    tags: ["Keys"],
+    summary: "Update key",
+    description: "Updates one key.",
+    "x-required-access": "admin",
+    security,
+    request: {
+      params: KeyIdParamSchema,
+      body: { required: true, content: { "application/json": { schema: KeyUpdateSchema } } },
+    },
+    responses: {
+      200: {
+        description: "Update result.",
+        content: { "application/json": { schema: GenericKeyResponseSchema } },
+      },
+      ...problemResponses,
+    },
+  }),
+  updateKey as never
+);
+
+keysRouter.openapi(
+  createRoute({
+    method: "delete",
+    path: "/keys/{keyId}",
+    middleware: requireAuth("admin"),
+    tags: ["Keys"],
+    summary: "Delete key",
+    description: "Deletes one key.",
+    "x-required-access": "admin",
+    security,
+    request: { params: KeyIdParamSchema },
+    responses: { 204: { description: "Key deleted." }, ...problemResponses },
+  }),
+  deleteKey as never
+);
 
 keysRouter.openapi(
   createRoute({

--- a/src/lib/api-client/v1/openapi-types.gen.ts
+++ b/src/lib/api-client/v1/openapi-types.gen.ts
@@ -32605,7 +32605,7 @@ export interface operations {
                     /** @description Key name. */
                     name: string;
                     /** @description Expiration date or null. */
-                    expiresAt?: string | unknown;
+                    expiresAt?: string | null;
                     /** @description Whether the key is enabled. */
                     isEnabled?: boolean;
                     /** @description Whether this key can login to the Web UI. */
@@ -33193,7 +33193,7 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        /** @description Unmasked key value. Returned only to admin callers. */
+                        /** @description Unmasked key value. Returned to admin callers and to the key owner; non-owners receive 403. */
                         key: string;
                     };
                 };
@@ -33712,7 +33712,7 @@ export interface operations {
                     /** @description Key name. */
                     name: string;
                     /** @description Expiration date or null. */
-                    expiresAt?: string | unknown;
+                    expiresAt?: string | null;
                     /** @description Whether the key is enabled. */
                     isEnabled?: boolean;
                     /** @description Whether this key can login to the Web UI. */

--- a/src/lib/api-client/v1/openapi-types.gen.ts
+++ b/src/lib/api-client/v1/openapi-types.gen.ts
@@ -2468,34 +2468,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/keys/{keyId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get key
-         * @description Gets one key view through the existing key limit usage guard.
-         */
-        get: operations["getKeysByKeyid"];
-        put?: never;
-        post?: never;
-        /**
-         * Delete key
-         * @description Deletes one key.
-         */
-        delete: operations["deleteKeysByKeyid"];
-        options?: never;
-        head?: never;
-        /**
-         * Update key
-         * @description Updates one key.
-         */
-        patch: operations["patchKeysByKeyid"];
-        trace?: never;
-    };
     "/api/v1/keys/{keyId}:enable": {
         parameters: {
             query?: never;
@@ -2554,6 +2526,34 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/api/v1/keys/{keyId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get key
+         * @description Gets one key view through the existing key limit usage guard.
+         */
+        get: operations["getKeysByKeyid"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete key
+         * @description Deletes one key.
+         */
+        delete: operations["deleteKeysByKeyid"];
+        options?: never;
+        head?: never;
+        /**
+         * Update key
+         * @description Updates one key.
+         */
+        patch: operations["patchKeysByKeyid"];
         trace?: never;
     };
     "/api/v1/keys/{keyId}/limits:reset": {
@@ -32806,6 +32806,548 @@ export interface operations {
             };
         };
     };
+    postKeysByKeyidEnable: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description Required only when authenticating with the auth-token cookie on mutation requests. */
+                "X-CCH-CSRF"?: string;
+            };
+            path: {
+                /** @description Key id. */
+                keyId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Target enabled state. */
+                    enabled: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Toggle result. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Invalid request. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Access denied. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Key not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+        };
+    };
+    postKeysByKeyidRenew: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description Required only when authenticating with the auth-token cookie on mutation requests. */
+                "X-CCH-CSRF"?: string;
+            };
+            path: {
+                /** @description Key id. */
+                keyId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description New expiration timestamp. */
+                    expiresAt: string;
+                    /** @description Enable the key while renewing. */
+                    enableKey?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Renew result. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Invalid request. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Access denied. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Key not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+        };
+    };
+    getKeysByKeyidReveal: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Key id. */
+                keyId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unmasked key. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Unmasked key value. Returned only to admin callers. */
+                        key: string;
+                    };
+                };
+            };
+            /** @description Invalid request. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Access denied. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Key not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+        };
+    };
     getKeysByKeyid: {
         parameters: {
             query?: never;
@@ -33218,548 +33760,6 @@ export interface operations {
                 content: {
                     "application/json": {
                         [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Invalid request. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-            /** @description Authentication required. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-            /** @description Access denied. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-            /** @description Key not found. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-        };
-    };
-    postKeysByKeyidEnable: {
-        parameters: {
-            query?: never;
-            header?: {
-                /** @description Required only when authenticating with the auth-token cookie on mutation requests. */
-                "X-CCH-CSRF"?: string;
-            };
-            path: {
-                /** @description Key id. */
-                keyId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** @description Target enabled state. */
-                    enabled: boolean;
-                };
-            };
-        };
-        responses: {
-            /** @description Toggle result. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Invalid request. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-            /** @description Authentication required. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-            /** @description Access denied. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-            /** @description Key not found. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-        };
-    };
-    postKeysByKeyidRenew: {
-        parameters: {
-            query?: never;
-            header?: {
-                /** @description Required only when authenticating with the auth-token cookie on mutation requests. */
-                "X-CCH-CSRF"?: string;
-            };
-            path: {
-                /** @description Key id. */
-                keyId: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** @description New expiration timestamp. */
-                    expiresAt: string;
-                    /** @description Enable the key while renewing. */
-                    enableKey?: boolean;
-                };
-            };
-        };
-        responses: {
-            /** @description Renew result. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Invalid request. */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-            /** @description Authentication required. */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-            /** @description Access denied. */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-            /** @description Key not found. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": {
-                        /** @description Stable problem type URI or URN. */
-                        type: string;
-                        /** @description Short problem title. */
-                        title: string;
-                        /** @description HTTP status code. */
-                        status: number;
-                        /** @description Human-readable error detail. */
-                        detail: string;
-                        /** @description Request path that produced the problem. */
-                        instance: string;
-                        /** @description Application error code for frontend i18n. */
-                        errorCode: string;
-                        /** @description Optional i18n parameters. */
-                        errorParams?: {
-                            [key: string]: unknown;
-                        };
-                        /** @description Optional request trace identifier. */
-                        traceId?: string;
-                        /** @description Validation failure details. */
-                        invalidParams?: {
-                            /** @description Path to the invalid input field. */
-                            path: (string | number)[];
-                            /** @description Machine-readable validation error code. */
-                            code: string;
-                            /** @description Validation error message. */
-                            message: string;
-                        }[];
-                    };
-                };
-            };
-        };
-    };
-    getKeysByKeyidReveal: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Key id. */
-                keyId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Unmasked key. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @description Unmasked key value. Returned only to admin callers. */
-                        key: string;
                     };
                 };
             };

--- a/src/lib/api/v1/schemas/keys.ts
+++ b/src/lib/api/v1/schemas/keys.ts
@@ -17,7 +17,7 @@ export const KeyListQuerySchema = z.object({
 
 const KeyMutationFields = {
   name: z.string().trim().min(1).max(64).describe("Key name."),
-  expiresAt: z.union([z.string(), z.null()]).optional().describe("Expiration date or null."),
+  expiresAt: z.string().nullable().optional().describe("Expiration date or null."),
   isEnabled: z.boolean().optional().describe("Whether the key is enabled."),
   canLoginWebUi: z.boolean().optional().describe("Whether this key can login to the Web UI."),
   limit5hUsd: z.number().min(0).max(10_000).nullable().optional().describe("Five-hour USD quota."),
@@ -130,7 +130,11 @@ export const KeyListResponseSchema = z.object({
 });
 
 export const KeyRevealResponseSchema = z.object({
-  key: z.string().describe("Unmasked key value. Returned only to admin callers."),
+  key: z
+    .string()
+    .describe(
+      "Unmasked key value. Returned to admin callers and to the key owner; non-owners receive 403."
+    ),
 });
 
 export type KeyCreateInput = z.infer<typeof KeyCreateSchema>;

--- a/tests/api/v1/keys/keys.test.ts
+++ b/tests/api/v1/keys/keys.test.ts
@@ -14,6 +14,7 @@ const toggleKeyEnabledMock = vi.hoisted(() => vi.fn());
 const renewKeyExpiresAtMock = vi.hoisted(() => vi.fn());
 const patchKeyLimitMock = vi.hoisted(() => vi.fn());
 const batchUpdateKeysMock = vi.hoisted(() => vi.fn());
+const getUnmaskedKeyMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/auth")>();
@@ -32,6 +33,7 @@ vi.mock("@/actions/keys", () => ({
   renewKeyExpiresAt: renewKeyExpiresAtMock,
   patchKeyLimit: patchKeyLimitMock,
   batchUpdateKeys: batchUpdateKeysMock,
+  getUnmaskedKey: getUnmaskedKeyMock,
 }));
 
 vi.mock("@/actions/key-quota", () => ({
@@ -86,6 +88,7 @@ describe("v1 key endpoints", () => {
       ok: true,
       data: { requestedCount: 1, updatedCount: 1, updatedIds: [10] },
     });
+    getUnmaskedKeyMock.mockResolvedValue({ ok: true, data: { key: "sk-revealed" } });
   });
 
   test("lists and creates user keys", async () => {
@@ -266,6 +269,19 @@ describe("v1 key endpoints", () => {
     expect(removeKeyMock).toHaveBeenCalledWith(10);
   });
 
+  test("reveals unmasked key value with no-store headers", async () => {
+    const revealed = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/keys/10:reveal",
+      headers,
+    });
+    expect(revealed.response.status).toBe(200);
+    expect(revealed.json).toEqual({ key: "sk-revealed" });
+    expect(revealed.response.headers.get("Cache-Control")).toContain("no-store");
+    expect(revealed.response.headers.get("Pragma")).toBe("no-cache");
+    expect(getUnmaskedKeyMock).toHaveBeenCalledWith(10);
+  });
+
   test("reads and mutates key limit quota endpoints", async () => {
     const limitUsage = await callV1Route({
       method: "GET",
@@ -375,6 +391,7 @@ describe("v1 key endpoints", () => {
     expect(doc.paths).toHaveProperty("/api/v1/keys/{keyId}");
     expect(doc.paths).toHaveProperty("/api/v1/keys/{keyId}:enable");
     expect(doc.paths).toHaveProperty("/api/v1/keys/{keyId}:renew");
+    expect(doc.paths).toHaveProperty("/api/v1/keys/{keyId}:reveal");
     expect(doc.paths).toHaveProperty("/api/v1/keys/{keyId}/limits:reset");
     expect(doc.paths).toHaveProperty("/api/v1/keys/{keyId}/limit-usage");
     expect(doc.paths).toHaveProperty("/api/v1/keys/{keyId}/quota");


### PR DESCRIPTION
## Summary

- Reorder Hono route registrations in `src/app/api/v1/resources/keys/router.ts` so the custom-method routes (`/keys/{id}:reveal`, `:enable`, `:renew`) register **before** the generic `GET/PATCH/DELETE /keys/{keyId}` block.
- Add the missing integration test for `GET /api/v1/keys/{id}:reveal` in `tests/api/v1/keys/keys.test.ts` (plus an OpenAPI doc assertion). The pre-existing `keys.crud.test.ts` only string-matches the test file via `readFileSync`, so it could not catch this regression.
- Regenerate `src/lib/api-client/v1/openapi-types.gen.ts` to reflect the path ordering — content unchanged, only path-block order shifts.

## Related Issues & PRs

- **Follow-up to #1149** — PR #1149 introduced the `keys:reveal` endpoint; this PR fixes a route ordering regression that caused the reveal functionality to return 400 errors.
- **Related to #1123** — Management API support for querying unmasked API keys.
- **Related to #1136** — RESTful management API v1 + frontend migration.

## Root Cause

Reproduces `GET /api/v1/keys/155:reveal` → 400 `request.validation_failed`, `keyId expected number received NaN` on the user management page.

Hono's RegExpRouter resolves overlapping matches in registration order. With the generic `GET /keys/{keyId}` registered first via `keysRouter.openapi(...)`, its auto-Zod-validating middleware captured `keyId="155:reveal"`, `z.coerce.number()` produced NaN, and the `defaultHook` returned the 400 the user saw. The specific `/keys/:keyId{[0-9]+:reveal}` route registered later was never hit, so the suffix-stripping logic in `parseKeyParams` never ran.

`POST /keys/{id}:enable` and `:renew` are not currently affected only because the generic CRUD routes use GET/PATCH/DELETE — moving them up too defends against a future generic POST route silently re-introducing the same bug.

## Solution

Reordered route registrations to ensure custom-method routes with colon-suffixes (`:reveal`, `:enable`, `:renew`) are registered **before** the generic `/keys/{keyId}` CRUD routes. This ensures Hono's RegExpRouter matches the more specific patterns first.

## Changes

### Core Fix
- `src/app/api/v1/resources/keys/router.ts` — Moved custom-method route registrations (enable, renew, reveal) above generic CRUD routes (GET/PATCH/DELETE `/keys/{keyId}`)

### Test Coverage
- `tests/api/v1/keys/keys.test.ts` — Added integration test for `GET /api/v1/keys/{id}:reveal` endpoint with cache-control header assertions

### Generated Types
- `src/lib/api-client/v1/openapi-types.gen.ts` — Regenerated to reflect path ordering changes (no functional changes)

## Test plan

- [x] `bunx vitest run tests/api/v1/keys/keys.test.ts` — 11/11 pass, includes new `reveals unmasked key value with no-store headers` case.
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — no new warnings (8 pre-existing, all in unrelated files).
- [x] `bun run openapi:check` — generated types in sync.
- [x] `bun run openapi:lint` — passes.
- [x] `bun run build` — production build succeeds.
- [ ] Manual: `bun run dev`, click copy/eye on a key in user management — no 400 toast, key is revealed/copied.

---

*Description enhanced with related issue links*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Route ordering regression fix: custom-method routes (`:reveal`, `:enable`, `:renew`) now register before the generic CRUD block, preventing Hono's RegExpRouter from capturing colon-suffixed paths and failing Zod coercion. Also adds a missing integration test for the reveal endpoint, simplifies the `expiresAt` Zod union type, and regenerates OpenAPI types.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted route-ordering fix with matching test coverage and no logic regressions.

No P0 or P1 findings. The route reordering is the correct solution for Hono's RegExpRouter behaviour, the schema change is semantically equivalent, the generated types are in sync, and the new integration test directly exercises the repaired code path.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/api/v1/resources/keys/router.ts | Core fix: moves :enable, :renew, :reveal registrations before the generic GET/PATCH/DELETE /keys/{keyId} block to prevent RegExpRouter from capturing colon-suffixes as NaN keyIds. |
| src/lib/api/v1/schemas/keys.ts | Clean-up: expiresAt changed from z.union([z.string(), z.null()]).optional() to z.string().nullable().optional() (semantically equivalent), and KeyRevealResponseSchema description updated to mention key-owner access. |
| tests/api/v1/keys/keys.test.ts | Adds getUnmaskedKeyMock and a new integration test for GET /api/v1/keys/10:reveal, asserting correct status, response body, Cache-Control: no-store, Pragma: no-cache, and mock invocation with the parsed integer id. |
| src/lib/api-client/v1/openapi-types.gen.ts | Regenerated file: path-block order shifted to match the new router registration order; expiresAt type corrected from string | unknown to string | null; getKeysByKeyidReveal description updated to reflect owner-access semantics. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant R as Hono RegExpRouter
    participant SR as Specific route (colon-suffix pattern)
    participant GR as Generic route /keys/{keyId}
    participant H as Handler

    Note over R: Before fix
    C->>R: GET /keys/155:reveal
    R->>GR: Matched generic route first
    GR-->>C: 400 - NaN coercion failure

    Note over R: After fix
    C->>R: GET /keys/155:reveal
    R->>SR: Matched specific route first
    SR->>H: Strips suffix, parses id
    H-->>C: 200 with unmasked value
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(keys): address PR review on schema a..."](https://github.com/ding113/claude-code-hub/commit/d74992983d6b6dd00ba0dd72fc04d5ca1d6ff50a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30666388)</sub>

<!-- /greptile_comment -->