### PR TITLE
fix(install): clarify branch selection prompt in deploy scripts

### DIFF
--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -220,25 +220,22 @@ function Select-Branch {
         }
         $normalized = $choice.Trim().ToLower()
 
-        switch ($normalized) {
-            { $_ -in "1", "main" } {
-                $script:IMAGE_TAG = "latest"
-                $script:BRANCH_NAME = "main"
-                Write-ColorOutput "Selected branch: main (image tag: latest)" -Type Success
-                break
-            }
-            { $_ -in "2", "dev" } {
-                $script:IMAGE_TAG = "dev"
-                $script:BRANCH_NAME = "dev"
-                Write-ColorOutput "Selected branch: dev (image tag: dev)" -Type Success
-                break
-            }
-            default {
-                Write-ColorOutput "Invalid choice. Type 1, 2, 'main', or 'dev' and press Enter." -Type Error
-                continue
-            }
+        # Use if/return rather than switch+break — in PowerShell `break` inside a
+        # switch exits the switch, not the surrounding while, so the loop control
+        # has to live at this scope.
+        if ($normalized -in "1", "main") {
+            $script:IMAGE_TAG = "latest"
+            $script:BRANCH_NAME = "main"
+            Write-ColorOutput "Selected branch: main (image tag: latest)" -Type Success
+            return
         }
-        break
+        if ($normalized -in "2", "dev") {
+            $script:IMAGE_TAG = "dev"
+            $script:BRANCH_NAME = "dev"
+            Write-ColorOutput "Selected branch: dev (image tag: dev)" -Type Success
+            return
+        }
+        Write-ColorOutput "Invalid choice. Type 1, 2, 'main', or 'dev' and press Enter." -Type Error
     }
 }
 

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -212,28 +212,29 @@ function Select-Branch {
     Write-Host "  1) main   (Stable release - recommended for production)" -ForegroundColor Green
     Write-Host "  2) dev    (Latest features - for testing)" -ForegroundColor Yellow
     Write-Host ""
-    
+
     while ($true) {
-        $choice = Read-Host "Enter your choice [1]"
+        $choice = Read-Host "Type 1 or 2 (or 'main'/'dev') and press Enter [default: 1]"
         if ([string]::IsNullOrWhiteSpace($choice)) {
             $choice = "1"
         }
-        
-        switch ($choice) {
-            "1" {
+        $normalized = $choice.Trim().ToLower()
+
+        switch ($normalized) {
+            { $_ -in "1", "main" } {
                 $script:IMAGE_TAG = "latest"
                 $script:BRANCH_NAME = "main"
                 Write-ColorOutput "Selected branch: main (image tag: latest)" -Type Success
                 break
             }
-            "2" {
+            { $_ -in "2", "dev" } {
                 $script:IMAGE_TAG = "dev"
                 $script:BRANCH_NAME = "dev"
                 Write-ColorOutput "Selected branch: dev (image tag: dev)" -Type Success
                 break
             }
             default {
-                Write-ColorOutput "Invalid choice. Please enter 1 or 2." -Type Error
+                Write-ColorOutput "Invalid choice. Type 1, 2, 'main', or 'dev' and press Enter." -Type Error
                 continue
             }
         }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -247,10 +247,11 @@ select_branch() {
 
     local choice normalized
     while true; do
-        read -p "Type 1 or 2 (or 'main'/'dev') and press Enter [default: 1]: " choice
-        choice=${choice:-1}
-        # Trim whitespace and lowercase
+        read -r -p "Type 1 or 2 (or 'main'/'dev') and press Enter [default: 1]: " choice
+        # Trim whitespace, lowercase, then apply default — so whitespace-only input
+        # also falls back to "1" (the bare ${choice:-1} would not trigger on "   ").
         normalized=$(printf '%s' "$choice" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        normalized=${normalized:-1}
 
         case "$normalized" in
             1|main)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -244,27 +244,29 @@ select_branch() {
     echo -e "  ${GREEN}1)${NC} main   (Stable release - recommended for production)"
     echo -e "  ${YELLOW}2)${NC} dev    (Latest features - for testing)"
     echo ""
-    
-    local choice
+
+    local choice normalized
     while true; do
-        read -p "Enter your choice [1]: " choice
+        read -p "Type 1 or 2 (or 'main'/'dev') and press Enter [default: 1]: " choice
         choice=${choice:-1}
-        
-        case $choice in
-            1)
+        # Trim whitespace and lowercase
+        normalized=$(printf '%s' "$choice" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+        case "$normalized" in
+            1|main)
                 IMAGE_TAG="latest"
                 BRANCH_NAME="main"
                 log_success "Selected branch: main (image tag: latest)"
                 break
                 ;;
-            2)
+            2|dev)
                 IMAGE_TAG="dev"
                 BRANCH_NAME="dev"
                 log_success "Selected branch: dev (image tag: dev)"
                 break
                 ;;
             *)
-                log_error "Invalid choice. Please enter 1 or 2."
+                log_error "Invalid choice. Type 1, 2, 'main', or 'dev' and press Enter."
                 ;;
         esac
     done


### PR DESCRIPTION
## Summary

User feedback: the install scripts' branch-selection step (main vs dev) is confusing — users don't know whether to use arrow keys, mouse, or type a digit, and the original prompt \`Enter your choice [1]:\` doesn't spell it out.

This PR updates both \`scripts/deploy.sh\` and \`scripts/deploy.ps1\`:

- Prompt now explicitly tells the user what to do: \`Type 1 or 2 (or 'main'/'dev') and press Enter [default: 1]:\`
- Accept the branch names \`main\` / \`dev\` as case-insensitive, whitespace-tolerant aliases for \`1\` / \`2\` — since users naturally type the label they see.
- Error message matches the new instruction.

## Test plan

Verified \`select_branch\` in \`deploy.sh\` against 9 input variants:
- [x] empty input → defaults to main
- [x] \`1\` → main, \`2\` → dev
- [x] \`main\` → main, \`dev\` → dev
- [x] \`MAIN\` (uppercase) → main
- [x] \` dev \` (whitespace) → dev
- [x] up-arrow keystroke → invalid + reprompt, then accepts next valid input
- [x] garbage then valid → reprompts, then accepts

PowerShell version mirrors the bash logic (no \`pwsh\` available locally to syntax-check, but the change is structurally identical and uses standard \`Trim()\` / \`ToLower()\` / \`switch -in\` idioms).

Pre-commit checks all green: \`bun run lint\`, \`bun run typecheck\`, \`bun run build\`, \`bun run test\` (5235 passed / 13 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the branch-selection UX in both deploy scripts by clarifying the prompt and accepting `main`/`dev` as typed aliases for `1`/`2`, with case-insensitive and whitespace-tolerant matching.

- **`deploy.sh`**: Normalisation now runs before the default substitution (`${normalized:-1}`), so whitespace-only input correctly falls back to `main` — the previous `${choice:-1}` guard only fired for a truly empty string.
- **`deploy.ps1`**: Adds `Trim().ToLower()` on top of the existing `IsNullOrWhiteSpace` guard, and replaces the `switch`+`break` pattern with `if`/`return` to correctly exit the enclosing `while` loop (a `break` inside a PowerShell `switch` exits only the `switch`, not the loop).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are limited to the interactive branch-selection prompt in both deploy scripts with no effect on non-interactive or automated paths.

Both scripts correctly normalise input before applying the default, handle case and whitespace uniformly, and the PowerShell rewrite avoids the `switch`+`break` scoping trap. The logic is straightforward and well-tested per the PR description.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/deploy.sh | Updated branch-selection prompt and normalization logic; accepts `1`/`main` and `2`/`dev` case-insensitively, and correctly applies the default after trimming so whitespace-only input falls back to `main`. |
| scripts/deploy.ps1 | Mirrors bash changes; replaces `switch`+`break` (which only exits the switch, not the while loop) with `if`/`return`, and adds `Trim().ToLower()` normalization after the existing `IsNullOrWhiteSpace` guard. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User presses Enter]) --> B{Input empty or whitespace-only?}
    B -- Yes --> C[Normalize to '1' / default]
    B -- No --> D[Trim + lowercase]
    D --> E{normalized value}
    C --> E
    E -- 1 or main --> F[IMAGE_TAG=latest\nBRANCH_NAME=main]
    E -- 2 or dev --> G[IMAGE_TAG=dev\nBRANCH_NAME=dev]
    E -- anything else --> H[Error: reprompt]
    H --> A
    F --> I([Done])
    G --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(install): address PR1188 review nits..."](https://github.com/ding113/claude-code-hub/commit/10aa76bcb530130b515196b5c5b74cc2196a729c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32278337)</sub>

<!-- /greptile_comment -->