### PR TITLE
fix(providers): drop Authorization for Claude Platform on AWS gateway

### DIFF
--- a/src/app/v1/_lib/headers.ts
+++ b/src/app/v1/_lib/headers.ts
@@ -64,6 +64,12 @@ export function resolveAnthropicAuthHeaders(
   // AWS External Anthropic 拒绝 Authorization+x-api-key 共存,且不接受 Bearer。
   // 上游硬约束优先级最高,即使调用方要求 forceBearerOnly 也按 x-api-key 单发。
   if (looksLikeAwsExternalAnthropicUrl(providerUrl)) {
+    if (options?.forceBearerOnly) {
+      logger.warn(
+        "[anthropic-auth] forceBearerOnly overridden for AWS External Anthropic gateway; sending x-api-key only",
+        { providerUrl }
+      );
+    }
     return {
       "x-api-key": apiKey,
     };

--- a/src/app/v1/_lib/headers.ts
+++ b/src/app/v1/_lib/headers.ts
@@ -39,11 +39,36 @@ export function looksLikeAnthropicProxyUrl(providerUrl?: string | null): boolean
   }
 }
 
+// Claude Platform on AWS gateway: `https://aws-external-anthropic.{region}.api.aws`.
+// 该网关使用 SigV4(Authorization)或 API Key(x-api-key)二选一鉴权;同时携带两者
+// 会被服务端拒绝(`request must not include both 'authorization' and 'x-api-key' headers`)。
+// Bearer 形式不被支持,所以代理只能走 x-api-key 路径。
+export function looksLikeAwsExternalAnthropicUrl(providerUrl?: string | null): boolean {
+  if (!providerUrl) {
+    return false;
+  }
+
+  try {
+    const hostname = new URL(providerUrl).hostname.toLowerCase();
+    return /^aws-external-anthropic\.[a-z0-9-]+\.api\.aws$/.test(hostname);
+  } catch {
+    return false;
+  }
+}
+
 export function resolveAnthropicAuthHeaders(
   apiKey: string,
   providerUrl?: string | null,
   options?: { forceBearerOnly?: boolean }
 ): Record<string, string> {
+  // AWS External Anthropic 拒绝 Authorization+x-api-key 共存,且不接受 Bearer。
+  // 上游硬约束优先级最高,即使调用方要求 forceBearerOnly 也按 x-api-key 单发。
+  if (looksLikeAwsExternalAnthropicUrl(providerUrl)) {
+    return {
+      "x-api-key": apiKey,
+    };
+  }
+
   if (options?.forceBearerOnly || looksLikeAnthropicProxyUrl(providerUrl)) {
     return {
       Authorization: `Bearer ${apiKey}`,

--- a/tests/unit/proxy/anthropic-auth-headers.test.ts
+++ b/tests/unit/proxy/anthropic-auth-headers.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   looksLikeAnthropicProxyUrl,
   looksLikeAwsExternalAnthropicUrl,
   resolveAnthropicAuthHeaders,
 } from "@/app/v1/_lib/headers";
+import { logger } from "@/lib/logger";
 
 describe("Anthropic auth header helpers", () => {
   it("treats official Anthropic domains as direct endpoints", () => {
@@ -90,6 +91,23 @@ describe("Anthropic auth header helpers", () => {
       ).toEqual({
         "x-api-key": "sk-test",
       });
+    });
+
+    it("warns when forceBearerOnly is silently overridden by the AWS guard", () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      try {
+        resolveAnthropicAuthHeaders("sk-test", "https://aws-external-anthropic.us-east-1.api.aws", {
+          forceBearerOnly: true,
+        });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0]?.[0]).toContain("forceBearerOnly");
+
+        warnSpy.mockClear();
+        resolveAnthropicAuthHeaders("sk-test", "https://aws-external-anthropic.us-east-1.api.aws");
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });

--- a/tests/unit/proxy/anthropic-auth-headers.test.ts
+++ b/tests/unit/proxy/anthropic-auth-headers.test.ts
@@ -47,9 +47,7 @@ describe("Anthropic auth header helpers", () => {
         )
       ).toBe(true);
       expect(
-        looksLikeAwsExternalAnthropicUrl(
-          "https://aws-external-anthropic.us-west-2.api.aws"
-        )
+        looksLikeAwsExternalAnthropicUrl("https://aws-external-anthropic.us-west-2.api.aws")
       ).toBe(true);
       expect(
         looksLikeAwsExternalAnthropicUrl(
@@ -63,12 +61,10 @@ describe("Anthropic auth header helpers", () => {
       expect(
         looksLikeAwsExternalAnthropicUrl("https://bedrock-runtime.us-east-1.amazonaws.com")
       ).toBe(false);
-      expect(
-        looksLikeAwsExternalAnthropicUrl("https://bedrock-mantle.us-east-1.api.aws")
-      ).toBe(false);
-      expect(looksLikeAwsExternalAnthropicUrl("https://my-aws-external-anthropic.com")).toBe(
+      expect(looksLikeAwsExternalAnthropicUrl("https://bedrock-mantle.us-east-1.api.aws")).toBe(
         false
       );
+      expect(looksLikeAwsExternalAnthropicUrl("https://my-aws-external-anthropic.com")).toBe(false);
       expect(looksLikeAwsExternalAnthropicUrl(undefined)).toBe(false);
       expect(looksLikeAwsExternalAnthropicUrl("not a url")).toBe(false);
     });
@@ -88,11 +84,9 @@ describe("Anthropic auth header helpers", () => {
       // AWS External Anthropic does not accept `Authorization: Bearer`; an upstream
       // hard constraint must win over the claude-auth provider preference.
       expect(
-        resolveAnthropicAuthHeaders(
-          "sk-test",
-          "https://aws-external-anthropic.us-east-1.api.aws",
-          { forceBearerOnly: true }
-        )
+        resolveAnthropicAuthHeaders("sk-test", "https://aws-external-anthropic.us-east-1.api.aws", {
+          forceBearerOnly: true,
+        })
       ).toEqual({
         "x-api-key": "sk-test",
       });

--- a/tests/unit/proxy/anthropic-auth-headers.test.ts
+++ b/tests/unit/proxy/anthropic-auth-headers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { looksLikeAnthropicProxyUrl, resolveAnthropicAuthHeaders } from "@/app/v1/_lib/headers";
+import {
+  looksLikeAnthropicProxyUrl,
+  looksLikeAwsExternalAnthropicUrl,
+  resolveAnthropicAuthHeaders,
+} from "@/app/v1/_lib/headers";
 
 describe("Anthropic auth header helpers", () => {
   it("treats official Anthropic domains as direct endpoints", () => {
@@ -32,6 +36,66 @@ describe("Anthropic auth header helpers", () => {
       })
     ).toEqual({
       Authorization: "Bearer sk-test",
+    });
+  });
+
+  describe("AWS External Anthropic (Claude Platform on AWS)", () => {
+    it("recognises aws-external-anthropic regional hosts", () => {
+      expect(
+        looksLikeAwsExternalAnthropicUrl(
+          "https://aws-external-anthropic.us-east-1.api.aws/v1/messages"
+        )
+      ).toBe(true);
+      expect(
+        looksLikeAwsExternalAnthropicUrl(
+          "https://aws-external-anthropic.us-west-2.api.aws"
+        )
+      ).toBe(true);
+      expect(
+        looksLikeAwsExternalAnthropicUrl(
+          "HTTPS://AWS-EXTERNAL-ANTHROPIC.EU-WEST-1.API.AWS/v1/messages"
+        )
+      ).toBe(true);
+    });
+
+    it("rejects unrelated hostnames including bedrock and api.anthropic.com", () => {
+      expect(looksLikeAwsExternalAnthropicUrl("https://api.anthropic.com/v1/messages")).toBe(false);
+      expect(
+        looksLikeAwsExternalAnthropicUrl("https://bedrock-runtime.us-east-1.amazonaws.com")
+      ).toBe(false);
+      expect(
+        looksLikeAwsExternalAnthropicUrl("https://bedrock-mantle.us-east-1.api.aws")
+      ).toBe(false);
+      expect(looksLikeAwsExternalAnthropicUrl("https://my-aws-external-anthropic.com")).toBe(
+        false
+      );
+      expect(looksLikeAwsExternalAnthropicUrl(undefined)).toBe(false);
+      expect(looksLikeAwsExternalAnthropicUrl("not a url")).toBe(false);
+    });
+
+    it("sends only x-api-key when proxying to aws-external-anthropic", () => {
+      expect(
+        resolveAnthropicAuthHeaders(
+          "sk-test",
+          "https://aws-external-anthropic.us-east-1.api.aws/v1/messages"
+        )
+      ).toEqual({
+        "x-api-key": "sk-test",
+      });
+    });
+
+    it("keeps x-api-key only even when forceBearerOnly is requested for AWS", () => {
+      // AWS External Anthropic does not accept `Authorization: Bearer`; an upstream
+      // hard constraint must win over the claude-auth provider preference.
+      expect(
+        resolveAnthropicAuthHeaders(
+          "sk-test",
+          "https://aws-external-anthropic.us-east-1.api.aws",
+          { forceBearerOnly: true }
+        )
+      ).toEqual({
+        "x-api-key": "sk-test",
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
Fix authentication header conflict when proxying to the **Claude Platform on AWS** gateway (`aws-external-anthropic.{region}.api.aws`). The gateway rejects requests containing both `Authorization` and `x-api-key` headers, but the proxy was sending both.

## Problem

Users reported that creating an Anthropic-type provider with URL `https://aws-external-anthropic.us-east-1.api.aws` fails with:

```
request must not include both 'authorization' and 'x-api-key' headers
```

**Root cause:** The AWS gateway accepts **either** SigV4 (`Authorization: AWS4-HMAC-SHA256 ...`) **or** API Key (`x-api-key`) authentication, but **not** `Authorization: Bearer`. However, `resolveAnthropicAuthHeaders()` in `headers.ts` was sending both `Authorization: Bearer` and `x-api-key` for all non-proxy Anthropic providers, triggering a 400 from the AWS gateway.

Users could not work around this via custom headers because `PROTECTED_AUTH_HEADER_NAMES` blocks `authorization` and `x-api-key`.

**Related:**
- Related to #1074 - previously optimized Anthropic auth header logic in the same `headers.ts`

## Solution

In `src/app/v1/_lib/headers.ts`:
- Added `looksLikeAwsExternalAnthropicUrl()` to detect `aws-external-anthropic.{region}.api.aws` hostnames via regex
- Modified `resolveAnthropicAuthHeaders()` to send **only** `x-api-key` (no `Authorization` header) when targeting the AWS gateway
- The upstream hard constraint takes priority even when `forceBearerOnly` is requested by the caller
- All other Anthropic-compatible domains, official domains, and proxy/relay detection remain unchanged

## Changes

### Core Changes
- `src/app/v1/_lib/headers.ts` (+25/-0) - New AWS gateway URL detection + auth header override

### Tests
- `tests/unit/proxy/anthropic-auth-headers.test.ts` (+59/-1) - 4 new test cases:
  - AWS regional hostname recognition (including case-insensitive)
  - Rejection of unrelated hostnames (bedrock, api.anthropic.com, etc.)
  - `x-api-key`-only output for AWS gateway URLs
  - `forceBearerOnly` override correctly ignored for AWS gateway

## User Configuration

| Field | Value |
| --- | --- |
| Provider Type | Anthropic (Claude) |
| URL | `https://aws-external-anthropic.{region}.api.aws` |
| API Key | Key from AWS Console (Claude Platform on AWS) |
| Custom Headers | `{"anthropic-workspace-id":"wrkspc_xxxxxxxx"}` |

`anthropic-workspace-id` is required by the AWS gateway and is not in `PROTECTED_AUTH_HEADER_NAMES`, so it can be set via existing custom headers.

## Test Plan
- [x] 4 unit tests covering AWS URL detection, rejection, auth header output, and `forceBearerOnly` override
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (679 files / 6027 passed / 13 skipped)
- [x] `bun run build`
- [x] `bun run openapi:check` & `bun run openapi:lint`

## References
- [Claude Platform on AWS - Authentication](https://platform.claude.com/docs/en/build-with-claude/claude-platform-on-aws#authentication)
- [Workspaces (AWS docs)](https://docs.aws.amazon.com/claude-platform/latest/userguide/workspaces.html)
- [Introducing Claude Platform on AWS (AWS blog)](https://aws.amazon.com/blogs/machine-learning/introducing-claude-platform-on-aws-anthropics-native-platform-through-your-aws-account/)
- [anthropic-sdk-python AnthropicAWS source](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/aws/_client.py) - `_api_key_auth` short-circuits when SigV4 is enabled

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a 400 error when routing requests to the Claude Platform on AWS gateway (`aws-external-anthropic.{region}.api.aws`), which rejects requests containing both `Authorization` and `x-api-key` headers simultaneously.

- Adds `looksLikeAwsExternalAnthropicUrl()` to detect the AWS gateway hostname via a regex anchored on both ends, and inserts an early-return in `resolveAnthropicAuthHeaders()` that emits only `x-api-key` (and logs a warning when `forceBearerOnly` is overridden).
- Covers the new behaviour with 4 unit tests: hostname recognition (including case-insensitive), rejection of unrelated domains, `x-api-key`-only output, and the `forceBearerOnly`-override warning path.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrow and well-tested, touching only the auth-header resolution path for a specific AWS hostname pattern.

The new detection function uses a properly anchored regex on the lowercased hostname (so case variants and port numbers are handled correctly), the early-return is placed before all other branches so it cannot be bypassed by the existing logic, and the forceBearerOnly override is both enforced and logged. The API key is not included in the warning log — only providerUrl is. Test coverage addresses the key scenarios including the silent-override warning path with proper spy teardown.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/headers.ts | Adds `looksLikeAwsExternalAnthropicUrl()` + early-return in `resolveAnthropicAuthHeaders()` that sends only `x-api-key` for the AWS gateway, correctly overriding `forceBearerOnly` with a logged warning. Logic and safety look correct. |
| tests/unit/proxy/anthropic-auth-headers.test.ts | Adds 4 well-structured test cases covering AWS URL recognition, rejection of unrelated hostnames, x-api-key-only output, and the forceBearerOnly warning path; spy is properly restored in finally block. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveAnthropicAuthHeaders\napiKey, providerUrl, options] --> B{looksLikeAwsExternalAnthropicUrl?}
    B -- yes --> C{forceBearerOnly\nrequested?}
    C -- yes --> D[logger.warn\nforceBearerOnly overridden]
    D --> E[return x-api-key only]
    C -- no --> E
    B -- no --> F{forceBearerOnly OR\nlooksLikeAnthropicProxyUrl?}
    F -- yes --> G[return Authorization: Bearer]
    F -- no --> H[return Authorization: Bearer\n+ x-api-key]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(headers): warn when forceBearerOnl..."](https://github.com/ding113/claude-code-hub/commit/79a53a838a34a07529c7c99f73bb1cc4f060cfde) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32556971)</sub>

<!-- /greptile_comment -->