### PR TITLE
fix(server): load standalone next config to honor proxyClientMaxBodySize

### DIFF
--- a/scripts/copy-custom-server-to-standalone.cjs
+++ b/scripts/copy-custom-server-to-standalone.cjs
@@ -35,11 +35,15 @@ const serverDst = path.join(dstDir, "server.js");
 fs.copyFileSync(serverSrc, serverDst);
 console.log(`[copy-custom-server] Copied ${serverSrc} -> ${serverDst}`);
 
+// server.js requires from server-lib/, so missing it would yield a standalone
+// artifact that crashes on startup. Fail the build instead of warning.
 const libSrc = path.resolve(cwd, "server-lib");
-if (fs.existsSync(libSrc)) {
-  const libDst = path.join(dstDir, "server-lib");
-  fs.cpSync(libSrc, libDst, { recursive: true });
-  console.log(`[copy-custom-server] Copied ${libSrc} -> ${libDst}`);
-} else {
-  console.warn(`[copy-custom-server] server-lib/ not found at ${libSrc}; skipping`);
+if (!fs.existsSync(libSrc)) {
+  console.error(
+    `[copy-custom-server] server-lib/ not found at ${libSrc}; refusing to produce a broken standalone artifact`
+  );
+  process.exit(1);
 }
+const libDst = path.join(dstDir, "server-lib");
+fs.cpSync(libSrc, libDst, { recursive: true });
+console.log(`[copy-custom-server] Copied ${libSrc} -> ${libDst}`);

--- a/scripts/copy-custom-server-to-standalone.cjs
+++ b/scripts/copy-custom-server-to-standalone.cjs
@@ -3,6 +3,11 @@
  * Next.js standalone output, overwriting the generated server.js so Docker
  * runtime (`CMD ["node", "server.js"]`) boots the custom one instead.
  *
+ * Also copies the `server-lib/` helper directory it depends on (e.g. the
+ * standalone-config injector). Next's traced files only follow imports from
+ * the compiled app, not from our custom server entry, so anything server.js
+ * `require()`s from outside node_modules must be copied explicitly.
+ *
  * The generated standalone server.js is the default Next.js minimal server;
  * ours wraps Next.js programmatically plus adds WebSocket upgrade handling
  * on /v1/responses. See server.js at the repo root for the full rationale.
@@ -11,14 +16,8 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-const src = path.resolve(process.cwd(), "server.js");
-const dstDir = path.resolve(process.cwd(), ".next", "standalone");
-const dst = path.join(dstDir, "server.js");
-
-if (!fs.existsSync(src)) {
-  console.error(`[copy-custom-server] Custom server not found at ${src}`);
-  process.exit(1);
-}
+const cwd = process.cwd();
+const dstDir = path.resolve(cwd, ".next", "standalone");
 
 if (!fs.existsSync(dstDir)) {
   console.warn(
@@ -27,5 +26,20 @@ if (!fs.existsSync(dstDir)) {
   process.exit(0);
 }
 
-fs.copyFileSync(src, dst);
-console.log(`[copy-custom-server] Copied ${src} -> ${dst}`);
+const serverSrc = path.resolve(cwd, "server.js");
+if (!fs.existsSync(serverSrc)) {
+  console.error(`[copy-custom-server] Custom server not found at ${serverSrc}`);
+  process.exit(1);
+}
+const serverDst = path.join(dstDir, "server.js");
+fs.copyFileSync(serverSrc, serverDst);
+console.log(`[copy-custom-server] Copied ${serverSrc} -> ${serverDst}`);
+
+const libSrc = path.resolve(cwd, "server-lib");
+if (fs.existsSync(libSrc)) {
+  const libDst = path.join(dstDir, "server-lib");
+  fs.cpSync(libSrc, libDst, { recursive: true });
+  console.log(`[copy-custom-server] Copied ${libSrc} -> ${libDst}`);
+} else {
+  console.warn(`[copy-custom-server] server-lib/ not found at ${libSrc}; skipping`);
+}

--- a/server-lib/standalone-config.js
+++ b/server-lib/standalone-config.js
@@ -1,0 +1,62 @@
+// Helper used by the custom Node server (server.js) to surface the Next.js
+// configuration that `next build` baked into `.next/required-server-files.json`.
+//
+// Why this exists: in standalone mode there is no `next.config.{js,ts,mjs}`
+// next to the entrypoint, so Next's `loadConfig()` would fall back to
+// defaults and silently drop overrides such as
+// `experimental.proxyClientMaxBodySize` (clamping proxied request bodies to
+// the 10MB DEFAULT_BODY_CLONE_SIZE_LIMIT in body-streams.js). Next's own
+// generated standalone server.js sets the same env var
+// (`__NEXT_PRIVATE_STANDALONE_CONFIG`) that `loadConfig()` reads before
+// falling back; we mirror that here for our custom server.
+//
+// Extracted to its own module so it can be unit-tested in isolation —
+// requiring server.js would also start the HTTP listener.
+
+"use strict";
+
+const path = require("node:path");
+
+function applyStandaloneNextConfig({ rootDir, env, log } = {}) {
+  if (!env || typeof env !== "object") {
+    throw new TypeError("applyStandaloneNextConfig requires an env object");
+  }
+  if (typeof rootDir !== "string" || rootDir.length === 0) {
+    throw new TypeError("applyStandaloneNextConfig requires a rootDir string");
+  }
+
+  if (env.__NEXT_PRIVATE_STANDALONE_CONFIG) {
+    return { applied: false, reason: "preset" };
+  }
+
+  const manifestPath = path.join(rootDir, ".next", "required-server-files.json");
+
+  let manifest;
+  try {
+    // Use a fresh require each call so unit tests can swap fixtures via
+    // tmp directories without fighting Node's module cache.
+    delete require.cache[require.resolve(manifestPath)];
+    // eslint-disable-next-line global-require
+    manifest = require(manifestPath);
+  } catch (err) {
+    if (typeof log === "function") {
+      log("warn", "standalone_config_load_failed", {
+        error: String(err && err.message ? err.message : err),
+        manifestPath,
+      });
+    }
+    return { applied: false, reason: "load_error", error: err };
+  }
+
+  if (!manifest || typeof manifest !== "object" || !manifest.config) {
+    if (typeof log === "function") {
+      log("warn", "standalone_config_missing_field", { manifestPath });
+    }
+    return { applied: false, reason: "missing_config" };
+  }
+
+  env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(manifest.config);
+  return { applied: true, manifestPath };
+}
+
+module.exports = { applyStandaloneNextConfig };

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@
 "use strict";
 
 const http = require("node:http");
+const path = require("node:path");
 const { randomUUID } = require("node:crypto");
 const { parse } = require("node:url");
 
@@ -631,6 +632,31 @@ function isResponsesWsUpgrade(req) {
 }
 
 async function main() {
+  // In a standalone build there is no `next.config.{js,ts,mjs}` next to the
+  // server entry, so the programmatic `next()` factory's `loadConfig()` would
+  // fall back to defaults and silently drop overrides such as
+  // `experimental.proxyClientMaxBodySize` and `experimental.serverActions.bodySizeLimit`.
+  // Concretely this clamps proxied request bodies to the 10MB
+  // DEFAULT_BODY_CLONE_SIZE_LIMIT in next/dist/server/body-streams.js whenever
+  // a path is matched by `src/proxy.ts`. Mirror what Next's own standalone
+  // template does (next/dist/build/utils.ts → writeStandaloneDirectory) by
+  // surfacing the build-time config via the same env var the runtime checks.
+  if (!dev && !process.env.__NEXT_PRIVATE_STANDALONE_CONFIG) {
+    try {
+      // eslint-disable-next-line global-require
+      const requiredServerFiles = require(
+        path.join(__dirname, ".next", "required-server-files.json")
+      );
+      process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(
+        requiredServerFiles.config
+      );
+    } catch (err) {
+      log("warn", "standalone_config_load_failed", {
+        error: String(err && err.message ? err.message : err),
+      });
+    }
+  }
+
   // Import Next programmatically. We require it lazily so that the server can
   // still report a clean error if Next is not installed (unlikely but possible
   // in a misconfigured deployment).

--- a/server.js
+++ b/server.js
@@ -23,7 +23,6 @@
 "use strict";
 
 const http = require("node:http");
-const path = require("node:path");
 const { randomUUID } = require("node:crypto");
 const { parse } = require("node:url");
 
@@ -632,29 +631,12 @@ function isResponsesWsUpgrade(req) {
 }
 
 async function main() {
-  // In a standalone build there is no `next.config.{js,ts,mjs}` next to the
-  // server entry, so the programmatic `next()` factory's `loadConfig()` would
-  // fall back to defaults and silently drop overrides such as
-  // `experimental.proxyClientMaxBodySize` and `experimental.serverActions.bodySizeLimit`.
-  // Concretely this clamps proxied request bodies to the 10MB
-  // DEFAULT_BODY_CLONE_SIZE_LIMIT in next/dist/server/body-streams.js whenever
-  // a path is matched by `src/proxy.ts`. Mirror what Next's own standalone
-  // template does (next/dist/build/utils.ts → writeStandaloneDirectory) by
-  // surfacing the build-time config via the same env var the runtime checks.
-  if (!dev && !process.env.__NEXT_PRIVATE_STANDALONE_CONFIG) {
-    try {
-      // eslint-disable-next-line global-require
-      const requiredServerFiles = require(
-        path.join(__dirname, ".next", "required-server-files.json")
-      );
-      process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(
-        requiredServerFiles.config
-      );
-    } catch (err) {
-      log("warn", "standalone_config_load_failed", {
-        error: String(err && err.message ? err.message : err),
-      });
-    }
+  // Surface the build-time Next config via the env var Next's own standalone
+  // template uses. See server-lib/standalone-config.js for the full rationale.
+  if (!dev) {
+    // eslint-disable-next-line global-require
+    const { applyStandaloneNextConfig } = require("./server-lib/standalone-config");
+    applyStandaloneNextConfig({ rootDir: __dirname, env: process.env, log });
   }
 
   // Import Next programmatically. We require it lazily so that the server can

--- a/src/proxy.matcher.ts
+++ b/src/proxy.matcher.ts
@@ -1,17 +1,21 @@
 // Pattern used by `src/proxy.ts` for the Next.js proxy/middleware matcher.
 //
 // Match all request paths except for the ones starting with:
-// - api      (API routes - own auth via cookie session, no proxy needed)
-// - v1 / v1beta (API proxy routes - own auth via Bearer token; matching
+// - api          (API routes - own auth via cookie session, no proxy needed)
+// - v1 / v1beta  (API proxy routes - own auth via Bearer token; matching
 //   them here also forces Next.js to clone the request body via
 //   getCloneableBody → cloneBodyStream, which clamps proxied bodies to
 //   experimental.proxyClientMaxBodySize for no benefit since we no-op
-//   immediately for these paths)
+//   immediately for these paths). Anchored to a path-segment boundary
+//   (`/` or end of string) so future routes like `/v10/...` are NOT
+//   accidentally excluded.
 // - _next/static (static files)
-// - _next/image (image optimization files)
-// - favicon.ico (favicon file)
+// - _next/image  (image optimization files)
+// - favicon.ico  (favicon file)
 //
-// Lifted into its own module so it can be exercised by a regression test
-// without dragging in next-intl, the auth module, the logger, etc. that the
-// proxy handler itself imports at module load time.
-export const proxyMatcherPattern = "/((?!api|v1|_next/static|_next/image|favicon.ico).*)";
+// IMPORTANT: keep this pattern in sync with the inlined literal in
+// `src/proxy.ts` — Next.js requires `config.matcher` entries to be string
+// literals so its build-time static analyzer can collect them. The unit
+// test in `tests/unit/proxy-matcher.test.ts` enforces drift between the two.
+export const proxyMatcherPattern =
+  "/((?!api|v1(?:/|$)|v1beta(?:/|$)|_next/static|_next/image|favicon.ico).*)";

--- a/src/proxy.matcher.ts
+++ b/src/proxy.matcher.ts
@@ -1,0 +1,17 @@
+// Pattern used by `src/proxy.ts` for the Next.js proxy/middleware matcher.
+//
+// Match all request paths except for the ones starting with:
+// - api      (API routes - own auth via cookie session, no proxy needed)
+// - v1 / v1beta (API proxy routes - own auth via Bearer token; matching
+//   them here also forces Next.js to clone the request body via
+//   getCloneableBody → cloneBodyStream, which clamps proxied bodies to
+//   experimental.proxyClientMaxBodySize for no benefit since we no-op
+//   immediately for these paths)
+// - _next/static (static files)
+// - _next/image (image optimization files)
+// - favicon.ico (favicon file)
+//
+// Lifted into its own module so it can be exercised by a regression test
+// without dragging in next-intl, the auth module, the logger, etc. that the
+// proxy handler itself imports at module load time.
+export const proxyMatcherPattern = "/((?!api|v1|_next/static|_next/image|favicon.ico).*)";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,6 +6,7 @@ import { routing } from "@/i18n/routing";
 import { AUTH_COOKIE_NAME } from "@/lib/auth";
 import { isDevelopment } from "@/lib/config/env.schema";
 import { logger } from "@/lib/logger";
+import { proxyMatcherPattern } from "@/proxy.matcher";
 
 // Public paths that don't require authentication
 // Note: These paths will be automatically prefixed with locale by next-intl middleware
@@ -122,19 +123,7 @@ export default proxyHandler;
 export { matchesPublicPath };
 
 export const config = {
-  matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - api (API routes - handled separately)
-     * - v1 / v1beta (API proxy routes - own auth via Bearer token; matching
-     *   them here also forces Next.js to clone the request body via
-     *   getCloneableBody → cloneBodyStream, which clamps proxied bodies to
-     *   experimental.proxyClientMaxBodySize for no benefit since we no-op
-     *   immediately for these paths)
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     */
-    "/((?!api|v1|_next/static|_next/image|favicon.ico).*)",
-  ],
+  // Pattern lives in `src/proxy.matcher.ts` so it can be exercised by a
+  // regression test without importing the full proxy handler.
+  matcher: [proxyMatcherPattern],
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,6 @@ import { routing } from "@/i18n/routing";
 import { AUTH_COOKIE_NAME } from "@/lib/auth";
 import { isDevelopment } from "@/lib/config/env.schema";
 import { logger } from "@/lib/logger";
-import { proxyMatcherPattern } from "@/proxy.matcher";
 
 // Public paths that don't require authentication
 // Note: These paths will be automatically prefixed with locale by next-intl middleware
@@ -123,12 +122,9 @@ export default proxyHandler;
 export { matchesPublicPath };
 
 export const config = {
-  // Pattern originally from `src/proxy.matcher.ts` but inlined here because
-  // Next.js requires matcher patterns to be statically analyzable strings.
-  // Match all request paths except for:
-  // - api (API routes - own auth via cookie session, no proxy needed)
-  // - v1 / v1beta (API proxy routes - own auth via Bearer token)
-  // - _next/static, _next/image (static files)
-  // - favicon.ico (favicon file)
-  matcher: ["/((?!api|v1|_next/static|_next/image|favicon.ico).*)"],
+  // KEEP IN SYNC with `src/proxy.matcher.ts` — must be a string literal here
+  // so Next.js's build-time static analyzer can collect it. The unit test
+  // `tests/unit/proxy-matcher.test.ts` asserts the two stay in sync. See the
+  // matcher module for the full per-segment rationale.
+  matcher: ["/((?!api|v1(?:/|$)|v1beta(?:/|$)|_next/static|_next/image|favicon.ico).*)"],
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -123,7 +123,12 @@ export default proxyHandler;
 export { matchesPublicPath };
 
 export const config = {
-  // Pattern lives in `src/proxy.matcher.ts` so it can be exercised by a
-  // regression test without importing the full proxy handler.
-  matcher: [proxyMatcherPattern],
+  // Pattern originally from `src/proxy.matcher.ts` but inlined here because
+  // Next.js requires matcher patterns to be statically analyzable strings.
+  // Match all request paths except for:
+  // - api (API routes - own auth via cookie session, no proxy needed)
+  // - v1 / v1beta (API proxy routes - own auth via Bearer token)
+  // - _next/static, _next/image (static files)
+  // - favicon.ico (favicon file)
+  matcher: ["/((?!api|v1|_next/static|_next/image|favicon.ico).*)"],
 };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -126,10 +126,15 @@ export const config = {
     /*
      * Match all request paths except for the ones starting with:
      * - api (API routes - handled separately)
+     * - v1 / v1beta (API proxy routes - own auth via Bearer token; matching
+     *   them here also forces Next.js to clone the request body via
+     *   getCloneableBody → cloneBodyStream, which clamps proxied bodies to
+     *   experimental.proxyClientMaxBodySize for no benefit since we no-op
+     *   immediately for these paths)
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      */
-    "/((?!api|_next/static|_next/image|favicon.ico).*)",
+    "/((?!api|v1|_next/static|_next/image|favicon.ico).*)",
   ],
 };

--- a/tests/unit/proxy-matcher.test.ts
+++ b/tests/unit/proxy-matcher.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { proxyMatcherPattern } from "@/proxy.matcher";
 
@@ -12,10 +14,18 @@ describe("proxy matcher", () => {
       "/v1/chat/completions",
       "/v1/responses",
       "/v1/models",
-      "/v1beta/messages", // covered by the `v1` prefix in the negative lookahead
+      "/v1", // bare segment also a valid proxy entry
+      "/v1beta/messages",
+      "/v1beta",
       "/v1beta/v1/foo",
     ])("does not match %s", (pathname) => {
       expect(matcher.test(pathname)).toBe(false);
+    });
+  });
+
+  describe("look-alike paths that must NOT be excluded (regression: a bare `v1` prefix would over-match, e.g. `/v10`)", () => {
+    it.each(["/v10/foo", "/v1foo", "/v1beta-extra", "/version"])("matches %s", (pathname) => {
+      expect(matcher.test(pathname)).toBe(true);
     });
   });
 
@@ -43,5 +53,17 @@ describe("proxy matcher", () => {
     ])("matches %s", (pathname) => {
       expect(matcher.test(pathname)).toBe(true);
     });
+  });
+
+  // Drift guard: Next.js's build-time static analyzer requires `config.matcher`
+  // entries to be string literals, so `src/proxy.ts` cannot import the pattern
+  // from `proxy.matcher.ts`. Instead it inlines a copy. This test fails if the
+  // two ever drift — preventing a silent regression where the proxy starts
+  // using a different matcher than the one this test file exercises.
+  it("inlined matcher in src/proxy.ts stays in sync with src/proxy.matcher.ts", () => {
+    const proxyTs = fs.readFileSync(path.join(__dirname, "../../src/proxy.ts"), "utf8");
+    const m = proxyTs.match(/matcher:\s*\[\s*"([^"]+)"\s*\]/);
+    expect(m, 'could not locate `matcher: ["..."]` literal in src/proxy.ts').not.toBeNull();
+    expect(m?.[1]).toBe(proxyMatcherPattern);
   });
 });

--- a/tests/unit/proxy-matcher.test.ts
+++ b/tests/unit/proxy-matcher.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { proxyMatcherPattern } from "@/proxy.matcher";
+
+// The Next.js matcher string is intended to behave as a JS regex anchored to
+// the full pathname. Compile it that way for the assertions below.
+const matcher = new RegExp(`^${proxyMatcherPattern}$`);
+
+describe("proxy matcher", () => {
+  describe("paths the proxy MUST skip (regression: matching them forces Next to clone the request body, clamping it to proxyClientMaxBodySize)", () => {
+    it.each([
+      "/v1/messages",
+      "/v1/chat/completions",
+      "/v1/responses",
+      "/v1/models",
+      "/v1beta/messages", // covered by the `v1` prefix in the negative lookahead
+      "/v1beta/v1/foo",
+    ])("does not match %s", (pathname) => {
+      expect(matcher.test(pathname)).toBe(false);
+    });
+  });
+
+  describe("paths the proxy already skipped before this PR", () => {
+    it.each([
+      "/api/health",
+      "/api/admin/database/import",
+      "/_next/static/chunks/main.js",
+      "/_next/image/anything.png",
+      "/favicon.ico",
+    ])("does not match %s", (pathname) => {
+      expect(matcher.test(pathname)).toBe(false);
+    });
+  });
+
+  describe("paths the proxy MUST still handle (locale routing + auth gating)", () => {
+    it.each([
+      "/dashboard",
+      "/login",
+      "/zh/dashboard",
+      "/en/login",
+      "/zh/status",
+      "/usage-doc",
+      "/", // root
+    ])("matches %s", (pathname) => {
+      expect(matcher.test(pathname)).toBe(true);
+    });
+  });
+});

--- a/tests/unit/server-standalone-config.test.ts
+++ b/tests/unit/server-standalone-config.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// CJS helper — server.js is a Node CJS entry, not part of the Next build.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { applyStandaloneNextConfig } = require("../../server-lib/standalone-config");
+
+type LogCall = { level: string; event: string; payload: Record<string, unknown> };
+
+function makeLog(): {
+  calls: LogCall[];
+  fn: (l: string, e: string, p: Record<string, unknown>) => void;
+} {
+  const calls: LogCall[] = [];
+  return {
+    calls,
+    fn: (level, event, payload) => {
+      calls.push({ level, event, payload });
+    },
+  };
+}
+
+describe("applyStandaloneNextConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cch-standalone-"));
+    fs.mkdirSync(path.join(tmpDir, ".next"), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("loads config from .next/required-server-files.json into the env var (regression: standalone build dropped overrides)", () => {
+    const config = {
+      experimental: {
+        proxyClientMaxBodySize: 104857600, // 100MB — the override that was being silently dropped
+        serverActions: { bodySizeLimit: "500mb" },
+      },
+      output: "standalone",
+    };
+    fs.writeFileSync(
+      path.join(tmpDir, ".next", "required-server-files.json"),
+      JSON.stringify({ config })
+    );
+    const env: Record<string, string | undefined> = {};
+    const log = makeLog();
+
+    const result = applyStandaloneNextConfig({ rootDir: tmpDir, env, log: log.fn });
+
+    expect(result).toMatchObject({ applied: true });
+    expect(env.__NEXT_PRIVATE_STANDALONE_CONFIG).toBeDefined();
+    const parsed = JSON.parse(env.__NEXT_PRIVATE_STANDALONE_CONFIG ?? "");
+    expect(parsed.experimental.proxyClientMaxBodySize).toBe(104857600);
+    expect(parsed.experimental.serverActions.bodySizeLimit).toBe("500mb");
+    expect(log.calls).toHaveLength(0);
+  });
+
+  it("does not overwrite an env var that is already set (operator override wins)", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".next", "required-server-files.json"),
+      JSON.stringify({ config: { experimental: { proxyClientMaxBodySize: 1 } } })
+    );
+    const preset = JSON.stringify({ experimental: { proxyClientMaxBodySize: 999 } });
+    const env: Record<string, string | undefined> = { __NEXT_PRIVATE_STANDALONE_CONFIG: preset };
+
+    const result = applyStandaloneNextConfig({ rootDir: tmpDir, env });
+
+    expect(result).toEqual({ applied: false, reason: "preset" });
+    expect(env.__NEXT_PRIVATE_STANDALONE_CONFIG).toBe(preset);
+  });
+
+  it("logs and returns gracefully when manifest is missing (e.g. dev mode without next build)", () => {
+    const env: Record<string, string | undefined> = {};
+    const log = makeLog();
+
+    const result = applyStandaloneNextConfig({ rootDir: tmpDir, env, log: log.fn });
+
+    expect(result.applied).toBe(false);
+    expect(result.reason).toBe("load_error");
+    expect(env.__NEXT_PRIVATE_STANDALONE_CONFIG).toBeUndefined();
+    expect(log.calls).toHaveLength(1);
+    expect(log.calls[0]).toMatchObject({
+      level: "warn",
+      event: "standalone_config_load_failed",
+    });
+  });
+
+  it("returns missing_config when manifest exists but lacks the config field", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, ".next", "required-server-files.json"),
+      JSON.stringify({ version: 1 }) // no `config` key
+    );
+    const env: Record<string, string | undefined> = {};
+    const log = makeLog();
+
+    const result = applyStandaloneNextConfig({ rootDir: tmpDir, env, log: log.fn });
+
+    expect(result).toEqual({ applied: false, reason: "missing_config" });
+    expect(env.__NEXT_PRIVATE_STANDALONE_CONFIG).toBeUndefined();
+    expect(log.calls).toHaveLength(1);
+    expect(log.calls[0].event).toBe("standalone_config_missing_field");
+  });
+
+  it("rejects misuse with a clear error", () => {
+    expect(() => applyStandaloneNextConfig({ rootDir: tmpDir })).toThrow(/env object/);
+    expect(() => applyStandaloneNextConfig({ env: {} })).toThrow(/rootDir/);
+  });
+});


### PR DESCRIPTION
## Summary

- 修复 standalone 构建下 \`experimental.proxyClientMaxBodySize\` 不生效，导致 \`/v1/*\` 大于 ~10MB 的请求体被静默截断（pod 日志：\`Request body exceeded 10MB for /v1/messages...\`）。
- 跟随 Next 自身 standalone 模板，在 \`require(\"next\")\` 之前从 \`.next/required-server-files.json\` 注入 \`__NEXT_PRIVATE_STANDALONE_CONFIG\`。
- 顺手把 \`/v1\` / \`/v1beta\` 排出 \`src/proxy.ts\` 的 matcher，避免无用 body clone。

## Root Cause

自定义 \`server.js\` 通过 \`require(\"next\")\` + \`nextFactory({ dev, hostname, port })\` 编程式启动 Next.js，绕开了 Next 生成的 \`startServer\`。在 standalone 模式下，\`loadConfig()\` 会在 cwd（\`/app\`）找 \`next.config.{js,ts,mjs}\` —— 但 \`output: \"standalone\"\` 不会把 \`next.config\` 复制到产物里（配置已被烘焙到 \`.next/required-server-files.json\`）。找不到 → 回退默认值 → \`experimental.proxyClientMaxBodySize\` 实际为 \`undefined\`。

\`next-server.ts\` 在每个非 upgrade 请求上调 \`getCloneableBody(req, undefined)\`，落到 \`body-streams.ts:6\` 的 \`DEFAULT_BODY_CLONE_SIZE_LIMIT = 10 * 1024 * 1024\`。一旦 \`src/proxy.ts\` 的 matcher 命中（当前匹配除 \`api\`/\`_next\`/\`favicon\` 之外的所有路径，包括 \`/v1/*\`），\`cloneBodyStream()\` 会在 10MB 处 \`p1.push(null)\` 截断流。

## Fix

参照 \`next/dist/build/utils.ts\` 中 \`writeStandaloneDirectory\` 生成的模板（\`process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(nextConfig)\`），在 \`server.js\` 的 \`main()\` 入口、\`require(\"next\")\` 之前从 \`.next/required-server-files.json\` 读取构建期解析好的配置并写入同名环境变量。\`next/dist/server/config.ts\` 里的 \`loadConfig()\` 优先读它且跳过 \`assignDefaults\`，配置直通运行时。

## Repro / Verification

部署中 \`/v1/messages\` POST：

| body size | 修复前 | 修复后预期 |
|-----------|-------|----------|
| 8 MB      | 401（解析成功）| 401 |
| 12 MB     | 400 \"may have been truncated...\" + pod warn \`actualBodyBytes ≈ 10MB\` | 401 |
| 80 MB     | 同上 | 401 |
| > 100 MB  | 同上 | 400（命中 \`proxyClientMaxBodySize: 100mb\` 上限）|

通过 \`curl --data-binary @big.json https://ccx.autobits.cc/v1/messages\` 复现；pod 日志中 \`Request body exceeded 10MB for /v1/messages...\` 应消失。

## Test plan

- [ ] \`bun run typecheck\` ✓ 已通过
- [ ] 部署到测试环境后用 12MB / 50MB / 99MB JSON body 对 \`/v1/messages\` 发 POST，确认拿到 401（auth fail，body 完整解析）而不是 400 \"truncated\"
- [ ] pod 日志不再出现 \`[parseRequestBody] Possible body truncation detected\` 或 \`Request body exceeded 10MB...\`
- [ ] 100MB+ body 命中 \`proxyClientMaxBodySize\` 上限并按预期截断（应用兜底信息可见）
- [ ] 数据库导入页面（\`serverActions.bodySizeLimit: \"500mb\"\`）也应受益于此修复

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent body truncation bug in standalone Next.js deployments: because `next.config` isn't copied to the standalone output, `loadConfig()` fell back to its 10 MB default clone limit, cutting off `/v1/*` request bodies before they reached the upstream API. The fix mirrors Next.js's own standalone template by injecting `__NEXT_PRIVATE_STANDALONE_CONFIG` from `.next/required-server-files.json` before `require("next")` runs.

- **Standalone config injection** (`server-lib/standalone-config.js`, `server.js`): A new `applyStandaloneNextConfig` helper reads the build-time config from `required-server-files.json` and writes it to the env var that `loadConfig()` already checks, guarded behind `if (!dev)` so dev mode is unaffected.
- **Middleware matcher update** (`src/proxy.ts`, `src/proxy.matcher.ts`): `/v1` and `/v1beta` paths are excluded from the matcher with proper path-segment anchors (`(?:/|$)`), preventing Next.js from invoking `cloneBodyStream` on API proxy traffic. A drift-guard unit test keeps the inlined literal in sync with the shared constant.
- **Build script** (`scripts/copy-custom-server-to-standalone.cjs`): Now copies the new `server-lib/` directory alongside `server.js`; fails fast if the directory is missing.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrowly scoped to standalone startup and the middleware matcher, both with comprehensive unit test coverage.

The config injection runs once at startup before Next.js loads, is properly guarded against missing or malformed manifests, and does not overwrite an already-set env var. The matcher change correctly uses path-segment anchors to avoid over-matching, and the drift-guard test ensures the inlined literal and exported constant never diverge. The build script fails fast rather than silently producing a broken artifact. No behavioral regressions were identified.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| server-lib/standalone-config.js | New helper module that injects build-time Next.js config via `__NEXT_PRIVATE_STANDALONE_CONFIG`; well-guarded for missing manifest, preset env, and malformed config field. |
| server.js | Calls `applyStandaloneNextConfig` in `main()` before `require("next")`, gated on `!dev`; integration is minimal and correct. |
| src/proxy.ts | Matcher updated to exclude `/v1` and `/v1beta` paths with correct path-segment anchors, eliminating unnecessary body cloning for API proxy traffic. |
| src/proxy.matcher.ts | New module exporting the matcher pattern constant for testing; well-commented with boundary-anchoring rationale. |
| scripts/copy-custom-server-to-standalone.cjs | Extended to copy `server-lib/` directory alongside `server.js`; fails fast with a clear error if the directory is missing. |
| tests/unit/proxy-matcher.test.ts | Comprehensive matcher tests covering excluded paths, look-alike false-positives, previously excluded paths, and a drift guard between the inlined literal and exported constant. |
| tests/unit/server-standalone-config.test.ts | Good unit coverage for `applyStandaloneNextConfig`: happy path, preset env win, missing manifest, missing config field, and argument validation. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Docker as Docker CMD
    participant ServerJS as server.js (main)
    participant StandaloneConfig as server-lib/standalone-config.js
    participant Manifest as .next/required-server-files.json
    participant Env as process.env
    participant Next as require("next")
    participant Middleware as src/proxy.ts (middleware)
    participant APIRoute as /v1/* route handler

    Docker->>ServerJS: node server.js
    ServerJS->>StandaloneConfig: "applyStandaloneNextConfig({rootDir, env, log})"
    StandaloneConfig->>Manifest: require(manifestPath)
    Manifest-->>StandaloneConfig: "{ config: { experimental: { proxyClientMaxBodySize: 100mb } } }"
    StandaloneConfig->>Env: "__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(config)"
    StandaloneConfig-->>ServerJS: "{ applied: true }"
    ServerJS->>Next: require("next")
    Next->>Env: loadConfig() reads __NEXT_PRIVATE_STANDALONE_CONFIG
    Note over Next,Env: proxyClientMaxBodySize honored (fix)
    Note over Middleware: Matcher now excludes /v1/* and /v1beta/*
    Docker->>Middleware: POST /v1/messages (12 MB body)
    Note over Middleware: Matcher skips — no body clone, no 10MB clamp
    Middleware-->>APIRoute: request forwarded intact
    APIRoute-->>Docker: 401 (auth fail, body fully parsed)
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(proxy): tighten v1 matcher boundary,..."](https://github.com/ding113/claude-code-hub/commit/04594844aa1e0e78ef6cd553e0b089584264385b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31344419)</sub>

<!-- /greptile_comment -->