### PR TITLE
fix(providers): 修复供应商统一测试前端无法展示后端返回结果

### DIFF
--- a/src/lib/api-client/v1/actions/providers.ts
+++ b/src/lib/api-client/v1/actions/providers.ts
@@ -185,7 +185,7 @@ export function testProviderGemini(data: unknown) {
 }
 
 export function testProviderUnified(data: unknown) {
-  return apiPost("/api/v1/providers/test:unified", data, dashboardCompatOptions);
+  return toActionResult(apiPost("/api/v1/providers/test:unified", data, dashboardCompatOptions));
 }
 
 export function getProviderTestPresets(providerType: string) {


### PR DESCRIPTION
## Summary

- `src/lib/api-client/v1/actions/providers.ts` 的 `testProviderUnified` 是同文件里唯一漏写 `toActionResult(...)` 包装的 `test*` 函数(应该是 #1140 v1 REST 重构时遗漏)。
- 后端 handler 经 `actionJson()` 把 `{ok,data}` 剥离为裸 body,前端 `api-test-button.tsx` 仍按 ActionResult 解构 → `response.ok` 永远是 `undefined` → 直接走失败分支提前 `return`,导致**无论后端返回什么,Toast 都显示"测试失败"且 `TestResultCard` 永不渲染**。
- 修复:与同文件其他 `testProviderXxx`(Anthropic / OpenAI Chat / OpenAI Responses / Gemini / Proxy)一致,加上 `toActionResult` 包装。

修改一行,前端调用方与结果卡片组件无须改动。

## Test plan

- [x] `bun run typecheck` 通过
- [x] `bun run lint` 无新增告警(预存在的 8 个 warnings 在 `tests/unit/proxy/response-handler-bill-non-success.test.ts`,与本次无关)
- [x] `bunx vitest run tests/unit/settings/providers/api-test-button.test.tsx` 9/9 通过
- [ ] 手动验证 `bun run dev` 后:
  - [ ] 成功路径(可用供应商):Toast 绿色"测试成功" + 模型/延迟,`TestResultCard` 展示三层校验、`requestUrl`、详情对话框可看 `rawResponse`
  - [ ] 401/403 路径:Toast 红色"测试失败" + `message`,`TestResultCard` 仍渲染并展示 `httpStatusCode: 403` / `subStatus: auth_error` / `requestUrl` / 原始 403 响应文本
  - [ ] 网络超时:`TestResultCard` 显示 `network_error` 详情
  - [ ] Gemini 路径(走 `testProviderGemini` 分支)继续工作正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a one-line omission in `src/lib/api-client/v1/actions/providers.ts` where `testProviderUnified` was the only `testProvider*` function not wrapped with `toActionResult`. Without the wrapper the frontend received a raw fetch body instead of an `ActionResult` shape, causing `response.ok` to always be `undefined` and every unified-test invocation to silently show "test failed" regardless of the actual backend result.

- `testProviderUnified` now wraps `apiPost(...)` with `toActionResult(...)`, matching the pattern used by `testProviderProxy`, `testProviderAnthropicMessages`, `testProviderOpenAIChatCompletions`, `testProviderOpenAIResponses`, and `testProviderGemini`.
- No callers or UI components required changes; the fix is purely on the API-client layer.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single-line addition of an already-imported wrapper that every other test function in the file already uses.

The fix is minimal, targeted, and directly verifiable by inspection: adding `toActionResult(...)` around the `apiPost` call in `testProviderUnified` matches the exact pattern used by the five sibling functions above it. No callers change, no new logic is introduced, and the existing unit tests (9/9 passing) cover the affected path.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/api-client/v1/actions/providers.ts | Added missing `toActionResult` wrapper to `testProviderUnified`, making it consistent with all other `testProvider*` functions in the file and fixing the silent failure on the unified test path. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as api-test-button.tsx
    participant Client as providers.ts (testProviderUnified)
    participant Compat as toActionResult (_compat.ts)
    participant API as /api/v1/providers/test:unified
    participant Handler as actionJson() backend handler

    UI->>Client: testProviderUnified(data)
    Client->>API: apiPost(...)
    API->>Handler: HTTP POST
    Handler-->>API: raw body (ok+data stripped)
    API-->>Compat: Promise raw body
    Compat-->>Client: ActionResult { ok, data }
    Client-->>UI: ActionResult
    UI->>UI: response.ok branch to success/failure toast + TestResultCard
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(providers): wrap unified test api-cl..."](https://github.com/ding113/claude-code-hub/commit/757d79bf0f463dc433c1d6e3f73a61f2f1792f6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30854930)</sub>

<!-- /greptile_comment -->