### PR TITLE
fix(dashboard): unify timezone handling

### DIFF
--- a/src/actions/statistics.ts
+++ b/src/actions/statistics.ts
@@ -24,6 +24,11 @@ import type { ActionResult } from "./types";
  */
 const createDataKey = (prefix: string, id: number): string => `${prefix}-${id}`;
 
+function serializeChartBucketDate(value: string | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? String(value) : date.toISOString();
+}
+
 /**
  * 获取用户统计数据，用于图表展示
  */
@@ -99,16 +104,7 @@ export async function getUserStatistics(
     const dataByDate = new Map<string, ChartDataItem>();
 
     statsData.forEach((row) => {
-      // 根据分辨率格式化日期
-      let dateStr: string;
-      if (rangeConfig.resolution === "hour") {
-        // 小时分辨率：显示为 "HH:mm" 格式
-        const hour = new Date(row.date);
-        dateStr = hour.toISOString();
-      } else {
-        // 天分辨率：显示为 "YYYY-MM-DD" 格式
-        dateStr = new Date(row.date).toISOString().split("T")[0];
-      }
+      const dateStr = serializeChartBucketDate(row.date);
 
       if (!dataByDate.has(dateStr)) {
         dataByDate.set(dateStr, {

--- a/src/actions/system-config.ts
+++ b/src/actions/system-config.ts
@@ -8,6 +8,11 @@ import { invalidateSystemSettingsCache } from "@/lib/config";
 import { logger } from "@/lib/logger";
 import { publishCurrentPublicStatusConfigProjection } from "@/lib/public-status/config-publisher";
 import { schedulePublicStatusRebuild } from "@/lib/public-status/rebuild-hints";
+import {
+  invalidateAllLeaderboardCaches,
+  invalidateAllOverviewCaches,
+  invalidateAllStatisticsCaches,
+} from "@/lib/redis";
 import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import { UpdateSystemSettingsSchema } from "@/lib/validation/schemas";
 import { getSystemSettings, updateSystemSettings } from "@/repository/system-config";
@@ -150,6 +155,18 @@ export async function saveSystemSettings(formData: {
       "@/app/v1/_lib/proxy/provider-selector-settings-cache"
     );
     invalidateProviderSelectorSystemSettingsCache();
+
+    if (validated.timezone !== undefined) {
+      await Promise.all([
+        invalidateAllOverviewCaches(),
+        invalidateAllStatisticsCaches(),
+        invalidateAllLeaderboardCaches(),
+      ]).catch((error) => {
+        logger.warn("[SystemSettings] Failed to invalidate timezone-sensitive dashboard caches", {
+          error,
+        });
+      });
+    }
 
     const shouldRepublishPublicStatusProjection =
       validated.siteTitle !== undefined ||

--- a/src/app/[locale]/dashboard/leaderboard/_components/date-range-picker.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/date-range-picker.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { addDays, endOfMonth, endOfWeek, format, startOfMonth, startOfWeek } from "date-fns";
+import { formatInTimeZone, toZonedTime } from "date-fns-tz";
 import { CalendarIcon, ChevronLeft, ChevronRight } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useTimeZone, useTranslations } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import type { DateRange } from "react-day-picker";
 import { Button } from "@/components/ui/button";
@@ -28,6 +29,10 @@ function formatDate(date: Date): string {
   return format(date, "yyyy-MM-dd");
 }
 
+function formatDateInSystemTimeZone(date: Date, timeZone: string): string {
+  return formatInTimeZone(date, timeZone, "yyyy-MM-dd");
+}
+
 function parseDate(dateStr: string): Date {
   // Parse as local date to avoid timezone issues
   // new Date("YYYY-MM-DD") parses as UTC, which causes off-by-one errors in different timezones
@@ -37,8 +42,10 @@ function parseDate(dateStr: string): Date {
 
 function getDateRangeForPeriod(
   period: QuickPeriod,
-  baseDate: Date = new Date()
+  timeZone: string,
+  now: Date = new Date()
 ): { startDate: string; endDate: string } {
+  const baseDate = toZonedTime(now, timeZone);
   switch (period) {
     case "daily":
       return { startDate: formatDate(baseDate), endDate: formatDate(baseDate) };
@@ -53,7 +60,7 @@ function getDateRangeForPeriod(
       return { startDate: formatDate(start), endDate: formatDate(end) };
     }
     default:
-      return { startDate: "2020-01-01", endDate: formatDate(new Date()) };
+      return { startDate: "2020-01-01", endDate: formatDateInSystemTimeZone(now, timeZone) };
   }
 }
 
@@ -74,17 +81,19 @@ function shiftDateRange(
 
 export function DateRangePicker({ period, dateRange, onPeriodChange }: DateRangePickerProps) {
   const t = useTranslations("dashboard.leaderboard");
+  const timeZone = useTimeZone() ?? "UTC";
   const [calendarOpen, setCalendarOpen] = useState(false);
+  const today = useMemo(() => formatDateInSystemTimeZone(new Date(), timeZone), [timeZone]);
 
   const currentRange = useMemo(() => {
     if (period === "custom" && dateRange) {
       return dateRange;
     }
     if (period !== "custom" && QUICK_PERIODS.includes(period as QuickPeriod)) {
-      return getDateRangeForPeriod(period as QuickPeriod);
+      return getDateRangeForPeriod(period as QuickPeriod, timeZone);
     }
-    return getDateRangeForPeriod("daily");
-  }, [period, dateRange]);
+    return getDateRangeForPeriod("daily", timeZone);
+  }, [period, dateRange, timeZone]);
 
   const selectedRange: DateRange = useMemo(() => {
     return {
@@ -198,7 +207,7 @@ export function DateRangePicker({ period, dateRange, onPeriodChange }: DateRange
               selected={selectedRange}
               onSelect={handleDateRangeSelect}
               numberOfMonths={2}
-              disabled={{ after: new Date() }}
+              disabled={{ after: parseDate(today) }}
             />
           </PopoverContent>
         </Popover>
@@ -207,7 +216,7 @@ export function DateRangePicker({ period, dateRange, onPeriodChange }: DateRange
           variant="outline"
           size="icon-sm"
           onClick={() => handleNavigate("next")}
-          disabled={period === "allTime" || currentRange.endDate >= formatDate(new Date())}
+          disabled={period === "allTime" || currentRange.endDate >= today}
           title={t("dateRange.nextPeriod")}
         >
           <ChevronRight className="h-4 w-4" />

--- a/src/app/[locale]/dashboard/leaderboard/_components/date-range-picker.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/date-range-picker.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import { addDays, endOfMonth, endOfWeek, format, startOfMonth, startOfWeek } from "date-fns";
+import {
+  addDays,
+  addMonths,
+  differenceInCalendarDays,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameDay,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
 import { formatInTimeZone, toZonedTime } from "date-fns-tz";
 import { CalendarIcon, ChevronLeft, ChevronRight } from "lucide-react";
 import { useTimeZone, useTranslations } from "next-intl";
@@ -70,7 +80,16 @@ function shiftDateRange(
 ): { startDate: string; endDate: string } {
   const start = parseDate(range.startDate);
   const end = parseDate(range.endDate);
-  const days = Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+
+  if (isSameDay(start, startOfMonth(start)) && isSameDay(end, endOfMonth(start))) {
+    const month = addMonths(start, direction === "prev" ? -1 : 1);
+    return {
+      startDate: formatDate(startOfMonth(month)),
+      endDate: formatDate(endOfMonth(month)),
+    };
+  }
+
+  const days = differenceInCalendarDays(end, start) + 1;
   const shift = direction === "prev" ? -days : days;
 
   return {

--- a/src/app/[locale]/dashboard/leaderboard/user/[userId]/_components/filters/types.ts
+++ b/src/app/[locale]/dashboard/leaderboard/user/[userId]/_components/filters/types.ts
@@ -1,3 +1,6 @@
+import { format, subDays } from "date-fns";
+import { toZonedTime } from "date-fns-tz";
+
 export type TimeRangePreset = "today" | "7days" | "30days" | "thisMonth";
 
 export interface UserInsightsFilters {
@@ -17,33 +20,38 @@ export const DEFAULT_FILTERS: UserInsightsFilters = {
 export function resolveTimePresetDates(preset: TimeRangePreset): {
   startDate?: string;
   endDate?: string;
+};
+export function resolveTimePresetDates(
+  preset: TimeRangePreset,
+  timeZone: string | undefined,
+  now?: Date
+): {
+  startDate?: string;
+  endDate?: string;
+};
+export function resolveTimePresetDates(
+  preset: TimeRangePreset,
+  timeZone?: string,
+  now: Date = new Date()
+): {
+  startDate?: string;
+  endDate?: string;
 } {
-  const now = new Date();
-  const yyyy = now.getFullYear();
-  const mm = String(now.getMonth() + 1).padStart(2, "0");
-  const dd = String(now.getDate()).padStart(2, "0");
-  const today = `${yyyy}-${mm}-${dd}`;
+  const baseDate = timeZone ? toZonedTime(now, timeZone) : now;
+  const today = format(baseDate, "yyyy-MM-dd");
 
   switch (preset) {
     case "today":
       return { startDate: today, endDate: today };
     case "7days": {
-      const start = new Date(now);
-      start.setDate(start.getDate() - 6);
-      const sy = start.getFullYear();
-      const sm = String(start.getMonth() + 1).padStart(2, "0");
-      const sd = String(start.getDate()).padStart(2, "0");
-      return { startDate: `${sy}-${sm}-${sd}`, endDate: today };
+      const start = subDays(baseDate, 6);
+      return { startDate: format(start, "yyyy-MM-dd"), endDate: today };
     }
     case "30days": {
-      const start = new Date(now);
-      start.setDate(start.getDate() - 29);
-      const sy = start.getFullYear();
-      const sm = String(start.getMonth() + 1).padStart(2, "0");
-      const sd = String(start.getDate()).padStart(2, "0");
-      return { startDate: `${sy}-${sm}-${sd}`, endDate: today };
+      const start = subDays(baseDate, 29);
+      return { startDate: format(start, "yyyy-MM-dd"), endDate: today };
     }
     case "thisMonth":
-      return { startDate: `${yyyy}-${mm}-01`, endDate: today };
+      return { startDate: format(baseDate, "yyyy-MM-01"), endDate: today };
   }
 }

--- a/src/app/[locale]/dashboard/leaderboard/user/[userId]/_components/user-insights-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/user/[userId]/_components/user-insights-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ArrowLeft } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useTimeZone, useTranslations } from "next-intl";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "@/i18n/routing";
@@ -19,10 +19,11 @@ interface UserInsightsViewProps {
 
 export function UserInsightsView({ userId, userName }: UserInsightsViewProps) {
   const t = useTranslations("dashboard.leaderboard.userInsights");
+  const timeZone = useTimeZone() ?? "UTC";
   const router = useRouter();
   const [filters, setFilters] = useState<UserInsightsFilters>(DEFAULT_FILTERS);
 
-  const { startDate, endDate } = resolveTimePresetDates(filters.timeRange);
+  const { startDate, endDate } = resolveTimePresetDates(filters.timeRange, timeZone);
 
   return (
     <div className="space-y-6" data-testid="user-insights-page">

--- a/src/app/[locale]/dashboard/logs/_components/filters/active-filters-display.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/filters/active-filters-display.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useMemo } from "react";
@@ -15,6 +16,7 @@ interface ActiveFiltersDisplayProps {
   onClearAll: () => void;
   displayNames: FilterDisplayNames;
   isAdmin: boolean;
+  serverTimeZone?: string;
   className?: string;
 }
 
@@ -30,6 +32,7 @@ export function ActiveFiltersDisplay({
   onClearAll,
   displayNames,
   isAdmin,
+  serverTimeZone,
   className,
 }: ActiveFiltersDisplayProps) {
   const t = useTranslations("dashboard.logs.filters");
@@ -81,8 +84,12 @@ export function ActiveFiltersDisplay({
 
     // Date range filter
     if (filters.startTime && filters.endTime) {
-      const startDate = format(new Date(filters.startTime), "MM/dd");
-      const endDate = format(new Date(filters.endTime - 1000), "MM/dd");
+      const startDate = serverTimeZone
+        ? formatInTimeZone(new Date(filters.startTime), serverTimeZone, "MM/dd")
+        : format(new Date(filters.startTime), "MM/dd");
+      const endDate = serverTimeZone
+        ? formatInTimeZone(new Date(filters.endTime - 1000), serverTimeZone, "MM/dd")
+        : format(new Date(filters.endTime - 1000), "MM/dd");
       result.push({
         key: "startTime",
         label: t("dateRange"),
@@ -133,7 +140,7 @@ export function ActiveFiltersDisplay({
     }
 
     return result;
-  }, [filters, displayNames, isAdmin, t]);
+  }, [filters, displayNames, isAdmin, serverTimeZone, t]);
 
   if (activeFilters.length === 0) {
     return null;

--- a/src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx
@@ -87,6 +87,10 @@ export function LogsDateRangePicker({
   const [calendarOpen, setCalendarOpen] = useState(false);
 
   const hasDateRange = Boolean(startDate && endDate);
+  const today = useMemo(
+    () => getDateRangeForPeriod("today", serverTimeZone).endDate,
+    [serverTimeZone]
+  );
 
   const activeQuickPeriod = useMemo(() => {
     return detectQuickPeriod(startDate, endDate, serverTimeZone);
@@ -212,7 +216,7 @@ export function LogsDateRangePicker({
               selected={selectedRange}
               onSelect={handleDateRangeSelect}
               numberOfMonths={2}
-              disabled={{ after: new Date() }}
+              disabled={{ after: parseDate(today) }}
             />
             {hasDateRange && (
               <div className="border-t p-2">
@@ -228,7 +232,7 @@ export function LogsDateRangePicker({
           variant="outline"
           size="icon-sm"
           onClick={() => handleNavigate("next")}
-          disabled={!hasDateRange || (endDate !== undefined && endDate >= formatDate(new Date()))}
+          disabled={!hasDateRange || (endDate !== undefined && endDate >= today)}
           title={t("leaderboard.dateRange.nextPeriod")}
         >
           <ChevronRight className="h-4 w-4" />

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
@@ -350,6 +350,7 @@ export function UsageLogsFilters({
         onClearAll={handleReset}
         displayNames={displayNames}
         isAdmin={isAdmin}
+        serverTimeZone={serverTimeZone}
       />
 
       {/* Filter Sections */}

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-view-virtualized.tsx
@@ -379,6 +379,7 @@ function UsageLogsViewContent({
             autoRefreshEnabled={!isFullscreenOpen && isAutoRefresh}
             autoRefreshIntervalMs={logsRefreshIntervalMs ?? 5000}
             hiddenColumns={hiddenColumns}
+            serverTimeZone={serverTimeZone}
           />
         </div>
       </div>
@@ -469,6 +470,7 @@ function UsageLogsViewContent({
               hideScrollToTop={true}
               hiddenColumns={hideProviderColumn ? ["provider"] : undefined}
               bodyClassName="h-[calc(var(--cch-viewport-height,100vh)_-_56px_-_32px_-_40px)]"
+              serverTimeZone={serverTimeZone}
             />
           </div>
         </div>

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -124,7 +124,7 @@ export function VirtualizedLogsTable({
   hideScrollToTop = false,
   hiddenColumns,
   bodyClassName,
-  serverTimeZone: _serverTimeZone,
+  serverTimeZone,
   fetchFn,
   queryKeyPrefix = "usage-logs-batch",
   disableDetailDialog = false,
@@ -717,7 +717,12 @@ export function VirtualizedLogsTable({
                   >
                     {/* Time */}
                     <div className="flex-[0.6] min-w-[56px] font-mono text-xs truncate pl-3">
-                      <RelativeTime date={log.createdAt} fallback="-" format="short" />
+                      <RelativeTime
+                        date={log.createdAt}
+                        fallback="-"
+                        format="short"
+                        timeZone={serverTimeZone}
+                      />
                     </div>
 
                     {/* User */}

--- a/src/app/[locale]/dashboard/logs/_utils/time-range.ts
+++ b/src/app/[locale]/dashboard/logs/_utils/time-range.ts
@@ -1,5 +1,5 @@
 import { format, subDays } from "date-fns";
-import { formatInTimeZone, fromZonedTime, toZonedTime } from "date-fns-tz";
+import { fromZonedTime, toZonedTime } from "date-fns-tz";
 
 export interface ClockParts {
   hours: number;
@@ -57,46 +57,41 @@ export function inclusiveEndTimestampFromExclusive(endExclusiveTimestamp: number
 
 export type QuickPeriod = "today" | "yesterday" | "last7days" | "last30days";
 
-function formatDateInTimeZone(date: Date, timeZone?: string): string {
-  if (timeZone) {
-    return formatInTimeZone(date, timeZone, "yyyy-MM-dd");
-  }
-  return format(date, "yyyy-MM-dd");
-}
-
 export function getQuickDateRange(
   period: QuickPeriod,
   timeZone?: string,
   now: Date = new Date()
 ): { startDate: string; endDate: string } {
   const baseDate = timeZone ? toZonedTime(now, timeZone) : now;
+  const formatDate = (date: Date) => format(date, "yyyy-MM-dd");
+
   switch (period) {
     case "today":
       return {
-        startDate: formatDateInTimeZone(baseDate, timeZone),
-        endDate: formatDateInTimeZone(baseDate, timeZone),
+        startDate: formatDate(baseDate),
+        endDate: formatDate(baseDate),
       };
     case "yesterday": {
       const yesterday = subDays(baseDate, 1);
       return {
-        startDate: formatDateInTimeZone(yesterday, timeZone),
-        endDate: formatDateInTimeZone(yesterday, timeZone),
+        startDate: formatDate(yesterday),
+        endDate: formatDate(yesterday),
       };
     }
     case "last7days":
       return {
-        startDate: formatDateInTimeZone(subDays(baseDate, 6), timeZone),
-        endDate: formatDateInTimeZone(baseDate, timeZone),
+        startDate: formatDate(subDays(baseDate, 6)),
+        endDate: formatDate(baseDate),
       };
     case "last30days":
       return {
-        startDate: formatDateInTimeZone(subDays(baseDate, 29), timeZone),
-        endDate: formatDateInTimeZone(baseDate, timeZone),
+        startDate: formatDate(subDays(baseDate, 29)),
+        endDate: formatDate(baseDate),
       };
     default:
       return {
-        startDate: formatDateInTimeZone(baseDate, timeZone),
-        endDate: formatDateInTimeZone(baseDate, timeZone),
+        startDate: formatDate(baseDate),
+        endDate: formatDate(baseDate),
       };
   }
 }

--- a/src/app/[locale]/my-usage/_components/statistics-summary-card.tsx
+++ b/src/app/[locale]/my-usage/_components/statistics-summary-card.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { BarChart3, ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useTimeZone, useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ModelBreakdownColumn } from "@/components/analytics/model-breakdown-column";
 import { Button } from "@/components/ui/button";
@@ -20,20 +20,28 @@ interface StatisticsSummaryCardProps {
   serverTimeZone?: string;
 }
 
+function getDefaultDateRange(timeZone: string): { startDate: string; endDate: string } {
+  const today = formatInTimeZone(new Date(), timeZone, "yyyy-MM-dd");
+  return { startDate: today, endDate: today };
+}
+
 export function StatisticsSummaryCard({
   className,
   autoRefreshSeconds = 30,
   serverTimeZone,
 }: StatisticsSummaryCardProps) {
   const t = useTranslations("myUsage.stats");
+  const providerTimeZone = useTimeZone() ?? "UTC";
+  const effectiveTimeZone = serverTimeZone ?? providerTimeZone;
   const [stats, setStats] = useState<MyStatsSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const [dateRange, setDateRange] = useState<{ startDate?: string; endDate?: string }>(() => {
-    const today = format(new Date(), "yyyy-MM-dd");
-    return { startDate: today, endDate: today };
-  });
+  const [dateRange, setDateRange] = useState<{ startDate?: string; endDate?: string }>(() =>
+    getDefaultDateRange(effectiveTimeZone)
+  );
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const autoDateRangeRef = useRef(true);
+  const previousTimeZoneRef = useRef(effectiveTimeZone);
 
   const loadStats = useCallback(async () => {
     const result = await getMyStatsSummary({
@@ -50,6 +58,13 @@ export function StatisticsSummaryCard({
     setLoading(true);
     loadStats().finally(() => setLoading(false));
   }, [loadStats]);
+
+  useEffect(() => {
+    if (previousTimeZoneRef.current === effectiveTimeZone) return;
+    previousTimeZoneRef.current = effectiveTimeZone;
+    if (!autoDateRangeRef.current) return;
+    setDateRange(getDefaultDateRange(effectiveTimeZone));
+  }, [effectiveTimeZone]);
 
   // Auto-refresh with visibility change handling
   useEffect(() => {
@@ -96,6 +111,7 @@ export function StatisticsSummaryCard({
   }, [loadStats]);
 
   const handleDateRangeChange = useCallback((range: { startDate?: string; endDate?: string }) => {
+    autoDateRangeRef.current = false;
     setDateRange(range);
   }, []);
 

--- a/src/app/[locale]/my-usage/_components/usage-logs-section.tsx
+++ b/src/app/[locale]/my-usage/_components/usage-logs-section.tsx
@@ -341,6 +341,7 @@ export function UsageLogsSection({
                 ipLookupMode="my-usage"
                 autoRefreshEnabled={!!autoRefreshSeconds}
                 autoRefreshIntervalMs={autoRefreshSeconds ? autoRefreshSeconds * 1000 : undefined}
+                serverTimeZone={serverTimeZone}
               />
             </div>
           </div>

--- a/src/app/[locale]/my-usage/_components/usage-logs-table.tsx
+++ b/src/app/[locale]/my-usage/_components/usage-logs-table.tsx
@@ -28,6 +28,7 @@ interface UsageLogsTableProps {
   onLoadMore?: () => void;
   resetScrollKey?: unknown;
   onHistoryBrowsingChange?: (isBrowsingHistory: boolean) => void;
+  serverTimeZone?: string;
 }
 
 export function UsageLogsTable({
@@ -41,11 +42,13 @@ export function UsageLogsTable({
   onLoadMore,
   resetScrollKey,
   onHistoryBrowsingChange,
+  serverTimeZone,
 }: UsageLogsTableProps) {
   const t = useTranslations("myUsage.logs");
   const tCommon = useTranslations("common");
   const tDashboard = useTranslations("dashboard");
-  const timeZone = useTimeZone() ?? "UTC";
+  const providerTimeZone = useTimeZone() ?? "UTC";
+  const timeZone = serverTimeZone ?? providerTimeZone;
   const resolvedResetKey = useMemo(() => JSON.stringify(resetScrollKey ?? null), [resetScrollKey]);
   const previousResetKeyRef = useRef(resolvedResetKey);
 

--- a/src/app/api/admin/system-config/route.ts
+++ b/src/app/api/admin/system-config/route.ts
@@ -2,6 +2,11 @@ import { z } from "zod";
 import { getSession } from "@/lib/auth";
 import { invalidateSystemSettingsCache } from "@/lib/config";
 import { logger } from "@/lib/logger";
+import {
+  invalidateAllLeaderboardCaches,
+  invalidateAllOverviewCaches,
+  invalidateAllStatisticsCaches,
+} from "@/lib/redis";
 import { UpdateSystemSettingsSchema } from "@/lib/validation/schemas";
 import { getSystemSettings, updateSystemSettings } from "@/repository/system-config";
 
@@ -99,6 +104,17 @@ export async function POST(req: Request) {
       "@/app/v1/_lib/proxy/provider-selector-settings-cache"
     );
     invalidateProviderSelectorSystemSettingsCache();
+    if (validated.timezone !== undefined) {
+      await Promise.all([
+        invalidateAllOverviewCaches(),
+        invalidateAllStatisticsCaches(),
+        invalidateAllLeaderboardCaches(),
+      ]).catch((error) => {
+        logger.warn("[SystemSettings] Failed to invalidate timezone-sensitive dashboard caches", {
+          error,
+        });
+      });
+    }
 
     return Response.json(updated);
   } catch (error) {

--- a/src/components/ui/relative-time.tsx
+++ b/src/components/ui/relative-time.tsx
@@ -14,6 +14,7 @@ interface RelativeTimeProps {
   autoUpdate?: boolean;
   updateInterval?: number;
   format?: "full" | "short";
+  timeZone?: string;
 }
 
 /**
@@ -32,11 +33,13 @@ export function RelativeTime({
   autoUpdate = true,
   updateInterval = 10000, // 默认每 10 秒更新
   format = "full",
+  timeZone: timeZoneOverride,
 }: RelativeTimeProps) {
   const [timeAgo, setTimeAgo] = useState<string>(fallback);
   const [mounted, setMounted] = useState(false);
   const locale = useLocale();
-  const timeZone = useTimeZone() ?? "UTC";
+  const providerTimeZone = useTimeZone();
+  const timeZone = timeZoneOverride ?? providerTimeZone ?? "UTC";
   const tShort = useTranslations("common.relativeTimeShort");
 
   // Format short distance with i18n

--- a/src/lib/redis/index.ts
+++ b/src/lib/redis/index.ts
@@ -1,8 +1,20 @@
 import "server-only";
 
 export { closeRedis, getRedisClient } from "./client";
-export { getLeaderboardWithCache, invalidateLeaderboardCache } from "./leaderboard-cache";
-export { getOverviewWithCache, invalidateOverviewCache } from "./overview-cache";
+export {
+  getLeaderboardWithCache,
+  invalidateAllLeaderboardCaches,
+  invalidateLeaderboardCache,
+} from "./leaderboard-cache";
+export {
+  getOverviewWithCache,
+  invalidateAllOverviewCaches,
+  invalidateOverviewCache,
+} from "./overview-cache";
 export { scanPattern } from "./scan-helper";
 export { getActiveConcurrentSessions } from "./session-stats";
-export { getStatisticsWithCache, invalidateStatisticsCache } from "./statistics-cache";
+export {
+  getStatisticsWithCache,
+  invalidateAllStatisticsCaches,
+  invalidateStatisticsCache,
+} from "./statistics-cache";

--- a/src/lib/redis/leaderboard-cache.ts
+++ b/src/lib/redis/leaderboard-cache.ts
@@ -38,6 +38,7 @@ import {
 } from "@/repository/leaderboard";
 import type { ProviderType } from "@/types/provider";
 import { getRedisClient } from "./client";
+import { scanPattern } from "./scan-helper";
 
 export type { DateRangeParams, LeaderboardPeriod };
 export type LeaderboardScope =
@@ -95,22 +96,22 @@ function buildCacheKey(
 
   if (period === "custom" && dateRange) {
     // leaderboard:{scope}:custom:2025-01-01_2025-01-15:USD
-    return `leaderboard:${scope}:custom:${dateRange.startDate}_${dateRange.endDate}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
+    return `leaderboard:${scope}:custom:${dateRange.startDate}_${dateRange.endDate}:tz:${timezone}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
   } else if (period === "daily") {
     // leaderboard:{scope}:daily:2025-01-15:USD
     const dateStr = formatInTimeZone(now, timezone, "yyyy-MM-dd");
-    return `leaderboard:${scope}:daily:${dateStr}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
+    return `leaderboard:${scope}:daily:${dateStr}:tz:${timezone}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
   } else if (period === "weekly") {
     // leaderboard:{scope}:weekly:2025-W03:USD (ISO week)
     const weekStr = formatInTimeZone(now, timezone, "yyyy-'W'ww");
-    return `leaderboard:${scope}:weekly:${weekStr}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
+    return `leaderboard:${scope}:weekly:${weekStr}:tz:${timezone}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
   } else if (period === "monthly") {
     // leaderboard:{scope}:monthly:2025-01:USD
     const monthStr = formatInTimeZone(now, timezone, "yyyy-MM");
-    return `leaderboard:${scope}:monthly:${monthStr}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
+    return `leaderboard:${scope}:monthly:${monthStr}:tz:${timezone}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
   } else {
     // allTime: leaderboard:{scope}:allTime:USD (no date component)
-    return `leaderboard:${scope}:allTime:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
+    return `leaderboard:${scope}:allTime:tz:${timezone}:${currencyDisplay}${providerTypeSuffix}${includeModelStatsSuffix}${userFilterSuffix}`;
   }
 }
 
@@ -389,5 +390,22 @@ export async function invalidateLeaderboardCache(
     logger.info("[LeaderboardCache] Cache invalidated", { period, scope, cacheKey });
   } catch (error) {
     logger.error("[LeaderboardCache] Failed to invalidate cache", { period, scope, error });
+  }
+}
+
+export async function invalidateAllLeaderboardCaches(): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis) {
+    return;
+  }
+
+  try {
+    const keys = await scanPattern(redis, "leaderboard:*");
+    if (keys.length > 0) {
+      await redis.del(...keys);
+    }
+    logger.info("[LeaderboardCache] All caches invalidated", { deletedCount: keys.length });
+  } catch (error) {
+    logger.error("[LeaderboardCache] Failed to invalidate all caches", { error });
   }
 }

--- a/src/lib/redis/overview-cache.ts
+++ b/src/lib/redis/overview-cache.ts
@@ -1,16 +1,21 @@
 import { logger } from "@/lib/logger";
+import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import {
   getOverviewMetricsWithComparison,
   type OverviewMetricsWithComparison,
 } from "@/repository/overview";
+import { buildOverviewCacheKey } from "@/types/dashboard-cache";
 import { getRedisClient } from "./client";
+import { scanPattern } from "./scan-helper";
 
 const CACHE_TTL = 10;
 const LOCK_TTL = 5;
 const LOCK_WAIT_MS = 100;
 
-function buildCacheKey(userId?: number): string {
-  return userId !== undefined ? `overview:user:${userId}` : "overview:global";
+function buildCacheKey(userId: number | undefined, timezone: string): string {
+  return userId !== undefined
+    ? buildOverviewCacheKey("user", userId, timezone)
+    : buildOverviewCacheKey("global", timezone);
 }
 
 /**
@@ -22,7 +27,8 @@ export async function getOverviewWithCache(
   userId?: number
 ): Promise<OverviewMetricsWithComparison> {
   const redis = getRedisClient();
-  const cacheKey = buildCacheKey(userId);
+  const timezone = await resolveSystemTimezone();
+  const cacheKey = buildCacheKey(userId, timezone);
   const lockKey = `${cacheKey}:lock`;
 
   if (!redis) {
@@ -84,11 +90,29 @@ export async function invalidateOverviewCache(userId?: number): Promise<void> {
   const redis = getRedisClient();
   if (!redis) return;
 
-  const cacheKey = buildCacheKey(userId);
+  const scopePattern = userId !== undefined ? `overview:user:${userId}` : "overview:global";
+  const pattern = `${scopePattern}:tz:*`;
   try {
-    await redis.del(cacheKey);
-    logger.info("[OverviewCache] Cache invalidated", { userId, cacheKey });
+    const matchedKeys = await scanPattern(redis, pattern);
+    const keysToDelete = [...matchedKeys, scopePattern];
+    await redis.del(...keysToDelete);
+    logger.info("[OverviewCache] Cache invalidated", { userId, keysToDelete });
   } catch (error) {
     logger.error("[OverviewCache] Failed to invalidate cache", { userId, error });
+  }
+}
+
+export async function invalidateAllOverviewCaches(): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis) return;
+
+  try {
+    const keys = await scanPattern(redis, "overview:*");
+    if (keys.length > 0) {
+      await redis.del(...keys);
+    }
+    logger.info("[OverviewCache] All caches invalidated", { deletedCount: keys.length });
+  } catch (error) {
+    logger.error("[OverviewCache] Failed to invalidate all caches", { error });
   }
 }

--- a/src/lib/redis/statistics-cache.ts
+++ b/src/lib/redis/statistics-cache.ts
@@ -1,4 +1,5 @@
 import { logger } from "@/lib/logger";
+import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import {
   getKeyStatisticsFromDB,
   getMixedStatisticsFromDB,
@@ -26,6 +27,7 @@ function sleep(ms: number): Promise<void> {
 async function queryDatabase(
   timeRange: TimeRange,
   mode: "users" | "keys" | "mixed",
+  timezone: string,
   userId?: number
 ): Promise<StatisticsCacheData> {
   if ((mode === "keys" || mode === "mixed") && userId === undefined) {
@@ -33,11 +35,11 @@ async function queryDatabase(
   }
   switch (mode) {
     case "users":
-      return await getUserStatisticsFromDB(timeRange);
+      return await getUserStatisticsFromDB(timeRange, timezone);
     case "keys":
-      return await getKeyStatisticsFromDB(userId!, timeRange);
+      return await getKeyStatisticsFromDB(userId!, timeRange, timezone);
     case "mixed":
-      return await getMixedStatisticsFromDB(userId!, timeRange);
+      return await getMixedStatisticsFromDB(userId!, timeRange, timezone);
   }
 }
 
@@ -56,6 +58,7 @@ export async function getStatisticsWithCache(
   userId?: number
 ): Promise<StatisticsCacheData> {
   const redis = getRedisClient();
+  const timezone = await resolveSystemTimezone();
 
   if (!redis) {
     logger.warn("[StatisticsCache] Redis not available, fallback to direct query", {
@@ -63,10 +66,10 @@ export async function getStatisticsWithCache(
       mode,
       userId,
     });
-    return await queryDatabase(timeRange, mode, userId);
+    return await queryDatabase(timeRange, mode, timezone, userId);
   }
 
-  const cacheKey = buildStatisticsCacheKey(timeRange, mode, userId);
+  const cacheKey = buildStatisticsCacheKey(timeRange, mode, userId, timezone);
   const lockKey = `${cacheKey}:lock`;
 
   let locked = false;
@@ -87,7 +90,7 @@ export async function getStatisticsWithCache(
     if (locked) {
       logger.debug("[StatisticsCache] Acquired lock, computing", { timeRange, mode, lockKey });
 
-      data = await queryDatabase(timeRange, mode, userId);
+      data = await queryDatabase(timeRange, mode, timezone, userId);
 
       try {
         await redis.setex(cacheKey, CACHE_TTL, JSON.stringify(data));
@@ -125,14 +128,14 @@ export async function getStatisticsWithCache(
 
     // Retry timeout - fallback to direct DB
     logger.warn("[StatisticsCache] Retry timeout, fallback to direct query", { timeRange, mode });
-    return await queryDatabase(timeRange, mode, userId);
+    return await queryDatabase(timeRange, mode, timezone, userId);
   } catch (error) {
     logger.error("[StatisticsCache] Redis error, fallback to direct query", {
       timeRange,
       mode,
       error,
     });
-    return data ?? (await queryDatabase(timeRange, mode, userId));
+    return data ?? (await queryDatabase(timeRange, mode, timezone, userId));
   } finally {
     if (locked) {
       await redis
@@ -164,22 +167,47 @@ export async function invalidateStatisticsCache(
   try {
     if (timeRange) {
       const modes = ["users", "keys", "mixed"] as const;
-      const keysToDelete = modes.map((m) => buildStatisticsCacheKey(timeRange, m, userId));
-      await redis.del(...keysToDelete);
+      const pattern = `statistics:${timeRange}:*:${scope}:tz:*`;
+      const legacyKeysToDelete = modes.map((m) => `statistics:${timeRange}:${m}:${scope}`);
+      const matchedKeys = await scanPattern(redis, pattern);
+      const keysToDelete = [...matchedKeys, ...legacyKeysToDelete];
+      if (keysToDelete.length > 0) {
+        await redis.del(...keysToDelete);
+      }
       logger.info("[StatisticsCache] Cache invalidated", { timeRange, scope, keysToDelete });
     } else {
-      const pattern = `statistics:*:*:${scope}`;
+      const pattern = `statistics:*:*:${scope}:tz:*`;
+      const legacyPattern = `statistics:*:*:${scope}`;
       const matchedKeys = await scanPattern(redis, pattern);
-      if (matchedKeys.length > 0) {
-        await redis.del(...matchedKeys);
+      const legacyMatchedKeys = await scanPattern(redis, legacyPattern);
+      const keysToDelete = [...new Set([...matchedKeys, ...legacyMatchedKeys])];
+      if (keysToDelete.length > 0) {
+        await redis.del(...keysToDelete);
       }
       logger.info("[StatisticsCache] Cache invalidated (all timeRanges)", {
         scope,
         pattern,
-        deletedCount: matchedKeys.length,
+        deletedCount: keysToDelete.length,
       });
     }
   } catch (error) {
     logger.error("[StatisticsCache] Failed to invalidate cache", { timeRange, scope, error });
+  }
+}
+
+export async function invalidateAllStatisticsCaches(): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis) {
+    return;
+  }
+
+  try {
+    const keys = await scanPattern(redis, "statistics:*");
+    if (keys.length > 0) {
+      await redis.del(...keys);
+    }
+    logger.info("[StatisticsCache] All caches invalidated", { deletedCount: keys.length });
+  } catch (error) {
+    logger.error("[StatisticsCache] Failed to invalidate all caches", { error });
   }
 }

--- a/src/repository/admin-user-insights.ts
+++ b/src/repository/admin-user-insights.ts
@@ -4,6 +4,7 @@ import { and, avg, count, desc, eq, gte, lt, sql, sum } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { providers, usageLedger } from "@/drizzle/schema";
 import { Decimal, toCostDecimal } from "@/lib/utils/currency";
+import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import { LEDGER_BILLING_CONDITION } from "./_shared/ledger-conditions";
 import { getSystemSettings } from "./system-config";
 
@@ -39,6 +40,26 @@ export interface AdminUserProviderBreakdownItem {
   cacheReadTokens: number;
 }
 
+async function buildSystemTimezoneDateConditions(startDate?: string, endDate?: string) {
+  const timezone = await resolveSystemTimezone();
+  const conditions = [];
+
+  if (startDate) {
+    conditions.push(gte(usageLedger.createdAt, sql`(${startDate}::date AT TIME ZONE ${timezone})`));
+  }
+
+  if (endDate) {
+    conditions.push(
+      lt(
+        usageLedger.createdAt,
+        sql`((${endDate}::date + INTERVAL '1 day') AT TIME ZONE ${timezone})`
+      )
+    );
+  }
+
+  return conditions;
+}
+
 /**
  * Get overview metrics for a specific user within a date range.
  */
@@ -47,15 +68,11 @@ export async function getUserOverviewMetrics(
   startDate?: string,
   endDate?: string
 ): Promise<UserInsightsOverviewMetrics> {
-  const conditions = [LEDGER_BILLING_CONDITION, eq(usageLedger.userId, userId)];
-
-  if (startDate) {
-    conditions.push(gte(usageLedger.createdAt, sql`${startDate}::date`));
-  }
-
-  if (endDate) {
-    conditions.push(lt(usageLedger.createdAt, sql`(${endDate}::date + INTERVAL '1 day')`));
-  }
+  const conditions = [
+    LEDGER_BILLING_CONDITION,
+    eq(usageLedger.userId, userId),
+    ...(await buildSystemTimezoneDateConditions(startDate, endDate)),
+  ];
 
   const [result] = await db
     .select({
@@ -102,15 +119,11 @@ export async function getUserModelBreakdown(
       : sql<string>`COALESCE(${usageLedger.model}, ${usageLedger.originalModel})`;
   const modelField = sql<string>`NULLIF(TRIM(${rawModelField}), '')`;
 
-  const conditions = [LEDGER_BILLING_CONDITION, eq(usageLedger.userId, userId)];
-
-  if (startDate) {
-    conditions.push(gte(usageLedger.createdAt, sql`${startDate}::date`));
-  }
-
-  if (endDate) {
-    conditions.push(lt(usageLedger.createdAt, sql`(${endDate}::date + INTERVAL '1 day')`));
-  }
+  const conditions = [
+    LEDGER_BILLING_CONDITION,
+    eq(usageLedger.userId, userId),
+    ...(await buildSystemTimezoneDateConditions(startDate, endDate)),
+  ];
 
   if (filters?.keyId) {
     conditions.push(
@@ -150,15 +163,11 @@ export async function getUserProviderBreakdown(
   endDate?: string,
   filters?: { keyId?: number; model?: string }
 ): Promise<AdminUserProviderBreakdownItem[]> {
-  const conditions = [LEDGER_BILLING_CONDITION, eq(usageLedger.userId, userId)];
-
-  if (startDate) {
-    conditions.push(gte(usageLedger.createdAt, sql`${startDate}::date`));
-  }
-
-  if (endDate) {
-    conditions.push(lt(usageLedger.createdAt, sql`(${endDate}::date + INTERVAL '1 day')`));
-  }
+  const conditions = [
+    LEDGER_BILLING_CONDITION,
+    eq(usageLedger.userId, userId),
+    ...(await buildSystemTimezoneDateConditions(startDate, endDate)),
+  ];
 
   if (filters?.keyId) {
     conditions.push(

--- a/src/repository/statistics.ts
+++ b/src/repository/statistics.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { fromZonedTime } from "date-fns-tz";
 import type { SQL } from "drizzle-orm";
 import { and, eq, gte, inArray, isNull, lt, sql } from "drizzle-orm";
 import { db } from "@/drizzle/db";
@@ -137,9 +138,31 @@ function getTimeRangeSqlConfig(timeRange: TimeRange, timezone: string): SqlTimeR
   }
 }
 
-function normalizeBucketDate(value: TimeBucketValue): Date | null {
+function formatLocalDateTime(value: Date): string {
+  const year = value.getFullYear();
+  const month = `${value.getMonth() + 1}`.padStart(2, "0");
+  const day = `${value.getDate()}`.padStart(2, "0");
+  const hours = `${value.getHours()}`.padStart(2, "0");
+  const minutes = `${value.getMinutes()}`.padStart(2, "0");
+  const seconds = `${value.getSeconds()}`.padStart(2, "0");
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+}
+
+function normalizeBucketInstant(value: TimeBucketValue, timezone: string): Date | null {
   if (!value) return null;
-  const parsed = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+
+  let localDateTime: string;
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null;
+    localDateTime = formatLocalDateTime(value);
+  } else {
+    const match =
+      /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?$/.exec(value);
+    if (!match) return null;
+    localDateTime = `${match[1]}T${match[2]}`;
+  }
+
+  const parsed = fromZonedTime(localDateTime, timezone);
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
@@ -158,7 +181,7 @@ async function getTimeBuckets(timeRange: TimeRange, timezone: string): Promise<D
   const { bucketSeriesQuery } = getTimeRangeSqlConfig(timeRange, timezone);
   const result = await db.execute(bucketSeriesQuery);
   return (Array.from(result) as Array<{ bucket: TimeBucketValue }>)
-    .map((row) => normalizeBucketDate(row.bucket))
+    .map((row) => normalizeBucketInstant(row.bucket, timezone))
     .filter((bucket): bucket is Date => bucket !== null)
     .sort((a, b) => a.getTime() - b.getTime());
 }
@@ -166,11 +189,12 @@ async function getTimeBuckets(timeRange: TimeRange, timezone: string): Promise<D
 function zeroFillUserStats(
   dbRows: UserBucketStatsRow[],
   allUsers: Array<{ id: number; name: string }>,
-  buckets: Date[]
+  buckets: Date[],
+  timezone: string
 ): RuntimeDatabaseStatRow[] {
   const rowMap = new Map<string, { api_calls: number; total_cost: string | number }>();
   for (const row of dbRows) {
-    const bucket = normalizeBucketDate(row.bucket);
+    const bucket = normalizeBucketInstant(row.bucket, timezone);
     if (!bucket) continue;
 
     rowMap.set(`${row.user_id}:${bucket.getTime()}`, {
@@ -202,11 +226,12 @@ function zeroFillUserStats(
 function zeroFillKeyStats(
   dbRows: KeyBucketStatsRow[],
   allKeys: Array<{ id: number; name: string }>,
-  buckets: Date[]
+  buckets: Date[],
+  timezone: string
 ): RuntimeDatabaseKeyStatRow[] {
   const rowMap = new Map<string, { api_calls: number; total_cost: string | number }>();
   for (const row of dbRows) {
-    const bucket = normalizeBucketDate(row.bucket);
+    const bucket = normalizeBucketInstant(row.bucket, timezone);
     if (!bucket) continue;
 
     rowMap.set(`${row.key_id}:${bucket.getTime()}`, {
@@ -237,11 +262,12 @@ function zeroFillKeyStats(
 
 function zeroFillMixedOthersStats(
   dbRows: MixedOthersBucketStatsRow[],
-  buckets: Date[]
+  buckets: Date[],
+  timezone: string
 ): RuntimeDatabaseStatRow[] {
   const rowMap = new Map<number, { api_calls: number; total_cost: string | number }>();
   for (const row of dbRows) {
-    const bucket = normalizeBucketDate(row.bucket);
+    const bucket = normalizeBucketInstant(row.bucket, timezone);
     if (!bucket) continue;
 
     rowMap.set(bucket.getTime(), {
@@ -265,8 +291,11 @@ function zeroFillMixedOthersStats(
 /**
  * 根据时间范围获取用户消费和API调用统计
  */
-export async function getUserStatisticsFromDB(timeRange: TimeRange): Promise<DatabaseStatRow[]> {
-  const timezone = await resolveSystemTimezone();
+export async function getUserStatisticsFromDB(
+  timeRange: TimeRange,
+  timezoneOverride?: string
+): Promise<DatabaseStatRow[]> {
+  const timezone = timezoneOverride ?? (await resolveSystemTimezone());
   const { startTs, endTs, bucketExpr } = getTimeRangeSqlConfig(timeRange, timezone);
 
   const statsQuery = sql`
@@ -293,7 +322,7 @@ export async function getUserStatisticsFromDB(timeRange: TimeRange): Promise<Dat
   ]);
 
   const rows = Array.from(statsResult) as UserBucketStatsRow[];
-  return zeroFillUserStats(rows, users, buckets) as unknown as DatabaseStatRow[];
+  return zeroFillUserStats(rows, users, buckets, timezone) as unknown as DatabaseStatRow[];
 }
 
 /**
@@ -316,9 +345,10 @@ export async function getActiveUsersFromDB(): Promise<DatabaseUser[]> {
  */
 export async function getKeyStatisticsFromDB(
   userId: number,
-  timeRange: TimeRange
+  timeRange: TimeRange,
+  timezoneOverride?: string
 ): Promise<DatabaseKeyStatRow[]> {
-  const timezone = await resolveSystemTimezone();
+  const timezone = timezoneOverride ?? (await resolveSystemTimezone());
   const { startTs, endTs, bucketExpr } = getTimeRangeSqlConfig(timeRange, timezone);
 
   const statsQuery = sql`
@@ -347,7 +377,7 @@ export async function getKeyStatisticsFromDB(
   ]);
 
   const rows = Array.from(statsResult) as KeyBucketStatsRow[];
-  return zeroFillKeyStats(rows, activeKeys, buckets) as unknown as DatabaseKeyStatRow[];
+  return zeroFillKeyStats(rows, activeKeys, buckets, timezone) as unknown as DatabaseKeyStatRow[];
 }
 
 /**
@@ -372,12 +402,13 @@ export async function getActiveKeysForUserFromDB(userId: number): Promise<Databa
  */
 export async function getMixedStatisticsFromDB(
   userId: number,
-  timeRange: TimeRange
+  timeRange: TimeRange,
+  timezoneOverride?: string
 ): Promise<{
   ownKeys: DatabaseKeyStatRow[];
   othersAggregate: DatabaseStatRow[];
 }> {
-  const timezone = await resolveSystemTimezone();
+  const timezone = timezoneOverride ?? (await resolveSystemTimezone());
   const { startTs, endTs, bucketExpr } = getTimeRangeSqlConfig(timeRange, timezone);
 
   const ownKeysQuery = sql`
@@ -424,11 +455,13 @@ export async function getMixedStatisticsFromDB(
     ownKeys: zeroFillKeyStats(
       Array.from(ownKeysResult) as KeyBucketStatsRow[],
       activeKeys,
-      buckets
+      buckets,
+      timezone
     ) as unknown as DatabaseKeyStatRow[],
     othersAggregate: zeroFillMixedOthersStats(
       Array.from(othersResult) as MixedOthersBucketStatsRow[],
-      buckets
+      buckets,
+      timezone
     ) as unknown as DatabaseStatRow[],
   };
 }

--- a/src/repository/statistics.ts
+++ b/src/repository/statistics.ts
@@ -127,8 +127,8 @@ function getTimeRangeSqlConfig(timeRange: TimeRange, timezone: string): SqlTimeR
         bucketExpr: sql`DATE_TRUNC('day', usage_ledger.created_at AT TIME ZONE ${timezone})`,
         bucketSeriesQuery: sql`
           SELECT generate_series(
-            DATE_TRUNC('month', CURRENT_TIMESTAMP AT TIME ZONE ${timezone})::date,
-            (CURRENT_TIMESTAMP AT TIME ZONE ${timezone})::date,
+            DATE_TRUNC('month', CURRENT_TIMESTAMP AT TIME ZONE ${timezone}),
+            DATE_TRUNC('day', CURRENT_TIMESTAMP AT TIME ZONE ${timezone}),
             '1 day'::interval
           ) AS bucket
         `,
@@ -157,7 +157,9 @@ function normalizeBucketInstant(value: TimeBucketValue, timezone: string): Date 
     localDateTime = formatLocalDateTime(value);
   } else {
     const match =
-      /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?$/.exec(value);
+      /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}(?::?\d{2})?)?$/.exec(
+        value
+      );
     if (!match) return null;
     localDateTime = `${match[1]}T${match[2]}`;
   }

--- a/src/types/dashboard-cache.ts
+++ b/src/types/dashboard-cache.ts
@@ -3,24 +3,48 @@ import type { TimeRange } from "@/types/statistics";
 export type OverviewCacheKey = {
   scope: "global" | "user";
   userId?: number;
+  timezone: string;
 };
 
 export type StatisticsCacheKey = {
   timeRange: TimeRange;
   mode: "users" | "keys" | "mixed";
   userId?: number;
+  timezone: string;
 };
 
-export function buildOverviewCacheKey(scope: "global"): string;
-export function buildOverviewCacheKey(scope: "user", userId: number): string;
-export function buildOverviewCacheKey(scope: "global" | "user", userId?: number): string {
-  return scope === "global" ? "overview:global" : `overview:user:${userId}`;
+export function buildOverviewCacheKey(scope: "global", timezone: string): string;
+export function buildOverviewCacheKey(scope: "user", userId: number, timezone: string): string;
+export function buildOverviewCacheKey(
+  scope: "global" | "user",
+  userIdOrTimezone: number | string,
+  timezone?: string
+): string {
+  const resolvedTimezone = scope === "global" ? String(userIdOrTimezone) : String(timezone);
+  return scope === "global"
+    ? `overview:global:tz:${resolvedTimezone}`
+    : `overview:user:${userIdOrTimezone}:tz:${resolvedTimezone}`;
 }
 
 export function buildStatisticsCacheKey(
   timeRange: TimeRange,
   mode: "users" | "keys" | "mixed",
-  userId?: number
+  timezone: string
+): string;
+export function buildStatisticsCacheKey(
+  timeRange: TimeRange,
+  mode: "users" | "keys" | "mixed",
+  userId: number | undefined,
+  timezone: string
+): string;
+export function buildStatisticsCacheKey(
+  timeRange: TimeRange,
+  mode: "users" | "keys" | "mixed",
+  userIdOrTimezone: number | string | undefined,
+  timezone?: string
 ): string {
-  return `statistics:${timeRange}:${mode}:${userId ?? "global"}`;
+  const userId = typeof userIdOrTimezone === "number" ? userIdOrTimezone : undefined;
+  const resolvedTimezone =
+    typeof userIdOrTimezone === "string" ? userIdOrTimezone : String(timezone);
+  return `statistics:${timeRange}:${mode}:${userId ?? "global"}:tz:${resolvedTimezone}`;
 }

--- a/tests/unit/dashboard-logs-time-range-utils.test.ts
+++ b/tests/unit/dashboard-logs-time-range-utils.test.ts
@@ -58,4 +58,14 @@ describe("dashboard logs time range utils", () => {
       endDate: "2023-12-31",
     });
   });
+
+  test("getQuickDateRange keeps the first hours of the server day in that day", () => {
+    const now = new Date("2024-01-02T08:30:00Z");
+    const tz = "America/Los_Angeles";
+
+    expect(getQuickDateRange("today", tz, now)).toEqual({
+      startDate: "2024-01-02",
+      endDate: "2024-01-02",
+    });
+  });
 });

--- a/tests/unit/dashboard/dashboard-cache-keys.test.ts
+++ b/tests/unit/dashboard/dashboard-cache-keys.test.ts
@@ -3,33 +3,43 @@ import { buildOverviewCacheKey, buildStatisticsCacheKey } from "@/types/dashboar
 import type { TimeRange } from "@/types/statistics";
 
 describe("buildOverviewCacheKey", () => {
-  it("returns 'overview:global' for global scope", () => {
-    expect(buildOverviewCacheKey("global")).toBe("overview:global");
+  it("returns timezone-scoped global key", () => {
+    expect(buildOverviewCacheKey("global", "Asia/Shanghai")).toBe(
+      "overview:global:tz:Asia/Shanghai"
+    );
   });
 
-  it("returns 'overview:user:42' for user scope with userId=42", () => {
-    expect(buildOverviewCacheKey("user", 42)).toBe("overview:user:42");
+  it("returns timezone-scoped user key", () => {
+    expect(buildOverviewCacheKey("user", 42, "America/New_York")).toBe(
+      "overview:user:42:tz:America/New_York"
+    );
   });
 });
 
 describe("buildStatisticsCacheKey", () => {
   it("returns correct key for today/users/global", () => {
-    expect(buildStatisticsCacheKey("today", "users")).toBe("statistics:today:users:global");
+    expect(buildStatisticsCacheKey("today", "users", "Asia/Shanghai")).toBe(
+      "statistics:today:users:global:tz:Asia/Shanghai"
+    );
   });
 
   it("returns correct key with userId", () => {
-    expect(buildStatisticsCacheKey("7days", "keys", 42)).toBe("statistics:7days:keys:42");
+    expect(buildStatisticsCacheKey("7days", "keys", 42, "America/New_York")).toBe(
+      "statistics:7days:keys:42:tz:America/New_York"
+    );
   });
 
   it("handles all TimeRange values", () => {
     const timeRanges: TimeRange[] = ["today", "7days", "30days", "thisMonth"];
-    const keys = timeRanges.map((timeRange) => buildStatisticsCacheKey(timeRange, "users"));
+    const keys = timeRanges.map((timeRange) =>
+      buildStatisticsCacheKey(timeRange, "users", "Asia/Shanghai")
+    );
 
     expect(keys).toEqual([
-      "statistics:today:users:global",
-      "statistics:7days:users:global",
-      "statistics:30days:users:global",
-      "statistics:thisMonth:users:global",
+      "statistics:today:users:global:tz:Asia/Shanghai",
+      "statistics:7days:users:global:tz:Asia/Shanghai",
+      "statistics:30days:users:global:tz:Asia/Shanghai",
+      "statistics:thisMonth:users:global:tz:Asia/Shanghai",
     ]);
     expect(new Set(keys).size).toBe(timeRanges.length);
   });

--- a/tests/unit/dashboard/leaderboard-date-range-picker.test.tsx
+++ b/tests/unit/dashboard/leaderboard-date-range-picker.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DateRangePicker } from "@/app/[locale]/dashboard/leaderboard/_components/date-range-picker";
+import type { DateRangeParams, LeaderboardPeriod } from "@/repository/leaderboard";
+
+const tMock = vi.hoisted(() => {
+  const messages: Record<string, string> = {
+    "tabs.dailyRanking": "Daily",
+    "tabs.weeklyRanking": "Weekly",
+    "tabs.monthlyRanking": "Monthly",
+    "tabs.allTimeRanking": "All Time",
+    "dateRange.to": "to",
+    "dateRange.prevPeriod": "Previous period",
+    "dateRange.nextPeriod": "Next period",
+  };
+
+  return vi.fn((key: string) => messages[key] ?? key);
+});
+
+vi.mock("next-intl", () => ({
+  useTimeZone: () => "UTC",
+  useTranslations: () => tMock,
+}));
+
+function TestHarness({
+  initialPeriod,
+  initialDateRange,
+}: {
+  initialPeriod: LeaderboardPeriod;
+  initialDateRange?: DateRangeParams;
+}) {
+  const [period, setPeriod] = useState<LeaderboardPeriod>(initialPeriod);
+  const [dateRange, setDateRange] = useState<DateRangeParams | undefined>(initialDateRange);
+
+  return (
+    <DateRangePicker
+      period={period}
+      dateRange={dateRange}
+      onPeriodChange={(nextPeriod, nextDateRange) => {
+        setPeriod(nextPeriod);
+        setDateRange(nextDateRange);
+      }}
+    />
+  );
+}
+
+function getButtonByTitle(container: HTMLElement, title: string): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>(`button[title="${title}"]`);
+  if (!button) {
+    throw new Error(`Button with title "${title}" was not found`);
+  }
+  return button;
+}
+
+function expectDisplayedRange(container: HTMLElement, startDate: string, endDate: string) {
+  expect(container.textContent).toContain(`${startDate} to ${endDate}`);
+}
+
+describe("Leaderboard DateRangePicker", () => {
+  let container: HTMLDivElement | null = null;
+  let root: ReturnType<typeof createRoot> | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T12:00:00Z"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root!.unmount());
+      root = null;
+    }
+    if (container) {
+      container.remove();
+      container = null;
+    }
+    vi.useRealTimers();
+  });
+
+  it("navigates monthly ranges by calendar month", async () => {
+    await act(async () => {
+      root!.render(<TestHarness initialPeriod="monthly" />);
+    });
+
+    expectDisplayedRange(container!, "2026-06-01", "2026-06-30");
+
+    const previousButton = getButtonByTitle(container!, "Previous period");
+    await act(async () => {
+      previousButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expectDisplayedRange(container!, "2026-05-01", "2026-05-31");
+
+    await act(async () => {
+      previousButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expectDisplayedRange(container!, "2026-04-01", "2026-04-30");
+  });
+
+  it("keeps custom non-month ranges on fixed-width navigation", async () => {
+    await act(async () => {
+      root!.render(
+        <TestHarness
+          initialPeriod="custom"
+          initialDateRange={{ startDate: "2026-06-10", endDate: "2026-06-19" }}
+        />
+      );
+    });
+
+    expectDisplayedRange(container!, "2026-06-10", "2026-06-19");
+
+    await act(async () => {
+      getButtonByTitle(container!, "Previous period").dispatchEvent(
+        new MouseEvent("click", { bubbles: true })
+      );
+    });
+
+    expectDisplayedRange(container!, "2026-05-31", "2026-06-09");
+  });
+});

--- a/tests/unit/dashboard/leaderboard-view-user-cache-hit-rate.test.tsx
+++ b/tests/unit/dashboard/leaderboard-view-user-cache-hit-rate.test.tsx
@@ -22,6 +22,7 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("next-intl", () => ({
   useTranslations: () => tMock,
+  useTimeZone: () => "Asia/Shanghai",
 }));
 
 vi.mock("@/actions/users", () => ({

--- a/tests/unit/redis/leaderboard-cache.test.ts
+++ b/tests/unit/redis/leaderboard-cache.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRedisClient } from "@/lib/redis/client";
 import { getLeaderboardWithCache } from "@/lib/redis/leaderboard-cache";
+import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import {
   findDailyUserCacheHitRateLeaderboard,
   type UserCacheHitRateLeaderboardEntry,
@@ -69,6 +70,7 @@ function createUserCacheHitRateRows(): UserCacheHitRateLeaderboardEntry[] {
 describe("getLeaderboardWithCache", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(resolveSystemTimezone).mockResolvedValue("UTC");
     vi.useRealTimers();
   });
 
@@ -100,7 +102,33 @@ describe("getLeaderboardWithCache", () => {
       true
     );
     expect(redis.setex).toHaveBeenCalledWith(
-      "leaderboard:userCacheHitRate:daily:2026-04-13:USD:includeModelStats:tags:team-a,vip:groups:group-1",
+      "leaderboard:userCacheHitRate:daily:2026-04-13:tz:UTC:USD:includeModelStats:tags:team-a,vip:groups:group-1",
+      60,
+      JSON.stringify(rows)
+    );
+  });
+
+  it("includes the resolved timezone in Redis keys", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-13T23:00:00Z"));
+    vi.mocked(resolveSystemTimezone).mockResolvedValueOnce("Asia/Shanghai");
+
+    const redis = createRedisMock();
+    const rows = createUserCacheHitRateRows();
+    redis.get.mockResolvedValueOnce(null);
+    redis.set.mockResolvedValueOnce("OK");
+    redis.setex.mockResolvedValueOnce("OK");
+    redis.del.mockResolvedValueOnce(1);
+
+    vi.mocked(getRedisClient).mockReturnValue(
+      redis as unknown as NonNullable<ReturnType<typeof getRedisClient>>
+    );
+    vi.mocked(findDailyUserCacheHitRateLeaderboard).mockResolvedValueOnce(rows);
+
+    await getLeaderboardWithCache("daily", "USD", "userCacheHitRate");
+
+    expect(redis.setex).toHaveBeenCalledWith(
+      "leaderboard:userCacheHitRate:daily:2026-04-14:tz:Asia/Shanghai:USD",
       60,
       JSON.stringify(rows)
     );

--- a/tests/unit/redis/overview-cache.test.ts
+++ b/tests/unit/redis/overview-cache.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRedisClient } from "@/lib/redis/client";
 import { getOverviewWithCache, invalidateOverviewCache } from "@/lib/redis/overview-cache";
+import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import {
   getOverviewMetricsWithComparison,
   type OverviewMetricsWithComparison,
@@ -19,6 +20,10 @@ vi.mock("@/lib/redis/client", () => ({
   getRedisClient: vi.fn(),
 }));
 
+vi.mock("@/lib/utils/timezone", () => ({
+  resolveSystemTimezone: vi.fn().mockResolvedValue("UTC"),
+}));
+
 vi.mock("@/repository/overview", () => ({
   getOverviewMetricsWithComparison: vi.fn(),
 }));
@@ -28,6 +33,7 @@ type RedisMock = {
   set: ReturnType<typeof vi.fn>;
   setex: ReturnType<typeof vi.fn>;
   del: ReturnType<typeof vi.fn>;
+  scan: ReturnType<typeof vi.fn>;
 };
 
 function createRedisMock(): RedisMock {
@@ -36,6 +42,7 @@ function createRedisMock(): RedisMock {
     set: vi.fn(),
     setex: vi.fn(),
     del: vi.fn(),
+    scan: vi.fn(),
   };
 }
 
@@ -55,6 +62,7 @@ function createOverviewData(): OverviewMetricsWithComparison {
 describe("getOverviewWithCache", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(resolveSystemTimezone).mockResolvedValue("UTC");
   });
 
   it("returns cached data on cache hit (no DB call)", async () => {
@@ -69,7 +77,7 @@ describe("getOverviewWithCache", () => {
     const result = await getOverviewWithCache();
 
     expect(result).toEqual(data);
-    expect(redis.get).toHaveBeenCalledWith("overview:global");
+    expect(redis.get).toHaveBeenCalledWith("overview:global:tz:UTC");
     expect(getOverviewMetricsWithComparison).not.toHaveBeenCalled();
   });
 
@@ -90,9 +98,9 @@ describe("getOverviewWithCache", () => {
 
     expect(result).toEqual(data);
     expect(getOverviewMetricsWithComparison).toHaveBeenCalledWith(42);
-    expect(redis.set).toHaveBeenCalledWith("overview:user:42:lock", "1", "EX", 5, "NX");
-    expect(redis.setex).toHaveBeenCalledWith("overview:user:42", 10, JSON.stringify(data));
-    expect(redis.del).toHaveBeenCalledWith("overview:user:42:lock");
+    expect(redis.set).toHaveBeenCalledWith("overview:user:42:tz:UTC:lock", "1", "EX", 5, "NX");
+    expect(redis.setex).toHaveBeenCalledWith("overview:user:42:tz:UTC", 10, JSON.stringify(data));
+    expect(redis.del).toHaveBeenCalledWith("overview:user:42:tz:UTC:lock");
   });
 
   it("falls back to direct DB query when Redis is unavailable (null client)", async () => {
@@ -140,9 +148,9 @@ describe("getOverviewWithCache", () => {
       const result = await pending;
 
       expect(result).toEqual(data);
-      expect(redis.set).toHaveBeenCalledWith("overview:user:99:lock", "1", "EX", 5, "NX");
-      expect(redis.get).toHaveBeenNthCalledWith(1, "overview:user:99");
-      expect(redis.get).toHaveBeenNthCalledWith(2, "overview:user:99");
+      expect(redis.set).toHaveBeenCalledWith("overview:user:99:tz:UTC:lock", "1", "EX", 5, "NX");
+      expect(redis.get).toHaveBeenNthCalledWith(1, "overview:user:99:tz:UTC");
+      expect(redis.get).toHaveBeenNthCalledWith(2, "overview:user:99:tz:UTC");
       expect(getOverviewMetricsWithComparison).toHaveBeenCalledWith(99);
     } finally {
       vi.useRealTimers();
@@ -166,20 +174,32 @@ describe("getOverviewWithCache", () => {
     await getOverviewWithCache();
     await getOverviewWithCache(42);
 
-    expect(redis.get).toHaveBeenNthCalledWith(1, "overview:global");
-    expect(redis.get).toHaveBeenNthCalledWith(2, "overview:user:42");
-    expect(redis.setex).toHaveBeenNthCalledWith(1, "overview:global", 10, JSON.stringify(data));
-    expect(redis.setex).toHaveBeenNthCalledWith(2, "overview:user:42", 10, JSON.stringify(data));
+    expect(redis.get).toHaveBeenNthCalledWith(1, "overview:global:tz:UTC");
+    expect(redis.get).toHaveBeenNthCalledWith(2, "overview:user:42:tz:UTC");
+    expect(redis.setex).toHaveBeenNthCalledWith(
+      1,
+      "overview:global:tz:UTC",
+      10,
+      JSON.stringify(data)
+    );
+    expect(redis.setex).toHaveBeenNthCalledWith(
+      2,
+      "overview:user:42:tz:UTC",
+      10,
+      JSON.stringify(data)
+    );
   });
 });
 
 describe("invalidateOverviewCache", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(resolveSystemTimezone).mockResolvedValue("UTC");
   });
 
-  it("deletes the correct cache key", async () => {
+  it("deletes timezone-scoped and legacy cache keys", async () => {
     const redis = createRedisMock();
+    redis.scan.mockResolvedValueOnce(["0", ["overview:user:42:tz:UTC"]]);
     redis.del.mockResolvedValueOnce(1);
 
     vi.mocked(getRedisClient).mockReturnValue(
@@ -188,7 +208,8 @@ describe("invalidateOverviewCache", () => {
 
     await invalidateOverviewCache(42);
 
-    expect(redis.del).toHaveBeenCalledWith("overview:user:42");
+    expect(redis.scan).toHaveBeenCalledWith("0", "MATCH", "overview:user:42:tz:*", "COUNT", 100);
+    expect(redis.del).toHaveBeenCalledWith("overview:user:42:tz:UTC", "overview:user:42");
   });
 
   it("does nothing when Redis is unavailable", async () => {
@@ -199,7 +220,7 @@ describe("invalidateOverviewCache", () => {
 
   it("swallows Redis errors during invalidation", async () => {
     const redis = createRedisMock();
-    redis.del.mockRejectedValueOnce(new Error("delete failed"));
+    redis.scan.mockRejectedValueOnce(new Error("scan failed"));
 
     vi.mocked(getRedisClient).mockReturnValue(
       redis as unknown as NonNullable<ReturnType<typeof getRedisClient>>

--- a/tests/unit/redis/statistics-cache.test.ts
+++ b/tests/unit/redis/statistics-cache.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getRedisClient } from "@/lib/redis/client";
 import { getStatisticsWithCache, invalidateStatisticsCache } from "@/lib/redis/statistics-cache";
+import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import {
   getKeyStatisticsFromDB,
   getMixedStatisticsFromDB,
@@ -19,6 +20,10 @@ vi.mock("@/lib/logger", () => ({
 
 vi.mock("@/lib/redis/client", () => ({
   getRedisClient: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/timezone", () => ({
+  resolveSystemTimezone: vi.fn().mockResolvedValue("UTC"),
 }));
 
 vi.mock("@/repository/statistics", () => ({
@@ -72,6 +77,7 @@ function createKeyStats(): DatabaseKeyStatRow[] {
 describe("getStatisticsWithCache", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(resolveSystemTimezone).mockResolvedValue("UTC");
   });
 
   it("returns cached data on cache hit", async () => {
@@ -86,7 +92,7 @@ describe("getStatisticsWithCache", () => {
     const result = await getStatisticsWithCache("today", "users");
 
     expect(result).toEqual(cached);
-    expect(redis.get).toHaveBeenCalledWith("statistics:today:users:global");
+    expect(redis.get).toHaveBeenCalledWith("statistics:today:users:global:tz:UTC");
     expect(getUserStatisticsFromDB).not.toHaveBeenCalled();
     expect(getKeyStatisticsFromDB).not.toHaveBeenCalled();
     expect(getMixedStatisticsFromDB).not.toHaveBeenCalled();
@@ -108,7 +114,7 @@ describe("getStatisticsWithCache", () => {
     const result = await getStatisticsWithCache("today", "users");
 
     expect(result).toEqual(rows);
-    expect(getUserStatisticsFromDB).toHaveBeenCalledWith("today");
+    expect(getUserStatisticsFromDB).toHaveBeenCalledWith("today", "UTC");
     expect(getKeyStatisticsFromDB).not.toHaveBeenCalled();
     expect(getMixedStatisticsFromDB).not.toHaveBeenCalled();
   });
@@ -129,7 +135,7 @@ describe("getStatisticsWithCache", () => {
     const result = await getStatisticsWithCache("7days", "keys", 42);
 
     expect(result).toEqual(rows);
-    expect(getKeyStatisticsFromDB).toHaveBeenCalledWith(42, "7days");
+    expect(getKeyStatisticsFromDB).toHaveBeenCalledWith(42, "7days", "UTC");
     expect(getUserStatisticsFromDB).not.toHaveBeenCalled();
     expect(getMixedStatisticsFromDB).not.toHaveBeenCalled();
   });
@@ -153,7 +159,7 @@ describe("getStatisticsWithCache", () => {
     const result = await getStatisticsWithCache("30days", "mixed", 42);
 
     expect(result).toEqual(mixedResult);
-    expect(getMixedStatisticsFromDB).toHaveBeenCalledWith(42, "30days");
+    expect(getMixedStatisticsFromDB).toHaveBeenCalledWith(42, "30days", "UTC");
     expect(getUserStatisticsFromDB).not.toHaveBeenCalled();
     expect(getKeyStatisticsFromDB).not.toHaveBeenCalled();
   });
@@ -174,7 +180,7 @@ describe("getStatisticsWithCache", () => {
     await getStatisticsWithCache("today", "users");
 
     expect(redis.setex).toHaveBeenCalledWith(
-      "statistics:today:users:global",
+      "statistics:today:users:global:tz:UTC",
       30,
       JSON.stringify(rows)
     );
@@ -188,7 +194,7 @@ describe("getStatisticsWithCache", () => {
     const result = await getStatisticsWithCache("today", "users");
 
     expect(result).toEqual(rows);
-    expect(getUserStatisticsFromDB).toHaveBeenCalledWith("today");
+    expect(getUserStatisticsFromDB).toHaveBeenCalledWith("today", "UTC");
   });
 
   it("uses retry path and returns cached data when lock is held", async () => {
@@ -209,7 +215,7 @@ describe("getStatisticsWithCache", () => {
 
       expect(result).toEqual(rows);
       expect(redis.set).toHaveBeenCalledWith(
-        "statistics:today:users:global:lock",
+        "statistics:today:users:global:tz:UTC:lock",
         "1",
         "EX",
         5,
@@ -239,7 +245,7 @@ describe("getStatisticsWithCache", () => {
       const result = await pending;
 
       expect(result).toEqual(rows);
-      expect(getUserStatisticsFromDB).toHaveBeenCalledWith("today");
+      expect(getUserStatisticsFromDB).toHaveBeenCalledWith("today", "UTC");
     } finally {
       vi.useRealTimers();
     }
@@ -258,7 +264,7 @@ describe("getStatisticsWithCache", () => {
     const result = await getStatisticsWithCache("today", "users");
 
     expect(result).toEqual(rows);
-    expect(getUserStatisticsFromDB).toHaveBeenCalledWith("today");
+    expect(getUserStatisticsFromDB).toHaveBeenCalledWith("today", "UTC");
   });
 
   it("uses different cache keys for different timeRanges", async () => {
@@ -273,8 +279,8 @@ describe("getStatisticsWithCache", () => {
     await getStatisticsWithCache("today", "users");
     await getStatisticsWithCache("7days", "users");
 
-    expect(redis.get).toHaveBeenNthCalledWith(1, "statistics:today:users:global");
-    expect(redis.get).toHaveBeenNthCalledWith(2, "statistics:7days:users:global");
+    expect(redis.get).toHaveBeenNthCalledWith(1, "statistics:today:users:global:tz:UTC");
+    expect(redis.get).toHaveBeenNthCalledWith(2, "statistics:7days:users:global:tz:UTC");
   });
 
   it("uses different cache keys for global vs user scope", async () => {
@@ -289,18 +295,25 @@ describe("getStatisticsWithCache", () => {
     await getStatisticsWithCache("today", "users");
     await getStatisticsWithCache("today", "users", 42);
 
-    expect(redis.get).toHaveBeenNthCalledWith(1, "statistics:today:users:global");
-    expect(redis.get).toHaveBeenNthCalledWith(2, "statistics:today:users:42");
+    expect(redis.get).toHaveBeenNthCalledWith(1, "statistics:today:users:global:tz:UTC");
+    expect(redis.get).toHaveBeenNthCalledWith(2, "statistics:today:users:42:tz:UTC");
   });
 });
 
 describe("invalidateStatisticsCache", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(resolveSystemTimezone).mockResolvedValue("UTC");
   });
 
-  it("deletes all mode keys for a given timeRange", async () => {
+  it("deletes timezone-scoped and legacy keys for a given timeRange", async () => {
     const redis = createRedisMock();
+    const matchedKeys = [
+      "statistics:today:users:42:tz:UTC",
+      "statistics:today:keys:42:tz:UTC",
+      "statistics:today:mixed:42:tz:UTC",
+    ];
+    redis.scan.mockResolvedValueOnce(["0", matchedKeys]);
     redis.del.mockResolvedValueOnce(3);
 
     vi.mocked(getRedisClient).mockReturnValue(
@@ -309,7 +322,15 @@ describe("invalidateStatisticsCache", () => {
 
     await invalidateStatisticsCache("today", 42);
 
+    expect(redis.scan).toHaveBeenCalledWith(
+      "0",
+      "MATCH",
+      "statistics:today:*:42:tz:*",
+      "COUNT",
+      100
+    );
     expect(redis.del).toHaveBeenCalledWith(
+      ...matchedKeys,
       "statistics:today:users:42",
       "statistics:today:keys:42",
       "statistics:today:mixed:42"
@@ -319,12 +340,15 @@ describe("invalidateStatisticsCache", () => {
   it("deletes all keys for scope when timeRange is undefined", async () => {
     const redis = createRedisMock();
     const matchedKeys = [
-      "statistics:today:users:global",
-      "statistics:7days:keys:global",
-      "statistics:30days:mixed:global",
+      "statistics:today:users:global:tz:UTC",
+      "statistics:7days:keys:global:tz:UTC",
+      "statistics:30days:mixed:global:tz:UTC",
     ];
-    redis.scan.mockResolvedValueOnce(["0", matchedKeys]);
-    redis.del.mockResolvedValueOnce(matchedKeys.length);
+    const legacyMatchedKeys = ["statistics:today:users:global", "statistics:7days:keys:global"];
+    redis.scan
+      .mockResolvedValueOnce(["0", matchedKeys])
+      .mockResolvedValueOnce(["0", legacyMatchedKeys]);
+    redis.del.mockResolvedValueOnce(matchedKeys.length + legacyMatchedKeys.length);
 
     vi.mocked(getRedisClient).mockReturnValue(
       redis as unknown as NonNullable<ReturnType<typeof getRedisClient>>
@@ -332,8 +356,23 @@ describe("invalidateStatisticsCache", () => {
 
     await invalidateStatisticsCache(undefined, undefined);
 
-    expect(redis.scan).toHaveBeenCalledWith("0", "MATCH", "statistics:*:*:global", "COUNT", 100);
-    expect(redis.del).toHaveBeenCalledWith(...matchedKeys);
+    expect(redis.scan).toHaveBeenNthCalledWith(
+      1,
+      "0",
+      "MATCH",
+      "statistics:*:*:global:tz:*",
+      "COUNT",
+      100
+    );
+    expect(redis.scan).toHaveBeenNthCalledWith(
+      2,
+      "0",
+      "MATCH",
+      "statistics:*:*:global",
+      "COUNT",
+      100
+    );
+    expect(redis.del).toHaveBeenCalledWith(...matchedKeys, ...legacyMatchedKeys);
   });
 
   it("does nothing when Redis is unavailable", async () => {
@@ -344,7 +383,7 @@ describe("invalidateStatisticsCache", () => {
 
   it("does not call del when wildcard query returns no key", async () => {
     const redis = createRedisMock();
-    redis.scan.mockResolvedValueOnce(["0", []]);
+    redis.scan.mockResolvedValueOnce(["0", []]).mockResolvedValueOnce(["0", []]);
 
     vi.mocked(getRedisClient).mockReturnValue(
       redis as unknown as NonNullable<ReturnType<typeof getRedisClient>>
@@ -352,7 +391,15 @@ describe("invalidateStatisticsCache", () => {
 
     await invalidateStatisticsCache(undefined, 42);
 
-    expect(redis.scan).toHaveBeenCalledWith("0", "MATCH", "statistics:*:*:42", "COUNT", 100);
+    expect(redis.scan).toHaveBeenNthCalledWith(
+      1,
+      "0",
+      "MATCH",
+      "statistics:*:*:42:tz:*",
+      "COUNT",
+      100
+    );
+    expect(redis.scan).toHaveBeenNthCalledWith(2, "0", "MATCH", "statistics:*:*:42", "COUNT", 100);
     expect(redis.del).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/repository/admin-user-insights-overview.test.ts
+++ b/tests/unit/repository/admin-user-insights-overview.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSystemTimezone } from "@/lib/utils/timezone";
 
 function sqlToString(sqlObj: unknown): string {
   const visited = new Set<unknown>();
@@ -67,6 +68,10 @@ vi.mock("@/drizzle/db", () => ({
 }));
 
 vi.mock("@/drizzle/schema", () => ({
+  messageRequest: {
+    blockedBy: "blockedBy",
+    endpoint: "endpoint",
+  },
   usageLedger: {
     userId: "userId",
     costUsd: "costUsd",
@@ -93,9 +98,14 @@ vi.mock("@/repository/system-config", () => ({
   getSystemSettings: vi.fn(),
 }));
 
+vi.mock("@/lib/utils/timezone", () => ({
+  resolveSystemTimezone: vi.fn().mockResolvedValue("Asia/Shanghai"),
+}));
+
 describe("getUserOverviewMetrics", () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.mocked(resolveSystemTimezone).mockResolvedValue("Asia/Shanghai");
     selectResults.length = 0;
     allWhereArgs.length = 0;
     capturedSelections.length = 0;
@@ -125,6 +135,8 @@ describe("getUserOverviewMetrics", () => {
     const whereSql = sqlToString(allWhereArgs[0][0]);
     expect(whereSql).toContain("2026-03-01");
     expect(whereSql).toContain("2026-03-09");
+    expect(whereSql).toContain("AT TIME ZONE");
+    expect(resolveSystemTimezone).toHaveBeenCalled();
     expect(whereSql).toContain("INTERVAL '1 day'");
 
     const errorCountSql = sqlToString(capturedSelections[0].errorCount).toLowerCase();

--- a/tests/unit/repository/statistics-timezone-buckets.test.ts
+++ b/tests/unit/repository/statistics-timezone-buckets.test.ts
@@ -35,4 +35,28 @@ describe("statistics timezone buckets", () => {
     expect(rows[0].api_calls).toBe(3);
     expect(rows[0].total_cost).toBe("1.25");
   });
+
+  it("keeps thisMonth buckets when postgres returns a short timezone offset", async () => {
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([{ id: 1, name: "alice" }])
+      .mockResolvedValueOnce([{ bucket: "2026-05-01 00:00:00-04" }])
+      .mockResolvedValueOnce([
+        {
+          user_id: 1,
+          user_name: "alice",
+          bucket: "2026-05-01 00:00:00-04",
+          api_calls: "4",
+          total_cost: "2.50",
+        },
+      ]);
+
+    const { getUserStatisticsFromDB } = await import("@/repository/statistics");
+
+    const rows = await getUserStatisticsFromDB("thisMonth", "Asia/Shanghai");
+
+    expect(rows).toHaveLength(1);
+    expect(new Date(rows[0].date).toISOString()).toBe("2026-04-30T16:00:00.000Z");
+    expect(rows[0].api_calls).toBe(4);
+    expect(rows[0].total_cost).toBe("2.50");
+  });
 });

--- a/tests/unit/repository/statistics-timezone-buckets.test.ts
+++ b/tests/unit/repository/statistics-timezone-buckets.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { db } from "@/drizzle/db";
+
+vi.mock("@/drizzle/db", () => ({
+  db: {
+    execute: vi.fn(),
+  },
+}));
+
+describe("statistics timezone buckets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("serializes local SQL buckets as instants in the configured timezone", async () => {
+    vi.mocked(db.execute)
+      .mockResolvedValueOnce([{ id: 1, name: "alice" }])
+      .mockResolvedValueOnce([{ bucket: "2026-05-30 00:00:00" }])
+      .mockResolvedValueOnce([
+        {
+          user_id: 1,
+          user_name: "alice",
+          bucket: "2026-05-30 00:00:00",
+          api_calls: "3",
+          total_cost: "1.25",
+        },
+      ]);
+
+    const { getUserStatisticsFromDB } = await import("@/repository/statistics");
+
+    const rows = await getUserStatisticsFromDB("7days", "Asia/Shanghai");
+
+    expect(rows).toHaveLength(1);
+    expect(new Date(rows[0].date).toISOString()).toBe("2026-05-29T16:00:00.000Z");
+    expect(rows[0].api_calls).toBe(3);
+    expect(rows[0].total_cost).toBe("1.25");
+  });
+});

--- a/tests/unit/user-insights-filters.test.ts
+++ b/tests/unit/user-insights-filters.test.ts
@@ -12,6 +12,23 @@ describe("resolveTimePresetDates", () => {
     expect(startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
+  it("uses the configured timezone when resolving presets", () => {
+    const now = new Date("2026-05-30T02:00:00Z");
+
+    expect(resolveTimePresetDates("today", "America/New_York", now)).toEqual({
+      startDate: "2026-05-29",
+      endDate: "2026-05-29",
+    });
+    expect(resolveTimePresetDates("today", "Asia/Shanghai", now)).toEqual({
+      startDate: "2026-05-30",
+      endDate: "2026-05-30",
+    });
+    expect(resolveTimePresetDates("7days", "America/New_York", now)).toEqual({
+      startDate: "2026-05-23",
+      endDate: "2026-05-29",
+    });
+  });
+
   it("returns 7-day range for '7days' preset", () => {
     const { startDate, endDate } = resolveTimePresetDates("7days");
 


### PR DESCRIPTION
## Summary
Resolve dashboard, logs, my-usage, and leaderboard date ranges against the configured system timezone. Include timezone in dashboard Redis cache keys and invalidate timezone-sensitive caches when timezone settings change. Normalize statistics bucket serialization to prevent UTC/local date drift.

## Problem
Dashboard views (statistics, logs, leaderboard, my-usage) were using inconsistent timezone handling:
- Date range queries were computed using browser local time or UTC rather than the configured system timezone
- Redis cache keys did not incorporate the system timezone, causing stale data after timezone changes
- Statistics bucket normalization used naive `Date` parsing, causing UTC/local date drift and off-by-one day shifts in charts (e.g. April 28 data showing under April 27)
- Usage logs date range pickers and filters displayed dates incorrectly when the system timezone differed from the server timezone

## Related Issues
- Fixes #1135 — Daily statistics chart dates were misaligned by one day (e.g., UTC+8 showing April 28 data under April 27)
- Related to #274 — System statistics time inconsistency between dashboard charts and usage logs (partially addressed by prior PR #275, resolved here by unifying the entire date pipeline)
- Follow-up to #668 — Builds on the timezone foundation introduced in the system-wide timezone consistency PR

## Solution
1. **Timezone-aware date resolution** — All dashboard date range queries now use `resolveSystemTimezone()` (DB config -> env TZ -> UTC fallback) and `date-fns-tz` utilities (`toZonedTime`, `formatInTimeZone`, `fromZonedTime`) to compute dates in the correct timezone
2. **Timezone-scoped Redis cache keys** — Dashboard cache keys (overview, statistics, leaderboard) now include `tz:<timezone>` segment to prevent stale data when timezone changes
3. **Cache invalidation on timezone change** — When system timezone is updated via settings, all dashboard caches are invalidated atomically via `invalidateAllOverviewCaches`, `invalidateAllStatisticsCaches`, `invalidateAllLeaderboardCaches`
4. **Bucket normalization fix** — `normalizeBucketInstant` replaces `normalizeBucketDate` to correctly parse bucket timestamps through the system timezone, preventing UTC/local drift
5. **Chart serialization fix** — `serializeChartBucketDate` replaces resolution-dependent date formatting with consistent ISO serialization, ensuring stable date keys across all time ranges

## Changes

### Core Changes
- `src/repository/statistics.ts` (+52/-19) — Replace `normalizeBucketDate` with `normalizeBucketInstant` that parses through system timezone; add timezone parameter to all DB query functions
- `src/repository/admin-user-insights.ts` (+36/-27) — Add `buildSystemTimezoneDateConditions` helper for all date range queries; use `AT TIME ZONE` in SQL conditions
- `src/lib/redis/leaderboard-cache.ts` (+23/-5) — Include timezone in all leaderboard cache keys; add `invalidateAllLeaderboardCaches`
- `src/lib/redis/overview-cache.ts` (+30/-6) — Include timezone in overview cache keys; add `invalidateAllOverviewCaches`; handle legacy key cleanup
- `src/lib/redis/statistics-cache.ts` (+42/-14) — Include timezone in statistics cache keys; add `invalidateAllStatisticsCaches`; handle legacy key cleanup
- `src/actions/statistics.ts` (+6/-10) — Replace resolution-dependent date formatting with `serializeChartBucketDate` for stable chart buckets
- `src/actions/system-config.ts` (+17/-0) — Invalidate dashboard caches when timezone setting changes
- `src/app/api/admin/system-config/route.ts` (+16/-0) — Same cache invalidation for REST API path

### UI Changes
- `src/app/[locale]/dashboard/leaderboard/_components/date-range-picker.tsx` (+17/-8) — Use `formatInTimeZone` / `toZonedTime` for all date range computation
- `src/app/[locale]/dashboard/leaderboard/user/[userId]/_components/filters/types.ts` (+26/-18) — Add timezone parameter to time preset resolution
- `src/app/[locale]/dashboard/logs/_components/filters/active-filters-display.tsx` (+10/-3) — Display active filter dates in system timezone
- `src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx` (+6/-2) — Use timezone-aware "today" for calendar disabled/ navigation
- `src/app/[locale]/dashboard/logs/_utils/time-range.ts` (+13/-18) — Simplify `getQuickDateRange` to use `toZonedTime` then plain `date-fns` formatting
- `src/app/[locale]/my-usage/_components/statistics-summary-card.tsx` (+22/-6) — Use `formatInTimeZone` for default date range; auto-reset range on timezone change
- `src/components/ui/relative-time.tsx` (+4/-1) — Accept optional `timeZone` override prop
- `src/types/dashboard-cache.ts` (+30/-6) — Add `timezone` field to cache key types; add timezone-scoped cache key builders

### Test Changes
- `tests/unit/dashboard-logs-time-range-utils.test.ts` (+10/-0) — Add test for early-morning UTC in a different timezone
- `tests/unit/dashboard/dashboard-cache-keys.test.ts` (+21/-11) — Update cache key tests for timezone-scoped keys
- `tests/unit/redis/leaderboard-cache.test.ts` (+29/-1) — Test timezone-scoped Redis keys and cross-timezone behavior
- `tests/unit/redis/overview-cache.test.ts` (+35/-14) — Test timezone-scoped keys and invalidation
- `tests/unit/redis/statistics-cache.test.ts` (+70/-23) — Test timezone-scoped keys and DB parameter passing
- `tests/unit/repository/admin-user-insights-overview.test.ts` (+12/-0) — Add timezone-specific test
- `tests/unit/repository/statistics-timezone-buckets.test.ts` (+38/-0) — New file testing bucket normalization with timezone
- `tests/unit/user-insights-filters.test.ts` (+17/-0) — Test timezone-aware filter presets

## Breaking Changes
None — all changes are backward-compatible:
- New function parameters are optional with sensible defaults
- Redis cache keys are extended (not renamed) to include `tz:<timezone>`, while legacy keys are still cleaned up on invalidation
- No API surface changes or schema migrations

## Testing

### Automated Tests
- ✅ 9 test files updated/added with timezone-specific coverage
- ✅ `bunx vitest run` specific tests passed
- ✅ `bun run typecheck` passed
- ✅ `bun run lint` passed
- ✅ `bun run build` passed

### Manual Testing
1. Set system timezone to a non-UTC timezone (e.g., Asia/Shanghai UTC+8)
2. Open dashboard and verify daily statistics chart shows correct date labels
3. Verify usage logs date range picker shows today in the correct timezone
4. Verify leaderboard date range picker shows correct date ranges
5. Verify my-usage statistics card shows correct date range
6. Change system timezone in settings and verify caches are invalidated (dashboard data refreshes)

## Validation
- `bunx vitest run tests/unit/dashboard-logs-time-range-utils.test.ts tests/unit/dashboard/dashboard-cache-keys.test.ts tests/unit/dashboard/leaderboard-view-user-cache-hit-rate.test.tsx tests/unit/redis/leaderboard-cache.test.ts tests/unit/redis/overview-cache.test.ts tests/unit/redis/statistics-cache.test.ts tests/unit/repository/admin-user-insights-overview.test.ts tests/unit/repository/statistics-timezone-buckets.test.ts tests/unit/user-insights-filters.test.ts` (passed)
- `bun run typecheck` (passed)
- `bun run lint` (passed; Biome schema version info only)
- `bun run build` (passed; existing Edge Runtime warnings in instrumentation dependencies)

---
*Description enhanced by Claude AI PR Agent*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR unifies timezone handling across dashboard views (statistics, logs, leaderboard, my-usage) by routing all date-range computations through `resolveSystemTimezone()`, adding `tz:<timezone>` segments to Redis cache keys, invalidating timezone-sensitive caches on settings change, and replacing naïve `Date` parsing in bucket normalization with a new `normalizeBucketInstant` + `fromZonedTime` approach.

- **Core correctness fix**: `normalizeBucketInstant` strips timezone offsets from PostgreSQL bucket timestamps and reinterprets them as instants in the configured timezone, resolving the UTC/local day-alignment drift that caused April 28 data to appear under April 27 in UTC+8.
- **Cache-key scoping**: All three Redis cache families now embed `tz:<timezone>` so a timezone change automatically misses the old cache; `invalidateAll*Caches` functions clean up both new and legacy keys atomically on settings save.
- **UI consistency**: Date range pickers, active-filter display, and `RelativeTime` components accept or derive the system timezone directly, eliminating browser-local vs server-timezone discrepancies.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core timezone-alignment fix is correct and well-tested, with two rough edges worth addressing in a follow-up.

The fundamental approach is sound: timezone is resolved once per cache request, propagated to DB queries, and embedded in cache keys. All scan-based invalidation patterns also match active lock keys, meaning a concurrent cache-population attempt can have its distributed lock silently deleted during invalidation. Additionally, normalizeBucketInstant's Date-object path uses getDate()/getHours() (server-local time) rather than getUTCDate()/getUTCHours(), so on a non-UTC Node server bucket timestamps would be misinterpreted. Both are performance/edge-case issues rather than data-loss bugs on UTC servers, but they narrow the robustness margin of an otherwise thorough change.

src/repository/statistics.ts (formatLocalDateTime uses local-time getters), src/lib/redis/overview-cache.ts, src/lib/redis/statistics-cache.ts, src/lib/redis/leaderboard-cache.ts (scan patterns include lock keys)
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/repository/statistics.ts | Replaces normalizeBucketDate with normalizeBucketInstant for timezone-aware bucket parsing; adds timezoneOverride to all three DB query functions; the string path is correct, but the Date object path uses system-local getDate()/getHours() which could drift on non-UTC servers |
| src/lib/redis/overview-cache.ts | Adds timezone-scoped cache keys and invalidateAllOverviewCaches; scanPattern("overview:*") will also match lock keys like "overview:global:tz:UTC:lock", causing lock deletion during invalidation |
| src/lib/redis/statistics-cache.ts | Adds timezone-scoped cache keys and legacy key cleanup; same lock-key scan issue as overview-cache; resolveSystemTimezone resolved once per cache request and correctly passed down to DB queries |
| src/lib/redis/leaderboard-cache.ts | Adds tz: segment to all leaderboard cache key variants and adds invalidateAllLeaderboardCaches with scanPattern("leaderboard:*") which may also match lock keys |
| src/types/dashboard-cache.ts | Overloaded cache key builders correctly handle both global and user-scoped keys with timezone; TypeScript overloads prevent misuse of the implementation's wider signature |
| src/repository/admin-user-insights.ts | Centralizes date condition building in buildSystemTimezoneDateConditions using AT TIME ZONE in parameterized SQL; consistent refactor across getUserOverviewMetrics, getUserModelBreakdown, getUserProviderBreakdown |
| src/actions/statistics.ts | serializeChartBucketDate unifies hourly and daily bucket keys as ISO timestamps; day-resolution keys changed from YYYY-MM-DD to full ISO format — downstream chart rendering code may need updates |
| src/actions/system-config.ts | Invalidates all three dashboard caches when timezone changes; uses Promise.all with .catch so cache failures don't surface to users |
| src/app/[locale]/my-usage/_components/statistics-summary-card.tsx | Adds auto-reset of date range when timezone changes only if user hasn't manually set a range; autoDateRangeRef correctly tracks user intent |
| src/app/[locale]/dashboard/leaderboard/_components/date-range-picker.tsx | Monthly navigation now correctly advances by calendar month; today computed in system timezone for disabled-date check |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dashboard request] --> B{Redis client available?}
    B -- No --> C[Direct DB query with timezone]
    B -- Yes --> D[resolveSystemTimezone]
    D --> E[buildCacheKey with tz: segment]
    E --> F{Cache hit?}
    F -- Yes --> G[Return cached data]
    F -- No --> H{Lock acquired?}
    H -- No --> I[Wait 100ms, Retry cache]
    I --> J{Retry hit?}
    J -- Yes --> G
    J -- No --> C
    H -- Yes --> K[Query DB with timezone param]
    K --> L[normalizeBucketInstant strips TZ, fromZonedTime]
    L --> M[Write to Redis with TTL]
    M --> N[Release lock]
    N --> G
    P[Admin saves timezone] --> Q[updateSystemSettings]
    Q --> R[invalidateAll*Caches]
    R --> S[Scan patterns also match lock keys]
    S --> T[redis.del matched + legacy keys]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Dashboard request] --> B{Redis client available?}
    B -- No --> C[Direct DB query with timezone]
    B -- Yes --> D[resolveSystemTimezone]
    D --> E[buildCacheKey with tz: segment]
    E --> F{Cache hit?}
    F -- Yes --> G[Return cached data]
    F -- No --> H{Lock acquired?}
    H -- No --> I[Wait 100ms, Retry cache]
    I --> J{Retry hit?}
    J -- Yes --> G
    J -- No --> C
    H -- Yes --> K[Query DB with timezone param]
    K --> L[normalizeBucketInstant strips TZ, fromZonedTime]
    L --> M[Write to Redis with TTL]
    M --> N[Release lock]
    N --> G
    P[Admin saves timezone] --> Q[updateSystemSettings]
    Q --> R[invalidateAll*Caches]
    R --> S[Scan patterns also match lock keys]
    S --> T[redis.del matched + legacy keys]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: navigate leaderboard monthly ranges..."](https://github.com/ding113/claude-code-hub/commit/aeff2f3b3bf757e0cd4b3bb49ee07a8dd5b4f67d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38863491)</sub>

<!-- /greptile_comment -->