### PR TITLE
feat(providers): 放宽供应商密钥长度上限至 1 MiB

### DIFF
--- a/src/lib/api/v1/schemas/providers.ts
+++ b/src/lib/api/v1/schemas/providers.ts
@@ -1,5 +1,6 @@
 import { z } from "@hono/zod-openapi";
 import { HIDDEN_PROVIDER_TYPES as HIDDEN_PROVIDER_TYPE_VALUES } from "@/lib/api/v1/_shared/constants";
+import { PROVIDER_KEY_MAX_LENGTH } from "@/lib/constants/provider.constants";
 import { ProviderTypeSchema } from "./_common";
 
 export const HIDDEN_PROVIDER_TYPES = new Set(HIDDEN_PROVIDER_TYPE_VALUES);
@@ -338,7 +339,7 @@ export const ProviderCreateSchema = z
   .object({
     name: z.string().trim().min(1).max(64).describe("Provider display name."),
     url: z.string().trim().url().max(255).describe("Provider upstream base URL."),
-    key: z.string().min(1).max(1024).describe("Provider API key. Write-only."),
+    key: z.string().min(1).max(PROVIDER_KEY_MAX_LENGTH).describe("Provider API key. Write-only."),
     is_enabled: z.boolean().optional().describe("Whether the provider is enabled."),
     weight: z.number().int().min(1).max(100).optional().describe("Provider routing weight."),
     priority: z.number().int().min(0).optional().describe("Provider routing priority."),
@@ -491,7 +492,12 @@ export const ProviderCreateSchema = z
 
 export const ProviderUpdateSchema = ProviderCreateSchema.omit({ key: true })
   .extend({
-    key: z.string().min(1).max(1024).optional().describe("Provider API key. Write-only."),
+    key: z
+      .string()
+      .min(1)
+      .max(PROVIDER_KEY_MAX_LENGTH)
+      .optional()
+      .describe("Provider API key. Write-only."),
     provider_type: ProviderTypeSchema.optional(),
   })
   .partial()

--- a/src/lib/constants/provider.constants.ts
+++ b/src/lib/constants/provider.constants.ts
@@ -22,6 +22,9 @@ export const PROVIDER_RULE_LIMITS = {
   MAX_TEXT_LENGTH: 4_096,
 } as const;
 
+// 供应商 API 密钥最大长度（字符数），取宽松上限即可
+export const PROVIDER_KEY_MAX_LENGTH = 1024 * 1024;
+
 export const PROVIDER_DEFAULTS = {
   IS_ENABLED: true,
   WEIGHT: 1,

--- a/src/lib/validation/schemas.test.ts
+++ b/src/lib/validation/schemas.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 
+import { PROVIDER_KEY_MAX_LENGTH } from "@/lib/constants/provider.constants";
 import {
   CreateProviderSchema,
   CreateUserSchema,
@@ -292,5 +293,50 @@ describe("Provider schemas - custom_headers", () => {
         }).success
       ).toBe(false);
     });
+  });
+});
+
+describe("Provider schemas - API 密钥长度限制", () => {
+  const createBase = {
+    name: "测试供应商",
+    url: "https://api.example.com",
+  };
+
+  test("CreateProviderSchema 接受远超旧 1024 限制的密钥", () => {
+    const longKey = "k".repeat(8192);
+    expect(CreateProviderSchema.safeParse({ ...createBase, key: longKey }).success).toBe(true);
+  });
+
+  test("CreateProviderSchema 接受长度正好为上限的密钥", () => {
+    const maxKey = "k".repeat(PROVIDER_KEY_MAX_LENGTH);
+    expect(CreateProviderSchema.safeParse({ ...createBase, key: maxKey }).success).toBe(true);
+  });
+
+  test("CreateProviderSchema 拒绝超出上限的密钥", () => {
+    const tooLongKey = "k".repeat(PROVIDER_KEY_MAX_LENGTH + 1);
+    expect(CreateProviderSchema.safeParse({ ...createBase, key: tooLongKey }).success).toBe(false);
+  });
+
+  test("CreateProviderSchema 仍拒绝空密钥", () => {
+    expect(CreateProviderSchema.safeParse({ ...createBase, key: "" }).success).toBe(false);
+  });
+
+  test("UpdateProviderSchema 接受远超旧 1024 限制的密钥", () => {
+    const longKey = "k".repeat(65536);
+    expect(UpdateProviderSchema.safeParse({ key: longKey }).success).toBe(true);
+  });
+
+  test("UpdateProviderSchema 接受长度正好为上限的密钥", () => {
+    const maxKey = "k".repeat(PROVIDER_KEY_MAX_LENGTH);
+    expect(UpdateProviderSchema.safeParse({ key: maxKey }).success).toBe(true);
+  });
+
+  test("UpdateProviderSchema 拒绝超出上限的密钥", () => {
+    const tooLongKey = "k".repeat(PROVIDER_KEY_MAX_LENGTH + 1);
+    expect(UpdateProviderSchema.safeParse({ key: tooLongKey }).success).toBe(false);
+  });
+
+  test("UpdateProviderSchema 仍拒绝空密钥", () => {
+    expect(UpdateProviderSchema.safeParse({ key: "" }).success).toBe(false);
   });
 });

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -704,7 +704,11 @@ export const UpdateProviderSchema = z
   .object({
     name: z.string().min(1).max(64).optional(),
     url: z.string().url().max(255).optional(),
-    key: z.string().min(1).max(PROVIDER_KEY_MAX_LENGTH).optional(),
+    key: z
+      .string()
+      .min(1, "API密钥不能为空")
+      .max(PROVIDER_KEY_MAX_LENGTH, "API密钥长度超出限制")
+      .optional(),
     is_enabled: z.boolean().optional(),
     weight: z
       .number()

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
   PROVIDER_DEFAULTS,
+  PROVIDER_KEY_MAX_LENGTH,
   PROVIDER_LIMITS,
   PROVIDER_TIMEOUT_LIMITS,
 } from "@/lib/constants/provider.constants";
@@ -457,7 +458,7 @@ export const CreateProviderSchema = z
   .object({
     name: z.string().min(1, "服务商名称不能为空").max(64, "服务商名称不能超过64个字符"),
     url: z.string().url("请输入有效的URL地址").max(255, "URL长度不能超过255个字符"),
-    key: z.string().min(1, "API密钥不能为空").max(1024, "API密钥长度不能超过1024个字符"),
+    key: z.string().min(1, "API密钥不能为空").max(PROVIDER_KEY_MAX_LENGTH, "API密钥长度超出限制"),
     // 数据库字段命名：下划线
     is_enabled: z.boolean().optional().default(PROVIDER_DEFAULTS.IS_ENABLED),
     weight: z
@@ -703,7 +704,7 @@ export const UpdateProviderSchema = z
   .object({
     name: z.string().min(1).max(64).optional(),
     url: z.string().url().max(255).optional(),
-    key: z.string().min(1).max(1024).optional(),
+    key: z.string().min(1).max(PROVIDER_KEY_MAX_LENGTH).optional(),
     is_enabled: z.boolean().optional(),
     weight: z
       .number()

--- a/tests/unit/api/v1/provider-schemas-key-length.test.ts
+++ b/tests/unit/api/v1/provider-schemas-key-length.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+
+import { ProviderCreateSchema, ProviderUpdateSchema } from "@/lib/api/v1/schemas/providers";
+import { PROVIDER_KEY_MAX_LENGTH } from "@/lib/constants/provider.constants";
+
+describe("v1 Provider schemas - API 密钥长度限制", () => {
+  const createBase = {
+    name: "test-provider",
+    url: "https://api.example.com",
+  };
+
+  test("ProviderCreateSchema 接受远超旧 1024 限制的密钥", () => {
+    const longKey = "k".repeat(8192);
+    expect(ProviderCreateSchema.safeParse({ ...createBase, key: longKey }).success).toBe(true);
+  });
+
+  test("ProviderCreateSchema 接受长度正好为上限的密钥", () => {
+    const maxKey = "k".repeat(PROVIDER_KEY_MAX_LENGTH);
+    expect(ProviderCreateSchema.safeParse({ ...createBase, key: maxKey }).success).toBe(true);
+  });
+
+  test("ProviderCreateSchema 拒绝超出上限的密钥", () => {
+    const tooLongKey = "k".repeat(PROVIDER_KEY_MAX_LENGTH + 1);
+    expect(ProviderCreateSchema.safeParse({ ...createBase, key: tooLongKey }).success).toBe(false);
+  });
+
+  test("ProviderCreateSchema 仍拒绝空密钥", () => {
+    expect(ProviderCreateSchema.safeParse({ ...createBase, key: "" }).success).toBe(false);
+  });
+
+  test("ProviderUpdateSchema 接受远超旧 1024 限制的密钥", () => {
+    const longKey = "k".repeat(65536);
+    expect(ProviderUpdateSchema.safeParse({ key: longKey }).success).toBe(true);
+  });
+
+  test("ProviderUpdateSchema 接受长度正好为上限的密钥", () => {
+    const maxKey = "k".repeat(PROVIDER_KEY_MAX_LENGTH);
+    expect(ProviderUpdateSchema.safeParse({ key: maxKey }).success).toBe(true);
+  });
+
+  test("ProviderUpdateSchema 拒绝超出上限的密钥", () => {
+    const tooLongKey = "k".repeat(PROVIDER_KEY_MAX_LENGTH + 1);
+    expect(ProviderUpdateSchema.safeParse({ key: tooLongKey }).success).toBe(false);
+  });
+
+  test("ProviderUpdateSchema 仍拒绝空密钥", () => {
+    expect(ProviderUpdateSchema.safeParse({ key: "" }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Raises the provider API key length limit from 1024 characters to 1 MiB (`PROVIDER_KEY_MAX_LENGTH = 1024 * 1024`) to support long tokens, JSON service-account credentials, and base64-encoded certificates that were previously rejected by Zod validation.

## Problem

Provider API keys were hard-limited to 1024 characters by Zod schema validation across both the internal and v1 API layers. This blocked legitimate use cases such as:
- Long-lived OAuth/JWT tokens
- GCP/Vertex AI JSON service account credentials
- Base64-encoded certificates

The database `providers.key` column is an unbounded `varchar` with no index dependency, so the 1024 limit was purely an application-layer constraint with no storage justification.

## Solution

- Introduced a single constant `PROVIDER_KEY_MAX_LENGTH` (1 MiB) in `src/lib/constants/provider.constants.ts`
- Replaced 4 hardcoded `.max(1024)` calls across both schema layers:
  - `src/lib/validation/schemas.ts`: `CreateProviderSchema` / `UpdateProviderSchema`
  - `src/lib/api/v1/schemas/providers.ts`: `ProviderCreateSchema` / `ProviderUpdateSchema`
- The generous upper bound serves only as a safeguard against abnormally large request payloads (the server body-size limit of 100-500 MB is a separate, unaffected constraint)

## Changes

### Core Changes
- `src/lib/constants/provider.constants.ts` - New `PROVIDER_KEY_MAX_LENGTH` constant (1 MiB)
- `src/lib/validation/schemas.ts` - Update `CreateProviderSchema` and `UpdateProviderSchema` key validation
- `src/lib/api/v1/schemas/providers.ts` - Update `ProviderCreateSchema` and `ProviderUpdateSchema` key validation

### Tests
- `src/lib/validation/schemas.test.ts` - 4 new boundary tests for internal schemas (key > 1024, key at max, key over max, empty key)
- `tests/unit/api/v1/provider-schemas-key-length.test.ts` - 8 new boundary tests for v1 API schemas (same coverage for both Create and Update)

## Breaking Changes

None. This is a relaxation of an existing constraint -- all previously valid keys remain valid. No database migration required.

## Testing

### Automated Tests
- [x] Unit tests added for `CreateProviderSchema` / `UpdateProviderSchema` (internal)
- [x] Unit tests added for `ProviderCreateSchema` / `ProviderUpdateSchema` (v1 API)
- [x] Boundary coverage: key exceeding old 1024 limit, key at exact new max, key exceeding new max, empty key

### Local Verification
- `build` / `lint` / `typecheck` / `test` (6023 passed) / `test:v1` (324 passed) / `openapi:check` / `openapi:lint` all passing

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] No database migration needed

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR relaxes the provider API key length limit from 1024 characters to 1 MiB by introducing a single shared constant `PROVIDER_KEY_MAX_LENGTH` and replacing four hardcoded `.max(1024)` Zod calls across both the internal and v1 API schema layers.

- **`src/lib/constants/provider.constants.ts`**: New `PROVIDER_KEY_MAX_LENGTH = 1024 * 1024` constant, consistently placed alongside other provider limits.
- **`src/lib/validation/schemas.ts` / `src/lib/api/v1/schemas/providers.ts`**: Both `Create` and `Update` provider schemas updated to reference the constant; `UpdateProviderSchema` also gains localized error messages on the key field.
- **Tests**: 16 new boundary tests across two test files confirm the old 1024-char limit is now accepted, the new 1 MiB ceiling holds, and empty keys are still rejected.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a pure relaxation of an application-layer constraint with no database impact.

The change is minimal and mechanical: one new constant replaces four hardcoded literals. The database column is an unbounded varchar so no migration is needed. All previously valid keys remain valid, and the new 1 MiB ceiling is well below the server body-size limit. Tests cover the critical boundaries for all four affected schemas.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/constants/provider.constants.ts | Adds PROVIDER_KEY_MAX_LENGTH = 1024 * 1024 constant — cleanly placed alongside other provider limits. |
| src/lib/validation/schemas.ts | Replaces two hardcoded .max(1024) calls with the shared constant; also adds localized error messages to UpdateProviderSchema's key field (minor positive improvement). |
| src/lib/api/v1/schemas/providers.ts | Replaces two hardcoded .max(1024) calls in ProviderCreateSchema and ProviderUpdateSchema with the shared constant; no other logic changes. |
| src/lib/validation/schemas.test.ts | Adds 8 boundary tests covering the old 1024 limit, the new max, one byte over max, and empty key for both Create and Update schemas. |
| tests/unit/api/v1/provider-schemas-key-length.test.ts | New test file mirroring the internal schema tests for the v1 API layer, with equivalent 8 boundary cases. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming API Request with provider key] --> B{Zod validation max=1048576}
    B -- "key.length > 1048576" --> C[400 Validation Error: key too long]
    B -- "key.length == 0" --> D[400 Validation Error: key empty]
    B -- "1 to 1048576 chars" --> E[Pass to handler]
    E --> F[Internal schemas CreateProviderSchema / UpdateProviderSchema]
    E --> G[v1 API schemas ProviderCreateSchema / ProviderUpdateSchema]
    F & G --> H[Database providers.key unbounded varchar]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["style(providers): 统一 UpdateProviderSchem..."](https://github.com/ding113/claude-code-hub/commit/64da95db1fea69cb8d9459417098de34a08fb199) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32496499)</sub>

<!-- /greptile_comment -->