### PR TITLE
fix(api-client): wrap provider group-count and model-suggestion wrappers in toActionResult

### DIFF
--- a/src/lib/api-client/v1/actions/providers.ts
+++ b/src/lib/api-client/v1/actions/providers.ts
@@ -61,7 +61,12 @@ export function getAvailableProviderGroups(userId?: number): Promise<string[]> {
 }
 
 export function getProviderGroupsWithCount() {
-  return apiGet(`/api/v1/providers/groups?include=count`, dashboardCompatOptions);
+  return toActionResult(
+    apiGet<Array<{ group: string; providerCount: number }>>(
+      `/api/v1/providers/groups?include=count`,
+      dashboardCompatOptions
+    )
+  );
 }
 
 export function addProvider(data: unknown) {
@@ -219,9 +224,11 @@ export function fetchUpstreamModels(data: unknown) {
 }
 
 export function getModelSuggestionsByProviderGroup(providerGroup?: string | null) {
-  return apiGet(
-    `/api/v1/providers/model-suggestions${searchParams({ providerGroup })}`,
-    dashboardCompatOptions
+  return toActionResult(
+    apiGet<string[]>(
+      `/api/v1/providers/model-suggestions${searchParams({ providerGroup })}`,
+      dashboardCompatOptions
+    )
   );
 }
 

--- a/tests/unit/api/v1/api-client-actions.test.ts
+++ b/tests/unit/api/v1/api-client-actions.test.ts
@@ -394,7 +394,11 @@ describe("v1 action compatibility client", () => {
 
   test("maps a failed provider group counts request to a failed ActionResult", async () => {
     getMock.mockRejectedValue(
-      new ApiError({ status: 403, errorCode: "auth.forbidden", detail: "Admin access is required." })
+      new ApiError({
+        status: 403,
+        errorCode: "auth.forbidden",
+        detail: "Admin access is required.",
+      })
     );
 
     const result = await providers.getProviderGroupsWithCount();

--- a/tests/unit/api/v1/api-client-actions.test.ts
+++ b/tests/unit/api/v1/api-client-actions.test.ts
@@ -373,4 +373,52 @@ describe("v1 action compatibility client", () => {
     expect(result).not.toHaveProperty("data");
     expect(result[1]?.circuitState).toBe("open");
   });
+
+  test("wraps provider group counts in ActionResult for the dashboard consumer", async () => {
+    // 后端 listProviderGroups 经 actionJson() 解包，直接返回裸数组；
+    // provider-group-select.tsx 却按 `{ ok, data }` 消费。若 api-client 不再包一层，
+    // `res.ok` 永远 undefined，每次展开用户编辑面板都会误报 "获取供应商分组统计失败"。
+    const groupCounts = [
+      { group: "default", providerCount: 2 },
+      { group: "prod", providerCount: 1 },
+    ];
+    getMock.mockResolvedValue(groupCounts);
+
+    const result = await providers.getProviderGroupsWithCount();
+
+    expect(getMock).toHaveBeenCalledWith("/api/v1/providers/groups?include=count", {
+      headers: { [DASHBOARD_COMPAT_HEADER]: "1" },
+    });
+    expect(result).toEqual({ ok: true, data: groupCounts });
+  });
+
+  test("maps a failed provider group counts request to a failed ActionResult", async () => {
+    getMock.mockRejectedValue(
+      new ApiError({ status: 403, errorCode: "auth.forbidden", detail: "Admin access is required." })
+    );
+
+    const result = await providers.getProviderGroupsWithCount();
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Admin access is required.",
+      errorCode: "auth.forbidden",
+      errorParams: undefined,
+    });
+  });
+
+  test("wraps model suggestions in ActionResult for the autocomplete consumer", async () => {
+    // 与分组统计同源：use-model-suggestions.ts 检查 `res.ok && res.data`，
+    // 裸数组会让自动补全静默失效（不报错但永远拿不到建议模型）。
+    const suggestions = ["claude-3-opus", "claude-3-sonnet"];
+    getMock.mockResolvedValue(suggestions);
+
+    const result = await providers.getModelSuggestionsByProviderGroup("default");
+
+    expect(getMock).toHaveBeenCalledWith(
+      "/api/v1/providers/model-suggestions?providerGroup=default",
+      { headers: { [DASHBOARD_COMPAT_HEADER]: "1" } }
+    );
+    expect(result).toEqual({ ok: true, data: suggestions });
+  });
 });

--- a/tests/unit/settings/providers/provider-form-endpoint-pool.test.tsx
+++ b/tests/unit/settings/providers/provider-form-endpoint-pool.test.tsx
@@ -31,7 +31,7 @@ const providersActionMocks = vi.hoisted(() => ({
   removeProvider: vi.fn(async () => ({ ok: true })),
   getUnmaskedProviderKey: vi.fn(async () => ({ ok: true, data: { key: "test-key" } })),
   getProviderTestPresets: vi.fn(async () => ({ ok: true, data: [] })),
-  getModelSuggestionsByProviderGroup: vi.fn(async () => []),
+  getModelSuggestionsByProviderGroup: vi.fn(async () => ({ ok: true, data: [] })),
   fetchUpstreamModels: vi.fn(async () => ({ ok: true, data: { models: [] } })),
 }));
 vi.mock("@/actions/providers", () => providersActionMocks);

--- a/tests/unit/settings/providers/provider-form-total-limit-ui.test.tsx
+++ b/tests/unit/settings/providers/provider-form-total-limit-ui.test.tsx
@@ -42,7 +42,7 @@ const providersActionMocks = vi.hoisted(() => ({
   removeProvider: vi.fn(async (_providerId: number) => ({ ok: true })),
   getUnmaskedProviderKey: vi.fn(async () => ({ ok: true, data: { key: "test-key" } })),
   getProviderTestPresets: vi.fn(async () => ({ ok: true, data: [] })),
-  getModelSuggestionsByProviderGroup: vi.fn(async () => []),
+  getModelSuggestionsByProviderGroup: vi.fn(async () => ({ ok: true, data: [] })),
   fetchUpstreamModels: vi.fn(async () => ({ ok: true, data: { models: [] } })),
 }));
 vi.mock("@/actions/providers", () => providersActionMocks);


### PR DESCRIPTION
**Related Issues/PRs:**
- Follow-up to #1158 — same bug pattern (`toActionResult` wrapper missing in `src/lib/api-client/v1/actions/providers.ts`), same fix approach
- Related to #1145 — builds on the `toActionResult` / `dashboardCompatOptions` pattern introduced in the dashboard API compatibility fix
- Related to #1136 — the v1 REST migration that introduced the action wrapper contract where this bug class originated
- Related to #560 — the provider group editing dialog that consumes these affected functions

## 问题

在用户管理页面展开「用户编辑面板」(创建/编辑用户对话框) 时,**100% 必现**前端报错 `获取供应商分组统计失败: undefined`,但所有后端接口均返回 200,无任何接口错误。

## 复现

实测确认 (本地登录后端 dev server 浏览器复现):

- `GET /api/v1/providers/groups?include=count` → **HTTP 200**,响应体为裸数组 `[]`(不含 `ok` 字段)。
- 控制台报错 `获取供应商分组统计失败:` (第二个参数为 `undefined`)。

## 根因

`src/lib/api-client/v1/actions/providers.ts` 中的 api-client 包装器 `getProviderGroupsWithCount` 与同类的 `getModelSuggestionsByProviderGroup` **直接返回了原始 HTTP body**,未包裹 `toActionResult`。

而后端 handler 经 `actionJson()` 解包后返回的是**裸数据**(数组/对象,没有 `ok`)。但 UI 消费方仍按旧的 `ActionResult { ok, data, error }` 形态消费:

```ts
// provider-group-select.tsx
getProviderGroupsWithCount().then((res) => {
  if (res.ok) { ... }                       // res 是数组 → res.ok === undefined → 走错误分支
  console.error("获取供应商分组统计失败:", res.error);  // res.error === undefined
  toast.error(res.error || loadFailedText);
});
```

`res.ok` 永远是 `undefined`,即使 HTTP 200 也会进入错误分支,故每次面板挂载必现该 toast。`getModelSuggestionsByProviderGroup` 是同类问题(`use-model-suggestions.ts` 检查 `res.ok && res.data`),只是表现为模型自动补全静默失效、不弹 toast。属于与 #1158 (`testProviderUnified`) 完全相同的契约错配类别。

> 该 bug 类对测试套件不可见:`tests/setup.ts` 全局把所有 `@/lib/api-client/v1/actions/*` 包装器 `vi.doMock` 替换为 server-action 实现(本身就返回 ActionResult),所以包装器的"重新封装"契约从未被默认套件覆盖。

## 修复

将两个包装器用 `toActionResult` 封装,与本文件其余函数及 #1158 的约定一致。React Query 直接消费的 `getProvidersHealthStatus` 仍保持裸返回不变。

## 测试 (TDD)

在 `tests/unit/api/v1/api-client-actions.test.ts`(该文件用 `vi.importActual` 加载**真实**包装器并 mock `@/lib/api-client/v1/client`,绕过全局替换)新增 3 个契约测试:成功封装、失败映射 (`ApiError` → `{ ok:false }`)、model-suggestions 封装。修复前 red,修复后 green。

浏览器实测:修复后展开对话框无任何控制台报错,分组字段正常挂载。

## 本地验证 (全绿)

- `bun run build` ✅
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test` ✅ 688 文件 / 6181 用例通过,0 失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a contract mismatch in the v1 API client: `getProviderGroupsWithCount` and `getModelSuggestionsByProviderGroup` were returning raw HTTP response bodies instead of the `ActionResult<T>` shape expected by their UI consumers, causing guaranteed false-error toasts whenever the provider-group edit panel was opened.

- **`providers.ts`**: Both affected wrappers are now wrapped with `toActionResult`, matching every other mutating/querying function in the file (except `getProvidersHealthStatus`, which is intentionally bare for React Query direct consumption).
- **`api-client-actions.test.ts`**: Three contract tests are added using `vi.importActual` to exercise the real wrappers against a mocked HTTP client — covering success and failure paths for `getProviderGroupsWithCount`, and the success path for `getModelSuggestionsByProviderGroup`.
- **`provider-form-*.test.tsx`**: Test mocks for `getModelSuggestionsByProviderGroup` are updated from the old bare-array shape to the correct `{ ok: true, data: [] }` shape, keeping existing tests consistent with the new contract.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is a minimal, targeted wrapping of two functions to match the contract already enforced everywhere else in the same file.

The change touches only two wrapper functions, adds three regression tests that were red before and green after, and updates two test mocks to stay in sync. The intentional exception (getProvidersHealthStatus kept bare for React Query) is preserved and explicitly documented in both the source and test comments. No new logic paths, no schema changes, no side effects introduced.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/api-client/v1/actions/providers.ts | Two functions wrapped in toActionResult to match the ActionResult contract expected by UI consumers; change is targeted and consistent with all other functions in the file. |
| tests/unit/api/v1/api-client-actions.test.ts | Three new contract tests added covering success + failure for getProviderGroupsWithCount and success for getModelSuggestionsByProviderGroup; uses vi.importActual to exercise real wrappers. |
| tests/unit/settings/providers/provider-form-endpoint-pool.test.tsx | Mock for getModelSuggestionsByProviderGroup updated from bare array to ActionResult shape to stay consistent with the new contract. |
| tests/unit/settings/providers/provider-form-total-limit-ui.test.tsx | Same mock update as provider-form-endpoint-pool.test.tsx — bare array replaced with ActionResult shape. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as provider-group-select.tsx
    participant AC as api-client/providers.ts
    participant BE as GET /api/v1/providers/groups?include=count

    Note over UI,BE: Before fix
    UI->>AC: getProviderGroupsWithCount()
    AC->>BE: apiGet(...)
    BE-->>AC: 200 [] (bare array)
    AC-->>UI: [] (bare array, no ok/data)
    UI->>UI: "res.ok === undefined → error branch"
    UI->>UI: toast.error(获取供应商分组统计失败: undefined)

    Note over UI,BE: After fix
    UI->>AC: getProviderGroupsWithCount()
    AC->>BE: apiGet(...)
    BE-->>AC: 200 [] (bare array)
    AC->>AC: toActionResult(promise)
    AC-->>UI: "{ ok: true, data: [] }"
    UI->>UI: "res.ok === true → success branch"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: align model-suggestion mocks with ..."](https://github.com/ding113/claude-code-hub/commit/801691b8093162d7fe3982e66209b60efecadcbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34901482)</sub>

<!-- /greptile_comment -->