### PR TITLE
fix(proxy): finalize completed responses streams after client abort

### DIFF
--- a/src/app/v1/_lib/proxy/response-fixer/index.ts
+++ b/src/app/v1/_lib/proxy/response-fixer/index.ts
@@ -24,11 +24,53 @@ const DEFAULT_CONFIG: ResponseFixerConfig = {
   maxFixSize: 1024 * 1024,
 };
 
+const UTF8_DECODER = new TextDecoder();
+const UTF8_ENCODER = new TextEncoder();
+
 function nowMs(): number {
   if (typeof performance !== "undefined" && typeof performance.now === "function") {
     return performance.now();
   }
   return Date.now();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasMeaningfulValue(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === "string") return value.length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (isRecord(value)) return Object.keys(value).length > 0;
+  return true;
+}
+
+function isInertChatCompletionChoice(choice: unknown): boolean {
+  if (!isRecord(choice)) return false;
+  if (choice.finish_reason != null) return false;
+
+  const delta = choice.delta;
+  if (!isRecord(delta)) {
+    return true;
+  }
+
+  for (const [key, value] of Object.entries(delta)) {
+    if (key === "role") continue;
+    if (hasMeaningfulValue(value)) return false;
+  }
+
+  return true;
+}
+
+function isInertChatCompletionChunkPayload(payload: unknown): boolean {
+  if (!isRecord(payload)) return false;
+  if (payload.object !== "chat.completion.chunk") return false;
+  if (hasMeaningfulValue(payload.usage)) return false;
+
+  const choices = payload.choices;
+  if (!Array.isArray(choices) || choices.length === 0) return false;
+  return choices.every(isInertChatCompletionChoice);
 }
 
 function toArrayBufferUint8Array(input: Uint8Array): Uint8Array<ArrayBuffer> {
@@ -385,6 +427,13 @@ export class ResponseFixer {
           }
         }
 
+        const filtered = ResponseFixer.filterInertResponsesChatCompletionChunks(session, data);
+        if (filtered.applied) {
+          applied.sse.applied = true;
+          applied.sse.details ??= filtered.details;
+          data = filtered.data;
+        }
+
         controller.enqueue(data);
       },
       flush(controller) {
@@ -416,6 +465,13 @@ export class ResponseFixer {
               applied.json.details ??= res.details;
               data = res.data;
             }
+          }
+
+          const filtered = ResponseFixer.filterInertResponsesChatCompletionChunks(session, data);
+          if (filtered.applied) {
+            applied.sse.applied = true;
+            applied.sse.details ??= filtered.details;
+            data = filtered.data;
           }
 
           controller.enqueue(data);
@@ -524,6 +580,75 @@ export class ResponseFixer {
     }
 
     return { data: concatUint8Chunks(chunks), applied };
+  }
+
+  private static filterInertResponsesChatCompletionChunks(
+    session: ProxySession,
+    data: Uint8Array
+  ): { data: Uint8Array; applied: boolean; details?: string } {
+    if (session.originalFormat !== "response") {
+      return { data, applied: false };
+    }
+
+    const text = UTF8_DECODER.decode(data);
+    if (!text.includes('"chat.completion.chunk"')) {
+      return { data, applied: false };
+    }
+
+    const lines = text.split("\n");
+    const out: string[] = [];
+    let applied = false;
+    let skipNextBlankLine = false;
+
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      const hasLineBreak = i < lines.length - 1;
+
+      if (skipNextBlankLine && ResponseFixer.isBlankSseSeparatorLine(line)) {
+        skipNextBlankLine = false;
+        continue;
+      }
+      skipNextBlankLine = false;
+
+      if (ResponseFixer.isInertChatCompletionDataLine(line)) {
+        applied = true;
+        skipNextBlankLine = true;
+        continue;
+      }
+
+      out.push(line);
+      if (hasLineBreak) out.push("\n");
+    }
+
+    if (!applied) {
+      return { data, applied: false };
+    }
+
+    return {
+      data: UTF8_ENCODER.encode(out.join("")),
+      applied: true,
+      details: "filtered_inert_chat_completion_chunk",
+    };
+  }
+
+  private static isInertChatCompletionDataLine(line: string): boolean {
+    if (!line.startsWith("data:")) return false;
+
+    let payloadText = line.slice(5);
+    if (payloadText.startsWith(" ")) {
+      payloadText = payloadText.slice(1);
+    }
+    if (!payloadText.startsWith("{")) return false;
+
+    try {
+      return isInertChatCompletionChunkPayload(JSON.parse(payloadText));
+    } catch {
+      return false;
+    }
+  }
+
+  private static isBlankSseSeparatorLine(line: string): boolean {
+    return line === "" || line === "\r";
   }
 
   private static fixMaybeDataJsonLine(

--- a/src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts
+++ b/src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts
@@ -44,6 +44,20 @@ function createSession() {
   } as any;
 }
 
+function createSseResponse(payloadLines: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(payloadLines.join("\n")));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
 describe("ResponseFixer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -202,6 +216,163 @@ describe("ResponseFixer", () => {
 
     const fixed = await ResponseFixer.process(session, response);
     expect(await fixed.text()).toBe('data: {"a":1}\n\n');
+    expect(session.getSpecialSettings()).toBeNull();
+  });
+
+  test("流式 Responses SSE：应过滤上游混入的空 Chat Completions chunk", async () => {
+    const { ResponseFixer } = await import("./index");
+
+    const session = createSession();
+    session.originalFormat = "response";
+    const encoder = new TextEncoder();
+    const emptyChatChunk = {
+      id: "chatcmpl-dummy",
+      object: "chat.completion.chunk",
+      created: 1780753978,
+      model: "gpt-5.5",
+      choices: [{ index: 0, delta: { role: "assistant", content: "" } }],
+    };
+    const responseDelta = {
+      type: "response.output_text.delta",
+      delta: "Hi",
+    };
+    const responseCompleted = {
+      type: "response.completed",
+      response: { id: "resp_test", object: "response" },
+    };
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            [
+              `data: ${JSON.stringify(emptyChatChunk)}`,
+              "",
+              "event: response.output_text.delta",
+              `data: ${JSON.stringify(responseDelta)}`,
+              "",
+              "event: response.completed",
+              `data: ${JSON.stringify(responseCompleted)}`,
+              "",
+            ].join("\n")
+          )
+        );
+        controller.close();
+      },
+    });
+
+    const response = new Response(stream, {
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    const fixed = await ResponseFixer.process(session, response);
+    const text = await fixed.text();
+
+    expect(text).not.toContain("chat.completion.chunk");
+    expect(text).not.toContain("chatcmpl-dummy");
+    expect(text.startsWith("event: response.output_text.delta")).toBe(true);
+    expect(text).toContain("response.output_text.delta");
+    expect(text).toContain("response.completed");
+    expect(session.getSpecialSettings()).not.toBeNull();
+  });
+
+  test("流式 Responses SSE：包含实际 content 的 Chat Completions chunk 应保留", async () => {
+    const { ResponseFixer } = await import("./index");
+
+    const session = createSession();
+    session.originalFormat = "response";
+    const chatChunk = {
+      id: "chatcmpl-content",
+      object: "chat.completion.chunk",
+      created: 1780753978,
+      model: "gpt-5.5",
+      choices: [{ index: 0, delta: { role: "assistant", content: "Hi" } }],
+    };
+
+    const fixed = await ResponseFixer.process(
+      session,
+      createSseResponse([`data: ${JSON.stringify(chatChunk)}`, ""])
+    );
+    const text = await fixed.text();
+
+    expect(text).toContain("chat.completion.chunk");
+    expect(text).toContain("chatcmpl-content");
+    expect(text).toContain('"content":"Hi"');
+    expect(session.getSpecialSettings()).toBeNull();
+  });
+
+  test("流式 Responses SSE：带 finish_reason 的 Chat Completions chunk 应保留", async () => {
+    const { ResponseFixer } = await import("./index");
+
+    const session = createSession();
+    session.originalFormat = "response";
+    const chatChunk = {
+      id: "chatcmpl-finish",
+      object: "chat.completion.chunk",
+      created: 1780753978,
+      model: "gpt-5.5",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    };
+
+    const fixed = await ResponseFixer.process(
+      session,
+      createSseResponse([`data: ${JSON.stringify(chatChunk)}`, ""])
+    );
+    const text = await fixed.text();
+
+    expect(text).toContain("chat.completion.chunk");
+    expect(text).toContain("chatcmpl-finish");
+    expect(text).toContain("finish_reason");
+    expect(session.getSpecialSettings()).toBeNull();
+  });
+
+  test("流式 Responses SSE：带 usage 的 Chat Completions chunk 应保留", async () => {
+    const { ResponseFixer } = await import("./index");
+
+    const session = createSession();
+    session.originalFormat = "response";
+    const chatChunk = {
+      id: "chatcmpl-usage",
+      object: "chat.completion.chunk",
+      created: 1780753978,
+      model: "gpt-5.5",
+      choices: [{ index: 0, delta: { role: "assistant", content: "" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    };
+
+    const fixed = await ResponseFixer.process(
+      session,
+      createSseResponse([`data: ${JSON.stringify(chatChunk)}`, ""])
+    );
+    const text = await fixed.text();
+
+    expect(text).toContain("chat.completion.chunk");
+    expect(text).toContain("chatcmpl-usage");
+    expect(text).toContain("prompt_tokens");
+    expect(session.getSpecialSettings()).toBeNull();
+  });
+
+  test("流式非 Responses SSE：空 Chat Completions chunk 应保留", async () => {
+    const { ResponseFixer } = await import("./index");
+
+    const session = createSession();
+    session.originalFormat = "chat";
+    const emptyChatChunk = {
+      id: "chatcmpl-chat-format",
+      object: "chat.completion.chunk",
+      created: 1780753978,
+      model: "gpt-5.5",
+      choices: [{ index: 0, delta: { role: "assistant", content: "" } }],
+    };
+
+    const fixed = await ResponseFixer.process(
+      session,
+      createSseResponse([`data: ${JSON.stringify(emptyChatChunk)}`, ""])
+    );
+    const text = await fixed.text();
+
+    expect(text).toContain("chat.completion.chunk");
+    expect(text).toContain("chatcmpl-chat-format");
     expect(session.getSpecialSettings()).toBeNull();
   });
 

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -560,6 +560,24 @@ async function finalizeDeferredStreamingFinalizationIfNeeded(
   const detected = shouldDetectFake200
     ? detectUpstreamErrorFromSseOrJsonText(allContent)
     : ({ isError: false } as const);
+  const clientAbortCompleteSuccess = (() => {
+    if (
+      streamEndedNormally ||
+      !clientAborted ||
+      upstreamStatusCode < 200 ||
+      upstreamStatusCode >= 300
+    ) {
+      return false;
+    }
+
+    const abortDetected = detectUpstreamErrorFromSseOrJsonText(allContent);
+    if (abortDetected.isError) {
+      return false;
+    }
+
+    const { usageMetrics } = parseUsageFromResponseText(allContent, provider?.providerType);
+    return hasPositiveBillableTokens(usageMetrics);
+  })();
 
   // “内部结算用”的状态码（不会改变客户端实际 HTTP 状态码）。
   // - 假 200：优先映射为“推断得到的 4xx/5xx”（未命中则回退 502），确保内部统计/熔断/会话绑定把它当作失败。
@@ -578,6 +596,9 @@ async function finalizeDeferredStreamingFinalizationIfNeeded(
       effectiveStatusCode = 502;
     }
     errorMessage = detected.detail ? `${detected.code}: ${detected.detail}` : detected.code;
+  } else if (clientAbortCompleteSuccess) {
+    effectiveStatusCode = upstreamStatusCode;
+    errorMessage = null;
   } else if (!streamEndedNormally) {
     effectiveStatusCode = clientAborted ? 499 : 502;
     errorMessage = clientAborted ? "CLIENT_ABORTED" : (abortReason ?? "STREAM_ABORTED");
@@ -596,7 +617,7 @@ async function finalizeDeferredStreamingFinalizationIfNeeded(
   }
 
   const shouldClearSessionBindingOnFailure =
-    !streamEndedNormally ||
+    (!streamEndedNormally && !clientAbortCompleteSuccess) ||
     detected.isError ||
     (upstreamStatusCode >= 400 && errorMessage !== null);
 
@@ -659,7 +680,7 @@ async function finalizeDeferredStreamingFinalizationIfNeeded(
   // 同时，为了让故障转移/熔断能正确工作：
   // - 客户端主动中断：不计入熔断器（这通常不是供应商问题）
   // - 非客户端中断：计入 provider/endpoint 熔断失败（与 timeout 路径保持一致）
-  if (!streamEndedNormally) {
+  if (!streamEndedNormally && !clientAbortCompleteSuccess) {
     await clearSessionBinding();
 
     if (!clientAborted && session.getEndpointPolicy().allowCircuitBreakerAccounting) {
@@ -2246,28 +2267,53 @@ export class ProxyResponseHandler {
     // 使用 AsyncTaskManager 管理后台处理任务
     const taskId = `stream-${messageContext?.id || `unknown-${Date.now()}`}`;
     const abortController = new AbortController();
+    const idleTimeoutMs =
+      provider.streamingIdleTimeoutMs > 0 ? provider.streamingIdleTimeoutMs : Infinity;
+    const clientAbortDrainTimeoutMs = idleTimeoutMs === Infinity ? 60_000 : idleTimeoutMs;
 
     // ⭐ 提升 idleTimeoutId 到外部作用域，以便客户端断开时能清除
     let idleTimeoutId: NodeJS.Timeout | null = null;
+    let clientAbortDrainTimeoutId: NodeJS.Timeout | null = null;
+    const clearClientAbortDrainTimer = () => {
+      if (clientAbortDrainTimeoutId) {
+        clearTimeout(clientAbortDrainTimeoutId);
+        clientAbortDrainTimeoutId = null;
+      }
+    };
     const cleanupClientAbortListener = bindClientAbortListener(session.clientAbortSignal, () => {
       logger.debug("ResponseHandler: Client disconnected, cleaning up", {
         taskId,
         providerId: provider.id,
         messageId: messageContext.id,
       });
-
-      // 客户端断开时清除 idle timeout，避免任务已取消后仍误触发。
-      if (idleTimeoutId) {
-        clearTimeout(idleTimeoutId);
-        idleTimeoutId = null;
-        logger.debug("ResponseHandler: Idle timeout cleared due to client disconnect", {
+      // Do not cancel internal accounting on pure client disconnect. If the
+      // upstream stream has already completed, the tee'd internal branch can
+      // still drain buffered final usage and record the request as successful.
+      // Idle/response timeout paths still abort via abortController.
+      clearClientAbortDrainTimer();
+      clientAbortDrainTimeoutId = setTimeout(() => {
+        logger.info("ResponseHandler: Client abort drain window exceeded", {
           taskId,
           providerId: provider.id,
+          messageId: messageContext.id,
+          clientAbortDrainTimeoutMs,
         });
-      }
 
-      AsyncTaskManager.cancel(taskId);
-      abortController.abort();
+        try {
+          const sessionWithController = session as typeof session & {
+            responseController?: AbortController;
+          };
+          sessionWithController.responseController?.abort(new Error("client_abort_drain_timeout"));
+        } catch (e) {
+          logger.warn("ResponseHandler: Failed to abort upstream after client drain timeout", {
+            taskId,
+            providerId: provider.id,
+            error: e,
+          });
+        }
+
+        abortController.abort(new Error("client_abort_drain_timeout"));
+      }, clientAbortDrainTimeoutMs);
     });
 
     const processingPromise = (async () => {
@@ -2280,9 +2326,6 @@ export class ProxyResponseHandler {
       let usageForCost: UsageMetrics | null = null;
       let isFirstChunk = true; // ⭐ 标记是否为第一块数据
 
-      // ⭐ 静默期 Watchdog：监控流式请求中途卡住（无新数据推送）
-      const idleTimeoutMs =
-        provider.streamingIdleTimeoutMs > 0 ? provider.streamingIdleTimeoutMs : Infinity;
       const startIdleTimer = () => {
         if (idleTimeoutMs === Infinity) return; // 禁用时跳过
         clearIdleTimer(); // 清除旧的
@@ -2655,7 +2698,7 @@ export class ProxyResponseHandler {
         let streamEndedNormally = false;
         while (true) {
           // 检查取消信号
-          if (session.clientAbortSignal?.aborted || abortController.signal.aborted) {
+          if (abortController.signal.aborted) {
             logger.info("ResponseHandler: Stream processing cancelled", {
               taskId,
               providerId: provider.id,
@@ -2933,6 +2976,7 @@ export class ProxyResponseHandler {
       } finally {
         // 确保资源释放
         cleanupClientAbortListener();
+        clearClientAbortDrainTimer();
         clearIdleTimer(); // ⭐ 清除静默期计时器（防止泄漏）
         try {
           reader.releaseLock();

--- a/tests/unit/proxy/response-handler-client-abort-drain.test.ts
+++ b/tests/unit/proxy/response-handler-client-abort-drain.test.ts
@@ -1,0 +1,512 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
+import { ProxyResponseHandler } from "@/app/v1/_lib/proxy/response-handler";
+import { ProxySession } from "@/app/v1/_lib/proxy/session";
+import { setDeferredStreamingFinalization } from "@/app/v1/_lib/proxy/stream-finalization";
+import { AsyncTaskManager } from "@/lib/async-task-manager";
+import { updateMessageRequestDetails, updateMessageRequestDuration } from "@/repository/message";
+import type { Provider } from "@/types/provider";
+
+const asyncTasks: Promise<void>[] = [];
+
+vi.mock("@/app/v1/_lib/proxy/response-fixer", () => ({
+  ResponseFixer: {
+    process: async (_session: unknown, response: Response) => response,
+  },
+}));
+
+vi.mock("@/lib/async-task-manager", () => ({
+  AsyncTaskManager: {
+    register: vi.fn((_taskId: string, promise: Promise<void>) => {
+      asyncTasks.push(promise);
+      return new AbortController();
+    }),
+    cleanup: vi.fn(),
+    cancel: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/config/system-settings-cache", () => ({
+  getCachedSystemSettings: vi.fn(async () => ({ billNonSuccessfulRequests: false })),
+}));
+
+vi.mock("@/lib/langfuse/emit-proxy-trace", () => ({
+  emitProxyLangfuseTrace: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/price-sync/cloud-price-updater", () => ({
+  requestCloudPriceTableSync: vi.fn(),
+}));
+
+vi.mock("@/lib/proxy-status-tracker", () => ({
+  ProxyStatusTracker: {
+    getInstance: () => ({
+      endRequest: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimitService: {
+    trackCost: vi.fn(),
+    trackUserDailyCost: vi.fn(),
+    decrementLeaseBudget: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/redis/live-chain-store", () => ({
+  deleteLiveChain: vi.fn(),
+}));
+
+vi.mock("@/lib/session-manager", () => ({
+  SessionManager: {
+    clearSessionProvider: vi.fn(),
+    extractCodexPromptCacheKey: vi.fn(),
+    storeSessionResponse: vi.fn(),
+    storeSessionRequestPhaseSnapshot: vi.fn(),
+    storeSessionResponsePhaseSnapshot: vi.fn(),
+    storeSessionRequestHeaders: vi.fn(),
+    storeSessionResponseHeaders: vi.fn(),
+    storeSessionSpecialSettings: vi.fn(),
+    storeSessionUpstreamRequestMeta: vi.fn(),
+    storeSessionUpstreamResponseMeta: vi.fn(),
+    updateSessionProvider: vi.fn(),
+    updateSessionUsage: vi.fn(),
+    updateSessionWithCodexCacheKey: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/session-tracker", () => ({
+  SessionTracker: {
+    refreshSession: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/circuit-breaker", () => ({
+  recordFailure: vi.fn(),
+  recordSuccess: vi.fn(),
+}));
+
+vi.mock("@/lib/endpoint-circuit-breaker", () => ({
+  recordEndpointFailure: vi.fn(),
+  recordEndpointSuccess: vi.fn(),
+  resetEndpointCircuit: vi.fn(),
+}));
+
+vi.mock("@/repository/message", () => ({
+  updateMessageRequestCostWithBreakdown: vi.fn(),
+  updateMessageRequestDetails: vi.fn(),
+  updateMessageRequestDuration: vi.fn(),
+}));
+
+function createProvider(): Provider {
+  return {
+    id: 1,
+    name: "avemujica-responses",
+    url: "https://api.test.invalid/v1",
+    key: "sk-test",
+    providerVendorId: null,
+    providerType: "codex",
+    isEnabled: true,
+    weight: 1,
+    priority: 1,
+    groupPriorities: null,
+    costMultiplier: 1,
+    groupTag: "OpenAI",
+    modelRedirects: null,
+    allowedModels: null,
+    mcpPassthroughType: "none",
+    mcpPassthroughUrl: null,
+    preserveClientIp: false,
+    limit5hUsd: null,
+    limitDailyUsd: null,
+    dailyResetMode: "fixed",
+    dailyResetTime: "00:00",
+    limitWeeklyUsd: null,
+    limitMonthlyUsd: null,
+    limitTotalUsd: null,
+    totalCostResetAt: null,
+    limitConcurrentSessions: 0,
+    maxRetryAttempts: null,
+    circuitBreakerFailureThreshold: 5,
+    circuitBreakerOpenDuration: 1_800_000,
+    circuitBreakerHalfOpenSuccessThreshold: 2,
+    proxyUrl: null,
+    proxyFallbackToDirect: false,
+    firstByteTimeoutStreamingMs: 0,
+    streamingIdleTimeoutMs: 0,
+    requestTimeoutNonStreamingMs: 0,
+    websiteUrl: null,
+    faviconUrl: null,
+    cacheTtlPreference: null,
+    context1mPreference: null,
+    codexReasoningEffortPreference: null,
+    codexReasoningSummaryPreference: null,
+    codexTextVerbosityPreference: null,
+    codexParallelToolCallsPreference: null,
+    anthropicMaxTokensPreference: null,
+    anthropicThinkingBudgetPreference: null,
+    geminiGoogleSearchPreference: null,
+    tpm: 0,
+    rpm: 0,
+    rpd: 0,
+    cc: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  } as Provider;
+}
+
+function createSession(signal: AbortSignal): ProxySession {
+  const provider = createProvider();
+  const user = { id: 1, name: "admin" };
+  const key = { id: 2, name: "Omni" };
+  const session = Object.create(ProxySession.prototype) as ProxySession;
+
+  Object.assign(session, {
+    authState: { success: true, user, key, apiKey: "sk-test" },
+    cacheTtlResolved: null,
+    clientAbortSignal: signal,
+    context: {},
+    context1mApplied: false,
+    forwardedRequestBody: "",
+    headerLog: "",
+    headers: new Headers(),
+    method: "POST",
+    messageContext: {
+      id: 123,
+      createdAt: new Date(),
+      user,
+      key,
+      apiKey: "sk-test",
+    },
+    originalFormat: "response",
+    originalModelName: "gpt-5.4-mini",
+    originalUrlPathname: "/v1/responses",
+    provider,
+    providerChain: [],
+    providerType: "codex",
+    request: {
+      log: "",
+      message: { model: "gpt-5.4-mini", stream: true },
+      model: "gpt-5.4-mini",
+    },
+    requestSequence: 1,
+    requestUrl: new URL("http://localhost/v1/responses"),
+    sessionId: null,
+    specialSettings: [],
+    startTime: Date.now(),
+    ttfbMs: null,
+    userAgent: "Go-http-client/1.1",
+    userName: "admin",
+    addProviderToChain(this: ProxySession & { providerChain: unknown[] }, prov: Provider, meta) {
+      this.providerChain.push({ id: prov.id, name: prov.name, ...(meta ?? {}) });
+    },
+    clearResponseTimeout: vi.fn(),
+    getContext1mApplied: () => false,
+    getCurrentModel: () => "gpt-5.4-mini",
+    getEndpoint: () => "/v1/responses",
+    getEndpointPolicy: () => resolveEndpointPolicy("/v1/responses"),
+    getGroupCostMultiplier: () => 1,
+    getOriginalModel: () => "gpt-5.4-mini",
+    getProviderChain: () => session.providerChain,
+    getResolvedPricingByBillingSource: async () => null,
+    getSpecialSettings: () => [],
+    isHeaderModified: () => false,
+    recordTtfb: vi.fn(),
+    releaseAgent: vi.fn(),
+    setContext1mApplied: vi.fn(),
+    shouldPersistSessionDebugArtifacts: () => false,
+    shouldTrackSessionObservability: () => false,
+  });
+
+  return session;
+}
+
+function createResponsesSse(): Response {
+  const body = [
+    `event: response.output_text.done\ndata: ${JSON.stringify({
+      type: "response.output_text.done",
+      text: "短标题",
+    })}`,
+    `event: response.completed\ndata: ${JSON.stringify({
+      type: "response.completed",
+      response: {
+        id: "resp_test",
+        model: "gpt-5.4-mini-2026-03-17",
+        usage: {
+          input_tokens: 463,
+          output_tokens: 11,
+        },
+      },
+    })}`,
+    "",
+  ].join("\n\n");
+
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function createErroredResponsesSse(): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          `event: response.output_text.delta\ndata: ${JSON.stringify({
+            type: "response.output_text.delta",
+            delta: "短",
+          })}\n\n`
+        )
+      );
+      const error = new Error("Response transmission interrupted");
+      error.name = "ResponseAborted";
+      controller.error(error);
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function createHangingResponsesSse(upstreamSignal: AbortSignal): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          `event: response.output_text.delta\ndata: ${JSON.stringify({
+            type: "response.output_text.delta",
+            delta: "短",
+          })}\n\n`
+        )
+      );
+      upstreamSignal.addEventListener(
+        "abort",
+        () => {
+          const error = new Error("client_abort_drain_timeout");
+          error.name = "AbortError";
+          controller.error(error);
+        },
+        { once: true }
+      );
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function createCompletedThenErroredResponsesSse(): Response {
+  const encoder = new TextEncoder();
+  const chunks = [
+    `event: response.output_text.done\ndata: ${JSON.stringify({
+      type: "response.output_text.done",
+      text: "短标题",
+    })}\n\n`,
+    `event: response.completed\ndata: ${JSON.stringify({
+      type: "response.completed",
+      response: {
+        id: "resp_test",
+        model: "gpt-5.4-mini-2026-03-17",
+        usage: {
+          input_tokens: 463,
+          output_tokens: 11,
+        },
+      },
+    })}\n\n`,
+  ];
+  let index = 0;
+
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[index++]));
+        return;
+      }
+
+      const error = new Error("Response transmission interrupted after final usage");
+      error.name = "ResponseAborted";
+      controller.error(error);
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+async function drainAsyncTasks(): Promise<void> {
+  while (asyncTasks.length > 0) {
+    const tasks = asyncTasks.splice(0, asyncTasks.length);
+    await Promise.allSettled(tasks);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("ProxyResponseHandler stream client abort finalization", () => {
+  beforeEach(() => {
+    asyncTasks.splice(0, asyncTasks.length);
+    vi.clearAllMocks();
+  });
+
+  it("finalizes a complete upstream responses stream as success when the downstream client already closed", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const session = createSession(controller.signal);
+    setDeferredStreamingFinalization(session, {
+      providerId: 1,
+      providerName: "avemujica-responses",
+      providerPriority: 1,
+      attemptNumber: 1,
+      totalProvidersAttempted: 1,
+      isFirstAttempt: true,
+      isFailoverSuccess: false,
+      endpointId: 42,
+      endpointUrl: "https://api.test.invalid/v1",
+      upstreamStatusCode: 200,
+    });
+
+    await ProxyResponseHandler.dispatch(session, createResponsesSse());
+    await drainAsyncTasks();
+
+    expect(AsyncTaskManager.cancel).not.toHaveBeenCalled();
+    expect(updateMessageRequestDuration).toHaveBeenCalledWith(123, expect.any(Number));
+    expect(updateMessageRequestDetails).toHaveBeenCalledWith(
+      123,
+      expect.objectContaining({
+        statusCode: 200,
+        inputTokens: 463,
+        outputTokens: 11,
+      })
+    );
+  });
+
+  it("reclassifies a client-aborted stream as success when final usage was already received", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const session = createSession(controller.signal);
+    setDeferredStreamingFinalization(session, {
+      providerId: 1,
+      providerName: "avemujica-responses",
+      providerPriority: 1,
+      attemptNumber: 1,
+      totalProvidersAttempted: 1,
+      isFirstAttempt: true,
+      isFailoverSuccess: false,
+      endpointId: 42,
+      endpointUrl: "https://api.test.invalid/v1",
+      upstreamStatusCode: 200,
+    });
+
+    await ProxyResponseHandler.dispatch(session, createCompletedThenErroredResponsesSse());
+    await drainAsyncTasks();
+
+    expect(AsyncTaskManager.cancel).not.toHaveBeenCalled();
+    expect(updateMessageRequestDetails).toHaveBeenCalledWith(
+      123,
+      expect.objectContaining({
+        statusCode: 200,
+        inputTokens: 463,
+        outputTokens: 11,
+        providerChain: [
+          expect.objectContaining({
+            reason: "request_success",
+            statusCode: 200,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("keeps a genuinely aborted upstream responses stream as 499", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const session = createSession(controller.signal);
+    setDeferredStreamingFinalization(session, {
+      providerId: 1,
+      providerName: "avemujica-responses",
+      providerPriority: 1,
+      attemptNumber: 1,
+      totalProvidersAttempted: 1,
+      isFirstAttempt: true,
+      isFailoverSuccess: false,
+      endpointId: 42,
+      endpointUrl: "https://api.test.invalid/v1",
+      upstreamStatusCode: 200,
+    });
+
+    await ProxyResponseHandler.dispatch(session, createErroredResponsesSse());
+    await drainAsyncTasks();
+
+    expect(AsyncTaskManager.cancel).not.toHaveBeenCalled();
+    expect(updateMessageRequestDetails).toHaveBeenCalledWith(
+      123,
+      expect.objectContaining({
+        statusCode: 499,
+        errorMessage: "CLIENT_ABORTED",
+      })
+    );
+  });
+
+  it("bounds client-abort drain when the upstream stream hangs", async () => {
+    vi.useFakeTimers();
+    try {
+      const clientController = new AbortController();
+      const upstreamController = new AbortController();
+      const session = createSession(clientController.signal);
+      Object.assign(session, { responseController: upstreamController });
+      setDeferredStreamingFinalization(session, {
+        providerId: 1,
+        providerName: "avemujica-responses",
+        providerPriority: 1,
+        attemptNumber: 1,
+        totalProvidersAttempted: 1,
+        isFirstAttempt: true,
+        isFailoverSuccess: false,
+        endpointId: 42,
+        endpointUrl: "https://api.test.invalid/v1",
+        upstreamStatusCode: 200,
+      });
+
+      await ProxyResponseHandler.dispatch(
+        session,
+        createHangingResponsesSse(upstreamController.signal)
+      );
+      clientController.abort();
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      const tasks = asyncTasks.splice(0, asyncTasks.length);
+      await Promise.allSettled(tasks);
+
+      expect(upstreamController.signal.aborted).toBe(true);
+      expect(AsyncTaskManager.cancel).not.toHaveBeenCalled();
+      expect(updateMessageRequestDetails).toHaveBeenCalledWith(
+        123,
+        expect.objectContaining({
+          statusCode: 499,
+          errorMessage: "CLIENT_ABORTED",
+        })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- keep internal stream accounting alive briefly after downstream disconnects so completed upstream Responses streams can finalize with their real 2xx status and usage instead of being stored as `499 CLIENT_ABORTED`
- bound that post-disconnect drain window so a hung upstream cannot keep the internal reader alive indefinitely when idle timeout is disabled
- filter inert `chat.completion.chunk` SSE data lines from `/v1/responses` output, while preserving non-empty chunks, finish markers, usage-bearing chunks, and non-Responses sessions

**Related Issues:**
- Fixes #1083 - completed Responses streams can be misreported as `499 CLIENT_ABORTED`
- Fixes #985 - upstream succeeds but CCH records 499 status
- Fixes #1242 - GPT-5.5 proxy calls show 499 in logs despite successful completion
- Related to #1234 - same Codex `/v1/responses` stream area; EPIPE crash addressed separately in #1239
- Alternative approach to #1249 - this PR preserves the internal drain path instead of intercepting terminal state before `tee()`

## Approach

1. **Client-abort finalization**
   - On pure client disconnect, the internal accounting branch is not immediately cancelled.
   - `finalizeDeferredStreamingFinalizationIfNeeded` reclassifies client-aborted streams as success only when the upstream status is 2xx, no upstream error payload is detected, and positive usage was parsed.
   - True mid-stream aborts still finalize as `499`, and timeout/upstream failures still finalize as failures.
   - A bounded drain timer aborts both the upstream `responseController` and local accounting loop if the drain window is exceeded.

2. **Responses SSE sanitizer**
   - `ResponseFixer` strips only inert `chat.completion.chunk` `data:` lines for `session.originalFormat === "response"`.
   - The immediately following blank SSE separator is also removed so filtering does not leave an orphan empty event frame.
   - Chunks with content, `finish_reason`, usage, or non-Responses format are preserved.

3. **Rebased on `dev`**
   - This branch is now based on `dev` and preserves #1247's hedge-loser billing semantics.
   - The winner cost update still uses `finalized.billHedgeLosers`, so client-abort success reclassification does not clobber additive loser billing.

## Commits

- `fix(proxy): finalize complete responses after client abort`
- `fix(proxy): sanitize inert chat chunks in responses streams`

## Validation

```bash
bunx @biomejs/biome@2.4.15 check src/app/v1/_lib/proxy/response-fixer/index.ts src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts src/app/v1/_lib/proxy/response-handler.ts tests/unit/proxy/response-handler-client-abort-drain.test.ts
bun run test src/app/v1/_lib/proxy/response-fixer/response-fixer.test.ts tests/unit/proxy/response-handler-client-abort-drain.test.ts
bun run build
```

Additional local check:

```bash
bun run test
```

This full local test run currently fails in two files outside this PR's changed paths:

- `tests/unit/k8s-deploy-shell-helpers.test.ts` - macOS `tr: Illegal byte sequence` in the `/dev/urandom` fallback path
- `src/components/ui/__tests__/language-switcher.test.tsx` - expected `console.error` call is not emitted in the blocked `sessionStorage` test

Those failures are reproducible when run individually and are not in files touched by this PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses two distinct problems in the Responses streaming proxy path: (1) false `499 CLIENT_ABORTED` status codes recorded for completed upstream streams when the downstream client disconnects before the internal accounting loop observes the final SSE event, and (2) schema-validation failures in strict Responses clients when OpenAI-compatible upstreams inject empty `chat.completion.chunk` events into a `/v1/responses` stream. It also introduces a hedge-loser billing feature that drains losing-race-attempt responses in the background to capture and bill their real token usage.

- **Client-abort drain**: On client disconnect, the internal `tee`'d accounting branch now continues draining buffered data rather than being cancelled immediately; a new `clientAbortCompleteSuccess` gate reclassifies the stream as the real 2xx status when 2xx upstream code, no fake-error detected, and positive billable tokens are all confirmed.
- **SSE sanitizer**: `ResponseFixer.filterInertResponsesChatCompletionChunks` strips inert `chat.completion.chunk` data lines (empty content, no tool calls, no finish reason, no usage) from Responses SSE output only when `session.originalFormat === \"response\"`, with the blank-line separator following each filtered line also elided via the `skipNextBlankLine` flag.
- **Hedge-loser billing**: Losing hedge attempts are kept alive to drain their response bodies, usage is parsed, and costs are accumulated onto the original request row via an idempotent SQL pattern (`winner: winnerCost + SUM(hedge_losers)`; `loser: costUsd += delta`) that is commutative regardless of ordering.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the drain-based reclassification is conservatively gated on three independent checks, the SSE sanitizer early-exits and returns original bytes when no inert chunk is present, and the hedge-loser billing SQL is commutative and idempotent regardless of winner/loser write ordering.

The clientAbortCompleteSuccess reclassification requires 2xx upstream status, no fake-error detected, and positive billable tokens — all three must hold simultaneously, making false reclassification of genuinely aborted streams effectively impossible. The SSE sanitizer's JSON.parse safety gate means malformed or partial chunks pass through unchanged. The concurrent-write SQL for hedge-loser billing converges to the correct grand total under all Postgres row-lock orderings because the winner uses an idempotent replacement (winnerCost + SUM(current losers)) and each loser uses an additive delta with a JSONB dedup guard. Four new unit tests cover the critical paths including the drain-timeout bound. Only a stale inline comment remains.

No files require special attention; the comment at line 558 of response-handler.ts is a documentation nit with no behavioral impact.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/response-handler.ts | Core drain logic: removes AsyncTaskManager.cancel/abortController.abort from client-disconnect handler, adds clientAbortDrainTimeoutMs safety bound, removes clientAbortSignal check from internal loop, and adds clientAbortCompleteSuccess reclassification. Also introduces finalizeHedgeLoserBilling and winnerLoserAware cost-write path. One inline comment (line 558) is stale after the new reclassification branch was added. |
| src/app/v1/_lib/proxy/response-fixer/index.ts | Adds filterInertResponsesChatCompletionChunks with skipNextBlankLine to remove inert chat chunks and their SSE separator from Responses streams. Module-level UTF8_DECODER/ENCODER singletons used in stateless mode, correct for per-chunk processing. |
| src/app/v1/_lib/proxy/forwarder.ts | Adds StreamingHedgeAttempt billing fields (billAsLoser, loserBillingStarted, firstChunk, billingSnapshot), startLoserBilling IIFE, handleAttemptFailure guard for billed-loser cleanup, commitWinner billing-context snapshot for initial-provider losers, and billHedgeLosers flag propagation. Idempotency guard and concurrent-write ordering are correct. |
| src/repository/message.ts | Adds updateMessageRequestWinnerCost (replacement write: winnerCost + SUM(hedge_losers)) and addMessageRequestHedgeLoserCost (additive write with JSONB dedup guard). SQL design is commutative and idempotent under retry; both functions bypass the async write buffer for durability. |
| drizzle/0104_watery_thunderbird.sql | Adds hedge_losers JSONB column and bill_hedge_losers boolean (default true). Recreates fn_is_message_request_finalized and fn_compute_message_request_success_rate_outcome to include hedge_loser_billed in finalization/exclusion logic. SQL stored procedures correctly updated. |
| src/lib/utils/hedge-billing.ts | New utility: summarizeHedgeBilling, buildHedgeBillingTable, findHedgeLoserCost. Winner cost derived as total − sum(losers), clamped at 0. Clean pure-function implementation. |
| tests/unit/proxy/response-handler-client-abort-drain.test.ts | Four new integration tests covering: completed stream finalized as 200 after pre-aborted client; reclassification when final usage received before stream error; genuinely aborted stream stays 499; drain timeout with fake timers bounds a hanging upstream and aborts it. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant ProxyResponseHandler
    participant InternalLoop as Internal Accounting Loop
    participant DB as Database

    Client->>ProxyResponseHandler: POST /v1/responses (streaming)
    ProxyResponseHandler->>ProxyResponseHandler: tee() body into client branch + internal branch
    ProxyResponseHandler-->>Client: stream chunks

    Note over Client: Client closes connection early
    Client--xProxyResponseHandler: disconnect (clientAbortSignal.aborted)

    ProxyResponseHandler->>ProxyResponseHandler: bindClientAbortListener fires
    Note over ProxyResponseHandler: start clientAbortDrainTimer (60s), do NOT cancel internal loop

    InternalLoop->>InternalLoop: continues draining buffered tee branch
    InternalLoop->>InternalLoop: reads response.completed with usage tokens

    alt "streamEndedNormally=false, clientAborted=true, 2xx + no fake error + positive usage"
        InternalLoop->>DB: "updateMessageRequestDetails(statusCode=200)"
        Note over InternalLoop: Reclassified as success
    else upstream truly aborted mid-stream
        InternalLoop->>DB: "updateMessageRequestDetails(statusCode=499, CLIENT_ABORTED)"
    end

    ProxyResponseHandler->>ProxyResponseHandler: clearClientAbortDrainTimer()
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/app/v1/_lib/proxy/response-handler.ts:558
**Stale inline comment after new reclassification branch**

The comment on this line states that skipping fake-200 detection means the stream "will still ultimately be finalized as abort/timeout failure below" (`最终仍会在下面按中断/超时视为失败结算`). The `clientAbortCompleteSuccess` path added just below can now reclassify a client-aborted stream as 2xx success, so the always-fails assertion no longer holds and should be updated to mention the new path.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(proxy): sanitize inert chat chunks i..."](https://github.com/ding113/claude-code-hub/commit/0e07d3813ff8d5abb17c6286470681874ac9de2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36011713)</sub>

<!-- /greptile_comment -->