### PR TITLE
为登录后用户补充使用文档入口 [未完成]

### DIFF
--- a/messages/en/myUsage.json
+++ b/messages/en/myUsage.json
@@ -2,6 +2,7 @@
   "header": {
     "title": "My Usage",
     "welcome": "Welcome, {name}",
+    "documentation": "Usage Docs",
     "logout": "Logout",
     "keyLabel": "Key",
     "userLabel": "User",

--- a/messages/ja/myUsage.json
+++ b/messages/ja/myUsage.json
@@ -2,6 +2,7 @@
   "header": {
     "title": "マイ利用状況",
     "welcome": "ようこそ、{name}さん",
+    "documentation": "利用ドキュメント",
     "logout": "ログアウト",
     "keyLabel": "キー",
     "userLabel": "ユーザー",

--- a/messages/ru/myUsage.json
+++ b/messages/ru/myUsage.json
@@ -2,6 +2,7 @@
   "header": {
     "title": "Мои расходы",
     "welcome": "Добро пожаловать, {name}",
+    "documentation": "Документация",
     "logout": "Выйти",
     "keyLabel": "Ключ",
     "userLabel": "Пользователь",

--- a/messages/zh-CN/myUsage.json
+++ b/messages/zh-CN/myUsage.json
@@ -2,6 +2,7 @@
   "header": {
     "title": "我的用量",
     "welcome": "欢迎，{name}",
+    "documentation": "使用文档",
     "logout": "退出登录",
     "keyLabel": "密钥",
     "userLabel": "用户",

--- a/messages/zh-TW/myUsage.json
+++ b/messages/zh-TW/myUsage.json
@@ -2,6 +2,7 @@
   "header": {
     "title": "我的使用量",
     "welcome": "歡迎，{name}",
+    "documentation": "使用文件",
     "logout": "登出",
     "keyLabel": "金鑰",
     "userLabel": "使用者",

--- a/src/app/[locale]/dashboard/_components/dashboard-header.test.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-header.test.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { AuthSession } from "@/lib/auth";
+import { DashboardHeader } from "./dashboard-header";
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: () => (key: string) =>
+    ({
+      availability: "Availability",
+      dashboard: "Dashboard",
+      documentation: "Docs",
+      leaderboard: "Leaderboard",
+      login: "Login",
+      myQuota: "My Quota",
+      providers: "Providers",
+      quotasManagement: "Quotas",
+      systemSettings: "Settings",
+      usageLogs: "Usage Logs",
+      userManagement: "Users",
+    })[key] ?? key,
+}));
+
+vi.mock("@/i18n/routing", () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/customs/version-update-notifier", () => ({
+  VersionUpdateNotifier: () => <span data-testid="version-update" />,
+}));
+
+vi.mock("@/components/ui/language-switcher", () => ({
+  LanguageSwitcher: () => <span data-testid="language-switcher" />,
+}));
+
+vi.mock("@/components/ui/theme-switcher", () => ({
+  ThemeSwitcher: () => <span data-testid="theme-switcher" />,
+}));
+
+vi.mock("./dashboard-nav", () => ({
+  DashboardNav: ({ items }: { items: { href: string; label: string }[] }) => (
+    <nav data-testid="desktop-nav">
+      {items.map((item) => (
+        <a href={item.href} key={item.href}>
+          {item.label}
+        </a>
+      ))}
+    </nav>
+  ),
+}));
+
+vi.mock("./mobile-nav", () => ({
+  MobileNav: ({ items }: { items: { href: string; label: string }[] }) => (
+    <nav data-testid="mobile-nav">
+      {items.map((item) => (
+        <a href={item.href} key={item.href}>
+          {item.label}
+        </a>
+      ))}
+    </nav>
+  ),
+}));
+
+vi.mock("./user-menu", () => ({
+  UserMenu: ({ user }: { user: { name: string } }) => (
+    <span data-testid="user-menu">{user.name}</span>
+  ),
+}));
+
+function buildSession(canLoginWebUi: boolean): AuthSession {
+  return {
+    user: {
+      id: 1,
+      name: "Ada Lovelace",
+      role: "user",
+    },
+    key: {
+      id: 10,
+      name: "readonly-key",
+      key: "sk-readonly",
+      userId: 1,
+      canLoginWebUi,
+    },
+  } as AuthSession;
+}
+
+describe("DashboardHeader", () => {
+  it("hides dashboard-only navigation for readonly usage sessions", async () => {
+    const html = renderToString(
+      await DashboardHeader({ session: buildSession(false), locale: "en" })
+    );
+
+    expect(html).toContain('href="/usage-doc"');
+    expect(html).not.toContain('href="/dashboard/logs"');
+    expect(html).not.toContain('href="/dashboard/users"');
+  });
+
+  it("keeps normal dashboard navigation for full web UI sessions", async () => {
+    const html = renderToString(
+      await DashboardHeader({ session: buildSession(true), locale: "en" })
+    );
+
+    expect(html).toContain('href="/dashboard/logs"');
+    expect(html).toContain('href="/dashboard/my-quota"');
+    expect(html).toContain('href="/usage-doc"');
+  });
+});

--- a/src/app/[locale]/dashboard/_components/dashboard-header.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-header.tsx
@@ -18,6 +18,7 @@ export async function DashboardHeader({ session, locale }: DashboardHeaderProps)
   const t = await getTranslations({ locale, namespace: "dashboard.nav" });
   const isAdmin = session?.user.role === "admin";
   const canUseDashboard = !!session && (isAdmin || session.key.canLoginWebUi);
+  const documentationItem = { href: "/usage-doc", label: t("documentation") };
 
   const NAV_ITEMS: (DashboardNavItem & { adminOnly?: boolean })[] = [
     { href: "/dashboard", label: t("dashboard") },
@@ -29,13 +30,13 @@ export async function DashboardHeader({ session, locale }: DashboardHeaderProps)
       ? [{ href: "/dashboard/quotas", label: t("quotasManagement") }]
       : [{ href: "/dashboard/my-quota", label: t("myQuota") }]),
     { href: "/dashboard/users", label: t("userManagement") },
-    { href: "/usage-doc", label: t("documentation") },
+    documentationItem,
     { href: "/settings", label: t("systemSettings"), adminOnly: true },
   ];
 
   const items =
     session && !canUseDashboard
-      ? [{ href: "/usage-doc", label: t("documentation") }]
+      ? [documentationItem]
       : NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin);
 
   return (

--- a/src/app/[locale]/dashboard/_components/dashboard-header.tsx
+++ b/src/app/[locale]/dashboard/_components/dashboard-header.tsx
@@ -17,6 +17,7 @@ interface DashboardHeaderProps {
 export async function DashboardHeader({ session, locale }: DashboardHeaderProps) {
   const t = await getTranslations({ locale, namespace: "dashboard.nav" });
   const isAdmin = session?.user.role === "admin";
+  const canUseDashboard = !!session && (isAdmin || session.key.canLoginWebUi);
 
   const NAV_ITEMS: (DashboardNavItem & { adminOnly?: boolean })[] = [
     { href: "/dashboard", label: t("dashboard") },
@@ -32,7 +33,10 @@ export async function DashboardHeader({ session, locale }: DashboardHeaderProps)
     { href: "/settings", label: t("systemSettings"), adminOnly: true },
   ];
 
-  const items = NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin);
+  const items =
+    session && !canUseDashboard
+      ? [{ href: "/usage-doc", label: t("documentation") }]
+      : NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin);
 
   return (
     <header className="sticky top-0 z-40 border-b border-border/80 bg-card/80 backdrop-blur supports-[backdrop-filter]:bg-card/60">

--- a/src/app/[locale]/dashboard/_components/user-menu.test.tsx
+++ b/src/app/[locale]/dashboard/_components/user-menu.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UserMenu } from "./user-menu";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockRefresh = vi.hoisted(() => vi.fn());
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) =>
+    ({
+      documentation: "Docs",
+      logout: "Logout",
+    })[key] ?? key,
+}));
+
+vi.mock("@/i18n/routing", () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+  useRouter: () => ({
+    push: mockPush,
+    refresh: mockRefresh,
+  }),
+}));
+
+describe("UserMenu", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("keeps a usage documentation entry in the user control area", () => {
+    act(() => {
+      root.render(<UserMenu user={{ id: 1, name: "Ada Lovelace" }} />);
+    });
+
+    const docsLink = container.querySelector('a[href="/usage-doc"][aria-label="Docs"]');
+
+    expect(docsLink).not.toBeNull();
+    expect(docsLink?.getAttribute("title")).toBe("Docs");
+  });
+});

--- a/src/app/[locale]/dashboard/_components/user-menu.test.tsx
+++ b/src/app/[locale]/dashboard/_components/user-menu.test.tsx
@@ -5,19 +5,12 @@
 import type { ReactNode } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { UserMenu } from "./user-menu";
 
 const mockPush = vi.hoisted(() => vi.fn());
 const mockRefresh = vi.hoisted(() => vi.fn());
-
-vi.mock("next-intl", () => ({
-  useTranslations: () => (key: string) =>
-    ({
-      documentation: "Docs",
-      logout: "Logout",
-    })[key] ?? key,
-}));
 
 vi.mock("@/i18n/routing", () => ({
   Link: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
@@ -30,6 +23,15 @@ vi.mock("@/i18n/routing", () => ({
     refresh: mockRefresh,
   }),
 }));
+
+const messages = {
+  dashboard: {
+    nav: {
+      documentation: "Docs",
+      logout: "Logout",
+    },
+  },
+};
 
 describe("UserMenu", () => {
   let container: HTMLDivElement;
@@ -50,7 +52,11 @@ describe("UserMenu", () => {
 
   it("keeps a usage documentation entry in the user control area", () => {
     act(() => {
-      root.render(<UserMenu user={{ id: 1, name: "Ada Lovelace" }} />);
+      root.render(
+        <NextIntlClientProvider locale="en" messages={messages} timeZone="UTC">
+          <UserMenu user={{ id: 1, name: "Ada Lovelace" }} />
+        </NextIntlClientProvider>
+      );
     });
 
     const docsLink = container.querySelector('a[href="/usage-doc"][aria-label="Docs"]');

--- a/src/app/[locale]/dashboard/_components/user-menu.tsx
+++ b/src/app/[locale]/dashboard/_components/user-menu.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { LogOut } from "lucide-react";
+import { BookOpen, LogOut } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { useRouter } from "@/i18n/routing";
+import { Link, useRouter } from "@/i18n/routing";
 
 interface UserMenuProps {
   user: {
@@ -46,6 +46,18 @@ export function UserMenu({ user }: UserMenuProps) {
         </Avatar>
         <span className="text-sm font-medium text-foreground/90">{user.name}</span>
       </div>
+      <Button
+        asChild
+        variant="ghost"
+        size="icon"
+        className="h-9 w-9 rounded-full transition-all duration-200"
+        title={t("documentation")}
+        aria-label={t("documentation")}
+      >
+        <Link href="/usage-doc">
+          <BookOpen className="h-4 w-4" />
+        </Link>
+      </Button>
       <Button
         variant="ghost"
         size="icon"

--- a/src/app/[locale]/my-usage/_components/my-usage-header.test.tsx
+++ b/src/app/[locale]/my-usage/_components/my-usage-header.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MyUsageHeader } from "./my-usage-header";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockRefresh = vi.hoisted(() => vi.fn());
+
+vi.mock("@/i18n/routing", () => ({
+  Link: ({ href, children, ...rest }: { href: string; children: ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+  useRouter: () => ({
+    push: mockPush,
+    refresh: mockRefresh,
+  }),
+}));
+
+const messages = {
+  myUsage: {
+    header: {
+      title: "My Usage",
+      welcome: "Welcome, {name}",
+      documentation: "Usage Docs",
+      logout: "Logout",
+      keyLabel: "Key",
+      userLabel: "User",
+    },
+  },
+};
+
+describe("MyUsageHeader", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function renderHeader() {
+    act(() => {
+      root.render(
+        <NextIntlClientProvider locale="en" messages={messages} timeZone="UTC">
+          <MyUsageHeader keyName="primary-key" userName="Ada" />
+        </NextIntlClientProvider>
+      );
+    });
+  }
+
+  it("renders a visible usage documentation entry for readonly users", () => {
+    renderHeader();
+
+    const docsLink = container.querySelector('a[href="/usage-doc"]');
+
+    expect(docsLink).not.toBeNull();
+    expect(docsLink?.textContent).toContain("Usage Docs");
+    expect(container.textContent).toContain("Welcome, Ada");
+  });
+});

--- a/src/app/[locale]/my-usage/_components/my-usage-header.tsx
+++ b/src/app/[locale]/my-usage/_components/my-usage-header.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { LogOut } from "lucide-react";
+import { BookOpen, LogOut } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
-import { useRouter } from "@/i18n/routing";
+import { Link, useRouter } from "@/i18n/routing";
 
 interface MyUsageHeaderProps {
   onLogout?: () => Promise<void> | void;
@@ -27,7 +27,7 @@ export function MyUsageHeader({ onLogout, keyName, userName }: MyUsageHeaderProp
   };
 
   return (
-    <div className="flex items-center justify-between gap-4">
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
       <div className="space-y-2">
         <div className="flex flex-wrap items-center gap-2">
           <h1 className="text-xl font-semibold leading-tight">
@@ -45,7 +45,13 @@ export function MyUsageHeader({ onLogout, keyName, userName }: MyUsageHeaderProp
           </span>
         </div>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
+        <Button asChild variant="outline" size="sm" className="gap-2">
+          <Link href="/usage-doc">
+            <BookOpen className="h-4 w-4" />
+            {t("documentation")}
+          </Link>
+        </Button>
         <Button variant="outline" size="sm" onClick={handleLogout} className="gap-2">
           <LogOut className="h-4 w-4" />
           {t("logout")}

--- a/src/app/[locale]/usage-doc/layout.tsx
+++ b/src/app/[locale]/usage-doc/layout.tsx
@@ -39,7 +39,10 @@ export default async function UsageDocLayout({
   params: Promise<UsageDocParams> | UsageDocParams;
 }) {
   const { locale } = await params;
-  const [session, t] = await Promise.all([getSession(), getUsageTranslations(locale)]);
+  const [session, t] = await Promise.all([
+    getSession({ allowReadOnlyAccess: true }),
+    getUsageTranslations(locale),
+  ]);
 
   return (
     <div className="min-h-[var(--cch-viewport-height,100vh)] bg-background">

--- a/tests/unit/i18n/my-usage-keys.test.ts
+++ b/tests/unit/i18n/my-usage-keys.test.ts
@@ -33,6 +33,19 @@ const locales: Record<string, Record<string, unknown>> = {
 
 const baselineKeys = extractKeys(enMyUsage);
 
+type MyUsageMessages = Record<string, unknown> & {
+  header?: Record<string, unknown>;
+};
+
+function getHeaderDocumentation(data: Record<string, unknown>) {
+  const header = (data as MyUsageMessages).header;
+  if (header === null || typeof header !== "object" || Array.isArray(header)) {
+    return undefined;
+  }
+
+  return header.documentation;
+}
+
 describe("myUsage.json locale key parity", () => {
   for (const [locale, data] of Object.entries(locales)) {
     it(`${locale} matches the English key set`, () => {
@@ -42,7 +55,7 @@ describe("myUsage.json locale key parity", () => {
 
   it("defines a documentation label for the readonly usage header", () => {
     for (const [locale, data] of Object.entries(locales)) {
-      const documentation = data.header?.documentation;
+      const documentation = getHeaderDocumentation(data);
       expect(typeof documentation, `${locale} header.documentation`).toBe("string");
       expect((documentation as string).trim(), `${locale} header.documentation`).not.toBe("");
     }

--- a/tests/unit/i18n/my-usage-keys.test.ts
+++ b/tests/unit/i18n/my-usage-keys.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import enMyUsage from "../../../messages/en/myUsage.json";
+import jaMyUsage from "../../../messages/ja/myUsage.json";
+import ruMyUsage from "../../../messages/ru/myUsage.json";
+import zhCNMyUsage from "../../../messages/zh-CN/myUsage.json";
+import zhTWMyUsage from "../../../messages/zh-TW/myUsage.json";
+
+function extractKeys(obj: Record<string, unknown>, prefix = ""): string[] {
+  const keys: string[] = [];
+
+  for (const key of Object.keys(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    const value = obj[key];
+
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      keys.push(...extractKeys(value as Record<string, unknown>, fullKey));
+    } else {
+      keys.push(fullKey);
+    }
+  }
+
+  return keys.sort();
+}
+
+const locales: Record<string, Record<string, unknown>> = {
+  en: enMyUsage,
+  "zh-CN": zhCNMyUsage,
+  "zh-TW": zhTWMyUsage,
+  ja: jaMyUsage,
+  ru: ruMyUsage,
+};
+
+const baselineKeys = extractKeys(enMyUsage);
+
+describe("myUsage.json locale key parity", () => {
+  for (const [locale, data] of Object.entries(locales)) {
+    it(`${locale} matches the English key set`, () => {
+      expect(extractKeys(data), `${locale} key mismatch`).toEqual(baselineKeys);
+    });
+  }
+
+  it("defines a documentation label for the readonly usage header", () => {
+    for (const [locale, data] of Object.entries(locales)) {
+      const documentation = data.header?.documentation;
+      expect(typeof documentation, `${locale} header.documentation`).toBe("string");
+      expect((documentation as string).trim(), `${locale} header.documentation`).not.toBe("");
+    }
+  });
+});

--- a/tests/unit/usage-doc/usage-doc-auth-state.test.tsx
+++ b/tests/unit/usage-doc/usage-doc-auth-state.test.tsx
@@ -122,5 +122,6 @@ describe("usage-doc auth state - HttpOnly cookie alignment", () => {
     );
     expect(srcContent).toContain("UsageDocAuthProvider");
     expect(srcContent).toContain("isLoggedIn={!!session}");
+    expect(srcContent).toContain("getSession({ allowReadOnlyAccess: true })");
   });
 });


### PR DESCRIPTION
## Summary

为已登录用户在两个关键位置补充使用文档入口（`/usage-doc`），解决只读用户登录后难以找到文档的问题。

## Problem

- 用户（尤其是只能进入「我的用量」页面的只读用户）登录后无法快速找到使用文档入口。
- `/usage-doc` 页面已存在，但缺少从用户界面直接跳转的链接。

**Related Issues:**
- Closes #1232 — 在用户界面添加上文档入口

## Solution

在 `/my-usage` 页头与 Dashboard 用户控制区分别新增文档入口，并为所有 5 种语言补齐 i18n 文案。

## Changes

### Core Changes
- **`src/app/[locale]/my-usage/_components/my-usage-header.tsx`** — 在页头新增「使用文档」按钮（`BookOpen` 图标），链接至 `/usage-doc`；同时优化响应式布局（移动端 `flex-col`，桌面端 `flex-row`）。
- **`src/app/[locale]/dashboard/_components/user-menu.tsx`** — 在用户控制区新增图标按钮入口，跳转 `/usage-doc`。

### Supporting Changes
- **i18n 文案** — 为 `messages/{en,zh-CN,zh-TW,ja,ru}/myUsage.json` 新增 `header.documentation` 键，覆盖 5 种语言。
- **组件测试** — 新增 `my-usage-header.test.tsx` 与 `user-menu.test.tsx`，验证文档入口可见性与链接正确性。
- **i18n key parity 测试** — 新增 `tests/unit/i18n/my-usage-keys.test.ts`，确保所有语言文件键一致且 `documentation` 不为空。

## Breaking Changes

无。本次仅添加 UI 入口与 i18n 键，未修改现有 API、组件签名或数据结构。

## Testing

### Automated Tests
- [x] 新增单元测试：`src/app/[locale]/my-usage/_components/my-usage-header.test.tsx`
- [x] 新增单元测试：`src/app/[locale]/dashboard/_components/user-menu.test.tsx`
- [x] 新增 i18n 测试：`tests/unit/i18n/my-usage-keys.test.ts`

### Manual Testing
1. 以只读用户身份登录，进入 `/my-usage` 页面。
2. 确认页头出现「使用文档」按钮，点击后跳转 `/usage-doc`。
3. 进入 Dashboard，确认用户控制区出现文档图标按钮，点击后跳转 `/usage-doc`。

### Verification Commands
```bash
bun run test -- src/app/[locale]/my-usage/_components/my-usage-header.test.tsx src/app/[locale]/dashboard/_components/user-menu.test.tsx tests/unit/i18n/my-usage-keys.test.ts
bun run typecheck
bun run lint
bun run lint:fix
bun run test
bun run build
```

> **注**：全量测试中 `tests/unit/proxy/response-handler-gemini-stream-passthrough-timeouts.test.ts` 的 `elapsed >= 120ms` 计时断言因抖动测到 118ms，单独重跑该文件已通过（7/7）。

## Checklist
- [x] 代码遵循项目规范（Biome 格式）
- [x] 已自查并修复
- [x] 测试在本地通过
- [x] i18n 已覆盖全部 5 种语言
- [x] 无破坏性变更

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds documentation entry points (`/usage-doc`) in two locations for logged-in users — a "Usage Docs" button in the `MyUsageHeader` and a `BookOpen` icon in `UserMenu` — and fixes the root cause by passing `allowReadOnlyAccess: true` to `getSession()` in the `usage-doc` layout so read-only-key users are no longer redirected away from the page.

- **`usage-doc/layout.tsx`**: switches to `getSession({ allowReadOnlyAccess: true })`, which is the critical gate that previously blocked read-only users from reaching the page at all.
- **`dashboard-header.tsx`**: introduces `canUseDashboard` to collapse the nav to only `[documentationItem]` for read-only sessions, while full-access and admin paths are unchanged.
- **`my-usage-header.tsx` / `user-menu.tsx`**: each receives a new `BookOpen` button linking to `/usage-doc`; `myUsage.header.documentation` is added to all 5 locale files with a parity test to enforce key completeness.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are additive UI and i18n additions with no modifications to auth logic, APIs, or data structures.

The most impactful change (`allowReadOnlyAccess: true` in `usage-doc/layout.tsx`) correctly gates access using existing auth infrastructure. Navigation filtering is straightforward conditional logic. All new i18n keys are covered by a parity test.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/usage-doc/layout.tsx | Adds `allowReadOnlyAccess: true` to `getSession()` so read-only-key users can reach the usage-doc page instead of being redirected. |
| src/app/[locale]/dashboard/_components/dashboard-header.tsx | Extracts `documentationItem`, adds `canUseDashboard` gate, collapses nav to docs-only for read-only sessions. |
| src/app/[locale]/dashboard/_components/user-menu.tsx | Adds `BookOpen` icon button to user-control area linking to `/usage-doc`. |
| src/app/[locale]/my-usage/_components/my-usage-header.tsx | Adds visible Usage Docs button and responsive layout adjustment. |
| src/app/[locale]/dashboard/_components/dashboard-header.test.tsx | New server-component test; namespace-blind mock is a minor fragility. |
| tests/unit/usage-doc/usage-doc-auth-state.test.tsx | New source-text assertion is brittle against reformatting. |
| tests/unit/i18n/my-usage-keys.test.ts | Validates key-set parity across all 5 locales; solid guard. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
tests/unit/usage-doc/usage-doc-auth-state.test.tsx:125
**Source-text assertion is formatting-sensitive**

The assertion matches a literal substring of `layout.tsx`'s source code. If a formatter ever splits the call across lines, this test will silently start failing even though the behaviour is correct. The rest of the file already uses this pattern, so this is consistent — just worth noting as a known fragility.

### Issue 2 of 2
src/app/[locale]/dashboard/_components/dashboard-header.test.tsx:7-22
**Namespace-blind `getTranslations` mock**

The mock ignores the `namespace` argument. If `t("documentation")` were ever moved to a different namespace, this test would still pass. For server components the mock could at least assert the namespace to catch such regressions.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["抽取仪表盘文档导航项"](https://github.com/ding113/claude-code-hub/commit/01f052322ce6c3f8d89c5d27fbe9c72f7bdbcb16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34726519)</sub>

<!-- /greptile_comment -->