### PR TITLE
fix(providers): accept glob wildcards in regex match mode

### DIFF
--- a/src/app/[locale]/settings/providers/_components/allowed-model-rule-editor.tsx
+++ b/src/app/[locale]/settings/providers/_components/allowed-model-rule-editor.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { PROVIDER_RULE_LIMITS } from "@/lib/constants/provider.constants";
+import { resolveProviderPatternRegex } from "@/lib/provider-pattern-regex";
 import type {
   AllowedModelRule,
   ProviderModelRedirectMatchType,
@@ -101,14 +102,13 @@ export function AllowedModelRuleEditor({
       return t("patternTooLong", { max: PROVIDER_RULE_LIMITS.MAX_TEXT_LENGTH });
     }
     if (normalized.matchType === "regex") {
-      try {
-        new RegExp(normalized.pattern);
-      } catch {
+      const compiled = resolveProviderPatternRegex(normalized.pattern);
+      if (!compiled) {
         return t("regexInvalid");
       }
 
       try {
-        if (!safeRegex(normalized.pattern)) {
+        if (!safeRegex(compiled.source)) {
           return t("regexUnsafe");
         }
       } catch {

--- a/src/app/[locale]/settings/providers/_components/model-redirect-editor.tsx
+++ b/src/app/[locale]/settings/providers/_components/model-redirect-editor.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { PROVIDER_RULE_LIMITS } from "@/lib/constants/provider.constants";
+import { resolveProviderPatternRegex } from "@/lib/provider-pattern-regex";
 import type { ProviderModelRedirectMatchType, ProviderModelRedirectRule } from "@/types/provider";
 
 interface ModelRedirectEditorProps {
@@ -104,14 +105,13 @@ export function ModelRedirectEditor({
       return t("targetTooLong", { max: PROVIDER_RULE_LIMITS.MAX_TEXT_LENGTH });
     }
     if (normalized.matchType === "regex") {
-      try {
-        new RegExp(normalized.source);
-      } catch {
+      const compiled = resolveProviderPatternRegex(normalized.source);
+      if (!compiled) {
         return t("regexInvalid");
       }
 
       try {
-        if (!safeRegex(normalized.source)) {
+        if (!safeRegex(compiled.source)) {
           return t("regexUnsafe");
         }
       } catch {

--- a/src/lib/model-pattern-matcher.ts
+++ b/src/lib/model-pattern-matcher.ts
@@ -1,3 +1,4 @@
+import { resolveProviderPatternRegex } from "@/lib/provider-pattern-regex";
 import type { ProviderModelRedirectMatchType } from "@/types/provider";
 
 export function matchesPattern(
@@ -14,13 +15,12 @@ export function matchesPattern(
       return model.endsWith(pattern);
     case "contains":
       return model.includes(pattern);
-    case "regex":
-      try {
-        // 不隐式补 ^/$，需要全字符串匹配时请显式写成 ^pattern$。
-        return new RegExp(pattern).test(model);
-      } catch {
-        return false;
-      }
+    case "regex": {
+      // 不隐式补 ^/$，需要全字符串匹配时请显式写成 ^pattern$。
+      // 解析失败时尝试把 `*`/`?` 当 glob 通配符，兼容旧版输入习惯。
+      const compiled = resolveProviderPatternRegex(pattern);
+      return compiled ? compiled.regex.test(model) : false;
+    }
     default:
       return false;
   }

--- a/src/lib/provider-allowed-model-schema.ts
+++ b/src/lib/provider-allowed-model-schema.ts
@@ -2,6 +2,7 @@ import safeRegex from "safe-regex";
 import { z } from "zod";
 import { normalizeAllowedModelRules } from "@/lib/allowed-model-rules";
 import { PROVIDER_RULE_LIMITS } from "@/lib/constants/provider.constants";
+import { resolveProviderPatternRegex } from "@/lib/provider-pattern-regex";
 import { PROVIDER_MODEL_REDIRECT_MATCH_TYPE_SCHEMA } from "./provider-model-redirect-schema";
 
 export const PROVIDER_ALLOWED_MODEL_RULE_SCHEMA = z
@@ -21,9 +22,8 @@ export const PROVIDER_ALLOWED_MODEL_RULE_SCHEMA = z
       return;
     }
 
-    try {
-      new RegExp(rule.pattern);
-    } catch {
+    const compiled = resolveProviderPatternRegex(rule.pattern);
+    if (!compiled) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "Allowed model regex is invalid",
@@ -33,7 +33,7 @@ export const PROVIDER_ALLOWED_MODEL_RULE_SCHEMA = z
     }
 
     try {
-      if (!safeRegex(rule.pattern)) {
+      if (!safeRegex(compiled.source)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "Allowed model regex has potential ReDoS risk",

--- a/src/lib/provider-model-redirect-schema.ts
+++ b/src/lib/provider-model-redirect-schema.ts
@@ -1,6 +1,7 @@
 import safeRegex from "safe-regex";
 import { z } from "zod";
 import { PROVIDER_RULE_LIMITS } from "@/lib/constants/provider.constants";
+import { resolveProviderPatternRegex } from "@/lib/provider-pattern-regex";
 
 export const PROVIDER_MODEL_REDIRECT_MATCH_TYPE_SCHEMA = z.enum([
   "exact",
@@ -35,9 +36,8 @@ export const PROVIDER_MODEL_REDIRECT_RULE_SCHEMA = z
       return;
     }
 
-    try {
-      new RegExp(rule.source);
-    } catch {
+    const compiled = resolveProviderPatternRegex(rule.source);
+    if (!compiled) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "Redirect regex is invalid",
@@ -47,7 +47,7 @@ export const PROVIDER_MODEL_REDIRECT_RULE_SCHEMA = z
     }
 
     try {
-      if (!safeRegex(rule.source)) {
+      if (!safeRegex(compiled.source)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "Redirect regex has potential ReDoS risk",

--- a/src/lib/provider-pattern-regex.ts
+++ b/src/lib/provider-pattern-regex.ts
@@ -1,0 +1,42 @@
+// 兼容旧版“通配符”习惯：用户在 regex 模式下输入 glob 风格的 `*` / `?` 时，
+// 先按标准正则解析；若解析失败再回退把 `*` 当 `.*`、`?` 当 `.` 处理。
+// 这样既保留了已经合法的正则语义（如 `a*`），又能让 `*`、`*.`、`claude-*`
+// 这类用户预期的通配符在校验和运行时都被接受。
+
+const GLOB_META = /[*?]/;
+const REGEX_META = /[\\^$.|()[\]{}+]/;
+
+export function globPatternToRegexSource(pattern: string): string {
+  let out = "";
+  for (const ch of pattern) {
+    if (ch === "*") {
+      out += ".*";
+    } else if (ch === "?") {
+      out += ".";
+    } else if (REGEX_META.test(ch)) {
+      out += `\\${ch}`;
+    } else {
+      out += ch;
+    }
+  }
+  return out;
+}
+
+export function resolveProviderPatternRegex(
+  pattern: string
+): { regex: RegExp; source: string } | null {
+  try {
+    return { regex: new RegExp(pattern), source: pattern };
+  } catch {}
+
+  if (!GLOB_META.test(pattern)) {
+    return null;
+  }
+
+  const globSource = globPatternToRegexSource(pattern);
+  try {
+    return { regex: new RegExp(globSource), source: globSource };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/provider-pattern-regex.ts
+++ b/src/lib/provider-pattern-regex.ts
@@ -1,42 +1,46 @@
 // 兼容旧版“通配符”习惯：用户在 regex 模式下输入 glob 风格的 `*` / `?` 时，
 // 先按标准正则解析；若解析失败再回退把 `*` 当 `.*`、`?` 当 `.` 处理。
-// 这样既保留了已经合法的正则语义（如 `a*`），又能让 `*`、`*.`、`claude-*`
+// 这样既保留了已经合法的正则语义（如 `a*`），又能让 `*`、`*.`、`*-opus-*`
 // 这类用户预期的通配符在校验和运行时都被接受。
+//
+// Glob fallback 路径下会在最终的正则两端加 `^...$`，让通配符语义贴近 shell glob
+// 的整串匹配（用户写 `*.foo` 时期望“以 `.foo` 结尾”，而不是 `bar.foo.baz` 这样
+// 子串包含也算匹配）。原本就合法的正则保持子串匹配语义不变。
 
 const GLOB_META = /[*?]/;
-const REGEX_META = /[\\^$.|()[\]{}+]/;
+const REGEX_META = /[\\^$.|()[\]{}+]/g;
+
+type Compiled = { regex: RegExp; source: string };
+
+// matchesPattern 在每次调度里都会调到这里，缓存避免重复 `new RegExp`。
+// pattern 是用户配置项、规模有限，但仍设上限防御异常增长。
+const CACHE_LIMIT = 1024;
+const cache = new Map<string, Compiled | null>();
 
 export function globPatternToRegexSource(pattern: string): string {
-  let out = "";
-  for (const ch of pattern) {
-    if (ch === "*") {
-      out += ".*";
-    } else if (ch === "?") {
-      out += ".";
-    } else if (REGEX_META.test(ch)) {
-      out += `\\${ch}`;
-    } else {
-      out += ch;
-    }
-  }
-  return out;
+  return pattern.replace(REGEX_META, "\\$&").replace(/\*/g, ".*").replace(/\?/g, ".");
 }
 
-export function resolveProviderPatternRegex(
-  pattern: string
-): { regex: RegExp; source: string } | null {
+export function resolveProviderPatternRegex(pattern: string): Compiled | null {
+  if (cache.has(pattern)) {
+    return cache.get(pattern) ?? null;
+  }
+
+  let result: Compiled | null = null;
   try {
-    return { regex: new RegExp(pattern), source: pattern };
+    result = { regex: new RegExp(pattern), source: pattern };
   } catch {}
 
-  if (!GLOB_META.test(pattern)) {
-    return null;
+  if (!result && GLOB_META.test(pattern)) {
+    const globSource = `^${globPatternToRegexSource(pattern)}$`;
+    try {
+      result = { regex: new RegExp(globSource), source: globSource };
+    } catch {}
   }
 
-  const globSource = globPatternToRegexSource(pattern);
-  try {
-    return { regex: new RegExp(globSource), source: globSource };
-  } catch {
-    return null;
+  if (cache.size >= CACHE_LIMIT) {
+    cache.clear();
   }
+  cache.set(pattern, result);
+  return result;
 }

--- a/tests/unit/lib/model-pattern-matcher.test.ts
+++ b/tests/unit/lib/model-pattern-matcher.test.ts
@@ -21,4 +21,19 @@ describe("matchesPattern", () => {
   it("returns false for invalid regex patterns instead of throwing", () => {
     expect(matchesPattern("claude-opus-4-1", "regex", "[")).toBe(false);
   });
+
+  describe("glob fallback for regex matching", () => {
+    it.each<[string, string, boolean]>([
+      ["*", "claude-opus-4-1", true],
+      ["*", "", true],
+      ["*.", "claude.opus", true],
+      ["*.", "claudeopus", false],
+      ["claude-*", "claude-opus-4-1", true],
+      ["claude-*", "gpt-4", false],
+      ["*-opus-*", "claude-opus-4-1", true],
+      ["*-opus-*", "claude-sonnet-4-1", false],
+    ])("regex pattern %s matches %s -> %s via glob fallback", (pattern, model, expected) => {
+      expect(matchesPattern(model, "regex", pattern)).toBe(expected);
+    });
+  });
 });

--- a/tests/unit/lib/model-pattern-matcher.test.ts
+++ b/tests/unit/lib/model-pattern-matcher.test.ts
@@ -26,7 +26,9 @@ describe("matchesPattern", () => {
     it.each<[string, string, boolean]>([
       ["*", "claude-opus-4-1", true],
       ["*", "", true],
-      ["*.", "claude.opus", true],
+      // 锚定 glob 后 `*.` 表示“以 . 结尾”，不再匹配子串中带点的 "claude.opus"。
+      ["*.", "claude.opus", false],
+      ["*.", "claude.opus.", true],
       ["*.", "claudeopus", false],
       ["claude-*", "claude-opus-4-1", true],
       ["claude-*", "gpt-4", false],

--- a/tests/unit/lib/provider-allowed-model-schema.test.ts
+++ b/tests/unit/lib/provider-allowed-model-schema.test.ts
@@ -49,4 +49,29 @@ describe("provider-allowed-model-schema", () => {
 
     expect(result.success).toBe(true);
   });
+
+  describe("regex 模式的 glob 通配符兼容", () => {
+    it.each<[string]>([
+      ["*"],
+      ["*."],
+      ["claude-*"],
+      ["*-opus-*"],
+      ["?"],
+    ])("接受 glob 风格的 pattern: %s", (pattern) => {
+      const result = PROVIDER_ALLOWED_MODEL_RULE_SCHEMA.safeParse({
+        matchType: "regex",
+        pattern,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("仍然拒绝纯粹无法解析的正则", () => {
+      const result = PROVIDER_ALLOWED_MODEL_RULE_SCHEMA.safeParse({
+        matchType: "regex",
+        pattern: "[",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/tests/unit/lib/provider-model-redirect-schema.test.ts
+++ b/tests/unit/lib/provider-model-redirect-schema.test.ts
@@ -51,4 +51,31 @@ describe("provider-model-redirect-schema", () => {
 
     expect(result.success).toBe(true);
   });
+
+  describe("regex 模式的 glob 通配符兼容", () => {
+    it.each<[string]>([
+      ["*"],
+      ["*."],
+      ["claude-*"],
+      ["*-opus-*"],
+      ["?"],
+    ])("接受 glob 风格的 source: %s", (source) => {
+      const result = PROVIDER_MODEL_REDIRECT_RULE_SCHEMA.safeParse({
+        matchType: "regex",
+        source,
+        target: "claude-sonnet-4-6",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("仍然拒绝纯粹无法解析的正则", () => {
+      const result = PROVIDER_MODEL_REDIRECT_RULE_SCHEMA.safeParse({
+        matchType: "regex",
+        source: "[",
+        target: "claude-sonnet-4-6",
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/tests/unit/lib/provider-pattern-regex.test.ts
+++ b/tests/unit/lib/provider-pattern-regex.test.ts
@@ -36,29 +36,56 @@ describe("resolveProviderPatternRegex", () => {
     expect(result?.regex.test("aaa")).toBe(true);
   });
 
-  it("falls back to glob when bare * is used", () => {
+  it("falls back to anchored glob when bare * is used", () => {
     const result = resolveProviderPatternRegex("*");
     expect(result).not.toBeNull();
-    expect(result?.source).toBe(".*");
+    expect(result?.source).toBe("^.*$");
     expect(result?.regex.test("claude-opus-4-1")).toBe(true);
     expect(result?.regex.test("")).toBe(true);
   });
 
-  it("falls back to glob for *.suffix style patterns", () => {
-    const result = resolveProviderPatternRegex("*.");
-    expect(result).not.toBeNull();
-    expect(result?.regex.test("claude-opus-4-1.")).toBe(true);
+  it("anchors glob fallback to avoid substring matches", () => {
+    const result = resolveProviderPatternRegex("*.foo");
+    expect(result?.source).toBe("^.*\\.foo$");
+    expect(result?.regex.test("claude.foo")).toBe(true);
+    // 不应匹配 `bar.foo.baz` —— shell glob 用户预期“以 .foo 结尾”，
+    // 而不是子串包含。
+    expect(result?.regex.test("bar.foo.baz")).toBe(false);
   });
 
-  it("falls back to glob for prefix-* patterns", () => {
-    const result = resolveProviderPatternRegex("claude-*");
-    expect(result).not.toBeNull();
-    expect(result?.regex.test("claude-opus-4-1")).toBe(true);
-    expect(result?.regex.test("gpt-4")).toBe(false);
+  it("falls back to anchored glob for *.style patterns", () => {
+    const result = resolveProviderPatternRegex("*.");
+    expect(result?.source).toBe("^.*\\.$");
+    expect(result?.regex.test("claude-opus-4-1.")).toBe(true);
+    expect(result?.regex.test("claude.opus")).toBe(false);
   });
 
   it("returns null for patterns that are neither valid regex nor glob-fixable", () => {
     expect(resolveProviderPatternRegex("[")).toBeNull();
     expect(resolveProviderPatternRegex("(")).toBeNull();
+  });
+
+  it("documents divergence: `claude-*` is valid regex and keeps regex semantics", () => {
+    // `claude-*` 是合法正则（claud + 零个或多个 e + 零个或多个 `-`，且不锚定），
+    // 因此走 regex 路径，与 shell glob 的“以 claude- 开头”略有差异。
+    const result = resolveProviderPatternRegex("claude-*");
+    expect(result?.source).toBe("claude-*");
+    expect(result?.regex.test("claude-opus-4-1")).toBe(true);
+    expect(result?.regex.test("gpt-4")).toBe(false);
+  });
+
+  it("falls back to anchored glob when `*` makes the pattern non-regex", () => {
+    // `*claude*` 在正则里非法，会走 glob 路径并锚定，语义贴近 shell glob 的
+    // “整串包含 claude”。
+    const result = resolveProviderPatternRegex("*claude*");
+    expect(result?.source).toBe("^.*claude.*$");
+    expect(result?.regex.test("myclaudemodel")).toBe(true);
+    expect(result?.regex.test("gpt-4")).toBe(false);
+  });
+
+  it("memoizes results across repeated calls for the same input", () => {
+    const a = resolveProviderPatternRegex("^claude-.*$");
+    const b = resolveProviderPatternRegex("^claude-.*$");
+    expect(a).toBe(b);
   });
 });

--- a/tests/unit/lib/provider-pattern-regex.test.ts
+++ b/tests/unit/lib/provider-pattern-regex.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  globPatternToRegexSource,
+  resolveProviderPatternRegex,
+} from "@/lib/provider-pattern-regex";
+
+describe("globPatternToRegexSource", () => {
+  it.each<[string, string]>([
+    ["*", ".*"],
+    ["*.", ".*\\."],
+    ["*-foo", ".*-foo"],
+    ["?", "."],
+    ["claude-*", "claude-.*"],
+    ["claude-?-opus", "claude-.-opus"],
+    ["a+b", "a\\+b"],
+    ["a.b", "a\\.b"],
+    ["(group)", "\\(group\\)"],
+  ])("converts %s to %s", (pattern, expected) => {
+    expect(globPatternToRegexSource(pattern)).toBe(expected);
+  });
+});
+
+describe("resolveProviderPatternRegex", () => {
+  it("returns the original regex when pattern is already valid", () => {
+    const result = resolveProviderPatternRegex("^claude-.*$");
+    expect(result).not.toBeNull();
+    expect(result?.source).toBe("^claude-.*$");
+    expect(result?.regex.test("claude-opus-4-1")).toBe(true);
+  });
+
+  it("preserves legal regex semantics for ambiguous patterns like a*", () => {
+    const result = resolveProviderPatternRegex("a*");
+    expect(result).not.toBeNull();
+    expect(result?.source).toBe("a*");
+    expect(result?.regex.test("")).toBe(true);
+    expect(result?.regex.test("aaa")).toBe(true);
+  });
+
+  it("falls back to glob when bare * is used", () => {
+    const result = resolveProviderPatternRegex("*");
+    expect(result).not.toBeNull();
+    expect(result?.source).toBe(".*");
+    expect(result?.regex.test("claude-opus-4-1")).toBe(true);
+    expect(result?.regex.test("")).toBe(true);
+  });
+
+  it("falls back to glob for *.suffix style patterns", () => {
+    const result = resolveProviderPatternRegex("*.");
+    expect(result).not.toBeNull();
+    expect(result?.regex.test("claude-opus-4-1.")).toBe(true);
+  });
+
+  it("falls back to glob for prefix-* patterns", () => {
+    const result = resolveProviderPatternRegex("claude-*");
+    expect(result).not.toBeNull();
+    expect(result?.regex.test("claude-opus-4-1")).toBe(true);
+    expect(result?.regex.test("gpt-4")).toBe(false);
+  });
+
+  it("returns null for patterns that are neither valid regex nor glob-fixable", () => {
+    expect(resolveProviderPatternRegex("[")).toBeNull();
+    expect(resolveProviderPatternRegex("(")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

When `matchType: regex` was introduced in #993 and #996, entering glob-style wildcards (`*`, `*.`, `claude-*`) in the provider model allowlist or redirect source fields started throwing "regex invalid" because bare `*` is not valid regex (`SyntaxError: Nothing to repeat`). This PR adds a glob-to-regex fallback: if a pattern fails `new RegExp(...)` **and** contains `*` or `?`, those characters are converted to their regex equivalents (`.*` / `.`) before retrying. Existing valid regex patterns are unaffected.

**Follow-up to:**
- #993 - feat: support provider model redirect rules
- #996 - feat: upgrade provider model allowlist matching and dispatch simulation

---

## 背景

用户反馈在「供应商配置 → 模型白名单 / 模型重定向」里,把匹配方式切到「正则匹配」后输入 `*` 或 `*.` 会直接报「正则表达式无效」,但旧版本是允许这样写的。

旧版字段是纯字符串(`allowedModels: string[]` 走精确匹配,`modelRedirects: Record<string, string>` 走 map 查找),所以 `*` 即便不会真正匹配任何东西,也不会触发任何校验报错。新版本引入 `matchType: regex` 之后(PR #993, #996),前后端都会直接对 pattern 调 `new RegExp(...)`,纯 `*` / `*.` 这种 glob 写法会抛 `SyntaxError: Nothing to repeat`,被中文文案翻译成「正则表达式无效」。

## 修复思路

不改变 regex 模式的语义,而是在校验和运行时**新增一个 glob fallback**:

- 先按标准正则解析 pattern,**合法就保持原样**(`a*`、`^claude-.*$` 等照旧)。
- 解析失败且 pattern 含 `*` 或 `?` 时,把 `*` 转为 `.*`、`?` 转为 `.`、其它正则元字符按字面转义,然后再尝试编译;成功就接受。
- 仍然过 `safeRegex` 检查 ReDoS,只是输入改成 fallback 后的最终 source。
- 校验和 `matchesPattern` 共用同一个 `resolveProviderPatternRegex`,前端、Zod schema、调度运行时三处行为一致。

## Changes

### Core Changes
- **New**: `src/lib/provider-pattern-regex.ts` — `resolveProviderPatternRegex()` tries standard regex first, falls back to glob-to-regex conversion when `*`/`?` present
- **Modified**: `src/lib/model-pattern-matcher.ts` — `matchesPattern("regex")` now uses `resolveProviderPatternRegex` instead of raw `new RegExp()`
- **Modified**: `src/lib/provider-model-redirect-schema.ts` — Zod superRefine uses resolved regex for validation and ReDoS check
- **Modified**: `src/lib/provider-allowed-model-schema.ts` — Same schema fix for allowed model rules

### UI Changes
- **Modified**: `src/app/[locale]/settings/providers/_components/model-redirect-editor.tsx` — Client-side validation uses `resolveProviderPatternRegex`
- **Modified**: `src/app/[locale]/settings/providers/_components/allowed-model-rule-editor.tsx` — Same validation fix

### Tests Added
- `tests/unit/lib/provider-pattern-regex.test.ts` — 64 lines covering `globPatternToRegexSource` and `resolveProviderPatternRegex` (valid regex passthrough, glob fallback, null on unfixable patterns)
- `tests/unit/lib/model-pattern-matcher.test.ts` — glob fallback cases: `*`, `*.`, `claude-*`, `*-opus-*`
- `tests/unit/lib/provider-model-redirect-schema.test.ts` — schema accepts glob patterns, still rejects `[`
- `tests/unit/lib/provider-allowed-model-schema.test.ts` — same coverage for allowed model schema

## Breaking Changes

None. Valid regex patterns are parsed first and their semantics are preserved unchanged. The glob fallback only activates when `new RegExp()` would have thrown.

## Test plan

- [x] `bun run typecheck` — exit 0
- [x] `bun run lint` — clean
- [x] `bun run test` — 6078 passed / 13 skipped / 0 failed
- [x] `bun run build` — exit 0
- [ ] Manual smoke test: in UI "model redirect / allowlist -> regex match", enter `*`, `*.`, `claude-*`, `a*` and verify save + runtime matching works as expected

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a glob-to-regex fallback in the provider model allowlist and redirect regex matching mode, so that bare glob wildcards (`*`, `*.`, `claude-*`) no longer throw "regex invalid" — they are now silently converted to anchored equivalents when `new RegExp()` fails. Previous review concerns (no memoization, unanchored substring matches) have both been addressed in this revision.

- **New `src/lib/provider-pattern-regex.ts`**: `resolveProviderPatternRegex` tries standard regex first; on failure, if the pattern contains `*` or `?`, converts via `globPatternToRegexSource` and wraps in `^...$` anchors. Results are memoized in a module-level `Map` capped at 1 024 entries.
- **Schema + UI + runtime alignment**: All four call-sites (`provider-allowed-model-schema`, `provider-model-redirect-schema`, and both editor components) now go through the same resolver, so validation and dispatch are consistent.
- **Tests**: 64-line unit suite covers passthrough, glob fallback, anchoring, memoization, and the documented `claude-*` semantic divergence.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all four call-sites are consistent, the glob fallback is narrowly scoped to patterns that were previously rejected outright, and the anchoring addition correctly prevents substring false-positives.

The change is well-contained: a new utility module consumed by four coordinated sites, with memoization and a ReDoS guard preserved. The only edge case (adjacent `*?` wildcards mangled by sequential substitution) is unrealistic for model-name patterns and produces a valid-but-wrong regex rather than a crash or security issue. All previously raised review concerns have been addressed.

src/lib/provider-pattern-regex.ts — specifically the three-step sequential substitution in `globPatternToRegexSource` for any future extension to more complex glob patterns.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/provider-pattern-regex.ts | New utility for glob-to-regex fallback; correct for all documented patterns; sequential `?`/`*` substitution has an edge-case ordering issue for adjacent wildcards (e.g. `*?`). |
| src/lib/model-pattern-matcher.ts | Clean consumer refactor — delegates to `resolveProviderPatternRegex` and handles null correctly. |
| src/lib/provider-allowed-model-schema.ts | Zod superRefine now uses resolved regex source for both validity and `safeRegex` checks — consistent with the new utility. |
| src/lib/provider-model-redirect-schema.ts | Same schema-validation fix as `provider-allowed-model-schema.ts`; straightforward and correct. |
| src/app/[locale]/settings/providers/_components/allowed-model-rule-editor.tsx | UI validation updated to use `resolveProviderPatternRegex` — mirrors schema logic, no issues. |
| src/app/[locale]/settings/providers/_components/model-redirect-editor.tsx | Same UI validation fix as `allowed-model-rule-editor.tsx`; correct. |
| tests/unit/lib/provider-pattern-regex.test.ts | Good coverage of the happy path, glob fallback, anchoring, memoization, and the documented `claude-*` semantic divergence; no adjacent `*?` case tested. |
| tests/unit/lib/model-pattern-matcher.test.ts | New glob-fallback test cases cover the main user-reported patterns correctly. |
| tests/unit/lib/provider-allowed-model-schema.test.ts | Schema tests accept glob patterns and reject unfixable ones — adequate coverage. |
| tests/unit/lib/provider-model-redirect-schema.test.ts | Mirrors the allowed-model schema tests; correct and sufficient. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pattern string] --> B{new RegExp\nthrows?}
    B -- No --> C[Compiled: regex=RegExp, source=pattern]
    B -- Yes --> D{contains\n* or ?}
    D -- No --> E[return null\n→ regexInvalid]
    D -- Yes --> F[globPatternToRegexSource\nescape meta, *→.*, ?→.]
    F --> G[wrap in ^...$]
    G --> H{new RegExp\nthrows again?}
    H -- No --> I[Compiled: anchored glob regex]
    H -- Yes --> E
    C --> J[cache & return Compiled]
    I --> J
    J --> K{caller}
    K -- matchesPattern --> L[regex.test model]
    K -- Zod schema --> M[safeRegex compiled.source]
    K -- UI editor --> M
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/lib/provider-pattern-regex.ts:21
**Sequential `*`/`?` substitution corrupts adjacent wildcard pairs**

`globPatternToRegexSource` first replaces `*` with `.*`, then replaces `?` with `.` on the already-mutated string. When both wildcards appear adjacent — e.g. `*?` (glob: "at least one character") — the second pass replaces the `?` that was introduced by step 2's `.*?` result:

1. REGEX_META: no change → `*?`
2. `*` → `.*` → `.*?`
3. `?` → `.` → `...` ← the lazy-quantifier `?` is consumed

Wrapped: `^...$` — matches strings of exactly 3 characters, not "at least one". A single-pass character-by-character conversion avoids this interaction entirely and would produce the correct `^.*.$` (which anchored means "one or more characters").

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(providers): address review feedback ..."](https://github.com/ding113/claude-code-hub/commit/9a72273103b4c860dda26f932009fa458501fad4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32645437)</sub>

<!-- /greptile_comment -->