### PR TITLE
test(api/v1): add OpenAPI-driven auth and tier sweeps

### DIFF
--- a/tests/api/v1/openapi-auth-sweep.test.ts
+++ b/tests/api/v1/openapi-auth-sweep.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Live OpenAPI sweep — for every operation declared in /api/v1/openapi.json,
+ * exercise the route against the in-process Hono app and confirm:
+ *   - operations declared `x-required-access: public` are reachable without auth
+ *     (any status other than 401 is accepted; the contract test already
+ *     validates the spec-level metadata)
+ *   - operations declared `x-required-access: read` or `admin` return 401 with
+ *     the `auth.missing` problem+json envelope when called without credentials
+ *
+ * The companion `openapi-tier-sweep.test.ts` uses mocked auth to verify that
+ * the documented tier matches the actually enforced tier (admin endpoints
+ * 403 for non-admins, read endpoints accept user keys, etc.).
+ */
+
+import { describe, expect, test } from "vitest";
+import { callV1Route } from "./test-utils";
+
+type Operation = {
+  "x-required-access"?: "public" | "read" | "admin";
+  operationId?: string;
+  security?: unknown[];
+};
+
+type OpenApiDocument = {
+  paths: Record<string, Record<string, Operation>>;
+};
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+type HttpMethod = (typeof HTTP_METHODS)[number];
+
+function pathToCallable(path: string): string {
+  // Convert OpenAPI templated paths like /users/{id}/keys -> concrete probe paths.
+  // The auth middleware runs before route-param validation, so any non-empty
+  // value works as a placeholder.
+  return path.replace(/\{[^}]+\}/g, "1");
+}
+
+async function exerciseWithoutAuth(method: HttpMethod, path: string) {
+  return callV1Route({
+    method,
+    pathname: pathToCallable(path),
+    body: method === "GET" || method === "DELETE" ? undefined : {},
+  });
+}
+
+describe("v1 OpenAPI live auth sweep", () => {
+  test("every operation enforces its documented x-required-access tier when called without credentials", async () => {
+    const { json } = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/openapi.json",
+    });
+    const document = json as OpenApiDocument;
+
+    const operations: Array<{ method: HttpMethod; path: string; tier: string }> = [];
+    for (const [path, item] of Object.entries(document.paths)) {
+      for (const [method, op] of Object.entries(item)) {
+        const upper = method.toUpperCase() as HttpMethod;
+        if (!HTTP_METHODS.includes(upper)) continue;
+        operations.push({
+          method: upper,
+          path,
+          tier: String(op["x-required-access"] ?? "missing"),
+        });
+      }
+    }
+
+    // sanity: we should be sweeping a non-trivial surface
+    expect(operations.length).toBeGreaterThanOrEqual(150);
+
+    const failures: string[] = [];
+
+    for (const op of operations) {
+      const label = `${op.tier.toUpperCase()} ${op.method} ${op.path}`;
+      const probeResult = await exerciseWithoutAuth(op.method, op.path);
+      const status = probeResult.response.status;
+      const contentType = probeResult.response.headers.get("content-type") ?? "";
+
+      if (op.tier === "public") {
+        // Public endpoints must NOT challenge with 401.
+        if (status === 401) {
+          failures.push(`${label}: public endpoint returned 401 (should not require auth)`);
+        }
+        continue;
+      }
+
+      if (op.tier === "read" || op.tier === "admin") {
+        if (status !== 401) {
+          failures.push(
+            `${label}: protected endpoint returned ${status} (expected 401 without auth)`
+          );
+          continue;
+        }
+        if (!contentType.includes("application/problem+json")) {
+          failures.push(
+            `${label}: 401 content-type is "${contentType}" (expected application/problem+json)`
+          );
+        }
+        const body = probeResult.json as { errorCode?: string; status?: number };
+        if (body?.errorCode !== "auth.missing") {
+          failures.push(`${label}: 401 errorCode is "${body?.errorCode}" (expected auth.missing)`);
+        }
+        if (body?.status !== 401) {
+          failures.push(`${label}: 401 body status is ${body?.status} (expected 401)`);
+        }
+        continue;
+      }
+
+      failures.push(`${label}: missing or unrecognized x-required-access`);
+    }
+
+    expect(failures).toEqual([]);
+  }, 60000);
+
+  test("public operations remain documented as public and reachable", async () => {
+    const { json } = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/openapi.json",
+    });
+    const document = json as OpenApiDocument;
+
+    const publicOps: Array<{ method: HttpMethod; path: string }> = [];
+    for (const [path, item] of Object.entries(document.paths)) {
+      for (const [method, op] of Object.entries(item)) {
+        if (op["x-required-access"] !== "public") continue;
+        publicOps.push({ method: method.toUpperCase() as HttpMethod, path });
+      }
+    }
+
+    // Public endpoints currently expected: /health and /public/status. If the
+    // count changes we want the contract test below to surface it explicitly.
+    expect(publicOps.length).toBeGreaterThanOrEqual(2);
+
+    for (const op of publicOps) {
+      const result = await exerciseWithoutAuth(op.method, op.path);
+      // Any 2xx-3xx-4xx is acceptable except 401, which would indicate the
+      // endpoint requires auth contrary to its declaration. Public endpoints
+      // may legitimately return 400 (bad query), 503 (degraded), etc.
+      expect(
+        result.response.status,
+        `${op.method} ${op.path} returned 401 despite being public`
+      ).not.toBe(401);
+    }
+  });
+
+  test("the documented set of public operations is the expected allow-list", async () => {
+    const { json } = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/openapi.json",
+    });
+    const document = json as OpenApiDocument;
+
+    const publicOps: string[] = [];
+    for (const [path, item] of Object.entries(document.paths)) {
+      for (const [method, op] of Object.entries(item)) {
+        if (op["x-required-access"] !== "public") continue;
+        publicOps.push(`${method.toUpperCase()} ${path}`);
+      }
+    }
+
+    // Only health and public status are intentionally public. Any new public
+    // endpoint must be added here explicitly so the security boundary is
+    // reviewed.
+    expect(publicOps.sort()).toEqual(["GET /api/v1/health", "GET /api/v1/public/status"].sort());
+  });
+});

--- a/tests/api/v1/openapi-tier-sweep.test.ts
+++ b/tests/api/v1/openapi-tier-sweep.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tier-enforcement sweep: with `validateAuthToken` mocked to return a
+ * non-admin session, every operation declared `x-required-access: admin`
+ * must reject with HTTP 403 (auth.forbidden) before any handler runs.
+ *
+ * This complements `openapi-auth-sweep.test.ts` (which exercises the same
+ * routes without credentials) by proving the middleware also rejects
+ * authenticated non-admin callers — the second half of the auth contract.
+ */
+
+import type { AuthSession } from "@/lib/auth";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const validateAuthTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return { ...actual, validateAuthToken: validateAuthTokenMock };
+});
+
+const { callV1Route } = await import("./test-utils");
+
+const nonAdminSession = {
+  user: { id: 99, role: "user", isEnabled: true },
+  key: { id: 99, userId: 99, key: "user-token", canLoginWebUi: true },
+} as AuthSession;
+
+type Operation = { "x-required-access"?: "public" | "read" | "admin" };
+type OpenApiDocument = { paths: Record<string, Record<string, Operation>> };
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+type HttpMethod = (typeof HTTP_METHODS)[number];
+
+function pathToCallable(path: string): string {
+  return path.replace(/\{[^}]+\}/g, "1");
+}
+
+async function exerciseAsUser(method: HttpMethod, path: string) {
+  return callV1Route({
+    method,
+    pathname: pathToCallable(path),
+    headers: { Authorization: "Bearer user-token" },
+    body: method === "GET" || method === "DELETE" ? undefined : {},
+  });
+}
+
+describe("v1 OpenAPI tier-enforcement sweep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validateAuthTokenMock.mockResolvedValue(nonAdminSession);
+  });
+
+  test("every admin-tier operation rejects non-admin authenticated callers with 403", async () => {
+    const { json } = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/openapi.json",
+    });
+    const document = json as OpenApiDocument;
+
+    const adminOps: Array<{ method: HttpMethod; path: string }> = [];
+    for (const [path, item] of Object.entries(document.paths)) {
+      for (const [method, op] of Object.entries(item)) {
+        const upper = method.toUpperCase() as HttpMethod;
+        if (!HTTP_METHODS.includes(upper)) continue;
+        if (op["x-required-access"] !== "admin") continue;
+        adminOps.push({ method: upper, path });
+      }
+    }
+
+    expect(adminOps.length).toBeGreaterThanOrEqual(100);
+
+    const failures: string[] = [];
+
+    for (const op of adminOps) {
+      const label = `${op.method} ${op.path}`;
+      const result = await exerciseAsUser(op.method, op.path);
+      const status = result.response.status;
+      const body = result.json as { errorCode?: string; status?: number } | undefined;
+
+      if (status !== 403) {
+        failures.push(`${label}: returned ${status} (expected 403 for non-admin caller)`);
+        continue;
+      }
+      if (!result.response.headers.get("content-type")?.includes("application/problem+json")) {
+        failures.push(`${label}: 403 missing application/problem+json content-type`);
+      }
+      // `auth.forbidden` is the standard envelope. `auth.api_key_admin_disabled`
+      // is emitted only when the caller uses an API key credential and admin
+      // access via API keys is globally disabled — both are valid 403 envelopes.
+      if (
+        body?.errorCode !== "auth.forbidden" &&
+        body?.errorCode !== "auth.api_key_admin_disabled"
+      ) {
+        failures.push(
+          `${label}: 403 errorCode is "${body?.errorCode}" (expected auth.forbidden or auth.api_key_admin_disabled)`
+        );
+      }
+    }
+
+    expect(failures).toEqual([]);
+  }, 60000);
+
+  test("non-admin authenticated callers do not get 401 on admin-tier operations (proves credential was accepted)", async () => {
+    const { json } = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/openapi.json",
+    });
+    const document = json as OpenApiDocument;
+
+    const adminOps: Array<{ method: HttpMethod; path: string }> = [];
+    for (const [path, item] of Object.entries(document.paths)) {
+      for (const [method, op] of Object.entries(item)) {
+        const upper = method.toUpperCase() as HttpMethod;
+        if (!HTTP_METHODS.includes(upper)) continue;
+        if (op["x-required-access"] !== "admin") continue;
+        adminOps.push({ method: upper, path });
+      }
+    }
+
+    for (const op of adminOps) {
+      const result = await exerciseAsUser(op.method, op.path);
+      expect(
+        result.response.status,
+        `${op.method} ${op.path} returned 401 — credential mock not wired through middleware`
+      ).not.toBe(401);
+    }
+  }, 60000);
+
+  test("read-tier operations accept non-admin callers (no 401 / no 403 at the auth boundary)", async () => {
+    const { json } = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/openapi.json",
+    });
+    const document = json as OpenApiDocument;
+
+    const readOps: Array<{ method: HttpMethod; path: string }> = [];
+    for (const [path, item] of Object.entries(document.paths)) {
+      for (const [method, op] of Object.entries(item)) {
+        const upper = method.toUpperCase() as HttpMethod;
+        if (!HTTP_METHODS.includes(upper)) continue;
+        if (op["x-required-access"] !== "read") continue;
+        readOps.push({ method: upper, path });
+      }
+    }
+
+    const failures: string[] = [];
+
+    for (const op of readOps) {
+      const result = await exerciseAsUser(op.method, op.path);
+      const status = result.response.status;
+      const body = result.json as { errorCode?: string } | undefined;
+
+      if (status === 401) {
+        failures.push(`${op.method} ${op.path}: returned 401 (read tier should accept user token)`);
+        continue;
+      }
+      if (status === 403 && body?.errorCode === "auth.forbidden") {
+        failures.push(
+          `${op.method} ${op.path}: returned auth.forbidden (read tier should not require admin)`
+        );
+      }
+    }
+
+    expect(failures).toEqual([]);
+  }, 60000);
+});


### PR DESCRIPTION
## Summary

- 新增 `tests/api/v1/openapi-auth-sweep.test.ts`:从 `/api/v1/openapi.json` 枚举出 175 个 operation,无凭证调用并校验 `x-required-access` 与运行时一致——`public` 不应返回 401,`read`/`admin` 必须返回 `application/problem+json` + `auth.missing`。同时把 public allow-list (`GET /api/v1/health`、`GET /api/v1/public/status`) 锁在测试里,防止新公开端点未经审查地加入。
- 新增 `tests/api/v1/openapi-tier-sweep.test.ts`:mock `validateAuthToken` 返回非管理员 session,断言所有 138 个 admin operation 拒绝为 `auth.forbidden`/`auth.api_key_admin_disabled`,所有 35 个 read operation 在认证边界放行(无 401/403)。

两个 sweep 一起把"OpenAPI 声明的 tier"和"实际中间件强制的 tier"绑死,任何新端点偏离契约都会立即在测试里暴露。

## 影响面

- 仅新增测试,无业务代码改动。
- v1 套件由基线 83 文件 / 304 测试上涨到 **85 文件 / 310 测试**。
- 关键文件覆盖率不变(`scripts/check-v1-critical-coverage.ts` 通过)。
- `scripts/lint-openapi.ts` 与 `bun scripts/generate-v1-types.ts --check` 均通过。

## Test plan

- [x] `bunx vitest run --config tests/configs/v1.config.ts` —— 310/310 passed
- [x] `bunx vitest run --config tests/configs/v1.config.ts --coverage` —— statements 88.34% / functions 98.83% / lines 98.19%
- [x] `bun scripts/check-v1-critical-coverage.ts` —— Critical v1 coverage check passed
- [x] `bun scripts/lint-openapi.ts` —— OpenAPI lint passed
- [x] `bun scripts/generate-v1-types.ts --check` —— exit 0
- [x] `bun run lint` —— Biome 通过
- [x] `bun run typecheck` —— tsgo 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds two new OpenAPI-driven sweep tests that bind the spec's declared `x-required-access` tier to the runtime middleware enforcement, catching any drift immediately when new endpoints are added.

- **`openapi-auth-sweep.test.ts`**: Fetches the live spec, probes all operations without credentials, and asserts public routes never 401 while read/admin routes return a proper `401 + auth.missing` problem+json envelope. A third test locks the public endpoint set to an explicit allow-list.
- **`openapi-tier-sweep.test.ts`**: Mocks `validateAuthToken` to return a non-admin session, verifies all 138 admin-tier operations 403 with `auth.forbidden` or `auth.api_key_admin_disabled`, and confirms all 35 read-tier operations pass the auth boundary without 401/403.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only addition with no business logic changes; safe to merge.

Both files add new sweep tests that probe the existing auth middleware. No production code is modified. The sweep logic is sound: failure accumulation is used throughout (minor inconsistency in one test aside), the mock setup via vi.hoisted is correct, and the public endpoint allow-list lock is a useful regression guard.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/api/v1/openapi-auth-sweep.test.ts | New sweep test that probes all 175+ operations without credentials, verifying public routes never return 401 and protected routes return a well-formed 401+auth.missing envelope. Includes an exact public-endpoint allow-list lock. |
| tests/api/v1/openapi-tier-sweep.test.ts | New sweep test that mocks validateAuthToken with a non-admin session and verifies all 138 admin-tier operations return 403, and all 35 read-tier operations pass auth. Test 2 uses an early-throw assertion pattern inconsistent with the failure-accumulation pattern in tests 1 and 3. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/api/v1/openapi-tier-sweep.test.ts:120-127
Test 2 uses an inline `expect()` that throws on the first 401 and abandons the rest of the sweep. Tests 1 and 3 use a `failures[]` accumulation pattern that reports all broken operations at once. When the mock isn't wired through for several operations, this test stops after the very first failure — leaving the other ~137 operations untested and making it harder to assess the blast radius.

```suggestion
    const wiredFailures: string[] = [];
    for (const op of adminOps) {
      const result = await exerciseAsUser(op.method, op.path);
      if (result.response.status === 401) {
        wiredFailures.push(
          `${op.method} ${op.path}: returned 401 — credential mock not wired through middleware`
        );
      }
    }
    expect(wiredFailures).toEqual([]);
  }, 60000);
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["test(api/v1): add OpenAPI-driven auth an..."](https://github.com/ding113/claude-code-hub/commit/7bd89561ca9c054e7728d41ba9229eb09d203f7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32110798)</sub>

<!-- /greptile_comment -->