### PR TITLE
feat: hide fake streaming whitelist and responses WS from system settings UI

### DIFF
--- a/src/app/[locale]/settings/config/_components/system-settings-form.tsx
+++ b/src/app/[locale]/settings/config/_components/system-settings-form.tsx
@@ -12,11 +12,8 @@ import {
   MapPin,
   Network,
   Pencil,
-  Plus,
-  Radio,
   Terminal,
   Thermometer,
-  Trash2,
   Wrench,
   Zap,
 } from "lucide-react";
@@ -24,7 +21,6 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
-import { GroupMultiSelect } from "@/app/[locale]/settings/request-filters/_components/group-multi-select";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { InlineWarning } from "@/components/ui/inline-warning";
@@ -668,30 +664,6 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
           />
         </div>
 
-        {/* Enable OpenAI Responses WebSocket (Codex only) */}
-        <div className="p-4 rounded-xl bg-white/[0.02] border border-white/5 flex items-center justify-between hover:bg-white/[0.04] transition-colors">
-          <div className="flex items-start gap-3">
-            <div className="w-8 h-8 flex items-center justify-center rounded-lg bg-cyan-500/10 text-cyan-400 shrink-0">
-              <Radio className="h-4 w-4" />
-            </div>
-            <div>
-              <p className="text-sm font-medium text-foreground">
-                {t("enableOpenaiResponsesWebsocket")}
-              </p>
-              <p className="text-xs text-muted-foreground mt-0.5">
-                {t("enableOpenaiResponsesWebsocketDesc")}
-              </p>
-            </div>
-          </div>
-          <Switch
-            id="enable-openai-responses-websocket"
-            aria-label={t("enableOpenaiResponsesWebsocket")}
-            checked={enableOpenaiResponsesWebsocket}
-            onCheckedChange={(checked) => setEnableOpenaiResponsesWebsocket(checked)}
-            disabled={isPending}
-          />
-        </div>
-
         <div className="p-4 rounded-xl bg-white/[0.02] border border-white/5 flex items-center justify-between hover:bg-white/[0.04] transition-colors">
           <div className="flex items-start gap-3">
             <div className="w-8 h-8 flex items-center justify-center rounded-lg bg-red-500/10 text-red-400 shrink-0">
@@ -850,109 +822,6 @@ export function SystemSettingsForm({ initialSettings }: SystemSettingsFormProps)
             onCheckedChange={(checked) => setAllowNonConversationEndpointProviderFallback(checked)}
             disabled={isPending}
           />
-        </div>
-
-        {/* Fake Streaming Whitelist */}
-        <div className="p-4 rounded-xl bg-white/[0.02] border border-white/5 space-y-3">
-          <div className="flex items-start gap-3">
-            <div className="w-8 h-8 flex items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-400 shrink-0">
-              <Radio className="h-4 w-4" />
-            </div>
-            <div>
-              <p className="text-sm font-medium text-foreground">{t("fakeStreaming.title")}</p>
-              <p className="text-xs text-muted-foreground mt-0.5">
-                {t("fakeStreaming.description")}
-              </p>
-            </div>
-          </div>
-
-          {fakeStreamingWhitelist.length === 0 ? (
-            <p className="text-xs text-muted-foreground italic px-1">
-              {t("fakeStreaming.emptyState")}
-            </p>
-          ) : (
-            <div className="space-y-2">
-              {fakeStreamingWhitelist.map((entry, index) => (
-                <div
-                  key={index}
-                  className="rounded-lg border border-border bg-muted/30 p-3 space-y-2"
-                >
-                  <div className="flex items-center gap-2">
-                    <Label
-                      htmlFor={`fake-streaming-model-${index}`}
-                      className="text-xs font-medium text-muted-foreground w-20 shrink-0"
-                    >
-                      {t("fakeStreaming.modelLabel")}
-                    </Label>
-                    <Input
-                      id={`fake-streaming-model-${index}`}
-                      data-testid={`fake-streaming-model-${index}`}
-                      value={entry.model}
-                      onChange={(event) => {
-                        const next = event.target.value;
-                        setFakeStreamingWhitelist((prev) =>
-                          prev.map((item, i) => (i === index ? { ...item, model: next } : item))
-                        );
-                      }}
-                      placeholder={t("fakeStreaming.modelPlaceholder")}
-                      disabled={isPending}
-                      className={inputClassName}
-                    />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      data-testid={`fake-streaming-remove-${index}`}
-                      onClick={() => {
-                        setFakeStreamingWhitelist((prev) => prev.filter((_, i) => i !== index));
-                      }}
-                      disabled={isPending}
-                      aria-label={t("fakeStreaming.remove")}
-                      className="shrink-0 text-destructive hover:text-destructive"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                  <div className="flex items-start gap-2">
-                    <Label className="text-xs font-medium text-muted-foreground w-20 shrink-0 pt-2">
-                      {t("fakeStreaming.groupsLabel")}
-                    </Label>
-                    <div className="flex-1 space-y-1">
-                      <GroupMultiSelect
-                        selectedGroupTags={entry.groupTags}
-                        onChange={(groupTags) => {
-                          setFakeStreamingWhitelist((prev) =>
-                            prev.map((item, i) => (i === index ? { ...item, groupTags } : item))
-                          );
-                        }}
-                        disabled={isPending}
-                      />
-                      {entry.groupTags.length === 0 ? (
-                        <p className="text-[11px] text-muted-foreground">
-                          {t("fakeStreaming.allGroupsHint")}
-                        </p>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            data-testid="fake-streaming-add"
-            onClick={() => {
-              setFakeStreamingWhitelist((prev) => [...prev, { model: "", groupTags: [] }]);
-            }}
-            disabled={isPending}
-            className="w-full"
-          >
-            <Plus className="h-4 w-4 mr-2" />
-            {t("fakeStreaming.addModel")}
-          </Button>
         </div>
 
         {/* Enable Codex Session ID Completion */}

--- a/src/types/system-config.ts
+++ b/src/types/system-config.ts
@@ -22,12 +22,7 @@ export interface FakeStreamingWhitelistEntry {
 
 // Default whitelist used when system_settings has no persisted value (legacy
 // upgrade path). A persisted empty array is preserved as explicit opt-out.
-export const DEFAULT_FAKE_STREAMING_WHITELIST: ReadonlyArray<FakeStreamingWhitelistEntry> = [
-  { model: "gpt-image-2", groupTags: [] },
-  { model: "gpt-image-1.5", groupTags: [] },
-  { model: "gemini-3.1-flash-image-preview", groupTags: [] },
-  { model: "gemini-3-pro-image-preview", groupTags: [] },
-];
+export const DEFAULT_FAKE_STREAMING_WHITELIST: ReadonlyArray<FakeStreamingWhitelistEntry> = [];
 
 export interface SystemSettings {
   id: number;

--- a/tests/unit/actions/system-config-fake-streaming-setting.test.ts
+++ b/tests/unit/actions/system-config-fake-streaming-setting.test.ts
@@ -60,12 +60,7 @@ vi.mock("@/lib/utils/timezone", () => ({
   isValidIANATimezone: vi.fn(() => true),
 }));
 
-const DEFAULT_FAKE_STREAMING_MODELS = [
-  { model: "gpt-image-2", groupTags: [] },
-  { model: "gpt-image-1.5", groupTags: [] },
-  { model: "gemini-3.1-flash-image-preview", groupTags: [] },
-  { model: "gemini-3-pro-image-preview", groupTags: [] },
-];
+const DEFAULT_FAKE_STREAMING_MODELS: { model: string; groupTags: string[] }[] = [];
 
 function createSettings(overrides: Record<string, unknown> = {}) {
   return {
@@ -131,7 +126,7 @@ describe("fake streaming whitelist system setting", () => {
   });
 
   describe("transformer defaults", () => {
-    test("defaults missing fake streaming config to requested image models", async () => {
+    test("defaults missing fake streaming config to the empty default", async () => {
       const { toSystemSettings } = await import("@/repository/_shared/transformers");
 
       const fromUndefined = toSystemSettings(undefined);
@@ -180,7 +175,7 @@ describe("fake streaming whitelist system setting", () => {
       expect(result.fakeStreamingWhitelist).toEqual(persisted);
     });
 
-    test("repository fallback (table missing) defaults to image models", async () => {
+    test("repository fallback (table missing) defaults to the empty default", async () => {
       vi.resetModules();
       vi.doUnmock("@/repository/system-config");
       vi.doMock("@/drizzle/db", () => ({

--- a/tests/unit/settings/system-settings-form-fake-streaming.test.tsx
+++ b/tests/unit/settings/system-settings-form-fake-streaming.test.tsx
@@ -146,22 +146,6 @@ async function submitForm() {
   });
 }
 
-function findRemoveButtons(): HTMLButtonElement[] {
-  return Array.from(
-    document.querySelectorAll<HTMLButtonElement>('button[data-testid^="fake-streaming-remove-"]')
-  );
-}
-
-function findAddButton(): HTMLButtonElement | null {
-  return document.querySelector<HTMLButtonElement>('button[data-testid="fake-streaming-add"]');
-}
-
-function findModelInputs(): HTMLInputElement[] {
-  return Array.from(
-    document.querySelectorAll<HTMLInputElement>('input[data-testid^="fake-streaming-model-"]')
-  );
-}
-
 describe("SystemSettingsForm fake streaming whitelist", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -185,55 +169,23 @@ describe("SystemSettingsForm fake streaming whitelist", () => {
     unmount();
   });
 
-  test("user can add a new model entry and saves it for all groups", async () => {
+  test("editor UI is no longer rendered", () => {
     const { unmount } = render(<SystemSettingsForm initialSettings={baseSettings} />);
 
-    const addBtn = findAddButton();
-    if (!addBtn) throw new Error("未找到 fake-streaming 添加按钮");
-
-    act(() => {
-      addBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    const inputs = findModelInputs();
-    expect(inputs.length).toBe(3);
-    const newRow = inputs[2];
-
-    act(() => {
-      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
-      setter?.call(newRow, "custom-model-x");
-      newRow.dispatchEvent(new Event("input", { bubbles: true }));
-    });
-
-    await submitForm();
-
-    expect(systemConfigActionMocks.saveSystemSettings).toHaveBeenCalledWith(
-      expect.objectContaining({
-        fakeStreamingWhitelist: [
-          { model: "gpt-image-2", groupTags: [] },
-          { model: "gemini-3.1-flash-image-preview", groupTags: [] },
-          { model: "custom-model-x", groupTags: [] },
-        ],
-      })
-    );
+    expect(document.querySelector('button[data-testid="fake-streaming-add"]')).toBeNull();
+    expect(document.querySelector('button[data-testid^="fake-streaming-remove-"]')).toBeNull();
+    expect(document.querySelector('input[data-testid^="fake-streaming-model-"]')).toBeNull();
 
     unmount();
   });
 
-  test("user can remove a model entry and the empty whitelist is preserved as opt-out", async () => {
-    const singleEntry = {
+  test("preserves an explicitly empty initial whitelist as opt-out", async () => {
+    const emptyInitial = {
       ...baseSettings,
-      fakeStreamingWhitelist: [{ model: "gpt-image-2", groupTags: [] }],
+      fakeStreamingWhitelist: [],
     } satisfies typeof baseSettings;
 
-    const { unmount } = render(<SystemSettingsForm initialSettings={singleEntry} />);
-
-    const removeBtns = findRemoveButtons();
-    expect(removeBtns.length).toBe(1);
-
-    act(() => {
-      removeBtns[0].dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
+    const { unmount } = render(<SystemSettingsForm initialSettings={emptyInitial} />);
 
     await submitForm();
 
@@ -247,18 +199,15 @@ describe("SystemSettingsForm fake streaming whitelist", () => {
   });
 
   test("trims whitespace and drops empty model entries before submitting", async () => {
-    const { unmount } = render(<SystemSettingsForm initialSettings={baseSettings} />);
+    const initial = {
+      ...baseSettings,
+      fakeStreamingWhitelist: [
+        { model: "  custom-image-model  ", groupTags: [] },
+        { model: "   ", groupTags: [] },
+      ],
+    } satisfies typeof baseSettings;
 
-    const inputs = findModelInputs();
-    expect(inputs.length).toBe(2);
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
-
-    act(() => {
-      setter?.call(inputs[0], "  custom-image-model  ");
-      inputs[0].dispatchEvent(new Event("input", { bubbles: true }));
-      setter?.call(inputs[1], "   ");
-      inputs[1].dispatchEvent(new Event("input", { bubbles: true }));
-    });
+    const { unmount } = render(<SystemSettingsForm initialSettings={initial} />);
 
     await submitForm();
 


### PR DESCRIPTION
## Summary

This PR hides two advanced system settings from the UI while preserving their backend functionality:

1. **Fake Streaming Whitelist**: Changed default from 4 image models to empty array (disabled by default) and removed the whitelist editor UI from system settings
2. **OpenAI Responses WebSocket**: Removed the toggle from system settings form (Codex-only feature)

Backend state variables and save payload remain intact - these features can still be configured via API or database.

## Problem

The Fake Streaming feature (added in PR #1132) and OpenAI Responses WebSocket (addressed in PRs #1153/#1154) were exposed as configurable UI elements in system settings. However:

- These are advanced features primarily for specific use cases (long-running image generation, Codex CLI)
- The default whitelist of 4 image models was auto-enabled, which may not be desired by all deployments
- These settings add complexity to the system settings UI for users who don't need them

## Solution

### UI Simplification
- Hide the Fake Streaming Whitelist editor from system settings form
- Hide the OpenAI Responses WebSocket toggle from system settings form
- Keep all state management and save logic intact for API/database configuration

### Default Policy Change
- DEFAULT_FAKE_STREAMING_WHITELIST changed from 4 models to empty array (empty/disabled by default)
- This allows deployments to explicitly opt-in to fake streaming rather than having it auto-enabled
- Existing persisted configurations are preserved

## Related Issues & PRs

### Context / History
- Related to #1150 - WebSocket connection issues with Codex CLI on /v1/responses endpoint (ongoing issue)
- Related to #1095 - User request for OpenAI WebSocket feature release

### Implementation History
- Follow-up to #1132 - The original fake streaming whitelist feature that added these UI elements
- Follow-up to #1153 - WebSocket close handshake fix for Responses API
- Follow-up to #1154 - WebSocket session lifecycle completion (persistent upstream sessions)

## Changes

| File | Change |
|------|--------|
| src/types/system-config.ts | DEFAULT_FAKE_STREAMING_WHITELIST to empty array |
| src/app/[locale]/settings/config/_components/system-settings-form.tsx | Removed Fake Streaming Whitelist editor section; Removed OpenAI Responses WebSocket toggle; Cleaned up unused imports (Plus, Radio, Trash2, GroupMultiSelect) |
| tests/unit/actions/system-config-fake-streaming-setting.test.ts | Updated test expectations to reflect empty default; test descriptions clarified |
| tests/unit/settings/system-settings-form-fake-streaming.test.tsx | Replaced UI interaction tests with state-driven tests (editor no longer rendered) |

## Verification

- bun run typecheck (verified)
- bun run lint (verified, only pre-existing warnings)
- bun run test (verified, all related tests updated and passing)

### Backend Compatibility
- State variables (fakeStreamingWhitelist, enableOpenaiResponsesWebsocket) remain in form state
- Save payload structure unchanged - existing API consumers unaffected
- Database schema unchanged - persisted settings preserved

## Breaking Changes

None - this is a UI-only change. The features remain functional via:
- Direct API calls to update system settings
- Database manipulation of system_settings table
- Any existing persisted settings continue to work

## Migration Notes

Deployments that relied on the default 4-model whitelist being auto-enabled will need to:

1. Via API: Set fakeStreamingWhitelist to the desired model list
2. Via Database: Update the system_settings table to include the whitelist

Pre-configured whitelist (pre-0.7.5):
- gpt-image-2 (all groups)
- gpt-image-1.5 (all groups)
- gemini-3.1-flash-image-preview (all groups)
- gemini-3-pro-image-preview (all groups)

## Testing Checklist
- System settings form renders without removed UI elements
- Form submission preserves existing whitelist values
- Empty whitelist is correctly saved as explicit opt-out
- Non-empty whitelist values are trimmed and empty entries dropped before save
- All existing unit tests pass with updated expectations

---
*Description enhanced by Claude AI - adds related Issue/PR context for better traceability*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hides the Fake Streaming Whitelist editor and the OpenAI Responses WebSocket toggle from the system settings UI while keeping both settings' state variables and save-payload fields intact, so previously configured values continue to be round-tripped to the server on every save.

- `DEFAULT_FAKE_STREAMING_WHITELIST` is changed from 4 hardcoded image-model entries to `[]`, meaning installations with no persisted whitelist (DB `null`) will now default to fake streaming disabled instead of the prior four-model set.
- The form component removes both UI sections and their associated imports (`GroupMultiSelect`, `Plus`, `Radio`, `Trash2`) but retains the state and persistence logic, so the feature is hidden rather than removed.
- Test suite is updated to replace DOM-interaction tests with state-driven equivalents; one locale-string test continues to validate i18n keys for the now-hidden UI section without explanation.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the only user-visible behaviour change is that fresh installations default to fake streaming disabled, which is the stated intent.

The form correctly keeps both hidden settings in state and in the save payload, so no data is silently dropped on save. The default change from four image models to an empty list is intentional, but deployments that relied on the implicit whitelist without ever explicitly saving it will silently lose fake-streaming for those models after the next settings save.

tests/unit/settings/system-settings-form-fake-streaming.test.tsx — the all-locales test validates strings for removed UI without explanation.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/types/system-config.ts | DEFAULT_FAKE_STREAMING_WHITELIST changed from 4 hardcoded image-model entries to an empty array; comment updated to reflect the new upgrade-path semantics. |
| src/app/[locale]/settings/config/_components/system-settings-form.tsx | Removed the Fake Streaming Whitelist editor UI and the OpenAI Responses WebSocket toggle from the rendered form; state variables and save-payload fields are kept intact so the hidden settings are still persisted on save. |
| tests/unit/actions/system-config-fake-streaming-setting.test.ts | DEFAULT_FAKE_STREAMING_MODELS updated to [] and test names updated to match the new empty-default semantics; all assertions remain accurate. |
| tests/unit/settings/system-settings-form-fake-streaming.test.tsx | UI-interaction tests replaced with state-driven equivalents; a locale-string test that validates strings for now-removed UI is retained without explanation, which could confuse future maintainers. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SystemSettingsForm mounts] --> B[useState: fakeStreamingWhitelist\ninitialised from initialSettings]
    A --> C[useState: enableOpenaiResponsesWebsocket\ninitialised from initialSettings]
    B --> D{UI editor\nrendered?}
    D -- Before this PR --> E[Fake Streaming Whitelist editor shown to user]
    D -- After this PR --> F[Editor hidden]
    C --> G{WebSocket toggle rendered?}
    G -- Before this PR --> H[Toggle shown to user]
    G -- After this PR --> I[Toggle hidden]
    F --> J[User clicks Save]
    I --> J
    E --> J
    H --> J
    J --> K[saveSystemSettings called with both values still in payload]
    K --> L[(DB values persisted unchanged)]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/unit/settings/system-settings-form-fake-streaming.test.tsx`, line 267-284 ([link](https://github.com/ding113/claude-code-hub/blob/ef9025d7fe85dee114a6be42c5e427d5c738d30a/tests/unit/settings/system-settings-form-fake-streaming.test.tsx#L267-L284)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Locale test validates strings for removed UI**

   The `"all locales define fake streaming labels"` test still asserts that every locale defines `title`, `description`, `modelLabel`, `groupsLabel`, `allGroupsHint`, `addModel`, `remove`, `modelPlaceholder`, and `emptyState` for the `fakeStreaming` section — but the form that renders those strings was deleted in this PR. The test will continue to pass (the message files still have the strings), but it now gives false coverage confidence for UI that isn't reachable. If the intent is to preserve the strings as a re-enablement safety net, a short comment stating that would prevent a future contributor from being confused by why the test exists.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/unit/settings/system-settings-form-fake-streaming.test.tsx
   Line: 267-284

   Comment:
   **Locale test validates strings for removed UI**

   The `"all locales define fake streaming labels"` test still asserts that every locale defines `title`, `description`, `modelLabel`, `groupsLabel`, `allGroupsHint`, `addModel`, `remove`, `modelPlaceholder`, and `emptyState` for the `fakeStreaming` section — but the form that renders those strings was deleted in this PR. The test will continue to pass (the message files still have the strings), but it now gives false coverage confidence for UI that isn't reachable. If the intent is to preserve the strings as a re-enablement safety net, a short comment stating that would prevent a future contributor from being confused by why the test exists.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/unit/settings/system-settings-form-fake-streaming.test.tsx:267-284
**Locale test validates strings for removed UI**

The `"all locales define fake streaming labels"` test still asserts that every locale defines `title`, `description`, `modelLabel`, `groupsLabel`, `allGroupsHint`, `addModel`, `remove`, `modelPlaceholder`, and `emptyState` for the `fakeStreaming` section — but the form that renders those strings was deleted in this PR. The test will continue to pass (the message files still have the strings), but it now gives false coverage confidence for UI that isn't reachable. If the intent is to preserve the strings as a re-enablement safety net, a short comment stating that would prevent a future contributor from being confused by why the test exists.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: hide fake streaming whitelist and ..."](https://github.com/ding113/claude-code-hub/commit/ef9025d7fe85dee114a6be42c5e427d5c738d30a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31299004)</sub>

<!-- /greptile_comment -->