### PR TITLE
release v0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "class-variance-authority": "^0.7",
     "clsx": "^2",
     "cmdk": "^1",
-    "date-fns": "^4",
+    "date-fns": "4.1.0",
     "date-fns-tz": "^3",
     "decimal.js-light": "^2",
     "dotenv": "^17",

--- a/src/actions/request-filters.ts
+++ b/src/actions/request-filters.ts
@@ -213,6 +213,7 @@ export async function createRequestFilterAction(data: {
   matchType?: RequestFilterMatchType;
   replacement?: unknown;
   priority?: number;
+  isEnabled?: boolean;
   bindingType?: RequestFilterBindingType;
   providerIds?: number[] | null;
   groupTags?: string[] | null;
@@ -243,6 +244,7 @@ export async function createRequestFilterAction(data: {
       matchType: data.matchType ?? null,
       replacement: data.replacement ?? null,
       priority: data.priority ?? 0,
+      isEnabled: data.isEnabled,
       bindingType: data.bindingType ?? "global",
       providerIds: data.providerIds ?? null,
       groupTags: data.groupTags ?? null,

--- a/src/actions/request-filters.ts
+++ b/src/actions/request-filters.ts
@@ -244,7 +244,7 @@ export async function createRequestFilterAction(data: {
       matchType: data.matchType ?? null,
       replacement: data.replacement ?? null,
       priority: data.priority ?? 0,
-      isEnabled: data.isEnabled,
+      isEnabled: data.isEnabled ?? true,
       bindingType: data.bindingType ?? "global",
       providerIds: data.providerIds ?? null,
       groupTags: data.groupTags ?? null,

--- a/src/app/[locale]/settings/providers/_components/allowed-model-rule-editor.tsx
+++ b/src/app/[locale]/settings/providers/_components/allowed-model-rule-editor.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { PROVIDER_RULE_LIMITS } from "@/lib/constants/provider.constants";
+import { resolveProviderPatternRegex } from "@/lib/provider-pattern-regex";
 import type {
   AllowedModelRule,
   ProviderModelRedirectMatchType,
@@ -101,14 +102,13 @@ export function AllowedModelRuleEditor({
       return t("patternTooLong", { max: PROVIDER_RULE_LIMITS.MAX_TEXT_LENGTH });
     }
     if (normalized.matchType === "regex") {
-      try {
-        new RegExp(normalized.pattern);
-      } catch {
+      const compiled = resolveProviderPatternRegex(normalized.pattern);
+      if (!compiled) {
         return t("regexInvalid");
       }
 
       try {
-        if (!safeRegex(normalized.pattern)) {
+        if (!safeRegex(compiled.source)) {
           return t("regexUnsafe");
         }
       } catch {

--- a/src/app/[locale]/settings/providers/_components/model-redirect-editor.tsx
+++ b/src/app/[locale]/settings/providers/_components/model-redirect-editor.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { PROVIDER_RULE_LIMITS } from "@/lib/constants/provider.constants";
+import { resolveProviderPatternRegex } from "@/lib/provider-pattern-regex";
 import type { ProviderModelRedirectMatchType, ProviderModelRedirectRule } from "@/types/provider";
 
 interface ModelRedirectEditorProps {
@@ -104,14 +105,13 @@ export function ModelRedirectEditor({
       return t("targetTooLong", { max: PROVIDER_RULE_LIMITS.MAX_TEXT_LENGTH });
     }
     if (normalized.matchType === "regex") {
-      try {
-        new RegExp(normalized.source);
-      } catch {
+      const compiled = resolveProviderPatternRegex(normalized.source);
+      if (!compiled) {
         return t("regexInvalid");
       }
 
       try {
-        if (!safeRegex(normalized.source)) {
+        if (!safeRegex(compiled.source)) {
           return t("regexUnsafe");
         }
       } catch {

--- a/src/app/[locale]/settings/providers/_components/provider-manager-loader.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-manager-loader.tsx
@@ -5,6 +5,7 @@ import {
   getProviderStatisticsAsync,
   getProviders,
   getProvidersHealthStatus,
+  type ProviderHealthStatus,
 } from "@/lib/api-client/v1/actions/providers";
 import { getSystemSettings } from "@/lib/api-client/v1/actions/system-config";
 import type { CurrencyCode } from "@/lib/utils/currency";
@@ -12,17 +13,6 @@ import type { ProviderDisplay, ProviderStatisticsMap } from "@/types/provider";
 import type { User } from "@/types/user";
 import { AddProviderDialog } from "./add-provider-dialog";
 import { ProviderManager } from "./provider-manager";
-
-type ProviderHealthStatus = Record<
-  number,
-  {
-    circuitState: "closed" | "open" | "half-open";
-    failureCount: number;
-    lastFailureTime: number | null;
-    circuitOpenUntil: number | null;
-    recoveryMinutes: number | null;
-  }
->;
 
 interface ProviderManagerLoaderProps {
   currentUser?: User;

--- a/src/app/[locale]/settings/providers/_components/provider-manager.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-manager.tsx
@@ -28,7 +28,12 @@ import { Switch } from "@/components/ui/switch";
 import { useDebounce } from "@/lib/hooks/use-debounce";
 import type { CurrencyCode } from "@/lib/utils/currency";
 import { parseProviderGroups, resolveProviderGroupsWithDefault } from "@/lib/utils/provider-group";
-import type { ProviderDisplay, ProviderStatisticsMap, ProviderType } from "@/types/provider";
+import type {
+  ProviderDisplay,
+  ProviderHealthStatus,
+  ProviderStatisticsMap,
+  ProviderType,
+} from "@/types/provider";
 import type { User } from "@/types/user";
 import {
   type BatchActionMode,
@@ -57,16 +62,7 @@ export type EndpointCircuitInfoMap = Record<
 interface ProviderManagerProps {
   providers: ProviderDisplay[];
   currentUser?: User;
-  healthStatus: Record<
-    number,
-    {
-      circuitState: "closed" | "open" | "half-open";
-      failureCount: number;
-      lastFailureTime: number | null;
-      circuitOpenUntil: number | null;
-      recoveryMinutes: number | null;
-    }
-  >;
+  healthStatus: ProviderHealthStatus;
   /** Endpoint-level circuit breaker info, keyed by provider ID */
   endpointCircuitInfo?: EndpointCircuitInfoMap;
   statistics?: ProviderStatisticsMap;

--- a/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
@@ -70,7 +70,12 @@ import { getContrastTextColor, getGroupColor } from "@/lib/utils/color";
 import type { CurrencyCode } from "@/lib/utils/currency";
 import { formatCurrency } from "@/lib/utils/currency";
 import { normalizeProviderGroupTag, parseProviderGroups } from "@/lib/utils/provider-group";
-import type { ProviderDisplay, ProviderStatistics, ProviderVendor } from "@/types/provider";
+import type {
+  ProviderCircuitHealth,
+  ProviderDisplay,
+  ProviderStatistics,
+  ProviderVendor,
+} from "@/types/provider";
 import type { User } from "@/types/user";
 import { ProviderForm } from "./forms/provider-form";
 import { GroupEditCombobox } from "./group-edit-combobox";
@@ -83,13 +88,7 @@ interface ProviderRichListItemProps {
   provider: ProviderDisplay;
   vendor?: ProviderVendor;
   currentUser?: User;
-  healthStatus?: {
-    circuitState: "closed" | "open" | "half-open";
-    failureCount: number;
-    lastFailureTime: number | null;
-    circuitOpenUntil: number | null;
-    recoveryMinutes: number | null;
-  };
+  healthStatus?: ProviderCircuitHealth;
   /** Endpoint-level circuit breaker info for this provider */
   endpointCircuitInfo?: Array<{
     endpointId: number;

--- a/src/app/v1/_lib/headers.ts
+++ b/src/app/v1/_lib/headers.ts
@@ -1,3 +1,4 @@
+import { redactUrlCredentials } from "@/lib/api/v1/_shared/redaction";
 import { logger } from "@/lib/logger";
 
 /**
@@ -50,7 +51,9 @@ export function looksLikeAwsExternalAnthropicUrl(providerUrl?: string | null): b
 
   try {
     const hostname = new URL(providerUrl).hostname.toLowerCase();
-    return /^aws-external-anthropic\.[a-z0-9-]+\.api\.aws$/.test(hostname);
+    // 区域段限定为 AWS 实际命名（`<area>-<direction>-<digit>`，如 `us-east-1`/`us-gov-west-1`），
+    // 避免 `aws-external-anthropic.fake.api.aws` 之类伪造主机伪装成网关。
+    return /^aws-external-anthropic\.[a-z]+(?:-[a-z]+)+-\d+\.api\.aws$/.test(hostname);
   } catch {
     return false;
   }
@@ -65,9 +68,10 @@ export function resolveAnthropicAuthHeaders(
   // 上游硬约束优先级最高,即使调用方要求 forceBearerOnly 也按 x-api-key 单发。
   if (looksLikeAwsExternalAnthropicUrl(providerUrl)) {
     if (options?.forceBearerOnly) {
+      // providerUrl 可能含 userinfo / query 凭据，落日志前必须脱敏。
       logger.warn(
         "[anthropic-auth] forceBearerOnly overridden for AWS External Anthropic gateway; sending x-api-key only",
-        { providerUrl }
+        { providerUrl: redactUrlCredentials(providerUrl) }
       );
     }
     return {

--- a/src/app/v1/_lib/headers.ts
+++ b/src/app/v1/_lib/headers.ts
@@ -39,11 +39,42 @@ export function looksLikeAnthropicProxyUrl(providerUrl?: string | null): boolean
   }
 }
 
+// Claude Platform on AWS gateway: `https://aws-external-anthropic.{region}.api.aws`.
+// 该网关使用 SigV4(Authorization)或 API Key(x-api-key)二选一鉴权;同时携带两者
+// 会被服务端拒绝(`request must not include both 'authorization' and 'x-api-key' headers`)。
+// Bearer 形式不被支持,所以代理只能走 x-api-key 路径。
+export function looksLikeAwsExternalAnthropicUrl(providerUrl?: string | null): boolean {
+  if (!providerUrl) {
+    return false;
+  }
+
+  try {
+    const hostname = new URL(providerUrl).hostname.toLowerCase();
+    return /^aws-external-anthropic\.[a-z0-9-]+\.api\.aws$/.test(hostname);
+  } catch {
+    return false;
+  }
+}
+
 export function resolveAnthropicAuthHeaders(
   apiKey: string,
   providerUrl?: string | null,
   options?: { forceBearerOnly?: boolean }
 ): Record<string, string> {
+  // AWS External Anthropic 拒绝 Authorization+x-api-key 共存,且不接受 Bearer。
+  // 上游硬约束优先级最高,即使调用方要求 forceBearerOnly 也按 x-api-key 单发。
+  if (looksLikeAwsExternalAnthropicUrl(providerUrl)) {
+    if (options?.forceBearerOnly) {
+      logger.warn(
+        "[anthropic-auth] forceBearerOnly overridden for AWS External Anthropic gateway; sending x-api-key only",
+        { providerUrl }
+      );
+    }
+    return {
+      "x-api-key": apiKey,
+    };
+  }
+
   if (options?.forceBearerOnly || looksLikeAnthropicProxyUrl(providerUrl)) {
     return {
       Authorization: `Bearer ${apiKey}`,

--- a/src/app/v1/_lib/headers.ts
+++ b/src/app/v1/_lib/headers.ts
@@ -1,4 +1,3 @@
-import { redactUrlCredentials } from "@/lib/api/v1/_shared/redaction";
 import { logger } from "@/lib/logger";
 
 /**
@@ -44,6 +43,15 @@ export function looksLikeAnthropicProxyUrl(providerUrl?: string | null): boolean
 // 该网关使用 SigV4(Authorization)或 API Key(x-api-key)二选一鉴权;同时携带两者
 // 会被服务端拒绝(`request must not include both 'authorization' and 'x-api-key' headers`)。
 // Bearer 形式不被支持,所以代理只能走 x-api-key 路径。
+function safeUrlHost(providerUrl?: string | null): string | undefined {
+  if (!providerUrl) return undefined;
+  try {
+    return new URL(providerUrl).host;
+  } catch {
+    return undefined;
+  }
+}
+
 export function looksLikeAwsExternalAnthropicUrl(providerUrl?: string | null): boolean {
   if (!providerUrl) {
     return false;
@@ -68,10 +76,11 @@ export function resolveAnthropicAuthHeaders(
   // 上游硬约束优先级最高,即使调用方要求 forceBearerOnly 也按 x-api-key 单发。
   if (looksLikeAwsExternalAnthropicUrl(providerUrl)) {
     if (options?.forceBearerOnly) {
-      // providerUrl 可能含 userinfo / query 凭据，落日志前必须脱敏。
+      // 只记录 host：userinfo / query / fragment 都可能携带签名 token 或 API key，
+      // 直接落整段 URL（甚至仅做 userinfo 脱敏）都会留出泄露面。
       logger.warn(
         "[anthropic-auth] forceBearerOnly overridden for AWS External Anthropic gateway; sending x-api-key only",
-        { providerUrl: redactUrlCredentials(providerUrl) }
+        { providerHost: safeUrlHost(providerUrl) }
       );
     }
     return {

--- a/src/lib/api-client/v1/actions/providers.ts
+++ b/src/lib/api-client/v1/actions/providers.ts
@@ -1,6 +1,10 @@
 import type { EditProviderResult, RemoveProviderResult } from "@/actions/providers";
 import { DASHBOARD_COMPAT_HEADER } from "@/lib/api/v1/_shared/constants";
-import type { ProviderDisplay, ProviderStatisticsMap } from "@/types/provider";
+import type {
+  ProviderDisplay,
+  ProviderHealthStatus,
+  ProviderStatisticsMap,
+} from "@/types/provider";
 import {
   apiDeleteWithHeaders,
   apiGet,
@@ -19,7 +23,12 @@ export type {
   ProviderBatchPreviewRow,
   RemoveProviderResult,
 } from "@/actions/providers";
-export type { ProviderDisplay, ProviderStatisticsMap } from "@/types/provider";
+export type {
+  ProviderCircuitHealth,
+  ProviderDisplay,
+  ProviderHealthStatus,
+  ProviderStatisticsMap,
+} from "@/types/provider";
 
 const dashboardCompatOptions = {
   headers: {
@@ -89,8 +98,10 @@ export function autoSortProviderPriority(args: unknown) {
   );
 }
 
-export function getProvidersHealthStatus() {
-  return toActionResult(apiGet("/api/v1/providers/health", dashboardCompatOptions));
+// 仪表盘内的 React Query 直接消费返回值；这里不要再用 `toActionResult` 包装，
+// 否则 consumer 会拿到 `{ ok, data }` 而非熔断状态 map，所有熔断指示器永远不显示。
+export function getProvidersHealthStatus(): Promise<ProviderHealthStatus> {
+  return apiGet<ProviderHealthStatus>("/api/v1/providers/health", dashboardCompatOptions);
 }
 
 export function resetProviderCircuit(providerId: number) {

--- a/src/lib/api-client/v1/openapi-types.gen.ts
+++ b/src/lib/api-client/v1/openapi-types.gen.ts
@@ -18669,7 +18669,7 @@ export interface operations {
                 /** @description Optional action category filter. */
                 category?: "auth" | "user" | "provider" | "provider_group" | "system_settings" | "key" | "notification" | "sensitive_word" | "model_price";
                 /** @description Optional success filter. */
-                success?: boolean | null;
+                success?: "true" | "false";
                 /** @description Optional inclusive start time. */
                 from?: string;
                 /** @description Optional inclusive end time. */

--- a/src/lib/api-client/v1/openapi-types.gen.ts
+++ b/src/lib/api-client/v1/openapi-types.gen.ts
@@ -15371,6 +15371,8 @@ export interface operations {
                     replacement?: unknown;
                     /** @description Filter priority. */
                     priority?: number;
+                    /** @description Whether the filter is enabled. */
+                    isEnabled?: boolean;
                     /**
                      * @description Binding type.
                      * @enum {string}
@@ -16354,6 +16356,8 @@ export interface operations {
                     replacement?: unknown;
                     /** @description Filter priority. */
                     priority?: number;
+                    /** @description Whether the filter is enabled. */
+                    isEnabled?: boolean;
                     /**
                      * @description Binding type.
                      * @enum {string}
@@ -16377,8 +16381,6 @@ export interface operations {
                     operations?: {
                         [key: string]: unknown;
                     }[] | null;
-                    /** @description Whether the filter is enabled. */
-                    isEnabled?: boolean;
                 };
             };
         };

--- a/src/lib/api/v1/schemas/audit-logs.ts
+++ b/src/lib/api/v1/schemas/audit-logs.ts
@@ -19,7 +19,12 @@ export const AuditLogListQuerySchema = z.object({
   cursor: z.string().min(1).optional().describe("Opaque pagination cursor."),
   limit: z.coerce.number().int().min(1).max(100).default(20).describe("Page size."),
   category: AuditCategorySchema.optional().describe("Optional action category filter."),
-  success: z.coerce.boolean().optional().describe("Optional success filter."),
+  // 注意: 不用 z.coerce.boolean()，因为 Boolean("false") === true 会让"失败"过滤器始终返回成功记录。
+  success: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((val) => (val === undefined ? undefined : val === "true"))
+    .describe("Optional success filter."),
   from: IsoDateTimeStringSchema.optional().describe("Optional inclusive start time."),
   to: IsoDateTimeStringSchema.optional().describe("Optional inclusive end time."),
 });

--- a/src/lib/api/v1/schemas/request-filters.ts
+++ b/src/lib/api/v1/schemas/request-filters.ts
@@ -60,6 +60,7 @@ export const RequestFilterCreateSchema = z
     matchType: RequestFilterMatchTypeSchema.optional().describe("Optional match type."),
     replacement: z.unknown().optional().describe("Replacement value."),
     priority: z.number().int().optional().describe("Filter priority."),
+    isEnabled: z.boolean().optional().describe("Whether the filter is enabled."),
     bindingType: RequestFilterBindingTypeSchema.optional().describe("Binding type."),
     providerIds: z
       .array(z.number().int().positive())
@@ -77,11 +78,7 @@ export const RequestFilterCreateSchema = z
   })
   .strict();
 
-export const RequestFilterUpdateSchema = RequestFilterCreateSchema.extend({
-  isEnabled: z.boolean().optional().describe("Whether the filter is enabled."),
-})
-  .partial()
-  .strict();
+export const RequestFilterUpdateSchema = RequestFilterCreateSchema.partial().strict();
 
 export const RequestFilterIdParamSchema = z.object({
   id: z.coerce.number().int().positive().describe("Request filter id."),

--- a/src/lib/model-pattern-matcher.ts
+++ b/src/lib/model-pattern-matcher.ts
@@ -1,3 +1,4 @@
+import { resolveProviderPatternRegex } from "@/lib/provider-pattern-regex";
 import type { ProviderModelRedirectMatchType } from "@/types/provider";
 
 export function matchesPattern(
@@ -14,13 +15,12 @@ export function matchesPattern(
       return model.endsWith(pattern);
     case "contains":
       return model.includes(pattern);
-    case "regex":
-      try {
-        // 不隐式补 ^/$，需要全字符串匹配时请显式写成 ^pattern$。
-        return new RegExp(pattern).test(model);
-      } catch {
-        return false;
-      }
+    case "regex": {
+      // 不隐式补 ^/$，需要全字符串匹配时请显式写成 ^pattern$。
+      // 解析失败时尝试把 `*`/`?` 当 glob 通配符，兼容旧版输入习惯。
+      const compiled = resolveProviderPatternRegex(pattern);
+      return compiled ? compiled.regex.test(model) : false;
+    }
     default:
       return false;
   }

--- a/src/lib/provider-allowed-model-schema.ts
+++ b/src/lib/provider-allowed-model-schema.ts
@@ -2,6 +2,7 @@ import safeRegex from "safe-regex";
 import { z } from "zod";
 import { normalizeAllowedModelRules } from "@/lib/allowed-model-rules";
 import { PROVIDER_RULE_LIMITS } from "@/lib/constants/provider.constants";
+import { resolveProviderPatternRegex } from "@/lib/provider-pattern-regex";
 import { PROVIDER_MODEL_REDIRECT_MATCH_TYPE_SCHEMA } from "./provider-model-redirect-schema";
 
 export const PROVIDER_ALLOWED_MODEL_RULE_SCHEMA = z
@@ -21,9 +22,8 @@ export const PROVIDER_ALLOWED_MODEL_RULE_SCHEMA = z
       return;
     }
 
-    try {
-      new RegExp(rule.pattern);
-    } catch {
+    const compiled = resolveProviderPatternRegex(rule.pattern);
+    if (!compiled) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "Allowed model regex is invalid",
@@ -33,7 +33,7 @@ export const PROVIDER_ALLOWED_MODEL_RULE_SCHEMA = z
     }
 
     try {
-      if (!safeRegex(rule.pattern)) {
+      if (!safeRegex(compiled.source)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "Allowed model regex has potential ReDoS risk",

--- a/src/lib/provider-model-redirect-schema.ts
+++ b/src/lib/provider-model-redirect-schema.ts
@@ -1,6 +1,7 @@
 import safeRegex from "safe-regex";
 import { z } from "zod";
 import { PROVIDER_RULE_LIMITS } from "@/lib/constants/provider.constants";
+import { resolveProviderPatternRegex } from "@/lib/provider-pattern-regex";
 
 export const PROVIDER_MODEL_REDIRECT_MATCH_TYPE_SCHEMA = z.enum([
   "exact",
@@ -35,9 +36,8 @@ export const PROVIDER_MODEL_REDIRECT_RULE_SCHEMA = z
       return;
     }
 
-    try {
-      new RegExp(rule.source);
-    } catch {
+    const compiled = resolveProviderPatternRegex(rule.source);
+    if (!compiled) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "Redirect regex is invalid",
@@ -47,7 +47,7 @@ export const PROVIDER_MODEL_REDIRECT_RULE_SCHEMA = z
     }
 
     try {
-      if (!safeRegex(rule.source)) {
+      if (!safeRegex(compiled.source)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "Redirect regex has potential ReDoS risk",

--- a/src/lib/provider-pattern-regex.ts
+++ b/src/lib/provider-pattern-regex.ts
@@ -1,0 +1,46 @@
+// 兼容旧版“通配符”习惯：用户在 regex 模式下输入 glob 风格的 `*` / `?` 时，
+// 先按标准正则解析；若解析失败再回退把 `*` 当 `.*`、`?` 当 `.` 处理。
+// 这样既保留了已经合法的正则语义（如 `a*`），又能让 `*`、`*.`、`*-opus-*`
+// 这类用户预期的通配符在校验和运行时都被接受。
+//
+// Glob fallback 路径下会在最终的正则两端加 `^...$`，让通配符语义贴近 shell glob
+// 的整串匹配（用户写 `*.foo` 时期望“以 `.foo` 结尾”，而不是 `bar.foo.baz` 这样
+// 子串包含也算匹配）。原本就合法的正则保持子串匹配语义不变。
+
+const GLOB_META = /[*?]/;
+const REGEX_META = /[\\^$.|()[\]{}+]/g;
+
+type Compiled = { regex: RegExp; source: string };
+
+// matchesPattern 在每次调度里都会调到这里，缓存避免重复 `new RegExp`。
+// pattern 是用户配置项、规模有限，但仍设上限防御异常增长。
+const CACHE_LIMIT = 1024;
+const cache = new Map<string, Compiled | null>();
+
+export function globPatternToRegexSource(pattern: string): string {
+  return pattern.replace(REGEX_META, "\\$&").replace(/\*/g, ".*").replace(/\?/g, ".");
+}
+
+export function resolveProviderPatternRegex(pattern: string): Compiled | null {
+  if (cache.has(pattern)) {
+    return cache.get(pattern) ?? null;
+  }
+
+  let result: Compiled | null = null;
+  try {
+    result = { regex: new RegExp(pattern), source: pattern };
+  } catch {}
+
+  if (!result && GLOB_META.test(pattern)) {
+    const globSource = `^${globPatternToRegexSource(pattern)}$`;
+    try {
+      result = { regex: new RegExp(globSource), source: globSource };
+    } catch {}
+  }
+
+  if (cache.size >= CACHE_LIMIT) {
+    cache.clear();
+  }
+  cache.set(pattern, result);
+  return result;
+}

--- a/src/lib/provider-testing/utils/test-prompts.ts
+++ b/src/lib/provider-testing/utils/test-prompts.ts
@@ -4,6 +4,7 @@
  * 这里保留协议级兜底默认值；真正执行时会优先使用 presets.ts 里的模板定义。
  */
 
+import { resolveAnthropicAuthHeaders } from "@/app/v1/_lib/headers";
 import { buildProxyUrl } from "@/app/v1/_lib/url";
 import type { ProviderType } from "@/types/provider";
 import type { ClaudeTestBody, CodexTestBody, GeminiTestBody, OpenAITestBody } from "../types";
@@ -140,47 +141,6 @@ const OPENAI_VERSIONED_FALLBACK_PATHS = [
   ["/v1/models", "/models"],
 ] as const;
 
-function looksLikeAnthropicProxy(providerUrl?: string): boolean {
-  if (!providerUrl) {
-    return false;
-  }
-
-  try {
-    const hostname = new URL(providerUrl).hostname.toLowerCase();
-    if (hostname.endsWith("anthropic.com") || hostname.endsWith("claude.ai")) {
-      return false;
-    }
-    // 只匹配常见 relay/proxy 标识，避免把普通业务域名里的 “gpt” 误识别成代理层。
-    return /(?:^|[.-])(proxy|relay|gateway|router|worker|openrouter|api2d|oaipro)(?:[.-]|$)/i.test(
-      hostname
-    );
-  } catch {
-    return false;
-  }
-}
-
-function resolveClaudeHeaders(providerType: ProviderType, apiKey: string, providerUrl?: string) {
-  const headers: Record<string, string> = {
-    "anthropic-version": "2023-06-01",
-    "content-type": "application/json",
-  };
-
-  if (providerType === "claude-auth") {
-    headers.Authorization = `Bearer ${apiKey}`;
-    return headers;
-  }
-
-  if (looksLikeAnthropicProxy(providerUrl)) {
-    headers.Authorization = `Bearer ${apiKey}`;
-    return headers;
-  }
-
-  // 对非代理 Anthropic 直连保留双头，兼容只认 x-api-key 或 Bearer 的 Anthropic-compatible 层。
-  headers["x-api-key"] = apiKey;
-  headers.Authorization = `Bearer ${apiKey}`;
-  return headers;
-}
-
 export function getTestBody(providerType: ProviderType, model?: string): Record<string, unknown> {
   const targetModel = model || DEFAULT_MODELS[providerType];
 
@@ -217,11 +177,12 @@ export function getTestHeaders(
   switch (providerType) {
     case "claude":
     case "claude-auth":
-      Object.assign(
-        headers,
-        CLAUDE_TEST_HEADERS,
-        resolveClaudeHeaders(providerType, apiKey, providerUrl)
-      );
+      Object.assign(headers, {
+        ...CLAUDE_TEST_HEADERS,
+        ...resolveAnthropicAuthHeaders(apiKey, providerUrl, {
+          forceBearerOnly: providerType === "claude-auth",
+        }),
+      });
       break;
     case "codex":
       Object.assign(headers, {

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -531,6 +531,23 @@ export interface ProviderStatistics {
  */
 export type ProviderStatisticsMap = Record<number, ProviderStatistics>;
 
+/**
+ * Provider-level (key/credential) circuit breaker snapshot.
+ * Mirrors the shape returned by `/api/v1/providers/health`.
+ */
+export interface ProviderCircuitHealth {
+  circuitState: "closed" | "open" | "half-open";
+  failureCount: number;
+  lastFailureTime: number | null;
+  circuitOpenUntil: number | null;
+  recoveryMinutes: number | null;
+}
+
+/**
+ * Map of provider ID to circuit-breaker health snapshot.
+ */
+export type ProviderHealthStatus = Record<number, ProviderCircuitHealth>;
+
 export interface CreateProviderData {
   name: string;
   url: string;

--- a/tests/api/v1/audit-logs/audit-logs.test.ts
+++ b/tests/api/v1/audit-logs/audit-logs.test.ts
@@ -99,6 +99,30 @@ describe("v1 audit log endpoints", () => {
     expect(detail.json).toMatchObject({ id: 11, operatorUserName: "admin" });
   });
 
+  test("forwards success=false as boolean false to the action layer", async () => {
+    const list = await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/audit-logs?success=false",
+      headers: { Authorization: "Bearer admin-token" },
+    });
+
+    expect(list.response.status).toBe(200);
+    expect(getAuditLogsBatchMock).toHaveBeenCalledTimes(1);
+    const call = getAuditLogsBatchMock.mock.calls[0][0] as { filter: { success?: boolean } };
+    expect(call.filter.success).toBe(false);
+  });
+
+  test("omits the success filter when the query param is absent", async () => {
+    await callV1Route({
+      method: "GET",
+      pathname: "/api/v1/audit-logs",
+      headers: { Authorization: "Bearer admin-token" },
+    });
+    expect(getAuditLogsBatchMock).toHaveBeenCalledTimes(1);
+    const call = getAuditLogsBatchMock.mock.calls[0][0] as { filter: { success?: boolean } };
+    expect(call.filter.success).toBeUndefined();
+  });
+
   test("returns problem+json for invalid cursor and missing detail", async () => {
     const invalid = await callV1Route({
       method: "GET",

--- a/tests/api/v1/request-filters/request-filters.test.ts
+++ b/tests/api/v1/request-filters/request-filters.test.ts
@@ -105,6 +105,48 @@ describe("v1 request filters endpoints", () => {
       target: "x-test",
     });
 
+    const createdDisabled = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/request-filters",
+      headers: { Authorization: "Bearer admin-token" },
+      body: {
+        name: "Disabled filter",
+        scope: "header",
+        action: "set",
+        target: "x-disabled",
+        isEnabled: false,
+      },
+    });
+    expect(createdDisabled.response.status).toBe(201);
+    expect(createRequestFilterActionMock).toHaveBeenLastCalledWith({
+      name: "Disabled filter",
+      scope: "header",
+      action: "set",
+      target: "x-disabled",
+      isEnabled: false,
+    });
+
+    const createdEnabled = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/request-filters",
+      headers: { Authorization: "Bearer admin-token" },
+      body: {
+        name: "Enabled filter",
+        scope: "header",
+        action: "set",
+        target: "x-enabled",
+        isEnabled: true,
+      },
+    });
+    expect(createdEnabled.response.status).toBe(201);
+    expect(createRequestFilterActionMock).toHaveBeenLastCalledWith({
+      name: "Enabled filter",
+      scope: "header",
+      action: "set",
+      target: "x-enabled",
+      isEnabled: true,
+    });
+
     const updated = await callV1Route({
       method: "PATCH",
       pathname: "/api/v1/request-filters/1",

--- a/tests/unit/api/v1/api-client-actions.test.ts
+++ b/tests/unit/api/v1/api-client-actions.test.ts
@@ -338,4 +338,37 @@ describe("v1 action compatibility client", () => {
       "/api/v1/usage-logs?cursorCreatedAt=2026-04-28T00%3A00%3A00.000Z&cursorId=42&limit=15"
     );
   });
+
+  test("returns the raw provider health map without ActionResult wrapping", async () => {
+    // 仪表盘的 useQuery 直接消费返回值；如果再被包成 `{ ok, data }`，
+    // 熔断状态指示器和重置按钮会因为 `healthStatus[id]?.circuitState` 永远 undefined 而不显示。
+    const healthMap = {
+      1: {
+        circuitState: "open" as const,
+        failureCount: 7,
+        lastFailureTime: 1_700_000_000_000,
+        circuitOpenUntil: 1_700_000_300_000,
+        recoveryMinutes: 5,
+      },
+      2: {
+        circuitState: "closed" as const,
+        failureCount: 0,
+        lastFailureTime: null,
+        circuitOpenUntil: null,
+        recoveryMinutes: null,
+      },
+    };
+    getMock.mockResolvedValue(healthMap);
+
+    const result = await providers.getProvidersHealthStatus();
+
+    expect(getMock).toHaveBeenCalledWith("/api/v1/providers/health", {
+      headers: { [DASHBOARD_COMPAT_HEADER]: "1" },
+    });
+    expect(result).toEqual(healthMap);
+    // Critical: the return must be the map itself, not the `{ ok, data }` wrapper.
+    expect(result).not.toHaveProperty("ok");
+    expect(result).not.toHaveProperty("data");
+    expect(result[1]?.circuitState).toBe("open");
+  });
 });

--- a/tests/unit/api/v1/audit-log-success-query-schema.test.ts
+++ b/tests/unit/api/v1/audit-log-success-query-schema.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+
+import { AuditLogListQuerySchema } from "@/lib/api/v1/schemas/audit-logs";
+
+describe("v1 AuditLogListQuerySchema - success 过滤器查询字符串解析", () => {
+  test("success=true 解析为 true", () => {
+    const result = AuditLogListQuerySchema.safeParse({ success: "true" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.success).toBe(true);
+    }
+  });
+
+  test("success=false 解析为 false（防止 Boolean('false')===true 的回归）", () => {
+    const result = AuditLogListQuerySchema.safeParse({ success: "false" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.success).toBe(false);
+    }
+  });
+
+  test("缺省 success 时保持 undefined（不应用过滤器）", () => {
+    const result = AuditLogListQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.success).toBeUndefined();
+    }
+  });
+
+  test("不支持的字符串被拒绝，返回校验错误", () => {
+    const result = AuditLogListQuerySchema.safeParse({ success: "maybe" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/lib/model-pattern-matcher.test.ts
+++ b/tests/unit/lib/model-pattern-matcher.test.ts
@@ -21,4 +21,21 @@ describe("matchesPattern", () => {
   it("returns false for invalid regex patterns instead of throwing", () => {
     expect(matchesPattern("claude-opus-4-1", "regex", "[")).toBe(false);
   });
+
+  describe("glob fallback for regex matching", () => {
+    it.each<[string, string, boolean]>([
+      ["*", "claude-opus-4-1", true],
+      ["*", "", true],
+      // 锚定 glob 后 `*.` 表示“以 . 结尾”，不再匹配子串中带点的 "claude.opus"。
+      ["*.", "claude.opus", false],
+      ["*.", "claude.opus.", true],
+      ["*.", "claudeopus", false],
+      ["claude-*", "claude-opus-4-1", true],
+      ["claude-*", "gpt-4", false],
+      ["*-opus-*", "claude-opus-4-1", true],
+      ["*-opus-*", "claude-sonnet-4-1", false],
+    ])("regex pattern %s matches %s -> %s via glob fallback", (pattern, model, expected) => {
+      expect(matchesPattern(model, "regex", pattern)).toBe(expected);
+    });
+  });
 });

--- a/tests/unit/lib/provider-allowed-model-schema.test.ts
+++ b/tests/unit/lib/provider-allowed-model-schema.test.ts
@@ -49,4 +49,29 @@ describe("provider-allowed-model-schema", () => {
 
     expect(result.success).toBe(true);
   });
+
+  describe("regex 模式的 glob 通配符兼容", () => {
+    it.each<[string]>([
+      ["*"],
+      ["*."],
+      ["claude-*"],
+      ["*-opus-*"],
+      ["?"],
+    ])("接受 glob 风格的 pattern: %s", (pattern) => {
+      const result = PROVIDER_ALLOWED_MODEL_RULE_SCHEMA.safeParse({
+        matchType: "regex",
+        pattern,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("仍然拒绝纯粹无法解析的正则", () => {
+      const result = PROVIDER_ALLOWED_MODEL_RULE_SCHEMA.safeParse({
+        matchType: "regex",
+        pattern: "[",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/tests/unit/lib/provider-model-redirect-schema.test.ts
+++ b/tests/unit/lib/provider-model-redirect-schema.test.ts
@@ -51,4 +51,31 @@ describe("provider-model-redirect-schema", () => {
 
     expect(result.success).toBe(true);
   });
+
+  describe("regex 模式的 glob 通配符兼容", () => {
+    it.each<[string]>([
+      ["*"],
+      ["*."],
+      ["claude-*"],
+      ["*-opus-*"],
+      ["?"],
+    ])("接受 glob 风格的 source: %s", (source) => {
+      const result = PROVIDER_MODEL_REDIRECT_RULE_SCHEMA.safeParse({
+        matchType: "regex",
+        source,
+        target: "claude-sonnet-4-6",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("仍然拒绝纯粹无法解析的正则", () => {
+      const result = PROVIDER_MODEL_REDIRECT_RULE_SCHEMA.safeParse({
+        matchType: "regex",
+        source: "[",
+        target: "claude-sonnet-4-6",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/tests/unit/lib/provider-pattern-regex.test.ts
+++ b/tests/unit/lib/provider-pattern-regex.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  globPatternToRegexSource,
+  resolveProviderPatternRegex,
+} from "@/lib/provider-pattern-regex";
+
+describe("globPatternToRegexSource", () => {
+  it.each<[string, string]>([
+    ["*", ".*"],
+    ["*.", ".*\\."],
+    ["*-foo", ".*-foo"],
+    ["?", "."],
+    ["claude-*", "claude-.*"],
+    ["claude-?-opus", "claude-.-opus"],
+    ["a+b", "a\\+b"],
+    ["a.b", "a\\.b"],
+    ["(group)", "\\(group\\)"],
+  ])("converts %s to %s", (pattern, expected) => {
+    expect(globPatternToRegexSource(pattern)).toBe(expected);
+  });
+});
+
+describe("resolveProviderPatternRegex", () => {
+  it("returns the original regex when pattern is already valid", () => {
+    const result = resolveProviderPatternRegex("^claude-.*$");
+    expect(result).not.toBeNull();
+    expect(result?.source).toBe("^claude-.*$");
+    expect(result?.regex.test("claude-opus-4-1")).toBe(true);
+  });
+
+  it("preserves legal regex semantics for ambiguous patterns like a*", () => {
+    const result = resolveProviderPatternRegex("a*");
+    expect(result).not.toBeNull();
+    expect(result?.source).toBe("a*");
+    expect(result?.regex.test("")).toBe(true);
+    expect(result?.regex.test("aaa")).toBe(true);
+  });
+
+  it("falls back to anchored glob when bare * is used", () => {
+    const result = resolveProviderPatternRegex("*");
+    expect(result).not.toBeNull();
+    expect(result?.source).toBe("^.*$");
+    expect(result?.regex.test("claude-opus-4-1")).toBe(true);
+    expect(result?.regex.test("")).toBe(true);
+  });
+
+  it("anchors glob fallback to avoid substring matches", () => {
+    const result = resolveProviderPatternRegex("*.foo");
+    expect(result?.source).toBe("^.*\\.foo$");
+    expect(result?.regex.test("claude.foo")).toBe(true);
+    // 不应匹配 `bar.foo.baz` —— shell glob 用户预期“以 .foo 结尾”，
+    // 而不是子串包含。
+    expect(result?.regex.test("bar.foo.baz")).toBe(false);
+  });
+
+  it("falls back to anchored glob for *.style patterns", () => {
+    const result = resolveProviderPatternRegex("*.");
+    expect(result?.source).toBe("^.*\\.$");
+    expect(result?.regex.test("claude-opus-4-1.")).toBe(true);
+    expect(result?.regex.test("claude.opus")).toBe(false);
+  });
+
+  it("returns null for patterns that are neither valid regex nor glob-fixable", () => {
+    expect(resolveProviderPatternRegex("[")).toBeNull();
+    expect(resolveProviderPatternRegex("(")).toBeNull();
+  });
+
+  it("documents divergence: `claude-*` is valid regex and keeps regex semantics", () => {
+    // `claude-*` 是合法正则（claud + 零个或多个 e + 零个或多个 `-`，且不锚定），
+    // 因此走 regex 路径，与 shell glob 的“以 claude- 开头”略有差异。
+    const result = resolveProviderPatternRegex("claude-*");
+    expect(result?.source).toBe("claude-*");
+    expect(result?.regex.test("claude-opus-4-1")).toBe(true);
+    expect(result?.regex.test("gpt-4")).toBe(false);
+  });
+
+  it("falls back to anchored glob when `*` makes the pattern non-regex", () => {
+    // `*claude*` 在正则里非法，会走 glob 路径并锚定，语义贴近 shell glob 的
+    // “整串包含 claude”。
+    const result = resolveProviderPatternRegex("*claude*");
+    expect(result?.source).toBe("^.*claude.*$");
+    expect(result?.regex.test("myclaudemodel")).toBe(true);
+    expect(result?.regex.test("gpt-4")).toBe(false);
+  });
+
+  it("memoizes results across repeated calls for the same input", () => {
+    const a = resolveProviderPatternRegex("^claude-.*$");
+    const b = resolveProviderPatternRegex("^claude-.*$");
+    expect(a).toBe(b);
+  });
+});

--- a/tests/unit/provider-testing/test-prompts-headers.test.ts
+++ b/tests/unit/provider-testing/test-prompts-headers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { getTestHeaders } from "@/lib/provider-testing/utils/test-prompts";
+
+describe("provider-testing getTestHeaders — Anthropic auth header selection", () => {
+  it("sends both x-api-key and Authorization for direct api.anthropic.com", () => {
+    const headers = getTestHeaders("claude", "sk-test", "https://api.anthropic.com");
+    expect(headers["x-api-key"]).toBe("sk-test");
+    expect(headers.Authorization).toBe("Bearer sk-test");
+  });
+
+  it("sends Bearer-only for proxy-like Anthropic relays", () => {
+    const headers = getTestHeaders("claude", "sk-test", "https://openrouter.example.com");
+    expect(headers.Authorization).toBe("Bearer sk-test");
+    expect(headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("sends Bearer-only for claude-auth regardless of URL", () => {
+    const headers = getTestHeaders("claude-auth", "sk-test", "https://api.anthropic.com");
+    expect(headers.Authorization).toBe("Bearer sk-test");
+    expect(headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("sends x-api-key only (no Authorization) for AWS External Anthropic gateway", () => {
+    const headers = getTestHeaders(
+      "claude",
+      "sk-test",
+      "https://aws-external-anthropic.us-east-1.api.aws/v1/messages"
+    );
+    expect(headers["x-api-key"]).toBe("sk-test");
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("keeps x-api-key only even when claude-auth + AWS URL combine (upstream wins)", () => {
+    const headers = getTestHeaders(
+      "claude-auth",
+      "sk-test",
+      "https://aws-external-anthropic.us-west-2.api.aws"
+    );
+    expect(headers["x-api-key"]).toBe("sk-test");
+    expect(headers.Authorization).toBeUndefined();
+  });
+});

--- a/tests/unit/proxy/anthropic-auth-headers.test.ts
+++ b/tests/unit/proxy/anthropic-auth-headers.test.ts
@@ -132,21 +132,27 @@ describe("Anthropic auth header helpers", () => {
       }
     });
 
-    it("redacts userinfo credentials from the warning's providerUrl metadata", () => {
+    it("only logs the URL host so userinfo / query / fragment secrets cannot leak", () => {
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       try {
         resolveAnthropicAuthHeaders(
           "sk-test",
-          "https://leaked-user:leaked-pass@aws-external-anthropic.us-east-1.api.aws/v1/messages",
+          "https://leaked-user:leaked-pass@aws-external-anthropic.us-east-1.api.aws/v1/messages?signature=leaked-sig&token=leaked-tok#leaked-frag",
           { forceBearerOnly: true }
         );
         expect(warnSpy).toHaveBeenCalledTimes(1);
-        const meta = warnSpy.mock.calls[0]?.[1] as { providerUrl?: string } | undefined;
-        expect(meta?.providerUrl).toBeDefined();
-        expect(meta?.providerUrl).not.toContain("leaked-user");
-        expect(meta?.providerUrl).not.toContain("leaked-pass");
-        expect(meta?.providerUrl).toContain("REDACTED");
-        expect(meta?.providerUrl).toContain("aws-external-anthropic.us-east-1.api.aws");
+        const meta = warnSpy.mock.calls[0]?.[1] as
+          | { providerHost?: string; providerUrl?: string }
+          | undefined;
+        // 整段 URL 不应出现在日志元数据中，避免任何 path/query/fragment 泄露面。
+        expect(meta?.providerUrl).toBeUndefined();
+        expect(meta?.providerHost).toBe("aws-external-anthropic.us-east-1.api.aws");
+        const serialized = JSON.stringify(meta);
+        expect(serialized).not.toContain("leaked-user");
+        expect(serialized).not.toContain("leaked-pass");
+        expect(serialized).not.toContain("leaked-sig");
+        expect(serialized).not.toContain("leaked-tok");
+        expect(serialized).not.toContain("leaked-frag");
       } finally {
         warnSpy.mockRestore();
       }

--- a/tests/unit/proxy/anthropic-auth-headers.test.ts
+++ b/tests/unit/proxy/anthropic-auth-headers.test.ts
@@ -70,6 +70,28 @@ describe("Anthropic auth header helpers", () => {
       expect(looksLikeAwsExternalAnthropicUrl("not a url")).toBe(false);
     });
 
+    it("rejects spoofed region segments that don't match the AWS region format", () => {
+      // 单段（非 `<area>-<direction>-<digit>` 形式）必须被拒绝，防止 `*.fake.api.aws` 伪装。
+      expect(looksLikeAwsExternalAnthropicUrl("https://aws-external-anthropic.fake.api.aws")).toBe(
+        false
+      );
+      expect(
+        looksLikeAwsExternalAnthropicUrl("https://aws-external-anthropic.us-east.api.aws")
+      ).toBe(false);
+      expect(
+        looksLikeAwsExternalAnthropicUrl("https://aws-external-anthropic.-east-1.api.aws")
+      ).toBe(false);
+    });
+
+    it("still accepts multi-segment AWS region names like us-gov-west-1", () => {
+      expect(
+        looksLikeAwsExternalAnthropicUrl("https://aws-external-anthropic.us-gov-west-1.api.aws")
+      ).toBe(true);
+      expect(
+        looksLikeAwsExternalAnthropicUrl("https://aws-external-anthropic.ap-southeast-1.api.aws")
+      ).toBe(true);
+    });
+
     it("sends only x-api-key when proxying to aws-external-anthropic", () => {
       expect(
         resolveAnthropicAuthHeaders(
@@ -105,6 +127,26 @@ describe("Anthropic auth header helpers", () => {
         warnSpy.mockClear();
         resolveAnthropicAuthHeaders("sk-test", "https://aws-external-anthropic.us-east-1.api.aws");
         expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("redacts userinfo credentials from the warning's providerUrl metadata", () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      try {
+        resolveAnthropicAuthHeaders(
+          "sk-test",
+          "https://leaked-user:leaked-pass@aws-external-anthropic.us-east-1.api.aws/v1/messages",
+          { forceBearerOnly: true }
+        );
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const meta = warnSpy.mock.calls[0]?.[1] as { providerUrl?: string } | undefined;
+        expect(meta?.providerUrl).toBeDefined();
+        expect(meta?.providerUrl).not.toContain("leaked-user");
+        expect(meta?.providerUrl).not.toContain("leaked-pass");
+        expect(meta?.providerUrl).toContain("REDACTED");
+        expect(meta?.providerUrl).toContain("aws-external-anthropic.us-east-1.api.aws");
       } finally {
         warnSpy.mockRestore();
       }

--- a/tests/unit/proxy/anthropic-auth-headers.test.ts
+++ b/tests/unit/proxy/anthropic-auth-headers.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { looksLikeAnthropicProxyUrl, resolveAnthropicAuthHeaders } from "@/app/v1/_lib/headers";
+import { describe, expect, it, vi } from "vitest";
+import {
+  looksLikeAnthropicProxyUrl,
+  looksLikeAwsExternalAnthropicUrl,
+  resolveAnthropicAuthHeaders,
+} from "@/app/v1/_lib/headers";
+import { logger } from "@/lib/logger";
 
 describe("Anthropic auth header helpers", () => {
   it("treats official Anthropic domains as direct endpoints", () => {
@@ -32,6 +37,77 @@ describe("Anthropic auth header helpers", () => {
       })
     ).toEqual({
       Authorization: "Bearer sk-test",
+    });
+  });
+
+  describe("AWS External Anthropic (Claude Platform on AWS)", () => {
+    it("recognises aws-external-anthropic regional hosts", () => {
+      expect(
+        looksLikeAwsExternalAnthropicUrl(
+          "https://aws-external-anthropic.us-east-1.api.aws/v1/messages"
+        )
+      ).toBe(true);
+      expect(
+        looksLikeAwsExternalAnthropicUrl("https://aws-external-anthropic.us-west-2.api.aws")
+      ).toBe(true);
+      expect(
+        looksLikeAwsExternalAnthropicUrl(
+          "HTTPS://AWS-EXTERNAL-ANTHROPIC.EU-WEST-1.API.AWS/v1/messages"
+        )
+      ).toBe(true);
+    });
+
+    it("rejects unrelated hostnames including bedrock and api.anthropic.com", () => {
+      expect(looksLikeAwsExternalAnthropicUrl("https://api.anthropic.com/v1/messages")).toBe(false);
+      expect(
+        looksLikeAwsExternalAnthropicUrl("https://bedrock-runtime.us-east-1.amazonaws.com")
+      ).toBe(false);
+      expect(looksLikeAwsExternalAnthropicUrl("https://bedrock-mantle.us-east-1.api.aws")).toBe(
+        false
+      );
+      expect(looksLikeAwsExternalAnthropicUrl("https://my-aws-external-anthropic.com")).toBe(false);
+      expect(looksLikeAwsExternalAnthropicUrl(undefined)).toBe(false);
+      expect(looksLikeAwsExternalAnthropicUrl("not a url")).toBe(false);
+    });
+
+    it("sends only x-api-key when proxying to aws-external-anthropic", () => {
+      expect(
+        resolveAnthropicAuthHeaders(
+          "sk-test",
+          "https://aws-external-anthropic.us-east-1.api.aws/v1/messages"
+        )
+      ).toEqual({
+        "x-api-key": "sk-test",
+      });
+    });
+
+    it("keeps x-api-key only even when forceBearerOnly is requested for AWS", () => {
+      // AWS External Anthropic does not accept `Authorization: Bearer`; an upstream
+      // hard constraint must win over the claude-auth provider preference.
+      expect(
+        resolveAnthropicAuthHeaders("sk-test", "https://aws-external-anthropic.us-east-1.api.aws", {
+          forceBearerOnly: true,
+        })
+      ).toEqual({
+        "x-api-key": "sk-test",
+      });
+    });
+
+    it("warns when forceBearerOnly is silently overridden by the AWS guard", () => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      try {
+        resolveAnthropicAuthHeaders("sk-test", "https://aws-external-anthropic.us-east-1.api.aws", {
+          forceBearerOnly: true,
+        });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0]?.[0]).toContain("forceBearerOnly");
+
+        warnSpy.mockClear();
+        resolveAnthropicAuthHeaders("sk-test", "https://aws-external-anthropic.us-east-1.api.aws");
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
Release v0.8.2 rolls up three bug fixes from the `dev` branch: AWS External Anthropic gateway auth header compatibility for both proxy and provider-testing paths, and a request filter API validation fix.

## Changes

### 1. Fix: Claude Platform on AWS gateway auth headers (proxy path)
**PR:** #1197 | **Files:** `src/app/v1/_lib/headers.ts`

The AWS External Anthropic gateway (`aws-external-anthropic.{region}.api.aws`) rejects requests containing both `Authorization` and `x-api-key` headers, and does not accept `Bearer` auth. The proxy was sending both, causing 400 errors.

- Added `looksLikeAwsExternalAnthropicUrl()` to detect AWS gateway hostnames
- Modified `resolveAnthropicAuthHeaders()` to send **only** `x-api-key` for this gateway
- Upstream hard constraint takes priority even when `forceBearerOnly` is requested (with a logged warning)

Related to #1074 (prior Anthropic auth header optimization in the same file)

### 2. Fix: Claude Platform on AWS gateway auth headers (provider-testing path)
**PR:** #1198 (follow-up to #1197) | **Files:** `src/lib/provider-testing/utils/test-prompts.ts`

The provider-testing code (`/api/v1/providers/test:anthropic-messages`) had a **forked copy** of the auth header logic (`resolveClaudeHeaders`) that was unaware of the AWS gateway constraint from #1197, still sending dual headers and causing 401 errors during provider tests.

- Deleted the duplicated `resolveClaudeHeaders` and `looksLikeAnthropicProxy` functions (~40 lines)
- Provider-testing now delegates to the shared `resolveAnthropicAuthHeaders` helper, keeping both paths in sync

### 3. Fix: Request filter `isEnabled` on create endpoint
**PR:** #1196 | **Files:** `src/actions/request-filters.ts`, `src/lib/api/v1/schemas/request-filters.ts`, `src/lib/api-client/v1/openapi-types.gen.ts`

`POST /api/v1/request-filters` returned a `400 unrecognized_keys` error when the body included `isEnabled`, even though the UI always sends it and the repository layer already supports it.

- Added `isEnabled` to `RequestFilterCreateSchema` and `createRequestFilterAction`
- Simplified `RequestFilterUpdateSchema` to derive from `.partial()` instead of `.extend()`
- Updated generated OpenAPI types to match

## Testing
- `tests/unit/proxy/anthropic-auth-headers.test.ts` — 4 new tests for AWS gateway URL detection, auth header output, and `forceBearerOnly` override behavior
- `tests/unit/provider-testing/test-prompts-headers.test.ts` — 5 new tests covering all Anthropic header-selection branches (direct, proxy, claude-auth, AWS, AWS+claude-auth)
- `tests/api/v1/request-filters/request-filters.test.ts` — 2 new tests for `isEnabled: false` and `isEnabled: true` on the create endpoint

## Breaking Changes
None. All changes are backwards-compatible:
- The AWS auth fix only affects a specific gateway hostname pattern
- `isEnabled` on create is a new optional field (defaults to `true` when omitted)
- `RequestFilterUpdateSchema` behavior is unchanged (`.partial()` now inherits `isEnabled` from the base schema)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This release rolls up four bug fixes: AWS External Anthropic gateway auth header compatibility (proxy and provider-testing paths), a `POST /api/v1/request-filters` `isEnabled` schema gap, a `Boolean("false") === true` bug in the audit-log `success` query filter, and a silent health-status wrapping bug that was hiding circuit-breaker indicators in the dashboard. It also introduces a glob-fallback layer for regex model patterns so users can write `claude-*` or `*-opus-*` without knowing regex syntax.

- **Auth headers**: `looksLikeAwsExternalAnthropicUrl` is added to `headers.ts`; provider-testing now delegates to the same shared helper instead of its own forked copy, keeping both paths in sync with the new AWS constraint.
- **Schema fixes**: `isEnabled` is promoted into `RequestFilterCreateSchema`, `RequestFilterUpdateSchema` is simplified to `.partial()`, and the audit-log `success` param switches from `z.coerce.boolean()` to an explicit enum+transform.
- **Glob-pattern fallback**: A new `provider-pattern-regex.ts` module compiles user patterns as regex first, falling back to glob-style `*`/`?` expansion when the raw string is not valid regex; the same resolver is wired into validation (Zod schemas, editor components) and runtime matching (`matchesPattern`)."
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the three targeted bug fixes; the new glob-fallback module has a logic defect in mixed *? patterns that should be corrected before the regex-pattern feature is relied upon in production.

The AWS auth header fix, isEnabled schema gap, audit-log boolean coerce bug, and health-status unwrap are all straightforward and well-tested. The glob-fallback module introduces a defect in `globPatternToRegexSource` where mixed `*?` patterns produce incorrect regex output due to inter-pass character replacement.

src/lib/provider-pattern-regex.ts — `globPatternToRegexSource` needs a character-by-character approach to avoid the inter-pass `?` replacement bug.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/provider-pattern-regex.ts | New file implementing glob-to-regex fallback with an LRU-less cache; sequential replace chain in `globPatternToRegexSource` produces wrong output for mixed `*?` patterns. |
| src/app/v1/_lib/headers.ts | Adds `looksLikeAwsExternalAnthropicUrl` with a well-anchored hostname regex and integrates it into `resolveAnthropicAuthHeaders` to send only `x-api-key` for AWS gateway; `forceBearerOnly` override is handled with a safe host-only log. |
| src/lib/provider-testing/utils/test-prompts.ts | Removes ~40 lines of duplicated auth-header logic and delegates to the shared `resolveAnthropicAuthHeaders`, keeping proxy and provider-test paths in sync. |
| src/actions/request-filters.ts | Adds `isEnabled` to the action parameter type and applies `?? true` default before forwarding to the repository layer, consistent with how `priority` and `bindingType` are handled. |
| src/lib/api/v1/schemas/audit-logs.ts | Replaces `z.coerce.boolean()` with `z.enum(["true","false"]).transform(...)` to prevent `Boolean("false") === true` from making the failure filter always return successful records. |
| src/lib/api-client/v1/actions/providers.ts | Removes `toActionResult` wrapping from `getProvidersHealthStatus` so React Query consumers receive the raw health map; also adds explicit `ProviderHealthStatus` return type. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resolveAnthropicAuthHeaders(apiKey, providerUrl, opts)"] --> B{looksLikeAwsExternalAnthropicUrl?}
    B -->|yes| C["x-api-key only\n(warn if forceBearerOnly)"]
    B -->|no| D{forceBearerOnly OR\nlooksLikeAnthropicProxyUrl?}
    D -->|yes| E["Authorization: Bearer only"]
    D -->|no| F["x-api-key + Authorization: Bearer"]

    G["resolveProviderPatternRegex(pattern)"] --> H{valid regex?}
    H -->|yes| I["Compiled{regex, source=pattern}"]
    H -->|no| J{contains * or ?}
    J -->|yes| K["globPatternToRegexSource → anchored ^…$"]
    K --> L["Compiled{regex, source=globSource}"]
    J -->|no| M["null — pattern rejected"]

    N["matchesPattern / Zod schema / editor"] --> G
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/lib/provider-pattern-regex.ts:20-22
Sequential `.replace()` chains corrupt patterns that mix `*` and `?`. When `*` is converted to `.*` in the second pass, the trailing `?` it introduces is immediately consumed by the third pass's `?` → `.` replacement.

Concrete failure: input `*?` (glob: "any chars, then any single char") yields `^...$` (exactly 3 chars) instead of `^.*.$` (length ≥ 1). Similarly `?*` yields `^...*$` (length ≥ 2) rather than `^..*$` (length ≥ 1). A character-by-character scan eliminates the inter-pass interference.

```suggestion
export function globPatternToRegexSource(pattern: string): string {
  let result = "";
  for (const ch of pattern) {
    if (ch === "*") result += ".*";
    else if (ch === "?") result += ".";
    else if (REGEX_META.test(ch)) result += "\\" + ch;
    else result += ch;
  }
  return result;
}
```

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(providers): accept glob wildcards in..."](https://github.com/ding113/claude-code-hub/commit/c6dee21b632352c148e7d81fb0e7f3632315bf1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32578817)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->