### PR TITLE
fix(proxy): exclude upstream 400/422 from breaker

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -135,6 +135,10 @@ function decodeRequestBodyAsJson(body: BodyInit | undefined): Record<string, unk
   }
 }
 
+function isNonRetryableUpstreamRequestError(error: Error): error is ProxyError {
+  return error instanceof ProxyError && (error.statusCode === 400 || error.statusCode === 422);
+}
+
 const OUTBOUND_TRANSPORT_HEADER_BLACKLIST = [
   "content-length",
   "connection",
@@ -1682,6 +1686,13 @@ export class ProxyForwarder {
               maxAttemptsPerProvider = Math.max(maxAttemptsPerProvider, attemptCount + 1);
               continue;
             }
+          }
+
+          if (
+            errorCategory === ErrorCategory.PROVIDER_ERROR &&
+            isNonRetryableUpstreamRequestError(lastError)
+          ) {
+            errorCategory = ErrorCategory.NON_RETRYABLE_CLIENT_ERROR;
           }
 
           // ⭐ 3. 不可重试的客户端输入错误处理（不计入熔断器，不重试，立即返回）

--- a/tests/unit/proxy/proxy-forwarder-retry-limit.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-retry-limit.test.ts
@@ -894,6 +894,41 @@ describe("ProxyForwarder - retry limit enforcement", () => {
   });
 });
 
+describe("ProxyForwarder - client request upstream errors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(categorizeErrorAsync).mockResolvedValue(ErrorCategory.PROVIDER_ERROR);
+  });
+
+  test("upstream 400 should not retry or count against provider circuit breaker", async () => {
+    const session = createSession();
+    const provider = createProvider({
+      providerVendorId: null,
+      maxRetryAttempts: 4,
+    });
+    session.setProvider(provider);
+
+    const doForward = vi.spyOn(
+      ProxyForwarder as unknown as { doForward: (...args: unknown[]) => unknown },
+      "doForward"
+    );
+    doForward.mockImplementationOnce(async () => {
+      throw new ProxyError("Provider returned 400: Bad Request", 400, {
+        body: '{"detail":"Bad Request"}',
+        providerId: provider.id,
+        providerName: provider.name,
+      });
+    });
+
+    await expect(ProxyForwarder.send(session)).rejects.toMatchObject({
+      statusCode: 400,
+    });
+
+    expect(doForward).toHaveBeenCalledTimes(1);
+    expect(mocks.recordFailure).not.toHaveBeenCalled();
+  });
+});
+
 describe("ProxyForwarder - endpoint stickiness on retry", () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary

Treat upstream 400/422 `ProxyError` responses as non-retryable client errors, preventing unnecessary retries and unfair circuit breaker penalization of healthy providers.

## Problem

When an upstream provider returns HTTP 400 (Bad Request) or 422 (Unprocessable Entity), the proxy previously classified these as `PROVIDER_ERROR`. This caused two issues:

1. **Wasteful retries**: The same malformed request is retried against the same or different providers, but the 400/422 will recur since the problem is in the request itself, not the provider.
2. **Unfair circuit breaker impact**: These errors count against the provider's health score, potentially marking healthy providers as unhealthy and excluding them from rotation.

This also contributes to the retry storm behavior described in #854, where upstream 400 errors (e.g., malformed image URLs with large base64 payloads) trigger repeated retries that generate oversized provider chains and stuck request records.

**Related Issues:**
- Related to #854 - upstream 400 errors were previously retried, contributing to retry storms and stuck-request issues
- Related to #1103 - same area of error classification refinement in proxy forwarder

## Solution

Reclassify upstream `ProxyError` responses with status codes 400 or 422 from `PROVIDER_ERROR` to `NON_RETRYABLE_CLIENT_ERROR` before retry and circuit breaker accounting. The existing `NON_RETRYABLE_CLIENT_ERROR` path already handles immediate return without retry or circuit breaker impact.

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/forwarder.ts` (+11)
  - Add `isNonRetryableUpstreamRequestError()` type guard that identifies `ProxyError` instances with status 400 or 422
  - Add reclassification logic after error categorization: if error is `PROVIDER_ERROR` and matches 400/422, reclassify as `NON_RETRYABLE_CLIENT_ERROR`

### Tests
- `tests/unit/proxy/proxy-forwarder-retry-limit.test.ts` (+35)
  - New test: verify upstream 400 does not trigger retry (`doForward` called exactly once)
  - New test: verify upstream 400 does not record failure against circuit breaker (`recordFailure` not called)

## Testing

```bash
bunx vitest run tests/unit/proxy/proxy-forwarder-retry-limit.test.ts
```

## Checklist
- [x] Code follows project conventions
- [x] Tests added for upstream 400 behavior
- [x] Target branch is `dev`

---
*Description enhanced by Claude AI*