### PR TITLE
fix(map): resolve GeoJSON namespace so release pipeline typechecks on fresh install

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2",
     "@tailwindcss/postcss": "^4.2.0",
+    "@types/geojson": "^7946.0.16",
     "@types/ioredis": "^5",
     "@types/node": "^25",
     "@types/pg": "^8",

--- a/src/components/ui/map.tsx
+++ b/src/components/ui/map.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type * as GeoJSON from "geojson";
 import { Loader2, Locate, Maximize, Minus, Plus, X } from "lucide-react";
 import MapLibreGL, { type MarkerOptions, type PopupOptions } from "maplibre-gl";
 import {


### PR DESCRIPTION
## 问题

Release 流水线(`Auto Release Pipeline`)在 `Install dependencies, type check, and format code` 步骤失败:

```
src/components/ui/map.tsx(1292,37): error TS2503: Cannot find namespace 'GeoJSON'.
... (共 12 处)
```

失败 run: https://github.com/ding113/claude-code-hub/actions/runs/26948118648/job/79506098306

## 根因

- `src/components/ui/map.tsx` 使用了全局 `GeoJSON` 命名空间(`GeoJSON.Point` / `GeoJSON.Feature` / `GeoJSON.FeatureCollection` / `GeoJSON.GeoJsonProperties`)。
- 该全局命名空间仅来自 `@types/geojson`,而它只是 `maplibre-gl` 的**间接依赖**(通过 `export as namespace GeoJSON` 提供 UMD 全局)。
- 本仓库 `bun.lock` 被 `.gitignore` 忽略、**未提交**,因此 CI 每次都是全新的非冻结 `bun install`。在 `maplibre-gl` 由 5.23 升到 5.24 等依赖变动后,全新安装下 tsgo(`@typescript/native-preview`)不再稳定地把 `@types/geojson` 的 UMD 全局自动纳入,导致找不到 `GeoJSON` 命名空间。
- 本地已复现:删除 `node_modules`+lockfile 全新 `bun install` 后,`bun run typecheck` 报出与 CI 完全一致的 12 处错误。

## 修复

1. `src/components/ui/map.tsx`:新增显式 `import type * as GeoJSON from "geojson";`,让 `GeoJSON.*` 通过模块解析获取,不再依赖会被破坏的 ambient UMD 全局。无需改动 12 处使用点。
2. `package.json`:将 `@types/geojson` 声明为直接 `devDependency`,保证 `"geojson"` specifier 在全新安装下始终可解析(不再依赖间接依赖的提升)。

## 本地验证(与 CI 相同条件:删 node_modules + 无 lockfile 全新安装)

- `bun run typecheck` (修复前复现 12 处报错,修复后通过)
- `bun run build` Compiled successfully
- `bun run test` 702 files / 6321 tests passed,13 skipped
- `bun run lint`
- `bun run format:check`

## Related

- Related to #1032 - Origin of `src/components/ui/map.tsx` which introduced the maplibre-gl dependency and the GeoJSON namespace usage that breaks under fresh install.
- Related to #1204 - Same class of CI typecheck failure: ambient type resolution lost after dependency version changes during non-frozen install.

---
*Description enhanced by Claude AI*