### PR TITLE
fix(proxy): 1h TTL override 覆盖顶层 system 字段并补齐单测

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -324,47 +324,74 @@ function resolveCacheTtlPreference(
   return normalize(keyPref) ?? normalize(providerPref) ?? null;
 }
 
-function applyCacheTtlOverrideToMessage(
+function applyTtlToContentBlocks(
+  blocks: unknown[],
+  ttl: CacheTtlResolved
+): { blocks: unknown[]; applied: boolean } {
+  let applied = false;
+  const next = blocks.map((item) => {
+    if (!item || typeof item !== "object") return item;
+    const itemObj = item as Record<string, unknown>;
+    const cacheControl = itemObj.cache_control;
+    if (!cacheControl || typeof cacheControl !== "object") return item;
+    const ccObj = cacheControl as Record<string, unknown>;
+    if (ccObj.type !== "ephemeral") return item;
+    applied = true;
+    return {
+      ...itemObj,
+      cache_control: {
+        ...ccObj,
+        ttl: ttl === "1h" ? "1h" : "5m",
+      },
+    };
+  });
+  return { blocks: next, applied };
+}
+
+export function applyCacheTtlOverrideToMessage(
   message: Record<string, unknown>,
   ttl: CacheTtlResolved
 ): boolean {
   let applied = false;
-  const messages = (message as Record<string, unknown>).messages;
 
-  if (!Array.isArray(messages)) {
-    return applied;
+  // 顶层 system 字段:可能是 string(忽略)或内容块数组
+  const system = message.system;
+  if (Array.isArray(system)) {
+    const result = applyTtlToContentBlocks(system, ttl);
+    message.system = result.blocks;
+    applied = applied || result.applied;
   }
 
-  for (const msg of messages) {
-    if (!msg || typeof msg !== "object") continue;
-    const msgObj = msg as Record<string, unknown>;
-    const content = msgObj.content;
-
-    if (!Array.isArray(content)) continue;
-
-    msgObj.content = content.map((item) => {
-      if (!item || typeof item !== "object") return item;
-      const itemObj = item as Record<string, unknown>;
-      const cacheControl = itemObj.cache_control;
-
-      if (cacheControl && typeof cacheControl === "object") {
-        const ccObj = cacheControl as Record<string, unknown>;
-        if (ccObj.type === "ephemeral") {
-          applied = true;
-          return {
-            ...itemObj,
-            cache_control: {
-              ...ccObj,
-              ttl: ttl === "1h" ? "1h" : "5m",
-            },
-          };
-        }
-      }
-      return item;
-    });
+  // messages[].content[]
+  const messages = message.messages;
+  if (Array.isArray(messages)) {
+    for (const msg of messages) {
+      if (!msg || typeof msg !== "object") continue;
+      const msgObj = msg as Record<string, unknown>;
+      const content = msgObj.content;
+      if (!Array.isArray(content)) continue;
+      const result = applyTtlToContentBlocks(content, ttl);
+      msgObj.content = result.blocks;
+      applied = applied || result.applied;
+    }
   }
 
   return applied;
+}
+
+export function mergeAnthropicCacheTtlBetaFlag(existing: string | null | undefined): string {
+  const betaFlags = new Set(
+    (existing ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+  betaFlags.add("extended-cache-ttl-2025-04-11");
+  // 确保包含基础的 prompt-caching 标记
+  if (betaFlags.size === 1) {
+    betaFlags.add("prompt-caching-2024-07-31");
+  }
+  return Array.from(betaFlags).join(", ");
 }
 
 function clampRetryAttempts(value: number): number {
@@ -4639,19 +4666,9 @@ export class ProxyForwarder {
 
     // 针对 1h 缓存 TTL，补充 Anthropic beta header（避免客户端遗漏）
     if (session.getCacheTtlResolved && session.getCacheTtlResolved() === "1h") {
-      const existingBeta = session.headers.get("anthropic-beta") || "";
-      const betaFlags = new Set(
-        existingBeta
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean)
+      overrides["anthropic-beta"] = mergeAnthropicCacheTtlBetaFlag(
+        session.headers.get("anthropic-beta")
       );
-      betaFlags.add("extended-cache-ttl-2025-04-11");
-      // 确保包含基础的 prompt-caching 标记
-      if (betaFlags.size === 1) {
-        betaFlags.add("prompt-caching-2024-07-31");
-      }
-      overrides["anthropic-beta"] = Array.from(betaFlags).join(", ");
     }
 
     const headerProcessor = HeaderProcessor.createForProxy({

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -355,11 +355,14 @@ export function applyCacheTtlOverrideToMessage(
   let applied = false;
 
   // 顶层 system 字段:可能是 string(忽略)或内容块数组
+  // 仅在确有命中时回写,避免 .map() 额外分配的新数组替换原引用
   const system = message.system;
   if (Array.isArray(system)) {
     const result = applyTtlToContentBlocks(system, ttl);
-    message.system = result.blocks;
-    applied = applied || result.applied;
+    if (result.applied) {
+      message.system = result.blocks;
+      applied = true;
+    }
   }
 
   // messages[].content[]
@@ -371,8 +374,10 @@ export function applyCacheTtlOverrideToMessage(
       const content = msgObj.content;
       if (!Array.isArray(content)) continue;
       const result = applyTtlToContentBlocks(content, ttl);
-      msgObj.content = result.blocks;
-      applied = applied || result.applied;
+      if (result.applied) {
+        msgObj.content = result.blocks;
+        applied = true;
+      }
     }
   }
 

--- a/tests/unit/proxy/cache-ttl-override.test.ts
+++ b/tests/unit/proxy/cache-ttl-override.test.ts
@@ -91,19 +91,23 @@ describe("applyCacheTtlOverrideToMessage", () => {
     expect(msgs[0].content[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
-  it("returns false and mutates nothing when there are no ephemeral breakpoints", () => {
+  it("returns false and preserves reference identity when there are no ephemeral breakpoints", () => {
+    const originalSystem = [{ type: "text", text: "no cache" }];
+    const originalMessageContent = [{ type: "text", text: "no cache here either" }];
     const message: Record<string, unknown> = {
-      system: [{ type: "text", text: "no cache" }],
-      messages: [{ role: "user", content: [{ type: "text", text: "no cache here either" }] }],
+      system: originalSystem,
+      messages: [{ role: "user", content: originalMessageContent }],
     };
 
     const applied = applyCacheTtlOverrideToMessage(message, "1h");
 
     expect(applied).toBe(false);
-    expect(message.system).toEqual([{ type: "text", text: "no cache" }]);
-    expect(message.messages).toEqual([
-      { role: "user", content: [{ type: "text", text: "no cache here either" }] },
-    ]);
+    // Reference identity should be preserved on the no-op path so downstream
+    // consumers that diff by reference (e.g. dirty-checking) don't see false positives.
+    expect(message.system).toBe(originalSystem);
+    expect((message.messages as Array<{ content: unknown }>)[0].content).toBe(
+      originalMessageContent
+    );
   });
 
   it("downgrades existing 1h ttl to 5m when override resolves to 5m", () => {
@@ -224,6 +228,20 @@ describe("mergeAnthropicCacheTtlBetaFlag", () => {
     const merged = mergeAnthropicCacheTtlBetaFlag(
       "extended-cache-ttl-2025-04-11, prompt-caching-2024-07-31"
     );
+    const flags = merged.split(",").map((s) => s.trim());
+    expect(flags).toEqual(
+      expect.arrayContaining(["extended-cache-ttl-2025-04-11", "prompt-caching-2024-07-31"])
+    );
+    expect(flags).toHaveLength(2);
+  });
+
+  it("preserves the size===1 backfill quirk when client only sent extended-cache-ttl-2025-04-11", () => {
+    // Document existing behavior: when the client sends only the extended-cache-ttl
+    // beta flag, after our `add()` (no-op) the set still has size 1, so the helper
+    // backfills `prompt-caching-2024-07-31` even though the client did not include it.
+    // This mirrors the inlined logic that pre-dated this refactor; preserved here so a
+    // future refactor that changes the contract has to update the test deliberately.
+    const merged = mergeAnthropicCacheTtlBetaFlag("extended-cache-ttl-2025-04-11");
     const flags = merged.split(",").map((s) => s.trim());
     expect(flags).toEqual(
       expect.arrayContaining(["extended-cache-ttl-2025-04-11", "prompt-caching-2024-07-31"])

--- a/tests/unit/proxy/cache-ttl-override.test.ts
+++ b/tests/unit/proxy/cache-ttl-override.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyCacheTtlOverrideToMessage,
+  mergeAnthropicCacheTtlBetaFlag,
+} from "@/app/v1/_lib/proxy/forwarder";
+
+describe("applyCacheTtlOverrideToMessage", () => {
+  it("rewrites ttl on top-level system content blocks with ephemeral cache_control", () => {
+    const message: Record<string, unknown> = {
+      system: [
+        {
+          type: "text",
+          text: "system prompt",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [],
+    };
+
+    const applied = applyCacheTtlOverrideToMessage(message, "1h");
+
+    expect(applied).toBe(true);
+    expect(message.system).toEqual([
+      {
+        type: "text",
+        text: "system prompt",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      },
+    ]);
+  });
+
+  it("leaves a string-form system field untouched", () => {
+    const message: Record<string, unknown> = {
+      system: "you are helpful",
+      messages: [],
+    };
+
+    const applied = applyCacheTtlOverrideToMessage(message, "1h");
+
+    expect(applied).toBe(false);
+    expect(message.system).toBe("you are helpful");
+  });
+
+  it("rewrites ttl on messages[].content[] ephemeral blocks (existing behavior)", () => {
+    const message: Record<string, unknown> = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "hello",
+              cache_control: { type: "ephemeral" },
+            },
+          ],
+        },
+      ],
+    };
+
+    const applied = applyCacheTtlOverrideToMessage(message, "1h");
+
+    expect(applied).toBe(true);
+    const messages = message.messages as Array<{
+      content: Array<{ cache_control: Record<string, unknown> }>;
+    }>;
+    expect(messages[0].content[0].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+  });
+
+  it("rewrites both system and messages breakpoints in a single pass", () => {
+    const message: Record<string, unknown> = {
+      system: [{ type: "text", text: "sys", cache_control: { type: "ephemeral" } }],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "u", cache_control: { type: "ephemeral" } }],
+        },
+      ],
+    };
+
+    const applied = applyCacheTtlOverrideToMessage(message, "1h");
+
+    expect(applied).toBe(true);
+    const sys = message.system as Array<{ cache_control: Record<string, unknown> }>;
+    const msgs = message.messages as Array<{
+      content: Array<{ cache_control: Record<string, unknown> }>;
+    }>;
+    expect(sys[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(msgs[0].content[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  it("returns false and mutates nothing when there are no ephemeral breakpoints", () => {
+    const message: Record<string, unknown> = {
+      system: [{ type: "text", text: "no cache" }],
+      messages: [{ role: "user", content: [{ type: "text", text: "no cache here either" }] }],
+    };
+
+    const applied = applyCacheTtlOverrideToMessage(message, "1h");
+
+    expect(applied).toBe(false);
+    expect(message.system).toEqual([{ type: "text", text: "no cache" }]);
+    expect(message.messages).toEqual([
+      { role: "user", content: [{ type: "text", text: "no cache here either" }] },
+    ]);
+  });
+
+  it("downgrades existing 1h ttl to 5m when override resolves to 5m", () => {
+    const message: Record<string, unknown> = {
+      system: [
+        {
+          type: "text",
+          text: "sys",
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "u",
+              cache_control: { type: "ephemeral", ttl: "1h" },
+            },
+          ],
+        },
+      ],
+    };
+
+    const applied = applyCacheTtlOverrideToMessage(message, "5m");
+
+    expect(applied).toBe(true);
+    const sys = message.system as Array<{ cache_control: Record<string, unknown> }>;
+    const msgs = message.messages as Array<{
+      content: Array<{ cache_control: Record<string, unknown> }>;
+    }>;
+    expect(sys[0].cache_control).toEqual({ type: "ephemeral", ttl: "5m" });
+    expect(msgs[0].content[0].cache_control).toEqual({ type: "ephemeral", ttl: "5m" });
+  });
+
+  it("ignores non-ephemeral cache_control entries and non-object cache_control", () => {
+    const message: Record<string, unknown> = {
+      system: [
+        // unknown cache_control type — must not be modified
+        {
+          type: "text",
+          text: "sys",
+          cache_control: { type: "persistent" },
+        },
+        // cache_control as a non-object — must not crash and must not mark applied
+        { type: "text", text: "weird", cache_control: "ephemeral" },
+      ],
+      messages: [],
+    };
+
+    const applied = applyCacheTtlOverrideToMessage(message, "1h");
+
+    expect(applied).toBe(false);
+    const sys = message.system as Array<Record<string, unknown>>;
+    expect(sys[0].cache_control).toEqual({ type: "persistent" });
+    expect(sys[1].cache_control).toBe("ephemeral");
+  });
+
+  it("handles missing system / messages gracefully", () => {
+    const message: Record<string, unknown> = {};
+    const applied = applyCacheTtlOverrideToMessage(message, "1h");
+    expect(applied).toBe(false);
+    expect(message).toEqual({});
+  });
+
+  it("preserves other fields on the content block when rewriting cache_control", () => {
+    const message: Record<string, unknown> = {
+      system: [
+        {
+          type: "text",
+          text: "sys",
+          extraField: "keepme",
+          cache_control: { type: "ephemeral", customExt: "x" },
+        },
+      ],
+      messages: [],
+    };
+
+    applyCacheTtlOverrideToMessage(message, "1h");
+
+    const sys = message.system as Array<Record<string, unknown>>;
+    expect(sys[0]).toEqual({
+      type: "text",
+      text: "sys",
+      extraField: "keepme",
+      cache_control: { type: "ephemeral", customExt: "x", ttl: "1h" },
+    });
+  });
+});
+
+describe("mergeAnthropicCacheTtlBetaFlag", () => {
+  it("adds extended-cache-ttl + prompt-caching when no existing beta is present", () => {
+    const merged = mergeAnthropicCacheTtlBetaFlag(null);
+    const flags = merged.split(",").map((s) => s.trim());
+    expect(flags).toEqual(
+      expect.arrayContaining(["extended-cache-ttl-2025-04-11", "prompt-caching-2024-07-31"])
+    );
+    expect(flags).toHaveLength(2);
+  });
+
+  it("treats undefined and empty string identically to null", () => {
+    expect(mergeAnthropicCacheTtlBetaFlag(undefined)).toBe(mergeAnthropicCacheTtlBetaFlag(null));
+    expect(mergeAnthropicCacheTtlBetaFlag("")).toBe(mergeAnthropicCacheTtlBetaFlag(null));
+  });
+
+  it("appends extended-cache-ttl to existing beta and skips prompt-caching backfill", () => {
+    const merged = mergeAnthropicCacheTtlBetaFlag("messages-2023-12-15");
+    const flags = merged.split(",").map((s) => s.trim());
+    expect(flags).toContain("messages-2023-12-15");
+    expect(flags).toContain("extended-cache-ttl-2025-04-11");
+    // size > 1 path: prompt-caching-2024-07-31 should NOT be auto-added
+    expect(flags).not.toContain("prompt-caching-2024-07-31");
+    expect(flags).toHaveLength(2);
+  });
+
+  it("dedupes when extended-cache-ttl is already present", () => {
+    const merged = mergeAnthropicCacheTtlBetaFlag(
+      "extended-cache-ttl-2025-04-11, prompt-caching-2024-07-31"
+    );
+    const flags = merged.split(",").map((s) => s.trim());
+    expect(flags).toEqual(
+      expect.arrayContaining(["extended-cache-ttl-2025-04-11", "prompt-caching-2024-07-31"])
+    );
+    expect(flags).toHaveLength(2);
+  });
+
+  it("trims whitespace and ignores empty segments in the existing header", () => {
+    const merged = mergeAnthropicCacheTtlBetaFlag("  ,  messages-2023-12-15  ,  ");
+    const flags = merged.split(",").map((s) => s.trim());
+    expect(flags).toContain("messages-2023-12-15");
+    expect(flags).toContain("extended-cache-ttl-2025-04-11");
+    expect(flags).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes an incomplete cache TTL override that only processed `messages[].content[]` but missed the **top-level `system` field** in Anthropic requests. Claude Code and similar clients place system prompts as content block arrays on `system` with `cache_control: { type: \"ephemeral\" }`. When a key/provider is configured with 1h TTL preference, these breakpoints weren't being rewritten with `ttl: \"1h\"`, causing Anthropic API errors when the `extended-cache-ttl-2025-04-11` beta flag is present.

## Problem

The `applyCacheTtlOverrideToMessage` function previously:
- Only traversed `messages[].content[]` for applying TTL overrides
- **Ignored the top-level `system` field** which Anthropic accepts as either a string or array of content blocks
- This created an inconsistency: messages had TTL applied but system blocks didn't, causing Anthropic to reject requests with mismatched cache breakpoints

## Solution

### Core Changes
1. **Extracted `applyTtlToContentBlocks` helper** - Reusable logic for applying TTL to any array of content blocks
2. **Extended override to `system` field** - Now handles both:
   - Top-level `system` array (when Claude Code sends system prompts as content blocks)
   - `messages[].content[]` (existing behavior preserved)
3. **String `system` handling** - Skips processing when `system` is a string (no cache breakpoints possible)
4. **Extracted `mergeAnthropicCacheTtlBetaFlag`** - Pure function for beta header management, enabling test coverage

### Preserved Semantics
- Only overwrites existing `ephemeral` breakpoints (doesn't inject new ones)
- `tools` field remains untouched (no automatic cache injection)
- Maintains backward compatibility for all existing request patterns

## Related PRs
- Related to #798 - Foundational cache TTL billing feature that introduced the 1h/5min TTL preference system

## Changes

| File | Change |
|------|--------|
| `src/app/v1/_lib/proxy/forwarder.ts` | Refactored `applyCacheTtlOverrideToMessage` with `applyTtlToContentBlocks` helper; extracted `mergeAnthropicCacheTtlBetaFlag` |
| `tests/unit/proxy/cache-ttl-override.test.ts` | New test suite with 14 test cases covering all scenarios |

## Test Coverage

New test file: `tests/unit/proxy/cache-ttl-override.test.ts` (241 lines)

### Test Cases (14 total)
- **System field coverage**: Top-level system content blocks, string system skip
- **Messages coverage**: Existing behavior preserved for `messages[].content[]`
- **Bidirectional processing**: Both system and messages in single pass
- **TTL override directions**: 1h upgrade and 5m downgrade
- **Edge cases**: Non-ephemeral entries untouched, missing fields handled gracefully, field preservation
- **Beta header logic**: Empty/undefined/null handling, deduplication, existing flag merging

### Verification
- [x] `bunx vitest run tests/unit/proxy/cache-ttl-override.test.ts` — 14/14 passing
- [x] `bun run typecheck` — No errors
- [x] `bun run lint` — No new warnings (8 pre-existing unrelated)
- [x] `bun run test` — 5882 passed / 13 skipped (full suite)
- [x] `bun run build` — Production build successful

### E2E Testing (Required)
- [ ] Configure `cacheTtlPreference: "1h"` on a key
- [ ] Send request with top-level `system: [{type:"text", text:"...", cache_control:{type:"ephemeral"}}]`
- [ ] Verify in dashboard session details:
  - `system[0].cache_control.ttl === "1h"` in upstream request
  - `anthropic-beta` header includes `extended-cache-ttl-2025-04-11`

## Breaking Changes
None. This fix only affects requests that:
1. Use Anthropic API format
2. Have array-style `system` field with `cache_control: { type: "ephemeral" }`
3. Are routed through a key/provider with `cacheTtlPreference: "1h"`

All existing requests continue to work unchanged.

## Technical Details

### Before (Problematic)
```typescript
// Only processed messages[].content[]
function applyCacheTtlOverrideToMessage(message, ttl) {
  const messages = message.messages;
  // ... iterate messages only, system field ignored
}
```

### After (Fixed)
```typescript
// Unified helper for any content block array
function applyTtlToContentBlocks(blocks, ttl) {
  // ... applies TTL to ephemeral cache_control entries
}

function applyCacheTtlOverrideToMessage(message, ttl) {
  // Handle top-level system
  if (Array.isArray(message.system)) {
    applyTtlToContentBlocks(message.system, ttl);
  }
  // Handle messages[].content[] (existing)
  // ...
}
```

---
*Original description preserved below*

## Summary (Original)

- `applyCacheTtlOverrideToMessage` 之前只遍历 `messages[].content[]`,**没有处理 Anthropic 请求体顶层 `system` 字段**。Claude Code 等客户端把系统提示作为内容块数组放在 `system` 上并打 `cache_control: { type: "ephemeral" }`。当 key/provider 配置 1h TTL 时,该字段上的断点没有被显式写为 `ttl: "1h"`,在带 `extended-cache-ttl-2025-04-11` beta 时会被 Anthropic 报错。
- 抽出 `applyTtlToContentBlocks` 内部小工具,让顶层 `system` 与 `messages[].content[]` 复用同一段覆写逻辑;`system` 为字符串时直接跳过。维持\"只覆写已有 ephemeral 断点\"的语义,不自动注入新断点(`tools` 字段同样不动)。
- 把 `anthropic-beta` header 1h 兜底逻辑抽成纯函数 `mergeAnthropicCacheTtlBetaFlag`,行为保持不变(仍在 betaFlags 仅含新 flag 时补 `prompt-caching-2024-07-31`),用于支持单测覆盖。
- 新增 `tests/unit/proxy/cache-ttl-override.test.ts`,14 条用例覆盖 system/messages 双向覆写、string-system 跳过、5m 反向覆写、非 ephemeral 不动、beta header 合并/去重/空头兜底等。

## Test plan (Original)

- [x] `bunx vitest run tests/unit/proxy/cache-ttl-override.test.ts` — 14/14 通过
- [x] `bun run typecheck` — 无错误
- [x] `bun run lint` — 无新增告警(已存在的 8 条 warning 不在本次改动范围)
- [x] `bun run test` — 5882 passed / 13 skipped(全量 664 个测试文件)
- [x] `bun run build` — 生产构建成功
- [ ] 端到端冒烟(需 1h TTL key 的 dev 环境):配置 `cacheTtlPreference: "1h"`,发带顶层 `system: [{type:"text",text:"...",cache_control:{type:"ephemeral"}}]` 的请求,在 dashboard session 详情确认 upstream `system[0].cache_control.ttl === "1h"` 且 `anthropic-beta` 含 `extended-cache-ttl-2025-04-11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a gap in the Anthropic cache TTL override logic: the top-level `system` field was silently skipped when rewriting `cache_control` breakpoints, causing API errors when the `extended-cache-ttl-2025-04-11` beta flag was present. The fix extracts a reusable `applyTtlToContentBlocks` helper and extends `applyCacheTtlOverrideToMessage` to cover `system` in addition to `messages[].content[]`.

- **`applyTtlToContentBlocks` helper**: shared logic for both `system` and `messages[].content[]`; only rewrites existing `ephemeral` breakpoints, preserves reference identity when no breakpoints match.
- **`mergeAnthropicCacheTtlBetaFlag` extraction**: inlined header-merge logic moved to a pure exported function, enabling the 14-case unit test suite added in `tests/unit/proxy/cache-ttl-override.test.ts`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, well-tested fix that extends existing TTL-override logic to cover a previously ignored field without altering any other behavior.

The refactor correctly guards all assignment paths with `if (result.applied)`, preserving reference identity on no-op calls. The `CacheTtlResolved` union is exhaustively handled by the ternary. The extracted `mergeAnthropicCacheTtlBetaFlag` is fully covered by the new test suite, including the documented `size === 1` backfill quirk.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/forwarder.ts | Extracted `applyTtlToContentBlocks` helper, extended `applyCacheTtlOverrideToMessage` to cover top-level `system`, and exported `mergeAnthropicCacheTtlBetaFlag` as a pure function; logic is correct and reference identity is preserved on no-op paths. |
| tests/unit/proxy/cache-ttl-override.test.ts | New 14-case unit test suite covering system/messages bidirectional TTL override, string-system skip, 5m downgrade, non-ephemeral preservation, reference identity, and beta-header merge/dedup logic. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[applyCacheTtlOverrideToMessage] --> B{system field?}
    B -->|Array| C[applyTtlToContentBlocks system blocks]
    B -->|string / missing| D[skip system]
    C --> E{any ephemeral breakpoints?}
    E -->|yes| F[write ttl to block, reassign message.system]
    E -->|no| G[preserve original reference]
    A --> H{messages field?}
    H -->|Array| I[loop messages]
    H -->|missing| J[skip messages]
    I --> K[applyTtlToContentBlocks content blocks per msg]
    K --> L{any ephemeral breakpoints?}
    L -->|yes| M[write ttl to block, reassign msgObj.content]
    L -->|no| N[preserve original reference]
    A --> O[return applied flag]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(proxy): 仅在命中时回写 system/content,补齐 be..."](https://github.com/ding113/claude-code-hub/commit/d9a6e75e71bd1ef3477ac9d27593fa81a45bab67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31294962)</sub>

<!-- /greptile_comment -->