### PR TITLE
修复可用性监控加载过慢

### DIFF
--- a/src/lib/availability/availability-service.ts
+++ b/src/lib/availability/availability-service.ts
@@ -4,7 +4,7 @@
  * Simple two-tier status: success (green) or failure (red)
  */
 
-import { and, eq, inArray, isNull, type SQLWrapper, sql } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, type SQLWrapper, sql } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { messageRequest, providers } from "@/drizzle/schema";
 import type {
@@ -62,19 +62,12 @@ export class AvailabilityQueryValidationError extends Error {
 }
 
 /**
- * 当前版本把“已终态”收敛为 `statusCode` 已落库。
- *
- * 已知限制：在当前异步写入/丢 patch 的极端场景，或未来新增了 `durationMs` / `errorMessage`
- * 已落库、但 `statusCode` 仍为空且已稳定结束的写路径时，这些记录会被当前可用性统计排除。
- * 届时应引入独立的 finalized 谓词，而不是直接放宽为 `durationMs IS NOT NULL`。
+ * 可用性监控用 `statusCode IS NOT NULL` 作为终态边界。
+ * 请求过程中的中间状态可能已经有 providerChain/errorMessage 片段，但仍不能算入可用性，
+ * 否则会把 requesting 中的请求误判为失败。success-rate outcome 仅用于终态记录的分类。
  */
 function buildAvailabilityFinalizedCondition() {
-  return sql`fn_is_message_request_finalized(
-    ${messageRequest.blockedBy},
-    ${messageRequest.statusCode},
-    ${messageRequest.providerChain},
-    ${messageRequest.errorMessage}
-  )`;
+  return isNotNull(messageRequest.statusCode);
 }
 
 function assertValidDate(date: Date, fieldName: string): Date {

--- a/tests/unit/lib/availability-service.test.ts
+++ b/tests/unit/lib/availability-service.test.ts
@@ -43,17 +43,21 @@ function findCteBoundary(
   queryText: string,
   cteName: string
 ): { cteStart: number; boundaryStart: number } | null {
+  if (queryText.length === 0 || cteName.length > 100 || !/^[a-z_][a-z0-9_]*$/i.test(cteName)) {
+    return null;
+  }
+
   const escapedName = cteName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = new RegExp(`(?:^|\\bwith\\s+|,\\s*)("?${escapedName}"?)\\s+as\\s*\\(`).exec(
+  const match = new RegExp(`(^|\\bwith\\s+|,\\s*)("?${escapedName}"?)\\s+as\\s*\\(`).exec(
     queryText
   );
 
-  if (!match?.[1]) {
+  if (!match?.[2]) {
     return null;
   }
 
   return {
-    cteStart: match.index + match[0].indexOf(match[1]),
+    cteStart: match.index + match[1].length,
     boundaryStart: match.index,
   };
 }

--- a/tests/unit/lib/availability-service.test.ts
+++ b/tests/unit/lib/availability-service.test.ts
@@ -39,15 +39,34 @@ function normalizeSql(sqlObject: unknown): string {
   return sqlToString(sqlObject).replace(/\s+/g, " ").trim().toLowerCase();
 }
 
-function extractFinalizedRequestsSql(queryText: string): string {
-  const start = queryText.indexOf("finalized_requests as");
-  const end = queryText.indexOf("provider_bucket_stats as");
+function findCteBoundary(
+  queryText: string,
+  cteName: string
+): { cteStart: number; boundaryStart: number } | null {
+  const escapedName = cteName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`(?:^|\\bwith\\s+|,\\s*)("?${escapedName}"?)\\s+as\\s*\\(`).exec(
+    queryText
+  );
 
-  if (start === -1 || end === -1 || end <= start) {
+  if (!match?.[1]) {
+    return null;
+  }
+
+  return {
+    cteStart: match.index + match[0].indexOf(match[1]),
+    boundaryStart: match.index,
+  };
+}
+
+function extractFinalizedRequestsSql(queryText: string): string {
+  const start = findCteBoundary(queryText, "finalized_requests");
+  const end = findCteBoundary(queryText, "provider_bucket_stats");
+
+  if (!start || !end || end.boundaryStart <= start.cteStart) {
     throw new Error("Could not locate finalized_requests CTE in query text");
   }
 
-  return queryText.slice(start, end);
+  return queryText.slice(start.cteStart, end.boundaryStart);
 }
 
 describe("availability-service", () => {

--- a/tests/unit/lib/availability-service.test.ts
+++ b/tests/unit/lib/availability-service.test.ts
@@ -43,6 +43,7 @@ function findCteBoundary(
   queryText: string,
   cteName: string
 ): { cteStart: number; boundaryStart: number } | null {
+  // cteName 先经长度/格式校验，再生成 escapedName 参与受控测试正则构造。
   if (queryText.length === 0 || cteName.length > 100 || !/^[a-z_][a-z0-9_]*$/i.test(cteName)) {
     return null;
   }
@@ -66,8 +67,14 @@ function extractFinalizedRequestsSql(queryText: string): string {
   const start = findCteBoundary(queryText, "finalized_requests");
   const end = findCteBoundary(queryText, "provider_bucket_stats");
 
-  if (!start || !end || end.boundaryStart <= start.cteStart) {
-    throw new Error("Could not locate finalized_requests CTE in query text");
+  if (!start) {
+    throw new Error("finalized_requests CTE not found in query text");
+  }
+  if (!end) {
+    throw new Error("provider_bucket_stats CTE not found in query text");
+  }
+  if (end.boundaryStart <= start.cteStart) {
+    throw new Error("finalized_requests CTE appears after provider_bucket_stats CTE");
   }
 
   return queryText.slice(start.cteStart, end.boundaryStart);

--- a/tests/unit/lib/availability-service.test.ts
+++ b/tests/unit/lib/availability-service.test.ts
@@ -309,7 +309,7 @@ describe("availability-service", () => {
 
     const queryText = normalizeSql(executeMock.mock.calls[0]?.[0]);
     const finalizedRequestsSql = extractFinalizedRequestsSql(queryText);
-    expect(finalizedRequestsSql).toContain("fn_is_message_request_finalized");
+    expect(finalizedRequestsSql).toContain('"status_code" is not null');
     expect(queryText).toContain("group by");
     expect(queryText).toContain("percentile_cont(0.95)");
     expect(queryText).toContain("row_number() over");
@@ -482,7 +482,7 @@ describe("availability-service", () => {
     const finalizedRequestsSql = extractFinalizedRequestsSql(
       normalizeSql(executeMock.mock.calls[0]?.[0])
     );
-    expect(finalizedRequestsSql).toContain("fn_is_message_request_finalized");
+    expect(finalizedRequestsSql).toContain('"status_code" is not null');
   });
 
   it("queryProviderAvailability 会保留 Gemini passthrough 终态(statusCode!=null 且 durationMs=null)", async () => {
@@ -515,6 +515,7 @@ describe("availability-service", () => {
     const finalizedRequestsSql = extractFinalizedRequestsSql(
       normalizeSql(executeMock.mock.calls[0]?.[0])
     );
+    expect(finalizedRequestsSql).toContain('"status_code" is not null');
     expect(finalizedRequestsSql).not.toMatch(/where .*duration_?ms.*is not null/);
   });
 
@@ -548,7 +549,7 @@ describe("availability-service", () => {
     const queryText = normalizeSql(executeMock.mock.calls[0]?.[0]);
     const finalizedRequestsSql = extractFinalizedRequestsSql(queryText);
 
-    expect(finalizedRequestsSql).toContain("fn_is_message_request_finalized");
+    expect(finalizedRequestsSql).toContain('"status_code" is not null');
     expect(queryText).toContain("fn_compute_message_request_success_rate_outcome");
     expect(queryText).toContain(`"successrateoutcome" = 'failure'`);
   });
@@ -717,7 +718,7 @@ describe("availability-service", () => {
     ]);
 
     const queryText = normalizeSql(executeMock.mock.calls[0]?.[0]);
-    expect(queryText).toContain("fn_is_message_request_finalized");
+    expect(queryText).toContain('"status_code" is not null');
     expect(queryText).toContain(">= now() - (15 * interval '1 minute')");
     expect(queryText).toContain("<= now()");
     expect(queryText).toContain("count(*) filter");


### PR DESCRIPTION
## Related Issues & PRs

- **Fixes #1168** — 可用性监控查询导致 PostgreSQL CPU 飙升至 100%，根因是 `fn_is_message_request_finalized` 函数调用使查询无法命中部分索引 `idx_message_request_provider_created_at_finalized_active`。
- **Related to #1080** — 该 PR 将可用性监控的终态判断从 `statusCode IS NOT NULL` 改为 `fn_is_message_request_finalized(...)`，引入了本次性能回归。
- **Related to #1018** — 该 PR 最初建立了 `statusCode IS NOT NULL` 终态边界并创建了对应的部分索引。

## 背景

可用性监控的聚合查询加载很久。排查后确认热路径查询原本依赖 `message_request` 上的部分索引：

`idx_message_request_provider_created_at_finalized_active`

该索引的谓词包含 `deleted_at IS NULL AND status_code IS NOT NULL`。近期查询条件改为 `fn_is_message_request_finalized(...)` 后，SQL 不再显式包含 `status_code IS NOT NULL`，Postgres 难以使用这个部分索引，导致 provider + 时间范围聚合容易退化为大范围扫描。

同时，可用性监控不能直接把 requesting 中已出现 `providerChain` / `errorMessage` 片段的请求计为终态，否则会把请求中的请求误算成失败。因此这里恢复用 `status_code IS NOT NULL` 作为可用性监控的终态边界，继续使用 `fn_compute_message_request_success_rate_outcome(...)` 对终态记录做成功/失败/排除分类。

## 改动

- 将可用性监控终态过滤恢复为 `statusCode IS NOT NULL`，重新对齐现有部分索引。
- 保留 success-rate outcome 函数作为终态记录分类逻辑，避免把请求中的中间状态误算为失败。
- 更新 availability service 单元测试，断言查询包含 `status_code IS NOT NULL`，并继续覆盖 outcome 分类函数。

## 验证

- `bunx vitest run tests/unit/lib/availability-service.test.ts`
- `bunx biome check src/lib/availability/availability-service.ts tests/unit/lib/availability-service.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:fix`
- `bun run test`
- `bun run build`

说明：`bun run build` 通过，过程中仍会输出仓库既有的 Edge Runtime 警告。

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores `status_code IS NOT NULL` as the finalized-request boundary in availability monitoring, replacing the `fn_is_message_request_finalized(...)` call that was preventing PostgreSQL from using the partial index `idx_message_request_provider_created_at_finalized_active`, causing full-scan degradation on the hot aggregation path.

- **`availability-service.ts`**: `buildAvailabilityFinalizedCondition()` now returns `isNotNull(messageRequest.statusCode)` (one line, uses the new `isNotNull` import). Outcome classification (`fn_compute_message_request_success_rate_outcome`) is preserved and still drives `greenCount`/`redCount` via `FILTER (WHERE successRateOutcome IN ('success', 'failure'))`, so blocked/excluded records with a statusCode remain harmless.
- **`availability-service.test.ts`**: `extractFinalizedRequestsSql` is hardened with a new `findCteBoundary` helper that uses a regex anchored to CTE keyword boundaries instead of a fragile `indexOf`. Four test assertions are updated from `fn_is_message_request_finalized` to `"status_code" is not null`; one previously missing assertion is added to the Gemini passthrough test.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted one-line revert in the finalized condition, backed by updated tests that assert the correct SQL predicate appears in the generated query.

The core change is a single, well-scoped substitution: replacing a PL/pgSQL function call with a direct column null-check that the existing partial index was already designed to serve. Outcome classification is untouched and still controls which finalized records count as green or red. The test helper improvement is strictly additive and more correct than the previous indexOf-based extraction. No logic paths were removed or silently skipped.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/availability/availability-service.ts | Reverts finalized-condition from fn_is_message_request_finalized(...) to isNotNull(statusCode) to re-align with the partial index predicate; adds isNotNull import; updates JSDoc comment |
| tests/unit/lib/availability-service.test.ts | Adds findCteBoundary() for more robust CTE boundary detection; updates assertions from fn_is_message_request_finalized to "status_code" is not null; adds one missing assertion to the Gemini passthrough test |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant AvailService as AvailabilityService
    participant DB as PostgreSQL

    Client->>AvailService: queryProviderAvailability(options)
    AvailService->>DB: "SELECT providers WHERE isEnabled=true"
    DB-->>AvailService: [providerList]

    AvailService->>DB: WITH finalized_requests AS (SELECT ... FROM message_request WHERE status_code IS NOT NULL AND deleted_at IS NULL), provider_bucket_stats AS (SELECT ... COUNT/AVG/PERCENTILE via fn_compute_outcome) SELECT ... FROM limited_provider_bucket_stats
    DB-->>AvailService: [bucketRows]
    AvailService-->>Client: AvailabilityQueryResult

    note over AvailService,DB: Previously: WHERE fn_is_message_request_finalized(...) skipped partial index
    note over AvailService,DB: Now: WHERE status_code IS NOT NULL hits idx_message_request_provider_created_at_finalized_active
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/unit/lib/availability-service.test.ts`, line 42-51 ([link](https://github.com/ding113/claude-code-hub/blob/7ea33820933e82685fe7e1bb3755812f9f69804a/tests/unit/lib/availability-service.test.ts#L42-L51)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`extractFinalizedRequestsSql` silently passes if anchor text collides**

   `extractFinalizedRequestsSql` slices between the first occurrence of `"finalized_requests as"` and `"provider_bucket_stats as"`. If Drizzle ever quotes identifiers differently or the CTE names shift, both `indexOf` calls can return `-1` and the guard throws — but if only the second sentinel is missing while the first is present, `end === -1` is caught. More critically, if any literal string in the query accidentally contains `"provider_bucket_stats as"` earlier than the actual CTE definition, the slice would be silently truncated, causing assertions on the extracted snippet to produce false-positives. A more robust anchor using a regex with a CTE keyword boundary would make this helper more resilient to query text drift.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/unit/lib/availability-service.test.ts
   Line: 42-51

   Comment:
   **`extractFinalizedRequestsSql` silently passes if anchor text collides**

   `extractFinalizedRequestsSql` slices between the first occurrence of `"finalized_requests as"` and `"provider_bucket_stats as"`. If Drizzle ever quotes identifiers differently or the CTE names shift, both `indexOf` calls can return `-1` and the guard throws — but if only the second sentinel is missing while the first is present, `end === -1` is caught. More critically, if any literal string in the query accidentally contains `"provider_bucket_stats as"` earlier than the actual CTE definition, the slice would be silently truncated, causing assertions on the extracted snippet to produce false-positives. A more robust anchor using a regex with a CTE keyword boundary would make this helper more resilient to query text drift.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["test: 优化 CTE 边界测试诊断"](https://github.com/ding113/claude-code-hub/commit/9cad7c58c74ae7b5846cb87d688f35bc80e8d980) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32159557)</sub>

<!-- /greptile_comment -->