### PR TITLE
fix(anthropic): normalize /v1/models created_at to second precision per API spec

### DIFF
--- a/src/app/v1/_lib/models/available-models.ts
+++ b/src/app/v1/_lib/models/available-models.ts
@@ -371,15 +371,30 @@ export function formatOpenAIResponse(models: FetchedModel[]): OpenAIModelsRespon
 }
 
 /**
+ * 将时间戳归一化为 Anthropic API 规范格式(秒级精度,不含毫秒)。
+ *
+ * 官方 Anthropic /v1/models 的 created_at 形如 `2026-05-29T09:22:44Z`,不含毫秒;
+ * 而 Date.toISOString() 始终输出 `.SSSZ`,部分上游也会带毫秒,因此统一去除。
+ * 无法解析的上游时间戳原样返回,避免抛错。
+ */
+function normalizeAnthropicTimestamp(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
  * 格式化为 Anthropic 响应
  */
 export function formatAnthropicResponse(models: FetchedModel[]): AnthropicModelsResponse {
-  const now = new Date().toISOString();
+  const now = normalizeAnthropicTimestamp(new Date().toISOString());
   const data = models.map((m) => ({
     id: m.id,
     type: "model" as const,
     display_name: m.displayName || m.id,
-    created_at: m.createdAt || now,
+    created_at: m.createdAt ? normalizeAnthropicTimestamp(m.createdAt) : now,
   }));
 
   return { data, has_more: false };

--- a/tests/unit/proxy/available-models.test.ts
+++ b/tests/unit/proxy/available-models.test.ts
@@ -204,6 +204,39 @@ describe("formatAnthropicResponse - Anthropic 格式响应", () => {
     const result: AnthropicModelsResponse = formatAnthropicResponse([{ id: "test-model" }]);
     expect(result.data[0].display_name).toBe("test-model");
   });
+
+  test("fallback created_at 不应包含毫秒(符合官方 API 规范)", () => {
+    const result: AnthropicModelsResponse = formatAnthropicResponse([{ id: "test-model" }]);
+    expect(result.data[0].created_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("上游带毫秒的 created_at 应被归一化为秒级精度", () => {
+    const result: AnthropicModelsResponse = formatAnthropicResponse([
+      { id: "claude-3-opus", createdAt: "2026-05-29T09:22:44.350Z" },
+    ]);
+    expect(result.data[0].created_at).toBe("2026-05-29T09:22:44Z");
+  });
+
+  test("上游已是秒级精度的 created_at 应保持不变", () => {
+    const result: AnthropicModelsResponse = formatAnthropicResponse([
+      { id: "claude-3-opus", createdAt: "2024-02-29T00:00:00Z" },
+    ]);
+    expect(result.data[0].created_at).toBe("2024-02-29T00:00:00Z");
+  });
+
+  test("非 Z 时区偏移的 created_at 应被归一化为 UTC 秒级精度", () => {
+    const result: AnthropicModelsResponse = formatAnthropicResponse([
+      { id: "claude-3-opus", createdAt: "2026-05-29T17:22:44.350+08:00" },
+    ]);
+    expect(result.data[0].created_at).toBe("2026-05-29T09:22:44Z");
+  });
+
+  test("无法解析的 created_at 应原样返回,不抛错", () => {
+    const result: AnthropicModelsResponse = formatAnthropicResponse([
+      { id: "claude-3-opus", createdAt: "not-a-valid-date" },
+    ]);
+    expect(result.data[0].created_at).toBe("not-a-valid-date");
+  });
 });
 
 describe("formatGeminiResponse - Gemini 格式响应", () => {


### PR DESCRIPTION
## 背景

修复 #1226:Anthropic 格式 `/v1/models` 响应中的 `created_at` 字段带有毫秒(如 `2026-05-29T09:22:44.350Z`),不符合官方 Anthropic API 规范——官方返回的是秒级精度、不含毫秒的时间戳(如 `2026-05-29T09:22:44Z`)。

## 根因

`src/app/v1/_lib/models/available-models.ts` 的 `formatAnthropicResponse`:

1. fallback 时间戳由 `new Date().toISOString()` 生成,该方法**始终**输出 `.SSSZ` 毫秒格式。
2. 当上游 provider 自身返回带毫秒的 `created_at` 时,该值被直接透传,未做归一化。

两种情况都会让响应偏离官方规范。

## 改动

- 新增 `normalizeAnthropicTimestamp(value)` 辅助函数:将时间戳统一归一化为秒级精度 UTC(去除毫秒部分);无法解析的上游时间戳原样返回,避免抛错。
- 在 `formatAnthropicResponse` 中对 fallback 时间戳与上游透传的 `createdAt` 同时应用归一化。

仅影响 Anthropic 格式的模型列表响应;OpenAI / Gemini 格式不受影响。

## 测试

新增 5 个单测覆盖:fallback 无毫秒、上游带毫秒被归一化、已是秒级精度保持不变、非 `Z` 时区偏移归一化为 UTC、非法时间戳原样返回。

本地验证(全部通过):
- `bun run typecheck` ✓
- `bun run lint` ✓
- `bun run build` ✓
- `bun run test` ✓(6168 passed / 13 skipped)

Fixes #1226

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR normalizes the `created_at` field in Anthropic `/v1/models` responses to second-precision UTC (e.g., `2026-05-29T09:22:44Z`) by introducing a `normalizeAnthropicTimestamp` helper, bringing the output in line with the official Anthropic API spec.

- A new private `normalizeAnthropicTimestamp(value)` function parses any incoming timestamp through `Date`, then re-serializes via `toISOString()` and strips the milliseconds with a regex — guaranteeing clean output for both the fallback `now` and upstream `createdAt` values.
- Five new unit tests cover the full edge-case surface: fallback format, upstream ms stripping, already-normalized passthrough, non-Z offset conversion, and invalid-string passthrough.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to the Anthropic model-list formatter, the normalisation logic is correct for all input shapes, and five new tests cover the full edge-case surface.

The core fix is sound: `toISOString()` always emits exactly three millisecond digits, so the regex `/\.\d{3}Z$/` always matches on the re-serialised output regardless of the original input format. Invalid inputs are passed through without throwing. OpenAI and Gemini formatters are untouched. The only observation is a minor redundancy in constructing the fallback timestamp.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/models/available-models.ts | Adds `normalizeAnthropicTimestamp` helper and applies it to both the fallback timestamp and upstream `createdAt` values in `formatAnthropicResponse`. Logic is correct; regex always matches because `toISOString()` guarantees exactly 3 decimal digits. |
| tests/unit/proxy/available-models.test.ts | Adds 5 new unit tests covering: fallback without ms, upstream ms stripped, already-second-precision preserved, non-Z timezone normalized to UTC, and invalid timestamp passthrough. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["formatAnthropicResponse(models)"] --> B["now = normalizeAnthropicTimestamp(new Date().toISOString())"]
    A --> C["models.map"]
    C --> D{"m.createdAt exists?"}
    D -- yes --> E["normalizeAnthropicTimestamp(m.createdAt)"]
    D -- no --> F["use now fallback"]
    E --> G["normalizeAnthropicTimestamp"]
    G --> I{"parsed date valid?"}
    I -- no --> J["return value as-is"]
    I -- yes --> K["toISOString then strip ms"]
    K --> L["YYYY-MM-DDTHH:mm:ssZ"]
    L --> H["created_at field"]
    F --> H
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/app/v1/_lib/models/available-models.ts:392
Calling `normalizeAnthropicTimestamp` on a freshly-generated `new Date().toISOString()` works correctly but is unnecessary: the helper parses the string back into a `Date` and re-serialises it, doing the same work twice. The regex can be applied directly to the already-valid ISO string.

```suggestion
  const now = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(anthropic): normalize created\_at to ..."](https://github.com/ding113/claude-code-hub/commit/caa456b4626d92c14710098078b7fdb01a7f003f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34571256)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->