### PR TITLE
fix(notification): 修复总开关关闭后排行榜/成本预警仍推送 & 成本预警间隔≥60分钟塌缩为每小时 (#1236)

### DIFF
--- a/src/actions/notifications.ts
+++ b/src/actions/notifications.ts
@@ -3,7 +3,6 @@
 import { emitActionAudit } from "@/lib/audit/emit";
 import { getSession } from "@/lib/auth";
 import type { NotificationJobType } from "@/lib/constants/notification.constants";
-import { logger } from "@/lib/logger";
 import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import { WebhookNotifier } from "@/lib/webhook";
 import { buildTestMessage } from "@/lib/webhook/templates/test-messages";
@@ -41,18 +40,10 @@ export async function updateNotificationSettingsAction(
     const before = await getNotificationSettings();
     const updated = await updateNotificationSettings(payload);
 
-    // 重新调度通知任务（仅生产环境）
-    if (process.env.NODE_ENV === "production") {
-      // 动态导入避免 Turbopack 编译 Bull 模块
-      const { scheduleNotifications } = await import("@/lib/notification/notification-queue");
-      await scheduleNotifications();
-    } else {
-      logger.warn({
-        action: "schedule_notifications_skipped",
-        reason: "development_mode",
-        message: "Notification scheduling is disabled in development mode",
-      });
-    }
+    // 重新调度通知任务，使总开关、子开关、时间/间隔等变更立即生效（添加/移除 repeatable 作业）。
+    // 动态导入避免静态加载 Bull；scheduleNotifications 内部已 fail-open，缺少 REDIS_URL 时不会影响设置保存。
+    const { scheduleNotifications } = await import("@/lib/notification/notification-queue");
+    await scheduleNotifications();
 
     emitActionAudit({
       category: "notification",

--- a/src/lib/notification/notification-queue.ts
+++ b/src/lib/notification/notification-queue.ts
@@ -424,9 +424,19 @@ function setupQueueProcessor(queue: Queue.Queue<NotificationJobData>): void {
         | undefined = data;
       let cooldownCommit: { keys: string[]; cooldownMinutes: number } | undefined;
       switch (type) {
-        case "circuit-breaker":
+        case "circuit-breaker": {
+          // 执行期再次校验开关：入队后若开关被关闭，遗留作业不应继续发送
+          const { getNotificationSettings } = await import("@/repository/notifications");
+          const settings = await getNotificationSettings();
+
+          if (!settings.enabled || !settings.circuitBreakerEnabled) {
+            logger.info({ action: "circuit_breaker_disabled", jobId: job.id });
+            return { success: true, skipped: true };
+          }
+
           message = buildCircuitBreakerMessage(data as CircuitBreakerAlertData, timezone);
           break;
+        }
         case "daily-leaderboard": {
           // 动态生成排行榜数据
           const { getNotificationSettings } = await import("@/repository/notifications");
@@ -721,14 +731,28 @@ export async function addNotificationJobForTarget(
 
 /**
  * 移除队列中所有 repeatable 定时任务。
- * 单个 key 移除失败（如 Redis 瞬时错误）不应中断整个重调度流程，否则会残留旧任务。
+ * 逐个尝试移除（单个 key 失败不影响其余 key），返回是否全部成功。
+ * 调用方应在“仍要新增任务”的场景下检查返回值：若有旧任务未能移除，
+ * 继续新增会导致旧任务与新任务同时触发（重复发送），应中止本次重调度等待重试。
  */
-async function removeAllRepeatableJobs(queue: Queue.Queue<NotificationJobData>): Promise<void> {
-  const repeatableJobs = await queue.getRepeatableJobs();
+async function removeAllRepeatableJobs(queue: Queue.Queue<NotificationJobData>): Promise<boolean> {
+  let repeatableJobs: Awaited<ReturnType<typeof queue.getRepeatableJobs>>;
+  try {
+    repeatableJobs = await queue.getRepeatableJobs();
+  } catch (error) {
+    logger.warn({
+      action: "notification_repeatable_list_failed",
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+
+  let allRemoved = true;
   for (const job of repeatableJobs) {
     try {
       await queue.removeRepeatableByKey(job.key);
     } catch (error) {
+      allRemoved = false;
       logger.warn({
         action: "notification_repeatable_remove_failed",
         key: job.key,
@@ -736,6 +760,35 @@ async function removeAllRepeatableJobs(queue: Queue.Queue<NotificationJobData>):
       });
     }
   }
+  return allRemoved;
+}
+
+/** 将“每 N 分钟”归一化到 [1, 1440] 分钟。 */
+function clampIntervalMinutes(rawMinutes: number): number {
+  return Math.min(Math.max(1, Math.trunc(rawMinutes)), 24 * 60);
+}
+
+/**
+ * 将“每 N 分钟”间隔映射为 Bull 的 repeat 选项。
+ * Bull cron 的分钟字段仅 0-59，且分钟步进表达式在 N 不整除 60 时（如 45）会在整点边界产生不均匀间隔，
+ * 因此仅当 N<=59 且能整除 60 时使用 cron（可携带时区）；否则退化为固定毫秒间隔
+ * （every 按固定节奏触发，不对齐整点、不支持时区，这是 Bull 的限制）。
+ */
+function intervalToRepeat(
+  intervalMinutes: number,
+  tz?: string
+): { cron: string; tz?: string } | { every: number } {
+  if (intervalMinutes <= 59 && 60 % intervalMinutes === 0) {
+    return tz
+      ? { cron: `*/${intervalMinutes} * * * *`, tz }
+      : { cron: `*/${intervalMinutes} * * * *` };
+  }
+  return { every: intervalMinutes * 60 * 1000 };
+}
+
+/** 生成 repeat 选项的可读日志标签。 */
+function describeRepeat(repeat: { cron: string } | { every: number }): string {
+  return "cron" in repeat ? repeat.cron : `every:${Math.round(repeat.every / 60000)}m`;
 }
 
 /**
@@ -752,14 +805,22 @@ export async function scheduleNotifications() {
     if (!settings.enabled) {
       logger.info({ action: "notifications_disabled" });
 
-      // 总开关关闭：移除所有已存在的定时任务
+      // 总开关关闭：移除所有已存在的定时任务（此处无需新增任务，移除失败不阻断）
       await removeAllRepeatableJobs(queue);
 
       return;
     }
 
-    // 移除旧的定时任务，避免改时间/改配置后旧任务残留导致重复或错误时间触发
-    await removeAllRepeatableJobs(queue);
+    // 移除旧的定时任务，避免改时间/改配置后旧任务残留导致重复或错误时间触发。
+    // 若移除未全部成功，则不再新增任务——否则旧任务会与新任务同时触发（重复发送），等待下次重调度重试。
+    const removedAll = await removeAllRepeatableJobs(queue);
+    if (!removedAll) {
+      logger.error({
+        action: "schedule_notifications_aborted",
+        reason: "stale_repeatable_remove_failed",
+      });
+      return;
+    }
 
     if (settings.useLegacyMode) {
       // legacy 模式：单 URL
@@ -791,11 +852,8 @@ export async function scheduleNotifications() {
       }
 
       if (settings.costAlertEnabled && settings.costAlertWebhook) {
-        const intervalRaw = settings.costAlertCheckInterval ?? 60; // 分钟
-        const interval = Math.min(Math.max(1, Math.trunc(intervalRaw)), 24 * 60);
-        // Bull cron 分钟字段只有 0-59，`*/60` 会塌缩成“每小时第 0 分”，所以 >=60 分钟改用固定间隔
-        const repeat =
-          interval <= 59 ? { cron: `*/${interval} * * * *` } : { every: interval * 60 * 1000 };
+        const interval = clampIntervalMinutes(settings.costAlertCheckInterval ?? 60);
+        const repeat = intervalToRepeat(interval);
 
         await queue.add(
           {
@@ -811,20 +869,15 @@ export async function scheduleNotifications() {
 
         logger.info({
           action: "cost_alert_scheduled",
-          schedule: "cron" in repeat ? repeat.cron : `every:${interval}m`,
+          schedule: describeRepeat(repeat),
           intervalMinutes: interval,
           mode: "legacy",
         });
       }
 
       if (settings.cacheHitRateAlertEnabled && settings.cacheHitRateAlertWebhook) {
-        const intervalMinutesRaw = settings.cacheHitRateAlertCheckInterval ?? 5;
-        const intervalMinutes = Math.max(1, Math.trunc(intervalMinutesRaw));
-        const clampedIntervalMinutes = Math.min(intervalMinutes, 24 * 60);
-        const repeat =
-          clampedIntervalMinutes <= 59
-            ? { cron: `*/${clampedIntervalMinutes} * * * *` }
-            : { every: clampedIntervalMinutes * 60 * 1000 };
+        const interval = clampIntervalMinutes(settings.cacheHitRateAlertCheckInterval ?? 5);
+        const repeat = intervalToRepeat(interval);
 
         await queue.add(
           {
@@ -836,8 +889,8 @@ export async function scheduleNotifications() {
 
         logger.info({
           action: "cache_hit_rate_alert_scheduled",
-          schedule: "cron" in repeat ? repeat.cron : `every:${clampedIntervalMinutes}m`,
-          intervalMinutes: clampedIntervalMinutes,
+          schedule: describeRepeat(repeat),
+          intervalMinutes: interval,
           mode: "legacy",
         });
       }
@@ -878,18 +931,14 @@ export async function scheduleNotifications() {
 
       if (settings.costAlertEnabled) {
         const bindings = await getEnabledBindingsByType("cost_alert");
-        const intervalRaw = settings.costAlertCheckInterval ?? 60;
-        const interval = Math.min(Math.max(1, Math.trunc(intervalRaw)), 24 * 60);
+        const interval = clampIntervalMinutes(settings.costAlertCheckInterval ?? 60);
 
         for (const binding of bindings) {
           const tz = binding.scheduleTimezone ?? systemTimezone;
-          // 优先级：绑定自定义 cron（支持 tz）> 默认间隔。
-          // Bull cron 分钟字段只有 0-59，默认间隔 >=60 分钟改用固定 every（不支持 tz）。
+          // 优先级：绑定自定义 cron（支持 tz）> 默认间隔（按 N 是否整除 60 选择 cron 或固定 every）。
           const repeat = binding.scheduleCron
             ? { cron: binding.scheduleCron, tz }
-            : interval <= 59
-              ? { cron: `*/${interval} * * * *`, tz }
-              : { every: interval * 60 * 1000 };
+            : intervalToRepeat(interval, tz);
 
           await queue.add(
             {
@@ -906,7 +955,7 @@ export async function scheduleNotifications() {
 
         logger.info({
           action: "cost_alert_scheduled",
-          schedule: interval <= 59 ? `*/${interval} * * * *` : `every:${interval}m`,
+          schedule: describeRepeat(intervalToRepeat(interval)),
           intervalMinutes: interval,
           targets: bindings.length,
           mode: "targets",
@@ -915,19 +964,12 @@ export async function scheduleNotifications() {
 
       if (settings.cacheHitRateAlertEnabled) {
         const bindings = await getEnabledBindingsByType("cache_hit_rate_alert");
-        const intervalMinutesRaw = settings.cacheHitRateAlertCheckInterval ?? 5;
-        const intervalMinutes = Math.max(1, Math.trunc(intervalMinutesRaw));
-        const clampedIntervalMinutes = Math.min(intervalMinutes, 24 * 60);
-        const defaultCron = `*/${clampedIntervalMinutes} * * * *`;
-        const repeat =
-          clampedIntervalMinutes <= 59
-            ? { cron: defaultCron, tz: systemTimezone }
-            : { every: clampedIntervalMinutes * 60 * 1000 };
+        const interval = clampIntervalMinutes(settings.cacheHitRateAlertCheckInterval ?? 5);
+        const repeat = intervalToRepeat(interval, systemTimezone);
 
         if (bindings.length > 0) {
           // 注意：这里刻意只调度一个共享的 repeat 作业，然后在处理器内 fan-out 到所有 bindings。
           // 这样可以避免对每个 binding 重复计算同一份 payload；代价是 binding 的 scheduleCron/scheduleTimezone 将被忽略。
-          // 另外：interval > 59 分钟会使用 repeat.every（固定间隔，不对齐整点，也不支持 tz），这是 Bull cron 分钟字段的限制。
           // 若未来需要支持 per-binding 的 cron/timezone，需要改为“每个 binding 一个 repeat 作业”或引入更细粒度的调度层。
           await queue.add(
             {
@@ -940,17 +982,16 @@ export async function scheduleNotifications() {
           );
           logger.info({
             action: "cache_hit_rate_alert_scheduled",
-            schedule: "cron" in repeat ? repeat.cron : `every:${clampedIntervalMinutes}m`,
-            intervalMinutes: clampedIntervalMinutes,
+            schedule: describeRepeat(repeat),
+            intervalMinutes: interval,
             targets: bindings.length,
             mode: "targets",
           });
         } else {
           logger.info({
             action: "cache_hit_rate_alert_schedule_skipped",
-            schedule:
-              clampedIntervalMinutes <= 59 ? defaultCron : `every:${clampedIntervalMinutes}m`,
-            intervalMinutes: clampedIntervalMinutes,
+            schedule: describeRepeat(repeat),
+            intervalMinutes: interval,
             reason: "no_bindings",
             mode: "targets",
           });

--- a/src/lib/notification/notification-queue.ts
+++ b/src/lib/notification/notification-queue.ts
@@ -431,6 +431,13 @@ function setupQueueProcessor(queue: Queue.Queue<NotificationJobData>): void {
           // 动态生成排行榜数据
           const { getNotificationSettings } = await import("@/repository/notifications");
           const settings = await getNotificationSettings();
+
+          // 执行期再次校验开关：总开关或子开关关闭后，遗留的 repeatable 作业不应继续发送
+          if (!settings.enabled || !settings.dailyLeaderboardEnabled) {
+            logger.info({ action: "daily_leaderboard_disabled", jobId: job.id });
+            return { success: true, skipped: true };
+          }
+
           const leaderboardData = await generateDailyLeaderboard(
             settings.dailyLeaderboardTopN || 5
           );
@@ -451,6 +458,13 @@ function setupQueueProcessor(queue: Queue.Queue<NotificationJobData>): void {
           // 动态生成成本预警数据
           const { getNotificationSettings } = await import("@/repository/notifications");
           const settings = await getNotificationSettings();
+
+          // 执行期再次校验开关：总开关或子开关关闭后，遗留的 repeatable 作业不应继续发送
+          if (!settings.enabled || !settings.costAlertEnabled) {
+            logger.info({ action: "cost_alert_disabled", jobId: job.id });
+            return { success: true, skipped: true };
+          }
+
           const alerts = await generateCostAlerts(
             parseFloat(settings.costAlertThreshold || "0.80")
           );
@@ -706,6 +720,25 @@ export async function addNotificationJobForTarget(
 }
 
 /**
+ * 移除队列中所有 repeatable 定时任务。
+ * 单个 key 移除失败（如 Redis 瞬时错误）不应中断整个重调度流程，否则会残留旧任务。
+ */
+async function removeAllRepeatableJobs(queue: Queue.Queue<NotificationJobData>): Promise<void> {
+  const repeatableJobs = await queue.getRepeatableJobs();
+  for (const job of repeatableJobs) {
+    try {
+      await queue.removeRepeatableByKey(job.key);
+    } catch (error) {
+      logger.warn({
+        action: "notification_repeatable_remove_failed",
+        key: job.key,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+/**
  * 调度定时通知任务
  */
 export async function scheduleNotifications() {
@@ -719,20 +752,14 @@ export async function scheduleNotifications() {
     if (!settings.enabled) {
       logger.info({ action: "notifications_disabled" });
 
-      // 移除所有已存在的定时任务
-      const repeatableJobs = await queue.getRepeatableJobs();
-      for (const job of repeatableJobs) {
-        await queue.removeRepeatableByKey(job.key);
-      }
+      // 总开关关闭：移除所有已存在的定时任务
+      await removeAllRepeatableJobs(queue);
 
       return;
     }
 
-    // 移除旧的定时任务
-    const repeatableJobs = await queue.getRepeatableJobs();
-    for (const job of repeatableJobs) {
-      await queue.removeRepeatableByKey(job.key);
-    }
+    // 移除旧的定时任务，避免改时间/改配置后旧任务残留导致重复或错误时间触发
+    await removeAllRepeatableJobs(queue);
 
     if (settings.useLegacyMode) {
       // legacy 模式：单 URL
@@ -764,8 +791,11 @@ export async function scheduleNotifications() {
       }
 
       if (settings.costAlertEnabled && settings.costAlertWebhook) {
-        const interval = settings.costAlertCheckInterval ?? 60; // 分钟
-        const cron = `*/${interval} * * * *`; // 每 N 分钟
+        const intervalRaw = settings.costAlertCheckInterval ?? 60; // 分钟
+        const interval = Math.min(Math.max(1, Math.trunc(intervalRaw)), 24 * 60);
+        // Bull cron 分钟字段只有 0-59，`*/60` 会塌缩成“每小时第 0 分”，所以 >=60 分钟改用固定间隔
+        const repeat =
+          interval <= 59 ? { cron: `*/${interval} * * * *` } : { every: interval * 60 * 1000 };
 
         await queue.add(
           {
@@ -774,14 +804,14 @@ export async function scheduleNotifications() {
             // data 字段省略，任务执行时动态生成
           },
           {
-            repeat: { cron },
+            repeat,
             jobId: "cost-alert-scheduled",
           }
         );
 
         logger.info({
           action: "cost_alert_scheduled",
-          schedule: cron,
+          schedule: "cron" in repeat ? repeat.cron : `every:${interval}m`,
           intervalMinutes: interval,
           mode: "legacy",
         });
@@ -848,12 +878,18 @@ export async function scheduleNotifications() {
 
       if (settings.costAlertEnabled) {
         const bindings = await getEnabledBindingsByType("cost_alert");
-        const interval = settings.costAlertCheckInterval ?? 60;
-        const defaultCron = `*/${interval} * * * *`;
+        const intervalRaw = settings.costAlertCheckInterval ?? 60;
+        const interval = Math.min(Math.max(1, Math.trunc(intervalRaw)), 24 * 60);
 
         for (const binding of bindings) {
-          const cron = binding.scheduleCron ?? defaultCron;
           const tz = binding.scheduleTimezone ?? systemTimezone;
+          // 优先级：绑定自定义 cron（支持 tz）> 默认间隔。
+          // Bull cron 分钟字段只有 0-59，默认间隔 >=60 分钟改用固定 every（不支持 tz）。
+          const repeat = binding.scheduleCron
+            ? { cron: binding.scheduleCron, tz }
+            : interval <= 59
+              ? { cron: `*/${interval} * * * *`, tz }
+              : { every: interval * 60 * 1000 };
 
           await queue.add(
             {
@@ -862,7 +898,7 @@ export async function scheduleNotifications() {
               bindingId: binding.id,
             },
             {
-              repeat: { cron, tz },
+              repeat,
               jobId: `cost-alert:${binding.id}`,
             }
           );
@@ -870,7 +906,7 @@ export async function scheduleNotifications() {
 
         logger.info({
           action: "cost_alert_scheduled",
-          schedule: defaultCron,
+          schedule: interval <= 59 ? `*/${interval} * * * *` : `every:${interval}m`,
           intervalMinutes: interval,
           targets: bindings.length,
           mode: "targets",

--- a/tests/unit/notification/notification-queue.test.ts
+++ b/tests/unit/notification/notification-queue.test.ts
@@ -270,6 +270,20 @@ describe("notification queue processor - circuit-breaker", () => {
     expect(mockSendWebhookMessage).not.toHaveBeenCalled();
   });
 
+  it("skips sending when the circuit-breaker sub-switch is off", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({ enabled: true, circuitBreakerEnabled: false })
+    );
+
+    const handler = await loadProcessor();
+    const result = await handler(
+      makeJob({ type: "circuit-breaker", webhookUrl: "https://example.com/hook", data })
+    );
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(mockSendWebhookMessage).not.toHaveBeenCalled();
+  });
+
   it("sends when both master and sub-switch are enabled", async () => {
     mockGetNotificationSettings.mockResolvedValue(
       makeSettings({ enabled: true, circuitBreakerEnabled: true })

--- a/tests/unit/notification/notification-queue.test.ts
+++ b/tests/unit/notification/notification-queue.test.ts
@@ -130,6 +130,7 @@ beforeEach(() => {
   mockSendWebhookMessage.mockResolvedValue({ success: true });
   mockGenerateDailyLeaderboard.mockResolvedValue({ date: "2026-06-02", entries: [] });
   mockGenerateCostAlerts.mockResolvedValue([{ providerName: "p" }]);
+  mockGetEnabledBindingsByType.mockResolvedValue([]);
   queueGetRepeatableJobs.mockResolvedValue([]);
 });
 
@@ -230,6 +231,58 @@ describe("notification queue processor - cost-alert", () => {
     expect(result).toEqual({ success: true, skipped: true });
     expect(mockSendWebhookMessage).not.toHaveBeenCalled();
   });
+
+  it("sends when both master and sub-switch are enabled", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({ enabled: true, costAlertEnabled: true })
+    );
+
+    const handler = await loadProcessor();
+    const result = await handler(
+      makeJob({ type: "cost-alert", webhookUrl: "https://example.com/hook" })
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(mockGenerateCostAlerts).toHaveBeenCalledTimes(1);
+    expect(mockSendWebhookMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("notification queue processor - circuit-breaker", () => {
+  const data = {
+    providerName: "OpenAI",
+    providerId: 1,
+    failureCount: 5,
+    retryAt: "2026-06-02T12:30:00Z",
+  };
+
+  it("skips sending when the master switch is off", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({ enabled: false, circuitBreakerEnabled: true })
+    );
+
+    const handler = await loadProcessor();
+    const result = await handler(
+      makeJob({ type: "circuit-breaker", webhookUrl: "https://example.com/hook", data })
+    );
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(mockSendWebhookMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends when both master and sub-switch are enabled", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({ enabled: true, circuitBreakerEnabled: true })
+    );
+
+    const handler = await loadProcessor();
+    const result = await handler(
+      makeJob({ type: "circuit-breaker", webhookUrl: "https://example.com/hook", data })
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(mockSendWebhookMessage).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("scheduleNotifications", () => {
@@ -245,7 +298,7 @@ describe("scheduleNotifications", () => {
     expect(queueAdd).not.toHaveBeenCalled();
   });
 
-  it("keeps rescheduling other jobs when one repeatable removal fails", async () => {
+  it("attempts to remove every repeatable job even when one removal fails (master off)", async () => {
     mockGetNotificationSettings.mockResolvedValue(makeSettings({ enabled: false }));
     queueGetRepeatableJobs.mockResolvedValue([{ key: "k1" }, { key: "k2" }]);
     queueRemoveRepeatableByKey.mockRejectedValueOnce(new Error("redis down"));
@@ -254,6 +307,97 @@ describe("scheduleNotifications", () => {
     await expect(scheduleNotifications()).resolves.toBeUndefined();
 
     expect(queueRemoveRepeatableByKey).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts adding new jobs when an old repeatable cannot be removed (avoids double-firing)", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({
+        enabled: true,
+        useLegacyMode: true,
+        costAlertEnabled: true,
+        costAlertWebhook: "https://example.com/hook",
+      })
+    );
+    queueGetRepeatableJobs.mockResolvedValue([{ key: "stale" }]);
+    queueRemoveRepeatableByKey.mockRejectedValueOnce(new Error("redis down"));
+
+    const { scheduleNotifications } = await import("@/lib/notification/notification-queue");
+    await scheduleNotifications();
+
+    // 旧任务未能移除时不得新增任务，否则新旧任务会同时触发
+    expect(queueAdd).not.toHaveBeenCalled();
+  });
+
+  it("uses {every} for an interval that does not divide 60 (legacy)", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({
+        enabled: true,
+        useLegacyMode: true,
+        costAlertEnabled: true,
+        costAlertWebhook: "https://example.com/hook",
+        costAlertCheckInterval: 45,
+      })
+    );
+
+    const { scheduleNotifications } = await import("@/lib/notification/notification-queue");
+    await scheduleNotifications();
+
+    const costCall = queueAdd.mock.calls.find(
+      (c) => (c[0] as { type?: string })?.type === "cost-alert"
+    );
+    expect((costCall?.[1] as { repeat?: unknown })?.repeat).toEqual({ every: 45 * 60 * 1000 });
+  });
+
+  it("schedules targets-mode cost-alert with binding jobId and tz (cron path)", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({
+        enabled: true,
+        useLegacyMode: false,
+        costAlertEnabled: true,
+        costAlertCheckInterval: 30,
+      })
+    );
+    mockGetEnabledBindingsByType.mockImplementation(async (type: string) =>
+      type === "cost_alert"
+        ? [{ id: 7, targetId: 3, scheduleCron: null, scheduleTimezone: "Asia/Tokyo" }]
+        : []
+    );
+
+    const { scheduleNotifications } = await import("@/lib/notification/notification-queue");
+    await scheduleNotifications();
+
+    const costCall = queueAdd.mock.calls.find(
+      (c) => (c[0] as { type?: string })?.type === "cost-alert"
+    );
+    expect(costCall?.[0]).toMatchObject({ type: "cost-alert", targetId: 3, bindingId: 7 });
+    expect(costCall?.[1]).toMatchObject({
+      repeat: { cron: "*/30 * * * *", tz: "Asia/Tokyo" },
+      jobId: "cost-alert:7",
+    });
+  });
+
+  it("schedules targets-mode cost-alert with {every} for interval >= 60 (drops tz)", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({
+        enabled: true,
+        useLegacyMode: false,
+        costAlertEnabled: true,
+        costAlertCheckInterval: 120,
+      })
+    );
+    mockGetEnabledBindingsByType.mockImplementation(async (type: string) =>
+      type === "cost_alert"
+        ? [{ id: 9, targetId: 4, scheduleCron: null, scheduleTimezone: "Asia/Tokyo" }]
+        : []
+    );
+
+    const { scheduleNotifications } = await import("@/lib/notification/notification-queue");
+    await scheduleNotifications();
+
+    const costCall = queueAdd.mock.calls.find(
+      (c) => (c[0] as { type?: string })?.type === "cost-alert"
+    );
+    expect((costCall?.[1] as { repeat?: unknown })?.repeat).toEqual({ every: 120 * 60 * 1000 });
   });
 
   it("uses {every} instead of */60 cron for cost-alert interval >= 60 (legacy)", async () => {

--- a/tests/unit/notification/notification-queue.test.ts
+++ b/tests/unit/notification/notification-queue.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// 受控的依赖 mock（在 beforeEach 中通过 vi.doMock 装配，跨 resetModules 复用同一组 spy）
+const mockGetNotificationSettings = vi.fn();
+const mockGenerateDailyLeaderboard = vi.fn();
+const mockGenerateCostAlerts = vi.fn();
+const mockSendWebhookMessage = vi.fn();
+const mockGetEnabledBindingsByType = vi.fn(async () => []);
+
+const queueAdd = vi.fn(async () => ({}));
+const queueGetRepeatableJobs = vi.fn(async () => [] as Array<{ key: string }>);
+const queueRemoveRepeatableByKey = vi.fn(async () => {});
+
+type MockJob = {
+  id: string;
+  timestamp: number;
+  data: Record<string, unknown>;
+  update: (data: unknown) => Promise<void>;
+};
+
+class MockQueue {
+  processHandler: ((job: MockJob) => Promise<unknown>) | null = null;
+  add = queueAdd;
+  getRepeatableJobs = queueGetRepeatableJobs;
+  removeRepeatableByKey = queueRemoveRepeatableByKey;
+  process = vi.fn((fn: (job: MockJob) => Promise<unknown>) => {
+    this.processHandler = fn;
+  });
+  on = vi.fn();
+  close = vi.fn(async () => {});
+
+  constructor() {
+    capturedQueue = this;
+  }
+}
+
+let capturedQueue: MockQueue | null = null;
+
+function makeSettings(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    enabled: false,
+    useLegacyMode: true,
+    circuitBreakerEnabled: false,
+    circuitBreakerWebhook: null,
+    dailyLeaderboardEnabled: false,
+    dailyLeaderboardWebhook: null,
+    dailyLeaderboardTime: "18:00",
+    dailyLeaderboardTopN: 5,
+    costAlertEnabled: false,
+    costAlertWebhook: null,
+    costAlertThreshold: "0.80",
+    costAlertCheckInterval: 60,
+    cacheHitRateAlertEnabled: false,
+    cacheHitRateAlertWebhook: null,
+    cacheHitRateAlertWindowMode: "auto",
+    cacheHitRateAlertCheckInterval: 5,
+    cacheHitRateAlertHistoricalLookbackDays: 7,
+    cacheHitRateAlertMinEligibleRequests: 20,
+    cacheHitRateAlertMinEligibleTokens: 0,
+    cacheHitRateAlertAbsMin: "0.05",
+    cacheHitRateAlertDropRel: "0.3",
+    cacheHitRateAlertDropAbs: "0.1",
+    cacheHitRateAlertCooldownMinutes: 30,
+    cacheHitRateAlertTopN: 10,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  capturedQueue = null;
+  process.env.REDIS_URL = "redis://localhost:6379";
+
+  vi.doMock("bull", () => ({ default: MockQueue }));
+
+  vi.doMock("@/repository/notifications", () => ({
+    getNotificationSettings: mockGetNotificationSettings,
+  }));
+
+  vi.doMock("@/repository/notification-bindings", () => ({
+    getEnabledBindingsByType: mockGetEnabledBindingsByType,
+    getBindingById: vi.fn(async () => null),
+  }));
+
+  vi.doMock("@/repository/webhook-targets", () => ({
+    getWebhookTargetById: vi.fn(async () => ({ isEnabled: true })),
+  }));
+
+  vi.doMock("@/lib/notification/tasks/daily-leaderboard", () => ({
+    generateDailyLeaderboard: mockGenerateDailyLeaderboard,
+  }));
+
+  vi.doMock("@/lib/notification/tasks/cost-alert", () => ({
+    generateCostAlerts: mockGenerateCostAlerts,
+  }));
+
+  vi.doMock("@/lib/notification/tasks/cache-hit-rate-alert", () => ({
+    applyCacheHitRateAlertCooldownToPayload: vi.fn(),
+    buildCacheHitRateAlertCooldownKey: vi.fn(),
+    commitCacheHitRateAlertCooldown: vi.fn(),
+    generateCacheHitRateAlertPayload: vi.fn(),
+  }));
+
+  vi.doMock("@/lib/webhook", () => ({
+    buildCacheHitRateAlertMessage: vi.fn(() => ({})),
+    buildCircuitBreakerMessage: vi.fn(() => ({})),
+    buildCostAlertMessage: vi.fn(() => ({})),
+    buildDailyLeaderboardMessage: vi.fn(() => ({})),
+    sendWebhookMessage: mockSendWebhookMessage,
+  }));
+
+  vi.doMock("@/lib/utils/timezone", () => ({
+    resolveSystemTimezone: vi.fn(async () => "UTC"),
+  }));
+
+  vi.doMock("@/lib/logger", () => ({
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trace: vi.fn(),
+      fatal: vi.fn(),
+    },
+  }));
+
+  mockSendWebhookMessage.mockResolvedValue({ success: true });
+  mockGenerateDailyLeaderboard.mockResolvedValue({ date: "2026-06-02", entries: [] });
+  mockGenerateCostAlerts.mockResolvedValue([{ providerName: "p" }]);
+  queueGetRepeatableJobs.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+/** 初始化队列并返回捕获的 process 处理器 */
+async function loadProcessor() {
+  const mod = await import("@/lib/notification/notification-queue");
+  // addNotificationJob 内部触发 getNotificationQueue()，注册并捕获 process 处理器
+  await mod.addNotificationJob("daily-leaderboard", "https://example.com/hook", {
+    date: "2026-06-02",
+    entries: [],
+  } as never);
+  if (!capturedQueue?.processHandler) {
+    throw new Error("process handler not captured");
+  }
+  return capturedQueue.processHandler;
+}
+
+function makeJob(data: Record<string, unknown>): MockJob {
+  return { id: "job-1", timestamp: 1000, data, update: vi.fn(async () => {}) };
+}
+
+describe("notification queue processor - daily-leaderboard", () => {
+  it("skips sending when the master switch is off (issue #1236)", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({ enabled: false, dailyLeaderboardEnabled: true })
+    );
+
+    const handler = await loadProcessor();
+    const result = await handler(
+      makeJob({ type: "daily-leaderboard", webhookUrl: "https://example.com/hook" })
+    );
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(mockGenerateDailyLeaderboard).not.toHaveBeenCalled();
+    expect(mockSendWebhookMessage).not.toHaveBeenCalled();
+  });
+
+  it("skips sending when the daily-leaderboard sub-switch is off", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({ enabled: true, dailyLeaderboardEnabled: false })
+    );
+
+    const handler = await loadProcessor();
+    const result = await handler(
+      makeJob({ type: "daily-leaderboard", webhookUrl: "https://example.com/hook" })
+    );
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(mockSendWebhookMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends when both master and sub-switch are enabled", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({ enabled: true, dailyLeaderboardEnabled: true })
+    );
+
+    const handler = await loadProcessor();
+    const result = await handler(
+      makeJob({ type: "daily-leaderboard", webhookUrl: "https://example.com/hook" })
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(mockGenerateDailyLeaderboard).toHaveBeenCalledTimes(1);
+    expect(mockSendWebhookMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("notification queue processor - cost-alert", () => {
+  it("skips sending when the master switch is off", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({ enabled: false, costAlertEnabled: true })
+    );
+
+    const handler = await loadProcessor();
+    const result = await handler(
+      makeJob({ type: "cost-alert", webhookUrl: "https://example.com/hook" })
+    );
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(mockGenerateCostAlerts).not.toHaveBeenCalled();
+    expect(mockSendWebhookMessage).not.toHaveBeenCalled();
+  });
+
+  it("skips sending when the cost-alert sub-switch is off", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({ enabled: true, costAlertEnabled: false })
+    );
+
+    const handler = await loadProcessor();
+    const result = await handler(
+      makeJob({ type: "cost-alert", webhookUrl: "https://example.com/hook" })
+    );
+
+    expect(result).toEqual({ success: true, skipped: true });
+    expect(mockSendWebhookMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("scheduleNotifications", () => {
+  it("removes all repeatable jobs when the master switch is off", async () => {
+    mockGetNotificationSettings.mockResolvedValue(makeSettings({ enabled: false }));
+    queueGetRepeatableJobs.mockResolvedValue([{ key: "k1" }, { key: "k2" }]);
+
+    const { scheduleNotifications } = await import("@/lib/notification/notification-queue");
+    await scheduleNotifications();
+
+    expect(queueRemoveRepeatableByKey).toHaveBeenCalledWith("k1");
+    expect(queueRemoveRepeatableByKey).toHaveBeenCalledWith("k2");
+    expect(queueAdd).not.toHaveBeenCalled();
+  });
+
+  it("keeps rescheduling other jobs when one repeatable removal fails", async () => {
+    mockGetNotificationSettings.mockResolvedValue(makeSettings({ enabled: false }));
+    queueGetRepeatableJobs.mockResolvedValue([{ key: "k1" }, { key: "k2" }]);
+    queueRemoveRepeatableByKey.mockRejectedValueOnce(new Error("redis down"));
+
+    const { scheduleNotifications } = await import("@/lib/notification/notification-queue");
+    await expect(scheduleNotifications()).resolves.toBeUndefined();
+
+    expect(queueRemoveRepeatableByKey).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses {every} instead of */60 cron for cost-alert interval >= 60 (legacy)", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({
+        enabled: true,
+        useLegacyMode: true,
+        costAlertEnabled: true,
+        costAlertWebhook: "https://example.com/hook",
+        costAlertCheckInterval: 60,
+      })
+    );
+
+    const { scheduleNotifications } = await import("@/lib/notification/notification-queue");
+    await scheduleNotifications();
+
+    const costCall = queueAdd.mock.calls.find(
+      (c) => (c[0] as { type?: string })?.type === "cost-alert"
+    );
+    expect((costCall?.[1] as { repeat?: unknown })?.repeat).toEqual({ every: 60 * 60 * 1000 });
+  });
+
+  it("uses a step cron for cost-alert interval < 60 (legacy)", async () => {
+    mockGetNotificationSettings.mockResolvedValue(
+      makeSettings({
+        enabled: true,
+        useLegacyMode: true,
+        costAlertEnabled: true,
+        costAlertWebhook: "https://example.com/hook",
+        costAlertCheckInterval: 30,
+      })
+    );
+
+    const { scheduleNotifications } = await import("@/lib/notification/notification-queue");
+    await scheduleNotifications();
+
+    const costCall = queueAdd.mock.calls.find(
+      (c) => (c[0] as { type?: string })?.type === "cost-alert"
+    );
+    expect((costCall?.[1] as { repeat?: unknown })?.repeat).toEqual({ cron: "*/30 * * * *" });
+  });
+});


### PR DESCRIPTION
## 背景

修复 #1236：用户反馈「每日用户消费排行榜」推送异常 ——

1. 设为每日 17:00 执行一次正常；
2. 改成 18:00 后变成每隔 1 小时执行；
3. 关闭通知总开关后，仍每隔 1 小时推送到企业微信。

## 根因分析

经多代理交叉排查（4 个并行调查 + 3 个对抗式验证 agent），定位到以下问题：

### 1. 执行期未复核开关（症状 3 的直接原因）
`notification-queue.ts` 队列处理器中，`daily-leaderboard` 与 `cost-alert` 两个 case **不会在任务执行时复核** `settings.enabled` / 子开关，只判断是否有数据。这与 `cache-hit-rate-alert`(`:267`) 及独立函数 `notifier.ts:139` 的行为不一致。因此当总开关关闭后，关闭前已入队的 repeatable 作业仍会继续触发并发送。

### 2. 仅生产环境重新调度（症状 2/3 的放大器）
`updateNotificationSettingsAction` 仅在 `NODE_ENV === "production"` 时调用 `scheduleNotifications()`，而默认值为 `"development"`。未显式设置该变量的自部署环境在改设置（含关闭总开关）时**不会刷新/移除 Bull repeatable 作业**，导致旧调度残留、关开关无效。`scheduleNotifications` 内部已 fail-open，启动入口与 `notification-bindings` 早已无条件调用它，移除该 gate 安全且一致。

### 3. 成本预警间隔 ≥60 分钟塌缩为每小时（真正的「每隔 1 小时」来源）
`cost-alert` 使用 `*/${interval} * * * *`，而 Bull 的 cron 分钟字段仅 0-59，`*/60` 会塌缩成「每小时第 0 分」，`*/120` 同样退化为每小时。默认 `costAlertCheckInterval=60` 即命中此 bug。`cache-hit-rate-alert` 早已用 `<=59 ? cron : every` 规避，此次让成本预警对齐该逻辑（legacy + targets 两条路径）。

## 改动

- **执行期复核开关**：`daily-leaderboard`、`cost-alert` 处理器在生成/发送前校验 `enabled` 与对应子开关，关闭即 `skipped`。
- **移除 NODE_ENV gate**：设置变更后始终重新调度，使开关/时间/间隔变更即时生效（添加/移除 repeatable 作业）。
- **成本预警间隔修复**：间隔 ≥60 分钟改用 `{ every }`，legacy 与 targets 模式一致；间隔做 `[1, 1440]` 归一化。
- **重调度健壮性**：抽取 `removeAllRepeatableJobs`，单个 key 移除失败（Redis 瞬时错误）不再中断整轮重调度。

## 测试

新增 `tests/unit/notification/notification-queue.test.ts`（9 个用例）：
- 总开关 / 子开关关闭时处理器 `skipped`，且不调用生成与发送；
- 开关全开时正常发送；
- 总开关关闭时 `scheduleNotifications` 移除全部 repeatable 作业；
- 单个移除失败不影响整体；
- 成本预警 interval=60 → `{ every: 3600000 }`，interval=30 → `*/30 * * * *`。

## 本地验证（全绿）

`build` ✅ / `lint` ✅ / `typecheck` ✅ / `test` ✅（6180 passed, 13 skipped，含本次新增 9 项）

## 范围说明

- 未对 per-binding 自定义 `scheduleCron` 加校验：`0 * * * *` 是合法 cron，属用户意图，非 bug。
- `circuit-breaker` 为事件驱动而非定时任务，无需此修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes three root causes behind #1236: (1) the queue processor for `daily-leaderboard` and `cost-alert` now re-checks `settings.enabled` / sub-switches at execution time so stale repeatable jobs can no longer fire after the master switch is turned off; (2) the `NODE_ENV === \"production\"` gate that silently prevented non-production deployments from rescheduling Bull jobs on settings changes is removed; (3) `*/60 * * * *` cron collapse is fixed by routing intervals ≥60 min through `{ every: ms }`.

- **Execution-time guard**: `circuit-breaker`, `daily-leaderboard`, and `cost-alert` processor branches all early-return `{ success: true, skipped: true }` when the relevant switches are off.
- **Interval routing**: new `intervalToRepeat(n, tz?)` helper centralises the `cron`-vs-`every` decision; `clampIntervalMinutes` normalises raw DB values to `[1, 1440]`.
- **Robustness**: `removeAllRepeatableJobs` tolerates single-key Redis failures; if any removal fails during rescheduling, `scheduleNotifications` aborts rather than creating duplicate jobs.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three documented bug scenarios are closed, the helpers are correct for all edge cases, and the added test suite exercises both the skip paths and the interval-routing decisions end-to-end.

The changes are narrowly scoped to the notification queue: adding execution-time guards, removing the environment gate that made settings changes a no-op in most self-hosted deployments, and fixing the cron collapse. No auth, data-model, or external API surfaces are touched. The intervalToRepeat helper handles boundary values correctly, and removeAllRepeatableJobs gracefully tolerates partial Redis failures without risking duplicate job scheduling.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/notification/notification-queue.ts | Core fix: adds execution-time settings guards to three processor cases, extracts removeAllRepeatableJobs / clampIntervalMinutes / intervalToRepeat helpers, and correctly routes intervals to cron or every. Edge cases handled correctly. |
| src/actions/notifications.ts | Removes NODE_ENV === production guard so scheduleNotifications() is always called after a settings update. |
| tests/unit/notification/notification-queue.test.ts | New test file with 15 cases covering master/sub-switch skipping, fault-tolerant removal, abort-on-partial-remove, and both legacy and targets-mode cron/every routing. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["test(notification): add circuit-breaker ..."](https://github.com/ding113/claude-code-hub/commit/d42200d98b5b4e0303a8b722e05a60180d0d4063) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35113049)</sub>

<!-- /greptile_comment -->