### PR TITLE
fix: 隔离 AgentPool 活跃 dispatcher 生命周期

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -3038,18 +3038,40 @@ export class ProxyForwarder {
       // ⭐ SSL 证书错误检测：标记 Agent 为不健康，下次请求将创建新 Agent
       const sslErrorCacheKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
       const sslErrorDispatcherId = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
-      if (isSSLCertificateError(err) && sslErrorCacheKey && sslErrorDispatcherId) {
-        const pool = getGlobalAgentPool();
-        pool.markUnhealthy(sslErrorCacheKey, err.message, sslErrorDispatcherId);
-        logger.warn("ProxyForwarder: SSL certificate error detected, marked agent as unhealthy", {
-          providerId: provider.id,
-          providerName: provider.name,
-          cacheKey: sslErrorCacheKey,
-          dispatcherId: sslErrorDispatcherId,
-          connectionType: proxyConfig ? "proxy" : "direct",
-          errorMessage: err.message,
-          errorCode: err.code,
-        });
+      if (isSSLCertificateError(err)) {
+        if (sslErrorCacheKey && sslErrorDispatcherId) {
+          const pool = getGlobalAgentPool();
+          pool.markUnhealthy(sslErrorCacheKey, err.message, sslErrorDispatcherId);
+          logger.warn("ProxyForwarder: SSL certificate error detected, marked agent as unhealthy", {
+            providerId: provider.id,
+            providerName: provider.name,
+            cacheKey: sslErrorCacheKey,
+            dispatcherId: sslErrorDispatcherId,
+            connectionType: proxyConfig ? "proxy" : "direct",
+            errorMessage: err.message,
+            errorCode: err.code,
+          });
+        } else if (sslErrorCacheKey) {
+          logger.warn(
+            "ProxyForwarder: SSL certificate error detected but dispatcherId is missing",
+            {
+              providerId: provider.id,
+              providerName: provider.name,
+              cacheKey: sslErrorCacheKey,
+              connectionType: proxyConfig ? "proxy" : "direct",
+              errorMessage: err.message,
+              errorCode: err.code,
+            }
+          );
+        } else {
+          logger.warn("ProxyForwarder: SSL certificate error detected without pooled agent", {
+            providerId: provider.id,
+            providerName: provider.name,
+            connectionType: proxyConfig ? "proxy" : "direct",
+            errorMessage: err.message,
+            errorCode: err.code,
+          });
+        }
       }
 
       // ⭐ 超时错误检测（优先级：response > client）

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -3241,6 +3241,18 @@ export class ProxyForwarder {
             cacheKey: http2CacheKey,
             dispatcherId: http2DispatcherId,
           });
+        } else if (http2CacheKey) {
+          logger.warn(
+            "ProxyForwarder: HTTP/2 protocol error detected but dispatcherId is missing",
+            {
+              providerId: provider.id,
+              providerName: provider.name,
+              cacheKey: http2CacheKey,
+              connectionType: proxyConfig ? "proxy" : "direct",
+              errorMessage: err.message || "(empty message)",
+              errorCode: err.code || "N/A",
+            }
+          );
         }
 
         // 如果使用了代理，创建不支持 HTTP/2 的代理 Agent

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -3169,9 +3169,13 @@ export class ProxyForwarder {
       // 场景：HTTP/2 连接失败（GOAWAY、RST_STREAM、PROTOCOL_ERROR 等）
       // 策略：透明回退到 HTTP/1.1，不触发供应商切换或熔断器
       if (enableHttp2 && isHttp2Error(err)) {
+        const http2CacheKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
+        const http2DispatcherId = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
         logger.warn("ProxyForwarder: HTTP/2 protocol error detected, falling back to HTTP/1.1", {
           providerId: provider.id,
           providerName: provider.name,
+          cacheKey: http2CacheKey,
+          dispatcherId: http2DispatcherId,
           errorName: err.name,
           errorMessage: err.message || "(empty message)",
           errorCode: err.code || "N/A",
@@ -3202,8 +3206,6 @@ export class ProxyForwarder {
         delete http1FallbackInit.dispatcher;
 
         // ⭐ 标记 HTTP/2 Agent 为不健康，避免后续请求重复失败
-        const http2CacheKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
-        const http2DispatcherId = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
         if (http2CacheKey && http2DispatcherId) {
           const pool = getGlobalAgentPool();
           pool.markUnhealthy(

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -3037,13 +3037,15 @@ export class ProxyForwarder {
 
       // ⭐ SSL 证书错误检测：标记 Agent 为不健康，下次请求将创建新 Agent
       const sslErrorCacheKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
+      const sslErrorDispatcherId = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
       if (isSSLCertificateError(err) && sslErrorCacheKey) {
         const pool = getGlobalAgentPool();
-        pool.markUnhealthy(sslErrorCacheKey, err.message);
+        pool.markUnhealthy(sslErrorCacheKey, err.message, sslErrorDispatcherId ?? undefined);
         logger.warn("ProxyForwarder: SSL certificate error detected, marked agent as unhealthy", {
           providerId: provider.id,
           providerName: provider.name,
           cacheKey: sslErrorCacheKey,
+          dispatcherId: sslErrorDispatcherId,
           connectionType: proxyConfig ? "proxy" : "direct",
           errorMessage: err.message,
           errorCode: err.code,
@@ -3201,13 +3203,19 @@ export class ProxyForwarder {
 
         // ⭐ 标记 HTTP/2 Agent 为不健康，避免后续请求重复失败
         const http2CacheKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
+        const http2DispatcherId = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
         if (http2CacheKey) {
           const pool = getGlobalAgentPool();
-          pool.markUnhealthy(http2CacheKey, `HTTP/2 protocol error: ${err.message}`);
+          pool.markUnhealthy(
+            http2CacheKey,
+            `HTTP/2 protocol error: ${err.message}`,
+            http2DispatcherId ?? undefined
+          );
           logger.debug("ProxyForwarder: Marked HTTP/2 agent as unhealthy due to protocol error", {
             providerId: provider.id,
             providerName: provider.name,
             cacheKey: http2CacheKey,
+            dispatcherId: http2DispatcherId,
           });
         }
 

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -3038,9 +3038,9 @@ export class ProxyForwarder {
       // ⭐ SSL 证书错误检测：标记 Agent 为不健康，下次请求将创建新 Agent
       const sslErrorCacheKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
       const sslErrorDispatcherId = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
-      if (isSSLCertificateError(err) && sslErrorCacheKey) {
+      if (isSSLCertificateError(err) && sslErrorCacheKey && sslErrorDispatcherId) {
         const pool = getGlobalAgentPool();
-        pool.markUnhealthy(sslErrorCacheKey, err.message, sslErrorDispatcherId ?? undefined);
+        pool.markUnhealthy(sslErrorCacheKey, err.message, sslErrorDispatcherId);
         logger.warn("ProxyForwarder: SSL certificate error detected, marked agent as unhealthy", {
           providerId: provider.id,
           providerName: provider.name,
@@ -3204,12 +3204,12 @@ export class ProxyForwarder {
         // ⭐ 标记 HTTP/2 Agent 为不健康，避免后续请求重复失败
         const http2CacheKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
         const http2DispatcherId = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
-        if (http2CacheKey) {
+        if (http2CacheKey && http2DispatcherId) {
           const pool = getGlobalAgentPool();
           pool.markUnhealthy(
             http2CacheKey,
             `HTTP/2 protocol error: ${err.message}`,
-            http2DispatcherId ?? undefined
+            http2DispatcherId
           );
           logger.debug("ProxyForwarder: Marked HTTP/2 agent as unhealthy due to protocol error", {
             providerId: provider.id,

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -16,7 +16,10 @@ import { logger } from "@/lib/logger";
  * Agent Pool Configuration
  */
 export interface AgentPoolConfig {
-  /** 最大存活 dispatcher 代数，包含 cached、retired，以及正在创建中的容量预留（默认：100） */
+  /**
+   * 最大 dispatcher 容量，通常包含 cached、retired，以及正在创建中的容量预留（默认：100）。
+   * 同 cacheKey 退役中的活跃旧代可提供 1 个替换 credit，避免满载时硬过期/unhealthy 后无法重建。
+   */
   maxTotalAgents: number;
   /** Agent TTL in milliseconds (default: 300000 = 5 minutes) */
   agentTtlMs: number;
@@ -663,7 +666,18 @@ export class AgentPoolImpl implements AgentPool {
     return this.cache.size + this.retiredAgents.size;
   }
 
-  private getReservedDispatcherCount(): number {
+  private getReplacementCapacityCredit(cacheKey: string): number {
+    // 同 cacheKey 的退役活跃旧代原本占用的是这个逻辑槽位。允许最多 1 个替换 credit，
+    // 让硬过期/unhealthy 后能重建当前可复用代；更多旧代仍计入容量，避免无限堆积。
+    for (const retired of this.retiredAgents.values()) {
+      if (retired.cacheKey === cacheKey && retired.activeRequests > 0) {
+        return 1;
+      }
+    }
+    return 0;
+  }
+
+  private getReservedDispatcherCount(replacementCacheKey?: string): number {
     let reserved = this.getLiveDispatcherCount();
     for (const cacheKey of this.pendingCreations.keys()) {
       // 创建完成到 finally 删除 pending 之间，cache 里已经有同 key dispatcher，
@@ -672,19 +686,27 @@ export class AgentPoolImpl implements AgentPool {
         reserved++;
       }
     }
-    return reserved;
+    if (replacementCacheKey) {
+      reserved -= this.getReplacementCapacityCredit(replacementCacheKey);
+    }
+    return Math.max(0, reserved);
   }
 
   private ensureCapacityForNewAgent(cacheKey: string): void {
-    this.reclaimCapacityForNewAgent();
+    this.reclaimCapacityForNewAgent(cacheKey);
 
-    if (this.getReservedDispatcherCount() < this.config.maxTotalAgents) {
+    if (this.getReservedDispatcherCount(cacheKey) < this.config.maxTotalAgents) {
       return;
     }
 
+    const reservedDispatchers = this.getReservedDispatcherCount();
+    const replacementCapacityCredit = this.getReplacementCapacityCredit(cacheKey);
     logger.warn("AgentPool: Live dispatcher capacity exhausted", {
       cacheKey,
       maxTotalAgents: this.config.maxTotalAgents,
+      reservedDispatchers,
+      effectiveReservedDispatchers: Math.max(0, reservedDispatchers - replacementCapacityCredit),
+      replacementCapacityCredit,
       cacheSize: this.cache.size,
       retiredAgents: this.retiredAgents.size,
       pendingCreations: this.pendingCreations.size,
@@ -694,14 +716,14 @@ export class AgentPoolImpl implements AgentPool {
     throw new Error(`AgentPool live dispatcher capacity exhausted: ${this.config.maxTotalAgents}`);
   }
 
-  private reclaimCapacityForNewAgent(): void {
+  private reclaimCapacityForNewAgent(cacheKey: string): void {
     if (this.getReservedDispatcherCount() < this.config.maxTotalAgents) {
       return;
     }
 
     this.cleanupRetiredAgents(Date.now());
 
-    if (this.getReservedDispatcherCount() < this.config.maxTotalAgents) {
+    if (this.getReservedDispatcherCount(cacheKey) < this.config.maxTotalAgents) {
       return;
     }
 

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -60,6 +60,12 @@ interface RetiredAgent extends CachedAgent {
   retireReason: string;
 }
 
+interface PendingAgentCreation {
+  promise: Promise<GetAgentResult>;
+  endpointKey: string;
+  startedAtEvictionSequence: number;
+}
+
 /**
  * Agent Pool Statistics
  */
@@ -216,9 +222,12 @@ export class AgentPoolImpl implements AgentPool {
     evictedAgents: 0,
   };
   /** Pending agent creation promises to prevent race conditions */
-  private pendingCreations: Map<string, Promise<GetAgentResult>> = new Map();
+  private pendingCreations: Map<string, PendingAgentCreation> = new Map();
   /** Monotonic counter for generating unique dispatcher ids per creation */
   private dispatcherIdCounter = 0;
+  /** 端点驱逐版本，用来拒绝驱逐期间才完成的 dispatcher 创建。 */
+  private endpointEvictionEpochs: Map<string, number> = new Map();
+  private endpointEvictionSequence = 0;
   /**
    * Pending destroy/close promises (best-effort).
    *
@@ -277,28 +286,32 @@ export class AgentPoolImpl implements AgentPool {
     // Check if there's a pending creation for this key (race condition prevention)
     const pending = this.pendingCreations.get(cacheKey);
     if (pending) {
-      // Wait for the pending creation and return its result
-      const result = await pending;
-      // ⚠️ 关键：等待 pending 创建的调用者也必须计入 activeRequests。
-      // 创建者在 createAgentWithCache 里把 activeRequests 初始化为 1（只代表它自己），
-      // 这里的每个等待者都要再 +1，否则一旦创建者完成并减到 0，cleanup/LRU 会在其它
-      // 仍在飞行中的请求头上把共享 agent 驱逐掉，又会把 STREAM_PROCESSING_ERROR 带回来。
-      const currentCached = this.cache.get(cacheKey);
-      if (currentCached && currentCached.id === result.dispatcherId) {
-        currentCached.activeRequests++;
-        currentCached.lastUsedAt = Date.now();
+      if (!this.isPendingCreationCurrent(pending)) {
+        this.pendingCreations.delete(cacheKey);
       } else {
-        const retired = this.retiredAgents.get(result.dispatcherId);
-        if (retired && retired.cacheKey === cacheKey) {
-          retired.activeRequests++;
-          retired.lastUsedAt = Date.now();
+        // Wait for the pending creation and return its result
+        const result = await pending.promise;
+        // ⚠️ 关键：等待 pending 创建的调用者也必须计入 activeRequests。
+        // 创建者在 createAgentWithCache 里把 activeRequests 初始化为 1（只代表它自己），
+        // 这里的每个等待者都要再 +1，否则一旦创建者完成并减到 0，cleanup/LRU 会在其它
+        // 仍在飞行中的请求头上把共享 agent 驱逐掉，又会把 STREAM_PROCESSING_ERROR 带回来。
+        const currentCached = this.cache.get(cacheKey);
+        if (currentCached && currentCached.id === result.dispatcherId) {
+          currentCached.activeRequests++;
+          currentCached.lastUsedAt = Date.now();
+        } else {
+          const retired = this.retiredAgents.get(result.dispatcherId);
+          if (retired && retired.cacheKey === cacheKey) {
+            retired.activeRequests++;
+            retired.lastUsedAt = Date.now();
+          }
         }
+        // Count as cache hit - we're reusing the pending result, not creating a new agent
+        // Note: Don't decrement cacheMisses here since we never incremented it for this request
+        this.stats.totalRequests++;
+        this.stats.cacheHits++;
+        return { ...result, isNew: false };
       }
-      // Count as cache hit - we're reusing the pending result, not creating a new agent
-      // Note: Don't decrement cacheMisses here since we never incremented it for this request
-      this.stats.totalRequests++;
-      this.stats.cacheHits++;
-      return { ...result, isNew: false };
     }
 
     this.ensureCapacityForNewAgent(cacheKey);
@@ -308,14 +321,27 @@ export class AgentPoolImpl implements AgentPool {
     this.stats.cacheMisses++;
 
     // Create the agent creation promise and store it
-    const creationPromise = this.createAgentWithCache(params, cacheKey);
-    this.pendingCreations.set(cacheKey, creationPromise);
+    const endpointKey = new URL(params.endpointUrl).origin;
+    const startedAtEvictionSequence = this.endpointEvictionSequence;
+    const creationPromise = this.createAgentWithCache(
+      params,
+      cacheKey,
+      endpointKey,
+      startedAtEvictionSequence
+    );
+    this.pendingCreations.set(cacheKey, {
+      promise: creationPromise,
+      endpointKey,
+      startedAtEvictionSequence,
+    });
 
     try {
       return await creationPromise;
     } finally {
       // Clean up pending creation
-      this.pendingCreations.delete(cacheKey);
+      if (this.pendingCreations.get(cacheKey)?.promise === creationPromise) {
+        this.pendingCreations.delete(cacheKey);
+      }
     }
   }
 
@@ -325,7 +351,9 @@ export class AgentPoolImpl implements AgentPool {
    */
   private async createAgentWithCache(
     params: GetAgentParams,
-    cacheKey: string
+    cacheKey: string,
+    endpointKey: string,
+    creationStartedAtEvictionSequence: number
   ): Promise<GetAgentResult> {
     // Create new agent
     const agent = await this.createAgent(params);
@@ -334,13 +362,17 @@ export class AgentPoolImpl implements AgentPool {
       throw new Error("AgentPool is shutting down");
     }
 
-    const url = new URL(params.endpointUrl);
+    if ((this.endpointEvictionEpochs.get(endpointKey) ?? 0) > creationStartedAtEvictionSequence) {
+      void this.closeAgent(agent, cacheKey);
+      throw new Error(`AgentPool endpoint was evicted during creation: ${endpointKey}`);
+    }
+
     const dispatcherId = `disp-${++this.dispatcherIdCounter}`;
 
     const newCached: CachedAgent = {
       id: dispatcherId,
       agent,
-      endpointKey: url.origin,
+      endpointKey,
       createdAt: Date.now(),
       lastUsedAt: Date.now(),
       requestCount: 1,
@@ -395,11 +427,11 @@ export class AgentPoolImpl implements AgentPool {
     const retired = this.retiredAgents.get(dispatcherId);
     if (retired && retired.cacheKey === cacheKey) {
       retired.healthy = false;
-      retired.retiredBy = "unhealthy";
-      retired.retireReason = reason;
       logger.warn("AgentPool: Retired agent marked as unhealthy", {
         cacheKey,
         dispatcherId,
+        retiredBy: retired.retiredBy,
+        retireReason: retired.retireReason,
         reason,
       });
       return;
@@ -414,6 +446,7 @@ export class AgentPoolImpl implements AgentPool {
   }
 
   async evictEndpoint(endpointKey: string): Promise<void> {
+    this.endpointEvictionEpochs.set(endpointKey, ++this.endpointEvictionSequence);
     const keysToEvict: string[] = [];
 
     for (const [key, cached] of this.cache.entries()) {
@@ -425,6 +458,13 @@ export class AgentPoolImpl implements AgentPool {
     for (const key of keysToEvict) {
       this.evictByKey(key, "endpoint", "endpoint eviction");
     }
+  }
+
+  private isPendingCreationCurrent(pending: PendingAgentCreation): boolean {
+    return (
+      (this.endpointEvictionEpochs.get(pending.endpointKey) ?? 0) <=
+      pending.startedAtEvictionSequence
+    );
   }
 
   getPoolStats(): AgentPoolStats {
@@ -529,6 +569,7 @@ export class AgentPoolImpl implements AgentPool {
     this.cache.clear();
     this.retiredAgents.clear();
     this.pendingCreations.clear();
+    this.endpointEvictionEpochs.clear();
 
     logger.info("AgentPool: Shutdown complete");
   }

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -16,7 +16,7 @@ import { logger } from "@/lib/logger";
  * Agent Pool Configuration
  */
 export interface AgentPoolConfig {
-  /** Maximum total number of live dispatcher generations, including retired active agents (default: 100) */
+  /** 最大存活 dispatcher 代数，包含 cached、retired，以及正在创建中的容量预留（默认：100） */
   maxTotalAgents: number;
   /** Agent TTL in milliseconds (default: 300000 = 5 minutes) */
   agentTtlMs: number;
@@ -522,6 +522,7 @@ export class AgentPoolImpl implements AgentPool {
 
     this.cache.clear();
     this.retiredAgents.clear();
+    this.pendingCreations.clear();
 
     logger.info("AgentPool: Shutdown complete");
   }

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -297,9 +297,10 @@ export class AgentPoolImpl implements AgentPool {
       return { ...result, isNew: false };
     }
 
+    this.ensureCapacityForNewAgent(cacheKey);
+
     // Cache miss - create new agent with race condition protection
     this.stats.cacheMisses++;
-    this.ensureCapacityForNewAgent(cacheKey);
 
     // Create the agent creation promise and store it
     const creationPromise = this.createAgentWithCache(params, cacheKey);

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -48,6 +48,15 @@ interface CachedAgent {
   activeRequests: number;
 }
 
+type AgentRetirementReason = "unhealthy" | "expired" | "lru" | "endpoint";
+
+interface RetiredAgent extends CachedAgent {
+  cacheKey: string;
+  retiredAt: number;
+  retiredBy: AgentRetirementReason;
+  retireReason: string;
+}
+
 /**
  * Agent Pool Statistics
  */
@@ -107,7 +116,7 @@ export interface AgentPool {
   /**
    * Mark an Agent as unhealthy (will be replaced on next getAgent call)
    */
-  markUnhealthy(cacheKey: string, reason: string): void;
+  markUnhealthy(cacheKey: string, reason: string, dispatcherId?: string): void;
 
   /**
    * Evict all Agents for a specific endpoint
@@ -175,12 +184,15 @@ const DEFAULT_CONFIG: AgentPoolConfig = {
   cleanupIntervalMs: 30000, // 30 seconds
 };
 
+const MAX_AGENT_LIFETIME_MS = 30 * 60 * 1000;
+const MAX_RETIRED_AGENT_LIFETIME_MS = 6 * 60 * 60 * 1000;
+
 /**
  * Agent Pool Implementation
  */
 export class AgentPoolImpl implements AgentPool {
   private cache: Map<string, CachedAgent> = new Map();
-  private unhealthyKeys: Set<string> = new Set();
+  private retiredAgents: Map<string, RetiredAgent> = new Map();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
   private config: AgentPoolConfig;
   private stats = {
@@ -223,20 +235,23 @@ export class AgentPoolImpl implements AgentPool {
     const cacheKey = generateAgentCacheKey(params);
     this.stats.totalRequests++;
 
-    // Check if marked as unhealthy
-    if (this.unhealthyKeys.has(cacheKey)) {
-      this.unhealthyKeys.delete(cacheKey);
-      await this.evictByKey(cacheKey);
-    }
-
     // Try to get from cache
     const cached = this.cache.get(cacheKey);
-    if (cached && !this.isExpired(cached)) {
+    const expirationReason = cached ? this.getExpirationReason(cached) : null;
+    if (cached?.healthy && !expirationReason) {
       cached.lastUsedAt = Date.now();
       cached.requestCount++;
       cached.activeRequests++;
       this.stats.cacheHits++;
       return { agent: cached.agent, isNew: false, cacheKey, dispatcherId: cached.id };
+    }
+
+    if (cached) {
+      this.evictByKey(
+        cacheKey,
+        cached.healthy ? (expirationReason ?? "expired") : "unhealthy",
+        cached.healthy ? (expirationReason ?? "expired") : "unhealthy"
+      );
     }
 
     // Check if there's a pending creation for this key (race condition prevention)
@@ -252,6 +267,12 @@ export class AgentPoolImpl implements AgentPool {
       if (currentCached && currentCached.id === result.dispatcherId) {
         currentCached.activeRequests++;
         currentCached.lastUsedAt = Date.now();
+      } else {
+        const retired = this.retiredAgents.get(result.dispatcherId);
+        if (retired && retired.cacheKey === cacheKey) {
+          retired.activeRequests++;
+          retired.lastUsedAt = Date.now();
+        }
       }
       // Count as cache hit - we're reusing the pending result, not creating a new agent
       // Note: Don't decrement cacheMisses here since we never incremented it for this request
@@ -263,7 +284,7 @@ export class AgentPoolImpl implements AgentPool {
     this.stats.cacheMisses++;
 
     // Create the agent creation promise and store it
-    const creationPromise = this.createAgentWithCache(params, cacheKey, cached);
+    const creationPromise = this.createAgentWithCache(params, cacheKey);
     this.pendingCreations.set(cacheKey, creationPromise);
 
     try {
@@ -280,14 +301,8 @@ export class AgentPoolImpl implements AgentPool {
    */
   private async createAgentWithCache(
     params: GetAgentParams,
-    cacheKey: string,
-    existingCached: CachedAgent | undefined
+    cacheKey: string
   ): Promise<GetAgentResult> {
-    // Evict old entry if exists
-    if (existingCached) {
-      await this.evictByKey(cacheKey);
-    }
-
     // Create new agent
     const agent = await this.createAgent(params);
     const url = new URL(params.endpointUrl);
@@ -320,13 +335,53 @@ export class AgentPoolImpl implements AgentPool {
     if (cached && cached.id === dispatcherId && cached.activeRequests > 0) {
       cached.activeRequests--;
       cached.lastUsedAt = Date.now(); // refresh TTL from stream completion
+      return;
+    }
+
+    const retired = this.retiredAgents.get(dispatcherId);
+    if (retired && retired.cacheKey === cacheKey && retired.activeRequests > 0) {
+      retired.activeRequests--;
+      retired.lastUsedAt = Date.now();
+
+      if (retired.activeRequests === 0) {
+        this.retiredAgents.delete(dispatcherId);
+        void this.closeAgent(retired.agent, cacheKey);
+      }
     }
   }
 
-  markUnhealthy(cacheKey: string, reason: string): void {
-    this.unhealthyKeys.add(cacheKey);
-    logger.warn("AgentPool: Agent marked as unhealthy", {
+  markUnhealthy(cacheKey: string, reason: string, dispatcherId?: string): void {
+    const cached = this.cache.get(cacheKey);
+    if (cached && (!dispatcherId || cached.id === dispatcherId)) {
+      cached.healthy = false;
+      this.evictByKey(cacheKey, "unhealthy", reason);
+      logger.warn("AgentPool: Agent marked as unhealthy", {
+        cacheKey,
+        dispatcherId: cached.id,
+        reason,
+      });
+      return;
+    }
+
+    if (dispatcherId) {
+      const retired = this.retiredAgents.get(dispatcherId);
+      if (retired && retired.cacheKey === cacheKey) {
+        retired.healthy = false;
+        retired.retiredBy = "unhealthy";
+        retired.retireReason = reason;
+        logger.warn("AgentPool: Retired agent marked as unhealthy", {
+          cacheKey,
+          dispatcherId,
+          reason,
+        });
+        return;
+      }
+    }
+
+    logger.debug("AgentPool: Ignored stale unhealthy mark", {
       cacheKey,
+      dispatcherId: dispatcherId ?? null,
+      currentDispatcherId: cached?.id ?? null,
       reason,
     });
   }
@@ -341,18 +396,23 @@ export class AgentPoolImpl implements AgentPool {
     }
 
     for (const key of keysToEvict) {
-      await this.evictByKey(key);
+      this.evictByKey(key, "endpoint", "endpoint eviction");
     }
   }
 
   getPoolStats(): AgentPoolStats {
-    const unhealthyCount = this.unhealthyKeys.size;
+    let unhealthyCount = 0;
     const hitRate =
       this.stats.totalRequests > 0 ? this.stats.cacheHits / this.stats.totalRequests : 0;
 
     let activeRequests = 0;
     for (const cached of this.cache.values()) {
       activeRequests += cached.activeRequests;
+      if (!cached.healthy) unhealthyCount++;
+    }
+    for (const retired of this.retiredAgents.values()) {
+      activeRequests += retired.activeRequests;
+      if (!retired.healthy) unhealthyCount++;
     }
 
     return {
@@ -372,14 +432,19 @@ export class AgentPoolImpl implements AgentPool {
     const keysToCleanup: string[] = [];
 
     for (const [key, cached] of this.cache.entries()) {
-      if (this.isExpired(cached, now)) {
+      if (this.getExpirationReason(cached, now)) {
         keysToCleanup.push(key);
       }
     }
 
+    let cleaned = 0;
     for (const key of keysToCleanup) {
-      await this.evictByKey(key);
+      if (this.evictByKey(key, "expired", "ttl cleanup")) {
+        cleaned++;
+      }
     }
+
+    cleaned += this.cleanupRetiredAgents(now);
 
     if (keysToCleanup.length > 0) {
       logger.debug("AgentPool: Cleaned up expired agents", {
@@ -387,7 +452,7 @@ export class AgentPoolImpl implements AgentPool {
       });
     }
 
-    return keysToCleanup.length;
+    return cleaned;
   }
 
   async shutdown(): Promise<void> {
@@ -397,9 +462,14 @@ export class AgentPoolImpl implements AgentPool {
     }
 
     // closeAgent 本身是 fire-and-forget（不 await destroy/close），这里并行触发即可。
-    await Promise.allSettled(
-      Array.from(this.cache.entries()).map(([key, cached]) => this.closeAgent(cached.agent, key))
-    );
+    await Promise.allSettled([
+      ...Array.from(this.cache.entries()).map(([key, cached]) =>
+        this.closeAgent(cached.agent, key)
+      ),
+      ...Array.from(this.retiredAgents.values()).map((retired) =>
+        this.closeAgent(retired.agent, retired.cacheKey)
+      ),
+    ]);
 
     // Best-effort：等待部分 pending cleanup 完成，但永不无限等待（避免重蹈 “close() 等待 in-flight” 的覆辙）
     if (this.pendingCleanups.size > 0) {
@@ -422,30 +492,87 @@ export class AgentPoolImpl implements AgentPool {
     }
 
     this.cache.clear();
-    this.unhealthyKeys.clear();
+    this.retiredAgents.clear();
 
     logger.info("AgentPool: Shutdown complete");
   }
 
-  private isExpired(cached: CachedAgent, now: number = Date.now()): boolean {
-    // Hard upper bound: force-expire after 30 minutes regardless of active requests
-    // Prevents permanent pinning if releaseAgent is never called (caller bug)
-    const MAX_AGENT_LIFETIME_MS = 30 * 60 * 1000;
-    if (now - cached.createdAt > MAX_AGENT_LIFETIME_MS) return true;
+  private getExpirationReason(cached: CachedAgent, now: number = Date.now()): "expired" | null {
+    // 30 分钟后不再把这个 dispatcher 分配给新请求。
+    // 正在传输的流只会被退役，不会被立刻 destroy，等自身 release 后再关闭。
+    if (now - cached.createdAt > MAX_AGENT_LIFETIME_MS) return "expired";
 
-    // Never expire agents with in-flight requests
-    if (cached.activeRequests > 0) return false;
+    // 普通 TTL 不清理仍有在途请求的 dispatcher。
+    if (cached.activeRequests > 0) return null;
 
-    return now - cached.lastUsedAt > this.config.agentTtlMs;
+    return now - cached.lastUsedAt > this.config.agentTtlMs ? "expired" : null;
   }
 
-  private async evictByKey(key: string): Promise<void> {
+  private evictByKey(key: string, retiredBy: AgentRetirementReason, retireReason: string): boolean {
     const cached = this.cache.get(key);
-    if (cached) {
-      await this.closeAgent(cached.agent, key);
-      this.cache.delete(key);
-      this.stats.evictedAgents++;
+    if (!cached) {
+      return false;
     }
+
+    this.cache.delete(key);
+    this.stats.evictedAgents++;
+    this.disposeCachedAgent(key, cached, retiredBy, retireReason);
+    return true;
+  }
+
+  private disposeCachedAgent(
+    key: string,
+    cached: CachedAgent,
+    retiredBy: AgentRetirementReason,
+    retireReason: string
+  ): void {
+    if (cached.activeRequests > 0) {
+      const retired: RetiredAgent = {
+        ...cached,
+        cacheKey: key,
+        healthy: retiredBy === "unhealthy" ? false : cached.healthy,
+        retiredAt: Date.now(),
+        retiredBy,
+        retireReason,
+      };
+      this.retiredAgents.set(cached.id, retired);
+      logger.debug("AgentPool: Retired active agent", {
+        cacheKey: key,
+        dispatcherId: cached.id,
+        activeRequests: cached.activeRequests,
+        retiredBy,
+      });
+      return;
+    }
+
+    void this.closeAgent(cached.agent, key);
+  }
+
+  private cleanupRetiredAgents(now: number): number {
+    let cleaned = 0;
+    for (const [dispatcherId, retired] of this.retiredAgents.entries()) {
+      const activeTooLong =
+        retired.activeRequests > 0 && now - retired.retiredAt > MAX_RETIRED_AGENT_LIFETIME_MS;
+      if (retired.activeRequests > 0 && !activeTooLong) {
+        continue;
+      }
+
+      if (activeTooLong) {
+        logger.warn("AgentPool: Force closing long-retired active agent", {
+          cacheKey: retired.cacheKey,
+          dispatcherId,
+          activeRequests: retired.activeRequests,
+          retiredBy: retired.retiredBy,
+          retiredForMs: now - retired.retiredAt,
+        });
+      }
+
+      this.retiredAgents.delete(dispatcherId);
+      void this.closeAgent(retired.agent, retired.cacheKey);
+      cleaned++;
+    }
+
+    return cleaned;
   }
 
   private async closeAgent(agent: Dispatcher, key: string): Promise<void> {
@@ -506,15 +633,17 @@ export class AgentPoolImpl implements AgentPool {
       return;
     }
 
-    // Sort by lastUsedAt (oldest first) for LRU eviction
-    const entries = Array.from(this.cache.entries()).sort(
-      ([, a], [, b]) => a.lastUsedAt - b.lastUsedAt
-    );
+    // LRU 优先清理空闲 dispatcher；只有容量压力下全是活跃请求时才退役活跃 dispatcher。
+    const entries = Array.from(this.cache.entries()).sort(([, a], [, b]) => {
+      const activeDelta = Number(a.activeRequests > 0) - Number(b.activeRequests > 0);
+      if (activeDelta !== 0) return activeDelta;
+      return a.lastUsedAt - b.lastUsedAt;
+    });
 
     const toEvict = entries.slice(0, this.cache.size - this.config.maxTotalAgents);
 
     for (const [key] of toEvict) {
-      await this.evictByKey(key);
+      this.evictByKey(key, "lru", "max size exceeded");
     }
   }
 

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -136,6 +136,11 @@ export interface AgentPool {
    * 返回值，避免旧请求迟到错误误伤同 cacheKey 的新 dispatcher。
    */
   markUnhealthy(cacheKey: string, reason: string, dispatcherId: string): void;
+  /**
+   * @deprecated 保留旧签名仅用于源码兼容。缺少 dispatcherId 时会记录 warn 并安全忽略，
+   * 不再回退到 cacheKey 级别驱逐，避免旧请求误伤新 dispatcher 代际。
+   */
+  markUnhealthy(cacheKey: string, reason: string): void;
 
   /**
    * Evict all Agents for a specific endpoint
@@ -415,7 +420,17 @@ export class AgentPoolImpl implements AgentPool {
     }
   }
 
-  markUnhealthy(cacheKey: string, reason: string, dispatcherId: string): void {
+  markUnhealthy(cacheKey: string, reason: string, dispatcherId: string): void;
+  markUnhealthy(cacheKey: string, reason: string): void;
+  markUnhealthy(cacheKey: string, reason: string, dispatcherId?: string): void {
+    if (!dispatcherId) {
+      logger.warn("AgentPool: Ignored cacheKey-only unhealthy mark", {
+        cacheKey,
+        reason,
+      });
+      return;
+    }
+
     const cached = this.cache.get(cacheKey);
     if (cached && cached.id === dispatcherId) {
       cached.healthy = false;

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -114,9 +114,13 @@ export interface AgentPool {
   releaseAgent(cacheKey: string, dispatcherId: string): void;
 
   /**
-   * Mark an Agent as unhealthy (will be replaced on next getAgent call)
+   * Mark one dispatcher generation as unhealthy.
+   *
+   * 空闲 dispatcher 会立即关闭；仍有在途请求的 dispatcher 会被退役，
+   * 等对应请求全部 release 后再关闭。dispatcherId 必须来自 getAgent()
+   * 返回值，避免旧请求迟到错误误伤同 cacheKey 的新 dispatcher。
    */
-  markUnhealthy(cacheKey: string, reason: string, dispatcherId?: string): void;
+  markUnhealthy(cacheKey: string, reason: string, dispatcherId: string): void;
 
   /**
    * Evict all Agents for a specific endpoint
@@ -194,6 +198,7 @@ export class AgentPoolImpl implements AgentPool {
   private cache: Map<string, CachedAgent> = new Map();
   private retiredAgents: Map<string, RetiredAgent> = new Map();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+  private isShuttingDown = false;
   private config: AgentPoolConfig;
   private stats = {
     totalRequests: 0,
@@ -232,14 +237,19 @@ export class AgentPoolImpl implements AgentPool {
   }
 
   async getAgent(params: GetAgentParams): Promise<GetAgentResult> {
+    if (this.isShuttingDown) {
+      throw new Error("AgentPool is shutting down");
+    }
+
     const cacheKey = generateAgentCacheKey(params);
     this.stats.totalRequests++;
 
     // Try to get from cache
+    const now = Date.now();
     const cached = this.cache.get(cacheKey);
-    const expirationReason = cached ? this.getExpirationReason(cached) : null;
+    const expirationReason = cached ? this.getExpirationReason(cached, now) : null;
     if (cached?.healthy && !expirationReason) {
-      cached.lastUsedAt = Date.now();
+      cached.lastUsedAt = now;
       cached.requestCount++;
       cached.activeRequests++;
       this.stats.cacheHits++;
@@ -247,11 +257,14 @@ export class AgentPoolImpl implements AgentPool {
     }
 
     if (cached) {
-      this.evictByKey(
-        cacheKey,
-        cached.healthy ? (expirationReason ?? "expired") : "unhealthy",
-        cached.healthy ? (expirationReason ?? "expired") : "unhealthy"
-      );
+      const retiredBy: AgentRetirementReason = cached.healthy ? "expired" : "unhealthy";
+      const retireReason =
+        retiredBy === "expired" && now - cached.createdAt > MAX_AGENT_LIFETIME_MS
+          ? "hard lifetime exceeded before reuse"
+          : retiredBy === "expired"
+            ? "ttl expired before reuse"
+            : "unhealthy before reuse";
+      this.evictByKey(cacheKey, retiredBy, retireReason);
     }
 
     // Check if there's a pending creation for this key (race condition prevention)
@@ -305,6 +318,11 @@ export class AgentPoolImpl implements AgentPool {
   ): Promise<GetAgentResult> {
     // Create new agent
     const agent = await this.createAgent(params);
+    if (this.isShuttingDown) {
+      void this.closeAgent(agent, cacheKey);
+      throw new Error("AgentPool is shutting down");
+    }
+
     const url = new URL(params.endpointUrl);
     const dispatcherId = `disp-${++this.dispatcherIdCounter}`;
 
@@ -350,9 +368,9 @@ export class AgentPoolImpl implements AgentPool {
     }
   }
 
-  markUnhealthy(cacheKey: string, reason: string, dispatcherId?: string): void {
+  markUnhealthy(cacheKey: string, reason: string, dispatcherId: string): void {
     const cached = this.cache.get(cacheKey);
-    if (cached && (!dispatcherId || cached.id === dispatcherId)) {
+    if (cached && cached.id === dispatcherId) {
       cached.healthy = false;
       this.evictByKey(cacheKey, "unhealthy", reason);
       logger.warn("AgentPool: Agent marked as unhealthy", {
@@ -363,24 +381,22 @@ export class AgentPoolImpl implements AgentPool {
       return;
     }
 
-    if (dispatcherId) {
-      const retired = this.retiredAgents.get(dispatcherId);
-      if (retired && retired.cacheKey === cacheKey) {
-        retired.healthy = false;
-        retired.retiredBy = "unhealthy";
-        retired.retireReason = reason;
-        logger.warn("AgentPool: Retired agent marked as unhealthy", {
-          cacheKey,
-          dispatcherId,
-          reason,
-        });
-        return;
-      }
+    const retired = this.retiredAgents.get(dispatcherId);
+    if (retired && retired.cacheKey === cacheKey) {
+      retired.healthy = false;
+      retired.retiredBy = "unhealthy";
+      retired.retireReason = reason;
+      logger.warn("AgentPool: Retired agent marked as unhealthy", {
+        cacheKey,
+        dispatcherId,
+        reason,
+      });
+      return;
     }
 
     logger.debug("AgentPool: Ignored stale unhealthy mark", {
       cacheKey,
-      dispatcherId: dispatcherId ?? null,
+      dispatcherId,
       currentDispatcherId: cached?.id ?? null,
       reason,
     });
@@ -437,18 +453,21 @@ export class AgentPoolImpl implements AgentPool {
       }
     }
 
-    let cleaned = 0;
+    let cleanedFromCache = 0;
     for (const key of keysToCleanup) {
       if (this.evictByKey(key, "expired", "ttl cleanup")) {
-        cleaned++;
+        cleanedFromCache++;
       }
     }
 
-    cleaned += this.cleanupRetiredAgents(now);
+    const cleanedFromRetired = this.cleanupRetiredAgents(now);
+    const cleaned = cleanedFromCache + cleanedFromRetired;
 
-    if (keysToCleanup.length > 0) {
+    if (cleaned > 0) {
       logger.debug("AgentPool: Cleaned up expired agents", {
-        count: keysToCleanup.length,
+        fromCache: cleanedFromCache,
+        fromRetired: cleanedFromRetired,
+        total: cleaned,
       });
     }
 
@@ -456,6 +475,8 @@ export class AgentPoolImpl implements AgentPool {
   }
 
   async shutdown(): Promise<void> {
+    this.isShuttingDown = true;
+
     if (this.cleanupTimer) {
       clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -212,6 +212,7 @@ const MAX_RETIRED_AGENT_LIFETIME_MS = 6 * 60 * 60 * 1000;
 export class AgentPoolImpl implements AgentPool {
   private cache: Map<string, CachedAgent> = new Map();
   private retiredAgents: Map<string, RetiredAgent> = new Map();
+  private activeRetiredCountsByCacheKey: Map<string, number> = new Map();
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
   private isShuttingDown = false;
   private config: AgentPoolConfig;
@@ -314,6 +315,8 @@ export class AgentPoolImpl implements AgentPool {
       }
     }
 
+    // 容量拒绝不计入 totalRequests/cacheMisses：调用方没有拿到 dispatcher，
+    // 这里保持“成功分配/复用”的命中率口径，避免背压噪声污染连接复用指标。
     this.ensureCapacityForNewAgent(cacheKey);
 
     // Cache miss - create new agent with race condition protection
@@ -406,6 +409,7 @@ export class AgentPoolImpl implements AgentPool {
 
       if (retired.activeRequests === 0) {
         this.retiredAgents.delete(dispatcherId);
+        this.decrementActiveRetiredCount(retired.cacheKey);
         void this.closeAgent(retired.agent, cacheKey);
       }
     }
@@ -568,6 +572,7 @@ export class AgentPoolImpl implements AgentPool {
 
     this.cache.clear();
     this.retiredAgents.clear();
+    this.activeRetiredCountsByCacheKey.clear();
     this.pendingCreations.clear();
     this.endpointEvictionEpochs.clear();
 
@@ -592,6 +597,8 @@ export class AgentPoolImpl implements AgentPool {
     }
 
     this.cache.delete(key);
+    // 统计口径是“从可复用 cache 驱逐的 dispatcher 代数”；
+    // active dispatcher 可能先进入 retired，稍后才真正关闭。
     this.stats.evictedAgents++;
     this.disposeCachedAgent(key, cached, retiredBy, retireReason);
     return true;
@@ -613,6 +620,7 @@ export class AgentPoolImpl implements AgentPool {
         retireReason,
       };
       this.retiredAgents.set(cached.id, retired);
+      this.incrementActiveRetiredCount(key);
       logger.debug("AgentPool: Retired active agent", {
         cacheKey: key,
         dispatcherId: cached.id,
@@ -645,6 +653,7 @@ export class AgentPoolImpl implements AgentPool {
       }
 
       this.retiredAgents.delete(dispatcherId);
+      this.decrementActiveRetiredCount(retired.cacheKey);
       void this.closeAgent(retired.agent, retired.cacheKey);
       cleaned++;
     }
@@ -712,12 +721,27 @@ export class AgentPoolImpl implements AgentPool {
   private getReplacementCapacityCredit(cacheKey: string): number {
     // 同 cacheKey 的退役活跃旧代原本占用的是这个逻辑槽位。允许最多 1 个替换 credit，
     // 让硬过期/unhealthy 后能重建当前可复用代；更多旧代仍计入容量，避免无限堆积。
-    for (const retired of this.retiredAgents.values()) {
-      if (retired.cacheKey === cacheKey && retired.activeRequests > 0) {
-        return 1;
-      }
+    return this.activeRetiredCountsByCacheKey.has(cacheKey) ? 1 : 0;
+  }
+
+  private incrementActiveRetiredCount(cacheKey: string): void {
+    this.activeRetiredCountsByCacheKey.set(
+      cacheKey,
+      (this.activeRetiredCountsByCacheKey.get(cacheKey) ?? 0) + 1
+    );
+  }
+
+  private decrementActiveRetiredCount(cacheKey: string): void {
+    const count = this.activeRetiredCountsByCacheKey.get(cacheKey);
+    if (!count) {
+      return;
     }
-    return 0;
+
+    if (count === 1) {
+      this.activeRetiredCountsByCacheKey.delete(cacheKey);
+    } else {
+      this.activeRetiredCountsByCacheKey.set(cacheKey, count - 1);
+    }
   }
 
   private getReservedDispatcherCount(replacementCacheKey?: string): number {

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -251,7 +251,6 @@ export class AgentPoolImpl implements AgentPool {
     }
 
     const cacheKey = generateAgentCacheKey(params);
-    this.stats.totalRequests++;
 
     // Try to get from cache
     const now = Date.now();
@@ -261,6 +260,7 @@ export class AgentPoolImpl implements AgentPool {
       cached.lastUsedAt = now;
       cached.requestCount++;
       cached.activeRequests++;
+      this.stats.totalRequests++;
       this.stats.cacheHits++;
       return { agent: cached.agent, isNew: false, cacheKey, dispatcherId: cached.id };
     }
@@ -296,6 +296,7 @@ export class AgentPoolImpl implements AgentPool {
       }
       // Count as cache hit - we're reusing the pending result, not creating a new agent
       // Note: Don't decrement cacheMisses here since we never incremented it for this request
+      this.stats.totalRequests++;
       this.stats.cacheHits++;
       return { ...result, isNew: false };
     }
@@ -303,6 +304,7 @@ export class AgentPoolImpl implements AgentPool {
     this.ensureCapacityForNewAgent(cacheKey);
 
     // Cache miss - create new agent with race condition protection
+    this.stats.totalRequests++;
     this.stats.cacheMisses++;
 
     // Create the agent creation promise and store it

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -324,10 +324,6 @@ export class AgentPoolImpl implements AgentPool {
     // 这里保持“成功分配/复用”的命中率口径，避免背压噪声污染连接复用指标。
     this.ensureCapacityForNewAgent(cacheKey);
 
-    // Cache miss - create new agent with race condition protection
-    this.stats.totalRequests++;
-    this.stats.cacheMisses++;
-
     // Create the agent creation promise and store it
     const endpointKey = new URL(params.endpointUrl).origin;
     const startedAtEvictionSequence = this.endpointEvictionSequence;
@@ -344,7 +340,10 @@ export class AgentPoolImpl implements AgentPool {
     });
 
     try {
-      return await creationPromise;
+      const result = await creationPromise;
+      this.stats.totalRequests++;
+      this.stats.cacheMisses++;
+      return result;
     } finally {
       // Clean up pending creation
       if (this.pendingCreations.get(cacheKey)?.promise === creationPromise) {
@@ -477,6 +476,12 @@ export class AgentPoolImpl implements AgentPool {
     for (const key of keysToEvict) {
       this.evictByKey(key, "endpoint", "endpoint eviction");
     }
+
+    for (const [key, pending] of this.pendingCreations.entries()) {
+      if (pending.endpointKey === endpointKey) {
+        this.pendingCreations.delete(key);
+      }
+    }
   }
 
   private isPendingCreationCurrent(pending: PendingAgentCreation): boolean {
@@ -505,7 +510,7 @@ export class AgentPoolImpl implements AgentPool {
       cacheSize: this.cache.size,
       retiredAgents: this.retiredAgents.size,
       liveAgents: this.getLiveDispatcherCount(),
-      pendingCreations: this.pendingCreations.size,
+      pendingCreations: this.getPendingCreationReservationCount(),
       totalRequests: this.stats.totalRequests,
       cacheHits: this.stats.cacheHits,
       cacheMisses: this.stats.cacheMisses,
@@ -761,7 +766,10 @@ export class AgentPoolImpl implements AgentPool {
 
   private getReservedDispatcherCount(replacementCacheKey?: string): number {
     let reserved = this.getLiveDispatcherCount();
-    for (const cacheKey of this.pendingCreations.keys()) {
+    for (const [cacheKey, pending] of this.pendingCreations.entries()) {
+      if (!this.isPendingCreationCurrent(pending)) {
+        continue;
+      }
       // 创建完成到 finally 删除 pending 之间，cache 里已经有同 key dispatcher，
       // 此时不要把 pending 和 cache 重复计数。
       if (!this.cache.has(cacheKey)) {
@@ -772,6 +780,16 @@ export class AgentPoolImpl implements AgentPool {
       reserved -= this.getReplacementCapacityCredit(replacementCacheKey);
     }
     return Math.max(0, reserved);
+  }
+
+  private getPendingCreationReservationCount(): number {
+    let reservedPendingCreations = 0;
+    for (const [cacheKey, pending] of this.pendingCreations.entries()) {
+      if (this.isPendingCreationCurrent(pending) && !this.cache.has(cacheKey)) {
+        reservedPendingCreations++;
+      }
+    }
+    return reservedPendingCreations;
   }
 
   private ensureCapacityForNewAgent(cacheKey: string): void {

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -730,11 +730,18 @@ export class AgentPoolImpl implements AgentPool {
   }
 
   private evictIdleCachedAgents(isWithinLimit: (reserved: number) => boolean): void {
+    const now = Date.now();
+
     // LRU 只回收空闲 dispatcher。活跃 dispatcher 已经代表真实在途请求；
     // 继续把它们转入 retired 不能释放 live 容量，只会突破 maxTotalAgents 的连接预算。
     const idleEntries = Array.from(this.cache.entries())
       .filter(([, cached]) => cached.activeRequests === 0)
-      .sort(([, a], [, b]) => a.lastUsedAt - b.lastUsedAt);
+      .sort(([, a], [, b]) => {
+        const aExpired = this.getExpirationReason(a, now) ? 0 : 1;
+        const bExpired = this.getExpirationReason(b, now) ? 0 : 1;
+        if (aExpired !== bExpired) return aExpired - bExpired;
+        return a.lastUsedAt - b.lastUsedAt;
+      });
 
     for (const [key] of idleEntries) {
       if (isWithinLimit(this.getReservedDispatcherCount())) {

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -351,7 +351,7 @@ export class AgentPoolImpl implements AgentPool {
     this.cache.set(cacheKey, newCached);
 
     // Enforce max size (LRU eviction)
-    this.enforceMaxSize();
+    this.enforceMaxSize(cacheKey);
 
     return { agent, isNew: true, cacheKey, dispatcherId };
   }
@@ -729,32 +729,41 @@ export class AgentPoolImpl implements AgentPool {
       return;
     }
 
-    this.evictIdleCachedAgentsUntilBelowLimit();
+    this.evictIdleCachedAgentsUntilBelowLimit(cacheKey);
   }
 
-  private enforceMaxSize(): void {
-    if (this.getReservedDispatcherCount() <= this.config.maxTotalAgents) {
+  private enforceMaxSize(replacementCacheKey?: string): void {
+    if (this.getReservedDispatcherCount(replacementCacheKey) <= this.config.maxTotalAgents) {
       return;
     }
 
     this.cleanupRetiredAgents(Date.now());
 
-    if (this.getReservedDispatcherCount() <= this.config.maxTotalAgents) {
+    if (this.getReservedDispatcherCount(replacementCacheKey) <= this.config.maxTotalAgents) {
       return;
     }
 
-    this.evictIdleCachedAgentsUntilAtLimit();
+    this.evictIdleCachedAgentsUntilAtLimit(replacementCacheKey);
   }
 
-  private evictIdleCachedAgentsUntilBelowLimit(): void {
-    this.evictIdleCachedAgents((reserved) => reserved < this.config.maxTotalAgents);
+  private evictIdleCachedAgentsUntilBelowLimit(replacementCacheKey?: string): void {
+    this.evictIdleCachedAgents(
+      (reserved) => reserved < this.config.maxTotalAgents,
+      replacementCacheKey
+    );
   }
 
-  private evictIdleCachedAgentsUntilAtLimit(): void {
-    this.evictIdleCachedAgents((reserved) => reserved <= this.config.maxTotalAgents);
+  private evictIdleCachedAgentsUntilAtLimit(replacementCacheKey?: string): void {
+    this.evictIdleCachedAgents(
+      (reserved) => reserved <= this.config.maxTotalAgents,
+      replacementCacheKey
+    );
   }
 
-  private evictIdleCachedAgents(isWithinLimit: (reserved: number) => boolean): void {
+  private evictIdleCachedAgents(
+    isWithinLimit: (reserved: number) => boolean,
+    replacementCacheKey?: string
+  ): void {
     const now = Date.now();
 
     // LRU 只回收空闲 dispatcher。活跃 dispatcher 已经代表真实在途请求；
@@ -769,7 +778,7 @@ export class AgentPoolImpl implements AgentPool {
       });
 
     for (const [key] of idleEntries) {
-      if (isWithinLimit(this.getReservedDispatcherCount())) {
+      if (isWithinLimit(this.getReservedDispatcherCount(replacementCacheKey))) {
         break;
       }
       this.evictByKey(key, "lru", "max live dispatcher capacity exceeded");

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -257,14 +257,12 @@ export class AgentPoolImpl implements AgentPool {
     }
 
     if (cached) {
-      const retiredBy: AgentRetirementReason = cached.healthy ? "expired" : "unhealthy";
+      // markUnhealthy 会同步驱逐当前 cache entry，因此这里的 cached entry 只会是已过期的健康实例。
       const retireReason =
-        retiredBy === "expired" && now - cached.createdAt > MAX_AGENT_LIFETIME_MS
+        now - cached.createdAt > MAX_AGENT_LIFETIME_MS
           ? "hard lifetime exceeded before reuse"
-          : retiredBy === "expired"
-            ? "ttl expired before reuse"
-            : "unhealthy before reuse";
-      this.evictByKey(cacheKey, retiredBy, retireReason);
+          : "ttl expired before reuse";
+      this.evictByKey(cacheKey, "expired", retireReason);
     }
 
     // Check if there's a pending creation for this key (race condition prevention)

--- a/src/lib/proxy-agent/agent-pool.ts
+++ b/src/lib/proxy-agent/agent-pool.ts
@@ -16,7 +16,7 @@ import { logger } from "@/lib/logger";
  * Agent Pool Configuration
  */
 export interface AgentPoolConfig {
-  /** Maximum total number of cached agents (default: 100) */
+  /** Maximum total number of live dispatcher generations, including retired active agents (default: 100) */
   maxTotalAgents: number;
   /** Agent TTL in milliseconds (default: 300000 = 5 minutes) */
   agentTtlMs: number;
@@ -62,13 +62,19 @@ interface RetiredAgent extends CachedAgent {
  */
 export interface AgentPoolStats {
   cacheSize: number;
+  /** Retired dispatcher generations still waiting for in-flight requests to finish */
+  retiredAgents: number;
+  /** Total live dispatcher generations: cached + retired */
+  liveAgents: number;
+  /** Pending dispatcher creations that have reserved capacity */
+  pendingCreations: number;
   totalRequests: number;
   cacheHits: number;
   cacheMisses: number;
   hitRate: number;
   unhealthyAgents: number;
   evictedAgents: number;
-  /** Total in-flight requests across all cached agents */
+  /** Total in-flight requests across cached and retired agents */
   activeRequests: number;
 }
 
@@ -293,6 +299,7 @@ export class AgentPoolImpl implements AgentPool {
 
     // Cache miss - create new agent with race condition protection
     this.stats.cacheMisses++;
+    this.ensureCapacityForNewAgent(cacheKey);
 
     // Create the agent creation promise and store it
     const creationPromise = this.createAgentWithCache(params, cacheKey);
@@ -338,7 +345,7 @@ export class AgentPoolImpl implements AgentPool {
     this.cache.set(cacheKey, newCached);
 
     // Enforce max size (LRU eviction)
-    await this.enforceMaxSize();
+    this.enforceMaxSize();
 
     return { agent, isNew: true, cacheKey, dispatcherId };
   }
@@ -431,6 +438,9 @@ export class AgentPoolImpl implements AgentPool {
 
     return {
       cacheSize: this.cache.size,
+      retiredAgents: this.retiredAgents.size,
+      liveAgents: this.getLiveDispatcherCount(),
+      pendingCreations: this.pendingCreations.size,
       totalRequests: this.stats.totalRequests,
       cacheHits: this.stats.cacheHits,
       cacheMisses: this.stats.cacheMisses,
@@ -647,22 +657,89 @@ export class AgentPoolImpl implements AgentPool {
     }
   }
 
-  private async enforceMaxSize(): Promise<void> {
-    if (this.cache.size <= this.config.maxTotalAgents) {
+  private getLiveDispatcherCount(): number {
+    return this.cache.size + this.retiredAgents.size;
+  }
+
+  private getReservedDispatcherCount(): number {
+    let reserved = this.getLiveDispatcherCount();
+    for (const cacheKey of this.pendingCreations.keys()) {
+      // 创建完成到 finally 删除 pending 之间，cache 里已经有同 key dispatcher，
+      // 此时不要把 pending 和 cache 重复计数。
+      if (!this.cache.has(cacheKey)) {
+        reserved++;
+      }
+    }
+    return reserved;
+  }
+
+  private ensureCapacityForNewAgent(cacheKey: string): void {
+    this.reclaimCapacityForNewAgent();
+
+    if (this.getReservedDispatcherCount() < this.config.maxTotalAgents) {
       return;
     }
 
-    // LRU 优先清理空闲 dispatcher；只有容量压力下全是活跃请求时才退役活跃 dispatcher。
-    const entries = Array.from(this.cache.entries()).sort(([, a], [, b]) => {
-      const activeDelta = Number(a.activeRequests > 0) - Number(b.activeRequests > 0);
-      if (activeDelta !== 0) return activeDelta;
-      return a.lastUsedAt - b.lastUsedAt;
+    logger.warn("AgentPool: Live dispatcher capacity exhausted", {
+      cacheKey,
+      maxTotalAgents: this.config.maxTotalAgents,
+      cacheSize: this.cache.size,
+      retiredAgents: this.retiredAgents.size,
+      pendingCreations: this.pendingCreations.size,
+      activeRequests: this.getPoolStats().activeRequests,
     });
 
-    const toEvict = entries.slice(0, this.cache.size - this.config.maxTotalAgents);
+    throw new Error(`AgentPool live dispatcher capacity exhausted: ${this.config.maxTotalAgents}`);
+  }
 
-    for (const [key] of toEvict) {
-      this.evictByKey(key, "lru", "max size exceeded");
+  private reclaimCapacityForNewAgent(): void {
+    if (this.getReservedDispatcherCount() < this.config.maxTotalAgents) {
+      return;
+    }
+
+    this.cleanupRetiredAgents(Date.now());
+
+    if (this.getReservedDispatcherCount() < this.config.maxTotalAgents) {
+      return;
+    }
+
+    this.evictIdleCachedAgentsUntilBelowLimit();
+  }
+
+  private enforceMaxSize(): void {
+    if (this.getReservedDispatcherCount() <= this.config.maxTotalAgents) {
+      return;
+    }
+
+    this.cleanupRetiredAgents(Date.now());
+
+    if (this.getReservedDispatcherCount() <= this.config.maxTotalAgents) {
+      return;
+    }
+
+    this.evictIdleCachedAgentsUntilAtLimit();
+  }
+
+  private evictIdleCachedAgentsUntilBelowLimit(): void {
+    this.evictIdleCachedAgents((reserved) => reserved < this.config.maxTotalAgents);
+  }
+
+  private evictIdleCachedAgentsUntilAtLimit(): void {
+    this.evictIdleCachedAgents((reserved) => reserved <= this.config.maxTotalAgents);
+  }
+
+  private evictIdleCachedAgents(isWithinLimit: (reserved: number) => boolean): void {
+    // LRU 只回收空闲 dispatcher。活跃 dispatcher 已经代表真实在途请求；
+    // 继续把它们转入 retired 不能释放 live 容量，只会突破 maxTotalAgents 的连接预算。
+    const idleEntries = Array.from(this.cache.entries())
+      .filter(([, cached]) => cached.activeRequests === 0)
+      .sort(([, a], [, b]) => a.lastUsedAt - b.lastUsedAt);
+
+    for (const [key] of idleEntries) {
+      if (isWithinLimit(this.getReservedDispatcherCount())) {
+        break;
+      }
+      this.evictByKey(key, "lru", "max live dispatcher capacity exceeded");
     }
   }
 

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -227,7 +227,7 @@ describe("AgentPool", () => {
       };
 
       const result1 = await pool.getAgent(params);
-      pool.markUnhealthy(result1.cacheKey, "SSL certificate error");
+      pool.markUnhealthy(result1.cacheKey, "SSL certificate error", result1.dispatcherId);
 
       const result2 = await pool.getAgent(params);
 
@@ -368,7 +368,7 @@ describe("AgentPool", () => {
       };
 
       const result = await pool.getAgent(params);
-      pool.markUnhealthy(result.cacheKey, "SSL certificate error");
+      pool.markUnhealthy(result.cacheKey, "SSL certificate error", result.dispatcherId);
 
       const stats = pool.getPoolStats();
       expect(stats.unhealthyAgents).toBe(1);
@@ -832,6 +832,40 @@ describe("AgentPool", () => {
       await pool2.shutdown();
     });
 
+    it("should force-close retired agents stuck active for more than 6 hours", async () => {
+      const pool2 = new AgentPoolImpl({
+        ...defaultConfig,
+        cleanupIntervalMs: 60 * 60 * 1000,
+      });
+
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      const r1 = await pool2.getAgent(params);
+      const agent1 = r1.agent as unknown as {
+        destroy?: () => Promise<void>;
+      };
+      const destroy1 = vi.fn().mockResolvedValue(undefined);
+      agent1.destroy = destroy1;
+
+      pool2.markUnhealthy(r1.cacheKey, "stuck retired stream", r1.dispatcherId);
+      expect(pool2.getPoolStats().cacheSize).toBe(0);
+      expect(pool2.getPoolStats().activeRequests).toBe(1);
+      expect(destroy1).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(6 * 60 * 60 * 1000 + 1);
+
+      const cleaned = await pool2.cleanup();
+      expect(cleaned).toBe(1);
+      expect(pool2.getPoolStats().activeRequests).toBe(0);
+      expect(destroy1).toHaveBeenCalledTimes(1);
+
+      await pool2.shutdown();
+    });
+
     it("should be a no-op when releasing non-existent key", () => {
       // Should not throw
       pool.releaseAgent("nonexistent-key", "disp-1");
@@ -984,6 +1018,39 @@ describe("AgentPool", () => {
       if (typeof agent.close === "function") {
         expect(agent.close).not.toHaveBeenCalled();
       }
+    });
+
+    it("should close a dispatcher created after shutdown starts instead of caching it", async () => {
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+      const lateAgent = {
+        close: vi.fn().mockResolvedValue(undefined),
+        destroy: vi.fn().mockResolvedValue(undefined),
+      };
+      let resolveCreate!: (agent: unknown) => void;
+      const createPromise = new Promise<unknown>((resolve) => {
+        resolveCreate = resolve;
+      });
+      const privatePool = pool as unknown as {
+        createAgent: () => Promise<unknown>;
+      };
+      privatePool.createAgent = vi.fn().mockReturnValue(createPromise);
+
+      const getPromise = pool.getAgent(params);
+      await Promise.resolve();
+      expect(privatePool.createAgent).toHaveBeenCalled();
+
+      await pool.shutdown();
+      resolveCreate(lateAgent);
+
+      await expect(getPromise).rejects.toThrow("AgentPool is shutting down");
+      expect(lateAgent.destroy).toHaveBeenCalledTimes(1);
+      expect(lateAgent.close).not.toHaveBeenCalled();
+      expect(pool.getPoolStats().cacheSize).toBe(0);
+      expect(pool.getPoolStats().activeRequests).toBe(0);
     });
   });
 });

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -612,6 +612,7 @@ describe("AgentPool", () => {
           })
         ).rejects.toThrow("AgentPool live dispatcher capacity exhausted");
 
+        expect(smallPool.getPoolStats().cacheMisses).toBe(2);
         expect(warnSpy).toHaveBeenCalledWith(
           "AgentPool: Live dispatcher capacity exhausted",
           expect.objectContaining({

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -332,6 +332,77 @@ describe("AgentPool", () => {
       expect(pool.getPoolStats().activeRequests).toBe(0);
     });
 
+    it("满载时同 cacheKey unhealthy 退役后仍应允许替换 dispatcher", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      const smallPool = new AgentPoolImpl({
+        ...defaultConfig,
+        maxTotalAgents: 2,
+        cleanupIntervalMs: 60 * 60 * 1000,
+      });
+
+      try {
+        const unhealthy = await smallPool.getAgent({
+          endpointUrl: "https://replace-unhealthy.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+        const unhealthyAgent = unhealthy.agent as unknown as {
+          destroy?: () => Promise<void>;
+        };
+        const unhealthyDestroy = vi.fn().mockResolvedValue(undefined);
+        unhealthyAgent.destroy = unhealthyDestroy;
+
+        const occupied = await smallPool.getAgent({
+          endpointUrl: "https://occupied-unhealthy.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+
+        smallPool.markUnhealthy(
+          unhealthy.cacheKey,
+          "SSL certificate error",
+          unhealthy.dispatcherId
+        );
+
+        const replacement = await smallPool.getAgent({
+          endpointUrl: "https://replace-unhealthy.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+
+        expect(replacement.isNew).toBe(true);
+        expect(replacement.dispatcherId).not.toBe(unhealthy.dispatcherId);
+        expect(unhealthyDestroy).not.toHaveBeenCalled();
+        expect(smallPool.getPoolStats()).toEqual(
+          expect.objectContaining({
+            activeRequests: 3,
+            cacheSize: 2,
+            liveAgents: 3,
+            retiredAgents: 1,
+          })
+        );
+
+        await expect(
+          smallPool.getAgent({
+            endpointUrl: "https://new-while-unhealthy-replacement-active.example.com/v1",
+            proxyUrl: null,
+            enableHttp2: false,
+          })
+        ).rejects.toThrow("AgentPool live dispatcher capacity exhausted");
+
+        smallPool.releaseAgent(unhealthy.cacheKey, unhealthy.dispatcherId);
+        expect(unhealthyDestroy).toHaveBeenCalledTimes(1);
+        expect(smallPool.getPoolStats().liveAgents).toBe(2);
+
+        smallPool.releaseAgent(occupied.cacheKey, occupied.dispatcherId);
+        smallPool.releaseAgent(replacement.cacheKey, replacement.dispatcherId);
+        expect(smallPool.getPoolStats().activeRequests).toBe(0);
+      } finally {
+        warnSpy.mockRestore();
+        await smallPool.shutdown();
+      }
+    });
+
     it("should ignore stale unhealthy marks for an older dispatcher generation", async () => {
       const params = {
         endpointUrl: "https://api.anthropic.com/v1/messages",
@@ -523,6 +594,7 @@ describe("AgentPool", () => {
         ...defaultConfig,
         maxTotalAgents: 2,
         agentTtlMs: 60 * 60 * 1000,
+        cleanupIntervalMs: 60 * 60 * 1000,
       });
 
       const expiring = await smallPool.getAgent({
@@ -575,6 +647,82 @@ describe("AgentPool", () => {
 
       smallPool.releaseAgent(newEntry.cacheKey, newEntry.dispatcherId);
       await smallPool.shutdown();
+    });
+
+    it("满载时同 cacheKey 硬过期退役后仍应允许替换 dispatcher", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      const smallPool = new AgentPoolImpl({
+        ...defaultConfig,
+        maxTotalAgents: 2,
+        cleanupIntervalMs: 60 * 60 * 1000,
+      });
+
+      try {
+        const expiring = await smallPool.getAgent({
+          endpointUrl: "https://replace-expired.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+        const expiringAgent = expiring.agent as unknown as {
+          destroy?: () => Promise<void>;
+        };
+        const expiringDestroy = vi.fn().mockResolvedValue(undefined);
+        expiringAgent.destroy = expiringDestroy;
+
+        const occupied = await smallPool.getAgent({
+          endpointUrl: "https://occupied.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+
+        vi.advanceTimersByTime(31 * 60 * 1000);
+
+        const replacement = await smallPool.getAgent({
+          endpointUrl: "https://replace-expired.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+
+        expect(replacement.isNew).toBe(true);
+        expect(replacement.dispatcherId).not.toBe(expiring.dispatcherId);
+        expect(expiringDestroy).not.toHaveBeenCalled();
+        expect(smallPool.getPoolStats()).toEqual(
+          expect.objectContaining({
+            activeRequests: 3,
+            cacheSize: 2,
+            liveAgents: 3,
+            retiredAgents: 1,
+          })
+        );
+
+        await expect(
+          smallPool.getAgent({
+            endpointUrl: "https://new-while-replacement-active.example.com/v1",
+            proxyUrl: null,
+            enableHttp2: false,
+          })
+        ).rejects.toThrow("AgentPool live dispatcher capacity exhausted");
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          "AgentPool: Live dispatcher capacity exhausted",
+          expect.objectContaining({
+            effectiveReservedDispatchers: 3,
+            replacementCapacityCredit: 0,
+            reservedDispatchers: 3,
+          })
+        );
+
+        smallPool.releaseAgent(expiring.cacheKey, expiring.dispatcherId);
+        expect(expiringDestroy).toHaveBeenCalledTimes(1);
+        expect(smallPool.getPoolStats().liveAgents).toBe(2);
+
+        smallPool.releaseAgent(occupied.cacheKey, occupied.dispatcherId);
+        smallPool.releaseAgent(replacement.cacheKey, replacement.dispatcherId);
+        expect(smallPool.getPoolStats().activeRequests).toBe(0);
+      } finally {
+        warnSpy.mockRestore();
+        await smallPool.shutdown();
+      }
     });
 
     it("should reject new dispatcher creation when all live capacity is active", async () => {

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -236,6 +236,39 @@ describe("AgentPool", () => {
       expect(result2.agent).not.toBe(result1.agent);
     });
 
+    it("旧两参数 markUnhealthy 应 warn 并安全忽略", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      const params = {
+        endpointUrl: "https://legacy-unhealthy.example.com/v1",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      try {
+        const result1 = await pool.getAgent(params);
+
+        pool.markUnhealthy(result1.cacheKey, "legacy caller without dispatcherId");
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          "AgentPool: Ignored cacheKey-only unhealthy mark",
+          expect.objectContaining({
+            cacheKey: result1.cacheKey,
+            reason: "legacy caller without dispatcherId",
+          })
+        );
+
+        const result2 = await pool.getAgent(params);
+        expect(result2.isNew).toBe(false);
+        expect(result2.agent).toBe(result1.agent);
+        expect(result2.dispatcherId).toBe(result1.dispatcherId);
+
+        pool.releaseAgent(result1.cacheKey, result1.dispatcherId);
+        pool.releaseAgent(result2.cacheKey, result2.dispatcherId);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it("should not hang when evicting an unhealthy agent whose close() never resolves", async () => {
       // 说明：beforeEach 使用了 fake timers，但此用例需要依赖真实 setTimeout 做“防卡死”断言
       await pool.shutdown();

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -31,11 +31,12 @@ vi.mock("fetch-socks", () => ({
 import {
   type AgentPool,
   AgentPoolImpl,
+  type AgentPoolConfig,
   generateAgentCacheKey,
   getGlobalAgentPool,
   resetGlobalAgentPool,
-  type AgentPoolConfig,
 } from "@/lib/proxy-agent/agent-pool";
+import { logger } from "@/lib/logger";
 
 describe("generateAgentCacheKey", () => {
   it("should generate correct cache key for direct connection", () => {
@@ -833,37 +834,51 @@ describe("AgentPool", () => {
     });
 
     it("should force-close retired agents stuck active for more than 6 hours", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       const pool2 = new AgentPoolImpl({
         ...defaultConfig,
         cleanupIntervalMs: 60 * 60 * 1000,
       });
 
-      const params = {
-        endpointUrl: "https://api.anthropic.com/v1/messages",
-        proxyUrl: null,
-        enableHttp2: false,
-      };
+      try {
+        const params = {
+          endpointUrl: "https://api.anthropic.com/v1/messages",
+          proxyUrl: null,
+          enableHttp2: false,
+        };
 
-      const r1 = await pool2.getAgent(params);
-      const agent1 = r1.agent as unknown as {
-        destroy?: () => Promise<void>;
-      };
-      const destroy1 = vi.fn().mockResolvedValue(undefined);
-      agent1.destroy = destroy1;
+        const r1 = await pool2.getAgent(params);
+        const agent1 = r1.agent as unknown as {
+          destroy?: () => Promise<void>;
+        };
+        const destroy1 = vi.fn().mockResolvedValue(undefined);
+        agent1.destroy = destroy1;
 
-      pool2.markUnhealthy(r1.cacheKey, "stuck retired stream", r1.dispatcherId);
-      expect(pool2.getPoolStats().cacheSize).toBe(0);
-      expect(pool2.getPoolStats().activeRequests).toBe(1);
-      expect(destroy1).not.toHaveBeenCalled();
+        pool2.markUnhealthy(r1.cacheKey, "stuck retired stream", r1.dispatcherId);
+        expect(pool2.getPoolStats().cacheSize).toBe(0);
+        expect(pool2.getPoolStats().activeRequests).toBe(1);
+        expect(destroy1).not.toHaveBeenCalled();
 
-      vi.advanceTimersByTime(6 * 60 * 60 * 1000 + 1);
+        vi.advanceTimersByTime(6 * 60 * 60 * 1000 + 1);
 
-      const cleaned = await pool2.cleanup();
-      expect(cleaned).toBe(1);
-      expect(pool2.getPoolStats().activeRequests).toBe(0);
-      expect(destroy1).toHaveBeenCalledTimes(1);
-
-      await pool2.shutdown();
+        const cleaned = await pool2.cleanup();
+        expect(cleaned).toBe(1);
+        expect(pool2.getPoolStats().activeRequests).toBe(0);
+        expect(destroy1).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          "AgentPool: Force closing long-retired active agent",
+          expect.objectContaining({
+            activeRequests: 1,
+            cacheKey: r1.cacheKey,
+            dispatcherId: r1.dispatcherId,
+            retiredBy: "unhealthy",
+            retiredForMs: 6 * 60 * 60 * 1000 + 1,
+          })
+        );
+      } finally {
+        warnSpy.mockRestore();
+        await pool2.shutdown();
+      }
     });
 
     it("should be a no-op when releasing non-existent key", () => {

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -1315,6 +1315,96 @@ describe("AgentPool", () => {
       }
     });
 
+    it("should not count failed creations as cache misses", async () => {
+      const createSpy = vi.spyOn(pool as any, "createAgent");
+      createSpy.mockRejectedValueOnce(new Error("create failed"));
+
+      try {
+        await expect(
+          pool.getAgent({
+            endpointUrl: "https://create-fails.example.com/v1",
+            proxyUrl: null,
+            enableHttp2: false,
+          })
+        ).rejects.toThrow("create failed");
+
+        expect(pool.getPoolStats()).toEqual(
+          expect.objectContaining({
+            cacheMisses: 0,
+            pendingCreations: 0,
+            totalRequests: 0,
+          })
+        );
+      } finally {
+        createSpy.mockRestore();
+      }
+    });
+
+    it("stale pending creation after endpoint eviction should not reserve capacity", async () => {
+      vi.useRealTimers();
+      const concurrentPool = new AgentPoolImpl({
+        ...defaultConfig,
+        maxTotalAgents: 1,
+      });
+
+      const lateAgent = {
+        close: vi.fn().mockResolvedValue(undefined),
+        destroy: vi.fn().mockResolvedValue(undefined),
+      };
+      const freshAgent = {
+        close: vi.fn().mockResolvedValue(undefined),
+        destroy: vi.fn().mockResolvedValue(undefined),
+      };
+      let resolveCreate!: (agent: unknown) => void;
+      const createPromise = new Promise<unknown>((resolve) => {
+        resolveCreate = resolve;
+      });
+      const createSpy = vi.spyOn(concurrentPool as any, "createAgent");
+      createSpy.mockImplementationOnce(() => createPromise);
+      let staleGetPromise: Promise<unknown> | null = null;
+
+      try {
+        staleGetPromise = concurrentPool.getAgent({
+          endpointUrl: "https://stale-pending.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+        await Promise.resolve();
+        expect(createSpy).toHaveBeenCalledTimes(1);
+
+        await concurrentPool.evictEndpoint("https://stale-pending.example.com");
+
+        createSpy.mockResolvedValueOnce(freshAgent);
+        const freshResult = await concurrentPool.getAgent({
+          endpointUrl: "https://fresh-after-eviction.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+
+        expect(freshResult.agent).toBe(freshAgent);
+        expect(concurrentPool.getPoolStats()).toEqual(
+          expect.objectContaining({
+            cacheSize: 1,
+            pendingCreations: 0,
+          })
+        );
+
+        resolveCreate(lateAgent);
+        await expect(staleGetPromise).rejects.toThrow(
+          "AgentPool endpoint was evicted during creation"
+        );
+        expect(lateAgent.destroy).toHaveBeenCalledTimes(1);
+
+        concurrentPool.releaseAgent(freshResult.cacheKey, freshResult.dispatcherId);
+      } finally {
+        resolveCreate(lateAgent);
+        await staleGetPromise?.catch(() => undefined);
+        createSpy.mockRestore();
+        await concurrentPool.shutdown();
+        vi.useFakeTimers();
+      }
+    });
+
     it("should release stale dispatcher generation without decrementing the current dispatcher", async () => {
       // 回归用例：cacheKey 相同但 dispatcher 已被重建时，旧 release 只应释放旧代 dispatcher
       const regenPool = new AgentPoolImpl({

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -760,7 +760,13 @@ describe("AgentPool", () => {
           })
         ).rejects.toThrow("AgentPool live dispatcher capacity exhausted");
 
-        expect(smallPool.getPoolStats().cacheMisses).toBe(2);
+        expect(smallPool.getPoolStats()).toEqual(
+          expect.objectContaining({
+            cacheMisses: 2,
+            hitRate: 0,
+            totalRequests: 2,
+          })
+        );
         expect(warnSpy).toHaveBeenCalledWith(
           "AgentPool: Live dispatcher capacity exhausted",
           expect.objectContaining({

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -725,6 +725,87 @@ describe("AgentPool", () => {
       }
     });
 
+    it("同 cacheKey 替换 credit 回收容量时不应额外淘汰空闲 dispatcher", async () => {
+      const smallPool = new AgentPoolImpl({
+        ...defaultConfig,
+        maxTotalAgents: 3,
+        cleanupIntervalMs: 3 * 60 * 60 * 1000,
+      });
+
+      try {
+        const original = await smallPool.getAgent({
+          endpointUrl: "https://credit-replacement.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+
+        const idleOld = await smallPool.getAgent({
+          endpointUrl: "https://idle-old.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+        const idleOldAgent = idleOld.agent as unknown as {
+          destroy?: () => Promise<void>;
+        };
+        const idleOldDestroy = vi.fn().mockResolvedValue(undefined);
+        idleOldAgent.destroy = idleOldDestroy;
+        smallPool.releaseAgent(idleOld.cacheKey, idleOld.dispatcherId);
+
+        vi.advanceTimersByTime(100);
+
+        const idleKeep = await smallPool.getAgent({
+          endpointUrl: "https://idle-keep.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+        const idleKeepAgent = idleKeep.agent as unknown as {
+          destroy?: () => Promise<void>;
+        };
+        const idleKeepDestroy = vi.fn().mockResolvedValue(undefined);
+        idleKeepAgent.destroy = idleKeepDestroy;
+        smallPool.releaseAgent(idleKeep.cacheKey, idleKeep.dispatcherId);
+
+        vi.advanceTimersByTime(31 * 60 * 1000);
+
+        const replacement1 = await smallPool.getAgent({
+          endpointUrl: "https://credit-replacement.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+
+        expect(replacement1.dispatcherId).not.toBe(original.dispatcherId);
+        expect(idleOldDestroy).not.toHaveBeenCalled();
+        expect(idleKeepDestroy).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(31 * 60 * 1000);
+
+        const replacement2 = await smallPool.getAgent({
+          endpointUrl: "https://credit-replacement.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+
+        expect(replacement2.dispatcherId).not.toBe(replacement1.dispatcherId);
+        expect(idleOldDestroy).toHaveBeenCalledTimes(1);
+        expect(idleKeepDestroy).not.toHaveBeenCalled();
+        expect(smallPool.getPoolStats()).toEqual(
+          expect.objectContaining({
+            activeRequests: 3,
+            cacheSize: 2,
+            liveAgents: 4,
+            retiredAgents: 2,
+          })
+        );
+
+        smallPool.releaseAgent(original.cacheKey, original.dispatcherId);
+        smallPool.releaseAgent(replacement1.cacheKey, replacement1.dispatcherId);
+        smallPool.releaseAgent(replacement2.cacheKey, replacement2.dispatcherId);
+        expect(smallPool.getPoolStats().activeRequests).toBe(0);
+      } finally {
+        await smallPool.shutdown();
+      }
+    });
+
     it("should reject new dispatcher creation when all live capacity is active", async () => {
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       const smallPool = new AgentPoolImpl({

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -486,20 +486,22 @@ describe("AgentPool", () => {
         maxTotalAgents: 2,
       });
 
-      // Create 3 agents (exceeds max of 2)
-      await smallPool.getAgent({
+      // Create 3 agents after releasing earlier requests so LRU can reclaim idle capacity.
+      const r1 = await smallPool.getAgent({
         endpointUrl: "https://api1.example.com/v1",
         proxyUrl: null,
         enableHttp2: false,
       });
+      smallPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
 
       vi.advanceTimersByTime(100);
 
-      await smallPool.getAgent({
+      const r2 = await smallPool.getAgent({
         endpointUrl: "https://api2.example.com/v1",
         proxyUrl: null,
         enableHttp2: false,
       });
+      smallPool.releaseAgent(r2.cacheKey, r2.dispatcherId);
 
       vi.advanceTimersByTime(100);
 
@@ -516,49 +518,77 @@ describe("AgentPool", () => {
       await smallPool.shutdown();
     });
 
-    it("should retire active LRU dispatcher and close it only after release", async () => {
+    it("should reject new dispatcher creation when all live capacity is active", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       const smallPool = new AgentPoolImpl({
         ...defaultConfig,
         maxTotalAgents: 2,
       });
 
-      const r1 = await smallPool.getAgent({
-        endpointUrl: "https://api1.example.com/v1",
-        proxyUrl: null,
-        enableHttp2: false,
-      });
-      const agent1 = r1.agent as unknown as {
-        destroy?: () => Promise<void>;
-      };
-      const destroy1 = vi.fn().mockResolvedValue(undefined);
-      agent1.destroy = destroy1;
+      try {
+        const r1 = await smallPool.getAgent({
+          endpointUrl: "https://api1.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+        const agent1 = r1.agent as unknown as {
+          destroy?: () => Promise<void>;
+        };
+        const destroy1 = vi.fn().mockResolvedValue(undefined);
+        agent1.destroy = destroy1;
 
-      vi.advanceTimersByTime(100);
-      const r2 = await smallPool.getAgent({
-        endpointUrl: "https://api2.example.com/v1",
-        proxyUrl: null,
-        enableHttp2: false,
-      });
+        vi.advanceTimersByTime(100);
+        const r2 = await smallPool.getAgent({
+          endpointUrl: "https://api2.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
 
-      vi.advanceTimersByTime(100);
-      const r3 = await smallPool.getAgent({
-        endpointUrl: "https://api3.example.com/v1",
-        proxyUrl: null,
-        enableHttp2: false,
-      });
+        vi.advanceTimersByTime(100);
+        await expect(
+          smallPool.getAgent({
+            endpointUrl: "https://api3.example.com/v1",
+            proxyUrl: null,
+            enableHttp2: false,
+          })
+        ).rejects.toThrow("AgentPool live dispatcher capacity exhausted");
 
-      expect(smallPool.getPoolStats().cacheSize).toBe(2);
-      expect(smallPool.getPoolStats().activeRequests).toBe(3);
-      expect(destroy1).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledWith(
+          "AgentPool: Live dispatcher capacity exhausted",
+          expect.objectContaining({
+            activeRequests: 2,
+            cacheSize: 2,
+            maxTotalAgents: 2,
+            pendingCreations: 0,
+            retiredAgents: 0,
+          })
+        );
+        expect(smallPool.getPoolStats().cacheSize).toBe(2);
+        expect(smallPool.getPoolStats().liveAgents).toBe(2);
+        expect(smallPool.getPoolStats().activeRequests).toBe(2);
+        expect(destroy1).not.toHaveBeenCalled();
 
-      smallPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
-      expect(destroy1).toHaveBeenCalledTimes(1);
+        smallPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
+        expect(smallPool.getPoolStats().activeRequests).toBe(1);
+        expect(destroy1).not.toHaveBeenCalled();
 
-      smallPool.releaseAgent(r2.cacheKey, r2.dispatcherId);
-      smallPool.releaseAgent(r3.cacheKey, r3.dispatcherId);
-      expect(smallPool.getPoolStats().activeRequests).toBe(0);
+        const r3 = await smallPool.getAgent({
+          endpointUrl: "https://api3.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+        expect(smallPool.getPoolStats().cacheSize).toBe(2);
+        expect(smallPool.getPoolStats().liveAgents).toBe(2);
+        expect(smallPool.getPoolStats().activeRequests).toBe(2);
+        expect(destroy1).toHaveBeenCalledTimes(1);
 
-      await smallPool.shutdown();
+        smallPool.releaseAgent(r2.cacheKey, r2.dispatcherId);
+        smallPool.releaseAgent(r3.cacheKey, r3.dispatcherId);
+        expect(smallPool.getPoolStats().activeRequests).toBe(0);
+      } finally {
+        warnSpy.mockRestore();
+        await smallPool.shutdown();
+      }
     });
   });
 
@@ -719,6 +749,71 @@ describe("AgentPool", () => {
 
         createSpy.mockRestore();
       } finally {
+        await concurrentPool.shutdown();
+        vi.useFakeTimers();
+      }
+    });
+
+    it("should count pending creations against live dispatcher capacity", async () => {
+      vi.useRealTimers();
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      const concurrentPool = new AgentPoolImpl({
+        ...defaultConfig,
+        maxTotalAgents: 1,
+      });
+      try {
+        let releaseCreate: (() => void) | null = null;
+        const createBlocker = new Promise<void>((resolve) => {
+          releaseCreate = resolve;
+        });
+
+        const createSpy = vi.spyOn(concurrentPool as any, "createAgent");
+        createSpy.mockImplementationOnce(async () => {
+          await createBlocker;
+          return {
+            close: vi.fn().mockResolvedValue(undefined),
+            destroy: vi.fn().mockResolvedValue(undefined),
+            options: {},
+          };
+        });
+
+        const p1 = concurrentPool.getAgent({
+          endpointUrl: "https://api1.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        await expect(
+          concurrentPool.getAgent({
+            endpointUrl: "https://api2.example.com/v1",
+            proxyUrl: null,
+            enableHttp2: false,
+          })
+        ).rejects.toThrow("AgentPool live dispatcher capacity exhausted");
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          "AgentPool: Live dispatcher capacity exhausted",
+          expect.objectContaining({
+            activeRequests: 0,
+            cacheSize: 0,
+            maxTotalAgents: 1,
+            pendingCreations: 1,
+            retiredAgents: 0,
+          })
+        );
+
+        releaseCreate?.();
+        const r1 = await p1;
+        expect(concurrentPool.getPoolStats().liveAgents).toBe(1);
+        expect(concurrentPool.getPoolStats().pendingCreations).toBe(0);
+
+        concurrentPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
+        createSpy.mockRestore();
+      } finally {
+        warnSpy.mockRestore();
         await concurrentPool.shutdown();
         vi.useFakeTimers();
       }

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -1203,14 +1203,12 @@ describe("AgentPool", () => {
       const createPromise = new Promise<unknown>((resolve) => {
         resolveCreate = resolve;
       });
-      const privatePool = pool as unknown as {
-        createAgent: () => Promise<unknown>;
-      };
-      privatePool.createAgent = vi.fn().mockReturnValue(createPromise);
+      const createSpy = vi.spyOn(pool as any, "createAgent");
+      createSpy.mockImplementationOnce(() => createPromise);
 
       const getPromise = pool.getAgent(params);
       await Promise.resolve();
-      expect(privatePool.createAgent).toHaveBeenCalled();
+      expect(createSpy).toHaveBeenCalled();
 
       await pool.shutdown();
       expect(pool.getPoolStats().pendingCreations).toBe(0);
@@ -1222,6 +1220,7 @@ describe("AgentPool", () => {
       expect(lateAgent.close).not.toHaveBeenCalled();
       expect(pool.getPoolStats().cacheSize).toBe(0);
       expect(pool.getPoolStats().activeRequests).toBe(0);
+      createSpy.mockRestore();
     });
   });
 });

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -1154,6 +1154,8 @@ describe("AgentPool", () => {
       expect(privatePool.createAgent).toHaveBeenCalled();
 
       await pool.shutdown();
+      expect(pool.getPoolStats().pendingCreations).toBe(0);
+
       resolveCreate(lateAgent);
 
       await expect(getPromise).rejects.toThrow("AgentPool is shutting down");

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -491,6 +491,107 @@ describe("AgentPool", () => {
       expect(h1Destroy).toHaveBeenCalledTimes(1);
       expect(h2Destroy).toHaveBeenCalledTimes(1);
     });
+
+    it("should close a dispatcher created after endpoint eviction instead of caching it", async () => {
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+      const lateAgent = {
+        close: vi.fn().mockResolvedValue(undefined),
+        destroy: vi.fn().mockResolvedValue(undefined),
+      };
+      const freshAgent = {
+        close: vi.fn().mockResolvedValue(undefined),
+        destroy: vi.fn().mockResolvedValue(undefined),
+      };
+      let resolveCreate!: (agent: unknown) => void;
+      const createPromise = new Promise<unknown>((resolve) => {
+        resolveCreate = resolve;
+      });
+      const createSpy = vi.spyOn(pool as any, "createAgent");
+      createSpy.mockImplementationOnce(() => createPromise);
+      let getPromise: Promise<unknown> | null = null;
+
+      try {
+        getPromise = pool.getAgent(params);
+        await Promise.resolve();
+        expect(createSpy).toHaveBeenCalled();
+
+        await pool.evictEndpoint("https://api.anthropic.com");
+
+        createSpy.mockResolvedValueOnce(freshAgent);
+        const freshResult = await pool.getAgent(params);
+        expect(freshResult.agent).toBe(freshAgent);
+        expect(freshResult.isNew).toBe(true);
+
+        resolveCreate(lateAgent);
+
+        await expect(getPromise).rejects.toThrow("AgentPool endpoint was evicted during creation");
+        expect(lateAgent.destroy).toHaveBeenCalledTimes(1);
+        expect(lateAgent.close).not.toHaveBeenCalled();
+        expect(pool.getPoolStats()).toEqual(
+          expect.objectContaining({
+            activeRequests: 1,
+            cacheSize: 1,
+            pendingCreations: 0,
+          })
+        );
+        pool.releaseAgent(freshResult.cacheKey, freshResult.dispatcherId);
+      } finally {
+        resolveCreate(lateAgent);
+        await getPromise?.catch(() => undefined);
+        createSpy.mockRestore();
+      }
+    });
+
+    it("should preserve retirement metadata when a retired dispatcher is later marked unhealthy", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+      try {
+        const result = await pool.getAgent({
+          endpointUrl: "https://api.anthropic.com/v1/messages",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+        const agent = result.agent as unknown as {
+          destroy?: () => Promise<void>;
+        };
+        const destroy = vi.fn().mockResolvedValue(undefined);
+        agent.destroy = destroy;
+
+        await pool.evictEndpoint("https://api.anthropic.com");
+        pool.markUnhealthy(result.cacheKey, "late SSL failure", result.dispatcherId);
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          "AgentPool: Retired agent marked as unhealthy",
+          expect.objectContaining({
+            cacheKey: result.cacheKey,
+            dispatcherId: result.dispatcherId,
+            reason: "late SSL failure",
+            retiredBy: "endpoint",
+            retireReason: "endpoint eviction",
+          })
+        );
+
+        vi.advanceTimersByTime(6 * 60 * 60 * 1000 + 1);
+        const cleaned = await pool.cleanup();
+
+        expect(cleaned).toBe(1);
+        expect(destroy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          "AgentPool: Force closing long-retired active agent",
+          expect.objectContaining({
+            cacheKey: result.cacheKey,
+            dispatcherId: result.dispatcherId,
+            retiredBy: "endpoint",
+          })
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 
   describe("expiration cleanup", () => {

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -279,18 +279,85 @@ describe("AgentPool", () => {
           return new Promise<void>(() => {});
         };
 
-        realPool.markUnhealthy(result1.cacheKey, "test-hang-close");
+        realPool.releaseAgent(result1.cacheKey, result1.dispatcherId);
+        realPool.markUnhealthy(result1.cacheKey, "test-hang-close", result1.dispatcherId);
 
         const result2 = await withTimeout(realPool.getAgent(params), 500);
         expect(result2.isNew).toBe(true);
         expect(result2.agent).not.toBe(result1.agent);
 
-        // 断言：即使 close() 处于 pending，也不会阻塞 getAgent()，且会触发 close 调用
+        // 断言：空闲 unhealthy dispatcher 即使 close() 处于 pending，也不会阻塞 getAgent()
         expect(closeCalled).toBe(true);
       } finally {
         await realPool.shutdown();
         vi.useFakeTimers();
       }
+    });
+
+    it("should retire unhealthy active dispatcher without destroying in-flight requests", async () => {
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      const result1 = await pool.getAgent(params);
+      const result2 = await pool.getAgent(params);
+      const agent1 = result1.agent as unknown as {
+        destroy?: () => Promise<void>;
+      };
+      const destroy1 = vi.fn().mockResolvedValue(undefined);
+      agent1.destroy = destroy1;
+
+      pool.markUnhealthy(result1.cacheKey, "SSL certificate error", result1.dispatcherId);
+
+      expect(pool.getPoolStats().cacheSize).toBe(0);
+      expect(pool.getPoolStats().activeRequests).toBe(2);
+      expect(destroy1).not.toHaveBeenCalled();
+
+      const result3 = await pool.getAgent(params);
+      expect(result3.isNew).toBe(true);
+      expect(result3.agent).not.toBe(result1.agent);
+      expect(result3.dispatcherId).not.toBe(result1.dispatcherId);
+      expect(pool.getPoolStats().activeRequests).toBe(3);
+
+      pool.releaseAgent(result1.cacheKey, result1.dispatcherId);
+      expect(destroy1).not.toHaveBeenCalled();
+
+      pool.releaseAgent(result2.cacheKey, result2.dispatcherId);
+      expect(destroy1).toHaveBeenCalledTimes(1);
+
+      pool.releaseAgent(result3.cacheKey, result3.dispatcherId);
+      expect(pool.getPoolStats().activeRequests).toBe(0);
+    });
+
+    it("should ignore stale unhealthy marks for an older dispatcher generation", async () => {
+      const params = {
+        endpointUrl: "https://api.anthropic.com/v1/messages",
+        proxyUrl: null,
+        enableHttp2: false,
+      };
+
+      const oldGeneration = await pool.getAgent(params);
+      pool.markUnhealthy(oldGeneration.cacheKey, "initial SSL failure", oldGeneration.dispatcherId);
+
+      const newGeneration = await pool.getAgent(params);
+      expect(newGeneration.dispatcherId).not.toBe(oldGeneration.dispatcherId);
+
+      pool.markUnhealthy(
+        oldGeneration.cacheKey,
+        "late SSL failure from old stream",
+        oldGeneration.dispatcherId
+      );
+
+      const reusedNewGeneration = await pool.getAgent(params);
+      expect(reusedNewGeneration.agent).toBe(newGeneration.agent);
+      expect(reusedNewGeneration.dispatcherId).toBe(newGeneration.dispatcherId);
+
+      pool.releaseAgent(oldGeneration.cacheKey, oldGeneration.dispatcherId);
+      pool.releaseAgent(newGeneration.cacheKey, newGeneration.dispatcherId);
+      pool.releaseAgent(reusedNewGeneration.cacheKey, reusedNewGeneration.dispatcherId);
+      expect(pool.getPoolStats().activeRequests).toBe(0);
     });
 
     it("should track unhealthy agents in stats", async () => {
@@ -309,16 +376,26 @@ describe("AgentPool", () => {
 
     it("should evict all Agents for endpoint on evictEndpoint", async () => {
       // Create agents for same endpoint with different configs
-      await pool.getAgent({
+      const h1 = await pool.getAgent({
         endpointUrl: "https://api.anthropic.com/v1/messages",
         proxyUrl: null,
         enableHttp2: false,
       });
-      await pool.getAgent({
+      const h2 = await pool.getAgent({
         endpointUrl: "https://api.anthropic.com/v1/messages",
         proxyUrl: null,
         enableHttp2: true,
       });
+      const h1Agent = h1.agent as unknown as {
+        destroy?: () => Promise<void>;
+      };
+      const h2Agent = h2.agent as unknown as {
+        destroy?: () => Promise<void>;
+      };
+      const h1Destroy = vi.fn().mockResolvedValue(undefined);
+      const h2Destroy = vi.fn().mockResolvedValue(undefined);
+      h1Agent.destroy = h1Destroy;
+      h2Agent.destroy = h2Destroy;
       await pool.getAgent({
         endpointUrl: "https://api.openai.com/v1/chat/completions",
         proxyUrl: null,
@@ -333,6 +410,14 @@ describe("AgentPool", () => {
       const statsAfter = pool.getPoolStats();
       expect(statsAfter.cacheSize).toBe(1);
       expect(statsAfter.evictedAgents).toBe(2);
+      expect(statsAfter.activeRequests).toBe(3);
+      expect(h1Destroy).not.toHaveBeenCalled();
+      expect(h2Destroy).not.toHaveBeenCalled();
+
+      pool.releaseAgent(h1.cacheKey, h1.dispatcherId);
+      pool.releaseAgent(h2.cacheKey, h2.dispatcherId);
+      expect(h1Destroy).toHaveBeenCalledTimes(1);
+      expect(h2Destroy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -426,6 +511,51 @@ describe("AgentPool", () => {
       // Should have evicted the oldest (LRU)
       const stats = smallPool.getPoolStats();
       expect(stats.cacheSize).toBeLessThanOrEqual(2);
+
+      await smallPool.shutdown();
+    });
+
+    it("should retire active LRU dispatcher and close it only after release", async () => {
+      const smallPool = new AgentPoolImpl({
+        ...defaultConfig,
+        maxTotalAgents: 2,
+      });
+
+      const r1 = await smallPool.getAgent({
+        endpointUrl: "https://api1.example.com/v1",
+        proxyUrl: null,
+        enableHttp2: false,
+      });
+      const agent1 = r1.agent as unknown as {
+        destroy?: () => Promise<void>;
+      };
+      const destroy1 = vi.fn().mockResolvedValue(undefined);
+      agent1.destroy = destroy1;
+
+      vi.advanceTimersByTime(100);
+      const r2 = await smallPool.getAgent({
+        endpointUrl: "https://api2.example.com/v1",
+        proxyUrl: null,
+        enableHttp2: false,
+      });
+
+      vi.advanceTimersByTime(100);
+      const r3 = await smallPool.getAgent({
+        endpointUrl: "https://api3.example.com/v1",
+        proxyUrl: null,
+        enableHttp2: false,
+      });
+
+      expect(smallPool.getPoolStats().cacheSize).toBe(2);
+      expect(smallPool.getPoolStats().activeRequests).toBe(3);
+      expect(destroy1).not.toHaveBeenCalled();
+
+      smallPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
+      expect(destroy1).toHaveBeenCalledTimes(1);
+
+      smallPool.releaseAgent(r2.cacheKey, r2.dispatcherId);
+      smallPool.releaseAgent(r3.cacheKey, r3.dispatcherId);
+      expect(smallPool.getPoolStats().activeRequests).toBe(0);
 
       await smallPool.shutdown();
     });
@@ -593,8 +723,8 @@ describe("AgentPool", () => {
       }
     });
 
-    it("should ignore releaseAgent from stale dispatcher generation", async () => {
-      // 回归用例：cacheKey 相同但 dispatcher 已被重建时，旧 release 不应误减新实例
+    it("should release stale dispatcher generation without decrementing the current dispatcher", async () => {
+      // 回归用例：cacheKey 相同但 dispatcher 已被重建时，旧 release 只应释放旧代 dispatcher
       const regenPool = new AgentPoolImpl({
         ...defaultConfig,
         agentTtlMs: 1000,
@@ -611,20 +741,24 @@ describe("AgentPool", () => {
       expect(regenPool.getPoolStats().activeRequests).toBe(1);
 
       // 模拟外部强制驱逐（例如 markUnhealthy 后下次 getAgent 触发 evictByKey）
-      regenPool.markUnhealthy(r1.cacheKey, "simulated SSL failure");
+      regenPool.markUnhealthy(r1.cacheKey, "simulated SSL failure", r1.dispatcherId);
 
       // 第二代 dispatcher（同 cacheKey，但 dispatcherId 必须不同）
       const r2 = await regenPool.getAgent(params);
       expect(r2.cacheKey).toBe(r1.cacheKey);
       expect(r2.dispatcherId).not.toBe(r1.dispatcherId);
-      expect(regenPool.getPoolStats().activeRequests).toBe(1);
+      expect(regenPool.getPoolStats().activeRequests).toBe(2);
 
-      // 用第一代 dispatcherId 释放 —— 必须被忽略
+      // 用第一代 dispatcherId 释放 —— 只关闭退役旧代，不应误减第二代
       regenPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
       expect(regenPool.getPoolStats().activeRequests).toBe(1);
+      const r3 = await regenPool.getAgent(params);
+      expect(r3.dispatcherId).toBe(r2.dispatcherId);
+      expect(regenPool.getPoolStats().activeRequests).toBe(2);
 
-      // 用第二代 dispatcherId 释放 —— 正常减到 0
+      // 第二代被两个请求持有，释放两次后归零
       regenPool.releaseAgent(r2.cacheKey, r2.dispatcherId);
+      regenPool.releaseAgent(r3.cacheKey, r3.dispatcherId);
       expect(regenPool.getPoolStats().activeRequests).toBe(0);
 
       await regenPool.shutdown();
@@ -660,10 +794,11 @@ describe("AgentPool", () => {
       await shortTtlPool.shutdown();
     });
 
-    it("should force-expire after hard upper bound regardless of active requests", async () => {
+    it("should retire after hard upper bound without destroying active requests", async () => {
       const pool2 = new AgentPoolImpl({
         ...defaultConfig,
         agentTtlMs: 1000,
+        cleanupIntervalMs: 60 * 60 * 1000,
       });
 
       const params = {
@@ -673,7 +808,12 @@ describe("AgentPool", () => {
       };
 
       // getAgent increments activeRequests (never released)
-      await pool2.getAgent(params);
+      const r1 = await pool2.getAgent(params);
+      const agent1 = r1.agent as unknown as {
+        destroy?: () => Promise<void>;
+      };
+      const destroy1 = vi.fn().mockResolvedValue(undefined);
+      agent1.destroy = destroy1;
       expect(pool2.getPoolStats().activeRequests).toBe(1);
 
       // Advance past 30-minute hard upper bound
@@ -682,6 +822,12 @@ describe("AgentPool", () => {
       const cleaned = await pool2.cleanup();
       expect(cleaned).toBe(1);
       expect(pool2.getPoolStats().cacheSize).toBe(0);
+      expect(pool2.getPoolStats().activeRequests).toBe(1);
+      expect(destroy1).not.toHaveBeenCalled();
+
+      pool2.releaseAgent(r1.cacheKey, r1.dispatcherId);
+      expect(destroy1).toHaveBeenCalledTimes(1);
+      expect(pool2.getPoolStats().activeRequests).toBe(0);
 
       await pool2.shutdown();
     });

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -907,6 +907,66 @@ describe("AgentPool", () => {
       }
     });
 
+    it("同 cacheKey 退役旧代 release 后应回收替换 credit", async () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      const smallPool = new AgentPoolImpl({
+        ...defaultConfig,
+        maxTotalAgents: 1,
+      });
+
+      try {
+        const endpointParams = {
+          endpointUrl: "https://credit-reclaim.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        };
+
+        const original = await smallPool.getAgent(endpointParams);
+        const originalAgent = original.agent as unknown as {
+          destroy?: () => Promise<void>;
+        };
+        const originalDestroy = vi.fn().mockResolvedValue(undefined);
+        originalAgent.destroy = originalDestroy;
+
+        smallPool.markUnhealthy(
+          original.cacheKey,
+          "replace active dispatcher",
+          original.dispatcherId
+        );
+
+        const replacement = await smallPool.getAgent(endpointParams);
+        expect(replacement.dispatcherId).not.toBe(original.dispatcherId);
+
+        smallPool.releaseAgent(original.cacheKey, original.dispatcherId);
+        expect(originalDestroy).toHaveBeenCalledTimes(1);
+
+        smallPool.releaseAgent(replacement.cacheKey, replacement.dispatcherId);
+        await smallPool.evictEndpoint("https://credit-reclaim.example.com");
+
+        const occupied = await smallPool.getAgent({
+          endpointUrl: "https://credit-occupied.example.com/v1",
+          proxyUrl: null,
+          enableHttp2: false,
+        });
+
+        await expect(smallPool.getAgent(endpointParams)).rejects.toThrow(
+          "AgentPool live dispatcher capacity exhausted"
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+          "AgentPool: Live dispatcher capacity exhausted",
+          expect.objectContaining({
+            cacheKey: original.cacheKey,
+            replacementCapacityCredit: 0,
+          })
+        );
+
+        smallPool.releaseAgent(occupied.cacheKey, occupied.dispatcherId);
+      } finally {
+        warnSpy.mockRestore();
+        await smallPool.shutdown();
+      }
+    });
+
     it("should reject new dispatcher creation when all live capacity is active", async () => {
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       const smallPool = new AgentPoolImpl({

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -778,36 +778,39 @@ describe("AgentPool", () => {
           };
         });
 
-        // 同时发起 3 个请求：首个进入 createAgentWithCache；后两个必须走 pendingCreations
-        const p1 = concurrentPool.getAgent(params);
-        const p2 = concurrentPool.getAgent(params);
-        const p3 = concurrentPool.getAgent(params);
+        try {
+          // 同时发起 3 个请求：首个进入 createAgentWithCache；后两个必须走 pendingCreations
+          const p1 = concurrentPool.getAgent(params);
+          const p2 = concurrentPool.getAgent(params);
+          const p3 = concurrentPool.getAgent(params);
 
-        // 稍微等一个 microtask，确保 p2/p3 已经进入 await pending 分支
-        await Promise.resolve();
-        await Promise.resolve();
+          // 稍微等一个 microtask，确保 p2/p3 已经进入 await pending 分支
+          await Promise.resolve();
+          await Promise.resolve();
 
-        // 放行创建
-        releaseCreate?.();
+          // 放行创建
+          releaseCreate?.();
 
-        const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+          const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
 
-        // 三个调用应拿到相同的 cacheKey 与 dispatcherId
-        expect(r2.cacheKey).toBe(r1.cacheKey);
-        expect(r3.cacheKey).toBe(r1.cacheKey);
-        expect(r2.dispatcherId).toBe(r1.dispatcherId);
-        expect(r3.dispatcherId).toBe(r1.dispatcherId);
+          // 三个调用应拿到相同的 cacheKey 与 dispatcherId
+          expect(r2.cacheKey).toBe(r1.cacheKey);
+          expect(r3.cacheKey).toBe(r1.cacheKey);
+          expect(r2.dispatcherId).toBe(r1.dispatcherId);
+          expect(r3.dispatcherId).toBe(r1.dispatcherId);
 
-        // 关键断言：所有 3 个并发 waiter 都应计入 activeRequests
-        expect(concurrentPool.getPoolStats().activeRequests).toBe(3);
+          // 关键断言：所有 3 个并发 waiter 都应计入 activeRequests
+          expect(concurrentPool.getPoolStats().activeRequests).toBe(3);
 
-        // 释放 3 次后归零，且仍能再多释一次（no-op）
-        concurrentPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
-        concurrentPool.releaseAgent(r2.cacheKey, r2.dispatcherId);
-        concurrentPool.releaseAgent(r3.cacheKey, r3.dispatcherId);
-        expect(concurrentPool.getPoolStats().activeRequests).toBe(0);
-
-        createSpy.mockRestore();
+          // 释放 3 次后归零，且仍能再多释一次（no-op）
+          concurrentPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
+          concurrentPool.releaseAgent(r2.cacheKey, r2.dispatcherId);
+          concurrentPool.releaseAgent(r3.cacheKey, r3.dispatcherId);
+          expect(concurrentPool.getPoolStats().activeRequests).toBe(0);
+        } finally {
+          releaseCreate?.();
+          createSpy.mockRestore();
+        }
       } finally {
         await concurrentPool.shutdown();
         vi.useFakeTimers();
@@ -837,41 +840,45 @@ describe("AgentPool", () => {
           };
         });
 
-        const p1 = concurrentPool.getAgent({
-          endpointUrl: "https://api1.example.com/v1",
-          proxyUrl: null,
-          enableHttp2: false,
-        });
-
-        await Promise.resolve();
-        await Promise.resolve();
-
-        await expect(
-          concurrentPool.getAgent({
-            endpointUrl: "https://api2.example.com/v1",
+        try {
+          const p1 = concurrentPool.getAgent({
+            endpointUrl: "https://api1.example.com/v1",
             proxyUrl: null,
             enableHttp2: false,
-          })
-        ).rejects.toThrow("AgentPool live dispatcher capacity exhausted");
+          });
 
-        expect(warnSpy).toHaveBeenCalledWith(
-          "AgentPool: Live dispatcher capacity exhausted",
-          expect.objectContaining({
-            activeRequests: 0,
-            cacheSize: 0,
-            maxTotalAgents: 1,
-            pendingCreations: 1,
-            retiredAgents: 0,
-          })
-        );
+          await Promise.resolve();
+          await Promise.resolve();
 
-        releaseCreate?.();
-        const r1 = await p1;
-        expect(concurrentPool.getPoolStats().liveAgents).toBe(1);
-        expect(concurrentPool.getPoolStats().pendingCreations).toBe(0);
+          await expect(
+            concurrentPool.getAgent({
+              endpointUrl: "https://api2.example.com/v1",
+              proxyUrl: null,
+              enableHttp2: false,
+            })
+          ).rejects.toThrow("AgentPool live dispatcher capacity exhausted");
 
-        concurrentPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
-        createSpy.mockRestore();
+          expect(warnSpy).toHaveBeenCalledWith(
+            "AgentPool: Live dispatcher capacity exhausted",
+            expect.objectContaining({
+              activeRequests: 0,
+              cacheSize: 0,
+              maxTotalAgents: 1,
+              pendingCreations: 1,
+              retiredAgents: 0,
+            })
+          );
+
+          releaseCreate?.();
+          const r1 = await p1;
+          expect(concurrentPool.getPoolStats().liveAgents).toBe(1);
+          expect(concurrentPool.getPoolStats().pendingCreations).toBe(0);
+
+          concurrentPool.releaseAgent(r1.cacheKey, r1.dispatcherId);
+        } finally {
+          releaseCreate?.();
+          createSpy.mockRestore();
+        }
       } finally {
         warnSpy.mockRestore();
         await concurrentPool.shutdown();
@@ -1206,22 +1213,28 @@ describe("AgentPool", () => {
       });
       const createSpy = vi.spyOn(pool as any, "createAgent");
       createSpy.mockImplementationOnce(() => createPromise);
+      let getPromise: Promise<unknown> | null = null;
 
-      const getPromise = pool.getAgent(params);
-      await Promise.resolve();
-      expect(createSpy).toHaveBeenCalled();
+      try {
+        getPromise = pool.getAgent(params);
+        await Promise.resolve();
+        expect(createSpy).toHaveBeenCalled();
 
-      await pool.shutdown();
-      expect(pool.getPoolStats().pendingCreations).toBe(0);
+        await pool.shutdown();
+        expect(pool.getPoolStats().pendingCreations).toBe(0);
 
-      resolveCreate(lateAgent);
+        resolveCreate(lateAgent);
 
-      await expect(getPromise).rejects.toThrow("AgentPool is shutting down");
-      expect(lateAgent.destroy).toHaveBeenCalledTimes(1);
-      expect(lateAgent.close).not.toHaveBeenCalled();
-      expect(pool.getPoolStats().cacheSize).toBe(0);
-      expect(pool.getPoolStats().activeRequests).toBe(0);
-      createSpy.mockRestore();
+        await expect(getPromise).rejects.toThrow("AgentPool is shutting down");
+        expect(lateAgent.destroy).toHaveBeenCalledTimes(1);
+        expect(lateAgent.close).not.toHaveBeenCalled();
+        expect(pool.getPoolStats().cacheSize).toBe(0);
+        expect(pool.getPoolStats().activeRequests).toBe(0);
+      } finally {
+        resolveCreate(lateAgent);
+        await getPromise?.catch(() => undefined);
+        createSpy.mockRestore();
+      }
     });
   });
 });

--- a/tests/unit/lib/proxy-agent/agent-pool.test.ts
+++ b/tests/unit/lib/proxy-agent/agent-pool.test.ts
@@ -518,6 +518,65 @@ describe("AgentPool", () => {
       await smallPool.shutdown();
     });
 
+    it("容量紧张时应优先淘汰已过期的空闲 dispatcher", async () => {
+      const smallPool = new AgentPoolImpl({
+        ...defaultConfig,
+        maxTotalAgents: 2,
+        agentTtlMs: 60 * 60 * 1000,
+      });
+
+      const expiring = await smallPool.getAgent({
+        endpointUrl: "https://expired.example.com/v1",
+        proxyUrl: null,
+        enableHttp2: false,
+      });
+      const expiringAgent = expiring.agent as unknown as {
+        destroy?: () => Promise<void>;
+      };
+      const expiringDestroy = vi.fn().mockResolvedValue(undefined);
+      expiringAgent.destroy = expiringDestroy;
+      smallPool.releaseAgent(expiring.cacheKey, expiring.dispatcherId);
+
+      vi.advanceTimersByTime(20 * 60 * 1000);
+
+      const validLru = await smallPool.getAgent({
+        endpointUrl: "https://valid-lru.example.com/v1",
+        proxyUrl: null,
+        enableHttp2: false,
+      });
+      const validLruAgent = validLru.agent as unknown as {
+        destroy?: () => Promise<void>;
+      };
+      const validLruDestroy = vi.fn().mockResolvedValue(undefined);
+      validLruAgent.destroy = validLruDestroy;
+      smallPool.releaseAgent(validLru.cacheKey, validLru.dispatcherId);
+
+      vi.advanceTimersByTime(9 * 60 * 1000 + 50 * 1000);
+
+      const reusedExpiring = await smallPool.getAgent({
+        endpointUrl: "https://expired.example.com/v1",
+        proxyUrl: null,
+        enableHttp2: false,
+      });
+      expect(reusedExpiring.dispatcherId).toBe(expiring.dispatcherId);
+      smallPool.releaseAgent(reusedExpiring.cacheKey, reusedExpiring.dispatcherId);
+
+      vi.advanceTimersByTime(11 * 1000);
+
+      const newEntry = await smallPool.getAgent({
+        endpointUrl: "https://new.example.com/v1",
+        proxyUrl: null,
+        enableHttp2: false,
+      });
+
+      expect(expiringDestroy).toHaveBeenCalledTimes(1);
+      expect(validLruDestroy).not.toHaveBeenCalled();
+      expect(smallPool.getPoolStats().cacheSize).toBe(2);
+
+      smallPool.releaseAgent(newEntry.cacheKey, newEntry.dispatcherId);
+      await smallPool.shutdown();
+    });
+
     it("should reject new dispatcher creation when all live capacity is active", async () => {
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       const smallPool = new AgentPoolImpl({


### PR DESCRIPTION
## 摘要

本 PR 将 AgentPool 的连接生命周期从 `cacheKey` 级别推进到 `dispatcherId`/代际级别，避免旧请求迟到的 SSL/HTTP2 错误、LRU、endpoint eviction 或 30 分钟硬过期误伤同 `cacheKey` 下已经重建的新 dispatcher。

## 主要变更

- `releaseAgent()` / 三参数 `markUnhealthy(cacheKey, reason, dispatcherId)` 都按 `dispatcherId` 精确作用到本次请求拿到的 dispatcher 代际。
- 旧两参数 `markUnhealthy(cacheKey, reason)` 签名保留为 deprecated 源码兼容入口，但运行时只会 warn 并安全忽略，不再回退到 cacheKey 级别驱逐。
- active dispatcher 被 unhealthy、LRU、endpoint eviction、硬过期命中时会先从可复用 cache 移入 `retiredAgents`，等自身请求全部 release 后再关闭。
- `retiredAgents` 独立追踪旧代 `activeRequests`，旧代 release 不会误减新代 dispatcher。
- 满载时允许同 `cacheKey` 的退役活跃旧代提供最多 1 个 replacement capacity credit，避免“旧代未释放导致新代无法重建”的死锁；credit 现在用 per-cacheKey 计数索引维护，避免每次容量计算遍历全部 retired dispatcher。
- endpoint eviction 记录 eviction epoch，并主动移除对应 endpoint 的 pending reservation；创建中的旧 dispatcher 如果在 endpoint eviction 后才完成，会被立即关闭并拒绝缓存，后续请求会创建新 dispatcher。
- pending creation 只有仍属于当前 endpoint eviction epoch 时才占用容量；已经失效的旧 pending 不会阻塞其它 key 新建。
- 创建失败、shutdown 中止、endpoint eviction 拒绝创建等没有成功分配 dispatcher 的路径不再计入 `totalRequests/cacheMisses`。
- SSL/HTTP2 错误路径携带 `dispatcherId` 标记 unhealthy；如果只有 `cacheKey` 没有 `dispatcherId`，现在都会显式 warn，避免静默跳过保护。
- 指标口径已在代码中补充说明：
  - `totalRequests` / `cacheMisses` 只统计已成功分配或复用 dispatcher 的调用，容量拒绝和创建失败不污染命中率。
  - `evictedAgents` 表示从可复用 cache 驱逐的 dispatcher 代数；active 代可能先进入 retired，稍后才真正关闭。

## 兼容性与升级

- Runtime / Docker / 数据迁移：无。Docker 用户升级不需要额外配置或手动迁移。
- Source-level AgentPool interface：保留旧两参数 `markUnhealthy(cacheKey, reason)` 签名以避免下游 TypeScript 编译中断，但该旧入口已 deprecated，并且只记录 warn 后 no-op。需要实际标记 unhealthy 的调用必须传入 `dispatcherId`，否则无法安全地区分旧流和新 dispatcher 代际。

## 验证

- `bunx vitest run tests/unit/lib/proxy-agent/agent-pool.test.ts`：52 passed
- `bun run typecheck`：通过
- `bun run lint`：通过
- `git diff --check`：通过
- `bun run build`：通过
- `bunx vitest run tests/unit/api/health-ready-shutdown.test.ts --silent`：2 passed
- `bunx vitest run tests/api/v1/openapi-tier-sweep.test.ts --silent`：3 passed

备注：本地多次完整 `bunx vitest run --bail=1 --silent` 在全量并发/累积上下文下出现与本 PR 无关的 API sweep / readiness 用例超时；这些失败用例单独复跑均通过。本 PR 触碰的 AgentPool 聚焦套件、类型、lint、build 均已通过，CI 继续作为隔离环境下的最终全量信号。

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the coarse `cacheKey`-level eviction model in `AgentPoolImpl` with a per-`dispatcherId` generation model, preventing late-arriving SSL/HTTP2 errors from evicting a newly-rebuilt dispatcher for the same key.

- **Retired-agent lifecycle**: active dispatchers evicted via `markUnhealthy`, LRU, hard-expiry, or endpoint-eviction are moved to a `retiredAgents` map instead of being closed immediately; they are closed only after their last in-flight `releaseAgent` call.
- **Replacement capacity credit**: a pool full of active dispatchers can still accept one replacement creation per `cacheKey` that has an active retired entry, preventing deadlock when a dispatcher hits its 30-minute lifetime while under load.
- **Endpoint eviction epochs**: a monotonic sequence guards against a `createAgentWithCache` that completes after its endpoint was evicted; the late creation is discarded rather than cached.
- **`markUnhealthy` interface change**: the 3-arg form is now the required operative signature; the 2-arg form no-ops with a `warn`, and its `dispatcherId` parameter is marked required on the `AgentPool` interface (not optional as the PR description states).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with awareness of the noted minor issues; the core retirement and capacity-credit logic is correct and well-tested.

The previously-flagged capacity-exhaustion deadlock, dead unhealthy branch, and interface backward-compatibility issues are all resolved in this revision. The remaining findings are minor: a dead-code guard in the stale-pending path, a redundant healthy pre-set, and a slightly over-eager reclaimCapacityForNewAgent guard that triggers unnecessary cleanup. None affect correctness at runtime. The new test suite is comprehensive and exercises the key lifecycle scenarios.

src/lib/proxy-agent/agent-pool.ts deserves a second read on the reclaimCapacityForNewAgent / ensureCapacityForNewAgent interaction and the stale-pending deletion path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/proxy-agent/agent-pool.ts | Core dispatcher lifecycle overhaul: adds retiredAgents map, replacement capacity credits, endpoint eviction epochs, and synchronous evictByKey. Logic is sound overall; three minor issues flagged (dead stale-pending path, redundant healthy pre-set, suboptimal reclaimCapacity guard). |
| src/app/v1/_lib/proxy/forwarder.ts | SSL and HTTP/2 error paths updated to pass dispatcherId to markUnhealthy; correctly falls back to a warn-only log when dispatcherId is absent. No issues found. |
| tests/unit/lib/proxy-agent/agent-pool.test.ts | Comprehensive new tests covering retirement lifecycle, replacement capacity credits, endpoint eviction races, and stale-dispatcher isolation. Existing tests updated for 3-arg markUnhealthy. Coverage is thorough. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getAgent called] --> B{isShuttingDown?}
    B -- yes --> ERR1[throw: shutting down]
    B -- no --> C{cache hit?\nhealthy && not expired}
    C -- yes --> D[increment activeRequests\nreturn cached dispatcher]
    C -- no --> E{cached but expired?}
    E -- yes --> F[evictByKey\ncacheKey, expired]
    F --> G{activeRequests > 0?}
    G -- yes --> H[move to retiredAgents\nincrementActiveRetiredCount]
    G -- no --> I[closeAgent fire-and-forget]
    H --> J{pending creation?}
    I --> J
    E -- no --> J
    J -- yes, current --> K[await pending.promise\nincrement activeRequests\nreturn result]
    J -- none --> L[ensureCapacityForNewAgent\nwith replacement credit]
    L --> M{capacity available?}
    M -- no --> ERR2[throw: capacity exhausted]
    M -- yes --> N[createAgentWithCache\ncheck eviction epoch]
    N --> O{endpoint evicted\nduring creation?}
    O -- yes --> ERR3[closeAgent, throw]
    O -- no --> P[cache.set newCached\nenforceMaxSize]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/lib/proxy-agent/agent-pool.ts:293-297
**Unreachable stale-pending deletion path**

The `!isPendingCreationCurrent(pending)` branch inside `getAgent` (lines 295–296) can never execute. `evictEndpoint` synchronously deletes every matching pending from `pendingCreations` before returning, and JS is single-threaded — there is no `await` between `const pending = this.pendingCreations.get(cacheKey)` and the `isPendingCreationCurrent` check. So by the time `getAgent` resumes after an `evictEndpoint` call, the entry has already been removed and `pending` will be `null`. The dead-code branch silently discards the pending entry without waiting on it, which could confuse future maintainers into thinking stale pendings routinely linger in the map.

### Issue 2 of 3
src/lib/proxy-agent/agent-pool.ts:819-830
**Unnecessary retired-agent cleanup triggered by overly conservative early-exit guard**

`reclaimCapacityForNewAgent` calls `getReservedDispatcherCount()` without a `replacementCacheKey` on line 820, while the downstream check on line 826 supplies the credit. In the common expired-active-dispatcher replacement scenario, the first check sees `reserved = maxTotalAgents` (credit would have shown `maxTotalAgents - 1`), skips the early return, and unconditionally runs `cleanupRetiredAgents` — which iterates all retired agents and finds nothing eligible to close. The capacity slot was already available via the credit; the cleanup is wasted work. Passing `cacheKey` to the first guard as well would make it consistent with the check that follows.

### Issue 3 of 3
src/lib/proxy-agent/agent-pool.ts:433-436
**Redundant `cached.healthy = false` pre-set before `evictByKey`**

`cached.healthy = false` is set on the live cache entry before calling `evictByKey(cacheKey, "unhealthy", reason)`. Inside `disposeCachedAgent` the spread `{...cached}` captures `healthy: false`, then the explicit guard `retiredBy === "unhealthy" ? false : cached.healthy` also produces `false`. The pre-set is harmless but redundant — the `retiredBy` check in `disposeCachedAgent` already guarantees the retired entry carries `healthy: false`. The pre-set on the cache entry could mislead readers into thinking it serves a purpose beyond what `disposeCachedAgent` already handles.

`````

</details>

<sub>Reviews (14): Last reviewed commit: ["fix: 收敛 AgentPool pending 与失败指标"](https://github.com/ding113/claude-code-hub/commit/3df76f1d4611f2a3a939df925d3cdd5d602f7ec4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32280398)</sub>

<!-- /greptile_comment -->