### PR TITLE
fix(proxy): request usage chunks for streaming chat

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -87,6 +87,7 @@ import {
   syncOpenAIImageMultipartFromLogicalBody,
   validateOpenAIImageRequest,
 } from "./openai-image-compat";
+import { ensureOpenAIChatStreamUsageOption } from "./openai-chat-usage-options";
 import { ProxyProviderResolver } from "./provider-selector";
 import type { ProxySession } from "./session";
 import { setDeferredStreamingFinalization } from "./stream-finalization";
@@ -2693,6 +2694,12 @@ export class ProxyForwarder {
           if (requestPath === "/v1/images/generations") {
             sanitizeGenerationsRequestForProvider(messageToSend, provider);
           }
+
+          ensureOpenAIChatStreamUsageOption(
+            messageToSend,
+            provider.providerType,
+            requestPath
+          );
 
           const validation = await validateOpenAIImageRequest({
             pathname: requestPath,

--- a/src/app/v1/_lib/proxy/openai-chat-usage-options.test.ts
+++ b/src/app/v1/_lib/proxy/openai-chat-usage-options.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { ensureOpenAIChatStreamUsageOption } from "./openai-chat-usage-options";
+
+describe("ensureOpenAIChatStreamUsageOption", () => {
+  it("adds include_usage for OpenAI-compatible streaming chat completions", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+    };
+
+    const changed = ensureOpenAIChatStreamUsageOption(
+      body,
+      "openai-compatible",
+      "/v1/chat/completions"
+    );
+
+    expect(changed).toBe(true);
+    expect(body.stream_options).toEqual({ include_usage: true });
+  });
+
+  it("preserves existing stream options while forcing include_usage", () => {
+    const body: Record<string, unknown> = {
+      stream: true,
+      stream_options: { foo: "bar", include_usage: false },
+    };
+
+    const changed = ensureOpenAIChatStreamUsageOption(
+      body,
+      "openai-compatible",
+      "/v1/chat/completions"
+    );
+
+    expect(changed).toBe(true);
+    expect(body.stream_options).toEqual({ foo: "bar", include_usage: true });
+  });
+
+  it("does not touch non-streaming chat completions", () => {
+    const body: Record<string, unknown> = {
+      stream: false,
+    };
+
+    const changed = ensureOpenAIChatStreamUsageOption(
+      body,
+      "openai-compatible",
+      "/v1/chat/completions"
+    );
+
+    expect(changed).toBe(false);
+    expect(body.stream_options).toBeUndefined();
+  });
+
+  it("does not touch other provider types", () => {
+    const body: Record<string, unknown> = {
+      stream: true,
+    };
+
+    const changed = ensureOpenAIChatStreamUsageOption(body, "claude", "/v1/chat/completions");
+
+    expect(changed).toBe(false);
+    expect(body.stream_options).toBeUndefined();
+  });
+});

--- a/src/app/v1/_lib/proxy/openai-chat-usage-options.ts
+++ b/src/app/v1/_lib/proxy/openai-chat-usage-options.ts
@@ -1,0 +1,36 @@
+const OPENAI_COMPATIBLE_PROVIDER_TYPES = new Set(["openai-compatible"]);
+
+export function ensureOpenAIChatStreamUsageOption(
+  body: Record<string, unknown>,
+  providerType: string | null | undefined,
+  requestPath: string
+): boolean {
+  if (!OPENAI_COMPATIBLE_PROVIDER_TYPES.has(providerType ?? "")) {
+    return false;
+  }
+
+  if (requestPath !== "/v1/chat/completions" || body.stream !== true) {
+    return false;
+  }
+
+  const streamOptions = body.stream_options;
+  if (streamOptions == null) {
+    body.stream_options = { include_usage: true };
+    return true;
+  }
+
+  if (typeof streamOptions !== "object" || Array.isArray(streamOptions)) {
+    return false;
+  }
+
+  const streamOptionsRecord = streamOptions as Record<string, unknown>;
+  if (streamOptionsRecord.include_usage === true) {
+    return false;
+  }
+
+  body.stream_options = {
+    ...streamOptionsRecord,
+    include_usage: true,
+  };
+  return true;
+}


### PR DESCRIPTION
## Summary

Ensure OpenAI-compatible streaming `/v1/chat/completions` requests include `stream_options.include_usage=true` before forwarding to upstream. This fixes missing usage accounting for streaming chat completions that could result in successful requests being logged with empty token fields and zero cost.

## Problem

For OpenAI-compatible providers, POST `/v1/chat/completions` streaming requests can complete successfully without a final usage chunk when the client does not send `stream_options.include_usage=true`.

In that case the proxy records a successful request with response content, but token fields stay empty and the calculated cost stays zero. This makes usage logs and quota accounting undercount successful streaming chat completions.

**Related Issues:**
- Fixes #1165 — OpenAI-compatible streaming chat completions can miss usage accounting
- Related to #1133 — Prior fix for OpenAI-compatible cache token double counting (same usage-accounting area)

## Solution

- Inject `stream_options.include_usage=true` into the request body for OpenAI-compatible `/v1/chat/completions` requests with `stream: true`
- Preserve any existing `stream_options` fields while forcing `include_usage` to `true`
- No-op for non-streaming requests, non-chat endpoints, and non-OpenAI-compatible provider types

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/openai-chat-usage-options.ts` (+36 lines) — New helper that mutates the request body to enforce `include_usage=true` only when applicable
- `src/app/v1/_lib/proxy/forwarder.ts` (+7 lines) — Call the helper before forwarding the request to upstream

### Supporting Changes
- `src/app/v1/_lib/proxy/openai-chat-usage-options.test.ts` (+63 lines) — Unit tests covering streaming, non-streaming, existing stream options preservation, and non-OpenAI-compatible provider types

## Breaking Changes

None. This only modifies the forwarded upstream request body; client-facing behavior is unchanged.

## Testing

### Automated Tests
- [x] Unit tests added (`openai-chat-usage-options.test.ts`, 4 cases)

### Manual Testing
1. Send a streaming chat completion request through an OpenAI-compatible provider without `stream_options`
2. Verify upstream receives `stream_options.include_usage=true`
3. Verify the final usage chunk is captured and token/cost fields are populated

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No documentation update needed (behavioral fix, no API surface change)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR injects `stream_options.include_usage=true` into outgoing OpenAI-compatible streaming `/v1/chat/completions` requests so that upstreams which would otherwise omit the final usage chunk always return token counts and a non-zero cost.

- A new `ensureOpenAIChatStreamUsageOption` utility handles the injection, preserving any existing `stream_options` fields; it is called in `forwarder.ts` after all provider transforms and before body serialisation.
- The function silently returns `false` (no injection) when `stream_options` is present but is not a plain object (e.g. an array or a primitive), leaving the usage chunk absent — the same failure mode the PR is trying to prevent.
- Unit tests cover streaming, non-streaming, and non-OpenAI-compatible cases, but do not exercise the non-object `stream_options` branch.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The change is narrow and well-tested for common paths, but a logic gap in the non-object stream_options branch means the injection can be silently skipped, leaving usage empty.

The core injection logic works correctly for the expected inputs, but the branch handling a non-null non-object stream_options returns false without injecting include_usage. A client sending stream_options as an array or primitive would still see empty token fields and zero cost after this fix, and the test suite does not cover this branch so the gap is invisible in CI.

openai-chat-usage-options.ts lines 22-24 (the early-return for non-object stream_options) and its corresponding test file warrant a second look.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/openai-chat-usage-options.ts | New utility that injects stream_options.include_usage=true for OpenAI-compatible streaming chat completions; silently skips injection when stream_options is a non-null non-object value, leaving usage empty in that edge case. |
| src/app/v1/_lib/proxy/openai-chat-usage-options.test.ts | New test file covering streaming, non-streaming, and non-OpenAI-compatible cases; missing coverage for stream_options being a non-object value (the silent-skip branch). |
| src/app/v1/_lib/proxy/forwarder.ts | One-line integration: calls ensureOpenAIChatStreamUsageOption on the outgoing body after all provider transforms and before serialization; return value is unused (by design, since the body is mutated in place). |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Outgoing request body] --> B{providerType == openai-compatible?}
    B -- No --> Z[return false — no change]
    B -- Yes --> C{path == /v1/chat/completions AND stream == true?}
    C -- No --> Z
    C -- Yes --> D{stream_options == null?}
    D -- Yes --> E[Set stream_options = include_usage: true]
    E --> Y[return true — body mutated]
    D -- No --> F{typeof stream_options == object AND not array?}
    F -- No --> Z2[return false — silent no-op]
    F -- Yes --> G{stream_options.include_usage === true?}
    G -- Yes --> Z3[return false — already set]
    G -- No --> H[Spread existing stream_options, force include_usage: true]
    H --> Y
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/app/v1/_lib/proxy/openai-chat-usage-options.ts:22-24
**Silent no-op when `stream_options` is an unexpected type**

When `stream_options` is present but is not a plain object (e.g. a client sends `stream_options: []` or `stream_options: "raw"`), the function returns `false` without injecting `include_usage: true`. The whole point of this function is to guarantee the usage chunk is requested, yet this branch silently skips the injection, leaving token fields empty and cost at zero — the exact failure mode the PR is trying to prevent. Since `stream_options` being a non-object is already a malformed request, the function could safely overwrite it with `{ include_usage: true }` (or at least log a warning and proceed) rather than bailing out silently.

### Issue 2 of 2
src/app/v1/_lib/proxy/openai-chat-usage-options.test.ts:21-34
**Missing coverage for the silent-skip branch**

There is no test for the case where `stream_options` is present but is a non-object (e.g. an array or a string). The function returns `false` without injecting `include_usage: true` in that situation, but the test suite never exercises it. Adding a case like `stream_options: []` would both document the (debatable) intended behaviour and catch any future change to that branch.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(proxy): request usage chunks for str..."](https://github.com/ding113/claude-code-hub/commit/008ac0a4d7ad86e7fba12d8d5f3c72f5786091f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31447772)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->