### PR TITLE
fix: update cloud price table URL

### DIFF
--- a/src/app/[locale]/settings/prices/_components/upload-price-dialog.tsx
+++ b/src/app/[locale]/settings/prices/_components/upload-price-dialog.tsx
@@ -249,7 +249,7 @@ export function UploadPriceDialog({
                   • {t("dialog.manualDownload")}{" "}
                   <a
                     className="text-blue-500 underline"
-                    href="https://claude-code-hub.app/config/prices-base.toml"
+                    href="https://docs.claude-code-hub.app/config/prices-base.toml"
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/src/lib/price-sync/cloud-price-table.ts
+++ b/src/lib/price-sync/cloud-price-table.ts
@@ -1,8 +1,27 @@
 import TOML from "@iarna/toml";
 import type { ModelPriceData } from "@/types/model-price";
 
-export const CLOUD_PRICE_TABLE_URL = "https://claude-code-hub.app/config/prices-base.toml";
+export const CLOUD_PRICE_TABLE_URL = "https://docs.claude-code-hub.app/config/prices-base.toml";
 const FETCH_TIMEOUT_MS = 10000;
+const LEGACY_CLOUD_PRICE_TABLE_HOST = "claude-code-hub.app";
+
+function isAllowedPriceTableRedirect(expectedUrl: URL, finalUrl: URL): boolean {
+  if (
+    finalUrl.protocol === expectedUrl.protocol &&
+    finalUrl.host === expectedUrl.host &&
+    finalUrl.pathname === expectedUrl.pathname
+  ) {
+    return true;
+  }
+
+  return (
+    expectedUrl.protocol === "https:" &&
+    finalUrl.protocol === "https:" &&
+    expectedUrl.host === LEGACY_CLOUD_PRICE_TABLE_HOST &&
+    finalUrl.host === new URL(CLOUD_PRICE_TABLE_URL).host &&
+    finalUrl.pathname === expectedUrl.pathname
+  );
+}
 
 export type CloudPriceTable = {
   metadata?: Record<string, unknown>;
@@ -76,11 +95,7 @@ export async function fetchCloudPriceTableToml(
     if (expectedUrl && typeof response.url === "string" && response.url) {
       try {
         const finalUrl = new URL(response.url);
-        if (
-          finalUrl.protocol !== expectedUrl.protocol ||
-          finalUrl.host !== expectedUrl.host ||
-          finalUrl.pathname !== expectedUrl.pathname
-        ) {
+        if (!isAllowedPriceTableRedirect(expectedUrl, finalUrl)) {
           return { ok: false, error: "云端价格表拉取失败：重定向到非预期地址" };
         }
       } catch {

--- a/tests/unit/price-sync/cloud-price-table.test.ts
+++ b/tests/unit/price-sync/cloud-price-table.test.ts
@@ -179,6 +179,23 @@ describe("fetchCloudPriceTableToml", () => {
     expect(result.ok).toBe(false);
   });
 
+  it("allows the legacy cloud price table URL to redirect to the docs host", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        url: "https://docs.claude-code-hub.app/config/prices-base.toml",
+        text: async () => "toml content",
+      }))
+    );
+
+    const result = await fetchCloudPriceTableToml(
+      "https://claude-code-hub.app/config/prices-base.toml"
+    );
+    expect(result.ok).toBe(true);
+  });
+
   it("returns ok=false when response url redirects to unexpected pathname", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary

- update the default cloud price table URL to `https://docs.claude-code-hub.app/config/prices-base.toml`
- allow the legacy `claude-code-hub.app` price table URL to redirect to the exact docs-host price table path
- update the manual price table download link
- add test coverage for the allowed legacy-host redirect

Fixes #1169.

## Test

Not run locally: dependencies are not installed in the clean worktree used for this patch.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates the cloud price table URL from `https://claude-code-hub.app/config/prices-base.toml` to `https://docs.claude-code-hub.app/config/prices-base.toml`, and adds a redirect-allowance so any existing callers still using the legacy host are not blocked.

- **`cloud-price-table.ts`**: `CLOUD_PRICE_TABLE_URL` constant updated; new `isAllowedPriceTableRedirect` helper permits the legacy `claude-code-hub.app` → `docs.claude-code-hub.app` subdomain redirect while all other cross-host redirects continue to be rejected.
- **`upload-price-dialog.tsx`**: Manual download link href updated to match the new URL.
- **`cloud-price-table.test.ts`**: New test verifies the legacy-host happy path; the complementary rejection case (legacy host → wrong final host) is not yet covered.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the change correctly tightens the redirect guard for the docs migration and the UI link is updated consistently.

All three changed files are coherent and the redirect logic correctly handles both the new default URL and the legacy host. The only gaps are a repeated `new URL(...)` parse that could be a module-level constant, and a missing negative test for the legacy-URL rejection path.

`src/lib/price-sync/cloud-price-table.ts` — the inline `new URL(CLOUD_PRICE_TABLE_URL)` call inside `isAllowedPriceTableRedirect` warrants a small cleanup.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/price-sync/cloud-price-table.ts | Updates default URL to the docs subdomain and introduces `isAllowedPriceTableRedirect` to permit the legacy host to forward to the new host; `new URL(CLOUD_PRICE_TABLE_URL)` should be a module-level constant instead of being computed per call. |
| src/app/[locale]/settings/prices/_components/upload-price-dialog.tsx | Single-line URL update in the manual download link from the legacy host to the new docs host; no logic changes. |
| tests/unit/price-sync/cloud-price-table.test.ts | Adds a passing test for the legacy → docs host redirect; the corresponding rejection path (legacy host → wrong target) is not covered. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fetchCloudPriceTableToml called] --> B{Parse expectedUrl}
    B -->|invalid URL| C[skip redirect check]
    B -->|valid URL| D[fetch URL]
    D --> E{response.url present?}
    E -->|no| F[skip redirect check]
    E -->|yes| G[parse finalUrl]
    G --> H{isAllowedPriceTableRedirect}
    H --> I{protocol + host + pathname match exactly?}
    I -->|yes| J[allowed ✅]
    I -->|no| K{expectedUrl.host == 'claude-code-hub.app'?}
    K -->|no| L[blocked ❌ redirect to unexpected address]
    K -->|yes| M{finalUrl.host == 'docs.claude-code-hub.app'?}
    M -->|no| L
    M -->|yes| N{pathnames match?}
    N -->|no| L
    N -->|yes| J
    J --> O{response.ok?}
    O -->|no| P[return ok=false HTTP error]
    O -->|yes| Q{body non-empty?}
    Q -->|no| R[return ok=false empty]
    Q -->|yes| S[return ok=true with TOML text]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/lib/price-sync/cloud-price-table.ts:4-6
`new URL(CLOUD_PRICE_TABLE_URL)` is reconstructed on every invocation of `isAllowedPriceTableRedirect` that reaches the legacy branch. Since `CLOUD_PRICE_TABLE_URL` is a module-level constant, this parse is always identical. Computing `DOCS_CLOUD_PRICE_TABLE_HOST` once at module load avoids the repeated allocation and makes the intent explicit.

```suggestion
export const CLOUD_PRICE_TABLE_URL = "https://docs.claude-code-hub.app/config/prices-base.toml";
const FETCH_TIMEOUT_MS = 10000;
const LEGACY_CLOUD_PRICE_TABLE_HOST = "claude-code-hub.app";
const DOCS_CLOUD_PRICE_TABLE_HOST = new URL(CLOUD_PRICE_TABLE_URL).host;
```

### Issue 2 of 3
src/lib/price-sync/cloud-price-table.ts:21
The inline `new URL(CLOUD_PRICE_TABLE_URL).host` can now reference the pre-computed constant.

```suggestion
    finalUrl.host === DOCS_CLOUD_PRICE_TABLE_HOST &&
```

### Issue 3 of 3
tests/unit/price-sync/cloud-price-table.test.ts:182-197
**Missing negative test for legacy-host redirect to wrong target**

The new test covers the happy path (legacy → docs host), but the failure case is not exercised: a response where `expectedUrl.host === "claude-code-hub.app"` but `finalUrl.host` is neither the legacy host nor `docs.claude-code-hub.app` should still return `ok: false`. The existing "redirects to unexpected host" test uses a non-legacy `example.test` URL, so that particular code path through `isAllowedPriceTableRedirect` is never exercised for the rejection branch.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: update cloud price table URL"](https://github.com/ding113/claude-code-hub/commit/6388f2b794cb6f63a5969f00e7c48f221a6f3a1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31492155)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->