### PR TITLE
fix(lifecycle): orchestrate graceful shutdown with server.close + bounded timeouts

### DIFF
--- a/server.js
+++ b/server.js
@@ -749,9 +749,21 @@ async function main() {
 function registerOrchestratedShutdown(server, wss) {
   let shuttingDown = false;
 
-  const drainMs = Number(process.env.SHUTDOWN_DRAIN_MS) || 15000;
-  const cleanupMs = Number(process.env.SHUTDOWN_CLEANUP_MS) || 10000;
-  const hardExitMs = Number(process.env.SHUTDOWN_HARD_EXIT_MS) || 25000;
+  // Positive integer parser: `Number("0") || default` would silently coerce an
+  // intentional 0 back to the default. Mirrors the parser in
+  // src/lib/langfuse/index.ts so operator overrides behave consistently.
+  const parsePosInt = (raw, fallback) => {
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : fallback;
+  };
+
+  // Defaults: drain + cleanup = 25s, with a 3s gap before the hard-exit
+  // watchdog. Without the gap, when both phases hit their cap the watchdog
+  // (registered at T=0) fires at the same instant as `process.exit(0)` and
+  // wins by ordering, falsely logging the shutdown as failed.
+  const drainMs = parsePosInt(process.env.SHUTDOWN_DRAIN_MS, 15000);
+  const cleanupMs = parsePosInt(process.env.SHUTDOWN_CLEANUP_MS, 10000);
+  const hardExitMs = parsePosInt(process.env.SHUTDOWN_HARD_EXIT_MS, 28000);
 
   const orchestratedShutdown = async (signal) => {
     if (shuttingDown) return;
@@ -805,6 +817,8 @@ function registerOrchestratedShutdown(server, wss) {
 
     // 4. Bounded drain — server.close() resolves only after every in-flight
     //    connection completes; we cap it so a stuck client can't hold us forever.
+    //    Clearing the timer on natural close avoids a misleading
+    //    "shutdown_drain_timeout" warning during the subsequent cleanup phase.
     await Promise.race([
       closeServer,
       new Promise((resolve) => {
@@ -813,6 +827,7 @@ function registerOrchestratedShutdown(server, wss) {
           resolve();
         }, drainMs);
         if (typeof t.unref === "function") t.unref();
+        closeServer.finally(() => clearTimeout(t));
       }),
     ]);
 

--- a/server.js
+++ b/server.js
@@ -693,8 +693,9 @@ async function main() {
     }
   });
 
+  let wss = null;
   if (WebSocketServer) {
-    const wss = new WebSocketServer({ noServer: true, maxPayload: WS_MAX_PAYLOAD_BYTES });
+    wss = new WebSocketServer({ noServer: true, maxPayload: WS_MAX_PAYLOAD_BYTES });
 
     server.on("upgrade", (req, socket, head) => {
       if (!isResponsesWsUpgrade(req)) {
@@ -729,6 +730,114 @@ async function main() {
       wsEnabled: !!WebSocketServer,
     });
   });
+
+  registerOrchestratedShutdown(server, wss);
+}
+
+// Graceful shutdown orchestration. Lives here (not in instrumentation.ts) because
+// only this process owns the `server` handle returned by http.createServer().
+//
+// Sequence (bounded by SHUTDOWN_HARD_EXIT_MS as the final safety net):
+//   1. Mark shutdown flag    -> /api/health/ready returns 503 -> Service drains
+//   2. server.close()        -> stop accepting; in-flight HTTP finishes
+//   3. wss.close()           -> reject new WS upgrades
+//   4. Wait for drain        -> bounded by SHUTDOWN_DRAIN_MS
+//   5. runApplicationCleanup -> Redis / Langfuse / msg buffer / schedulers; bounded
+//      by SHUTDOWN_CLEANUP_MS. Inside cleanup, asyncTaskManager.cleanupAll() runs
+//      LAST so streaming responses had a chance to finish during step 4.
+//   6. process.exit(0)
+function registerOrchestratedShutdown(server, wss) {
+  let shuttingDown = false;
+
+  const drainMs = Number(process.env.SHUTDOWN_DRAIN_MS) || 15000;
+  const cleanupMs = Number(process.env.SHUTDOWN_CLEANUP_MS) || 10000;
+  const hardExitMs = Number(process.env.SHUTDOWN_HARD_EXIT_MS) || 25000;
+
+  const orchestratedShutdown = async (signal) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    log("info", "shutdown_received", { signal, drainMs, cleanupMs, hardExitMs });
+
+    // Final safety: even if every step below hangs, this terminates the process.
+    // .unref() so the timer itself doesn't keep the event loop alive.
+    const hardExit = setTimeout(() => {
+      log("error", "shutdown_hard_exit_watchdog", { hardExitMs });
+      process.exit(1);
+    }, hardExitMs);
+    if (typeof hardExit.unref === "function") hardExit.unref();
+
+    // 1. Flip readiness BEFORE closing the listener so probes already in flight
+    //    see 503 and the Service starts removing this pod from endpoints.
+    const lifecycle = globalThis.__CCH_LIFECYCLE__;
+    try {
+      lifecycle?.markShuttingDown?.();
+    } catch (err) {
+      log("warn", "shutdown_mark_failed", { error: String(err && err.message ? err.message : err) });
+    }
+
+    // 2 + 3. Stop accepting new connections.
+    const closeServer = new Promise((resolve) => {
+      try {
+        server.close((err) => {
+          if (err) {
+            log("warn", "shutdown_server_close_error", {
+              error: String(err && err.message ? err.message : err),
+            });
+          }
+          resolve();
+        });
+      } catch (err) {
+        log("warn", "shutdown_server_close_threw", {
+          error: String(err && err.message ? err.message : err),
+        });
+        resolve();
+      }
+    });
+    if (wss && typeof wss.close === "function") {
+      try {
+        wss.close();
+      } catch (err) {
+        log("warn", "shutdown_wss_close_error", {
+          error: String(err && err.message ? err.message : err),
+        });
+      }
+    }
+
+    // 4. Bounded drain — server.close() resolves only after every in-flight
+    //    connection completes; we cap it so a stuck client can't hold us forever.
+    await Promise.race([
+      closeServer,
+      new Promise((resolve) => {
+        const t = setTimeout(() => {
+          log("warn", "shutdown_drain_timeout", { drainMs });
+          resolve();
+        }, drainMs);
+        if (typeof t.unref === "function") t.unref();
+      }),
+    ]);
+
+    // 5. Application-level cleanup.
+    try {
+      if (typeof lifecycle?.runApplicationCleanup === "function") {
+        await lifecycle.runApplicationCleanup(signal, { totalTimeoutMs: cleanupMs });
+      } else {
+        log("warn", "shutdown_cleanup_unavailable", {
+          reason: "lifecycle_globals_not_bound",
+        });
+      }
+    } catch (err) {
+      log("warn", "shutdown_cleanup_error", {
+        error: String(err && err.message ? err.message : err),
+      });
+    }
+
+    log("info", "shutdown_complete", { signal });
+    clearTimeout(hardExit);
+    process.exit(0);
+  };
+
+  process.once("SIGTERM", () => void orchestratedShutdown("SIGTERM"));
+  process.once("SIGINT", () => void orchestratedShutdown("SIGINT"));
 }
 
 // Exposed for tests; not part of the long-lived server entrypoint.
@@ -737,6 +846,7 @@ module.exports = {
   isNextDevMode,
   handleWebSocketConnection,
   forwardToInternalHttp,
+  registerOrchestratedShutdown,
   WS_MAX_PAYLOAD_BYTES,
   MAX_PENDING_BYTES,
 };

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -3,7 +3,7 @@
  * 在服务器启动时自动执行数据库迁移
  */
 
-import { startCacheCleanup, stopCacheCleanup } from "@/lib/cache/session-cache";
+import { startCacheCleanup } from "@/lib/cache/session-cache";
 import { logger } from "@/lib/logger";
 import { CHANNEL_API_KEYS_UPDATED, subscribeCacheInvalidation } from "@/lib/redis/pubsub";
 import { apiKeyVacuumFilter } from "@/lib/security/api-key-vacuum-filter";
@@ -276,125 +276,11 @@ export async function register() {
 
     if (!instrumentationState.__CCH_SHUTDOWN_HOOKS_REGISTERED__) {
       instrumentationState.__CCH_SHUTDOWN_HOOKS_REGISTERED__ = true;
-
-      const shutdownHandler = async (signal: string) => {
-        if (instrumentationState.__CCH_SHUTDOWN_IN_PROGRESS__) {
-          return;
-        }
-        instrumentationState.__CCH_SHUTDOWN_IN_PROGRESS__ = true;
-
-        const startedAt = instrumentationState.__CCH_PROCESS_STARTED_AT__;
-        const uptimeSeconds =
-          startedAt !== undefined ? Math.round((Date.now() - startedAt) / 1000) : null;
-        logger.info("[Lifecycle] Process exiting", {
-          pid: process.pid,
-          signal,
-          uptimeSeconds,
-        });
-        logger.info(`[Instrumentation] Received ${signal}, cleaning up...`);
-
-        try {
-          stopCacheCleanup();
-          instrumentationState.__CCH_CACHE_CLEANUP_STARTED__ = false;
-        } catch (error) {
-          logger.warn("[Instrumentation] Failed to stop cache cleanup", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        try {
-          instrumentationState.__CCH_API_KEY_VF_SYNC_CLEANUP__?.();
-          instrumentationState.__CCH_API_KEY_VF_SYNC_STARTED__ = false;
-        } catch (error) {
-          logger.warn("[Instrumentation] Failed to cleanup API key vacuum filter sync", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        try {
-          const { stopEndpointProbeScheduler } = await import(
-            "@/lib/provider-endpoints/probe-scheduler"
-          );
-          stopEndpointProbeScheduler();
-        } catch (error) {
-          logger.warn("[Instrumentation] Failed to stop endpoint probe scheduler", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        try {
-          const { stopPublicStatusRebuildScheduler } = await import(
-            "@/lib/public-status/scheduler"
-          );
-          await stopPublicStatusRebuildScheduler();
-        } catch (error) {
-          logger.warn("[Instrumentation] Failed to stop public status rebuild scheduler", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        try {
-          const { stopEndpointProbeLogCleanup } = await import(
-            "@/lib/provider-endpoints/probe-log-cleanup"
-          );
-          stopEndpointProbeLogCleanup();
-        } catch (error) {
-          logger.warn("[Instrumentation] Failed to stop endpoint probe log cleanup", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        try {
-          const { closeRedis } = await import("@/lib/redis");
-          await closeRedis();
-        } catch (error) {
-          logger.warn("[Instrumentation] Failed to close Redis connection", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        // Flush Langfuse pending spans
-        try {
-          const { shutdownLangfuse } = await import("@/lib/langfuse");
-          await shutdownLangfuse();
-        } catch (error) {
-          logger.warn("[Instrumentation] Failed to shutdown Langfuse", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        // 尽力将 message_request 的异步批量更新刷入数据库（避免终止时丢失尾部日志）
-        try {
-          const { stopMessageRequestWriteBuffer } = await import(
-            "@/repository/message-write-buffer"
-          );
-          await stopMessageRequestWriteBuffer();
-        } catch (error) {
-          logger.warn("[Instrumentation] Failed to stop message request write buffer", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-
-        try {
-          if (instrumentationState.__CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__) {
-            clearInterval(instrumentationState.__CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__);
-            instrumentationState.__CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__ = undefined;
-            instrumentationState.__CCH_CLOUD_PRICE_SYNC_STARTED__ = false;
-          }
-        } catch (error) {
-          logger.warn("[Instrumentation] Failed to stop cloud price sync scheduler", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      };
-
-      process.once("SIGTERM", () => {
-        void shutdownHandler("SIGTERM");
-      });
-
-      process.once("SIGINT", () => {
-        void shutdownHandler("SIGINT");
-      });
+      // SIGTERM/SIGINT 注册移到 server.js，因为它持有 HTTP server 句柄、可以先
+      // server.close() 再让 application cleanup 跑。这里只把 cleanup 函数集
+      // 挂到 globalThis 让 server.js 桥接调用。
+      const { bindLifecycleGlobals } = await import("@/lib/lifecycle/shutdown");
+      bindLifecycleGlobals();
     }
 
     // 生产环境: 执行完整初始化(迁移 + 价格表 + 清理任务 + 通知任务)

--- a/src/lib/async-task-manager.ts
+++ b/src/lib/async-task-manager.ts
@@ -48,19 +48,17 @@ class AsyncTaskManagerClass {
       return;
     }
 
-    // 定义统一的清理处理器
-    const exitHandler = (signal: string) => {
-      logger.info(`[AsyncTaskManager] Received ${signal}, cleaning up all tasks`, {
+    // SIGTERM/SIGINT 的取消时机由 src/lib/lifecycle/shutdown.ts 编排：
+    // 不在 drain 阶段取消任务（否则 server.close() 的 drain 完全失去意义——
+    // SSE/流式响应正期望被允许自然结束）。编排器进入 cleanup 阶段后才会调用
+    // shutdownAllAsyncTasks()。这里只保留 beforeExit 兜底，覆盖事件循环自然
+    // 耗尽路径（例如脚本类调用方未触发 SIGTERM）。
+    process.once("beforeExit", () => {
+      logger.info("[AsyncTaskManager] beforeExit reached, cancelling remaining tasks", {
         activeTaskCount: this.tasks.size,
       });
       this.cleanupAll();
-    };
-
-    // 监听所有退出信号（确保 Docker 环境下优雅关闭）
-    // 使用 once 而非 on，避免重复注册（特别是热重载场景）
-    process.once("SIGTERM", () => exitHandler("SIGTERM")); // Docker stop
-    process.once("SIGINT", () => exitHandler("SIGINT")); // Ctrl+C
-    process.once("beforeExit", () => exitHandler("beforeExit")); // 正常退出
+    });
 
     // 每分钟检查并清理超时任务（>10 分钟未完成，防止内存泄漏）
     this.cleanupInterval = setInterval(() => {
@@ -208,7 +206,7 @@ class AsyncTaskManagerClass {
   /**
    * 清理所有任务（进程退出时调用）
    */
-  private cleanupAll(): void {
+  cleanupAll(): void {
     logger.info("[AsyncTaskManager] Cleaning up all tasks", {
       count: this.tasks.size,
     });
@@ -247,3 +245,9 @@ class AsyncTaskManagerClass {
 const g = globalThis as unknown as { __ASYNC_TASK_MANAGER__?: AsyncTaskManagerClass };
 export const AsyncTaskManager =
   g.__ASYNC_TASK_MANAGER__ ?? (g.__ASYNC_TASK_MANAGER__ = new AsyncTaskManagerClass());
+
+// 供 shutdown 编排器调用：在 cleanup 阶段（server.close 完成后）才取消残留任务，
+// 避免 drain 期间打断流式响应。
+export function shutdownAllAsyncTasks(): void {
+  AsyncTaskManager.cleanupAll();
+}

--- a/src/lib/health/checker.ts
+++ b/src/lib/health/checker.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/drizzle/db";
+import { isShuttingDown } from "@/lib/lifecycle/shutdown";
 import { logger } from "@/lib/logger";
 import { getRedisClient } from "@/lib/redis/client";
 import { APP_VERSION } from "@/lib/version";
@@ -140,6 +141,24 @@ export async function checkProxy(): Promise<ComponentHealth> {
 
 export async function checkReadiness(): Promise<HealthCheckResponse> {
   const version = getAppVersion();
+
+  // Shutdown 中立即返回 503，让 Service/Ingress 在 server.close() drain 之前就摘流，
+  // 否则新连接还会被路由到正在 drain 的 pod 上。
+  if (isShuttingDown()) {
+    const downForShutdown: ComponentHealth = { status: "down", message: "shutting_down" };
+    return {
+      status: "unhealthy",
+      timestamp: new Date().toISOString(),
+      version,
+      uptime: Math.round(process.uptime()),
+      components: {
+        database: downForShutdown,
+        redis: downForShutdown,
+        proxy: downForShutdown,
+      },
+    };
+  }
+
   const [database, redis, proxy] = await Promise.all([checkDatabase(), checkRedis(), checkProxy()]);
 
   // DB 必需，Redis/Proxy 可选（降级但不摘流量）

--- a/src/lib/langfuse/index.ts
+++ b/src/lib/langfuse/index.ts
@@ -68,25 +68,62 @@ export async function initLangfuse(): Promise<void> {
   }
 }
 
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 3000;
+
+function getShutdownTimeoutMs(): number {
+  const raw = process.env.LANGFUSE_SHUTDOWN_TIMEOUT_MS;
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SHUTDOWN_TIMEOUT_MS;
+}
+
+async function withTimeout(p: Promise<unknown>, ms: number, label: string): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      logger.warn(`[Langfuse] ${label} timed out`, { ms });
+      resolve();
+    }, ms);
+  });
+  try {
+    await Promise.race([
+      p.then(
+        () => undefined,
+        (error) => {
+          logger.warn(`[Langfuse] ${label} failed`, {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      ),
+      timeout,
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 /**
  * Flush pending spans and shut down the SDK.
  * Called during graceful shutdown (SIGTERM/SIGINT).
+ *
+ * forceFlush 是无超时的网络刷盘——曾在生产观察到耗时 3 分钟，远超 K8s 默认 30s
+ * grace period。这里用 Promise.race + setTimeout 强制上限，超时只记日志不抛错，
+ * 让关闭流程继续往下走。
  */
 export async function shutdownLangfuse(): Promise<void> {
   if (!initialized || !spanProcessor) {
     return;
   }
 
-  try {
-    await spanProcessor.forceFlush();
-    if (sdk) {
-      await sdk.shutdown();
-    }
-    initialized = false;
-    logger.info("[Langfuse] Shutdown complete");
-  } catch (error) {
-    logger.warn("[Langfuse] Shutdown error", {
-      error: error instanceof Error ? error.message : String(error),
-    });
+  const timeoutMs = getShutdownTimeoutMs();
+  const localProcessor = spanProcessor;
+  const localSdk = sdk;
+  initialized = false;
+  spanProcessor = null;
+  sdk = null;
+
+  await withTimeout(localProcessor.forceFlush(), timeoutMs, "forceFlush");
+  if (localSdk) {
+    await withTimeout(localSdk.shutdown(), timeoutMs, "sdk.shutdown");
   }
+  logger.info("[Langfuse] Shutdown complete");
 }

--- a/src/lib/lifecycle/shutdown.ts
+++ b/src/lib/lifecycle/shutdown.ts
@@ -1,0 +1,215 @@
+import { logger } from "@/lib/logger";
+
+// 单进程级 shutdown 状态：readiness 探针读取它在收到 SIGTERM 后立刻返回 503，
+// 让 Service/Ingress 提前摘流，避免新连接打到正在 drain 的 pod 上。
+let shuttingDown = false;
+
+export function markShuttingDown(): void {
+  if (!shuttingDown) {
+    shuttingDown = true;
+    logger.info("[Shutdown] marked as shutting down");
+  }
+}
+
+export function isShuttingDown(): boolean {
+  return shuttingDown;
+}
+
+// 仅供测试重置内部状态，正常代码路径不使用。
+export function __resetShutdownStateForTests(): void {
+  shuttingDown = false;
+}
+
+// 单步 timeout：超时 / 失败都不能让整个关闭流程被阻塞，因此 catch + 计时器双保险。
+async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      logger.warn(`[Shutdown] ${label} timed out`, { ms });
+      resolve();
+    }, ms);
+  });
+  try {
+    await Promise.race([
+      p.then(
+        () => undefined,
+        (error) => {
+          logger.warn(`[Shutdown] ${label} failed`, {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      ),
+      timeout,
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+const DEFAULT_STEP_TIMEOUT_MS = 3000;
+const DEFAULT_TOTAL_TIMEOUT_MS = 10000;
+
+export interface RunCleanupOptions {
+  totalTimeoutMs?: number;
+  perStepTimeoutMs?: number;
+}
+
+// 串行执行每一步的资源回收。每步超时不阻塞后续步骤；整体超时是兜底保护。
+export async function runApplicationCleanup(
+  signal: string,
+  opts: RunCleanupOptions = {}
+): Promise<void> {
+  const stepMs = opts.perStepTimeoutMs ?? DEFAULT_STEP_TIMEOUT_MS;
+  const totalMs = opts.totalTimeoutMs ?? DEFAULT_TOTAL_TIMEOUT_MS;
+
+  const startedAt = Date.now();
+  logger.info("[Shutdown] application cleanup starting", { signal, totalMs, stepMs });
+
+  const work = (async () => {
+    // 1. 停止本地周期任务（不需要做 IO，几乎是同步）
+    await withTimeout(
+      (async () => {
+        const { stopCacheCleanup } = await import("@/lib/cache/session-cache");
+        stopCacheCleanup();
+      })(),
+      stepMs,
+      "stopCacheCleanup"
+    );
+
+    // 2. 端点探测调度器
+    await withTimeout(
+      (async () => {
+        const { stopEndpointProbeScheduler } = await import(
+          "@/lib/provider-endpoints/probe-scheduler"
+        );
+        stopEndpointProbeScheduler();
+      })(),
+      stepMs,
+      "stopEndpointProbeScheduler"
+    );
+
+    // 3. 公共状态重建调度器
+    await withTimeout(
+      (async () => {
+        const { stopPublicStatusRebuildScheduler } = await import("@/lib/public-status/scheduler");
+        await stopPublicStatusRebuildScheduler();
+      })(),
+      stepMs,
+      "stopPublicStatusRebuildScheduler"
+    );
+
+    // 4. 端点探测日志清理
+    await withTimeout(
+      (async () => {
+        const { stopEndpointProbeLogCleanup } = await import(
+          "@/lib/provider-endpoints/probe-log-cleanup"
+        );
+        stopEndpointProbeLogCleanup();
+      })(),
+      stepMs,
+      "stopEndpointProbeLogCleanup"
+    );
+
+    // 5. 取消仍在飞的后台异步任务。
+    //    必须排在 message-buffer flush 之前——任务被 abort 时仍会写出尾部日志/用量记录，
+    //    flush 才能把这些尾部更新真正落库。
+    await withTimeout(
+      (async () => {
+        const { shutdownAllAsyncTasks } = await import("@/lib/async-task-manager");
+        shutdownAllAsyncTasks();
+      })(),
+      stepMs,
+      "shutdownAllAsyncTasks"
+    );
+
+    // 6. 刷写 message_request 异步写缓冲
+    await withTimeout(
+      (async () => {
+        const { stopMessageRequestWriteBuffer } = await import("@/repository/message-write-buffer");
+        await stopMessageRequestWriteBuffer();
+      })(),
+      stepMs,
+      "stopMessageRequestWriteBuffer"
+    );
+
+    // 7. Langfuse 自带超时（LANGFUSE_SHUTDOWN_TIMEOUT_MS），这里再加一层兜底
+    await withTimeout(
+      (async () => {
+        const { shutdownLangfuse } = await import("@/lib/langfuse");
+        await shutdownLangfuse();
+      })(),
+      stepMs,
+      "shutdownLangfuse"
+    );
+
+    // 8. Redis 连接最后关：上面的步骤可能仍在写日志/缓存
+    await withTimeout(
+      (async () => {
+        const { closeRedis } = await import("@/lib/redis");
+        await closeRedis();
+      })(),
+      stepMs,
+      "closeRedis"
+    );
+
+    // 9. API Key Vacuum Filter 订阅清理 —— 同步函数，不需要 timeout
+    try {
+      const g = globalThis as unknown as {
+        __CCH_API_KEY_VF_SYNC_CLEANUP__?: (() => void) | null;
+      };
+      g.__CCH_API_KEY_VF_SYNC_CLEANUP__?.();
+    } catch (error) {
+      logger.warn("[Shutdown] api-key vacuum filter cleanup failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    // 10. 云价格定时同步
+    try {
+      const g = globalThis as unknown as {
+        __CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__?: ReturnType<typeof setInterval>;
+      };
+      if (g.__CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__) {
+        clearInterval(g.__CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__);
+        g.__CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__ = undefined;
+      }
+    } catch (error) {
+      logger.warn("[Shutdown] cloud price sync scheduler cleanup failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  })();
+
+  const total = new Promise<void>((resolve) => {
+    const t = setTimeout(() => {
+      logger.warn("[Shutdown] application cleanup total timeout reached", { totalMs });
+      resolve();
+    }, totalMs);
+    work.finally(() => clearTimeout(t));
+  });
+
+  await Promise.race([work, total]);
+
+  logger.info("[Shutdown] application cleanup complete", {
+    signal,
+    elapsedMs: Date.now() - startedAt,
+  });
+}
+
+interface LifecycleGlobals {
+  markShuttingDown: () => void;
+  isShuttingDown: () => boolean;
+  runApplicationCleanup: (signal: string, opts?: RunCleanupOptions) => Promise<void>;
+}
+
+// 让 server.js（CommonJS 入口，无法直接 import TS 模块）通过 globalThis 调用关闭逻辑。
+// 与本仓库其他桥接惯例一致：参见 src/app/v1/_lib/responses-ws/upstream-adapter.ts:332。
+export function bindLifecycleGlobals(): void {
+  const g = globalThis as unknown as { __CCH_LIFECYCLE__?: LifecycleGlobals };
+  if (g.__CCH_LIFECYCLE__) return;
+  g.__CCH_LIFECYCLE__ = {
+    markShuttingDown,
+    isShuttingDown,
+    runApplicationCleanup,
+  };
+}

--- a/tests/unit/api/health-ready-shutdown.test.ts
+++ b/tests/unit/api/health-ready-shutdown.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe.sequential("readiness probe respects shutdown flag", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 503 unhealthy when shutting down without calling component checks", async () => {
+    const checkDatabase = vi.fn(async () => ({ status: "up" as const, latencyMs: 1 }));
+    const checkRedis = vi.fn(async () => ({ status: "up" as const, latencyMs: 1 }));
+    const checkProxy = vi.fn(async () => ({ status: "up" as const, latencyMs: 1 }));
+
+    vi.doMock("@/drizzle/db", () => ({ db: { execute: vi.fn() } }));
+    vi.doMock("@/lib/redis/client", () => ({ getRedisClient: vi.fn(() => null) }));
+
+    const checkerModule = await import("@/lib/health/checker");
+    // Override the public component check exports for isolation: but the actual
+    // checker uses internal references — so instead we go through the
+    // shutdown flag short-circuit and assert no calls to db.execute were made.
+    const dbModule = await import("@/drizzle/db");
+
+    const { markShuttingDown, __resetShutdownStateForTests } = await import(
+      "@/lib/lifecycle/shutdown"
+    );
+    __resetShutdownStateForTests();
+
+    // Sanity: healthy when not shutting down (we mock db.execute to resolve)
+    vi.mocked(
+      dbModule.db.execute as unknown as (...args: unknown[]) => Promise<unknown>
+    ).mockResolvedValue([{ "?column?": 1 }]);
+    const healthBefore = await checkerModule.checkReadiness();
+    expect(healthBefore.components.database.message).not.toBe("shutting_down");
+
+    markShuttingDown();
+
+    const health = await checkerModule.checkReadiness();
+    expect(health.status).toBe("unhealthy");
+    expect(health.components.database).toMatchObject({
+      status: "down",
+      message: "shutting_down",
+    });
+    expect(health.components.redis).toMatchObject({ status: "down", message: "shutting_down" });
+    expect(health.components.proxy).toMatchObject({ status: "down", message: "shutting_down" });
+
+    // The point of the early-return: don't waste time on real component checks.
+    // After markShuttingDown(), db.execute should not be called again.
+    const callCountBefore = vi.mocked(
+      dbModule.db.execute as unknown as (...args: unknown[]) => Promise<unknown>
+    ).mock.calls.length;
+    await checkerModule.checkReadiness();
+    const callCountAfter = vi.mocked(
+      dbModule.db.execute as unknown as (...args: unknown[]) => Promise<unknown>
+    ).mock.calls.length;
+    expect(callCountAfter).toBe(callCountBefore);
+
+    __resetShutdownStateForTests();
+
+    // Unused mocks to keep TS happy
+    void checkDatabase;
+    void checkRedis;
+    void checkProxy;
+  });
+
+  it("handleReadinessRequest returns HTTP 503 when shutting down", async () => {
+    vi.doMock("@/drizzle/db", () => ({ db: { execute: vi.fn(async () => [{ "?column?": 1 }]) } }));
+    vi.doMock("@/lib/redis/client", () => ({ getRedisClient: vi.fn(() => null) }));
+
+    const { handleReadinessRequest } = await import("@/lib/health/checker");
+    const { markShuttingDown, __resetShutdownStateForTests } = await import(
+      "@/lib/lifecycle/shutdown"
+    );
+    __resetShutdownStateForTests();
+
+    markShuttingDown();
+
+    const response = await handleReadinessRequest("test_shutdown");
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.status).toBe("unhealthy");
+
+    __resetShutdownStateForTests();
+  });
+});

--- a/tests/unit/api/health-ready-shutdown.test.ts
+++ b/tests/unit/api/health-ready-shutdown.test.ts
@@ -15,10 +15,6 @@ describe.sequential("readiness probe respects shutdown flag", () => {
   });
 
   it("returns 503 unhealthy when shutting down without calling component checks", async () => {
-    const checkDatabase = vi.fn(async () => ({ status: "up" as const, latencyMs: 1 }));
-    const checkRedis = vi.fn(async () => ({ status: "up" as const, latencyMs: 1 }));
-    const checkProxy = vi.fn(async () => ({ status: "up" as const, latencyMs: 1 }));
-
     vi.doMock("@/drizzle/db", () => ({ db: { execute: vi.fn() } }));
     vi.doMock("@/lib/redis/client", () => ({ getRedisClient: vi.fn(() => null) }));
 
@@ -63,11 +59,6 @@ describe.sequential("readiness probe respects shutdown flag", () => {
     expect(callCountAfter).toBe(callCountBefore);
 
     __resetShutdownStateForTests();
-
-    // Unused mocks to keep TS happy
-    void checkDatabase;
-    void checkRedis;
-    void checkProxy;
   });
 
   it("handleReadinessRequest returns HTTP 503 when shutting down", async () => {

--- a/tests/unit/langfuse/shutdown-timeout.test.ts
+++ b/tests/unit/langfuse/shutdown-timeout.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe.sequential("shutdownLangfuse", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it("is a no-op when not initialized", async () => {
+    const { shutdownLangfuse } = await import("@/lib/langfuse");
+    const started = Date.now();
+    await shutdownLangfuse();
+    expect(Date.now() - started).toBeLessThan(200);
+  });
+
+  it("times out when forceFlush hangs and still calls sdk.shutdown afterward", async () => {
+    // We construct fake spanProcessor + sdk objects and inject them into the
+    // module's private state via a doMock that returns wrapper functions. The
+    // public shutdownLangfuse() is then called and must complete within bounded
+    // time even though forceFlush() never resolves.
+    vi.stubEnv("LANGFUSE_SHUTDOWN_TIMEOUT_MS", "100");
+
+    let forceFlushCalled = false;
+    let sdkShutdownCalled = false;
+
+    const fakeSpanProcessor = {
+      forceFlush: () => {
+        forceFlushCalled = true;
+        return new Promise(() => {}); // hang
+      },
+      onStart: () => {},
+      onEnd: () => {},
+      shutdown: () => Promise.resolve(),
+    };
+    const fakeSdk = {
+      start: () => {},
+      shutdown: () => {
+        sdkShutdownCalled = true;
+        return Promise.resolve();
+      },
+    };
+
+    vi.doMock("@langfuse/otel", () => ({
+      LangfuseSpanProcessor: function () {
+        return fakeSpanProcessor;
+      },
+    }));
+    vi.doMock("@opentelemetry/sdk-node", () => ({
+      NodeSDK: function () {
+        return fakeSdk;
+      },
+    }));
+    vi.doMock("@opentelemetry/sdk-trace-base", () => ({
+      TraceIdRatioBasedSampler: function () {
+        return {};
+      },
+    }));
+
+    vi.stubEnv("LANGFUSE_PUBLIC_KEY", "pk-test");
+    vi.stubEnv("LANGFUSE_SECRET_KEY", "sk-test");
+
+    const { initLangfuse, shutdownLangfuse } = await import("@/lib/langfuse");
+    await initLangfuse();
+
+    const started = Date.now();
+    await shutdownLangfuse();
+    const elapsed = Date.now() - started;
+
+    expect(forceFlushCalled).toBe(true);
+    expect(sdkShutdownCalled).toBe(true);
+    // 100ms forceFlush timeout + ~0ms sdk.shutdown — must complete promptly.
+    expect(elapsed).toBeGreaterThanOrEqual(90);
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  it("LANGFUSE_SHUTDOWN_TIMEOUT_MS is honored (50ms cap)", async () => {
+    vi.stubEnv("LANGFUSE_SHUTDOWN_TIMEOUT_MS", "50");
+
+    const fakeSpanProcessor = {
+      forceFlush: () => new Promise(() => {}), // hang
+      onStart: () => {},
+      onEnd: () => {},
+      shutdown: () => Promise.resolve(),
+    };
+    const fakeSdk = {
+      start: () => {},
+      shutdown: () => Promise.resolve(),
+    };
+
+    vi.doMock("@langfuse/otel", () => ({
+      LangfuseSpanProcessor: function () {
+        return fakeSpanProcessor;
+      },
+    }));
+    vi.doMock("@opentelemetry/sdk-node", () => ({
+      NodeSDK: function () {
+        return fakeSdk;
+      },
+    }));
+
+    vi.stubEnv("LANGFUSE_PUBLIC_KEY", "pk-test");
+    vi.stubEnv("LANGFUSE_SECRET_KEY", "sk-test");
+
+    const { initLangfuse, shutdownLangfuse } = await import("@/lib/langfuse");
+    await initLangfuse();
+
+    const started = Date.now();
+    await shutdownLangfuse();
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeGreaterThanOrEqual(40);
+    expect(elapsed).toBeLessThan(500);
+  });
+});

--- a/tests/unit/langfuse/shutdown-timeout.test.ts
+++ b/tests/unit/langfuse/shutdown-timeout.test.ts
@@ -55,19 +55,21 @@ describe.sequential("shutdownLangfuse", () => {
     };
 
     vi.doMock("@langfuse/otel", () => ({
-      LangfuseSpanProcessor: function () {
-        return fakeSpanProcessor;
+      LangfuseSpanProcessor: class {
+        constructor() {
+          Object.assign(this, fakeSpanProcessor);
+        }
       },
     }));
     vi.doMock("@opentelemetry/sdk-node", () => ({
-      NodeSDK: function () {
-        return fakeSdk;
+      NodeSDK: class {
+        constructor() {
+          Object.assign(this, fakeSdk);
+        }
       },
     }));
     vi.doMock("@opentelemetry/sdk-trace-base", () => ({
-      TraceIdRatioBasedSampler: function () {
-        return {};
-      },
+      TraceIdRatioBasedSampler: class {},
     }));
 
     vi.stubEnv("LANGFUSE_PUBLIC_KEY", "pk-test");
@@ -102,13 +104,17 @@ describe.sequential("shutdownLangfuse", () => {
     };
 
     vi.doMock("@langfuse/otel", () => ({
-      LangfuseSpanProcessor: function () {
-        return fakeSpanProcessor;
+      LangfuseSpanProcessor: class {
+        constructor() {
+          Object.assign(this, fakeSpanProcessor);
+        }
       },
     }));
     vi.doMock("@opentelemetry/sdk-node", () => ({
-      NodeSDK: function () {
-        return fakeSdk;
+      NodeSDK: class {
+        constructor() {
+          Object.assign(this, fakeSdk);
+        }
       },
     }));
 

--- a/tests/unit/lib/async-task-manager-edge-runtime.test.ts
+++ b/tests/unit/lib/async-task-manager-edge-runtime.test.ts
@@ -52,7 +52,7 @@ describe.sequential("AsyncTaskManager edge runtime", () => {
     expect(processOnceSpy).not.toHaveBeenCalled();
   });
 
-  it("registers exit hooks when NEXT_RUNTIME is nodejs", async () => {
+  it("registers only beforeExit when NEXT_RUNTIME is nodejs (SIGTERM/SIGINT are owned by server.js orchestrator)", async () => {
     vi.useFakeTimers();
 
     const processOnceSpy = vi.spyOn(process, "once");
@@ -61,13 +61,13 @@ describe.sequential("AsyncTaskManager edge runtime", () => {
     const { AsyncTaskManager } = await import("@/lib/async-task-manager");
     AsyncTaskManager.register("t1", Promise.resolve());
 
-    expect(processOnceSpy).toHaveBeenCalledTimes(3);
-    expect(processOnceSpy).toHaveBeenNthCalledWith(1, "SIGTERM", expect.any(Function));
-    expect(processOnceSpy).toHaveBeenNthCalledWith(2, "SIGINT", expect.any(Function));
-    expect(processOnceSpy).toHaveBeenNthCalledWith(3, "beforeExit", expect.any(Function));
+    const signals = processOnceSpy.mock.calls.map((c) => c[0]);
+    expect(signals).toContain("beforeExit");
+    expect(signals).not.toContain("SIGTERM");
+    expect(signals).not.toContain("SIGINT");
   });
 
-  it("handles exit signal callback by running cleanupAll", async () => {
+  it("beforeExit callback runs cleanupAll", async () => {
     vi.useFakeTimers();
 
     const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
@@ -82,19 +82,34 @@ describe.sequential("AsyncTaskManager edge runtime", () => {
     });
     const controller = AsyncTaskManager.register("t1", taskPromise);
 
-    const sigtermHandler = processOnceSpy.mock.calls.find((c) => c[0] === "SIGTERM")?.[1];
-    const sigintHandler = processOnceSpy.mock.calls.find((c) => c[0] === "SIGINT")?.[1];
     const beforeExitHandler = processOnceSpy.mock.calls.find((c) => c[0] === "beforeExit")?.[1];
-    expect(sigtermHandler).toBeTypeOf("function");
-    expect(sigintHandler).toBeTypeOf("function");
     expect(beforeExitHandler).toBeTypeOf("function");
 
-    sigtermHandler?.();
-    sigintHandler?.();
     beforeExitHandler?.();
 
     expect(controller.signal.aborted).toBe(true);
     expect(clearIntervalSpy).toHaveBeenCalled();
+
+    resolveTask!();
+    await taskPromise;
+  });
+
+  it("shutdownAllAsyncTasks cancels all in-flight tasks", async () => {
+    process.env.CI = "true";
+    process.env.NEXT_RUNTIME = "nodejs";
+
+    const { AsyncTaskManager, shutdownAllAsyncTasks } = await import("@/lib/async-task-manager");
+
+    let resolveTask: () => void;
+    const taskPromise = new Promise<void>((resolve) => {
+      resolveTask = resolve;
+    });
+    const controller = AsyncTaskManager.register("t1", taskPromise);
+    expect(controller.signal.aborted).toBe(false);
+
+    shutdownAllAsyncTasks();
+
+    expect(controller.signal.aborted).toBe(true);
 
     resolveTask!();
     await taskPromise;

--- a/tests/unit/lib/shutdown.test.ts
+++ b/tests/unit/lib/shutdown.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe.sequential("lifecycle/shutdown", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useRealTimers();
+    delete (globalThis as unknown as { __CCH_LIFECYCLE__?: unknown }).__CCH_LIFECYCLE__;
+    delete (globalThis as unknown as { __CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__?: unknown })
+      .__CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__;
+    delete (globalThis as unknown as { __CCH_API_KEY_VF_SYNC_CLEANUP__?: unknown })
+      .__CCH_API_KEY_VF_SYNC_CLEANUP__;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it("markShuttingDown flips isShuttingDown idempotently", async () => {
+    const { markShuttingDown, isShuttingDown, __resetShutdownStateForTests } = await import(
+      "@/lib/lifecycle/shutdown"
+    );
+    __resetShutdownStateForTests();
+
+    expect(isShuttingDown()).toBe(false);
+    markShuttingDown();
+    expect(isShuttingDown()).toBe(true);
+    markShuttingDown();
+    expect(isShuttingDown()).toBe(true);
+  });
+
+  it("bindLifecycleGlobals attaches once and re-binding is a no-op", async () => {
+    const { bindLifecycleGlobals } = await import("@/lib/lifecycle/shutdown");
+
+    bindLifecycleGlobals();
+    const first = (globalThis as unknown as { __CCH_LIFECYCLE__?: unknown }).__CCH_LIFECYCLE__;
+    expect(first).toBeDefined();
+
+    bindLifecycleGlobals();
+    const second = (globalThis as unknown as { __CCH_LIFECYCLE__?: unknown }).__CCH_LIFECYCLE__;
+    expect(second).toBe(first);
+  });
+
+  it("runApplicationCleanup invokes the staged modules and survives one step throwing", async () => {
+    const stopCache = vi.fn();
+    const stopProbe = vi.fn();
+    const stopPublicStatus = vi.fn(async () => {});
+    const stopProbeLog = vi.fn();
+    const shutdownTasks = vi.fn(() => {
+      throw new Error("simulated tasks shutdown failure");
+    });
+    const stopWriteBuffer = vi.fn(async () => {});
+    const shutdownLf = vi.fn(async () => {});
+    const closeRedis = vi.fn(async () => {});
+
+    vi.doMock("@/lib/cache/session-cache", () => ({ stopCacheCleanup: stopCache }));
+    vi.doMock("@/lib/provider-endpoints/probe-scheduler", () => ({
+      stopEndpointProbeScheduler: stopProbe,
+    }));
+    vi.doMock("@/lib/public-status/scheduler", () => ({
+      stopPublicStatusRebuildScheduler: stopPublicStatus,
+    }));
+    vi.doMock("@/lib/provider-endpoints/probe-log-cleanup", () => ({
+      stopEndpointProbeLogCleanup: stopProbeLog,
+    }));
+    vi.doMock("@/lib/async-task-manager", () => ({ shutdownAllAsyncTasks: shutdownTasks }));
+    vi.doMock("@/repository/message-write-buffer", () => ({
+      stopMessageRequestWriteBuffer: stopWriteBuffer,
+    }));
+    vi.doMock("@/lib/langfuse", () => ({ shutdownLangfuse: shutdownLf }));
+    vi.doMock("@/lib/redis", () => ({ closeRedis }));
+
+    const cleanupSpy = vi.fn();
+    (
+      globalThis as unknown as { __CCH_API_KEY_VF_SYNC_CLEANUP__?: () => void }
+    ).__CCH_API_KEY_VF_SYNC_CLEANUP__ = cleanupSpy;
+
+    const intervalId = setInterval(() => {}, 60_000);
+    (
+      globalThis as unknown as {
+        __CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__?: ReturnType<typeof setInterval>;
+      }
+    ).__CCH_CLOUD_PRICE_SYNC_INTERVAL_ID__ = intervalId;
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+
+    const { runApplicationCleanup } = await import("@/lib/lifecycle/shutdown");
+
+    await runApplicationCleanup("SIGTERM", { totalTimeoutMs: 5_000, perStepTimeoutMs: 500 });
+
+    expect(stopCache).toHaveBeenCalled();
+    expect(stopProbe).toHaveBeenCalled();
+    expect(stopPublicStatus).toHaveBeenCalled();
+    expect(stopProbeLog).toHaveBeenCalled();
+    expect(shutdownTasks).toHaveBeenCalled();
+    expect(stopWriteBuffer).toHaveBeenCalled();
+    expect(shutdownLf).toHaveBeenCalled();
+    expect(closeRedis).toHaveBeenCalled();
+    expect(cleanupSpy).toHaveBeenCalled();
+    expect(clearIntervalSpy).toHaveBeenCalledWith(intervalId);
+  });
+
+  it("runApplicationCleanup returns within totalTimeoutMs even if one step hangs", async () => {
+    let releaseHang: () => void = () => {};
+    const hang = new Promise<void>((resolve) => {
+      releaseHang = resolve;
+    });
+
+    vi.doMock("@/lib/cache/session-cache", () => ({ stopCacheCleanup: () => {} }));
+    vi.doMock("@/lib/provider-endpoints/probe-scheduler", () => ({
+      stopEndpointProbeScheduler: () => {},
+    }));
+    vi.doMock("@/lib/public-status/scheduler", () => ({
+      stopPublicStatusRebuildScheduler: async () => {},
+    }));
+    vi.doMock("@/lib/provider-endpoints/probe-log-cleanup", () => ({
+      stopEndpointProbeLogCleanup: () => {},
+    }));
+    vi.doMock("@/lib/async-task-manager", () => ({ shutdownAllAsyncTasks: () => {} }));
+    vi.doMock("@/repository/message-write-buffer", () => ({
+      stopMessageRequestWriteBuffer: async () => {},
+    }));
+    // The hanging step
+    vi.doMock("@/lib/langfuse", () => ({ shutdownLangfuse: async () => hang }));
+    vi.doMock("@/lib/redis", () => ({ closeRedis: async () => {} }));
+
+    const { runApplicationCleanup } = await import("@/lib/lifecycle/shutdown");
+    const started = Date.now();
+    await runApplicationCleanup("SIGTERM", { totalTimeoutMs: 300, perStepTimeoutMs: 100 });
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeLessThan(2_000);
+    releaseHang();
+  });
+});

--- a/tests/unit/server-shutdown.test.ts
+++ b/tests/unit/server-shutdown.test.ts
@@ -1,0 +1,181 @@
+/**
+ * server.js orchestrated shutdown: SIGTERM/SIGINT path.
+ *
+ * We exercise the exported `registerOrchestratedShutdown(server, wss)` against
+ * fake server/wss objects and inspect:
+ *  - server.close() and wss.close() are invoked
+ *  - globalThis.__CCH_LIFECYCLE__.markShuttingDown / runApplicationCleanup are called
+ *  - process.exit(0) is reached
+ *  - drain timeout fires when server.close never finishes
+ */
+
+import { createRequire } from "node:module";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireFromHere = createRequire(import.meta.url);
+
+type ServerJsModule = {
+  registerOrchestratedShutdown: (
+    server: { close: (cb: (err?: Error) => void) => void; on?: unknown },
+    wss: { close: () => void } | null
+  ) => void;
+};
+
+function loadServerModule(): ServerJsModule {
+  return requireFromHere("../../server.js") as ServerJsModule;
+}
+
+describe.sequential("registerOrchestratedShutdown", () => {
+  let prevExit: typeof process.exit;
+  let originalSigterm: typeof process.on;
+
+  beforeEach(() => {
+    prevExit = process.exit;
+    originalSigterm = process.on;
+    delete (globalThis as unknown as { __CCH_LIFECYCLE__?: unknown }).__CCH_LIFECYCLE__;
+  });
+
+  afterEach(() => {
+    process.exit = prevExit;
+    process.on = originalSigterm;
+    process.removeAllListeners("SIGTERM");
+    process.removeAllListeners("SIGINT");
+    delete (globalThis as unknown as { __CCH_LIFECYCLE__?: unknown }).__CCH_LIFECYCLE__;
+    delete process.env.SHUTDOWN_DRAIN_MS;
+    delete process.env.SHUTDOWN_CLEANUP_MS;
+    delete process.env.SHUTDOWN_HARD_EXIT_MS;
+  });
+
+  it("runs the full sequence: markShuttingDown -> server.close -> runApplicationCleanup -> exit(0)", async () => {
+    process.env.SHUTDOWN_DRAIN_MS = "500";
+    process.env.SHUTDOWN_CLEANUP_MS = "500";
+    process.env.SHUTDOWN_HARD_EXIT_MS = "5000";
+
+    const closeServer = vi.fn((cb: (err?: Error) => void) => {
+      setTimeout(() => cb(), 5);
+    });
+    const closeWss = vi.fn();
+    const server = { close: closeServer };
+    const wss = { close: closeWss };
+
+    const markShuttingDown = vi.fn();
+    const isShuttingDown = vi.fn(() => true);
+    const runApplicationCleanup = vi.fn(async () => {});
+    (globalThis as unknown as { __CCH_LIFECYCLE__?: unknown }).__CCH_LIFECYCLE__ = {
+      markShuttingDown,
+      isShuttingDown,
+      runApplicationCleanup,
+    };
+
+    const exitSpy = vi.fn() as unknown as typeof process.exit;
+    process.exit = exitSpy;
+
+    const { registerOrchestratedShutdown } = loadServerModule();
+    registerOrchestratedShutdown(server, wss);
+
+    // Trigger SIGTERM
+    process.emit("SIGTERM");
+
+    // Allow the async handler to complete
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(markShuttingDown).toHaveBeenCalledTimes(1);
+    expect(closeServer).toHaveBeenCalledTimes(1);
+    expect(closeWss).toHaveBeenCalledTimes(1);
+    expect(runApplicationCleanup).toHaveBeenCalledWith(
+      "SIGTERM",
+      expect.objectContaining({ totalTimeoutMs: 500 })
+    );
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("drain timeout fires when server.close never resolves", async () => {
+    process.env.SHUTDOWN_DRAIN_MS = "100";
+    process.env.SHUTDOWN_CLEANUP_MS = "100";
+    process.env.SHUTDOWN_HARD_EXIT_MS = "5000";
+
+    const closeServer = vi.fn((_cb: (err?: Error) => void) => {
+      // Never call the callback — simulating a stuck in-flight connection.
+    });
+    const server = { close: closeServer };
+
+    const runApplicationCleanup = vi.fn(async () => {});
+    (globalThis as unknown as { __CCH_LIFECYCLE__?: unknown }).__CCH_LIFECYCLE__ = {
+      markShuttingDown: vi.fn(),
+      isShuttingDown: vi.fn(() => true),
+      runApplicationCleanup,
+    };
+
+    const exitSpy = vi.fn() as unknown as typeof process.exit;
+    process.exit = exitSpy;
+
+    const { registerOrchestratedShutdown } = loadServerModule();
+    registerOrchestratedShutdown(server, null);
+
+    const started = Date.now();
+    process.emit("SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const elapsed = Date.now() - started;
+
+    expect(closeServer).toHaveBeenCalled();
+    expect(runApplicationCleanup).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    // drain (100ms) + cleanup (~0) < 500ms total
+    expect(elapsed).toBeLessThan(1_500);
+  });
+
+  it("ignores duplicate SIGTERM (idempotent)", async () => {
+    process.env.SHUTDOWN_DRAIN_MS = "50";
+    process.env.SHUTDOWN_CLEANUP_MS = "50";
+    process.env.SHUTDOWN_HARD_EXIT_MS = "5000";
+
+    const closeServer = vi.fn((cb: (err?: Error) => void) => setTimeout(cb, 1));
+    const server = { close: closeServer };
+
+    const runApplicationCleanup = vi.fn(async () => {});
+    (globalThis as unknown as { __CCH_LIFECYCLE__?: unknown }).__CCH_LIFECYCLE__ = {
+      markShuttingDown: vi.fn(),
+      isShuttingDown: vi.fn(() => true),
+      runApplicationCleanup,
+    };
+
+    const exitSpy = vi.fn() as unknown as typeof process.exit;
+    process.exit = exitSpy;
+
+    const { registerOrchestratedShutdown } = loadServerModule();
+    registerOrchestratedShutdown(server, null);
+
+    process.emit("SIGTERM");
+    // process.once should remove the listener after first fire — second emit is a no-op
+    process.emit("SIGTERM");
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(closeServer).toHaveBeenCalledTimes(1);
+    expect(runApplicationCleanup).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("survives missing lifecycle globals (logs warning, still exits)", async () => {
+    process.env.SHUTDOWN_DRAIN_MS = "50";
+    process.env.SHUTDOWN_CLEANUP_MS = "50";
+    process.env.SHUTDOWN_HARD_EXIT_MS = "5000";
+
+    const closeServer = vi.fn((cb: (err?: Error) => void) => setTimeout(cb, 1));
+    const server = { close: closeServer };
+
+    delete (globalThis as unknown as { __CCH_LIFECYCLE__?: unknown }).__CCH_LIFECYCLE__;
+
+    const exitSpy = vi.fn() as unknown as typeof process.exit;
+    process.exit = exitSpy;
+
+    const { registerOrchestratedShutdown } = loadServerModule();
+    registerOrchestratedShutdown(server, null);
+
+    process.emit("SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(closeServer).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+});


### PR DESCRIPTION
## Summary

K8s/Docker rolling deploys were losing in-flight requests and being SIGKILL'd because the existing SIGTERM handler had three gaps and one bug:

1. **`server.close()` was never called** — the HTTP listener kept accepting new connections after SIGTERM until SIGKILL; in-flight requests were torn down abruptly.
2. **No explicit `process.exit()`** — the process relied on event-loop exhaustion, but residual sockets / undici dispatchers kept it alive past grace period.
3. **Langfuse `forceFlush()` was unbounded** — observed to hang for 3 minutes in production, blocking every cleanup step that followed (Redis, message buffer) and exhausting the K8s 30s grace period.
4. **`async-task-manager` aborted streaming responses on SIGTERM** — its own listener `cleanupAll()`-ed all in-flight async tasks immediately, so any drain attempt was meaningless: SSE streams were cancelled before `server.close()` could finish.

## Related Issues

- **Follow-up to #1152** — Replaces the initial `instrumentation.ts`-based shutdown approach with a fully orchestrated `server.js`-based sequence that properly drains in-flight requests.
- **Related to #1147** — Addresses the graceful shutdown gap identified during the SIGSEGV investigation (no shutdown markers, no `server.close()` on SIGTERM).
- **Related to #1019** — Builds on the K8s health probes by adding shutdown-aware readiness signaling (`/api/health/ready` returns 503 during drain so the Service removes the pod from the load balancer).
- **Related to #589** — Further evolves `async-task-manager.ts` signal handling: the Edge Runtime `process.once` workaround is no longer needed because the SIGTERM listener is removed entirely (cleanup now happens in the orchestrated cleanup stage).

## New shutdown sequence

Orchestration moves to `server.js` (which owns the `http.Server` handle). `instrumentation.ts` no longer registers SIGTERM/SIGINT — it just binds the cleanup function set onto `globalThis.__CCH_LIFECYCLE__` so `server.js` can call it. (Same bridging pattern as the existing `__cchCleanupResponsesWsSession`.)

```
SIGTERM
  -> 1. markShuttingDown()       — /api/health/ready returns 503; Service starts draining
  -> 2. server.close()           — stop accepting; in-flight HTTP completes
       wss.close()               — reject new WS upgrades
  -> 3. await drain              — bounded by SHUTDOWN_DRAIN_MS (default 15s)
       (async-task-manager NO LONGER cancels here — streams can finish)
  -> 4. runApplicationCleanup()  — bounded by SHUTDOWN_CLEANUP_MS (default 10s)
       schedulers / tasks / msg buffer / Langfuse / Redis (each step timeouted)
  -> 5. process.exit(0)
  -> Hard-exit watchdog at SHUTDOWN_HARD_EXIT_MS (default 25s) — fires process.exit(1)
     if any step deadlocks. .unref()'d so it doesn't itself keep the loop alive.
```

Time budget fits a K8s default 30s grace period with ~5s buffer.

## Tunable envs

| Env | Default | Purpose |
|---|---|---|
| `SHUTDOWN_DRAIN_MS` | 15000 | Wait for in-flight HTTP/WS to finish after `server.close()` |
| `SHUTDOWN_CLEANUP_MS` | 10000 | Total cap for application-level cleanup pipeline |
| `SHUTDOWN_HARD_EXIT_MS` | 25000 | Watchdog forces `exit(1)` if everything else hangs |
| `LANGFUSE_SHUTDOWN_TIMEOUT_MS` | 3000 | Per-step cap on `forceFlush` and `sdk.shutdown` |

## Test plan

- [x] `bun run lint` passes
- [x] `bun run lint:fix` clean
- [x] `bun run typecheck` clean for my changes (one pre-existing error on `dev` in `trace-proxy-request.ts:411` — `setTraceIO` — unrelated to this PR; CI installs the v5 SDK fresh and should resolve it)
- [x] `bun run test` — all 5931 tests pass (24 new tests in this PR)
- [ ] End-to-end SIGTERM smoke test on dev environment:
  ```bash
  NODE_ENV=production bun run start &
  curl -N http://localhost:3000/api/health &  # long-poll
  kill -TERM <pid>
  # Expect: shutdown_received logged immediately, /api/health/ready -> 503,
  # in-flight curl completes, process exits within ~25s with code 0
  ```

## Non-goals

- Not touching `circuit-breaker-probe.ts` — its independent SIGTERM listener is correct as-is.
- No backwards-compat shims — old `shutdownHandler` removed cleanly per repo conventions.

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the old `instrumentation.ts`-based SIGTERM handler with a fully orchestrated shutdown sequence in `server.js` that correctly calls `server.close()`, drains in-flight HTTP/WS connections within a configurable deadline, then runs application-level cleanup (schedulers, async tasks, message buffer, Langfuse, Redis) before calling `process.exit(0)`, with a hard-exit watchdog as the ultimate safety net.

- **New shutdown sequence** (`server.js` `registerOrchestratedShutdown`): marks readiness 503 → `server.close()` + `wss.close()` → drain bounded by `SHUTDOWN_DRAIN_MS` → `runApplicationCleanup` bounded by `SHUTDOWN_CLEANUP_MS` → `process.exit(0)`; hard watchdog at `SHUTDOWN_HARD_EXIT_MS` with `.unref()`.
- **`src/lib/lifecycle/shutdown.ts`**: new module exposing `markShuttingDown`, `isShuttingDown`, `runApplicationCleanup` (10 serialised steps each with per-step timeout), and `bindLifecycleGlobals` for the CommonJS bridge; `async-task-manager` cleanup (step 5) is now deferred to the post-drain cleanup phase so SSE streams can finish naturally.
- **`src/lib/langfuse/index.ts`**: `shutdownLangfuse` now uses `Promise.race` + `clearTimeout` to cap both `forceFlush` and `sdk.shutdown` at `LANGFUSE_SHUTDOWN_TIMEOUT_MS` (default 3 s), fixing the production hang.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the orchestration logic is well-structured and the edge cases (double SIGTERM, missing lifecycle globals, stuck connections) are all handled gracefully with fall-through paths.

All changed paths have correct error isolation, the timer interactions are correct, and 24 new tests cover the critical flows. The only notable subtlety — that the per-step `withTimeout` wrapping `shutdownLangfuse` can expire at the same instant as the inner `LANGFUSE_SHUTDOWN_TIMEOUT_MS`, causing `sdk.shutdown()` to run without a bounded deadline — is a non-blocking nuance rather than a breakage, since `process.exit(0)` follows shortly regardless.

src/lib/lifecycle/shutdown.ts — the Langfuse step's outer vs. inner timeout interaction is worth a second look before tuning LANGFUSE_SHUTDOWN_TIMEOUT_MS in production.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| server.js | Adds `registerOrchestratedShutdown` — properly calls `server.close()`, drains with `SHUTDOWN_DRAIN_MS`, then defers to lifecycle globals for app cleanup. `parsePosInt` correctly avoids the `|| default` coercion bug. Hard-exit watchdog is `.unref()`'d. SIGTERM/SIGINT both use `process.once` for idempotency. |
| src/lib/lifecycle/shutdown.ts | New shutdown orchestration module. Serialised 10-step cleanup with per-step and total timeouts. The Langfuse step has overlapping inner/outer timeout layers that can cause `sdk.shutdown()` to be skipped when `forceFlush` hangs for the full `LANGFUSE_SHUTDOWN_TIMEOUT_MS`. |
| src/lib/langfuse/index.ts | Adds bounded timeouts to `shutdownLangfuse`. Sets `initialized=false` before async work to prevent re-entrant shutdown. Contains a `withTimeout` helper identical to the one in `lifecycle/shutdown.ts`. |
| src/instrumentation.ts | SIGTERM/SIGINT handlers removed; now just calls `bindLifecycleGlobals()` so server.js can bridge into TypeScript cleanup logic. Clean removal of old `shutdownHandler`. |
| src/lib/async-task-manager.ts | SIGTERM/SIGINT listeners removed; only `beforeExit` fallback retained for non-SIGTERM paths. `cleanupAll()` made public and re-exported as `shutdownAllAsyncTasks()` for the orchestrator. |
| src/lib/health/checker.ts | Adds early-return 503 path in `checkReadiness()` when `isShuttingDown()` is true, correctly short-circuiting all component DB/Redis checks during drain. |
| tests/unit/lib/shutdown.test.ts | Covers idempotency, `bindLifecycleGlobals`, step-failure resilience, and total-timeout cap. Good use of `vi.doMock` per test. |
| tests/unit/server-shutdown.test.ts | Tests full shutdown sequence, drain timeout, idempotency, and missing lifecycle globals — well-structured with fake server/wss objects. |
| tests/unit/api/health-ready-shutdown.test.ts | Tests the 503 short-circuit on `checkReadiness()` and `handleReadinessRequest()` during shutdown. Correctly resets module state between tests. |
| tests/unit/langfuse/shutdown-timeout.test.ts | Verifies no-op when uninitialised, timeout enforcement, and `LANGFUSE_SHUTDOWN_TIMEOUT_MS` env var honoring — uses real timers for accurate elapsed-time assertions. |
| tests/unit/lib/async-task-manager-edge-runtime.test.ts | Updated to reflect that only `beforeExit` is registered by async-task-manager; adds `shutdownAllAsyncTasks` cancellation test. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant OS as OS/K8s
    participant SJS as server.js
    participant HC as health/checker
    participant LC as lifecycle/shutdown
    participant ATM as async-task-manager
    participant LF as langfuse
    participant RD as Redis

    OS->>SJS: SIGTERM
    SJS->>SJS: "shuttingDown = true (idempotent)"
    SJS->>SJS: set hardExit watchdog (28s, unref'd)
    SJS->>LC: markShuttingDown()
    HC-->>OS: /api/health/ready → 503
    SJS->>SJS: server.close() + wss.close()
    Note over SJS: drain phase (≤15s SHUTDOWN_DRAIN_MS)
    SJS-->>SJS: in-flight HTTP/WS drain
    SJS->>LC: "runApplicationCleanup(signal, totalTimeoutMs=10s)"
    Note over LC: serial steps, each ≤3s per-step
    LC->>LC: stopCacheCleanup / schedulers (steps 1-4)
    LC->>ATM: shutdownAllAsyncTasks() (step 5)
    LC->>LC: stopMessageRequestWriteBuffer (step 6)
    LC->>LF: shutdownLangfuse() (step 7, inner ≤3s each)
    LF->>LF: forceFlush() with timeout
    LF->>LF: sdk.shutdown() with timeout
    LC->>RD: closeRedis() (step 8)
    LC->>LC: API key VF + cloud price cleanup (9-10)
    LC-->>SJS: cleanup complete (or total timeout)
    SJS->>SJS: clearTimeout(hardExit)
    SJS->>OS: process.exit(0)
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib/lifecycle/shutdown.ts:135-143
The outer `perStepTimeoutMs` (3 s default) and the inner `LANGFUSE_SHUTDOWN_TIMEOUT_MS` (3 s default) both fire at roughly the same instant when `forceFlush` hangs. Because the outer timer is registered a few microseconds before the inner one, it wins the event-loop ordering and the Langfuse step resolves, leaving `sdk.shutdown()` as a background fire-and-forget that is killed by the subsequent `process.exit(0)`. If an operator tunes `LANGFUSE_SHUTDOWN_TIMEOUT_MS=2000` expecting 2 s for each of `forceFlush` and `sdk.shutdown`, the 3 s outer cap means `sdk.shutdown()` effectively gets at most 1 s of bounded execution before the step is abandoned. Setting `perStepTimeoutMs` equal to `2 × LANGFUSE_SHUTDOWN_TIMEOUT_MS` (or more) when calling `runApplicationCleanup` from `server.js` preserves the semantics the inner timeout was designed to give.

```suggestion
    // 7. Langfuse 自带超时（LANGFUSE_SHUTDOWN_TIMEOUT_MS，默认 3s），内部对
    //    forceFlush 和 sdk.shutdown 各加一层限制。外部的 stepMs 必须大于
    //    两个内部超时之和，否则 sdk.shutdown 来不及运行就被外层截断。
    //    默认: LANGFUSE_SHUTDOWN_TIMEOUT_MS(3s) * 2 = 6s，stepMs 用 6s 留余量。
    const langfuseStepMs = Math.max(stepMs, getShutdownTimeoutMs() * 2);
    await withTimeout(
      (async () => {
        const { shutdownLangfuse } = await import("@/lib/langfuse");
        await shutdownLangfuse();
      })(),
      langfuseStepMs,
      "shutdownLangfuse"
    );
```

### Issue 2 of 2
src/lib/langfuse/index.ts:79-102
**Duplicated `withTimeout` utility**

An identical `withTimeout` helper (same signature, same `Promise.race` + `clearTimeout` logic) already exists in `src/lib/lifecycle/shutdown.ts`. Moving the private helper to a shared location (e.g., `src/lib/utils/with-timeout.ts`) would eliminate the duplication and ensure any future fix is applied in one place.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(lifecycle): widen hard-exit gap, par..."](https://github.com/ding113/claude-code-hub/commit/1766bddda68bd03b7ebc82f2d1b434f60c1d2679) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31920859)</sub>

<!-- /greptile_comment -->