### PR TITLE
fix: 规则保存后即时生效（同步内存缓存 + 刷新列表），无需手动点刷新

### DIFF
--- a/src/actions/error-rules.ts
+++ b/src/actions/error-rules.ts
@@ -178,8 +178,13 @@ export async function createErrorRuleAction(data: {
 
     // 刷新缓存（事件广播，支持多 worker 同步）
     await emitErrorRulesUpdated();
-    // 本进程立即同步内存缓存，确保规则改动对代理请求即时生效，无需手动点"刷新缓存"。
-    await errorRuleDetector.reload();
+    // 上面的 emit 已在本进程触发一次携带最新数据的 reload，这里复用它即可（无需补跑第二轮）。
+    // reload 仅为本进程缓存同步（跨 worker 由 emit 覆盖），失败不应把已成功的写入误报为失败。
+    try {
+      await errorRuleDetector.reload();
+    } catch (reloadError) {
+      logger.warn("[ErrorRulesAction] Failed to reload detector after mutation", { reloadError });
+    }
 
     revalidatePath("/settings/error-rules");
 
@@ -313,8 +318,13 @@ export async function updateErrorRuleAction(
 
     // 刷新缓存（事件广播，支持多 worker 同步）
     await emitErrorRulesUpdated();
-    // 本进程立即同步内存缓存，确保规则改动对代理请求即时生效，无需手动点"刷新缓存"。
-    await errorRuleDetector.reload();
+    // 上面的 emit 已在本进程触发一次携带最新数据的 reload，这里复用它即可（无需补跑第二轮）。
+    // reload 仅为本进程缓存同步（跨 worker 由 emit 覆盖），失败不应把已成功的写入误报为失败。
+    try {
+      await errorRuleDetector.reload();
+    } catch (reloadError) {
+      logger.warn("[ErrorRulesAction] Failed to reload detector after mutation", { reloadError });
+    }
 
     revalidatePath("/settings/error-rules");
 
@@ -369,8 +379,13 @@ export async function deleteErrorRuleAction(id: number): Promise<ActionResult> {
 
     // 刷新缓存（事件广播，支持多 worker 同步）
     await emitErrorRulesUpdated();
-    // 本进程立即同步内存缓存，确保规则改动对代理请求即时生效，无需手动点"刷新缓存"。
-    await errorRuleDetector.reload();
+    // 上面的 emit 已在本进程触发一次携带最新数据的 reload，这里复用它即可（无需补跑第二轮）。
+    // reload 仅为本进程缓存同步（跨 worker 由 emit 覆盖），失败不应把已成功的写入误报为失败。
+    try {
+      await errorRuleDetector.reload();
+    } catch (reloadError) {
+      logger.warn("[ErrorRulesAction] Failed to reload detector after mutation", { reloadError });
+    }
 
     revalidatePath("/settings/error-rules");
 
@@ -418,8 +433,9 @@ export async function refreshCacheAction(): Promise<
     // 1. 同步默认规则到数据库
     const syncResult = await repo.syncDefaultErrorRules();
 
-    // 2. 重新加载缓存
-    await errorRuleDetector.reload();
+    // 2. 重新加载缓存：手动刷新必须读到刚同步的默认规则，
+    //    若已有在途 reload 则排队补跑一轮（queueIfRunning），确保拿到同步后的最新快照。
+    await errorRuleDetector.reload({ queueIfRunning: true });
 
     const stats = errorRuleDetector.getStats();
 

--- a/src/actions/error-rules.ts
+++ b/src/actions/error-rules.ts
@@ -178,6 +178,8 @@ export async function createErrorRuleAction(data: {
 
     // 刷新缓存（事件广播，支持多 worker 同步）
     await emitErrorRulesUpdated();
+    // 本进程立即同步内存缓存，确保规则改动对代理请求即时生效，无需手动点"刷新缓存"。
+    await errorRuleDetector.reload();
 
     revalidatePath("/settings/error-rules");
 
@@ -311,6 +313,8 @@ export async function updateErrorRuleAction(
 
     // 刷新缓存（事件广播，支持多 worker 同步）
     await emitErrorRulesUpdated();
+    // 本进程立即同步内存缓存，确保规则改动对代理请求即时生效，无需手动点"刷新缓存"。
+    await errorRuleDetector.reload();
 
     revalidatePath("/settings/error-rules");
 
@@ -365,6 +369,8 @@ export async function deleteErrorRuleAction(id: number): Promise<ActionResult> {
 
     // 刷新缓存（事件广播，支持多 worker 同步）
     await emitErrorRulesUpdated();
+    // 本进程立即同步内存缓存，确保规则改动对代理请求即时生效，无需手动点"刷新缓存"。
+    await errorRuleDetector.reload();
 
     revalidatePath("/settings/error-rules");
 

--- a/src/actions/request-filters.ts
+++ b/src/actions/request-filters.ts
@@ -254,7 +254,13 @@ export async function createRequestFilterAction(data: {
     });
 
     // 立即同步内存缓存，确保新规则对代理请求即时生效，无需用户手动点"刷新缓存"。
-    await requestFilterEngine.reload();
+    // 仓储层已在写入后触发一次本进程 reload，这里 reload(false) 复用它（不补跑第二轮）；
+    // reload 仅为缓存同步，失败不应把已成功的写入误报为失败。
+    try {
+      await requestFilterEngine.reload(false);
+    } catch (reloadError) {
+      logger.warn("[RequestFiltersAction] Failed to reload engine after create", { reloadError });
+    }
     revalidatePath(SETTINGS_PATH);
     return { ok: true, data: created };
   } catch (error) {
@@ -381,7 +387,13 @@ export async function updateRequestFilterAction(
     }
 
     // 立即同步内存缓存，确保规则改动对代理请求即时生效，无需用户手动点"刷新缓存"。
-    await requestFilterEngine.reload();
+    // 仓储层已在写入后触发一次本进程 reload，这里 reload(false) 复用它（不补跑第二轮）；
+    // reload 仅为缓存同步，失败不应把已成功的写入误报为失败。
+    try {
+      await requestFilterEngine.reload(false);
+    } catch (reloadError) {
+      logger.warn("[RequestFiltersAction] Failed to reload engine after update", { reloadError });
+    }
     revalidatePath(SETTINGS_PATH);
     return { ok: true, data: updated };
   } catch (error) {
@@ -398,7 +410,13 @@ export async function deleteRequestFilterAction(id: number): Promise<ActionResul
     const ok = await deleteRequestFilter(id);
     if (!ok) return { ok: false, error: "记录不存在" };
     // 立即同步内存缓存，确保删除对代理请求即时生效，无需用户手动点"刷新缓存"。
-    await requestFilterEngine.reload();
+    // 仓储层已在写入后触发一次本进程 reload，这里 reload(false) 复用它（不补跑第二轮）；
+    // reload 仅为缓存同步，失败不应把已成功的写入误报为失败。
+    try {
+      await requestFilterEngine.reload(false);
+    } catch (reloadError) {
+      logger.warn("[RequestFiltersAction] Failed to reload engine after delete", { reloadError });
+    }
     revalidatePath(SETTINGS_PATH);
     return { ok: true };
   } catch (error) {

--- a/src/actions/request-filters.ts
+++ b/src/actions/request-filters.ts
@@ -253,6 +253,8 @@ export async function createRequestFilterAction(data: {
       operations: data.operations ?? null,
     });
 
+    // 立即同步内存缓存，确保新规则对代理请求即时生效，无需用户手动点"刷新缓存"。
+    await requestFilterEngine.reload();
     revalidatePath(SETTINGS_PATH);
     return { ok: true, data: created };
   } catch (error) {
@@ -378,6 +380,8 @@ export async function updateRequestFilterAction(
       return { ok: false, error: "记录不存在" };
     }
 
+    // 立即同步内存缓存，确保规则改动对代理请求即时生效，无需用户手动点"刷新缓存"。
+    await requestFilterEngine.reload();
     revalidatePath(SETTINGS_PATH);
     return { ok: true, data: updated };
   } catch (error) {
@@ -393,6 +397,8 @@ export async function deleteRequestFilterAction(id: number): Promise<ActionResul
   try {
     const ok = await deleteRequestFilter(id);
     if (!ok) return { ok: false, error: "记录不存在" };
+    // 立即同步内存缓存，确保删除对代理请求即时生效，无需用户手动点"刷新缓存"。
+    await requestFilterEngine.reload();
     revalidatePath(SETTINGS_PATH);
     return { ok: true };
   } catch (error) {

--- a/src/app/[locale]/settings/error-rules/_components/add-rule-dialog.tsx
+++ b/src/app/[locale]/settings/error-rules/_components/add-rule-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -30,6 +31,7 @@ import { RegexTester } from "./regex-tester";
 
 export function AddRuleDialog() {
   const t = useTranslations("settings");
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [pattern, setPattern] = useState("");
@@ -106,6 +108,7 @@ export function AddRuleDialog() {
       if (result.ok) {
         toast.success(t("errorRules.addSuccess"));
         setOpen(false);
+        router.refresh();
         // Reset form
         setPattern("");
         setCategory("");

--- a/src/app/[locale]/settings/error-rules/_components/edit-rule-dialog.tsx
+++ b/src/app/[locale]/settings/error-rules/_components/edit-rule-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -34,6 +35,7 @@ interface EditRuleDialogProps {
 
 export function EditRuleDialog({ rule, open, onOpenChange }: EditRuleDialogProps) {
   const t = useTranslations("settings");
+  const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [pattern, setPattern] = useState("");
   const [category, setCategory] = useState("");
@@ -127,6 +129,7 @@ export function EditRuleDialog({ rule, open, onOpenChange }: EditRuleDialogProps
       if (result.ok) {
         toast.success(t("errorRules.editSuccess"));
         onOpenChange(false);
+        router.refresh();
       } else {
         toast.error(result.error);
       }

--- a/src/app/[locale]/settings/error-rules/_components/refresh-cache-button.tsx
+++ b/src/app/[locale]/settings/error-rules/_components/refresh-cache-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { RefreshCw } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -21,6 +22,7 @@ interface RefreshCacheButtonProps {
 
 export function RefreshCacheButton({ stats }: RefreshCacheButtonProps) {
   const t = useTranslations("settings");
+  const router = useRouter();
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const handleRefresh = async () => {
@@ -32,6 +34,7 @@ export function RefreshCacheButton({ stats }: RefreshCacheButtonProps) {
       if (result.ok) {
         const count = result.data.stats.totalCount;
         toast.success(t("errorRules.refreshCacheSuccess", { count }));
+        router.refresh();
       } else {
         toast.error(result.error);
       }

--- a/src/app/[locale]/settings/error-rules/_components/rule-list-table.tsx
+++ b/src/app/[locale]/settings/error-rules/_components/rule-list-table.tsx
@@ -2,6 +2,7 @@
 
 import { formatInTimeZone } from "date-fns-tz";
 import { AlertTriangle, Pencil, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useTimeZone, useTranslations } from "next-intl";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -33,6 +34,7 @@ const categoryColors: Record<string, { bg: string; text: string }> = {
 
 export function RuleListTable({ rules }: RuleListTableProps) {
   const t = useTranslations("settings");
+  const router = useRouter();
   const timeZone = useTimeZone() ?? "UTC";
   const [selectedRule, setSelectedRule] = useState<ErrorRule | null>(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -42,6 +44,7 @@ export function RuleListTable({ rules }: RuleListTableProps) {
 
     if (result.ok) {
       toast.success(isEnabled ? t("errorRules.enable") : t("errorRules.disable"));
+      router.refresh();
     } else {
       toast.error(result.error);
     }
@@ -61,6 +64,7 @@ export function RuleListTable({ rules }: RuleListTableProps) {
 
     if (result.ok) {
       toast.success(t("errorRules.deleteSuccess"));
+      router.refresh();
     } else {
       toast.error(result.error);
     }

--- a/src/lib/error-rule-detector.ts
+++ b/src/lib/error-rule-detector.ts
@@ -171,10 +171,11 @@ class ErrorRuleDetector {
    */
   async reload(options: { queueIfRunning?: boolean } = {}): Promise<void> {
     if (this.activeReloadPromise) {
-      // 无论是事件驱动还是显式调用，只要有 in-flight reload 就排队补跑一轮，
-      // 确保调用方写库后的显式 reload 不会拿到旧快照。
-      this.reloadRequestedWhileLoading = true;
+      // queueIfRunning=true（事件驱动 / 手动刷新）排队补跑一轮，确保读到最新写入；
+      // 默认（action 在 emit 已触发 reload 之后调用）直接复用这次在途 reload，
+      // 避免对同一次写入做两次冗余 DB 读、并让保存响应少等一轮。
       if (options.queueIfRunning) {
+        this.reloadRequestedWhileLoading = true;
         logger.info("[ErrorRuleDetector] Reload already in progress, queueing another pass");
       }
       return this.activeReloadPromise;

--- a/src/lib/request-filter-engine.ts
+++ b/src/lib/request-filter-engine.ts
@@ -449,11 +449,9 @@ export class RequestFilterEngine {
   }
 
   private async ensureInitialized(): Promise<void> {
-    // 有在途 reload（含排队补跑）时等待它完成，避免读到补跑前的旧快照。
-    if (this.activeReloadPromise) {
-      await this.activeReloadPromise;
-      return;
-    }
+    // 已初始化后立即返回，绝不让代理热路径阻塞等待在途 reload：
+    // loadFilters() 对各 bucket 做同步整体替换，请求读到的恒为某个一致快照；
+    // 用户保存后的"即时生效"由 action 侧 await reload() 保证，无需并发代理请求陪跑一次 DB 读。
     if (this.isInitialized) return;
     if (!this.initializationPromise) {
       this.initializationPromise = this.reload().finally(() => {

--- a/src/lib/request-filter-engine.ts
+++ b/src/lib/request-filter-engine.ts
@@ -278,6 +278,8 @@ export class RequestFilterEngine {
   private isLoading = false;
   private isInitialized = false;
   private initializationPromise: Promise<void> | null = null;
+  private activeReloadPromise: Promise<void> | null = null; // 合并并发 reload
+  private reloadRequestedWhileLoading = false; // reload 期间收到的补跑请求
 
   private eventEmitterCleanup: (() => void) | null = null;
   private redisPubSubCleanup: (() => void) | null = null;
@@ -337,18 +339,42 @@ export class RequestFilterEngine {
   }
 
   async reload(): Promise<void> {
-    if (this.isLoading) return;
-    this.isLoading = true;
-
-    try {
-      const { getActiveRequestFilters } = await import("@/repository/request-filters");
-      const filters = await getActiveRequestFilters();
-      this.loadFilters(filters);
-    } catch (error) {
-      logger.error("[RequestFilterEngine] Failed to reload filters", { error });
-    } finally {
-      this.isLoading = false;
+    if (this.activeReloadPromise) {
+      // 已有 reload 在途时排队补跑一轮：保存规则后的显式 reload 不能被丢弃，
+      // 否则代理仍会命中旧的内存快照，必须等用户手动点"刷新缓存"才生效。
+      this.reloadRequestedWhileLoading = true;
+      return this.activeReloadPromise;
     }
+
+    const reloadLoop = (async () => {
+      do {
+        // reload 期间若又收到补跑请求，本轮结束后立刻再跑一轮，避免新规则落库却没进缓存。
+        this.reloadRequestedWhileLoading = false;
+        this.isLoading = true;
+
+        try {
+          const { getActiveRequestFilters } = await import("@/repository/request-filters");
+          const filters = await getActiveRequestFilters();
+          this.loadFilters(filters);
+        } catch (error) {
+          logger.error("[RequestFilterEngine] Failed to reload filters", { error });
+        } finally {
+          this.isLoading = false;
+        }
+      } while (this.reloadRequestedWhileLoading);
+    })();
+
+    this.activeReloadPromise = reloadLoop.finally(() => {
+      // 极窄窗口：do/while 已判定无需继续，但 finally 微任务执行前又来了新请求，
+      // 此处再检查一次，避免晚到的补跑被静默吞掉。
+      const shouldRestart = this.reloadRequestedWhileLoading;
+      this.activeReloadPromise = null;
+      if (shouldRestart) {
+        return this.reload();
+      }
+    });
+
+    return this.activeReloadPromise;
   }
 
   /** Shared filter loading logic (used by reload and setFiltersForTest) */
@@ -423,6 +449,11 @@ export class RequestFilterEngine {
   }
 
   private async ensureInitialized(): Promise<void> {
+    // 有在途 reload（含排队补跑）时等待它完成，避免读到补跑前的旧快照。
+    if (this.activeReloadPromise) {
+      await this.activeReloadPromise;
+      return;
+    }
     if (this.isInitialized) return;
     if (!this.initializationPromise) {
       this.initializationPromise = this.reload().finally(() => {

--- a/src/lib/request-filter-engine.ts
+++ b/src/lib/request-filter-engine.ts
@@ -338,11 +338,16 @@ export class RequestFilterEngine {
     }
   }
 
-  async reload(): Promise<void> {
+  async reload(queue = true): Promise<void> {
     if (this.activeReloadPromise) {
-      // 已有 reload 在途时排队补跑一轮：保存规则后的显式 reload 不能被丢弃，
-      // 否则代理仍会命中旧的内存快照，必须等用户手动点"刷新缓存"才生效。
-      this.reloadRequestedWhileLoading = true;
+      // 已有 reload 在途：
+      // - queue=true（默认 / 事件驱动 / 手动刷新）排队补跑一轮，确保写库后的显式 reload
+      //   不被丢弃，否则代理仍命中旧快照、必须手动点"刷新缓存"才生效。
+      // - queue=false（action 在 emit 已触发 reload 之后调用）直接复用这次在途 reload，
+      //   避免对同一次写入做两次冗余的 DB 读、并让保存响应少等一轮。
+      if (queue) {
+        this.reloadRequestedWhileLoading = true;
+      }
       return this.activeReloadPromise;
     }
 
@@ -453,6 +458,11 @@ export class RequestFilterEngine {
     // loadFilters() 对各 bucket 做同步整体替换，请求读到的恒为某个一致快照；
     // 用户保存后的"即时生效"由 action 侧 await reload() 保证，无需并发代理请求陪跑一次 DB 读。
     if (this.isInitialized) return;
+    // 仅在「尚未初始化」且已有在途 reload 时复用它，避免冷启动期间重复打库。
+    if (this.activeReloadPromise) {
+      await this.activeReloadPromise;
+      return;
+    }
     if (!this.initializationPromise) {
       this.initializationPromise = this.reload().finally(() => {
         this.initializationPromise = null;

--- a/tests/unit/actions/error-rules-cache-reload.test.ts
+++ b/tests/unit/actions/error-rules-cache-reload.test.ts
@@ -115,4 +115,21 @@ describe("error-rules actions reload the detector on mutation", () => {
     expect(res.ok).toBe(false);
     expect(reloadMock).not.toHaveBeenCalled();
   });
+
+  it("still returns ok:true when the detector reload throws (cache sync is best-effort)", async () => {
+    createErrorRuleMock.mockResolvedValue(baseRule);
+    reloadMock.mockRejectedValueOnce(new Error("boom"));
+
+    const { createErrorRuleAction } = await import("@/actions/error-rules");
+    const res = await createErrorRuleAction({
+      pattern: "boom",
+      category: "prompt_limit",
+      matchType: "contains",
+    });
+
+    // The DB write succeeded; a failed best-effort cache reload must NOT flip the
+    // action to failed (which would prompt the user to retry and double-create).
+    expect(res.ok).toBe(true);
+    expect(reloadMock).toHaveBeenCalled();
+  });
 });

--- a/tests/unit/actions/error-rules-cache-reload.test.ts
+++ b/tests/unit/actions/error-rules-cache-reload.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+const reloadMock = vi.fn(async () => {});
+const emitErrorRulesUpdatedMock = vi.fn(async () => {});
+const createErrorRuleMock = vi.fn();
+const updateErrorRuleMock = vi.fn();
+const deleteErrorRuleMock = vi.fn();
+const getErrorRuleByIdMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/emit-event", () => ({
+  emitErrorRulesUpdated: emitErrorRulesUpdatedMock,
+}));
+
+vi.mock("@/lib/error-override-validator", () => ({
+  validateErrorOverrideResponse: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/error-rule-detector", () => ({
+  errorRuleDetector: {
+    reload: reloadMock,
+    getStats: vi.fn(() => ({ totalCount: 0 })),
+    ensureInitialized: vi.fn(async () => {}),
+    detectAsync: vi.fn(async () => ({ matched: false })),
+  },
+}));
+
+vi.mock("@/repository/error-rules", () => ({
+  createErrorRule: createErrorRuleMock,
+  updateErrorRule: updateErrorRuleMock,
+  deleteErrorRule: deleteErrorRuleMock,
+  getErrorRuleById: getErrorRuleByIdMock,
+  getAllErrorRules: vi.fn(async () => []),
+  syncDefaultErrorRules: vi.fn(async () => ({ inserted: 0, updated: 0, skipped: 0, deleted: 0 })),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const baseRule = {
+  id: 1,
+  pattern: "boom",
+  category: "prompt_limit" as const,
+  matchType: "contains" as const,
+  description: null,
+  overrideResponse: null,
+  overrideStatusCode: null,
+  isEnabled: true,
+  isDefault: false,
+  priority: 0,
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+};
+
+describe("error-rules actions reload the detector on mutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
+  });
+
+  it("createErrorRuleAction reloads the detector after a successful create", async () => {
+    createErrorRuleMock.mockResolvedValue(baseRule);
+
+    const { createErrorRuleAction } = await import("@/actions/error-rules");
+    const res = await createErrorRuleAction({
+      pattern: "boom",
+      category: "prompt_limit",
+      matchType: "contains",
+    });
+
+    expect(res.ok).toBe(true);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("updateErrorRuleAction reloads the detector after a successful update", async () => {
+    getErrorRuleByIdMock.mockResolvedValue(baseRule);
+    updateErrorRuleMock.mockResolvedValue({ ...baseRule, isEnabled: false });
+
+    const { updateErrorRuleAction } = await import("@/actions/error-rules");
+    const res = await updateErrorRuleAction(1, { isEnabled: false });
+
+    expect(res.ok).toBe(true);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("deleteErrorRuleAction reloads the detector after a successful delete", async () => {
+    deleteErrorRuleMock.mockResolvedValue(true);
+
+    const { deleteErrorRuleAction } = await import("@/actions/error-rules");
+    const res = await deleteErrorRuleAction(1);
+
+    expect(res.ok).toBe(true);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload the detector when the delete target does not exist", async () => {
+    deleteErrorRuleMock.mockResolvedValue(false);
+
+    const { deleteErrorRuleAction } = await import("@/actions/error-rules");
+    const res = await deleteErrorRuleAction(999);
+
+    expect(res.ok).toBe(false);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/actions/request-filters-cache-reload.test.ts
+++ b/tests/unit/actions/request-filters-cache-reload.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+const reloadMock = vi.fn(async () => {});
+const createRequestFilterMock = vi.fn();
+const updateRequestFilterMock = vi.fn();
+const deleteRequestFilterMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/request-filter-engine", () => ({
+  requestFilterEngine: {
+    reload: reloadMock,
+    getStats: vi.fn(() => ({ count: 0 })),
+  },
+}));
+
+vi.mock("@/repository/request-filters", () => ({
+  createRequestFilter: createRequestFilterMock,
+  deleteRequestFilter: deleteRequestFilterMock,
+  getAllRequestFilters: vi.fn(async () => []),
+  getRequestFilterById: vi.fn(async () => null),
+  updateRequestFilter: updateRequestFilterMock,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const baseFilter = {
+  id: 1,
+  name: "f",
+  description: null,
+  scope: "header" as const,
+  action: "remove" as const,
+  matchType: null,
+  target: "x-test",
+  replacement: null,
+  priority: 0,
+  isEnabled: true,
+  bindingType: "global" as const,
+  providerIds: null,
+  groupTags: null,
+  ruleMode: "simple" as const,
+  executionPhase: "guard" as const,
+  operations: null,
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+};
+
+describe("request-filters actions reload the engine on mutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ user: { id: 1, role: "admin" } });
+  });
+
+  it("createRequestFilterAction reloads the engine after a successful create", async () => {
+    createRequestFilterMock.mockResolvedValue(baseFilter);
+
+    const { createRequestFilterAction } = await import("@/actions/request-filters");
+    const res = await createRequestFilterAction({
+      name: "f",
+      scope: "header",
+      action: "remove",
+      target: "x-test",
+      bindingType: "global",
+    });
+
+    expect(res.ok).toBe(true);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("updateRequestFilterAction reloads the engine after a successful update", async () => {
+    updateRequestFilterMock.mockResolvedValue(baseFilter);
+
+    const { updateRequestFilterAction } = await import("@/actions/request-filters");
+    const res = await updateRequestFilterAction(1, { isEnabled: false });
+
+    expect(res.ok).toBe(true);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("deleteRequestFilterAction reloads the engine after a successful delete", async () => {
+    deleteRequestFilterMock.mockResolvedValue(true);
+
+    const { deleteRequestFilterAction } = await import("@/actions/request-filters");
+    const res = await deleteRequestFilterAction(1);
+
+    expect(res.ok).toBe(true);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload the engine when the update target does not exist", async () => {
+    updateRequestFilterMock.mockResolvedValue(null);
+
+    const { updateRequestFilterAction } = await import("@/actions/request-filters");
+    const res = await updateRequestFilterAction(999, { isEnabled: false });
+
+    expect(res.ok).toBe(false);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it("does not reload the engine when the delete target does not exist", async () => {
+    deleteRequestFilterMock.mockResolvedValue(false);
+
+    const { deleteRequestFilterAction } = await import("@/actions/request-filters");
+    const res = await deleteRequestFilterAction(999);
+
+    expect(res.ok).toBe(false);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/actions/request-filters-cache-reload.test.ts
+++ b/tests/unit/actions/request-filters-cache-reload.test.ts
@@ -78,6 +78,28 @@ describe("request-filters actions reload the engine on mutation", () => {
 
     expect(res.ok).toBe(true);
     expect(reloadMock).toHaveBeenCalledTimes(1);
+    // reload(false): the repository emit already kicked off a fresh reload; the
+    // action reuses it instead of forcing a redundant second DB read.
+    expect(reloadMock).toHaveBeenCalledWith(false);
+  });
+
+  it("still returns ok:true when the engine reload throws (cache sync is best-effort)", async () => {
+    createRequestFilterMock.mockResolvedValue(baseFilter);
+    reloadMock.mockRejectedValueOnce(new Error("boom"));
+
+    const { createRequestFilterAction } = await import("@/actions/request-filters");
+    const res = await createRequestFilterAction({
+      name: "f",
+      scope: "header",
+      action: "remove",
+      target: "x-test",
+      bindingType: "global",
+    });
+
+    // The DB write succeeded; a failed best-effort cache reload must NOT flip the
+    // action to failed (which would prompt the user to retry and double-create).
+    expect(res.ok).toBe(true);
+    expect(reloadMock).toHaveBeenCalled();
   });
 
   it("updateRequestFilterAction reloads the engine after a successful update", async () => {

--- a/tests/unit/error-rules-list-refresh-ui.test.tsx
+++ b/tests/unit/error-rules-list-refresh-ui.test.tsx
@@ -17,6 +17,10 @@ const refreshMock = vi.fn();
 const updateErrorRuleActionMock = vi.fn(async () => ({ ok: true }));
 const deleteErrorRuleActionMock = vi.fn(async () => ({ ok: true }));
 const createErrorRuleActionMock = vi.fn(async () => ({ ok: true }));
+const refreshCacheActionMock = vi.fn(async () => ({
+  ok: true,
+  data: { stats: { totalCount: 3 } },
+}));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: refreshMock, push: vi.fn(), replace: vi.fn() }),
@@ -35,6 +39,7 @@ vi.mock("@/lib/api-client/v1/actions/error-rules", () => ({
   updateErrorRuleAction: updateErrorRuleActionMock,
   deleteErrorRuleAction: deleteErrorRuleActionMock,
   createErrorRuleAction: createErrorRuleActionMock,
+  refreshCacheAction: refreshCacheActionMock,
 }));
 
 // --- UI primitive stubs (Radix portals/providers are noise for this test) ---
@@ -80,10 +85,32 @@ vi.mock("@/components/ui/dialog", () => ({
 }));
 
 vi.mock("@/components/ui/select", () => ({
-  Select: ({ children }: any) => <div>{children}</div>,
-  SelectContent: ({ children }: any) => <div>{children}</div>,
-  SelectItem: ({ children }: any) => <div>{children}</div>,
-  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  // Drivable native <select> so tests can set the category and submit successfully.
+  Select: ({ value, onValueChange }: any) => (
+    <select
+      data-testid="category-select"
+      value={value ?? ""}
+      onChange={(e) => onValueChange?.(e.target.value)}
+    >
+      <option value="" />
+      {[
+        "prompt_limit",
+        "content_filter",
+        "pdf_limit",
+        "thinking_error",
+        "parameter_error",
+        "invalid_request",
+        "cache_limit",
+      ].map((c) => (
+        <option key={c} value={c}>
+          {c}
+        </option>
+      ))}
+    </select>
+  ),
+  SelectContent: () => null,
+  SelectItem: () => null,
+  SelectTrigger: () => null,
   SelectValue: () => null,
 }));
 
@@ -130,6 +157,19 @@ async function flush() {
   await act(async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
+}
+
+// Sets a React-controlled element's value via the native setter, then fires the
+// event React listens to (input for text, change for select) so state updates.
+function setControlledValue(
+  el: HTMLInputElement | HTMLSelectElement,
+  proto: { prototype: object },
+  value: string,
+  eventName: "input" | "change"
+) {
+  const setter = Object.getOwnPropertyDescriptor(proto.prototype, "value")?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event(eventName, { bubbles: true }));
 }
 
 beforeEach(() => {
@@ -205,6 +245,60 @@ describe("error rules list refresh after mutation", () => {
     await flush();
 
     expect(updateErrorRuleActionMock).toHaveBeenCalled();
+    expect(refreshMock).toHaveBeenCalled();
+  });
+
+  test("creating a rule refreshes the list", async () => {
+    const { AddRuleDialog } = await import(
+      "@/app/[locale]/settings/error-rules/_components/add-rule-dialog"
+    );
+
+    await mount(<AddRuleDialog />);
+
+    // Drive the controlled pattern input and category select, then submit.
+    await act(async () => {
+      setControlledValue(
+        container.querySelector("#pattern") as HTMLInputElement,
+        window.HTMLInputElement,
+        "boom",
+        "input"
+      );
+      setControlledValue(
+        container.querySelector('[data-testid="category-select"]') as HTMLSelectElement,
+        window.HTMLSelectElement,
+        "prompt_limit",
+        "change"
+      );
+    });
+
+    const form = container.querySelector("form") as HTMLFormElement;
+    expect(form).toBeTruthy();
+
+    await act(async () => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+
+    expect(createErrorRuleActionMock).toHaveBeenCalled();
+    expect(refreshMock).toHaveBeenCalled();
+  });
+
+  test("refreshing the cache refreshes the list", async () => {
+    const { RefreshCacheButton } = await import(
+      "@/app/[locale]/settings/error-rules/_components/refresh-cache-button"
+    );
+
+    await mount(<RefreshCacheButton stats={null} />);
+
+    const button = container.querySelector("button") as HTMLButtonElement;
+    expect(button).toBeTruthy();
+
+    await act(async () => {
+      button.click();
+    });
+    await flush();
+
+    expect(refreshCacheActionMock).toHaveBeenCalled();
     expect(refreshMock).toHaveBeenCalled();
   });
 });

--- a/tests/unit/error-rules-list-refresh-ui.test.tsx
+++ b/tests/unit/error-rules-list-refresh-ui.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Regression: editing/toggling/deleting an error rule must refresh the list
+ * immediately (router.refresh) instead of leaving stale data until a manual
+ * page/cache refresh. Mirrors the behavior request-filters already has.
+ */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { ErrorRule } from "@/repository/error-rules";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const refreshMock = vi.fn();
+const updateErrorRuleActionMock = vi.fn(async () => ({ ok: true }));
+const deleteErrorRuleActionMock = vi.fn(async () => ({ ok: true }));
+const createErrorRuleActionMock = vi.fn(async () => ({ ok: true }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: refreshMock, push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+  useTimeZone: () => "UTC",
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/api-client/v1/actions/error-rules", () => ({
+  updateErrorRuleAction: updateErrorRuleActionMock,
+  deleteErrorRuleAction: deleteErrorRuleActionMock,
+  createErrorRuleAction: createErrorRuleActionMock,
+}));
+
+// --- UI primitive stubs (Radix portals/providers are noise for this test) ---
+vi.mock("@/components/ui/switch", () => ({
+  Switch: ({ checked, onCheckedChange, "aria-label": ariaLabel }: any) => (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={!!checked}
+      aria-label={ariaLabel}
+      onClick={() => onCheckedChange?.(!checked)}
+    />
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, disabled, type }: any) => (
+    <button type={type ?? "button"} onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: any) => <>{children}</>,
+  TooltipTrigger: ({ children }: any) => <>{children}</>,
+  TooltipContent: () => null,
+  TooltipProvider: ({ children }: any) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <div>{children}</div>,
+  DialogTrigger: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: () => null,
+}));
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children }: any) => <label>{children}</label>,
+}));
+
+vi.mock("@/app/[locale]/settings/error-rules/_components/override-section", () => ({
+  OverrideSection: () => null,
+}));
+
+vi.mock("@/app/[locale]/settings/error-rules/_components/regex-tester", () => ({
+  RegexTester: () => null,
+}));
+
+const rule: ErrorRule = {
+  id: 42,
+  pattern: "boom",
+  category: "prompt_limit",
+  matchType: "contains",
+  description: "test rule",
+  overrideResponse: null,
+  overrideStatusCode: null,
+  isEnabled: true,
+  isDefault: false,
+  priority: 0,
+  createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function mount(element: React.ReactNode) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(element);
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal(
+    "confirm",
+    vi.fn(() => true)
+  );
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  vi.unstubAllGlobals();
+});
+
+describe("error rules list refresh after mutation", () => {
+  test("toggling a rule refreshes the list", async () => {
+    const { RuleListTable } = await import(
+      "@/app/[locale]/settings/error-rules/_components/rule-list-table"
+    );
+
+    await mount(<RuleListTable rules={[rule]} />);
+
+    const toggle = container.querySelector('button[role="switch"]') as HTMLButtonElement;
+    expect(toggle).toBeTruthy();
+
+    await act(async () => {
+      toggle.click();
+    });
+    await flush();
+
+    expect(updateErrorRuleActionMock).toHaveBeenCalledWith(42, { isEnabled: false });
+    expect(refreshMock).toHaveBeenCalled();
+  });
+
+  test("deleting a rule refreshes the list", async () => {
+    const { RuleListTable } = await import(
+      "@/app/[locale]/settings/error-rules/_components/rule-list-table"
+    );
+
+    await mount(<RuleListTable rules={[rule]} />);
+
+    const deleteButton = container
+      .querySelector(".lucide-trash-2")
+      ?.closest("button") as HTMLButtonElement;
+    expect(deleteButton).toBeTruthy();
+
+    await act(async () => {
+      deleteButton.click();
+    });
+    await flush();
+
+    expect(deleteErrorRuleActionMock).toHaveBeenCalledWith(42);
+    expect(refreshMock).toHaveBeenCalled();
+  });
+
+  test("saving an edited rule refreshes the list", async () => {
+    const { EditRuleDialog } = await import(
+      "@/app/[locale]/settings/error-rules/_components/edit-rule-dialog"
+    );
+
+    await mount(<EditRuleDialog rule={rule} open={true} onOpenChange={vi.fn()} />);
+
+    const form = container.querySelector("form") as HTMLFormElement;
+    expect(form).toBeTruthy();
+
+    await act(async () => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+
+    expect(updateErrorRuleActionMock).toHaveBeenCalled();
+    expect(refreshMock).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/lib/request-filter-engine-reload-queue.test.ts
+++ b/tests/unit/lib/request-filter-engine-reload-queue.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { RequestFilter } from "@/repository/request-filters";
+
+const mocks = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  return {
+    getActiveRequestFilters: vi.fn(),
+    subscribeCacheInvalidation: vi.fn(async () => undefined),
+    eventEmitter: {
+      on(event: string, handler: (...args: unknown[]) => void) {
+        const current = listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
+        current.add(handler);
+        listeners.set(event, current);
+      },
+      off(event: string, handler: (...args: unknown[]) => void) {
+        listeners.get(event)?.delete(handler);
+      },
+      emit(event: string, ...args: unknown[]) {
+        for (const handler of listeners.get(event) ?? []) {
+          handler(...args);
+        }
+      },
+      removeAllListeners() {
+        listeners.clear();
+      },
+    },
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      trace: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/repository/request-filters", () => ({
+  getActiveRequestFilters: mocks.getActiveRequestFilters,
+}));
+
+vi.mock("@/lib/event-emitter", () => ({
+  eventEmitter: mocks.eventEmitter,
+}));
+
+vi.mock("@/lib/redis/pubsub", () => ({
+  CHANNEL_REQUEST_FILTERS_UPDATED: "requestFiltersUpdated",
+  subscribeCacheInvalidation: mocks.subscribeCacheInvalidation,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: mocks.logger,
+}));
+
+let nextId = 1;
+function buildFilter(overrides?: Partial<RequestFilter>): RequestFilter {
+  return {
+    id: nextId++,
+    name: "filter",
+    description: null,
+    scope: "header",
+    action: "remove",
+    matchType: null,
+    target: "x-test-header",
+    replacement: null,
+    priority: 0,
+    isEnabled: true,
+    bindingType: "global",
+    providerIds: null,
+    groupTags: null,
+    ruleMode: "simple",
+    executionPhase: "guard",
+    operations: null,
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+/** Returns an array of N distinct global-guard filters. */
+function filters(n: number): RequestFilter[] {
+  return Array.from({ length: n }, () => buildFilter());
+}
+
+describe("RequestFilterEngine reload queue", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.eventEmitter.removeAllListeners();
+    // The engine is a globalThis singleton that survives resetModules, so its
+    // event listener only registers on first construction. Drop it so the next
+    // test re-imports a fresh engine that re-subscribes to mocks.eventEmitter.
+    delete (globalThis as Record<string, unknown>).__CCH_REQUEST_FILTER_ENGINE__;
+    nextId = 1;
+  });
+
+  test("applies a reload requested while another reload is in-flight (not dropped)", async () => {
+    let resolveFirstLoad: ((value: RequestFilter[]) => void) | undefined;
+
+    // First load is slow and returns 1 filter (the "old" snapshot).
+    // Second load returns 2 filters (the "new" snapshot saved by the user).
+    mocks.getActiveRequestFilters
+      .mockImplementationOnce(
+        () =>
+          new Promise<RequestFilter[]>((resolve) => {
+            resolveFirstLoad = resolve;
+          })
+      )
+      .mockResolvedValueOnce(filters(2));
+
+    const { requestFilterEngine } = await import("@/lib/request-filter-engine");
+    // Allow the constructor's async event-listener wiring to settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const firstReload = requestFilterEngine.reload(); // starts load #1 (pending)
+    const secondReload = requestFilterEngine.reload(); // requested mid-flight -> must queue
+
+    // Let the dynamic import inside reload() settle so load #1 actually calls
+    // getActiveRequestFilters (assigning resolveFirstLoad) before we resolve it.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveFirstLoad?.(filters(1));
+    await Promise.all([firstReload, secondReload]);
+
+    // The concurrent reload must NOT be silently dropped: a second DB read runs
+    // and the engine ends up reflecting the newest snapshot (2 filters), not the
+    // stale one (1 filter).
+    expect(mocks.getActiveRequestFilters).toHaveBeenCalledTimes(2);
+    expect(requestFilterEngine.getStats().count).toBe(2);
+  });
+
+  test("a requestFiltersUpdated event during a reload triggers a queued rerun", async () => {
+    let resolveFirstLoad: ((value: RequestFilter[]) => void) | undefined;
+
+    mocks.getActiveRequestFilters
+      .mockImplementationOnce(
+        () =>
+          new Promise<RequestFilter[]>((resolve) => {
+            resolveFirstLoad = resolve;
+          })
+      )
+      .mockResolvedValueOnce(filters(3));
+
+    const { requestFilterEngine } = await import("@/lib/request-filter-engine");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const firstReload = requestFilterEngine.reload();
+    mocks.eventEmitter.emit("requestFiltersUpdated");
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveFirstLoad?.(filters(1));
+    await firstReload;
+    // Let the queued rerun (kicked by the event handler) settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.getActiveRequestFilters).toHaveBeenCalledTimes(2);
+    expect(requestFilterEngine.getStats().count).toBe(3);
+  });
+
+  test("an awaited reload after an in-flight reload observes the freshest snapshot", async () => {
+    // Models the save path: the repository emits an event (fire-and-forget reload),
+    // then the action awaits its own reload. The awaited reload must resolve only
+    // after a pass that reflects the just-written rows.
+    let resolveFirstLoad: ((value: RequestFilter[]) => void) | undefined;
+
+    mocks.getActiveRequestFilters
+      .mockImplementationOnce(
+        () =>
+          new Promise<RequestFilter[]>((resolve) => {
+            resolveFirstLoad = resolve;
+          })
+      )
+      .mockResolvedValueOnce(filters(5));
+
+    const { requestFilterEngine } = await import("@/lib/request-filter-engine");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Event-driven (fire-and-forget) reload starts first.
+    void requestFilterEngine.reload();
+    // Action's awaited reload races in while the first is still loading.
+    const awaitedReload = requestFilterEngine.reload();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveFirstLoad?.(filters(1));
+    await awaitedReload;
+
+    expect(mocks.getActiveRequestFilters).toHaveBeenCalledTimes(2);
+    expect(requestFilterEngine.getStats().count).toBe(5);
+  });
+});

--- a/tests/unit/lib/request-filter-engine-reload-queue.test.ts
+++ b/tests/unit/lib/request-filter-engine-reload-queue.test.ts
@@ -187,4 +187,30 @@ describe("RequestFilterEngine reload queue", () => {
     expect(mocks.getActiveRequestFilters).toHaveBeenCalledTimes(2);
     expect(requestFilterEngine.getStats().count).toBe(5);
   });
+
+  test("reload(false) reuses an in-flight reload without forcing a redundant rerun", async () => {
+    let resolveLoad: ((value: RequestFilter[]) => void) | undefined;
+
+    // Only ONE DB read should happen: the second reload(false) must reuse the
+    // in-flight load instead of queueing a second pass.
+    mocks.getActiveRequestFilters.mockImplementationOnce(
+      () =>
+        new Promise<RequestFilter[]>((resolve) => {
+          resolveLoad = resolve;
+        })
+    );
+
+    const { requestFilterEngine } = await import("@/lib/request-filter-engine");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const first = requestFilterEngine.reload(false); // starts load #1
+    const second = requestFilterEngine.reload(false); // in-flight + queue=false -> reuse
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveLoad?.(filters(2));
+    await Promise.all([first, second]);
+
+    expect(mocks.getActiveRequestFilters).toHaveBeenCalledTimes(1);
+    expect(requestFilterEngine.getStats().count).toBe(2);
+  });
 });


### PR DESCRIPTION
## 问题

请求过滤器（Request Filters）和错误规则（Error Rules）在新增/编辑/删除/启停后，**需要手动点击"刷新缓存"按钮才会真正生效**。用户在请求过滤器侧可稳定复现。

## 复现与根因分析

定位到代理运行时有一层**进程内内存缓存**（`RequestFilterEngine` / `ErrorRuleDetector`），代理请求实际命中的是这层缓存，而非数据库。

回答用户的两个问题：

1. **数据修改后会自动刷新吗？**
   - 请求过滤器：UI 列表会刷新（`filter-dialog`/`filter-table` 已调用 `router.refresh()`），但**代理内存缓存只靠仓储层 fire-and-forget 的事件触发 `void reload()`**，动作层从不 `await`。
   - 错误规则：**UI 列表完全不刷新**（`add/edit/toggle/delete` 均未调用 `router.refresh()`，仅靠 `revalidatePath`——经 REST 客户端调用时不会触发客户端重渲染），代理内存缓存同样只靠 fire-and-forget 事件。
2. **是否需要主动点刷新按钮？** 是。"刷新缓存"按钮是唯一会 **`await reload()`** 同步刷新内存缓存的路径。

此外 `RequestFilterEngine.reload()` 有一个隐患：`if (this.isLoading) return;` 会在已有 reload 进行中时**静默丢弃**并发的 reload（没有补跑队列，不同于已经健壮的 `ErrorRuleDetector`）。

## 改动

**服务端（让规则对代理即时生效）**
- `RequestFilterEngine.reload()`：移植 `ErrorRuleDetector` 的 `activeReloadPromise` + `reloadRequestedWhileLoading` 补跑队列，并发 reload 不再被丢弃；`ensureInitialized()` 会等待在途 reload 完成，避免读到旧快照。
- `request-filters` / `error-rules` 的 create/update/delete 动作：写库成功后**直接 `await reload()`**，确保返回前本进程缓存已是最新。仍保留事件广播（Redis pub/sub）用于多 worker 同步。

**前端（让列表即时更新）**
- 错误规则的 `add-rule-dialog`、`edit-rule-dialog`、`rule-list-table`（启停 + 删除）、`refresh-cache-button` 全部在成功后调用 `router.refresh()`，与请求过滤器已有行为对齐。

## 测试（TDD，先红后绿）

新增 4 个测试文件，均先确认 RED 再实现转 GREEN：
- `request-filter-engine-reload-queue.test.ts`：并发/事件触发的 reload 不再被丢弃，`await` 的 reload 能观察到最新快照。
- `request-filters-cache-reload.test.ts` / `error-rules-cache-reload.test.ts`：create/update/delete 成功后会 `await` 引擎/检测器的 `reload()`，失败时不会。
- `error-rules-list-refresh-ui.test.tsx`：错误规则启停/删除/编辑保存后会调用 `router.refresh()`。

## 验证

- `bun run build` ✅
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test` ✅ 6262 passed / 13 skipped（696 文件）

## Related PRs

- Follow-up to #710 — extends the original hot-reload cache invalidation mechanism (globalThis singletons + Redis pub/sub) to await reloads synchronously after mutations, rather than relying on fire-and-forget events.
- Follow-up to #1006 — ports the `activeReloadPromise` + `reloadRequestedWhileLoading` queued reload pattern from `ErrorRuleDetector` to `RequestFilterEngine`, closing the concurrent-reload race window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes stale in-memory caches in `RequestFilterEngine` and `ErrorRuleDetector` by: (1) porting the `activeReloadPromise` + `reloadRequestedWhileLoading` do/while queued-reload pattern from `ErrorRuleDetector` to `RequestFilterEngine`, and (2) adding explicit `await reload()` calls in the create/update/delete server actions so the cache is synced before the response is returned, eliminating the "must click Refresh Cache" workaround. UI components for error-rules also receive `router.refresh()` calls on mutation success to align them with the existing behavior in request-filter components.

- **Engine reload logic** (`request-filter-engine.ts`): replaces the silent-discard `if (isLoading) return` with a do/while queued-reload loop identical to `ErrorRuleDetector`'s; `ensureInitialized()` gains an `activeReloadPromise` fast-path for cold-start deduplication.
- **Action-layer cache sync** (`request-filters.ts`, `error-rules.ts`): all create/update/delete actions now `await reload()` after the DB write; `ErrorRuleDetector.reload()` gains a `queueIfRunning` option so the `refreshCacheAction` can force a full re-read while normal action calls reuse any in-flight promise without queuing a redundant second pass.
- **UI list refresh** (`add-rule-dialog`, `edit-rule-dialog`, `rule-list-table`, `refresh-cache-button`): adds `router.refresh()` on success, mirroring the existing behavior in the request-filter equivalents.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge. Core reload logic is correct in all single-mutation and concurrent-mutation scenarios; cache integrity is maintained through the do/while queued-reload pattern, and action failures are handled gracefully without flipping mutation results.

The queued do/while pattern correctly handles both the common case (no pre-existing in-flight reload) and the concurrent case (pre-existing reload from a prior mutation) — the event handler's queue=true ensures a follow-up iteration that the awaited promise covers. The only notable gap is a test that uses the wrong calling convention for the action path, but this does not affect production behaviour. All mutation paths are guarded, the best-effort catch blocks prevent reload errors from poisoning successful writes, and the full test suite passes.

tests/unit/lib/request-filter-engine-reload-queue.test.ts — test #3 should model the action's reload(false) convention alongside the event handler's reload() call to accurately represent the concurrent-mutation scenario.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/request-filter-engine.ts | Replaces silent-discard reload guard with queued do/while pattern; adds activeReloadPromise fast-path to ensureInitialized. Core logic is correct, but unconditional return after awaiting activeReloadPromise in ensureInitialized (pre-existing issue) remains; see previous thread. |
| src/lib/error-rule-detector.ts | Adds queueIfRunning option to reload(); event handler retains queueIfRunning:true for correctness; action calls default (false) to avoid redundant DB reads. Change is minimal and correct. |
| src/actions/error-rules.ts | Adds try/catch await reload() after each successful mutation and uses queueIfRunning:true for the manual refresh action. Best-effort cache sync correctly does not flip ok:false on reload failure. |
| src/actions/request-filters.ts | Adds try/catch await reload(false) after each successful create/update/delete; reload placed correctly after null-check guard so it only fires on actual DB success. |
| tests/unit/lib/request-filter-engine-reload-queue.test.ts | Covers queued-reload and event-driven scenarios well, but test #3 uses reload() (queue=true default) for the "action's awaited reload" rather than reload(false) as the action actually calls, making the test comment misleading. |
| tests/unit/actions/error-rules-cache-reload.test.ts | Good coverage: verifies reload is called on success and skipped on failure, and that a reload error doesn't flip the action result. |
| tests/unit/actions/request-filters-cache-reload.test.ts | Good coverage for create/update/delete paths; create test explicitly verifies reload(false) argument. Update and delete tests don't assert the argument but verify call count. |
| tests/unit/error-rules-list-refresh-ui.test.tsx | Comprehensive UI regression tests for all mutation flows (toggle, delete, edit, add, refresh cache) verifying router.refresh() is called. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as UI Component
    participant Action as Server Action
    participant Repo as Repository Layer
    participant EE as EventEmitter
    participant Engine as RequestFilterEngine / ErrorRuleDetector
    participant DB as Database

    UI->>Action: createRequestFilterAction(data)
    Action->>Repo: createRequestFilter(data)
    Repo->>DB: INSERT
    DB-->>Repo: created record
    Repo->>EE: emit("requestFiltersUpdated") [sync]
    EE->>Engine: "void reload() [queue=true, fire-and-forget]"
    Note over Engine: activeReloadPromise = new do/while loop
    Repo-->>Action: created record

    Action->>Engine: await reload(false)
    Note over Engine: activeReloadPromise already set →<br/>return existing promise (no second round queued)
    Engine->>DB: SELECT active filters
    DB-->>Engine: [fresh rows including new record]
    Engine-->>Engine: "loadFilters() → isInitialized = true"
    Engine-->>Action: promise resolves (cache is current)

    Action->>UI: "{ ok: true }"
    UI->>UI: router.refresh()

    Note over Engine,DB: Concurrent mutation scenario (pre-existing in-flight reload)
    Engine->>DB: "SELECT (reload #prev, started before write)"
    Action->>Engine: "[event fires] void reload() [queue=true]"
    Note over Engine: reloadRequestedWhileLoading = true
    Action->>Engine: await reload(false) → returns promisePrev
    DB-->>Engine: [stale snapshot]
    Engine->>DB: SELECT again (second do/while iteration)
    DB-->>Engine: [fresh rows]
    Engine-->>Action: promisePrev resolves (both iterations done)
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/request-filter-engine.ts`, line 470-492 ([link](https://github.com/ding113/claude-code-hub/blob/c8811c6dfded749f328405adad13ca5b7160b817/src/lib/request-filter-engine.ts#L470-L492)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Fast-path in `applyGlobal` / `applyForProvider` can bypass the new reload-wait**

   Both `applyGlobal` and `applyForProvider` have an early return `if (this.isInitialized && this.<filters>.length === 0) return;` that fires before `ensureInitialized()` is called. When a user adds the very first global guard filter, the engine is initialized with an empty list. A concurrent proxy request entering this fast path will return immediately — even if `activeReloadPromise` is set for a reload that would load the new filter. The new `ensureInitialized()` guard added in this PR only helps when there are already filters in the bucket. This is a pre-existing design trade-off, but it limits the correctness guarantee the PR aims to provide for the "add first rule" case.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/request-filter-engine.ts
   Line: 470-492

   Comment:
   **Fast-path in `applyGlobal` / `applyForProvider` can bypass the new reload-wait**

   Both `applyGlobal` and `applyForProvider` have an early return `if (this.isInitialized && this.<filters>.length === 0) return;` that fires before `ensureInitialized()` is called. When a user adds the very first global guard filter, the engine is initialized with an empty list. A concurrent proxy request entering this fast path will return immediately — even if `activeReloadPromise` is set for a reload that would load the new filter. The new `ensureInitialized()` guard added in this PR only helps when there are already filters in the bucket. This is a pre-existing design trade-off, but it limits the correctness guarantee the PR aims to provide for the "add first rule" case.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/unit/lib/request-filter-engine-reload-queue.test.ts:1102-1131
**Test models the wrong calling convention for the action path**

This test uses the default `reload()` (queue=true) for "the action's awaited reload", but the action code calls `reload(false)`. If the second call were changed to `reload(false)`, no second DB read would be queued (because only the event handler's `reload(true)` sets `reloadRequestedWhileLoading`), so the test would resolve with 1 filter rather than 5 — contradicting the assertion.

To accurately model the real scenario where an in-flight reload is already running when a mutation lands, the test needs **three** calls: one for the pre-existing reload (started before the write), one simulating the event handler (`void reload()`, queue=true, which sets `reloadRequestedWhileLoading = true`), and one for the action (`reload(false)`, which reuses the promise). The current two-call structure with `reload(true)` as the "action" call inflates the guarantee and leaves the actual `reload(false)` path untested.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(cache): tolerate reload failures and..."](https://github.com/ding113/claude-code-hub/commit/384e9cc65324aaa2e83c3110e121d03a3410d066) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35359121)</sub>

<!-- /greptile_comment -->