### PR TITLE
fix(model-prices): protect locally-uploaded prices from cloud auto-sync overwrite (local-first)

### DIFF
--- a/src/actions/model-prices.ts
+++ b/src/actions/model-prices.ts
@@ -180,11 +180,11 @@ export async function processPriceTableInternal(
           continue;
         }
 
-        // 本地优先：当本次写入来自云端/自动同步（source='litellm'）时，
-        // 跳过用户手动维护的模型，除非显式列入覆盖列表。
-        // 用户显式上传（source='manual'）属于权威导入，不受此保护跳过。
+        // 本地优先：仅当本次写入来自云端/自动同步（source='litellm'）时，
+        // 才跳过用户手动维护的模型，除非显式列入覆盖列表。
+        // 用户显式上传（source='manual'）属于权威导入，不受此保护跳过，可正常覆盖。
         const isManualPrice = manualPrices.has(modelName);
-        if (isManualPrice && !overwriteSet.has(modelName)) {
+        if (source === "litellm" && isManualPrice && !overwriteSet.has(modelName)) {
           // 跳过手动添加的模型，记录到 skippedConflicts
           result.skippedConflicts?.push(modelName);
           result.unchanged.push(modelName);
@@ -202,10 +202,9 @@ export async function processPriceTableInternal(
           existingPrice.source !== source ||
           !isPriceDataEqual(existingPrice.priceData, priceData)
         ) {
-          // 价格或来源发生变化：先删除该模型的所有旧记录再写入新记录，
-          // 避免同名记录在表中堆积（litellm 孤儿行，或 manual + litellm 并存）。
-          await deleteModelPriceByName(modelName);
-          await createModelPrice(modelName, priceData, source);
+          // 价格或来源发生变化：用事务原子地“删旧 + 插新”替换该模型的所有记录，
+          // 既保证不会在崩溃时丢失价格，又避免同名记录堆积（litellm 孤儿行，或 manual + litellm 并存）。
+          await upsertModelPrice(modelName, priceData, source);
           result.updated.push(modelName);
         } else {
           // 价格未发生变化，不需要更新

--- a/src/actions/model-prices.ts
+++ b/src/actions/model-prices.ts
@@ -25,6 +25,7 @@ import {
 import type {
   ModelPrice,
   ModelPriceData,
+  ModelPriceSource,
   PriceTableJson,
   PriceUpdateResult,
   SyncConflict,
@@ -98,13 +99,17 @@ function buildManualPriceDataFromProviderPricing(
 
 /**
  * 价格表处理核心逻辑（内部函数，无权限检查）
- * 用于系统初始化和 Web UI 上传
+ * 用于系统初始化、云端自动同步和 Web UI 上传
  * @param jsonContent - 价格表 JSON 内容
  * @param overwriteManual - 可选，要覆盖的手动添加模型名称列表
+ * @param source - 写入记录的来源。云端/自动同步为 'litellm'（默认）；
+ *   用户在本地显式上传的价格表为 'manual'，使其遵循“本地优先”原则、
+ *   不被后续云端自动同步覆盖。
  */
 export async function processPriceTableInternal(
   jsonContent: string,
-  overwriteManual?: string[]
+  overwriteManual?: string[],
+  source: ModelPriceSource = "litellm"
 ): Promise<ActionResult<PriceUpdateResult>> {
   try {
     // 解析JSON内容
@@ -156,7 +161,10 @@ export async function processPriceTableInternal(
     };
 
     // 处理每个模型的价格
-    for (const [modelName, priceData] of entries) {
+    for (const [rawModelName, priceData] of entries) {
+      // 与 manual 记录入库时（upsertModelPrice 使用 trim 后的名称）保持一致地归一化，
+      // 避免云端表里带空白的同名键绕过本地手动模型的保护检查。
+      const modelName = typeof rawModelName === "string" ? rawModelName.trim() : rawModelName;
       try {
         // 验证价格数据基本类型
         if (typeof priceData !== "object" || priceData === null) {
@@ -172,7 +180,9 @@ export async function processPriceTableInternal(
           continue;
         }
 
-        // 检查是否存在手动添加的价格且不在覆盖列表中
+        // 本地优先：当本次写入来自云端/自动同步（source='litellm'）时，
+        // 跳过用户手动维护的模型，除非显式列入覆盖列表。
+        // 用户显式上传（source='manual'）属于权威导入，不受此保护跳过。
         const isManualPrice = manualPrices.has(modelName);
         if (isManualPrice && !overwriteSet.has(modelName)) {
           // 跳过手动添加的模型，记录到 skippedConflicts
@@ -186,15 +196,16 @@ export async function processPriceTableInternal(
 
         if (!existingPrice) {
           // 模型不存在，新增记录
-          await createModelPrice(modelName, priceData, "litellm");
+          await createModelPrice(modelName, priceData, source);
           result.added.push(modelName);
-        } else if (!isPriceDataEqual(existingPrice.priceData, priceData)) {
-          // 模型存在但价格发生变化
-          // 如果是手动模型且在覆盖列表中，先删除旧记录
-          if (isManualPrice && overwriteSet.has(modelName)) {
-            await deleteModelPriceByName(modelName);
-          }
-          await createModelPrice(modelName, priceData, "litellm");
+        } else if (
+          existingPrice.source !== source ||
+          !isPriceDataEqual(existingPrice.priceData, priceData)
+        ) {
+          // 价格或来源发生变化：先删除该模型的所有旧记录再写入新记录，
+          // 避免同名记录在表中堆积（litellm 孤儿行，或 manual + litellm 并存）。
+          await deleteModelPriceByName(modelName);
+          await createModelPrice(modelName, priceData, source);
           result.updated.push(modelName);
         } else {
           // 价格未发生变化，不需要更新
@@ -261,7 +272,9 @@ export async function uploadPriceTable(
     jsonContent = JSON.stringify(parseResult.data.models);
   }
 
-  const result = await processPriceTableInternal(jsonContent, overwriteManual);
+  // 用户显式上传的价格表视为“本地优先”的权威来源，标记为 manual，
+  // 使其不会被后续云端自动同步静默覆盖。
+  const result = await processPriceTableInternal(jsonContent, overwriteManual, "manual");
 
   if (result.ok) {
     emitActionAudit({

--- a/src/repository/model-price.ts
+++ b/src/repository/model-price.ts
@@ -267,24 +267,24 @@ export async function createModelPrice(
 
 /**
  * 更新或插入模型价格（先删除旧记录，再插入新记录）
- * 用于手动维护单个模型价格，source 固定为 'manual'
+ * 用于手动维护单个模型价格或批量替换；source 默认为 'manual'。
  */
 export async function upsertModelPrice(
   modelName: string,
-  priceData: ModelPriceData
+  priceData: ModelPriceData,
+  source: ModelPriceSource = "manual"
 ): Promise<ModelPrice> {
   // 使用事务确保删除和插入的原子性
   return await db.transaction(async (tx) => {
     // 先删除该模型的所有旧记录
     await tx.delete(modelPrices).where(eq(modelPrices.modelName, modelName));
 
-    // 插入新记录，source 固定为 'manual'
     const [price] = await tx
       .insert(modelPrices)
       .values({
         modelName: modelName,
         priceData: priceData,
-        source: "manual",
+        source: source,
       })
       .returning();
     return toModelPrice(price);

--- a/tests/unit/actions/model-prices.test.ts
+++ b/tests/unit/actions/model-prices.test.ts
@@ -488,8 +488,7 @@ describe("Model Price Actions", () => {
 
       findAllManualPricesMock.mockResolvedValue(new Map([["custom-model", manualPrice]]));
       findAllLatestPricesMock.mockResolvedValue([manualPrice]);
-      deleteModelPriceByNameMock.mockResolvedValue(undefined);
-      createModelPriceMock.mockResolvedValue(
+      upsertModelPriceMock.mockResolvedValue(
         makeMockPrice(
           "custom-model",
           {
@@ -513,8 +512,12 @@ describe("Model Price Actions", () => {
 
       expect(result.ok).toBe(true);
       expect(result.data?.updated).toContain("custom-model");
-      expect(deleteModelPriceByNameMock).toHaveBeenCalledWith("custom-model");
-      expect(createModelPriceMock).toHaveBeenCalled();
+      // The overwrite is an atomic replace (delete + insert in one transaction).
+      expect(upsertModelPriceMock).toHaveBeenCalledWith(
+        "custom-model",
+        expect.any(Object),
+        "litellm"
+      );
     });
 
     it("should add new models with litellm source", async () => {
@@ -649,7 +652,7 @@ describe("Model Price Actions", () => {
       expect(deleteModelPriceByNameMock).not.toHaveBeenCalled();
     });
 
-    it("should delete stale rows before inserting when a cloud price changes (no orphan rows)", async () => {
+    it("should atomically replace a changed cloud price via upsert (no orphan rows)", async () => {
       const existing = makeMockPrice(
         "cloud-model",
         { mode: "chat", input_cost_per_token: 0.001 },
@@ -657,8 +660,7 @@ describe("Model Price Actions", () => {
       );
       findAllManualPricesMock.mockResolvedValue(new Map());
       findAllLatestPricesMock.mockResolvedValue([existing]);
-      deleteModelPriceByNameMock.mockResolvedValue(undefined);
-      createModelPriceMock.mockResolvedValue(
+      upsertModelPriceMock.mockResolvedValue(
         makeMockPrice("cloud-model", { mode: "chat", input_cost_per_token: 0.002 }, "litellm")
       );
 
@@ -669,12 +671,13 @@ describe("Model Price Actions", () => {
 
       expect(result.ok).toBe(true);
       expect(result.data?.updated).toContain("cloud-model");
-      expect(deleteModelPriceByNameMock).toHaveBeenCalledWith("cloud-model");
-      expect(createModelPriceMock).toHaveBeenCalledWith(
+      // Transactional replace, not a separate delete + insert.
+      expect(upsertModelPriceMock).toHaveBeenCalledWith(
         "cloud-model",
         expect.any(Object),
         "litellm"
       );
+      expect(createModelPriceMock).not.toHaveBeenCalled();
     });
 
     it("should convert an existing cloud (litellm) model to manual on local upload", async () => {
@@ -685,8 +688,7 @@ describe("Model Price Actions", () => {
       );
       findAllManualPricesMock.mockResolvedValue(new Map());
       findAllLatestPricesMock.mockResolvedValue([existing]);
-      deleteModelPriceByNameMock.mockResolvedValue(undefined);
-      createModelPriceMock.mockResolvedValue(
+      upsertModelPriceMock.mockResolvedValue(
         makeMockPrice("shared-model", { mode: "chat", input_cost_per_token: 0.001 }, "manual")
       );
 
@@ -699,12 +701,34 @@ describe("Model Price Actions", () => {
 
       expect(result.ok).toBe(true);
       expect(result.data?.updated).toContain("shared-model");
-      expect(deleteModelPriceByNameMock).toHaveBeenCalledWith("shared-model");
-      expect(createModelPriceMock).toHaveBeenCalledWith(
+      expect(upsertModelPriceMock).toHaveBeenCalledWith(
         "shared-model",
         expect.any(Object),
         "manual"
       );
+    });
+
+    it("should update an existing manual model on local re-upload (manual source bypasses skip)", async () => {
+      // Regression: re-uploading a price file to revise a user's own model must apply,
+      // not be silently skipped as a conflict.
+      const manualPrice = makeMockPrice("my-model", { mode: "chat", input_cost_per_token: 0.1 });
+      findAllManualPricesMock.mockResolvedValue(new Map([["my-model", manualPrice]]));
+      findAllLatestPricesMock.mockResolvedValue([manualPrice]);
+      upsertModelPriceMock.mockResolvedValue(
+        makeMockPrice("my-model", { mode: "chat", input_cost_per_token: 0.2 }, "manual")
+      );
+
+      const { processPriceTableInternal } = await import("@/actions/model-prices");
+      const result = await processPriceTableInternal(
+        JSON.stringify({ "my-model": { mode: "chat", input_cost_per_token: 0.2 } }),
+        undefined,
+        "manual"
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.data?.updated).toContain("my-model");
+      expect(result.data?.skippedConflicts).not.toContain("my-model");
+      expect(upsertModelPriceMock).toHaveBeenCalledWith("my-model", expect.any(Object), "manual");
     });
 
     it("should normalize whitespace in cloud model names before manual protection", async () => {

--- a/tests/unit/actions/model-prices.test.ts
+++ b/tests/unit/actions/model-prices.test.ts
@@ -608,6 +608,152 @@ describe("Model Price Actions", () => {
       expect(result.data?.unchanged).toContain("safe-model");
       expect(createModelPriceMock).not.toHaveBeenCalled();
     });
+
+    it("should persist models with the manual source when source='manual' (local upload)", async () => {
+      findAllManualPricesMock.mockResolvedValue(new Map());
+      findAllLatestPricesMock.mockResolvedValue([]);
+      createModelPriceMock.mockResolvedValue(
+        makeMockPrice("new-model", { mode: "chat" }, "manual")
+      );
+
+      const { processPriceTableInternal } = await import("@/actions/model-prices");
+      const result = await processPriceTableInternal(
+        JSON.stringify({ "new-model": { mode: "chat", input_cost_per_token: 0.000001 } }),
+        undefined,
+        "manual"
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.data?.added).toContain("new-model");
+      expect(createModelPriceMock).toHaveBeenCalledWith("new-model", expect.any(Object), "manual");
+    });
+
+    it("should protect a locally-uploaded (manual) model from later auto-sync overwrite", async () => {
+      // Regression: a user-created local model must survive an unattended cloud sync.
+      const manualPrice = makeMockPrice("my-custom-model", {
+        mode: "chat",
+        input_cost_per_token: 0.123,
+      });
+      findAllManualPricesMock.mockResolvedValue(new Map([["my-custom-model", manualPrice]]));
+      findAllLatestPricesMock.mockResolvedValue([manualPrice]);
+
+      const { processPriceTableInternal } = await import("@/actions/model-prices");
+      // Auto-sync writes 'litellm' (default) with a different cloud price and no overwrite list.
+      const result = await processPriceTableInternal(
+        JSON.stringify({ "my-custom-model": { mode: "chat", input_cost_per_token: 0.999 } })
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.data?.skippedConflicts).toContain("my-custom-model");
+      expect(createModelPriceMock).not.toHaveBeenCalled();
+      expect(deleteModelPriceByNameMock).not.toHaveBeenCalled();
+    });
+
+    it("should delete stale rows before inserting when a cloud price changes (no orphan rows)", async () => {
+      const existing = makeMockPrice(
+        "cloud-model",
+        { mode: "chat", input_cost_per_token: 0.001 },
+        "litellm"
+      );
+      findAllManualPricesMock.mockResolvedValue(new Map());
+      findAllLatestPricesMock.mockResolvedValue([existing]);
+      deleteModelPriceByNameMock.mockResolvedValue(undefined);
+      createModelPriceMock.mockResolvedValue(
+        makeMockPrice("cloud-model", { mode: "chat", input_cost_per_token: 0.002 }, "litellm")
+      );
+
+      const { processPriceTableInternal } = await import("@/actions/model-prices");
+      const result = await processPriceTableInternal(
+        JSON.stringify({ "cloud-model": { mode: "chat", input_cost_per_token: 0.002 } })
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.data?.updated).toContain("cloud-model");
+      expect(deleteModelPriceByNameMock).toHaveBeenCalledWith("cloud-model");
+      expect(createModelPriceMock).toHaveBeenCalledWith(
+        "cloud-model",
+        expect.any(Object),
+        "litellm"
+      );
+    });
+
+    it("should convert an existing cloud (litellm) model to manual on local upload", async () => {
+      const existing = makeMockPrice(
+        "shared-model",
+        { mode: "chat", input_cost_per_token: 0.001 },
+        "litellm"
+      );
+      findAllManualPricesMock.mockResolvedValue(new Map());
+      findAllLatestPricesMock.mockResolvedValue([existing]);
+      deleteModelPriceByNameMock.mockResolvedValue(undefined);
+      createModelPriceMock.mockResolvedValue(
+        makeMockPrice("shared-model", { mode: "chat", input_cost_per_token: 0.001 }, "manual")
+      );
+
+      const { processPriceTableInternal } = await import("@/actions/model-prices");
+      const result = await processPriceTableInternal(
+        JSON.stringify({ "shared-model": { mode: "chat", input_cost_per_token: 0.001 } }),
+        undefined,
+        "manual"
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.data?.updated).toContain("shared-model");
+      expect(deleteModelPriceByNameMock).toHaveBeenCalledWith("shared-model");
+      expect(createModelPriceMock).toHaveBeenCalledWith(
+        "shared-model",
+        expect.any(Object),
+        "manual"
+      );
+    });
+
+    it("should normalize whitespace in cloud model names before manual protection", async () => {
+      const manualPrice = makeMockPrice("claude-3", { mode: "chat", input_cost_per_token: 0.123 });
+      findAllManualPricesMock.mockResolvedValue(new Map([["claude-3", manualPrice]]));
+      findAllLatestPricesMock.mockResolvedValue([manualPrice]);
+
+      const { processPriceTableInternal } = await import("@/actions/model-prices");
+      const result = await processPriceTableInternal(
+        JSON.stringify({ "  claude-3  ": { mode: "chat", input_cost_per_token: 0.999 } })
+      );
+
+      expect(result.ok).toBe(true);
+      expect(result.data?.skippedConflicts).toContain("claude-3");
+      expect(createModelPriceMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("uploadPriceTable - local-first", () => {
+    it("should store uploaded models with manual source so auto-sync cannot overwrite them", async () => {
+      findAllManualPricesMock.mockResolvedValue(new Map());
+      findAllLatestPricesMock.mockResolvedValue([]);
+      createModelPriceMock.mockResolvedValue(
+        makeMockPrice("my-custom-model", { mode: "chat", input_cost_per_token: 0.001 }, "manual")
+      );
+
+      const { uploadPriceTable } = await import("@/actions/model-prices");
+      const result = await uploadPriceTable(
+        JSON.stringify({ "my-custom-model": { mode: "chat", input_cost_per_token: 0.001 } })
+      );
+
+      expect(result.ok).toBe(true);
+      expect(createModelPriceMock).toHaveBeenCalledWith(
+        "my-custom-model",
+        expect.any(Object),
+        "manual"
+      );
+    });
+
+    it("should reject non-admin users", async () => {
+      getSessionMock.mockResolvedValue({ user: { id: 2, role: "user" } });
+
+      const { uploadPriceTable } = await import("@/actions/model-prices");
+      const result = await uploadPriceTable(JSON.stringify({ x: { mode: "chat" } }));
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("无权限");
+      expect(createModelPriceMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("pinModelPricingProviderAsManual", () => {


### PR DESCRIPTION
## 问题

用户反馈：在模型价格表中创建/导入的本地模型，在后续**自动同步**时会被云端价格**静默覆盖**(无任何警告),无论该模型 ID 是否与云端已有模型相同。期望遵循「本地优先」原则——自动同步不得覆盖用户手动维护的模型。

## 根因

价格表合并核心 `processPriceTableInternal` 把它写入的**每一行**都硬编码为 `source='litellm'`。两个入口都经过它:

- **「添加模型」对话框** → `upsertSingleModelPrice` → `upsertModelPrice`,写入 `source='manual'`,**受保护**(合并时被跳过)。
- **「上传价格表」** → `uploadPriceTable` → `processPriceTableInternal`,写入 `source='litellm'`,**不受保护**。

因此用户**上传**的本地模型对 `findAllManualPrices()` 不可见,合并时第 177 行的本地优先跳过保护永不命中;下次自动同步(启动定时器每 30 分钟 / `missing-model` 触发)价格不同就插入新的 litellm 行覆盖用户价格,且残留孤儿行。对话框路径本身是正确受保护的。

真实 Postgres 端到端复现确认:上传模型(litellelm)价格 `0.123` 被自动同步覆盖为 `0.999` 并残留两行;对话框模型(manual)保持不变。

## 修复(均在 `processPriceTableInternal` 这一处)

1. 新增 `source` 参数(默认 `'litellm'`,后台/云端同步行为不变)。`uploadPriceTable` 传 `'manual'` → 用户显式上传的本地模型自此受本地优先保护,不再被自动同步覆盖。
2. update 分支改为「先删旧行再写入」→ 修复 litellm 孤儿行堆积;并让「上传覆盖云端同名模型」干净转换为 manual,避免 manual + litellm 同名并存。
3. 云端模型名 `trim` 归一化后再做保护比对,防止带空白的同名键绕过保护(与 manual 入库时的 `trim` 对齐)。

行为变化:管理员显式上传的价格此后不会被自动同步覆盖;旧的孤儿行会在下次该模型价格更新时清理。仍可通过「同步」按钮(带冲突确认弹窗)或重新上传刷新。

## 测试

`tests/unit/actions/model-prices.test.ts` 新增 7 个用例(其中 5 个在修复前会失败):
- `source='manual'` 时按 manual 入库;上传入口写入 manual;
- 已 manual 的本地模型在后续自动同步中被跳过(症状守卫);
- 价格变化时先删旧行(无孤儿行);上传将云端 litellm 模型转为 manual;
- 云端模型名空白归一化后命中保护;`uploadPriceTable` 非管理员拒绝。

本地全绿(worktree 内并行执行):`bun run build`、`bun run lint`、`bun run typecheck`、`bun run test`(687 文件 / 6181 passed)。

## Related

- Follow-up to #573 — PR #573 introduced the `source` (`litellm` | `manual`) field and local-first protection for the dialog path, but missed the upload path (`processPriceTableInternal` always hardcoded `source='litellm'`). This PR closes that gap.
- Related to #405 — Original feature request for custom model pricing. This PR fixes a data-integrity bug in the manual pricing feature that was introduced to address #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a local-first data-integrity gap: models uploaded via the bulk-upload UI were written with `source='litellm'`, making them invisible to the manual-price protection check and vulnerable to silent cloud auto-sync overwrites. The fix threads a `source` parameter through `processPriceTableInternal`, sets it to `'manual'` on the upload path, and replaces the fragmented delete+create update branch with a transactional `upsertModelPrice` call.

- **Local-first protection extended to uploads**: the skip guard is now gated on `source === \"litellm\"`, so cloud auto-sync skips uploaded models while the upload path itself is fully authoritative.
- **Atomic updates via upsert**: all model-update operations now go through `upsertModelPrice` (delete + insert in a single DB transaction), eliminating the orphan-row accumulation and the data-loss window that existed in the prior non-atomic path.
- **`overwriteManual` is now dead code on the upload path**: since `source='manual'` bypasses the skip guard entirely, any list passed by the conflict-resolution UI has no effect — worth documenting or removing from the upload signature to avoid confusion.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is well-scoped, the update path is now transactional, and 7 targeted tests cover the key scenarios including the regression guard.

The core logic change is small and correctness-preserving: the skip-guard addition is additive, the `upsertModelPrice` call replaces a fragile non-atomic pattern with a transactional one, and no existing callers of the repository function are broken by the new optional parameter. The only observations are a dead-code parameter and an unnecessary type-guard, neither of which affects runtime correctness.

src/actions/model-prices.ts — the `overwriteManual` parameter in `uploadPriceTable` is now effectively ignored and worth a clarifying comment or signature cleanup.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/actions/model-prices.ts | Adds `source` parameter to `processPriceTableInternal` (defaults to 'litellm'); upload path now passes 'manual'; local-first skip guard now gated on `source === "litellm"`; update branch replaced with transactional `upsertModelPrice`. The `overwriteManual` param is accepted but becomes a no-op on the upload path. |
| src/repository/model-price.ts | Generalises `upsertModelPrice` to accept an optional `source` parameter (defaults to 'manual'), enabling reuse from the bulk-sync path with 'litellm'. Existing single-model dialog callers are unaffected. |
| tests/unit/actions/model-prices.test.ts | Adds 7 new unit tests covering local-first upload, auto-sync protection, atomic upsert, litellm→manual conversion, whitespace normalization, and admin guard. Existing test updated to expect `upsertModelPriceMock`. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processPriceTableInternal] --> B{source param}
    B -->|'litellm' default
auto-sync / init| C{isManualPrice?}
    B -->|'manual'
uploadPriceTable| E{existingPrice?}
    C -->|yes + NOT in overwriteSet| D[skip → skippedConflicts]
    C -->|no, OR in overwriteSet| E
    E -->|no| F[createModelPrice source]
    E -->|yes, source differs OR price differs| G[upsertModelPrice transaction: delete + insert source]
    E -->|yes, same source AND same price| H[unchanged]
    G --> I[(DB: modelPrices)]
    F --> I
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/actions/model-prices.ts:167
The `typeof rawModelName === "string"` branch is never false: `Object.entries()` called on a JSON-parsed object always yields `string` keys. The fallback arm that returns the non-string value as-is is dead code and would produce a type mismatch (a non-string `modelName`) further down the loop. The defensive check can be simplified to a plain `.trim()` call.

```suggestion
      const modelName = rawModelName.trim();
```

### Issue 2 of 2
src/actions/model-prices.ts:276
**`overwriteManual` becomes a no-op on the upload path**

Because the upload now passes `source='manual'`, the skip-guard (`source === "litellm" && isManualPrice && !overwriteSet.has(modelName)`) never fires, so the set built from `overwriteManual` is never consulted. Any caller that forwards a selection from the conflict-resolution UI would see all models processed regardless of what was selected. Consider documenting that `overwriteManual` has no effect when `source='manual'`, or removing it from the upload signature to avoid misleading future callers.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(model-prices): allow manual re-uploa..."](https://github.com/ding113/claude-code-hub/commit/21731a830763975ee84e9b6596e4ae54138faed1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35139105)</sub>

<!-- /greptile_comment -->