### PR TITLE
fix(provider-testing): drop Authorization for Claude Platform on AWS in test path

### DIFF
--- a/src/lib/provider-testing/utils/test-prompts.ts
+++ b/src/lib/provider-testing/utils/test-prompts.ts
@@ -141,16 +141,6 @@ const OPENAI_VERSIONED_FALLBACK_PATHS = [
   ["/v1/models", "/models"],
 ] as const;
 
-function resolveClaudeHeaders(providerType: ProviderType, apiKey: string, providerUrl?: string) {
-  return {
-    "anthropic-version": "2023-06-01",
-    "content-type": "application/json",
-    ...resolveAnthropicAuthHeaders(apiKey, providerUrl, {
-      forceBearerOnly: providerType === "claude-auth",
-    }),
-  };
-}
-
 export function getTestBody(providerType: ProviderType, model?: string): Record<string, unknown> {
   const targetModel = model || DEFAULT_MODELS[providerType];
 
@@ -187,11 +177,12 @@ export function getTestHeaders(
   switch (providerType) {
     case "claude":
     case "claude-auth":
-      Object.assign(
-        headers,
-        CLAUDE_TEST_HEADERS,
-        resolveClaudeHeaders(providerType, apiKey, providerUrl)
-      );
+      Object.assign(headers, {
+        ...CLAUDE_TEST_HEADERS,
+        ...resolveAnthropicAuthHeaders(apiKey, providerUrl, {
+          forceBearerOnly: providerType === "claude-auth",
+        }),
+      });
       break;
     case "codex":
       Object.assign(headers, {

--- a/src/lib/provider-testing/utils/test-prompts.ts
+++ b/src/lib/provider-testing/utils/test-prompts.ts
@@ -4,6 +4,7 @@
  * 这里保留协议级兜底默认值；真正执行时会优先使用 presets.ts 里的模板定义。
  */
 
+import { resolveAnthropicAuthHeaders } from "@/app/v1/_lib/headers";
 import { buildProxyUrl } from "@/app/v1/_lib/url";
 import type { ProviderType } from "@/types/provider";
 import type { ClaudeTestBody, CodexTestBody, GeminiTestBody, OpenAITestBody } from "../types";
@@ -140,45 +141,14 @@ const OPENAI_VERSIONED_FALLBACK_PATHS = [
   ["/v1/models", "/models"],
 ] as const;
 
-function looksLikeAnthropicProxy(providerUrl?: string): boolean {
-  if (!providerUrl) {
-    return false;
-  }
-
-  try {
-    const hostname = new URL(providerUrl).hostname.toLowerCase();
-    if (hostname.endsWith("anthropic.com") || hostname.endsWith("claude.ai")) {
-      return false;
-    }
-    // 只匹配常见 relay/proxy 标识，避免把普通业务域名里的 “gpt” 误识别成代理层。
-    return /(?:^|[.-])(proxy|relay|gateway|router|worker|openrouter|api2d|oaipro)(?:[.-]|$)/i.test(
-      hostname
-    );
-  } catch {
-    return false;
-  }
-}
-
 function resolveClaudeHeaders(providerType: ProviderType, apiKey: string, providerUrl?: string) {
-  const headers: Record<string, string> = {
+  return {
     "anthropic-version": "2023-06-01",
     "content-type": "application/json",
+    ...resolveAnthropicAuthHeaders(apiKey, providerUrl, {
+      forceBearerOnly: providerType === "claude-auth",
+    }),
   };
-
-  if (providerType === "claude-auth") {
-    headers.Authorization = `Bearer ${apiKey}`;
-    return headers;
-  }
-
-  if (looksLikeAnthropicProxy(providerUrl)) {
-    headers.Authorization = `Bearer ${apiKey}`;
-    return headers;
-  }
-
-  // 对非代理 Anthropic 直连保留双头，兼容只认 x-api-key 或 Bearer 的 Anthropic-compatible 层。
-  headers["x-api-key"] = apiKey;
-  headers.Authorization = `Bearer ${apiKey}`;
-  return headers;
 }
 
 export function getTestBody(providerType: ProviderType, model?: string): Record<string, unknown> {

--- a/tests/unit/provider-testing/test-prompts-headers.test.ts
+++ b/tests/unit/provider-testing/test-prompts-headers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { getTestHeaders } from "@/lib/provider-testing/utils/test-prompts";
+
+describe("provider-testing getTestHeaders — Anthropic auth header selection", () => {
+  it("sends both x-api-key and Authorization for direct api.anthropic.com", () => {
+    const headers = getTestHeaders("claude", "sk-test", "https://api.anthropic.com");
+    expect(headers["x-api-key"]).toBe("sk-test");
+    expect(headers.Authorization).toBe("Bearer sk-test");
+  });
+
+  it("sends Bearer-only for proxy-like Anthropic relays", () => {
+    const headers = getTestHeaders("claude", "sk-test", "https://openrouter.example.com");
+    expect(headers.Authorization).toBe("Bearer sk-test");
+    expect(headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("sends Bearer-only for claude-auth regardless of URL", () => {
+    const headers = getTestHeaders("claude-auth", "sk-test", "https://api.anthropic.com");
+    expect(headers.Authorization).toBe("Bearer sk-test");
+    expect(headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("sends x-api-key only (no Authorization) for AWS External Anthropic gateway", () => {
+    const headers = getTestHeaders(
+      "claude",
+      "sk-test",
+      "https://aws-external-anthropic.us-east-1.api.aws/v1/messages"
+    );
+    expect(headers["x-api-key"]).toBe("sk-test");
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("keeps x-api-key only even when claude-auth + AWS URL combine (upstream wins)", () => {
+    const headers = getTestHeaders(
+      "claude-auth",
+      "sk-test",
+      "https://aws-external-anthropic.us-west-2.api.aws"
+    );
+    expect(headers["x-api-key"]).toBe("sk-test");
+    expect(headers.Authorization).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 背景

#1197 修复了 **代理转发** 路径在 AWS External Anthropic 网关上的双 header 问题,但用户报告 **供应商测试** 入口(`/api/v1/providers/test:anthropic-messages` 等)仍然报:

```
HTTP 401
{"type":"error","error":{"type":"authentication_error",
 "message":"request must not include both 'authorization' and 'x-api-key' headers"}}
```

## 根因

供应商测试有**独立的 header 构造器** `resolveClaudeHeaders`(`src/lib/provider-testing/utils/test-prompts.ts:162-182`),自己复制了一份和主流程 `resolveAnthropicAuthHeaders` 类似但**分叉**的逻辑(并且本地的 `looksLikeAnthropicProxy` 也只是 `looksLikeAnthropicProxyUrl` 的简化版)。于是 #1197 的 AWS 识别 + 仅 `x-api-key` 行为没有覆盖到测试路径。

## 修复

让测试路径**复用**主流程 helper:
- 删除本地的 `looksLikeAnthropicProxy`(冗余)与手写的鉴权分支。
- `resolveClaudeHeaders` 现在直接 `...resolveAnthropicAuthHeaders(apiKey, providerUrl, { forceBearerOnly: providerType === "claude-auth" })`,只保留 `anthropic-version` / `content-type` 通用头。
- AWS 网关命中 → 只发 `x-api-key`(由共享 helper 保证),不再撞 401。

## Test Plan
- [x] 新增 `tests/unit/provider-testing/test-prompts-headers.test.ts`,5 条用例覆盖:
  - `api.anthropic.com` 直连:双头
  - 代理 relay(`openrouter.example.com`):Bearer-only
  - `claude-auth` 直连:Bearer-only(无 `x-api-key`)
  - `aws-external-anthropic.*.api.aws`:仅 `x-api-key`(无 `Authorization`)
  - `claude-auth` + AWS URL:仍仅 `x-api-key`(上游硬约束优先)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test`(680 files / 6033 passed / 13 skipped)
- [x] `bun run build`

## 后续

主流程(#1197)与测试路径(本 PR)之外,如果还有别的入口自带 Anthropic header 构造(例如 cron probe / circuit breaker probe 等),都应复用 `resolveAnthropicAuthHeaders` 而不是自己再分叉一份。本 PR 顺手已经消除了一份重复实现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a 401 authentication error on the AWS External Anthropic gateway by replacing the locally forked `resolveClaudeHeaders` function in the provider-testing path with the shared `resolveAnthropicAuthHeaders` helper already used in the main proxy path.

- **Root cause patched**: The provider-testing code had its own header-building logic that was unaware of the AWS-only-`x-api-key` constraint, sending both `Authorization` and `x-api-key` and triggering a 401. Delegating to the canonical helper ensures both paths stay in sync.
- **Dead code removed**: `looksLikeAnthropicProxy` (a simplified re-implementation of the shared `looksLikeAnthropicProxyUrl`) is deleted, eliminating one fork of the logic.
- **Tests added**: Five unit tests cover all header-selection branches (direct, proxy-relay, `claude-auth`, AWS gateway, and the AWS-override-`forceBearerOnly` edge case).
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change eliminates a duplicated auth-header builder and replaces it with the already-battle-tested shared helper, directly fixing the reported 401.

The refactor is a straightforward delegation to an existing, tested function. The deleted local fork had no unique behaviour worth preserving, all five header-selection branches are now covered by unit tests, and the fix matches the root cause described in the PR.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/provider-testing/utils/test-prompts.ts | Removes the forked resolveClaudeHeaders / looksLikeAnthropicProxy helpers and delegates to resolveAnthropicAuthHeaders; CLAUDE_TEST_HEADERS spread is still needed since the shared helper only returns auth headers. |
| tests/unit/provider-testing/test-prompts-headers.test.ts | New unit tests covering all five header-selection branches; URL fixtures correctly exercise each code path in the shared helper. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getTestHeaders called
with providerType='claude'/'claude-auth'] --> B{Switch on providerType}
    B -- claude / claude-auth --> C["Spread CLAUDE_TEST_HEADERS
(anthropic-version, content-type)"]
    C --> D["Call resolveAnthropicAuthHeaders
(apiKey, providerUrl, forceBearerOnly)"]
    D --> E{looksLikeAwsExternalAnthropicUrl?}
    E -- YES --> F["Return: x-api-key only
(forceBearerOnly overridden)"]
    E -- NO --> G{forceBearerOnly OR
looksLikeAnthropicProxyUrl?}
    G -- YES --> H["Return: Authorization: Bearer only"]
    G -- NO --> I["Return: Authorization: Bearer
+ x-api-key (both)"]
    F --> J[Final headers merged into response]
    H --> J
    I --> J
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/provider-testing/utils/test-prompts.ts`, line 190-194 ([link](https://github.com/ding113/claude-code-hub/blob/c420bc91e125c0e26d534a92cb11dc7d44c080f3/src/lib/provider-testing/utils/test-prompts.ts#L190-L194)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> After this refactor `resolveClaudeHeaders` already includes `"anthropic-version"` and `"content-type"` in its return value, so passing `CLAUDE_TEST_HEADERS` first in the `Object.assign` call is now a no-op — those two keys are overwritten immediately by the result of `resolveClaudeHeaders` with identical values. The `CLAUDE_TEST_HEADERS` argument can be dropped here.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/provider-testing/utils/test-prompts.ts
   Line: 190-194

   Comment:
   After this refactor `resolveClaudeHeaders` already includes `"anthropic-version"` and `"content-type"` in its return value, so passing `CLAUDE_TEST_HEADERS` first in the `Object.assign` call is now a no-op — those two keys are overwritten immediately by the result of `resolveClaudeHeaders` with identical values. The `CLAUDE_TEST_HEADERS` argument can be dropped here.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(provider-testing): inline resol..."](https://github.com/ding113/claude-code-hub/commit/66881cce78b7467b84d6e859bfa0f530b244adac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32565604)</sub>

<!-- /greptile_comment -->