### PR TITLE
fix(proxy): normalize nullable Responses output fields

### DIFF
--- a/src/app/v1/_lib/proxy/response-fixer/index.ts
+++ b/src/app/v1/_lib/proxy/response-fixer/index.ts
@@ -4,6 +4,7 @@ import { SessionManager } from "@/lib/session-manager";
 import { updateMessageRequestDetails } from "@/repository/message";
 import type { ResponseFixerSpecialSetting } from "@/types/special-settings";
 import type { ResponseFixerConfig } from "@/types/system-config";
+import { normalizeResponseOutput } from "../response-output-normalizer";
 import type { ProxySession } from "../session";
 import { EncodingFixer } from "./encoding-fixer";
 import { JsonFixer } from "./json-fixer";
@@ -287,11 +288,12 @@ export class ResponseFixer {
 
     const headers = cleanResponseHeaders(response.headers);
 
-    return new Response(toArrayBufferUint8Array(data), {
+    const fixedResponse = new Response(toArrayBufferUint8Array(data), {
       status: response.status,
       statusText: response.statusText,
       headers,
     });
+    return await normalizeResponseOutput(session, fixedResponse);
   }
 
   private static processStream(

--- a/src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts
+++ b/src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts
@@ -76,14 +76,29 @@ describe("ResponseFixer", () => {
     });
 
     const session = createSession();
-    const response = new Response('{"a":1}', {
+    session.originalFormat = "response";
+    const response = new Response('{"object":"response","output":null}', {
       headers: { "content-type": "application/json" },
     });
 
     const fixed = await ResponseFixer.process(session, response);
-    expect(await fixed.text()).toBe('{"a":1}');
+    expect(await fixed.text()).toBe('{"object":"response","output":null}');
     expect(fixed.headers.get("x-cch-response-fixer")).toBeNull();
     expect(session.getSpecialSettings()).toBeNull();
+  });
+
+  test("非流式 Responses 响应：启用时应执行输出归一化", async () => {
+    const { ResponseFixer } = await import("./index");
+
+    const session = createSession();
+    session.originalFormat = "response";
+    const response = new Response('{"object":"response","output":null}', {
+      headers: { "content-type": "application/json" },
+    });
+
+    const fixed = await ResponseFixer.process(session, response);
+
+    expect(await fixed.json()).toMatchObject({ object: "response", output: [] });
   });
 
   test("非流式响应：命中编码修复时应写入 specialSettings 并持久化", async () => {

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -44,7 +44,6 @@ import type { GeminiResponse } from "../gemini/types";
 import { extractActualResponseModelForProvider } from "./actual-response-model";
 import { bindClientAbortListener } from "./client-abort-listener";
 import { isClientAbortError, isTransportError } from "./errors";
-import { normalizeResponseOutput } from "./response-output-normalizer";
 import type { ProxySession } from "./session";
 import { consumeDeferredStreamingFinalization } from "./stream-finalization";
 
@@ -878,6 +877,7 @@ export class ProxyResponseHandler {
     let fixedResponse = response;
     if (!session.getEndpointPolicy().bypassResponseRectifier) {
       try {
+        // raw passthrough 端点跳过 ResponseFixer，也跳过其中的 Responses 输出归一化。
         fixedResponse = await ResponseFixer.process(session, response);
       } catch (error) {
         logger.error(
@@ -897,10 +897,7 @@ export class ProxyResponseHandler {
     const isSSE = contentType.includes("text/event-stream");
 
     if (!isSSE) {
-      const normalizedResponse = session.getEndpointPolicy().bypassResponseRectifier
-        ? fixedResponse
-        : await normalizeResponseOutput(session, fixedResponse);
-      return await ProxyResponseHandler.handleNonStream(session, normalizedResponse);
+      return await ProxyResponseHandler.handleNonStream(session, fixedResponse);
     }
 
     return await ProxyResponseHandler.handleStream(session, fixedResponse);

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -44,6 +44,7 @@ import type { GeminiResponse } from "../gemini/types";
 import { extractActualResponseModelForProvider } from "./actual-response-model";
 import { bindClientAbortListener } from "./client-abort-listener";
 import { isClientAbortError, isTransportError } from "./errors";
+import { normalizeResponseOutput } from "./response-output-normalizer";
 import type { ProxySession } from "./session";
 import { consumeDeferredStreamingFinalization } from "./stream-finalization";
 
@@ -896,7 +897,10 @@ export class ProxyResponseHandler {
     const isSSE = contentType.includes("text/event-stream");
 
     if (!isSSE) {
-      return await ProxyResponseHandler.handleNonStream(session, fixedResponse);
+      const normalizedResponse = session.getEndpointPolicy().bypassResponseRectifier
+        ? fixedResponse
+        : await normalizeResponseOutput(session, fixedResponse);
+      return await ProxyResponseHandler.handleNonStream(session, normalizedResponse);
     }
 
     return await ProxyResponseHandler.handleStream(session, fixedResponse);

--- a/src/app/v1/_lib/proxy/response-output-normalizer.ts
+++ b/src/app/v1/_lib/proxy/response-output-normalizer.ts
@@ -14,13 +14,15 @@ function isRecord(value: unknown): value is JsonRecord {
 }
 
 function isJsonContentType(contentType: string): boolean {
-  return contentType.includes("application/json") || contentType.includes("+json");
+  const normalized = contentType.toLowerCase();
+  return normalized.includes("application/json") || normalized.includes("+json");
 }
 
 function cleanResponseHeaders(headers: Headers): Headers {
   const cleaned = new Headers(headers);
   cleaned.delete("transfer-encoding");
   cleaned.delete("content-length");
+  cleaned.delete("content-encoding");
   return cleaned;
 }
 

--- a/src/app/v1/_lib/proxy/response-output-normalizer.ts
+++ b/src/app/v1/_lib/proxy/response-output-normalizer.ts
@@ -1,0 +1,187 @@
+import { logger } from "@/lib/logger";
+import type { ProxySession } from "./session";
+
+type JsonRecord = Record<string, unknown>;
+
+export type ResponseOutputNormalizationResult = {
+  payload: unknown;
+  applied: boolean;
+  fixes: string[];
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isJsonContentType(contentType: string): boolean {
+  return contentType.includes("application/json") || contentType.includes("+json");
+}
+
+function cleanResponseHeaders(headers: Headers): Headers {
+  const cleaned = new Headers(headers);
+  cleaned.delete("transfer-encoding");
+  cleaned.delete("content-length");
+  return cleaned;
+}
+
+function stringifyArguments(value: unknown): string {
+  if (value == null) return "{}";
+  if (typeof value === "string") return value;
+
+  try {
+    return JSON.stringify(value) ?? "{}";
+  } catch {
+    return String(value);
+  }
+}
+
+function normalizeFunctionArguments(
+  target: JsonRecord,
+  key: string,
+  fixes: string[],
+  path: string
+): void {
+  if (!(key in target)) return;
+
+  const value = target[key];
+  const normalized = stringifyArguments(value);
+  if (normalized === value) return;
+
+  target[key] = normalized;
+  fixes.push(`${path}.${key}`);
+}
+
+function normalizeContentPart(part: unknown, fixes: string[], path: string): void {
+  if (!isRecord(part)) return;
+
+  if ("text" in part && part.text === null) {
+    part.text = "";
+    fixes.push(`${path}.text`);
+  }
+
+  if ("annotations" in part && part.annotations === null) {
+    part.annotations = [];
+    fixes.push(`${path}.annotations`);
+  }
+
+  if ("logprobs" in part && part.logprobs === null) {
+    part.logprobs = [];
+    fixes.push(`${path}.logprobs`);
+  }
+}
+
+function normalizeToolCall(toolCall: unknown, fixes: string[], path: string): void {
+  if (!isRecord(toolCall)) return;
+
+  const nestedFunction = toolCall.function;
+  if (isRecord(nestedFunction)) {
+    normalizeFunctionArguments(nestedFunction, "arguments", fixes, `${path}.function`);
+  }
+}
+
+function normalizeOutputItem(item: unknown, fixes: string[], path: string): void {
+  if (!isRecord(item)) return;
+
+  // Responses API 的 message.content 是数组；部分兼容上游会把空内容写成 null。
+  if ("content" in item) {
+    if (item.content === null) {
+      item.content = [];
+      fixes.push(`${path}.content`);
+    } else if (Array.isArray(item.content)) {
+      item.content.forEach((part, index) => {
+        normalizeContentPart(part, fixes, `${path}.content[${index}]`);
+      });
+    }
+  }
+
+  if ("summary" in item && item.summary === null) {
+    item.summary = [];
+    fixes.push(`${path}.summary`);
+  }
+
+  normalizeFunctionArguments(item, "arguments", fixes, path);
+
+  const nestedFunction = item.function;
+  if (isRecord(nestedFunction)) {
+    normalizeFunctionArguments(nestedFunction, "arguments", fixes, `${path}.function`);
+  }
+
+  if (Array.isArray(item.tool_calls)) {
+    item.tool_calls.forEach((toolCall, index) => {
+      normalizeToolCall(toolCall, fixes, `${path}.tool_calls[${index}]`);
+    });
+  }
+}
+
+export function normalizeResponseOutputPayload(
+  payload: unknown
+): ResponseOutputNormalizationResult {
+  const fixes: string[] = [];
+
+  if (!isRecord(payload) || payload.object !== "response") {
+    return { payload, applied: false, fixes };
+  }
+
+  if ("output" in payload) {
+    if (payload.output === null) {
+      payload.output = [];
+      fixes.push("output");
+    } else if (Array.isArray(payload.output)) {
+      payload.output.forEach((item, index) => {
+        normalizeOutputItem(item, fixes, `output[${index}]`);
+      });
+    }
+  }
+
+  if ("tools" in payload && payload.tools === null) {
+    payload.tools = [];
+    fixes.push("tools");
+  }
+
+  return { payload, applied: fixes.length > 0, fixes };
+}
+
+export async function normalizeResponseOutput(
+  session: ProxySession,
+  response: Response
+): Promise<Response> {
+  if (session.originalFormat !== "response") return response;
+  if (response.status < 200 || response.status >= 300) return response;
+
+  const contentType = response.headers.get("content-type") || "";
+  if (!isJsonContentType(contentType)) return response;
+
+  let rawText: string;
+  try {
+    rawText = await response.clone().text();
+  } catch (error) {
+    logger.warn("[ResponseOutputNormalizer] Failed to read response clone", {
+      error: error instanceof Error ? error.message : String(error),
+      sessionId: session.sessionId ?? null,
+      requestSequence: session.requestSequence ?? null,
+    });
+    return response;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    return response;
+  }
+
+  const result = normalizeResponseOutputPayload(parsed);
+  if (!result.applied) return response;
+
+  logger.info("[ResponseOutputNormalizer] Normalized Responses API output", {
+    fixes: result.fixes,
+    sessionId: session.sessionId ?? null,
+    requestSequence: session.requestSequence ?? null,
+  });
+
+  return new Response(JSON.stringify(result.payload), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: cleanResponseHeaders(response.headers),
+  });
+}

--- a/tests/unit/proxy/response-output-normalizer.test.ts
+++ b/tests/unit/proxy/response-output-normalizer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeResponseOutput,
   normalizeResponseOutputPayload,
@@ -8,6 +8,10 @@ import type { ProxySession } from "@/app/v1/_lib/proxy/session";
 vi.mock("@/lib/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 function createResponseSession(): ProxySession {
   return {
@@ -130,8 +134,9 @@ describe("normalizeResponseOutput", () => {
       {
         status: 200,
         headers: {
-          "content-type": "application/json",
+          "content-type": "Application/JSON",
           "content-length": "999",
+          "content-encoding": "gzip",
         },
       }
     );
@@ -140,6 +145,7 @@ describe("normalizeResponseOutput", () => {
     const body = await normalized.json();
 
     expect(normalized.headers.has("content-length")).toBe(false);
+    expect(normalized.headers.has("content-encoding")).toBe(false);
     expect(body.output[0].content[0]).toMatchObject({ text: "", annotations: [] });
   });
 
@@ -154,6 +160,66 @@ describe("normalizeResponseOutput", () => {
     } as unknown as ProxySession;
 
     const normalized = await normalizeResponseOutput(session, response);
+
+    expect(normalized).toBe(response);
+  });
+
+  it("returns the original response when no normalization is needed", async () => {
+    const response = new Response(
+      JSON.stringify({
+        id: "resp_test",
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            id: "msg_1",
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            content: [],
+          },
+        ],
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
+
+    const normalized = await normalizeResponseOutput(createResponseSession(), response);
+
+    expect(normalized).toBe(response);
+  });
+
+  it("skips non-2xx responses", async () => {
+    const response = new Response('{"object":"response","output":null}', {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    });
+
+    const normalized = await normalizeResponseOutput(createResponseSession(), response);
+
+    expect(normalized).toBe(response);
+  });
+
+  it("skips non-JSON content types", async () => {
+    const response = new Response("text", {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    });
+
+    const normalized = await normalizeResponseOutput(createResponseSession(), response);
+
+    expect(normalized).toBe(response);
+  });
+
+  it("returns the original response when JSON parsing fails", async () => {
+    const response = new Response("not json", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    const normalized = await normalizeResponseOutput(createResponseSession(), response);
 
     expect(normalized).toBe(response);
   });

--- a/tests/unit/proxy/response-output-normalizer.test.ts
+++ b/tests/unit/proxy/response-output-normalizer.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  normalizeResponseOutput,
+  normalizeResponseOutputPayload,
+} from "@/app/v1/_lib/proxy/response-output-normalizer";
+import type { ProxySession } from "@/app/v1/_lib/proxy/session";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+function createResponseSession(): ProxySession {
+  return {
+    originalFormat: "response",
+    sessionId: "sess_test",
+    requestSequence: 1,
+  } as unknown as ProxySession;
+}
+
+describe("normalizeResponseOutputPayload", () => {
+  it("normalizes nullable Responses fields that official SDKs parse as arrays or strings", () => {
+    const payload = {
+      id: "resp_test",
+      object: "response",
+      status: "completed",
+      output: [
+        {
+          id: "msg_1",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: null,
+        },
+        {
+          id: "msg_2",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [
+            {
+              type: "output_text",
+              text: null,
+              annotations: null,
+              logprobs: null,
+            },
+          ],
+        },
+        {
+          id: "fc_1",
+          type: "function_call",
+          name: "lookup",
+          arguments: null,
+        },
+        {
+          id: "tc_1",
+          type: "tool_calls",
+          tool_calls: [{ function: { name: "search", arguments: { q: "ok" } } }],
+        },
+        {
+          id: "rs_1",
+          type: "reasoning",
+          summary: null,
+        },
+      ],
+      tools: null,
+      usage: null,
+    };
+
+    const result = normalizeResponseOutputPayload(payload);
+
+    expect(result.applied).toBe(true);
+    expect(payload.output[0].content).toEqual([]);
+    expect(payload.output[1].content[0]).toMatchObject({
+      text: "",
+      annotations: [],
+      logprobs: [],
+    });
+    expect(payload.output[2].arguments).toBe("{}");
+    expect(payload.output[3].tool_calls[0].function.arguments).toBe('{"q":"ok"}');
+    expect(payload.output[4].summary).toEqual([]);
+    expect(payload.tools).toEqual([]);
+    expect(payload.usage).toBeNull();
+  });
+
+  it("normalizes top-level null output to an empty array", () => {
+    const payload = {
+      id: "resp_test",
+      object: "response",
+      status: "completed",
+      output: null,
+    };
+
+    const result = normalizeResponseOutputPayload(payload);
+
+    expect(result).toMatchObject({ applied: true });
+    expect(payload.output).toEqual([]);
+  });
+
+  it("leaves non-response JSON payloads untouched", () => {
+    const payload = {
+      object: "list",
+      output: null,
+      data: [],
+    };
+
+    const result = normalizeResponseOutputPayload(payload);
+
+    expect(result.applied).toBe(false);
+    expect(payload.output).toBeNull();
+  });
+});
+
+describe("normalizeResponseOutput", () => {
+  it("returns a new SDK-compatible JSON response when nullable fields are fixed", async () => {
+    const response = new Response(
+      JSON.stringify({
+        id: "resp_test",
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            id: "msg_1",
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text: null, annotations: null }],
+          },
+        ],
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "content-length": "999",
+        },
+      }
+    );
+
+    const normalized = await normalizeResponseOutput(createResponseSession(), response);
+    const body = await normalized.json();
+
+    expect(normalized.headers.has("content-length")).toBe(false);
+    expect(body.output[0].content[0]).toMatchObject({ text: "", annotations: [] });
+  });
+
+  it("skips non-Responses client formats", async () => {
+    const response = new Response('{"object":"response","output":null}', {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    const session = {
+      ...createResponseSession(),
+      originalFormat: "openai",
+    } as unknown as ProxySession;
+
+    const normalized = await normalizeResponseOutput(session, response);
+
+    expect(normalized).toBe(response);
+  });
+});


### PR DESCRIPTION
## Summary

Normalize nullable fields in non-streaming OpenAI Responses payloads before returning them to clients, ensuring compatibility with the official `openai-python` SDK parser.

Fixes #1219

## Problem

When using CCH as an OpenAI-compatible proxy for `/v1/responses`, the raw HTTP response can be successful (`HTTP 200`, `status: completed`), but clients using the official `openai-python` Responses API parser fail with:

```
TypeError: 'NoneType' object is not iterable
```

This occurs because some upstream providers return `null` for fields where the OpenAI Responses schema expects arrays, strings, or objects. The proxy passes these `null` values through unchanged, causing the SDK parser to crash before the caller can read `response.output_text`.

## Solution

Add a response output normalizer (`response-output-normalizer.ts`) that runs on non-SSE responses after the existing `ResponseFixer` pipeline, before the response is returned to the client.

**Normalization rules applied:**

| Field | Before | After |
|-------|--------|-------|
| `output` | `null` | `[]` |
| `message.content` | `null` | `[]` |
| `text` (output_text) | `null` | `""` |
| `annotations` | `null` | `[]` |
| `logprobs` | `null` | `[]` |
| `function_call.arguments` | `null` or object | `"{}"` or JSON string |
| `tools` | `null` | `[]` |
| `summary` (reasoning) | `null` | `[]` |

**Design decisions:**
- Scoped to `originalFormat === "response"` only (OpenAI Responses API format)
- Skipped when `bypassResponseRectifier` is enabled on the endpoint policy
- Only processes 2xx JSON responses
- Preserves `usage: null` (no normalization needed)
- Strips `transfer-encoding` and `content-length` headers after re-serialization
- Logs each applied fix for observability

This is the output-side counterpart to the existing request-input rectifier added in #888.

## Changes

| File | Change | Purpose |
|------|--------|---------|
| `src/app/v1/_lib/proxy/response-output-normalizer.ts` | Added | Core normalizer: payload normalization + response wrapper |
| `src/app/v1/_lib/proxy/response-handler.ts` | Modified | Integrate normalizer before `handleNonStream()` |
| `tests/unit/proxy/response-output-normalizer.test.ts` | Added | Unit tests for payload and response-level normalization |

## Testing

- [x] Unit tests added: `normalizeResponseOutputPayload` (3 tests) + `normalizeResponseOutput` (2 tests)
- [x] Type check passes (`bun run typecheck`)
- [x] Lint passes (`bun run lint`)
- [x] Build passes (`bun run build`)
- [x] Verified with `openai==2.24.0` local parser smoke test

## Related

- Fixes #1219 - OpenAI-compatible /v1/responses returns 200 but openai-python parser fails
- Follow-up to #888 - feat: add response input rectifier for /v1/responses (request-side counterpart)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `ResponseOutputNormalizer` that converts `null` Responses API fields (`output`, `content`, `text`, `annotations`, `logprobs`, `tools`, `summary`, `function.arguments`) to their SDK-expected types (empty array, empty string, or serialized JSON), fixing `TypeError: 'NoneType' object is not iterable` crashes in the `openai-python` parser when upstream providers return nulls.

- **New file** `response-output-normalizer.ts`: clones and parses the fixed response body, applies targeted null→default coercions, re-serializes, and strips `content-encoding`/`content-length`/`transfer-encoding` headers; gracefully falls back to the original response on parse failure.
- **Integration** in `ResponseFixer.processNonStream`: normalizer runs as the final step after the encoding and JSON fixers, scoped to `originalFormat === \"response\"` non-SSE 2xx responses.
- **Tests**: 9 unit tests covering all normalization paths, format guards, error fallbacks, and header stripping.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the normalizer is additive, scoped to Responses-format non-streaming responses, and falls back to the original response on any error.

The logic is correct for all cases reviewed: null-to-default coercions, format/status/content-type guards, graceful fallback on JSON parse failure, and correct header cleanup. The one design note — that the normalizer is also skipped when enableResponseFixer is false — is reflected in an explicit test and is an intentional architectural choice, not a defect on the changed path.

No files require special attention, though the coupling between enableResponseFixer and the normalizer in response-fixer/index.ts is worth a second look if the normalizer is ever meant to operate independently.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/response-output-normalizer.ts | New normalizer: correctly guards on format/status/content-type, handles null→array/string/serialized-JSON conversions, and gracefully falls back on parse failure. |
| src/app/v1/_lib/proxy/response-fixer/index.ts | Integrates normalizer at the tail of processNonStream; the normalizer is silently skipped when enableResponseFixer is false, coupling two independent concerns under one feature flag. |
| src/app/v1/_lib/proxy/response-handler.ts | Adds a comment clarifying that bypassResponseRectifier skips both the fixer and the embedded normalizer; no logic changes. |
| src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts | Updates disabled-fixer test to use a Responses-format payload and verifies null is preserved; adds a new test confirming normalization fires when the fixer is enabled. |
| tests/unit/proxy/response-output-normalizer.test.ts | Comprehensive unit tests covering payload normalization (null output, nested content parts, function arguments) and response-level behaviour (header stripping, format guard, error fallbacks). |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Handler as ProxyResponseHandler
    participant Fixer as ResponseFixer
    participant Normalizer as ResponseOutputNormalizer

    Client->>Handler: "non-streaming request (originalFormat=response)"
    Handler->>Handler: bypassResponseRectifier?
    alt "bypass = true"
        Handler-->>Client: raw upstream response (null fields preserved)
    else "bypass = false"
        Handler->>Fixer: process(session, response)
        Fixer->>Fixer: enableResponseFixer?
        alt fixer disabled
            Fixer-->>Handler: raw response (normalizer also skipped)
        else fixer enabled
            Fixer->>Fixer: EncodingFixer + JsonFixer
            Fixer->>Normalizer: normalizeResponseOutput(session, fixedResponse)
            Normalizer->>Normalizer: "originalFormat === response?"
            Normalizer->>Normalizer: 2xx + JSON content-type?
            Normalizer->>Normalizer: clone + parse body
            Normalizer->>Normalizer: normalizeResponseOutputPayload()
            alt null fields found
                Normalizer-->>Fixer: "new Response (nulls to array/string/{})"
            else no fixes needed
                Normalizer-->>Fixer: original response (identity)
            end
            Fixer-->>Handler: normalizedResponse
        end
        Handler-->>Client: normalized response
    end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/app/v1/_lib/proxy/response-fixer/index.ts:217-220
The normalizer is embedded inside `processNonStream`, which is only reached when `enableResponseFixer` is `true`. When the fixer is disabled (`enableResponseFixer: false`), `ResponseFixer.process` returns the raw response at line 219 before `processNonStream` is ever called, so `normalizeResponseOutput` is silently skipped. The two concerns — JSON repair and schema normalization — are independent: a deployment that opts out of the fixer to avoid its overhead will still expose the `TypeError: 'NoneType' object is not iterable` crash for Responses API clients. The test "禁用时应原样透传" now explicitly asserts `output: null` is preserved in this case, confirming the bypass is intentional, but the PR description only mentions `bypassResponseRectifier` as the skip condition, which may mislead operators who disable the fixer for unrelated reasons. Consider calling `normalizeResponseOutput` unconditionally from `ResponseFixer.process` (after the early-return guard) so the normalizer's lifecycle is independent of `enableResponseFixer`.

```suggestion
    const enabled = settings.enableResponseFixer ?? true;
    if (!enabled) {
      return await normalizeResponseOutput(session, response);
    }
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(proxy): 完善 Responses 输出归一化边界"](https://github.com/ding113/claude-code-hub/commit/6640f4b606f9e095415d97cd92ae31dc690005d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34143520)</sub>

<!-- /greptile_comment -->