### PR TITLE
feat(logs): 竞速输家计费逐次拆分展示(token 用量 + 费用 + 合并总额)

### DIFF
--- a/messages/en/dashboard.json
+++ b/messages/en/dashboard.json
@@ -326,6 +326,15 @@
         "hedgeWinner": "Winner",
         "hedgeLoser": "Loser",
         "hedgeLosersTotal": "Racing Losers",
+        "hedgeMergedCount": "Merged {count} attempts",
+        "hedgeWinnerShort": "Winner",
+        "hedgeLoserShort": "Loser",
+        "hedgeColAttempt": "Attempt",
+        "hedgeColCacheRead": "Cache R",
+        "hedgeColCacheWrite": "Cache W",
+        "hedgeColCost": "Cost",
+        "hedgeTokenTotal": "Total tokens",
+        "hedgeReclaimedNotDelivered": "Response reclaimed, not delivered to client",
         "unitPricePer1M": "@ {price} / 1M",
         "unit": {
           "tokens": "tokens"
@@ -447,6 +456,15 @@
       "hedgeWinner": "Winner",
       "hedgeLoser": "Loser",
       "hedgeLosersTotal": "Racing Losers",
+      "hedgeMergedCount": "Merged {count} attempts",
+      "hedgeWinnerShort": "Winner",
+      "hedgeLoserShort": "Loser",
+      "hedgeColAttempt": "Attempt",
+      "hedgeColCacheRead": "Cache R",
+      "hedgeColCacheWrite": "Cache W",
+      "hedgeColCost": "Cost",
+      "hedgeTokenTotal": "Total tokens",
+      "hedgeReclaimedNotDelivered": "Response reclaimed, not delivered to client",
       "unit": {
         "tokens": "tokens"
       }

--- a/messages/ja/dashboard.json
+++ b/messages/ja/dashboard.json
@@ -326,6 +326,15 @@
         "hedgeWinner": "勝者",
         "hedgeLoser": "敗者",
         "hedgeLosersTotal": "競争の敗者合計",
+        "hedgeMergedCount": "{count} 件を合算",
+        "hedgeWinnerShort": "勝者",
+        "hedgeLoserShort": "敗者",
+        "hedgeColAttempt": "試行",
+        "hedgeColCacheRead": "キャッシュR",
+        "hedgeColCacheWrite": "キャッシュW",
+        "hedgeColCost": "費用",
+        "hedgeTokenTotal": "トークン合計",
+        "hedgeReclaimedNotDelivered": "応答を回収、クライアントには未送信",
         "unitPricePer1M": "@ {price} / 1M",
         "unit": {
           "tokens": "トークン"
@@ -447,6 +456,15 @@
       "hedgeWinner": "勝者",
       "hedgeLoser": "敗者",
       "hedgeLosersTotal": "競争の敗者合計",
+      "hedgeMergedCount": "{count} 件を合算",
+      "hedgeWinnerShort": "勝者",
+      "hedgeLoserShort": "敗者",
+      "hedgeColAttempt": "試行",
+      "hedgeColCacheRead": "キャッシュR",
+      "hedgeColCacheWrite": "キャッシュW",
+      "hedgeColCost": "費用",
+      "hedgeTokenTotal": "トークン合計",
+      "hedgeReclaimedNotDelivered": "応答を回収、クライアントには未送信",
       "unit": {
         "tokens": "トークン"
       }

--- a/messages/ru/dashboard.json
+++ b/messages/ru/dashboard.json
@@ -326,6 +326,15 @@
         "hedgeWinner": "Победитель",
         "hedgeLoser": "Проигравший",
         "hedgeLosersTotal": "Проигравшие в гонке",
+        "hedgeMergedCount": "Объединено попыток: {count}",
+        "hedgeWinnerShort": "Победитель",
+        "hedgeLoserShort": "Проигравший",
+        "hedgeColAttempt": "Попытка",
+        "hedgeColCacheRead": "Кэш R",
+        "hedgeColCacheWrite": "Кэш W",
+        "hedgeColCost": "Стоимость",
+        "hedgeTokenTotal": "Всего токенов",
+        "hedgeReclaimedNotDelivered": "Ответ получен, но не отправлен клиенту",
         "unitPricePer1M": "@ {price} / 1M",
         "unit": {
           "tokens": "токенов"
@@ -447,6 +456,15 @@
       "hedgeWinner": "Победитель",
       "hedgeLoser": "Проигравший",
       "hedgeLosersTotal": "Проигравшие в гонке",
+      "hedgeMergedCount": "Объединено попыток: {count}",
+      "hedgeWinnerShort": "Победитель",
+      "hedgeLoserShort": "Проигравший",
+      "hedgeColAttempt": "Попытка",
+      "hedgeColCacheRead": "Кэш R",
+      "hedgeColCacheWrite": "Кэш W",
+      "hedgeColCost": "Стоимость",
+      "hedgeTokenTotal": "Всего токенов",
+      "hedgeReclaimedNotDelivered": "Ответ получен, но не отправлен клиенту",
       "unit": {
         "tokens": "токенов"
       }

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -326,6 +326,15 @@
         "hedgeWinner": "竞速赢家",
         "hedgeLoser": "竞速输家",
         "hedgeLosersTotal": "竞速输家合计",
+        "hedgeMergedCount": "合并 {count} 次",
+        "hedgeWinnerShort": "赢家",
+        "hedgeLoserShort": "输家",
+        "hedgeColAttempt": "尝试",
+        "hedgeColCacheRead": "缓存R",
+        "hedgeColCacheWrite": "缓存W",
+        "hedgeColCost": "费用",
+        "hedgeTokenTotal": "Token 合计",
+        "hedgeReclaimedNotDelivered": "已拿回响应，未交付客户端",
         "unitPricePer1M": "@ {price} / 1M",
         "unit": {
           "tokens": "tokens"
@@ -447,6 +456,15 @@
       "hedgeWinner": "竞速赢家",
       "hedgeLoser": "竞速输家",
       "hedgeLosersTotal": "竞速输家合计",
+      "hedgeMergedCount": "合并 {count} 次",
+      "hedgeWinnerShort": "赢家",
+      "hedgeLoserShort": "输家",
+      "hedgeColAttempt": "尝试",
+      "hedgeColCacheRead": "缓存R",
+      "hedgeColCacheWrite": "缓存W",
+      "hedgeColCost": "费用",
+      "hedgeTokenTotal": "Token 合计",
+      "hedgeReclaimedNotDelivered": "已拿回响应，未交付客户端",
       "unit": {
         "tokens": "tokens"
       }

--- a/messages/zh-TW/dashboard.json
+++ b/messages/zh-TW/dashboard.json
@@ -326,6 +326,15 @@
         "hedgeWinner": "競速贏家",
         "hedgeLoser": "競速輸家",
         "hedgeLosersTotal": "競速輸家合計",
+        "hedgeMergedCount": "合併 {count} 次",
+        "hedgeWinnerShort": "贏家",
+        "hedgeLoserShort": "輸家",
+        "hedgeColAttempt": "嘗試",
+        "hedgeColCacheRead": "快取R",
+        "hedgeColCacheWrite": "快取W",
+        "hedgeColCost": "費用",
+        "hedgeTokenTotal": "Token 合計",
+        "hedgeReclaimedNotDelivered": "已取回回應，未交付用戶端",
         "unitPricePer1M": "@ {price} / 1M",
         "unit": {
           "tokens": "tokens"
@@ -447,6 +456,15 @@
       "hedgeWinner": "競速贏家",
       "hedgeLoser": "競速輸家",
       "hedgeLosersTotal": "競速輸家合計",
+      "hedgeMergedCount": "合併 {count} 次",
+      "hedgeWinnerShort": "贏家",
+      "hedgeLoserShort": "輸家",
+      "hedgeColAttempt": "嘗試",
+      "hedgeColCacheRead": "快取R",
+      "hedgeColCacheWrite": "快取W",
+      "hedgeColCost": "費用",
+      "hedgeTokenTotal": "Token 合計",
+      "hedgeReclaimedNotDelivered": "已取回回應，未交付用戶端",
       "unit": {
         "tokens": "tokens"
       }

--- a/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/LogicTraceTab.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/LogicTraceTab.tsx
@@ -23,9 +23,9 @@ import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { getSessionOriginChain } from "@/lib/api-client/v1/actions/session-origin-chain";
-import { cn } from "@/lib/utils";
+import { cn, formatTokenAmount } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/currency";
-import { findHedgeLoserCost } from "@/lib/utils/hedge-billing";
+import { findHedgeLoserCost, summarizeHedgeBilling } from "@/lib/utils/hedge-billing";
 import { formatProbability, formatProviderTimeline } from "@/lib/utils/provider-chain-formatter";
 import type { ProviderChainItem } from "@/types/message";
 import { type LogicTraceTabProps, parseBlockedReason } from "../types";
@@ -68,10 +68,78 @@ export function LogicTraceTab({
   blockedReason,
   requestSequence,
   hedgeLosers,
+  costUsd,
+  inputTokens,
+  outputTokens,
+  cacheCreationInputTokens,
+  cacheReadInputTokens,
   initialExpandedChainIndex,
 }: LogicTraceTabProps) {
   const t = useTranslations("dashboard.logs.details");
   const tChain = useTranslations("provider-chain");
+  // Winner cost is the request total minus every billed loser; only present
+  // when this request actually billed hedge losers.
+  const hedgeSummary = summarizeHedgeBilling(costUsd, hedgeLosers);
+
+  // Render the reclaimed token usage + billed cost for one hedge attempt
+  // (winner or loser) inside its decision-chain step.
+  const renderHedgeAttemptUsage = (params: {
+    accent: "winner" | "loser";
+    costUsd: string;
+    inputTokens?: number | null;
+    outputTokens?: number | null;
+    cacheCreationInputTokens?: number | null;
+    cacheReadInputTokens?: number | null;
+  }) => {
+    const isLoser = params.accent === "loser";
+    const hasTokens =
+      (params.inputTokens ?? 0) > 0 ||
+      (params.outputTokens ?? 0) > 0 ||
+      (params.cacheCreationInputTokens ?? 0) > 0 ||
+      (params.cacheReadInputTokens ?? 0) > 0;
+    const tokenParts = [
+      `${t("billingDetails.input")} ${formatTokenAmount(params.inputTokens ?? 0)}`,
+      `${t("billingDetails.output")} ${formatTokenAmount(params.outputTokens ?? 0)}`,
+    ];
+    if ((params.cacheCreationInputTokens ?? 0) > 0) {
+      tokenParts.push(
+        `${t("billingDetails.hedgeColCacheWrite")} ${formatTokenAmount(params.cacheCreationInputTokens ?? 0)}`
+      );
+    }
+    if ((params.cacheReadInputTokens ?? 0) > 0) {
+      tokenParts.push(
+        `${t("billingDetails.hedgeColCacheRead")} ${formatTokenAmount(params.cacheReadInputTokens ?? 0)}`
+      );
+    }
+    return (
+      <div className="space-y-1">
+        {isLoser && (
+          <div className="text-[11px] text-muted-foreground">
+            {t("billingDetails.hedgeReclaimedNotDelivered")}
+          </div>
+        )}
+        <div className="flex items-center gap-2 flex-wrap">
+          {hasTokens && (
+            <span className="font-mono text-[11px] text-muted-foreground">
+              {tokenParts.join(" · ")}
+            </span>
+          )}
+          <Badge
+            variant="outline"
+            className={cn(
+              "text-[10px]",
+              isLoser
+                ? "bg-rose-50 dark:bg-rose-950/20 border-rose-200 dark:border-rose-800 text-rose-700 dark:text-rose-300"
+                : "bg-emerald-50 dark:bg-emerald-950/20 border-emerald-200 dark:border-emerald-800 text-emerald-700 dark:text-emerald-300"
+            )}
+          >
+            {isLoser ? t("billingDetails.hedgeLoser") : t("billingDetails.hedgeWinner")}:{" "}
+            {formatCurrency(params.costUsd, "USD", 6)}
+          </Badge>
+        </div>
+      </div>
+    );
+  };
   const [timelineCopied, setTimelineCopied] = useState(false);
   const [originOpen, setOriginOpen] = useState(false);
   const [originChain, setOriginChain] = useState<ProviderChainItem[] | null | undefined>(undefined);
@@ -721,6 +789,7 @@ export function LogicTraceTab({
 
             // Determine icon based on type
             const isHedgeTriggered = item.reason === "hedge_triggered";
+            const isHedgeWinner = item.reason === "hedge_winner";
             const isHedgeLoser = item.reason === "hedge_loser_cancelled";
             const isHedgeLoserBilled = item.reason === "hedge_loser_billed";
             const isClientAbort = item.reason === "client_abort";
@@ -796,18 +865,29 @@ export function LogicTraceTab({
                 defaultExpanded={initialExpandedChainIndex === index}
                 details={
                   <div className="space-y-2 text-xs">
-                    {/* Hedge Loser Billed Cost */}
-                    {hedgeLoserBilling && (
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <Badge
-                          variant="outline"
-                          className="text-[10px] bg-amber-50 dark:bg-amber-950/20 border-amber-200 dark:border-amber-800 text-amber-700 dark:text-amber-300"
-                        >
-                          {t("billingDetails.hedgeLoser")}:{" "}
-                          {formatCurrency(hedgeLoserBilling.costUsd, "USD", 6)}
-                        </Badge>
-                      </div>
-                    )}
+                    {/* Hedge winner reclaimed usage + billed cost (only on a race
+                        that actually billed losers, so non-hedge steps are unaffected) */}
+                    {isHedgeWinner &&
+                      hedgeSummary &&
+                      renderHedgeAttemptUsage({
+                        accent: "winner",
+                        costUsd: hedgeSummary.winnerCost,
+                        inputTokens,
+                        outputTokens,
+                        cacheCreationInputTokens,
+                        cacheReadInputTokens,
+                      })}
+
+                    {/* Hedge loser reclaimed usage + billed cost */}
+                    {hedgeLoserBilling &&
+                      renderHedgeAttemptUsage({
+                        accent: "loser",
+                        costUsd: hedgeLoserBilling.costUsd,
+                        inputTokens: hedgeLoserBilling.inputTokens,
+                        outputTokens: hedgeLoserBilling.outputTokens,
+                        cacheCreationInputTokens: hedgeLoserBilling.cacheCreationInputTokens,
+                        cacheReadInputTokens: hedgeLoserBilling.cacheReadInputTokens,
+                      })}
 
                     {/* Session Reuse Info */}
                     {isSessionReuse && item.decisionContext && (

--- a/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx
@@ -12,6 +12,8 @@ import {
   Loader2,
   Monitor,
   Settings2,
+  Trophy,
+  XCircle,
   Zap,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -26,7 +28,7 @@ import { Link } from "@/i18n/routing";
 import { cn, formatTokenAmount } from "@/lib/utils";
 import { extractAnthropicEffortInfo } from "@/lib/utils/anthropic-effort";
 import { formatCurrency } from "@/lib/utils/currency";
-import { summarizeHedgeBilling } from "@/lib/utils/hedge-billing";
+import { buildHedgeBillingTable } from "@/lib/utils/hedge-billing";
 import { resolveModelAuditDisplay } from "@/lib/utils/model-audit-display";
 import {
   getPricingResolutionSpecialSetting,
@@ -63,6 +65,7 @@ export function SummaryTab({
   groupCostMultiplier,
   costBreakdown,
   hedgeLosers,
+  providerChain,
   context1mApplied,
   durationMs,
   ttfbMs,
@@ -618,32 +621,137 @@ export function SummaryTab({
               })()}
             </div>
 
-            {/* Provider Racing (hedge) split */}
+            {/* Provider Racing (hedge) per-attempt billing table. Each attempt
+                (winner + every billed loser) shows the token usage it reclaimed
+                and its billed cost, so the merged request total is fully itemized. */}
             {(() => {
-              const hedgeSummary = summarizeHedgeBilling(costUsd, hedgeLosers);
-              if (!hedgeSummary) return null;
+              const hedgeWinnerStep =
+                providerChain?.find((item) => item.reason === "hedge_winner") ?? null;
+              const hedgeTable = buildHedgeBillingTable(costUsd, hedgeLosers, {
+                providerId: hedgeWinnerStep?.id ?? null,
+                providerName: hedgeWinnerStep?.name ?? null,
+                attemptNumber: hedgeWinnerStep?.attemptNumber ?? null,
+                inputTokens,
+                outputTokens,
+                cacheCreationInputTokens,
+                cacheReadInputTokens,
+              });
+              if (!hedgeTable) return null;
+              const tokenCols =
+                2 + (hedgeTable.hasCacheWrite ? 1 : 0) + (hedgeTable.hasCacheRead ? 1 : 0);
               return (
-                <div className="pt-3 border-t space-y-2 text-sm">
-                  <div className="font-medium text-muted-foreground">
-                    {t("billingDetails.hedgeRacing")}
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">
-                      {t("billingDetails.hedgeWinner")}:
+                <div className="pt-3 border-t space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-medium text-muted-foreground">
+                      {t("billingDetails.hedgeRacing")}
                     </span>
-                    <span className="font-mono">
-                      {formatCurrency(hedgeSummary.winnerCost, "USD", 6)}
-                    </span>
+                    <Badge variant="outline" className="text-[10px]">
+                      {t("billingDetails.hedgeMergedCount", { count: hedgeTable.count })}
+                    </Badge>
                   </div>
-                  {hedgeSummary.losers.map((loser) => (
-                    <div
-                      key={`${loser.providerId}-${loser.attemptNumber}`}
-                      className="flex justify-between text-rose-600 dark:text-rose-400"
-                    >
-                      <span className="truncate">{loser.providerName}:</span>
-                      <span className="font-mono">{formatCurrency(loser.costUsd, "USD", 6)}</span>
-                    </div>
-                  ))}
+                  <div className="overflow-x-auto rounded-md border">
+                    <table className="w-full text-xs">
+                      <thead>
+                        <tr className="border-b bg-muted/40 text-muted-foreground">
+                          <th className="px-2 py-1.5 text-left font-medium">
+                            {t("billingDetails.hedgeColAttempt")}
+                          </th>
+                          <th className="px-2 py-1.5 text-right font-medium">
+                            {t("billingDetails.input")}
+                          </th>
+                          <th className="px-2 py-1.5 text-right font-medium">
+                            {t("billingDetails.output")}
+                          </th>
+                          {hedgeTable.hasCacheWrite && (
+                            <th className="px-2 py-1.5 text-right font-medium">
+                              {t("billingDetails.hedgeColCacheWrite")}
+                            </th>
+                          )}
+                          {hedgeTable.hasCacheRead && (
+                            <th className="px-2 py-1.5 text-right font-medium">
+                              {t("billingDetails.hedgeColCacheRead")}
+                            </th>
+                          )}
+                          <th className="px-2 py-1.5 text-right font-medium">
+                            {t("billingDetails.hedgeColCost")}
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {hedgeTable.attempts.map((attempt) => {
+                          const isWinner = attempt.kind === "winner";
+                          return (
+                            <tr
+                              key={`${attempt.kind}-${attempt.providerId ?? "na"}-${attempt.attemptNumber ?? 0}`}
+                              className="border-b last:border-0"
+                            >
+                              <td className="px-2 py-1.5">
+                                <div className="flex items-center gap-1.5 min-w-0">
+                                  {isWinner ? (
+                                    <Trophy className="h-3 w-3 shrink-0 text-emerald-600" />
+                                  ) : (
+                                    <XCircle className="h-3 w-3 shrink-0 text-rose-500" />
+                                  )}
+                                  <span
+                                    className={cn(
+                                      "truncate",
+                                      isWinner
+                                        ? "text-foreground"
+                                        : "text-rose-600 dark:text-rose-400"
+                                    )}
+                                  >
+                                    {attempt.providerName ??
+                                      (isWinner
+                                        ? t("billingDetails.hedgeWinnerShort")
+                                        : t("billingDetails.hedgeLoserShort"))}
+                                  </span>
+                                  {attempt.attemptNumber != null && (
+                                    <span className="shrink-0 text-muted-foreground">
+                                      #{attempt.attemptNumber}
+                                    </span>
+                                  )}
+                                </div>
+                              </td>
+                              <td className="px-2 py-1.5 text-right font-mono">
+                                {formatTokenAmount(attempt.inputTokens)}
+                              </td>
+                              <td className="px-2 py-1.5 text-right font-mono">
+                                {formatTokenAmount(attempt.outputTokens)}
+                              </td>
+                              {hedgeTable.hasCacheWrite && (
+                                <td className="px-2 py-1.5 text-right font-mono">
+                                  {formatTokenAmount(attempt.cacheCreationInputTokens)}
+                                </td>
+                              )}
+                              {hedgeTable.hasCacheRead && (
+                                <td className="px-2 py-1.5 text-right font-mono">
+                                  {formatTokenAmount(attempt.cacheReadInputTokens)}
+                                </td>
+                              )}
+                              <td
+                                className={cn(
+                                  "px-2 py-1.5 text-right font-mono",
+                                  isWinner ? "" : "text-rose-600 dark:text-rose-400"
+                                )}
+                              >
+                                {formatCurrency(attempt.costUsd, "USD", 6)}
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                      <tfoot>
+                        <tr className="border-t bg-muted/40 font-medium">
+                          <td className="px-2 py-1.5" colSpan={1 + tokenCols}>
+                            {t("billingDetails.hedgeMergedCount", { count: hedgeTable.count })}
+                          </td>
+                          <td className="px-2 py-1.5 text-right font-mono text-emerald-600">
+                            {formatCurrency(hedgeTable.total, "USD", 6)}
+                          </td>
+                        </tr>
+                      </tfoot>
+                    </table>
+                  </div>
                 </div>
               );
             })()}

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-table.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-table.test.tsx
@@ -129,6 +129,50 @@ describe("usage-logs-table multiplier badge", () => {
     expect(html).toContain("0.20x");
   });
 
+  test("renders the hedge billing split with cache tokens in the cost tooltip", () => {
+    const html = renderToStaticMarkup(
+      <UsageLogsTable
+        logs={[
+          makeLog({
+            id: 1,
+            costUsd: "0.030000",
+            inputTokens: 100,
+            outputTokens: 50,
+            hedgeLosers: [
+              {
+                providerId: 2,
+                providerName: "loser-a",
+                attemptNumber: 2,
+                costUsd: "0.010000",
+                inputTokens: 80,
+                outputTokens: 20,
+                cacheCreationInputTokens: 0,
+                cacheReadInputTokens: 5000,
+              },
+            ],
+          }),
+        ]}
+        total={1}
+        page={1}
+        pageSize={50}
+        onPageChange={() => {}}
+        isPending={false}
+      />
+    );
+
+    expect(html).toContain("logs.billingDetails.hedgeRacing");
+    expect(html).toContain("logs.billingDetails.hedgeMergedCount");
+    expect(html).toContain("logs.billingDetails.hedgeWinner");
+    expect(html).toContain("loser-a");
+    // winnerCost = costUsd - sum(losers) = 0.030 - 0.010
+    expect(html).toContain("$0.020000");
+    expect(html).toContain("$0.010000");
+    // Token-total line includes cache-read (present) but omits cache-write (zero).
+    expect(html).toContain("logs.billingDetails.hedgeTokenTotal");
+    expect(html).toContain("logs.billingDetails.hedgeColCacheRead");
+    expect(html).not.toContain("logs.billingDetails.hedgeColCacheWrite");
+  });
+
   test("renders warmup skipped and blocked labels", () => {
     const htmlWarmup = renderToStaticMarkup(
       <UsageLogsTable

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
@@ -21,7 +21,7 @@ import { cn, formatTokenAmount } from "@/lib/utils";
 import { copyTextToClipboard } from "@/lib/utils/clipboard";
 import type { CurrencyCode } from "@/lib/utils/currency";
 import { formatCurrency } from "@/lib/utils/currency";
-import { summarizeHedgeBilling } from "@/lib/utils/hedge-billing";
+import { buildHedgeBillingTable } from "@/lib/utils/hedge-billing";
 import {
   calculateOutputRate,
   formatDuration,
@@ -479,35 +479,62 @@ export function UsageLogsTable({
                                 </div>
                               )}
                               {(() => {
-                                const hedgeSummary = summarizeHedgeBilling(
+                                const hedgeTable = buildHedgeBillingTable(
                                   log.costUsd,
-                                  log.hedgeLosers
+                                  log.hedgeLosers,
+                                  {
+                                    inputTokens: log.inputTokens,
+                                    outputTokens: log.outputTokens,
+                                    cacheCreationInputTokens: log.cacheCreationInputTokens,
+                                    cacheReadInputTokens: log.cacheReadInputTokens,
+                                  }
                                 );
-                                if (!hedgeSummary) return null;
+                                if (!hedgeTable) return null;
                                 return (
                                   <div className="mt-1 border-t pt-1 space-y-0.5">
-                                    <div className="font-medium">
-                                      {t("logs.billingDetails.hedgeRacing")}
+                                    <div className="flex items-center justify-between gap-2">
+                                      <span className="font-medium">
+                                        {t("logs.billingDetails.hedgeRacing")}
+                                      </span>
+                                      <span className="rounded-full border px-1.5 text-[10px] text-muted-foreground">
+                                        {t("logs.billingDetails.hedgeMergedCount", {
+                                          count: hedgeTable.count,
+                                        })}
+                                      </span>
                                     </div>
                                     <div className="flex justify-between gap-3">
                                       <span className="text-muted-foreground">
                                         {t("logs.billingDetails.hedgeWinner")}
                                       </span>
                                       <span className="font-mono">
-                                        {formatCurrency(hedgeSummary.winnerCost, currencyCode, 6)}
+                                        {formatCurrency(hedgeTable.winnerCost, currencyCode, 6)}
                                       </span>
                                     </div>
-                                    {hedgeSummary.losers.map((loser) => (
-                                      <div
-                                        key={`${loser.providerId}-${loser.attemptNumber}`}
-                                        className="flex justify-between gap-3 text-rose-600 dark:text-rose-400"
-                                      >
-                                        <span className="truncate">{loser.providerName}</span>
-                                        <span className="font-mono">
-                                          {formatCurrency(loser.costUsd, currencyCode, 6)}
-                                        </span>
-                                      </div>
-                                    ))}
+                                    {hedgeTable.attempts
+                                      .filter((attempt) => attempt.kind === "loser")
+                                      .map((loser) => (
+                                        <div
+                                          key={`${loser.providerId}-${loser.attemptNumber}`}
+                                          className="flex justify-between gap-3 text-rose-600 dark:text-rose-400"
+                                        >
+                                          <span className="truncate">
+                                            {loser.providerName ??
+                                              t("logs.billingDetails.hedgeLoserShort")}
+                                          </span>
+                                          <span className="font-mono">
+                                            {formatCurrency(loser.costUsd, currencyCode, 6)}
+                                          </span>
+                                        </div>
+                                      ))}
+                                    <div className="flex justify-between gap-3 border-t pt-1 text-muted-foreground">
+                                      <span>{t("logs.billingDetails.hedgeTokenTotal")}</span>
+                                      <span className="font-mono">
+                                        {formatTokenAmount(hedgeTable.tokenTotals.inputTokens)}{" "}
+                                        {t("logs.billingDetails.input")} ·{" "}
+                                        {formatTokenAmount(hedgeTable.tokenTotals.outputTokens)}{" "}
+                                        {t("logs.billingDetails.output")}
+                                      </span>
+                                    </div>
                                   </div>
                                 );
                               })()}

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
@@ -529,10 +529,20 @@ export function UsageLogsTable({
                                     <div className="flex justify-between gap-3 border-t pt-1 text-muted-foreground">
                                       <span>{t("logs.billingDetails.hedgeTokenTotal")}</span>
                                       <span className="font-mono">
-                                        {formatTokenAmount(hedgeTable.tokenTotals.inputTokens)}{" "}
-                                        {t("logs.billingDetails.input")} ·{" "}
-                                        {formatTokenAmount(hedgeTable.tokenTotals.outputTokens)}{" "}
-                                        {t("logs.billingDetails.output")}
+                                        {[
+                                          `${formatTokenAmount(hedgeTable.tokenTotals.inputTokens)} ${t("logs.billingDetails.input")}`,
+                                          `${formatTokenAmount(hedgeTable.tokenTotals.outputTokens)} ${t("logs.billingDetails.output")}`,
+                                          ...(hedgeTable.hasCacheWrite
+                                            ? [
+                                                `${formatTokenAmount(hedgeTable.tokenTotals.cacheCreationInputTokens)} ${t("logs.billingDetails.hedgeColCacheWrite")}`,
+                                              ]
+                                            : []),
+                                          ...(hedgeTable.hasCacheRead
+                                            ? [
+                                                `${formatTokenAmount(hedgeTable.tokenTotals.cacheReadInputTokens)} ${t("logs.billingDetails.hedgeColCacheRead")}`,
+                                              ]
+                                            : []),
+                                        ].join(" · ")}
                                       </span>
                                     </div>
                                   </div>

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
@@ -625,6 +625,42 @@ describe("virtualized-logs-table multiplier badge", () => {
     expect(tooltip.textContent).not.toContain("logs.billingDetails.providerMultiplier");
     expect(tooltip.textContent).not.toContain("logs.billingDetails.pricingProvider");
   });
+
+  test("renders the hedge billing split with cache tokens in the cost tooltip", () => {
+    const tooltip = renderCostTooltipWithLog({
+      costUsd: "0.030000",
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      costBreakdown: null,
+      hedgeLosers: [
+        {
+          providerId: 2,
+          providerName: "loser-a",
+          attemptNumber: 2,
+          costUsd: "0.010000",
+          inputTokens: 80,
+          outputTokens: 20,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 5000,
+        },
+      ],
+    });
+
+    // Merged-count badge + winner/loser split render for a hedged request.
+    expect(tooltip.textContent).toContain("logs.billingDetails.hedgeRacing");
+    expect(tooltip.textContent).toContain("logs.billingDetails.hedgeMergedCount");
+    expect(tooltip.textContent).toContain("logs.billingDetails.hedgeWinner");
+    expect(tooltip.textContent).toContain("loser-a");
+    // winnerCost = costUsd - sum(losers) = 0.030 - 0.010
+    expect(tooltip.textContent).toContain("$0.020000");
+    expect(tooltip.textContent).toContain("$0.010000");
+    // Token-total line includes cache-read (present) but omits cache-write (zero).
+    expect(tooltip.textContent).toContain("logs.billingDetails.hedgeTokenTotal");
+    expect(tooltip.textContent).toContain("logs.billingDetails.hedgeColCacheRead");
+    expect(tooltip.textContent).not.toContain("logs.billingDetails.hedgeColCacheWrite");
+  });
 });
 
 describe("virtualized-logs-table live chain display", () => {

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -29,7 +29,7 @@ import { cn, formatTokenAmount } from "@/lib/utils";
 import { copyTextToClipboard } from "@/lib/utils/clipboard";
 import type { CurrencyCode } from "@/lib/utils/currency";
 import { Decimal, formatCurrency, toDecimal } from "@/lib/utils/currency";
-import { summarizeHedgeBilling } from "@/lib/utils/hedge-billing";
+import { buildHedgeBillingTable } from "@/lib/utils/hedge-billing";
 import {
   calculateOutputRate,
   formatDuration,
@@ -434,28 +434,50 @@ export function VirtualizedLogsTable({
     const isActiveMultiplier = (value: number) =>
       Number.isFinite(value) && value > 0 && value !== 1;
 
-    const hedgeSummary = summarizeHedgeBilling(log.costUsd, log.hedgeLosers);
-    const hedgeSection = hedgeSummary ? (
+    const hedgeTable = buildHedgeBillingTable(log.costUsd, log.hedgeLosers, {
+      inputTokens: log.inputTokens,
+      outputTokens: log.outputTokens,
+      cacheCreationInputTokens: log.cacheCreationInputTokens,
+      cacheReadInputTokens: log.cacheReadInputTokens,
+    });
+    const hedgeSection = hedgeTable ? (
       <div className="space-y-2 border-t border-background/20 pt-2">
-        <span className="text-[11px] font-semibold text-background/80">
-          {t("logs.billingDetails.hedgeRacing")}
-        </span>
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[11px] font-semibold text-background/80">
+            {t("logs.billingDetails.hedgeRacing")}
+          </span>
+          <span className="rounded-full bg-background/15 px-1.5 py-0.5 text-[10px] text-background/80">
+            {t("logs.billingDetails.hedgeMergedCount", { count: hedgeTable.count })}
+          </span>
+        </div>
         <div className="space-y-2">
           {renderSummaryRow({
             label: t("logs.billingDetails.hedgeWinner"),
-            primary: formatCurrency(hedgeSummary.winnerCost, currencyCode, 6),
+            primary: formatCurrency(hedgeTable.winnerCost, currencyCode, 6),
           })}
-          {hedgeSummary.losers.map((loser) => (
-            <div
-              key={`${loser.providerId}-${loser.attemptNumber}`}
-              className="flex items-start justify-between gap-3"
-            >
-              <span className="text-[11px] text-rose-300/80 truncate">{loser.providerName}</span>
-              <span className={cn(amountClassName, "text-rose-300/80")}>
-                {formatCurrency(loser.costUsd, currencyCode, 6)}
-              </span>
-            </div>
-          ))}
+          {hedgeTable.attempts
+            .filter((attempt) => attempt.kind === "loser")
+            .map((loser) => (
+              <div
+                key={`${loser.providerId}-${loser.attemptNumber}`}
+                className="flex items-start justify-between gap-3"
+              >
+                <span className="text-[11px] text-rose-300/80 truncate">
+                  {loser.providerName ?? t("logs.billingDetails.hedgeLoserShort")}
+                </span>
+                <span className={cn(amountClassName, "text-rose-300/80")}>
+                  {formatCurrency(loser.costUsd, currencyCode, 6)}
+                </span>
+              </div>
+            ))}
+        </div>
+        <div className="flex items-center justify-between gap-3 border-t border-background/20 pt-2 text-[11px] text-background/70">
+          <span>{t("logs.billingDetails.hedgeTokenTotal")}</span>
+          <span className="font-mono">
+            {formatTokenAmount(hedgeTable.tokenTotals.inputTokens)} {t("logs.billingDetails.input")}{" "}
+            · {formatTokenAmount(hedgeTable.tokenTotals.outputTokens)}{" "}
+            {t("logs.billingDetails.output")}
+          </span>
         </div>
       </div>
     ) : null;

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -474,9 +474,20 @@ export function VirtualizedLogsTable({
         <div className="flex items-center justify-between gap-3 border-t border-background/20 pt-2 text-[11px] text-background/70">
           <span>{t("logs.billingDetails.hedgeTokenTotal")}</span>
           <span className="font-mono">
-            {formatTokenAmount(hedgeTable.tokenTotals.inputTokens)} {t("logs.billingDetails.input")}{" "}
-            · {formatTokenAmount(hedgeTable.tokenTotals.outputTokens)}{" "}
-            {t("logs.billingDetails.output")}
+            {[
+              `${formatTokenAmount(hedgeTable.tokenTotals.inputTokens)} ${t("logs.billingDetails.input")}`,
+              `${formatTokenAmount(hedgeTable.tokenTotals.outputTokens)} ${t("logs.billingDetails.output")}`,
+              ...(hedgeTable.hasCacheWrite
+                ? [
+                    `${formatTokenAmount(hedgeTable.tokenTotals.cacheCreationInputTokens)} ${t("logs.billingDetails.hedgeColCacheWrite")}`,
+                  ]
+                : []),
+              ...(hedgeTable.hasCacheRead
+                ? [
+                    `${formatTokenAmount(hedgeTable.tokenTotals.cacheReadInputTokens)} ${t("logs.billingDetails.hedgeColCacheRead")}`,
+                  ]
+                : []),
+            ].join(" · ")}
           </span>
         </div>
       </div>

--- a/src/lib/utils/hedge-billing.ts
+++ b/src/lib/utils/hedge-billing.ts
@@ -46,6 +46,133 @@ export function summarizeHedgeBilling(
 }
 
 /**
+ * One row of the per-attempt hedge billing table: the winner plus each billed
+ * loser, each carrying its reclaimed token usage and its billed cost so the UI
+ * can show exactly how the merged request total was composed.
+ */
+export interface HedgeAttemptRow {
+  kind: "winner" | "loser";
+  providerId: number | null;
+  providerName: string | null;
+  /** Hedge attempt sequence (1 = initial provider); null when unknown. */
+  attemptNumber: number | null;
+  /** Billed cost (decimal string) for this attempt. */
+  costUsd: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+}
+
+/**
+ * Full per-attempt billing breakdown for a hedged request: the winner row plus
+ * one row per billed loser, with summed token totals and the grand total. The
+ * request list tooltips and the detail dialog billing card derive from this; the
+ * decision chain derives from the same {@link summarizeHedgeBilling} primitive,
+ * so all surfaces agree on the winner/loser/total figures.
+ */
+export interface HedgeBillingTable {
+  /** Winner first, then losers ordered by attempt number. */
+  attempts: HedgeAttemptRow[];
+  /** Grand-total cost (decimal string) — winner + all losers. */
+  total: string;
+  /** Winner's cost = total - sum(losers), clamped at 0 (decimal string). */
+  winnerCost: string;
+  /** Number of billed attempts (1 winner + N losers). */
+  count: number;
+  /** Whether any attempt read from cache (controls the cache-read column). */
+  hasCacheRead: boolean;
+  /** Whether any attempt wrote to cache (controls the cache-write column). */
+  hasCacheWrite: boolean;
+  /** Token usage summed across every attempt. */
+  tokenTotals: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheCreationInputTokens: number;
+    cacheReadInputTokens: number;
+  };
+}
+
+/** Winner token/identity context (from the finalized request row). */
+export interface HedgeWinnerInput {
+  providerId?: number | null;
+  providerName?: string | null;
+  attemptNumber?: number | null;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  cacheCreationInputTokens?: number | null;
+  cacheReadInputTokens?: number | null;
+}
+
+function toCount(value: number | null | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/**
+ * Build the per-attempt billing table for a hedged request, or null when no
+ * hedge loser was billed (the common case — render nothing extra then). The
+ * winner's token usage comes from the finalized request row; each loser's usage
+ * is read from its stored billing entry.
+ */
+export function buildHedgeBillingTable(
+  costUsd: string | null | undefined,
+  hedgeLosers: HedgeLoserBilling[] | null | undefined,
+  winner?: HedgeWinnerInput
+): HedgeBillingTable | null {
+  const summary = summarizeHedgeBilling(costUsd, hedgeLosers);
+  if (!summary) {
+    return null;
+  }
+
+  const winnerRow: HedgeAttemptRow = {
+    kind: "winner",
+    providerId: winner?.providerId ?? null,
+    providerName: winner?.providerName ?? null,
+    attemptNumber: winner?.attemptNumber ?? null,
+    costUsd: summary.winnerCost,
+    inputTokens: toCount(winner?.inputTokens),
+    outputTokens: toCount(winner?.outputTokens),
+    cacheCreationInputTokens: toCount(winner?.cacheCreationInputTokens),
+    cacheReadInputTokens: toCount(winner?.cacheReadInputTokens),
+  };
+
+  const loserRows: HedgeAttemptRow[] = [...summary.losers]
+    .sort((a, b) => a.attemptNumber - b.attemptNumber)
+    .map((loser) => ({
+      kind: "loser" as const,
+      providerId: loser.providerId,
+      providerName: loser.providerName,
+      attemptNumber: loser.attemptNumber,
+      costUsd: loser.costUsd,
+      inputTokens: toCount(loser.inputTokens),
+      outputTokens: toCount(loser.outputTokens),
+      cacheCreationInputTokens: toCount(loser.cacheCreationInputTokens),
+      cacheReadInputTokens: toCount(loser.cacheReadInputTokens),
+    }));
+
+  const attempts = [winnerRow, ...loserRows];
+  const tokenTotals = attempts.reduce(
+    (acc, attempt) => ({
+      inputTokens: acc.inputTokens + attempt.inputTokens,
+      outputTokens: acc.outputTokens + attempt.outputTokens,
+      cacheCreationInputTokens: acc.cacheCreationInputTokens + attempt.cacheCreationInputTokens,
+      cacheReadInputTokens: acc.cacheReadInputTokens + attempt.cacheReadInputTokens,
+    }),
+    { inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 }
+  );
+
+  return {
+    attempts,
+    total: summary.total,
+    winnerCost: summary.winnerCost,
+    count: attempts.length,
+    hasCacheRead: attempts.some((attempt) => attempt.cacheReadInputTokens > 0),
+    hasCacheWrite: attempts.some((attempt) => attempt.cacheCreationInputTokens > 0),
+    tokenTotals,
+  };
+}
+
+/**
  * Look up the billed cost for a specific hedge loser by provider + attempt, used
  * to annotate decision-chain entries. Returns null when not found.
  */

--- a/tests/unit/lib/hedge-billing.test.ts
+++ b/tests/unit/lib/hedge-billing.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { HedgeLoserBilling } from "@/types/cost-breakdown";
-import { findHedgeLoserCost, summarizeHedgeBilling } from "@/lib/utils/hedge-billing";
+import {
+  buildHedgeBillingTable,
+  findHedgeLoserCost,
+  summarizeHedgeBilling,
+} from "@/lib/utils/hedge-billing";
 
 function loser(overrides: Partial<HedgeLoserBilling>): HedgeLoserBilling {
   return {
@@ -42,6 +46,106 @@ describe("summarizeHedgeBilling", () => {
     expect(Number(summary?.total)).toBe(0);
     expect(Number(summary?.winnerCost)).toBe(0);
     expect(Number(summary?.loserTotal)).toBeCloseTo(0.5, 9);
+  });
+});
+
+describe("buildHedgeBillingTable", () => {
+  it("returns null when there are no losers", () => {
+    expect(buildHedgeBillingTable("0.01", null, { inputTokens: 5 })).toBeNull();
+    expect(buildHedgeBillingTable("0.01", [])).toBeNull();
+  });
+
+  it("puts the winner first, then losers sorted by attempt number", () => {
+    const table = buildHedgeBillingTable(
+      "0.010",
+      [
+        loser({ providerId: 3, providerName: "loserB", attemptNumber: 3, costUsd: "0.002" }),
+        loser({ providerId: 2, providerName: "loserA", attemptNumber: 2, costUsd: "0.003" }),
+      ],
+      { providerId: 1, providerName: "winner", attemptNumber: 1 }
+    );
+    expect(table).not.toBeNull();
+    expect(table?.attempts.map((a) => a.kind)).toEqual(["winner", "loser", "loser"]);
+    expect(table?.attempts.map((a) => a.providerName)).toEqual(["winner", "loserA", "loserB"]);
+    expect(table?.count).toBe(3);
+    expect(Number(table?.winnerCost)).toBeCloseTo(0.005, 9);
+    expect(Number(table?.total)).toBeCloseTo(0.01, 9);
+  });
+
+  it("sums token usage across every attempt", () => {
+    const table = buildHedgeBillingTable(
+      "0.02",
+      [
+        loser({
+          providerId: 2,
+          attemptNumber: 2,
+          costUsd: "0.004",
+          inputTokens: 1000,
+          outputTokens: 200,
+          cacheReadInputTokens: 50,
+        }),
+      ],
+      {
+        inputTokens: 1000,
+        outputTokens: 800,
+        cacheCreationInputTokens: 300,
+        cacheReadInputTokens: 0,
+      }
+    );
+    expect(table?.tokenTotals).toEqual({
+      inputTokens: 2000,
+      outputTokens: 1000,
+      cacheCreationInputTokens: 300,
+      cacheReadInputTokens: 50,
+    });
+    expect(table?.hasCacheRead).toBe(true);
+    expect(table?.hasCacheWrite).toBe(true);
+  });
+
+  it("coerces missing/invalid token counts to zero and defaults provider fields to null", () => {
+    const table = buildHedgeBillingTable("0.01", [
+      loser({ providerId: 2, attemptNumber: 2, costUsd: "0.001", inputTokens: undefined }),
+    ]);
+    const winner = table?.attempts[0];
+    expect(winner?.providerName).toBeNull();
+    expect(winner?.attemptNumber).toBeNull();
+    expect(winner?.inputTokens).toBe(0);
+    expect(table?.attempts[1]?.inputTokens).toBe(0);
+    expect(table?.hasCacheRead).toBe(false);
+    expect(table?.hasCacheWrite).toBe(false);
+  });
+
+  it("clamps negative, NaN, and zero token counts to zero (toCount value>0 / isFinite guard)", () => {
+    const table = buildHedgeBillingTable(
+      "0.01",
+      [
+        loser({
+          providerId: 2,
+          attemptNumber: 2,
+          costUsd: "0.001",
+          inputTokens: -50,
+          outputTokens: Number.NaN,
+          cacheReadInputTokens: 0,
+          cacheCreationInputTokens: Number.POSITIVE_INFINITY,
+        }),
+      ],
+      { inputTokens: -1, outputTokens: Number.NaN }
+    );
+    const loserRow = table?.attempts[1];
+    expect(loserRow?.inputTokens).toBe(0);
+    expect(loserRow?.outputTokens).toBe(0);
+    expect(loserRow?.cacheReadInputTokens).toBe(0);
+    expect(loserRow?.cacheCreationInputTokens).toBe(0);
+    expect(table?.attempts[0]?.inputTokens).toBe(0);
+    expect(table?.attempts[0]?.outputTokens).toBe(0);
+    expect(table?.tokenTotals).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+    });
+    expect(table?.hasCacheRead).toBe(false);
+    expect(table?.hasCacheWrite).toBe(false);
   });
 });
 


### PR DESCRIPTION
## 背景

`#1247` 引入了"供应商竞速输家计费"(保活拿回响应 + 幂等累加回写),但前端只显示了"输家已计费"——决策链里没有输家实际拿回的 token 用量,计费概览也没把多次请求的计费清晰拆分。用户无法看清一个请求的费用到底是怎么算出来的。

本 PR 是**纯前端**重设计(每次尝试的 token 用量与费用早已持久化在 `message_request.hedge_losers` 与行 `costUsd`,无需后端改动),让赢家与每个输家各自的 token、各自的费用、以及合并总额一目了然。

## 改动

- **计费概览(详情卡 `SummaryTab`)**:用一张**逐次表格**替换原先的费用列表——行 = 每次尝试(🏆 赢家 / ✗ 各输家,带供应商名 + #序号),列 = 输入/输出/(缓存写)/(缓存读)/费用(缓存列有值才显示),表脚 = "合并 N 次请求 → 总额"。
- **决策链(`LogicTraceTab`)**:赢家步骤补上 token 网格 + 费用;输家步骤新增"已拿回响应,未交付客户端"备注 + token 网格 + 计费金额。
- **列表 Tooltip(`usage-logs-table` / `virtualized-logs-table`)**:费用拆分 + "合并 N 次"徽章 + token 合计行。
- **共享派生 `buildHedgeBillingTable`**(`src/lib/utils/hedge-billing.ts`):三处 UI 的单一事实来源,`winnerCost = costUsd − Σ(输家)` 夹紧 ≥0,token 跨尝试求和;附单元测试。
- **i18n**:5 语言 × 2 命名空间新增 9 个 key。

## 设计决策

用户在三个 UI 选项上拍板:计费卡=逐次表格;Tooltip=费用拆分+token合计+次数徽章(每次明细留给详情卡);决策链=赢家与输家都展示 token+费用。

## 验证

- `bun run build` ✅ · `bun run typecheck` ✅ · `bun run test` 6342 passed / 13 skipped ✅ · biome ✅
- 经多智能体深度评审(5 人评审组)+ `/code-review` xhigh 复核:**无 correctness 阻断项**;金额计算、token 求和、`colSpan`、React key、5 语言 i18n 对齐均确认正确。复核中发现的 4 项小问题已在本 PR 内修复(0-token 显示守卫、负数/NaN 钳制测试、文档注释更正、移除死字段)。

## 后续(本 PR 未做)

- 抽取两张表共享的 Tooltip 渲染组件,消除 `usage-logs-table` / `virtualized-logs-table` 的重复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR is a pure frontend redesign that replaces the single "hedge losers billed" indicator with a per-attempt billing breakdown across three surfaces: the `SummaryTab` billing card (now a full table), the `LogicTraceTab` decision chain (winner and loser steps each show reclaimed token usage and cost), and both table row tooltips (cost split + token totals). All three surfaces derive from a new shared `buildHedgeBillingTable` utility, which builds on the existing `summarizeHedgeBilling` primitive and adds token aggregation, cache-column visibility flags, and winner-first row ordering.

- **`src/lib/utils/hedge-billing.ts`**: New `buildHedgeBillingTable` function is the single source of truth; `toCount` coerces invalid (negative, NaN, Infinity) values to zero; winner cost is still derived as `total − Σ(losers)` clamped at 0.
- **UI surfaces** (`SummaryTab`, `LogicTraceTab`, `usage-logs-table`, `virtualized-logs-table`): All migrated from `summarizeHedgeBilling` to `buildHedgeBillingTable`; cache columns are shown conditionally; 9 i18n keys added across 5 languages; comprehensive component tests added alongside unit tests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is frontend-only and purely additive — no backend, database, or API contract is altered.

All cost and token math is delegated to the well-tested buildHedgeBillingTable / summarizeHedgeBilling chain. The colSpan arithmetic in the new SummaryTab table is correct. Edge cases (negative/NaN/Infinity token counts, missing winner context, absent providerChain) are explicitly handled and covered by unit tests. Build, typecheck, and the full test suite all pass per the PR description.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/lib/utils/hedge-billing.ts | New buildHedgeBillingTable wraps the existing summarizeHedgeBilling; toCount safely coerces invalid numbers to 0; loser sort is safe since HedgeLoserBilling.attemptNumber is number (non-nullable). Logic is correct. |
| src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx | Replaces the flat winner/loser list with a full per-attempt table; colSpan calculation (1 + tokenCols) correctly spans all columns except the last cost column; winner identity gracefully degrades to fallback text when providerChain is absent. |
| src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/LogicTraceTab.tsx | Adds renderHedgeAttemptUsage helper for winner/loser token+cost display in the decision chain; token label ordering uses label-first ("Input 300") which is inconsistent with the tooltip tables. |
| src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx | Migrated to buildHedgeBillingTable; adds cost split, token totals with conditional cache columns, and merged-count badge to the cost tooltip. |
| src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx | Mirror of usage-logs-table changes; identical token totals rendering logic including conditional cache columns. |
| tests/unit/lib/hedge-billing.test.ts | Good coverage: null/empty cases, winner-first ordering, token sums across attempts, null/missing field coercion, negative/NaN/Infinity clamping via toCount. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request row data\ncostUsd + hedgeLosers + tokens] --> B[buildHedgeBillingTable]
    B --> C{hedgeLosers\npresent?}
    C -- No --> D[null — render nothing]
    C -- Yes --> E[summarizeHedgeBilling\nwinnerCost = total − Σlosers ≥ 0]
    E --> F[Build winnerRow\nfrom request-row tokens]
    E --> G[Build loserRows\nsorted by attemptNumber]
    F --> H[attempts = winner + losers]
    G --> H
    H --> I[tokenTotals = Σ all attempts]
    H --> J[hasCacheRead / hasCacheWrite flags]
    I --> K[HedgeBillingTable]
    J --> K
    K --> L[SummaryTab\nper-attempt table with\nconditional cache columns]
    K --> M[usage-logs-table tooltip\ncost split + token totals]
    K --> N[virtualized-logs-table tooltip\ncost split + token totals]
    E --> O[LogicTraceTab\ndecision-chain badges\nwinner + loser steps]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx`, line 587-594 ([link](https://github.com/ding113/claude-code-hub/blob/7f2715397a4c7fc38f13e7ad39b34588b11b7e92/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx#L587-L594)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cache token totals silently dropped from tooltip**

   `buildHedgeBillingTable` always computes `tokenTotals.cacheCreationInputTokens` and `tokenTotals.cacheReadInputTokens`, but the "Total tokens" row in the tooltip only renders input and output. For requests that used prompt caching heavily (where cache tokens can represent a significant share of spend), the per-attempt total in the tooltip is misleading — it shows the cheaper `output` count but omits the potentially large cache-write volume. The detailed `SummaryTab` table does display cache columns, so only the compact tooltip is affected.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
   Line: 587-594

   Comment:
   **Cache token totals silently dropped from tooltip**

   `buildHedgeBillingTable` always computes `tokenTotals.cacheCreationInputTokens` and `tokenTotals.cacheReadInputTokens`, but the "Total tokens" row in the tooltip only renders input and output. For requests that used prompt caching heavily (where cache tokens can represent a significant share of spend), the per-attempt total in the tooltip is misleading — it shows the cheaper `output` count but omits the potentially large cache-write volume. The detailed `SummaryTab` table does display cache columns, so only the compact tooltip is affected.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx`, line 680-686 ([link](https://github.com/ding113/claude-code-hub/blob/7f2715397a4c7fc38f13e7ad39b34588b11b7e92/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx#L680-L686)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cache token totals silently dropped from tooltip**

   Same as `usage-logs-table.tsx`: the "Total tokens" summary line only shows input and output from `hedgeTable.tokenTotals`, while `cacheCreationInputTokens` and `cacheReadInputTokens` are computed but never rendered. For cache-heavy hedge requests the displayed total significantly understates actual token usage. The `SummaryTab` table already handles this correctly with its optional cache columns.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
   Line: 680-686

   Comment:
   **Cache token totals silently dropped from tooltip**

   Same as `usage-logs-table.tsx`: the "Total tokens" summary line only shows input and output from `hedgeTable.tokenTotals`, while `cacheCreationInputTokens` and `cacheReadInputTokens` are computed but never rendered. For cache-heavy hedge requests the displayed total significantly understates actual token usage. The `SummaryTab` table already handles this correctly with its optional cache columns.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/LogicTraceTab.tsx:100-113
Token label ordering is reversed compared to the tooltip tables. Both `usage-logs-table` and `virtualized-logs-table` format token counts as `"300 Input · 50 Output"` (count-first), but `renderHedgeAttemptUsage` here builds them as `"Input 300 · Output 50"` (label-first). A user jumping between the decision-chain view and the table tooltip will see the same data in two different orderings. Aligning to the count-first convention used by the other two surfaces would remove the inconsistency.

```suggestion
    const tokenParts = [
      `${formatTokenAmount(params.inputTokens ?? 0)} ${t("billingDetails.input")}`,
      `${formatTokenAmount(params.outputTokens ?? 0)} ${t("billingDetails.output")}`,
    ];
    if ((params.cacheCreationInputTokens ?? 0) > 0) {
      tokenParts.push(
        `${formatTokenAmount(params.cacheCreationInputTokens ?? 0)} ${t("billingDetails.hedgeColCacheWrite")}`
      );
    }
    if ((params.cacheReadInputTokens ?? 0) > 0) {
      tokenParts.push(
        `${formatTokenAmount(params.cacheReadInputTokens ?? 0)} ${t("billingDetails.hedgeColCacheRead")}`
      );
    }
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(logs): include cache tokens in hedg..."](https://github.com/ding113/claude-code-hub/commit/26aba1311f13cd0f9b7d7011e521ebfdb835b761) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35978706)</sub>

<!-- /greptile_comment -->