### PR TITLE
fix(request-filters): accept isEnabled on create endpoint

### DIFF
--- a/src/actions/request-filters.ts
+++ b/src/actions/request-filters.ts
@@ -213,6 +213,7 @@ export async function createRequestFilterAction(data: {
   matchType?: RequestFilterMatchType;
   replacement?: unknown;
   priority?: number;
+  isEnabled?: boolean;
   bindingType?: RequestFilterBindingType;
   providerIds?: number[] | null;
   groupTags?: string[] | null;
@@ -243,6 +244,7 @@ export async function createRequestFilterAction(data: {
       matchType: data.matchType ?? null,
       replacement: data.replacement ?? null,
       priority: data.priority ?? 0,
+      isEnabled: data.isEnabled,
       bindingType: data.bindingType ?? "global",
       providerIds: data.providerIds ?? null,
       groupTags: data.groupTags ?? null,

--- a/src/lib/api-client/v1/openapi-types.gen.ts
+++ b/src/lib/api-client/v1/openapi-types.gen.ts
@@ -15371,6 +15371,8 @@ export interface operations {
                     replacement?: unknown;
                     /** @description Filter priority. */
                     priority?: number;
+                    /** @description Whether the filter is enabled. */
+                    isEnabled?: boolean;
                     /**
                      * @description Binding type.
                      * @enum {string}
@@ -16354,6 +16356,8 @@ export interface operations {
                     replacement?: unknown;
                     /** @description Filter priority. */
                     priority?: number;
+                    /** @description Whether the filter is enabled. */
+                    isEnabled?: boolean;
                     /**
                      * @description Binding type.
                      * @enum {string}
@@ -16377,8 +16381,6 @@ export interface operations {
                     operations?: {
                         [key: string]: unknown;
                     }[] | null;
-                    /** @description Whether the filter is enabled. */
-                    isEnabled?: boolean;
                 };
             };
         };

--- a/src/lib/api/v1/schemas/request-filters.ts
+++ b/src/lib/api/v1/schemas/request-filters.ts
@@ -60,6 +60,7 @@ export const RequestFilterCreateSchema = z
     matchType: RequestFilterMatchTypeSchema.optional().describe("Optional match type."),
     replacement: z.unknown().optional().describe("Replacement value."),
     priority: z.number().int().optional().describe("Filter priority."),
+    isEnabled: z.boolean().optional().describe("Whether the filter is enabled."),
     bindingType: RequestFilterBindingTypeSchema.optional().describe("Binding type."),
     providerIds: z
       .array(z.number().int().positive())
@@ -77,11 +78,7 @@ export const RequestFilterCreateSchema = z
   })
   .strict();
 
-export const RequestFilterUpdateSchema = RequestFilterCreateSchema.extend({
-  isEnabled: z.boolean().optional().describe("Whether the filter is enabled."),
-})
-  .partial()
-  .strict();
+export const RequestFilterUpdateSchema = RequestFilterCreateSchema.partial().strict();
 
 export const RequestFilterIdParamSchema = z.object({
   id: z.coerce.number().int().positive().describe("Request filter id."),

--- a/tests/api/v1/request-filters/request-filters.test.ts
+++ b/tests/api/v1/request-filters/request-filters.test.ts
@@ -105,6 +105,48 @@ describe("v1 request filters endpoints", () => {
       target: "x-test",
     });
 
+    const createdDisabled = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/request-filters",
+      headers: { Authorization: "Bearer admin-token" },
+      body: {
+        name: "Disabled filter",
+        scope: "header",
+        action: "set",
+        target: "x-disabled",
+        isEnabled: false,
+      },
+    });
+    expect(createdDisabled.response.status).toBe(201);
+    expect(createRequestFilterActionMock).toHaveBeenLastCalledWith({
+      name: "Disabled filter",
+      scope: "header",
+      action: "set",
+      target: "x-disabled",
+      isEnabled: false,
+    });
+
+    const createdEnabled = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/request-filters",
+      headers: { Authorization: "Bearer admin-token" },
+      body: {
+        name: "Enabled filter",
+        scope: "header",
+        action: "set",
+        target: "x-enabled",
+        isEnabled: true,
+      },
+    });
+    expect(createdEnabled.response.status).toBe(201);
+    expect(createRequestFilterActionMock).toHaveBeenLastCalledWith({
+      name: "Enabled filter",
+      scope: "header",
+      action: "set",
+      target: "x-enabled",
+      isEnabled: true,
+    });
+
     const updated = await callV1Route({
       method: "PATCH",
       pathname: "/api/v1/request-filters/1",


### PR DESCRIPTION
## Summary
- 修复创建请求过滤器接口 `POST /api/v1/request-filters` 在请求体携带 `isEnabled` 时返回 `request.validation_failed` / `unrecognized_keys` 的报错。
- UI(`filter-dialog.tsx`)在创建模式下也会把 `isEnabled`(默认 `true`,且面板允许切换)放进 payload,但 `RequestFilterCreateSchema.strict()` 与 `createRequestFilterAction` 都没有声明该字段;仓库层 `createRequestFilter` 本身已支持,只是从未把值透传下去。
- 将 `isEnabled` 加入 `RequestFilterCreateSchema` 与 server action 的入参类型,并把值传给仓库;`RequestFilterUpdateSchema` 已经通过 `.partial()` 继承新字段,所以可以去掉之前的 `.extend()` 包装。

## Reproducer
旧行为:
```
POST /api/v1/request-filters
{ "name": "x", "scope": "header", "action": "set", "target": "x-test", "isEnabled": false }
=> 400  errorCode: "request.validation_failed",
        invalidParams: [{ path: [], code: "unrecognized_keys", message: "Unrecognized key: \"isEnabled\"" }]
```

新行为:201 Created,过滤器以传入的 `isEnabled` 状态落库。

## Test plan
- [x] `tests/api/v1/request-filters/request-filters.test.ts`:补充 create + `isEnabled: false`/`true` 的覆盖,先红后绿。
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (679 files / 6023 passed)
- [x] `bun run build`
- [x] `bun run openapi:check` & `bun run openapi:lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a validation error (`unrecognized_keys`) on `POST /api/v1/request-filters` when the request body included `isEnabled`. The root cause was that `RequestFilterCreateSchema` used `.strict()` but did not declare `isEnabled`, even though the UI dialog always included it and the repository layer already accepted it.

- Adds `isEnabled?: boolean` to `RequestFilterCreateSchema` and to `createRequestFilterAction`'s parameter type, then threads the value through to the repository call — which already defaulted it to `true` when omitted.
- Simplifies `RequestFilterUpdateSchema` from `RequestFilterCreateSchema.extend({ isEnabled: ... }).partial().strict()` to just `RequestFilterCreateSchema.partial().strict()`, since `isEnabled` is now part of the base schema.
- Updates the generated OpenAPI client types and adds test coverage for `isEnabled: false` and `isEnabled: true` on the create endpoint.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a minimal, well-scoped addition of one optional field through an existing validation → action → repository pipeline.

All four changed files are consistent: the schema, the server action, the generated OpenAPI types, and the tests all reflect the same change. The repository layer already handled `isEnabled` with a sensible `?? true` default, so no data-layer risk exists. The `RequestFilterUpdateSchema` simplification is a no-op in behavior. New tests cover both `false` and `true` values explicitly.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/api/v1/schemas/request-filters.ts | Adds `isEnabled` to `RequestFilterCreateSchema` and simplifies `RequestFilterUpdateSchema` by deriving it directly from `partial()` — correct and clean. |
| src/actions/request-filters.ts | Adds `isEnabled?: boolean` to the action's parameter type and forwards it to the repository, which already applies the `?? true` default. |
| src/lib/api-client/v1/openapi-types.gen.ts | Generated file updated to reflect `isEnabled` now appearing in the create-endpoint body and repositioned in the update-endpoint body; consistent with schema changes. |
| tests/api/v1/request-filters/request-filters.test.ts | Adds two new test cases covering `isEnabled: false` and `isEnabled: true` on the create endpoint, verifying both HTTP status and action mock arguments. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as filter-dialog.tsx
    participant API as POST /api/v1/request-filters
    participant Schema as RequestFilterCreateSchema
    participant Action as createRequestFilterAction
    participant Repo as createRequestFilter (DB)

    UI->>API: "{ name, scope, action, target, isEnabled }"
    API->>Schema: validate(body) — now includes isEnabled
    Schema-->>API: parsed (isEnabled passed through)
    API->>Action: "createRequestFilterAction({ ..., isEnabled })"
    Action->>Repo: "{ ..., isEnabled: data.isEnabled }"
    Repo->>Repo: isEnabled ?? true (default applied)
    Repo-->>Action: RequestFilter row
    Action-->>API: "{ ok: true, data }"
    API-->>UI: 201 Created
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(request-filters): accept isEnabled o..."](https://github.com/ding113/claude-code-hub/commit/8311e616e912d40821b84bfcb081bb9625a6248d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32555214)</sub>

<!-- /greptile_comment -->