### PR TITLE
fix(providers): restore circuit-breaker indicator and reset action

### DIFF
--- a/src/app/[locale]/settings/providers/_components/provider-manager-loader.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-manager-loader.tsx
@@ -5,6 +5,7 @@ import {
   getProviderStatisticsAsync,
   getProviders,
   getProvidersHealthStatus,
+  type ProviderHealthStatus,
 } from "@/lib/api-client/v1/actions/providers";
 import { getSystemSettings } from "@/lib/api-client/v1/actions/system-config";
 import type { CurrencyCode } from "@/lib/utils/currency";
@@ -12,17 +13,6 @@ import type { ProviderDisplay, ProviderStatisticsMap } from "@/types/provider";
 import type { User } from "@/types/user";
 import { AddProviderDialog } from "./add-provider-dialog";
 import { ProviderManager } from "./provider-manager";
-
-type ProviderHealthStatus = Record<
-  number,
-  {
-    circuitState: "closed" | "open" | "half-open";
-    failureCount: number;
-    lastFailureTime: number | null;
-    circuitOpenUntil: number | null;
-    recoveryMinutes: number | null;
-  }
->;
 
 interface ProviderManagerLoaderProps {
   currentUser?: User;

--- a/src/app/[locale]/settings/providers/_components/provider-manager.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-manager.tsx
@@ -28,7 +28,12 @@ import { Switch } from "@/components/ui/switch";
 import { useDebounce } from "@/lib/hooks/use-debounce";
 import type { CurrencyCode } from "@/lib/utils/currency";
 import { parseProviderGroups, resolveProviderGroupsWithDefault } from "@/lib/utils/provider-group";
-import type { ProviderDisplay, ProviderStatisticsMap, ProviderType } from "@/types/provider";
+import type {
+  ProviderDisplay,
+  ProviderHealthStatus,
+  ProviderStatisticsMap,
+  ProviderType,
+} from "@/types/provider";
 import type { User } from "@/types/user";
 import {
   type BatchActionMode,
@@ -57,16 +62,7 @@ export type EndpointCircuitInfoMap = Record<
 interface ProviderManagerProps {
   providers: ProviderDisplay[];
   currentUser?: User;
-  healthStatus: Record<
-    number,
-    {
-      circuitState: "closed" | "open" | "half-open";
-      failureCount: number;
-      lastFailureTime: number | null;
-      circuitOpenUntil: number | null;
-      recoveryMinutes: number | null;
-    }
-  >;
+  healthStatus: ProviderHealthStatus;
   /** Endpoint-level circuit breaker info, keyed by provider ID */
   endpointCircuitInfo?: EndpointCircuitInfoMap;
   statistics?: ProviderStatisticsMap;

--- a/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
+++ b/src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx
@@ -70,7 +70,12 @@ import { getContrastTextColor, getGroupColor } from "@/lib/utils/color";
 import type { CurrencyCode } from "@/lib/utils/currency";
 import { formatCurrency } from "@/lib/utils/currency";
 import { normalizeProviderGroupTag, parseProviderGroups } from "@/lib/utils/provider-group";
-import type { ProviderDisplay, ProviderStatistics, ProviderVendor } from "@/types/provider";
+import type {
+  ProviderCircuitHealth,
+  ProviderDisplay,
+  ProviderStatistics,
+  ProviderVendor,
+} from "@/types/provider";
 import type { User } from "@/types/user";
 import { ProviderForm } from "./forms/provider-form";
 import { GroupEditCombobox } from "./group-edit-combobox";
@@ -83,13 +88,7 @@ interface ProviderRichListItemProps {
   provider: ProviderDisplay;
   vendor?: ProviderVendor;
   currentUser?: User;
-  healthStatus?: {
-    circuitState: "closed" | "open" | "half-open";
-    failureCount: number;
-    lastFailureTime: number | null;
-    circuitOpenUntil: number | null;
-    recoveryMinutes: number | null;
-  };
+  healthStatus?: ProviderCircuitHealth;
   /** Endpoint-level circuit breaker info for this provider */
   endpointCircuitInfo?: Array<{
     endpointId: number;

--- a/src/lib/api-client/v1/actions/providers.ts
+++ b/src/lib/api-client/v1/actions/providers.ts
@@ -1,6 +1,10 @@
 import type { EditProviderResult, RemoveProviderResult } from "@/actions/providers";
 import { DASHBOARD_COMPAT_HEADER } from "@/lib/api/v1/_shared/constants";
-import type { ProviderDisplay, ProviderStatisticsMap } from "@/types/provider";
+import type {
+  ProviderDisplay,
+  ProviderHealthStatus,
+  ProviderStatisticsMap,
+} from "@/types/provider";
 import {
   apiDeleteWithHeaders,
   apiGet,
@@ -19,7 +23,12 @@ export type {
   ProviderBatchPreviewRow,
   RemoveProviderResult,
 } from "@/actions/providers";
-export type { ProviderDisplay, ProviderStatisticsMap } from "@/types/provider";
+export type {
+  ProviderCircuitHealth,
+  ProviderDisplay,
+  ProviderHealthStatus,
+  ProviderStatisticsMap,
+} from "@/types/provider";
 
 const dashboardCompatOptions = {
   headers: {
@@ -88,17 +97,6 @@ export function autoSortProviderPriority(args: unknown) {
     apiPost("/api/v1/providers:autoSortPriority", args, dashboardCompatOptions)
   );
 }
-
-export type ProviderHealthStatus = Record<
-  number,
-  {
-    circuitState: "closed" | "open" | "half-open";
-    failureCount: number;
-    lastFailureTime: number | null;
-    circuitOpenUntil: number | null;
-    recoveryMinutes: number | null;
-  }
->;
 
 // 仪表盘内的 React Query 直接消费返回值；这里不要再用 `toActionResult` 包装，
 // 否则 consumer 会拿到 `{ ok, data }` 而非熔断状态 map，所有熔断指示器永远不显示。

--- a/src/lib/api-client/v1/actions/providers.ts
+++ b/src/lib/api-client/v1/actions/providers.ts
@@ -89,8 +89,21 @@ export function autoSortProviderPriority(args: unknown) {
   );
 }
 
-export function getProvidersHealthStatus() {
-  return toActionResult(apiGet("/api/v1/providers/health", dashboardCompatOptions));
+export type ProviderHealthStatus = Record<
+  number,
+  {
+    circuitState: "closed" | "open" | "half-open";
+    failureCount: number;
+    lastFailureTime: number | null;
+    circuitOpenUntil: number | null;
+    recoveryMinutes: number | null;
+  }
+>;
+
+// 仪表盘内的 React Query 直接消费返回值；这里不要再用 `toActionResult` 包装，
+// 否则 consumer 会拿到 `{ ok, data }` 而非熔断状态 map，所有熔断指示器永远不显示。
+export function getProvidersHealthStatus(): Promise<ProviderHealthStatus> {
+  return apiGet<ProviderHealthStatus>("/api/v1/providers/health", dashboardCompatOptions);
 }
 
 export function resetProviderCircuit(providerId: number) {

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -531,6 +531,23 @@ export interface ProviderStatistics {
  */
 export type ProviderStatisticsMap = Record<number, ProviderStatistics>;
 
+/**
+ * Provider-level (key/credential) circuit breaker snapshot.
+ * Mirrors the shape returned by `/api/v1/providers/health`.
+ */
+export interface ProviderCircuitHealth {
+  circuitState: "closed" | "open" | "half-open";
+  failureCount: number;
+  lastFailureTime: number | null;
+  circuitOpenUntil: number | null;
+  recoveryMinutes: number | null;
+}
+
+/**
+ * Map of provider ID to circuit-breaker health snapshot.
+ */
+export type ProviderHealthStatus = Record<number, ProviderCircuitHealth>;
+
 export interface CreateProviderData {
   name: string;
   url: string;

--- a/tests/unit/api/v1/api-client-actions.test.ts
+++ b/tests/unit/api/v1/api-client-actions.test.ts
@@ -338,4 +338,37 @@ describe("v1 action compatibility client", () => {
       "/api/v1/usage-logs?cursorCreatedAt=2026-04-28T00%3A00%3A00.000Z&cursorId=42&limit=15"
     );
   });
+
+  test("returns the raw provider health map without ActionResult wrapping", async () => {
+    // 仪表盘的 useQuery 直接消费返回值；如果再被包成 `{ ok, data }`，
+    // 熔断状态指示器和重置按钮会因为 `healthStatus[id]?.circuitState` 永远 undefined 而不显示。
+    const healthMap = {
+      1: {
+        circuitState: "open" as const,
+        failureCount: 7,
+        lastFailureTime: 1_700_000_000_000,
+        circuitOpenUntil: 1_700_000_300_000,
+        recoveryMinutes: 5,
+      },
+      2: {
+        circuitState: "closed" as const,
+        failureCount: 0,
+        lastFailureTime: null,
+        circuitOpenUntil: null,
+        recoveryMinutes: null,
+      },
+    };
+    getMock.mockResolvedValue(healthMap);
+
+    const result = await providers.getProvidersHealthStatus();
+
+    expect(getMock).toHaveBeenCalledWith("/api/v1/providers/health", {
+      headers: { [DASHBOARD_COMPAT_HEADER]: "1" },
+    });
+    expect(result).toEqual(healthMap);
+    // Critical: the return must be the map itself, not the `{ ok, data }` wrapper.
+    expect(result).not.toHaveProperty("ok");
+    expect(result).not.toHaveProperty("data");
+    expect(result[1]?.circuitState).toBe("open");
+  });
 });


### PR DESCRIPTION
## Summary

Provider 管理页里的「熔断中」状态指示器与「重置熔断」按钮当前完全失效：即便服务商真的处在熔断状态，UI 也不会高亮，菜单里看不到重置项，导致用户无法重置。

## Root cause

`src/lib/api-client/v1/actions/providers.ts` 中 `getProvidersHealthStatus` 把 `/api/v1/providers/health` 的响应错误地用 `toActionResult` 又包了一层：

```ts
// before
export function getProvidersHealthStatus() {
  return toActionResult(apiGet("/api/v1/providers/health", dashboardCompatOptions));
}
```

但消费方 `provider-manager-loader.tsx` 是 React Query 直接消费返回值，并且类型强转为 `Record<number, HealthEntry>`：

```ts
const { data: healthStatus = {} as ProviderHealthStatus } = useQuery<ProviderHealthStatus>({
  queryKey: ["providers-health"],
  queryFn: getProvidersHealthStatus,
  ...
});
```

实际拿到的 data 形如 `{ ok: true, data: { 1: {...} } }`，再去 `healthStatus[providerId]?.circuitState` 永远是 undefined：

- `provider-manager.tsx:121` 的 `hasAnyCircuitOpen` 恒为 false → 熔断筛选/计数永远是 0
- `provider-rich-list-item.tsx:494` 的 `hasKeyCircuitOpen` 恒为 false → 红色边框、destructive badge 不展示
- 同文件 dropdown 中 `actionResetCircuit` 项只在 `circuitState === "open"` 时显示 → 用户看不到「重置熔断」入口

REST 端点本身一直返回原始 map（见 `tests/api/v1/providers/providers.read.test.ts:720` 的 `expect(health.json).toEqual({ "1": { circuitState: "closed", failureCount: 0 } })`），且同文件中的 `getProviders` / `getProviderStatisticsAsync` 都没有套 `toActionResult`，是这次健康接口对齐时漏掉的。

Bug 是在 #1140 (`refactor: add v1 REST management OpenAPI`) 把 dashboard 客户端接到新版 v1 路由时引入的。

## Fix

- 去掉 `getProvidersHealthStatus` 上的 `toActionResult`，让函数直接返回 `Promise<ProviderHealthStatus>`；
- 把 `ProviderHealthStatus` 提到 api-client 同文件导出，loader 复用同一份类型，避免再次出现「类型说一套、运行时另一套」的错位；
- 新增单测 `tests/unit/api/v1/api-client-actions.test.ts > returns the raw provider health map without ActionResult wrapping`，锁住「不能再次被 ActionResult 包装」这一契约。

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 6043 passed, 13 skipped
- [x] `bun run build`
- [ ] 在真实环境触发任一服务商进入熔断（或临时把 Redis 中 `circuit:provider:<id>` 设为 `open`），打开 `/dashboard/providers`，验证：
  - 服务商左侧出现红色高亮边框
  - 「熔断中」/「Key 熔断」badge 出现
  - 顶部筛选条上「熔断中 (N)」计数显示
  - 行内 dropdown 出现「重置熔断」菜单项，点击后调用 `/api/v1/providers/{id}/circuit:reset` 并刷新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the circuit-breaker indicator and reset action in the Provider Manager UI were never shown, because `getProvidersHealthStatus` was wrapping the API response in `toActionResult`, causing consumers to receive `{ ok, data }` instead of the raw health map.

- **Core fix**: Removes `toActionResult` from `getProvidersHealthStatus` so `apiGet` returns `Promise<ProviderHealthStatus>` directly, matching what React Query consumers expect.
- **Type consolidation**: Extracts `ProviderCircuitHealth` and `ProviderHealthStatus` into `src/types/provider.ts` and re-exports them from the api-client actions barrel, eliminating duplicated inline type definitions across three component files.
- **Regression test**: Adds a unit test that asserts the return value is the raw map and explicitly checks `result` does not have `ok` or `data` properties.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted one-line removal of an incorrect wrapper, with no logic added and a dedicated regression test locking the contract.

The fix is minimal and well-scoped: one function loses its `toActionResult` call, three inline type definitions are replaced with a shared canonical type, and a new unit test explicitly guards against re-introducing the wrapper. The API endpoint contract is unchanged, the type shapes are identical, and the rest of the codebase that uses `toActionResult` for mutation endpoints is untouched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/api-client/v1/actions/providers.ts | Core fix: drops `toActionResult` wrapper on `getProvidersHealthStatus`, restoring raw-map return type; also re-exports the new shared types. |
| src/types/provider.ts | Adds canonical `ProviderCircuitHealth` interface and `ProviderHealthStatus` type alias to replace three independent inline definitions. |
| src/app/[locale]/settings/providers/_components/provider-manager-loader.tsx | Removes locally-defined `ProviderHealthStatus` and imports the canonical type; no logic changes. |
| src/app/[locale]/settings/providers/_components/provider-manager.tsx | Replaces inline `healthStatus` prop type with imported `ProviderHealthStatus`; no logic changes. |
| src/app/[locale]/settings/providers/_components/provider-rich-list-item.tsx | Replaces inline `healthStatus` prop type with imported `ProviderCircuitHealth`; no logic changes. |
| tests/unit/api/v1/api-client-actions.test.ts | New test asserts that `getProvidersHealthStatus` returns the raw health map and explicitly checks absence of `ok`/`data` wrapper properties. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as provider-manager-loader.tsx
    participant RQ as React Query
    participant AC as getProvidersHealthStatus()
    participant API as /api/v1/providers/health

    Note over AC,API: Before fix (broken)
    UI->>RQ: useQuery queryFn getProvidersHealthStatus
    RQ->>AC: call queryFn
    AC->>API: apiGet(...)
    API-->>AC: raw health map
    AC-->>RQ: toActionResult wraps to ok+data
    RQ-->>UI: "data = { ok, data: {...} }"
    UI->>UI: "healthStatus[id]?.circuitState = undefined"
    Note over UI: Circuit indicator never shown

    Note over AC,API: After fix (correct)
    UI->>RQ: useQuery queryFn getProvidersHealthStatus
    RQ->>AC: call queryFn
    AC->>API: apiGet(...)
    API-->>AC: raw health map
    AC-->>RQ: raw health map returned directly
    RQ-->>UI: "data = { 1: { circuitState: open } }"
    UI->>UI: "healthStatus[id]?.circuitState = open"
    Note over UI: Red border + badge + reset menu shown
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(providers): centralize circuit-..."](https://github.com/ding113/claude-code-hub/commit/5f83e25c8b208ef5ff66de1c3109e5770ce5bdae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32608376)</sub>

<!-- /greptile_comment -->