### PR TITLE
feat(my-usage): expose quota compatibility fields

### DIFF
--- a/docs/examples/api-key-quota-extractor-compatible.js
+++ b/docs/examples/api-key-quota-extractor-compatible.js
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Claude Code Hub getMyQuota extractor for ccswitch-style quota checks.
+ *
+ * Direct usage:
+ *   node docs/examples/api-key-quota-extractor-compatible.js https://cch.example.com sk-your-api-key
+ *
+ * ccswitch template usage:
+ *   Import or paste the exported `ccswitchTemplate` object.
+ *
+ * The request is:
+ *   POST /api/actions/my-usage/getMyQuota
+ *   Authorization: Bearer <apiKey>
+ *   Content-Type: application/json
+ *   Body: {}
+ */
+
+function toNumber(value, fallback = null) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function toBoolean(value, fallback = false) {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function toStringOrNull(value) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function pickWindow(quotaWindows, name) {
+  if (!quotaWindows || typeof quotaWindows !== "object") {
+    return {};
+  }
+  const value = quotaWindows[name];
+  return value && typeof value === "object" ? value : {};
+}
+
+function normalizeQuotaResponse(response) {
+  const data =
+    response && response.ok === true && response.data && typeof response.data === "object"
+      ? response.data
+      : {};
+
+  const quotaWindows =
+    data.quotaWindows && typeof data.quotaWindows === "object" ? data.quotaWindows : {};
+  const fiveHour = pickWindow(quotaWindows, "fiveHour");
+  const daily = pickWindow(quotaWindows, "daily");
+  const weekly = pickWindow(quotaWindows, "weekly");
+  const monthly = pickWindow(quotaWindows, "monthly");
+  const total = pickWindow(quotaWindows, "total");
+
+  const keyEnabled = toBoolean(data.keyIsEnabled, true);
+  const userEnabled = toBoolean(data.userIsEnabled, true);
+  const remaining = toNumber(data.remaining, toNumber(total.remainingUsd, null));
+  const todayRemaining = toNumber(
+    data.todayRemainingUsd,
+    toNumber(daily.remainingUsd, toNumber(data.remainingDailyUsd, null))
+  );
+
+  return {
+    ok: response && response.ok === true,
+    isValid: response && response.ok === true && keyEnabled && userEnabled,
+    invalidMessage: response && response.ok === true ? undefined : "Quota request failed",
+
+    planName: "Claude Code Hub Usage",
+    unit: typeof data.unit === "string" ? data.unit : "USD",
+
+    keyName: toStringOrNull(data.keyName),
+    userName: toStringOrNull(data.userName),
+    providerGroup: toStringOrNull(data.providerGroup),
+    keyIsEnabled: keyEnabled,
+    userIsEnabled: userEnabled,
+
+    remaining,
+    todayRemaining,
+    todayUsed: toNumber(data.todayUsedUsd, toNumber(daily.usedUsd, 0)),
+    todayUsedPercent: toNumber(data.todayUsedPercent, toNumber(daily.usedPercent, null)),
+    todayRemainingPercent: toNumber(
+      data.todayRemainingPercent,
+      toNumber(daily.remainingPercent, null)
+    ),
+    remainingPercent: toNumber(data.remainingPercent, toNumber(total.remainingPercent, null)),
+
+    remaining5h: toNumber(fiveHour.remainingUsd, toNumber(data.remaining5hUsd, null)),
+    remainingDaily: toNumber(daily.remainingUsd, toNumber(data.remainingDailyUsd, null)),
+    remainingWeekly: toNumber(weekly.remainingUsd, toNumber(data.remainingWeeklyUsd, null)),
+    remainingMonthly: toNumber(monthly.remainingUsd, toNumber(data.remainingMonthlyUsd, null)),
+    remainingTotal: toNumber(total.remainingUsd, toNumber(data.remainingTotalUsd, null)),
+
+    total: toNumber(total.limitUsd, toNumber(data.limitTotalUsd, null)),
+    used: toNumber(total.usedUsd, toNumber(data.usedTotalUsd, 0)),
+    rpmLimit: toNumber(data.rpmLimit, null),
+    concurrentSessions: toNumber(data.concurrentSessions, 0),
+    concurrentSessionsLimit: toNumber(data.concurrentSessionsLimit, null),
+    expiresAt: toStringOrNull(data.expiresAt),
+    resetMode: toStringOrNull(data.resetMode),
+    resetTime: toStringOrNull(data.resetTime),
+
+    quotaWindows: {
+      fiveHour,
+      daily,
+      weekly,
+      monthly,
+      total,
+    },
+
+    balance: remaining,
+    dailyBalance: todayRemaining,
+    weeklyBalance: toNumber(weekly.remainingUsd, toNumber(data.remainingWeeklyUsd, null)),
+    monthlyBalance: toNumber(monthly.remainingUsd, toNumber(data.remainingMonthlyUsd, null)),
+    extra: [
+      `5h=${toNumber(fiveHour.remainingUsd, "unlimited")}`,
+      `daily=${todayRemaining ?? "unlimited"}`,
+      `weekly=${toNumber(weekly.remainingUsd, "unlimited")}`,
+      `monthly=${toNumber(monthly.remainingUsd, "unlimited")}`,
+      `total=${toNumber(total.remainingUsd, remaining ?? "unlimited")}`,
+    ].join(" "),
+  };
+}
+
+const ccswitchTemplate = {
+  request: {
+    url: "{{baseUrl}}/api/actions/my-usage/getMyQuota",
+    method: "POST",
+    headers: {
+      Authorization: "Bearer {{apiKey}}",
+      "Content-Type": "application/json",
+      "User-Agent": "cc-switch/1.0",
+    },
+    body: "{}",
+  },
+  extractor: normalizeQuotaResponse,
+};
+
+async function fetchQuota(baseUrl, apiKey) {
+  const response = await fetch(new URL("/api/actions/my-usage/getMyQuota", baseUrl), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "User-Agent": "cc-switch/1.0",
+    },
+    body: "{}",
+  });
+
+  const text = await response.text();
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error(`Quota API did not return JSON: HTTP ${response.status}`);
+  }
+
+  if (!response.ok || payload.ok !== true) {
+    throw new Error(payload && typeof payload.error === "string" ? payload.error : `HTTP ${response.status}`);
+  }
+
+  return normalizeQuotaResponse(payload);
+}
+
+async function main() {
+  const [, , baseUrl, apiKey] = process.argv;
+  if (!baseUrl || !apiKey) {
+    process.stderr.write(
+      "Usage: node docs/examples/api-key-quota-extractor-compatible.js <baseUrl> <apiKey>\n"
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const quota = await fetchQuota(baseUrl, apiKey);
+  process.stdout.write(`${JSON.stringify(quota, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  ccswitchTemplate,
+  fetchQuota,
+  normalizeQuotaResponse,
+};

--- a/docs/usage-only-quota-extractor.md
+++ b/docs/usage-only-quota-extractor.md
@@ -1,0 +1,73 @@
+# Usage-Only Quota Extractor
+
+This note documents the minimal compatibility path for external quota checks.
+It does not add a new endpoint or a new authentication surface.
+
+## Endpoint
+
+Call the existing action route with the API key as a Bearer token:
+
+```bash
+curl -sS "$CCH_BASE_URL/api/actions/my-usage/getMyQuota" \
+  -H "Authorization: Bearer $CCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{}'
+```
+
+The route is `POST /api/actions/my-usage/getMyQuota`. The request body is `{}`.
+It uses the existing `allowReadOnlyAccess` path, so read-only keys can query
+their own usage data without gaining access to admin-only actions.
+
+## Response Fields
+
+The response shape is the standard action wrapper:
+
+- `ok`: true when the action succeeds.
+- `data`: quota payload for the current key and user.
+
+Useful compatibility fields under `data` include:
+
+- `remaining`: the most restrictive remaining USD amount across configured quota windows, or `null` when unlimited.
+- `todayRemainingUsd`: remaining USD amount for the daily window.
+- `todayUsedUsd`: used USD amount for the daily window.
+- `todayRemainingPercent`: remaining percentage for the daily window.
+- `remainingPercent`: the most restrictive remaining percentage across configured quota windows.
+- `quotaWindows`: structured `fiveHour`, `daily`, `weekly`, `monthly`, and `total` quota windows.
+- `remaining5hUsd`, `remainingDailyUsd`, `remainingWeeklyUsd`, `remainingMonthlyUsd`, `remainingTotalUsd`: flat remaining aliases.
+- `rpmLimit`, `concurrentSessions`, `concurrentSessionsLimit`: rate and session limits.
+- `keyName`, `userName`, `providerGroup`, `keyIsEnabled`, `userIsEnabled`: key and user metadata.
+
+Each `quotaWindows.*` entry contains:
+
+- `period`
+- `limitUsd`
+- `usedUsd`
+- `remainingUsd`
+- `usedPercent`
+- `remainingPercent`
+- `isUnlimited`
+- `isExhausted`
+
+## Example Script
+
+Use `docs/examples/api-key-quota-extractor-compatible.js` as either a direct
+Node.js checker or as a ccswitch-style template source.
+
+Direct check:
+
+```bash
+node docs/examples/api-key-quota-extractor-compatible.js "$CCH_BASE_URL" "$CCH_API_KEY"
+```
+
+The normalized output includes ccswitch-friendly fields such as `remaining`,
+`todayRemaining`, `quotaWindows`, `balance`, `dailyBalance`, `weeklyBalance`,
+and `monthlyBalance`.
+
+## PR Note
+
+This is a compatibility extension for clients that already consume usage data.
+It documents and normalizes the existing `getMyQuota` response fields. It does
+not introduce a public quota endpoint, does not accept API keys in request
+bodies, and does not bypass the existing `allowReadOnlyAccess` authorization
+gate.

--- a/src/actions/my-usage.ts
+++ b/src/actions/my-usage.ts
@@ -171,6 +171,17 @@ export interface MyUsageMetadata {
   billingModelSource: BillingModelSource;
 }
 
+export interface MyUsageQuotaWindow {
+  period: "5h" | "daily" | "weekly" | "monthly" | "total";
+  limitUsd: number | null;
+  usedUsd: number;
+  remainingUsd: number | null;
+  usedPercent: number | null;
+  remainingPercent: number | null;
+  isUnlimited: boolean;
+  isExhausted: boolean;
+}
+
 export interface MyUsageQuota {
   keyLimit5hUsd: number | null;
   keyLimitDailyUsd: number | null;
@@ -208,12 +219,165 @@ export interface MyUsageQuota {
   keyName: string;
   keyIsEnabled: boolean;
 
+  providerGroup: string | null;
+
+  limit5hUsd: number | null;
+  used5hUsd: number;
+  remaining5hUsd: number | null;
+
+  limitDailyUsd: number | null;
+  usedDailyUsd: number;
+  remainingDailyUsd: number | null;
+
+  limitWeeklyUsd: number | null;
+  usedWeeklyUsd: number;
+  remainingWeeklyUsd: number | null;
+
+  limitMonthlyUsd: number | null;
+  usedMonthlyUsd: number;
+  remainingMonthlyUsd: number | null;
+
+  limitTotalUsd: number | null;
+  usedTotalUsd: number;
+  remainingTotalUsd: number | null;
+
+  quotaWindows: {
+    fiveHour: MyUsageQuotaWindow;
+    daily: MyUsageQuotaWindow;
+    weekly: MyUsageQuotaWindow;
+    monthly: MyUsageQuotaWindow;
+    total: MyUsageQuotaWindow;
+  };
+  todayUsedUsd: number;
+  todayRemainingUsd: number | null;
+  todayUsedPercent: number | null;
+  todayRemainingPercent: number | null;
+  remainingPercent: number | null;
+
+  rpmLimit: number | null;
+  concurrentSessions: number;
+  concurrentSessionsLimit: number | null;
+
   userAllowedModels: string[];
   userAllowedClients: string[];
 
   expiresAt: Date | null;
   dailyResetMode: "fixed" | "rolling";
   dailyResetTime: string;
+  resetMode: "fixed" | "rolling";
+  resetTime: string;
+  remaining: number | null;
+  unit: "USD";
+}
+
+type EffectiveQuotaWindow = {
+  limit: number | null;
+  used: number;
+  remaining: number | null;
+};
+
+function normalizeQuotaLimit(limit: number | null | undefined): number | null {
+  if (limit == null || limit <= 0) {
+    return null;
+  }
+
+  return limit;
+}
+
+function clampRemaining(limit: number, used: number): number {
+  return Math.max(limit - used, 0);
+}
+
+function resolveEffectiveQuotaWindow(
+  candidates: Array<{ limit: number | null | undefined; used: number }>
+): EffectiveQuotaWindow {
+  const boundedCandidates = candidates
+    .map((candidate) => ({
+      limit: normalizeQuotaLimit(candidate.limit),
+      used: candidate.used,
+    }))
+    .filter((candidate): candidate is { limit: number; used: number } => candidate.limit != null)
+    .map((candidate) => ({
+      limit: candidate.limit,
+      used: candidate.used,
+      remaining: clampRemaining(candidate.limit, candidate.used),
+    }));
+
+  if (boundedCandidates.length === 0) {
+    return {
+      limit: null,
+      used: Math.max(...candidates.map((candidate) => candidate.used), 0),
+      remaining: null,
+    };
+  }
+
+  const mostRestrictive = boundedCandidates.reduce((current, candidate) => {
+    if (candidate.remaining < current.remaining) {
+      return candidate;
+    }
+
+    if (candidate.remaining === current.remaining && candidate.limit < current.limit) {
+      return candidate;
+    }
+
+    return current;
+  });
+
+  return mostRestrictive;
+}
+
+function resolveOverallRemaining(values: Array<number | null>): number | null {
+  const boundedValues = values.filter((value): value is number => value != null);
+  if (boundedValues.length === 0) {
+    return null;
+  }
+
+  return Math.max(Math.min(...boundedValues), 0);
+}
+
+function round2(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function buildQuotaWindow(
+  period: MyUsageQuotaWindow["period"],
+  window: EffectiveQuotaWindow
+): MyUsageQuotaWindow {
+  const limitUsd = window.limit == null ? null : round2(window.limit);
+  const usedUsd = round2(window.used);
+  const remainingUsd = window.remaining == null ? null : round2(window.remaining);
+  const hasPositiveLimit = limitUsd != null && limitUsd > 0;
+
+  return {
+    period,
+    limitUsd,
+    usedUsd,
+    remainingUsd,
+    usedPercent: hasPositiveLimit ? round2((window.used / limitUsd) * 100) : null,
+    remainingPercent:
+      hasPositiveLimit && remainingUsd != null ? round2((remainingUsd / limitUsd) * 100) : null,
+    isUnlimited: limitUsd == null,
+    isExhausted: remainingUsd != null && remainingUsd <= 0,
+  };
+}
+
+function resolveOverallRemainingPercent(windows: MyUsageQuotaWindow[]): number | null {
+  const values = windows
+    .map((window) => window.remainingPercent)
+    .filter((value): value is number => value != null);
+
+  if (values.length === 0) {
+    return null;
+  }
+
+  return Math.max(Math.min(...values), 0);
+}
+
+function resolveTotalLimitWithMonthlyFallback(params: {
+  totalLimit: number | null | undefined;
+  monthlyLimit: number | null | undefined;
+}): number | null {
+  return params.totalLimit ?? params.monthlyLimit ?? null;
 }
 
 export interface MyTodayStats {
@@ -475,13 +639,59 @@ export async function getMyQuota(): Promise<ActionResult<MyUsageQuota>> {
     } = userCosts;
     const resolvedKeyCurrent5hUsd = keyFixed5hUsd ?? keyCurrent5hUsd;
     const resolvedUserCurrent5hUsd = userFixed5hUsd ?? userCurrent5hUsd;
+    const keyLimitTotalUsd = resolveTotalLimitWithMonthlyFallback({
+      totalLimit: key.limitTotalUsd,
+      monthlyLimit: key.limitMonthlyUsd,
+    });
+    const userLimitTotalUsd = resolveTotalLimitWithMonthlyFallback({
+      totalLimit: user.limitTotalUsd,
+      monthlyLimit: user.limitMonthlyUsd,
+    });
+
+    const effective5h = resolveEffectiveQuotaWindow([
+      { limit: key.limit5hUsd, used: resolvedKeyCurrent5hUsd },
+      { limit: user.limit5hUsd, used: resolvedUserCurrent5hUsd },
+    ]);
+    const effectiveDaily = resolveEffectiveQuotaWindow([
+      { limit: key.limitDailyUsd, used: keyCostDaily },
+      { limit: user.dailyQuota, used: userCostDaily },
+    ]);
+    const effectiveWeekly = resolveEffectiveQuotaWindow([
+      { limit: key.limitWeeklyUsd, used: keyCostWeekly },
+      { limit: user.limitWeeklyUsd, used: userCostWeekly },
+    ]);
+    const effectiveMonthly = resolveEffectiveQuotaWindow([
+      { limit: key.limitMonthlyUsd, used: keyCostMonthly },
+      { limit: user.limitMonthlyUsd, used: userCostMonthly },
+    ]);
+    const effectiveTotal = resolveEffectiveQuotaWindow([
+      { limit: keyLimitTotalUsd, used: keyTotalCost },
+      { limit: userLimitTotalUsd, used: userTotalCost },
+    ]);
+    const overallRemaining = resolveOverallRemaining([
+      effective5h.remaining,
+      effectiveDaily.remaining,
+      effectiveWeekly.remaining,
+      effectiveMonthly.remaining,
+      effectiveTotal.remaining,
+    ]);
+    const quotaWindows = {
+      fiveHour: buildQuotaWindow("5h", effective5h),
+      daily: buildQuotaWindow("daily", effectiveDaily),
+      weekly: buildQuotaWindow("weekly", effectiveWeekly),
+      monthly: buildQuotaWindow("monthly", effectiveMonthly),
+      total: buildQuotaWindow("total", effectiveTotal),
+    };
+    const concurrentSessions = Math.max(keyConcurrent, userKeyConcurrent);
+    const concurrentSessionsLimit =
+      effectiveKeyConcurrentLimit > 0 ? effectiveKeyConcurrentLimit : null;
 
     const quota: MyUsageQuota = {
       keyLimit5hUsd: key.limit5hUsd ?? null,
       keyLimitDailyUsd: key.limitDailyUsd ?? null,
       keyLimitWeeklyUsd: key.limitWeeklyUsd ?? null,
       keyLimitMonthlyUsd: key.limitMonthlyUsd ?? null,
-      keyLimitTotalUsd: key.limitTotalUsd ?? null,
+      keyLimitTotalUsd,
       keyLimitConcurrentSessions: effectiveKeyConcurrentLimit,
       keyCurrent5hUsd: resolvedKeyCurrent5hUsd,
       keyCurrentDailyUsd: keyCostDaily,
@@ -493,7 +703,7 @@ export async function getMyQuota(): Promise<ActionResult<MyUsageQuota>> {
       userLimit5hUsd: user.limit5hUsd ?? null,
       userLimitWeeklyUsd: user.limitWeeklyUsd ?? null,
       userLimitMonthlyUsd: user.limitMonthlyUsd ?? null,
-      userLimitTotalUsd: user.limitTotalUsd ?? null,
+      userLimitTotalUsd,
       userLimitConcurrentSessions: user.limitConcurrentSessions ?? null,
       userRpmLimit: user.rpm ?? null,
       userCurrent5hUsd: resolvedUserCurrent5hUsd,
@@ -513,12 +723,49 @@ export async function getMyQuota(): Promise<ActionResult<MyUsageQuota>> {
       keyName: key.name,
       keyIsEnabled: key.isEnabled ?? true,
 
+      providerGroup: key.providerGroup ?? user.providerGroup ?? null,
+
+      limit5hUsd: effective5h.limit,
+      used5hUsd: effective5h.used,
+      remaining5hUsd: effective5h.remaining,
+
+      limitDailyUsd: effectiveDaily.limit,
+      usedDailyUsd: effectiveDaily.used,
+      remainingDailyUsd: effectiveDaily.remaining,
+
+      limitWeeklyUsd: effectiveWeekly.limit,
+      usedWeeklyUsd: effectiveWeekly.used,
+      remainingWeeklyUsd: effectiveWeekly.remaining,
+
+      limitMonthlyUsd: effectiveMonthly.limit,
+      usedMonthlyUsd: effectiveMonthly.used,
+      remainingMonthlyUsd: effectiveMonthly.remaining,
+
+      limitTotalUsd: effectiveTotal.limit,
+      usedTotalUsd: effectiveTotal.used,
+      remainingTotalUsd: effectiveTotal.remaining,
+
+      quotaWindows,
+      todayUsedUsd: quotaWindows.daily.usedUsd,
+      todayRemainingUsd: quotaWindows.daily.remainingUsd,
+      todayUsedPercent: quotaWindows.daily.usedPercent,
+      todayRemainingPercent: quotaWindows.daily.remainingPercent,
+      remainingPercent: resolveOverallRemainingPercent(Object.values(quotaWindows)),
+
+      rpmLimit: user.rpm ?? null,
+      concurrentSessions,
+      concurrentSessionsLimit,
+
       userAllowedModels: user.allowedModels ?? [],
       userAllowedClients: user.allowedClients ?? [],
 
       expiresAt: key.expiresAt ?? null,
       dailyResetMode: key.dailyResetMode ?? "fixed",
       dailyResetTime: key.dailyResetTime ?? "00:00",
+      resetMode: key.dailyResetMode ?? "fixed",
+      resetTime: key.dailyResetTime ?? "00:00",
+      remaining: overallRemaining,
+      unit: "USD",
     };
 
     return { ok: true, data: quota };

--- a/src/app/api/actions/[...route]/route.ts
+++ b/src/app/api/actions/[...route]/route.ts
@@ -1205,6 +1205,17 @@ const { route: getMyUsageMetadataRoute, handler: getMyUsageMetadataHandler } = c
 );
 app.openapi(getMyUsageMetadataRoute, getMyUsageMetadataHandler);
 
+const myUsageQuotaWindowSchema = z.object({
+  period: z.enum(["5h", "daily", "weekly", "monthly", "total"]),
+  limitUsd: z.number().nullable().describe("该周期有效限额；null 表示不限额"),
+  usedUsd: z.number().describe("该周期已用金额"),
+  remainingUsd: z.number().nullable().describe("该周期剩余金额；null 表示不限额"),
+  usedPercent: z.number().nullable().describe("该周期已用百分比；null 表示不限额或限额为 0"),
+  remainingPercent: z.number().nullable().describe("该周期剩余百分比；null 表示不限额或限额为 0"),
+  isUnlimited: z.boolean().describe("该周期是否不限额"),
+  isExhausted: z.boolean().describe("该周期是否已无剩余额度"),
+});
+
 const { route: getMyQuotaRoute, handler: getMyQuotaHandler } = createActionRoute(
   "my-usage",
   "getMyQuota",
@@ -1230,6 +1241,7 @@ const { route: getMyQuotaRoute, handler: getMyQuotaHandler } = createActionRoute
       userLimitMonthlyUsd: z.number().nullable(),
       userLimitTotalUsd: z.number().nullable(),
       userLimitConcurrentSessions: z.number().nullable(),
+      userRpmLimit: z.number().nullable(),
       userCurrent5hUsd: z.number(),
       userCurrentDailyUsd: z.number(),
       userCurrentWeeklyUsd: z.number(),
@@ -1247,9 +1259,58 @@ const { route: getMyQuotaRoute, handler: getMyQuotaHandler } = createActionRoute
       keyName: z.string(),
       keyIsEnabled: z.boolean(),
 
+      providerGroup: z.string().nullable(),
+
+      limit5hUsd: z.number().nullable(),
+      used5hUsd: z.number(),
+      remaining5hUsd: z.number().nullable(),
+
+      limitDailyUsd: z.number().nullable(),
+      usedDailyUsd: z.number(),
+      remainingDailyUsd: z.number().nullable(),
+
+      limitWeeklyUsd: z.number().nullable(),
+      usedWeeklyUsd: z.number(),
+      remainingWeeklyUsd: z.number().nullable(),
+
+      limitMonthlyUsd: z.number().nullable(),
+      usedMonthlyUsd: z.number(),
+      remainingMonthlyUsd: z.number().nullable(),
+
+      limitTotalUsd: z.number().nullable(),
+      usedTotalUsd: z.number(),
+      remainingTotalUsd: z.number().nullable(),
+
+      quotaWindows: z.object({
+        fiveHour: myUsageQuotaWindowSchema,
+        daily: myUsageQuotaWindowSchema,
+        weekly: myUsageQuotaWindowSchema,
+        monthly: myUsageQuotaWindowSchema,
+        total: myUsageQuotaWindowSchema,
+      }),
+      todayUsedUsd: z.number().describe("按当前 Key 日限额窗口计算的已用金额"),
+      todayRemainingUsd: z.number().nullable().describe("按当前 Key 日限额窗口计算的剩余金额"),
+      todayUsedPercent: z.number().nullable().describe("按当前 Key 日限额窗口计算的已用百分比"),
+      todayRemainingPercent: z
+        .number()
+        .nullable()
+        .describe("按当前 Key 日限额窗口计算的剩余百分比"),
+      remainingPercent: z.number().nullable().describe("所有已配置金额限额中最少的剩余百分比"),
+
+      rpmLimit: z.number().nullable(),
+      concurrentSessions: z.number(),
+      concurrentSessionsLimit: z.number().nullable(),
+
+      userAllowedModels: z.array(z.string()),
+      userAllowedClients: z.array(z.string()),
+
       expiresAt: z.string().nullable(),
       dailyResetMode: z.enum(["fixed", "rolling"]),
       dailyResetTime: z.string(),
+      resetMode: z.enum(["fixed", "rolling"]),
+      resetTime: z.string(),
+      remaining: z.number().nullable(),
+      unit: z.literal("USD"),
     }),
     description: "获取当前会话的限额与当前使用量（仅返回自己的数据）",
     summary: "获取我的限额与用量",

--- a/tests/api/my-usage-readonly.test.ts
+++ b/tests/api/my-usage-readonly.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { keys, messageRequest, usageLedger, users } from "@/drizzle/schema";
 
@@ -349,6 +349,28 @@ describe.skipIf(!process.env.DSN)("my-usage API：只读 Key 自助查询", () =
     });
     createdKeyIds.push(readonlyKey.id);
 
+    await db
+      .update(users)
+      .set({
+        rpmLimit: 60,
+        dailyLimitUsd: "15",
+        limit5hUsd: "12",
+        limitWeeklyUsd: "25",
+        limitMonthlyUsd: "35",
+        providerGroup: "default",
+      })
+      .where(eq(users.id, user.id));
+
+    await db
+      .update(keys)
+      .set({
+        limit5hUsd: "10",
+        limitDailyUsd: "20",
+        limitWeeklyUsd: "30",
+        limitMonthlyUsd: "40",
+      })
+      .where(eq(keys.id, readonlyKey.id));
+
     const now = new Date();
     const msgId = await createMessage({
       userId: user.id,
@@ -373,6 +395,83 @@ describe.skipIf(!process.env.DSN)("my-usage API：只读 Key 自助查询", () =
     expect(stats.response.status).toBe(200);
     expect(stats.json).toMatchObject({ ok: true });
     expect((stats.json as any).data.calls).toBe(1);
+
+    const quota = await callActionsRoute({
+      method: "POST",
+      pathname: "/api/actions/my-usage/getMyQuota",
+      headers: { Authorization: currentAuthorization },
+      body: {},
+    });
+    expect(quota.response.status).toBe(200);
+    expect(quota.json).toMatchObject({ ok: true });
+
+    const quotaData = (quota.json as { ok: boolean; data: Record<string, unknown> }).data;
+    expect(quotaData.keyName).toBe(readonlyKey.name);
+    expect(quotaData.userName).toBe(user.name);
+    expect(quotaData.providerGroup).toBe("default");
+    expect(quotaData.keyIsEnabled).toBe(true);
+    expect(quotaData.userIsEnabled).toBe(true);
+    expect(quotaData.rpmLimit).toBe(60);
+    expect(quotaData.unit).toBe("USD");
+    expect(quotaData.remaining).toBeTypeOf("number");
+    expect(quotaData.remaining5hUsd).toBeTypeOf("number");
+    expect(quotaData.remainingDailyUsd).toBeTypeOf("number");
+    expect(quotaData.remainingWeeklyUsd).toBeTypeOf("number");
+    expect(quotaData.remainingMonthlyUsd).toBeTypeOf("number");
+    expect(quotaData.used5hUsd).toBeTypeOf("number");
+    expect(quotaData.usedDailyUsd).toBeTypeOf("number");
+    expect(quotaData.usedWeeklyUsd).toBeTypeOf("number");
+    expect(quotaData.usedMonthlyUsd).toBeTypeOf("number");
+    expect(quotaData.limit5hUsd).toBe(10);
+    expect(quotaData.limitDailyUsd).toBe(15);
+    expect(quotaData.limitWeeklyUsd).toBe(25);
+    expect(quotaData.limitMonthlyUsd).toBe(35);
+    expect(quotaData.limitTotalUsd).toBe(35);
+    expect(quotaData.todayUsedUsd).toBeCloseTo(0.01, 6);
+    expect(quotaData.todayRemainingUsd).toBeCloseTo(14.99, 6);
+    expect(quotaData.todayUsedPercent).toBeCloseTo(0.07, 6);
+    expect(quotaData.todayRemainingPercent).toBeCloseTo(99.93, 6);
+    expect(quotaData.remainingPercent).toBeCloseTo(99.9, 6);
+    expect(quotaData.quotaWindows).toMatchObject({
+      fiveHour: {
+        period: "5h",
+        limitUsd: 10,
+        usedUsd: 0.01,
+        remainingUsd: 9.99,
+        usedPercent: 0.1,
+        remainingPercent: 99.9,
+        isUnlimited: false,
+        isExhausted: false,
+      },
+      daily: {
+        period: "daily",
+        limitUsd: 15,
+        usedUsd: 0.01,
+        remainingUsd: 14.99,
+        usedPercent: 0.07,
+        remainingPercent: 99.93,
+        isUnlimited: false,
+        isExhausted: false,
+      },
+      weekly: {
+        period: "weekly",
+        limitUsd: 25,
+        usedUsd: 0.01,
+        remainingUsd: 24.99,
+      },
+      monthly: {
+        period: "monthly",
+        limitUsd: 35,
+        usedUsd: 0.01,
+        remainingUsd: 34.99,
+      },
+      total: {
+        period: "total",
+        limitUsd: 35,
+        usedUsd: 0.01,
+        remainingUsd: 34.99,
+      },
+    });
 
     // Issue #687 fix: getUsers 现在也支持 allowReadOnlyAccess
     const usersApi = await callActionsRoute({

--- a/tests/unit/actions/total-usage-semantics.test.ts
+++ b/tests/unit/actions/total-usage-semantics.test.ts
@@ -25,6 +25,7 @@ const sumUserQuotaCostsMock = vi.fn();
 const sumUserCostInTimeRangeMock = vi.fn();
 const getTimeRangeForPeriodMock = vi.fn();
 const getTimeRangeForPeriodWithModeMock = vi.fn();
+const getCurrentCostMock = vi.fn();
 const getKeySessionCountMock = vi.fn();
 const getUserSessionCountMock = vi.fn();
 const findUserByIdMock = vi.fn();
@@ -44,6 +45,12 @@ vi.mock("@/repository/statistics", () => ({
 vi.mock("@/lib/rate-limit/time-utils", () => ({
   getTimeRangeForPeriod: (...args: unknown[]) => getTimeRangeForPeriodMock(...args),
   getTimeRangeForPeriodWithMode: (...args: unknown[]) => getTimeRangeForPeriodWithModeMock(...args),
+}));
+
+vi.mock("@/lib/rate-limit/service", () => ({
+  RateLimitService: {
+    getCurrentCost: (...args: unknown[]) => getCurrentCostMock(...args),
+  },
 }));
 
 vi.mock("@/lib/session-tracker", () => ({
@@ -84,6 +91,7 @@ describe("total-usage-semantics", () => {
     // Default cost mocks
     sumUserTotalCostMock.mockResolvedValue(0);
     sumUserCostInTimeRangeMock.mockResolvedValue(0);
+    getCurrentCostMock.mockResolvedValue(0);
     getKeySessionCountMock.mockResolvedValue(0);
     getUserSessionCountMock.mockResolvedValue(0);
 
@@ -199,6 +207,230 @@ describe("total-usage-semantics", () => {
         ALL_TIME_MAX_AGE_DAYS,
         null
       );
+    });
+
+    it("should keep local usage API compatibility fields on getMyQuota", async () => {
+      getSessionMock.mockResolvedValue({
+        key: {
+          id: 1,
+          key: "test-key-hash",
+          name: "Test Key",
+          dailyResetTime: "00:00",
+          dailyResetMode: "fixed",
+          limit5hUsd: 10,
+          limitDailyUsd: 20,
+          limitWeeklyUsd: 30,
+          limitMonthlyUsd: 40,
+          limitTotalUsd: null,
+          limitConcurrentSessions: 3,
+          providerGroup: "default",
+          isEnabled: true,
+          expiresAt: null,
+        },
+        user: {
+          id: 1,
+          name: "Test User",
+          dailyResetTime: "00:00",
+          dailyResetMode: "fixed",
+          limit5hUsd: 12,
+          dailyQuota: 15,
+          limitWeeklyUsd: 25,
+          limitMonthlyUsd: 35,
+          limitTotalUsd: null,
+          limitConcurrentSessions: 2,
+          rpm: 60,
+          providerGroup: "default",
+          isEnabled: true,
+          expiresAt: null,
+          allowedModels: ["gpt-5.3-codex"],
+          allowedClients: ["codex-cli"],
+        },
+      });
+      sumKeyQuotaCostsByIdMock.mockResolvedValue({
+        cost5h: 2,
+        costDaily: 3,
+        costWeekly: 4,
+        costMonthly: 5,
+        costTotal: 6,
+      });
+      sumUserQuotaCostsMock.mockResolvedValue({
+        cost5h: 1,
+        costDaily: 2,
+        costWeekly: 3,
+        costMonthly: 4,
+        costTotal: 5,
+      });
+      getKeySessionCountMock.mockResolvedValue(1);
+      getUserSessionCountMock.mockResolvedValue(2);
+
+      const { getMyQuota } = await import("@/actions/my-usage");
+      const result = await getMyQuota();
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.data.providerGroup).toBe("default");
+      expect(result.data.userRpmLimit).toBe(60);
+      expect(result.data.rpmLimit).toBe(60);
+      expect(result.data.unit).toBe("USD");
+      expect(result.data.resetMode).toBe("fixed");
+      expect(result.data.resetTime).toBe("00:00");
+      expect(result.data.userAllowedModels).toEqual(["gpt-5.3-codex"]);
+      expect(result.data.userAllowedClients).toEqual(["codex-cli"]);
+      expect(result.data.limit5hUsd).toBe(10);
+      expect(result.data.used5hUsd).toBe(2);
+      expect(result.data.remaining5hUsd).toBe(8);
+      expect(result.data.limitDailyUsd).toBe(15);
+      expect(result.data.usedDailyUsd).toBe(2);
+      expect(result.data.remainingDailyUsd).toBe(13);
+      expect(result.data.limitWeeklyUsd).toBe(25);
+      expect(result.data.usedWeeklyUsd).toBe(3);
+      expect(result.data.remainingWeeklyUsd).toBe(22);
+      expect(result.data.limitMonthlyUsd).toBe(35);
+      expect(result.data.usedMonthlyUsd).toBe(4);
+      expect(result.data.remainingMonthlyUsd).toBe(31);
+      expect(result.data.limitTotalUsd).toBe(35);
+      expect(result.data.usedTotalUsd).toBe(5);
+      expect(result.data.remainingTotalUsd).toBe(30);
+      expect(result.data.remaining).toBe(8);
+      expect(result.data.remainingPercent).toBeCloseTo(80, 6);
+      expect(result.data.concurrentSessions).toBe(2);
+      expect(result.data.concurrentSessionsLimit).toBe(3);
+      expect(result.data.todayUsedUsd).toBe(result.data.quotaWindows.daily.usedUsd);
+      expect(result.data.todayRemainingUsd).toBe(result.data.quotaWindows.daily.remainingUsd);
+      expect(result.data.todayUsedPercent).toBe(result.data.quotaWindows.daily.usedPercent);
+      expect(result.data.todayRemainingPercent).toBe(
+        result.data.quotaWindows.daily.remainingPercent
+      );
+      expect(result.data.quotaWindows.fiveHour).toMatchObject({
+        period: "5h",
+        limitUsd: 10,
+        usedUsd: 2,
+        remainingUsd: 8,
+        isUnlimited: false,
+        isExhausted: false,
+      });
+      expect(result.data.quotaWindows.daily).toMatchObject({
+        period: "daily",
+        limitUsd: 15,
+        usedUsd: 2,
+        remainingUsd: 13,
+        isUnlimited: false,
+        isExhausted: false,
+      });
+      expect(result.data.quotaWindows.weekly).toMatchObject({
+        period: "weekly",
+        limitUsd: 25,
+        usedUsd: 3,
+        remainingUsd: 22,
+        isUnlimited: false,
+        isExhausted: false,
+      });
+      expect(result.data.quotaWindows.monthly).toMatchObject({
+        period: "monthly",
+        limitUsd: 35,
+        usedUsd: 4,
+        remainingUsd: 31,
+        isUnlimited: false,
+        isExhausted: false,
+      });
+      expect(result.data.quotaWindows.total).toMatchObject({
+        period: "total",
+        limitUsd: 35,
+        usedUsd: 5,
+        remainingUsd: 30,
+        isUnlimited: false,
+        isExhausted: false,
+      });
+    });
+
+    it("should treat zero quota limits as unlimited in compatibility fields", async () => {
+      getSessionMock.mockResolvedValue({
+        key: {
+          id: 1,
+          key: "test-key-hash",
+          name: "Test Key",
+          dailyResetTime: "00:00",
+          dailyResetMode: "fixed",
+          limit5hUsd: 0,
+          limitDailyUsd: 0,
+          limitWeeklyUsd: 0,
+          limitMonthlyUsd: 0,
+          limitTotalUsd: 0,
+          limitConcurrentSessions: 0,
+          providerGroup: null,
+          isEnabled: true,
+          expiresAt: null,
+        },
+        user: {
+          id: 1,
+          name: "Test User",
+          dailyResetTime: "00:00",
+          dailyResetMode: "fixed",
+          limit5hUsd: 0,
+          dailyQuota: 0,
+          limitWeeklyUsd: 0,
+          limitMonthlyUsd: 0,
+          limitTotalUsd: 0,
+          limitConcurrentSessions: 0,
+          rpm: null,
+          providerGroup: null,
+          isEnabled: true,
+          expiresAt: null,
+          allowedModels: [],
+          allowedClients: [],
+        },
+      });
+      sumKeyQuotaCostsByIdMock.mockResolvedValue({
+        cost5h: 2,
+        costDaily: 3,
+        costWeekly: 4,
+        costMonthly: 5,
+        costTotal: 6,
+      });
+      sumUserQuotaCostsMock.mockResolvedValue({
+        cost5h: 1,
+        costDaily: 2,
+        costWeekly: 3,
+        costMonthly: 4,
+        costTotal: 5,
+      });
+
+      const { getMyQuota } = await import("@/actions/my-usage");
+      const result = await getMyQuota();
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.data.limit5hUsd).toBeNull();
+      expect(result.data.limitDailyUsd).toBeNull();
+      expect(result.data.limitWeeklyUsd).toBeNull();
+      expect(result.data.limitMonthlyUsd).toBeNull();
+      expect(result.data.limitTotalUsd).toBeNull();
+      expect(result.data.remaining).toBeNull();
+      expect(result.data.remainingPercent).toBeNull();
+      expect(result.data.todayRemainingUsd).toBeNull();
+      expect(result.data.todayUsedPercent).toBeNull();
+      expect(result.data.todayRemainingPercent).toBeNull();
+      expect(result.data.concurrentSessionsLimit).toBeNull();
+      expect(result.data.quotaWindows.fiveHour).toMatchObject({
+        limitUsd: null,
+        usedUsd: 2,
+        remainingUsd: null,
+        usedPercent: null,
+        remainingPercent: null,
+        isUnlimited: true,
+        isExhausted: false,
+      });
+      expect(result.data.quotaWindows.daily).toMatchObject({
+        limitUsd: null,
+        usedUsd: 3,
+        remainingUsd: null,
+        usedPercent: null,
+        remainingPercent: null,
+        isUnlimited: true,
+        isExhausted: false,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

This PR extends the existing self-service `my-usage/getMyQuota` action response with compatibility fields for external quota checkers and ccswitch-style clients.

It does not add a new public quota endpoint. The route remains:

- `POST /api/actions/my-usage/getMyQuota`
- `Authorization: Bearer <api key>`
- Request body: `{}`
- Existing `allowReadOnlyAccess` auth path

## Problem

External quota checkers and ccswitch-style clients needed a standardized way to consume quota data from Claude Code Hub. The existing `getMyQuota` response lacked structured window data and flat compatibility aliases that these tools expect.

## Solution

Added comprehensive compatibility fields to the `getMyQuota` response while maintaining backward compatibility with existing clients.

### Core Changes

**src/actions/my-usage.ts** (+249 lines)
- Added `MyUsageQuotaWindow` interface with structured quota window data
- Added helper functions for quota calculations:
  - `normalizeQuotaLimit()` - treats 0/negative limits as unlimited
  - `resolveEffectiveQuotaWindow()` - finds most restrictive limit between key and user
  - `resolveOverallRemaining()` - calculates overall remaining across all windows
  - `buildQuotaWindow()` - constructs standardized window objects
- Added new response fields:
  - Structured `quotaWindows` object with `fiveHour`, `daily`, `weekly`, `monthly`, `total`
  - Flat compatibility aliases: `remaining`, `remaining5hUsd`, `todayRemainingUsd`, `remainingPercent`
  - Rate/session limits: `rpmLimit`, `concurrentSessions`, `concurrentSessionsLimit`
  - Metadata fields: `providerGroup`, `resetMode`, `resetTime`, `unit`
- Total limit now falls back to monthly quota when no explicit total quota is set

**src/app/api/actions/[...route]/route.ts** (+61 lines)
- Added Zod schema for `myUsageQuotaWindowSchema`
- Extended OpenAPI response schema with all new compatibility fields

**docs/examples/api-key-quota-extractor-compatible.js** (new file)
- Node.js extractor template for ccswitch-style quota checks
- Provides `normalizeQuotaResponse()` function for client-side normalization
- Includes both direct usage and ccswitch template export modes

**docs/usage-only-quota-extractor.md** (new file)
- Documentation for the minimal compatibility path
- Response field reference
- Usage examples

**tests/unit/actions/total-usage-semantics.test.ts** (+232 lines)
- Unit tests for compatibility fields on `getMyQuota`
- Tests for zero-quota-as-unlimited semantics

**tests/api/my-usage-readonly.test.ts** (+100 lines)
- Integration tests for read-only key quota queries
- Verifies all new response fields are populated correctly

## Breaking Changes

None. All changes are backward compatible:
- Existing fields remain unchanged
- New fields are additive only
- Zero/negative limits treated as unlimited (matches existing enforcement semantics)

## Testing

### Automated Tests
- [x] Unit tests added in `tests/unit/actions/total-usage-semantics.test.ts`
- [x] Integration tests added in `tests/api/my-usage-readonly.test.ts`

### Manual Verification
```bash
# Syntax check
node --check docs/examples/api-key-quota-extractor-compatible.js

# Unit tests
pnpm exec vitest run tests/unit/actions/total-usage-semantics.test.ts --reporter=verbose

# API integrity tests
pnpm exec vitest run tests/api/api-actions-integrity.test.ts --reporter=verbose

# Type checking
pnpm typecheck
```

### Example Response
The enhanced response now includes:
```json
{
  "ok": true,
  "data": {
    "remaining": 7.5,
    "todayRemainingUsd": 2.25,
    "remainingPercent": 85.0,
    "quotaWindows": {
      "daily": { "remainingUsd": 2.25, "usedUsd": 0.75, "limitUsd": 3.0, ... },
      "total": { "remainingUsd": 7.5, "usedUsd": 2.5, "limitUsd": 10.0, ... }
    },
    "rpmLimit": 60,
    "concurrentSessions": 2,
    "concurrentSessionsLimit": 5,
    "unit": "USD"
  }
}
```

## Security Notes

- Extractor uses existing action wrapper shape (`{ ok, data }`)
- Does not accept API keys in request bodies
- Sends API key only through Bearer token header
- Uses existing `allowReadOnlyAccess` authorization gate

## Checklist

- [x] Code follows project conventions (Biome formatting)
- [x] Self-review completed
- [x] Unit tests pass
- [x] Type checking passes
- [x] Documentation added (examples + usage guide)
- [x] Backward compatibility maintained
- [x] No breaking changes

---
*Original PR by @dofastted*  
*Description enhanced with additional structure for reviewer clarity*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing `getMyQuota` action response with structured `quotaWindows` objects and flat compatibility aliases (`remaining`, `todayRemainingUsd`, `remainingPercent`, `rpmLimit`, concurrency fields, etc.) for ccswitch-style clients, without adding a new endpoint or auth surface.

- Adds `MyUsageQuotaWindow` interface and five quota windows (`fiveHour`, `daily`, `weekly`, `monthly`, `total`) computed via `resolveEffectiveQuotaWindow`, which picks the most-restrictive key/user candidate per period.
- Adds flat alias fields and backfills previously missing Zod schema declarations for `userRpmLimit`, `userAllowedModels`, and `userAllowedClients`.
- Silently changes the semantics of the existing `keyLimitTotalUsd` and `userLimitTotalUsd` fields by falling back to the monthly limit when no total limit is set, and exposes `concurrentSessions` as `Math.max(keyConcurrent, userKeyConcurrent)`, which may reflect sessions from other keys.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Hold for the two logic issues in src/actions/my-usage.ts before merging.

The core quota-window computation logic is well-structured and the new fields are thoroughly tested. However, two issues in my-usage.ts need resolution: the keyLimitTotalUsd/userLimitTotalUsd fields now silently return the monthly limit as a fallback, changing the meaning of existing API fields that ccswitch-style clients may use to detect whether a total quota is configured. Additionally, concurrentSessions is computed as Math.max(keyConcurrent, userKeyConcurrent), where userKeyConcurrent tracks sessions across all keys for the user — this can inflate the displayed value relative to concurrentSessionsLimit, which is a key-level limit.

src/actions/my-usage.ts — the resolveTotalLimitWithMonthlyFallback usage and the concurrentSessions derivation both warrant a closer look before this ships.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/actions/my-usage.ts | Adds quota window computation logic and 20+ new compatibility fields; introduces a semantic break to the existing keyLimitTotalUsd/userLimitTotalUsd fields (monthly fallback) and a potentially misleading concurrentSessions value derived from cross-key session counts. |
| src/app/api/actions/[...route]/route.ts | Adds the new quota fields and myUsageQuotaWindowSchema to the OpenAPI/Zod response schema; also backfills previously missing userRpmLimit, userAllowedModels, and userAllowedClients schema declarations. |
| docs/examples/api-key-quota-extractor-compatible.js | New Node.js example/ccswitch-template; normalizes response fields with safe fallbacks and does not accept API keys in request bodies. |
| tests/api/my-usage-readonly.test.ts | Extends the read-only API integration test with limit/usage assertions for the new quota fields; limitTotalUsd asserted as 35 confirms the intentional monthly fallback behavior. |
| tests/unit/actions/total-usage-semantics.test.ts | Adds unit tests for new compatibility fields and the zero-limit-as-unlimited semantics; mocks are well-isolated. |
| docs/usage-only-quota-extractor.md | Documentation-only file; accurately describes the endpoint, auth mechanism, and new response fields. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as ccswitch / CLI client
    participant Route as POST /api/actions/my-usage/getMyQuota
    participant Action as getMyQuota() action
    participant DB as DB / SessionTracker

    Client->>Route: Bearer apiKey, body: {}
    Route->>Action: allowReadOnlyAccess auth path
    Action->>DB: sumKeyQuotaCostsById, sumUserQuotaCosts
    Action->>DB: SessionTracker.getKeySessionCount(key.id)
    Action->>DB: getUserConcurrentSessions(user.id)
    DB-->>Action: costs, keyConcurrent, userKeyConcurrent
    Action->>Action: resolveEffectiveQuotaWindow (5h/daily/weekly/monthly/total)
    Action->>Action: buildQuotaWindow x5 -> quotaWindows
    Action->>Action: resolveOverallRemaining -> remaining
    Action->>Action: Math.max(keyConcurrent, userKeyConcurrent) -> concurrentSessions
    Action-->>Route: ok, data: MyUsageQuota
    Route-->>Client: ok true, data with remaining, quotaWindows
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/actions/my-usage.ts`, line 516-517 ([link](https://github.com/ding113/claude-code-hub/blob/25eeeb7cc6c412a5b6440832c69a497f30eb94e5/src/actions/my-usage.ts#L516-L517)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Breaking semantic change to `keyLimitTotalUsd` / `userLimitTotalUsd`**

   These two existing response fields previously returned `key.limitTotalUsd ?? null` and `user.limitTotalUsd ?? null`, giving `null` whenever no explicit total quota was configured. After this PR they return the monthly limit as a fallback. Any client that checks `keyLimitTotalUsd === null` to detect "no total quota set" — including ccswitch-style consumers this PR targets — will now silently receive a non-null number for every user who has a monthly limit but no total limit, causing them to enforce a total cap that was never intended.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/actions/my-usage.ts
   Line: 516-517

   Comment:
   **Breaking semantic change to `keyLimitTotalUsd` / `userLimitTotalUsd`**

   These two existing response fields previously returned `key.limitTotalUsd ?? null` and `user.limitTotalUsd ?? null`, giving `null` whenever no explicit total quota was configured. After this PR they return the monthly limit as a fallback. Any client that checks `keyLimitTotalUsd === null` to detect "no total quota set" — including ccswitch-style consumers this PR targets — will now silently receive a non-null number for every user who has a monthly limit but no total limit, causing them to enforce a total cap that was never intended.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/actions/my-usage.ts:516-517
**Breaking semantic change to `keyLimitTotalUsd` / `userLimitTotalUsd`**

These two existing response fields previously returned `key.limitTotalUsd ?? null` and `user.limitTotalUsd ?? null`, giving `null` whenever no explicit total quota was configured. After this PR they return the monthly limit as a fallback. Any client that checks `keyLimitTotalUsd === null` to detect "no total quota set" — including ccswitch-style consumers this PR targets — will now silently receive a non-null number for every user who has a monthly limit but no total limit, causing them to enforce a total cap that was never intended.

### Issue 2 of 2
src/actions/my-usage.ts:685-687
**`concurrentSessions` may reflect sessions from other keys**

`keyConcurrent` comes from `SessionTracker.getKeySessionCount(key.id)` (sessions on this key only), while `userKeyConcurrent` comes from `getUserConcurrentSessions(user.id)` (sessions for the user, potentially across all keys). `Math.max(keyConcurrent, userKeyConcurrent)` means that when a user has active sessions on other keys, the displayed `concurrentSessions` value will exceed this key's actual session count. Since `concurrentSessionsLimit` is derived from key-level and user-level limit config, a consumer comparing `concurrentSessions` against `concurrentSessionsLimit` will see inflated utilization and potentially believe the quota is more consumed than it is for this specific key.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(my-usage): expose quota compatibili..."](https://github.com/ding113/claude-code-hub/commit/25eeeb7cc6c412a5b6440832c69a497f30eb94e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30817298)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->