### PR TITLE
fix(proxy): preserve hedge loser Codex priority billing

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -217,6 +217,7 @@ type StreamingHedgeAttempt = {
   billingSnapshot: {
     originalModel: string | null;
     redirectedModel: string | null;
+    requestedServiceTier: string | null;
     context1mApplied: boolean;
     groupCostMultiplier: number;
   } | null;
@@ -4285,9 +4286,12 @@ export class ProxyForwarder {
         // loser's own billing context FIRST so it is priced against its own model, not the winner's.
         for (const other of attempts) {
           if (other !== attempt && other.session === session && other.billAsLoser) {
+            const loserRequest = session.request.message as Record<string, unknown>;
             other.billingSnapshot = {
               originalModel: session.getOriginalModel(),
               redirectedModel: session.getCurrentModel(),
+              requestedServiceTier:
+                typeof loserRequest.service_tier === "string" ? loserRequest.service_tier : null,
               context1mApplied: session.getContext1mApplied(),
               groupCostMultiplier: session.getGroupCostMultiplier(),
             };

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -263,8 +263,8 @@ async function resolveCodexPriorityBillingDecision(
   }
 
   const requestedServiceTier =
-    options && "requestedServiceTier" in options
-      ? (options.requestedServiceTier ?? null)
+    options?.requestedServiceTier !== undefined
+      ? options.requestedServiceTier
       : getRequestedCodexServiceTier(session, provider);
   let billingSourcePreference: Awaited<ReturnType<ProxySession["getCodexPriorityBillingSource"]>> =
     "requested";
@@ -3903,7 +3903,12 @@ export async function finalizeHedgeLoserBilling(params: {
       billableUsage,
       priorityServiceTierApplied,
       resolvedPricing,
-      longContextPricing
+      longContextPricing,
+      {
+        provider,
+        context1mApplied,
+        groupCostMultiplier,
+      }
     );
 
     logger.info("[HedgeLoserBilling] Billed hedge loser", {
@@ -4171,6 +4176,12 @@ export async function finalizeRequestStats(
 /**
  * 追踪消费到 Redis（用于限流）
  */
+type TrackCostBillingOverrides = {
+  provider?: Provider | null;
+  context1mApplied?: boolean;
+  groupCostMultiplier?: number;
+};
+
 async function trackCostToRedis(
   session: ProxySession,
   usage: UsageMetrics | null,
@@ -4178,14 +4189,15 @@ async function trackCostToRedis(
   resolvedPricingOverride?: Awaited<
     ReturnType<ProxySession["getResolvedPricingByBillingSource"]>
   > | null,
-  longContextPricingOverride?: ResolvedLongContextPricing | null
+  longContextPricingOverride?: ResolvedLongContextPricing | null,
+  billingOverrides?: TrackCostBillingOverrides
 ): Promise<void> {
   if (!usage || !session.sessionId) return;
   if (isNonBillingUsageEndpoint(session)) return;
 
   try {
     const messageContext = session.messageContext;
-    const provider = session.provider;
+    const provider = billingOverrides?.provider ?? session.provider;
     const key = session.authState?.key;
     const user = session.authState?.user;
 
@@ -4211,10 +4223,10 @@ async function trackCostToRedis(
       resolvedPricing.priceData,
       buildCostCalculationOptions(
         provider.costMultiplier,
-        session.getContext1mApplied(),
+        billingOverrides?.context1mApplied ?? session.getContext1mApplied(),
         priorityServiceTierApplied,
         longContextPricing,
-        session.getGroupCostMultiplier()
+        billingOverrides?.groupCostMultiplier ?? session.getGroupCostMultiplier()
       )
     );
     if (cost.lte(0)) return;

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -188,8 +188,11 @@ function ensurePricingResolutionSpecialSetting(
   });
 }
 
-function getRequestedCodexServiceTier(session: ProxySession): string | null {
-  if (session.provider?.providerType !== "codex") {
+function getRequestedCodexServiceTier(
+  session: ProxySession,
+  provider?: Provider | null
+): string | null {
+  if ((provider ?? session.provider)?.providerType !== "codex") {
     return null;
   }
 
@@ -248,13 +251,21 @@ type CodexPriorityBillingDecision = {
 
 async function resolveCodexPriorityBillingDecision(
   session: ProxySession,
-  actualServiceTier: string | null
+  actualServiceTier: string | null,
+  options?: {
+    provider?: Provider | null;
+    requestedServiceTier?: string | null;
+  }
 ): Promise<CodexPriorityBillingDecision | null> {
-  if (session.provider?.providerType !== "codex") {
+  const provider = options?.provider ?? session.provider;
+  if (provider?.providerType !== "codex") {
     return null;
   }
 
-  const requestedServiceTier = getRequestedCodexServiceTier(session);
+  const requestedServiceTier =
+    options && "requestedServiceTier" in options
+      ? (options.requestedServiceTier ?? null)
+      : getRequestedCodexServiceTier(session, provider);
   let billingSourcePreference: Awaited<ReturnType<ProxySession["getCodexPriorityBillingSource"]>> =
     "requested";
 
@@ -3773,6 +3784,7 @@ export async function finalizeHedgeLoserBilling(params: {
   billingContext?: {
     originalModel: string | null;
     redirectedModel: string | null;
+    requestedServiceTier: string | null;
     context1mApplied: boolean;
     groupCostMultiplier: number;
   };
@@ -3836,8 +3848,12 @@ export async function finalizeHedgeLoserBilling(params: {
 
     const actualServiceTier = parseServiceTierFromResponseText(allContent);
     const priorityServiceTierApplied =
-      (await resolveCodexPriorityBillingDecision(loserSession, actualServiceTier))
-        ?.effectivePriority ?? false;
+      (
+        await resolveCodexPriorityBillingDecision(loserSession, actualServiceTier, {
+          provider,
+          ...(billingContext ? { requestedServiceTier: billingContext.requestedServiceTier } : {}),
+        })
+      )?.effectivePriority ?? false;
     // Mirror the winner: a Codex loser with a large prompt must trigger the 1M context tier,
     // else it under-bills. Only mutate for shadow-session losers (no snapshot) — the initial
     // loser uses its pre-pollution snapshot and must not mutate the shared/original session.

--- a/tests/unit/proxy/response-handler-hedge-loser-priority.test.ts
+++ b/tests/unit/proxy/response-handler-hedge-loser-priority.test.ts
@@ -4,6 +4,9 @@ const mocks = vi.hoisted(() => ({
   addMessageRequestHedgeLoserCost: vi.fn(async () => {}),
   detectUpstreamErrorFromSseOrJsonText: vi.fn(() => ({ isError: false })),
   isNonBillingEndpoint: vi.fn(() => false),
+  trackCost: vi.fn(async () => {}),
+  trackUserDailyCost: vi.fn(async () => {}),
+  decrementLeaseBudget: vi.fn(async () => {}),
 }));
 
 vi.mock("@/repository/message", () => ({
@@ -38,6 +41,14 @@ vi.mock("@/lib/utils/upstream-error-detection", () => ({
   inferUpstreamErrorStatusCodeFromText: vi.fn(() => null),
 }));
 
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimitService: {
+    trackCost: mocks.trackCost,
+    trackUserDailyCost: mocks.trackUserDailyCost,
+    decrementLeaseBudget: mocks.decrementLeaseBudget,
+  },
+}));
+
 vi.mock(import("@/lib/utils/performance-formatter"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -49,7 +60,7 @@ vi.mock(import("@/lib/utils/performance-formatter"), async (importOriginal) => {
 import { finalizeHedgeLoserBilling } from "@/app/v1/_lib/proxy/response-handler";
 import type { Provider } from "@/types/provider";
 
-function createCodexProvider(): Provider {
+function createCodexProvider(overrides: Partial<Provider> = {}): Provider {
   return {
     id: 11,
     name: "initial-codex-loser",
@@ -106,10 +117,18 @@ function createCodexProvider(): Provider {
     createdAt: new Date(),
     updatedAt: new Date(),
     deletedAt: null,
+    ...overrides,
   };
 }
 
-function createLoserSession(provider: Provider) {
+function createLoserSession(
+  provider: Provider,
+  overrides: {
+    sessionId?: string | null;
+    context1mApplied?: boolean;
+    groupCostMultiplier?: number;
+  } = {}
+) {
   return {
     provider,
     request: {
@@ -119,15 +138,28 @@ function createLoserSession(provider: Provider) {
         service_tier: "default",
       },
     },
-    sessionId: null,
-    messageContext: null,
-    authState: { key: null, user: null },
+    sessionId: overrides.sessionId ?? "session-1",
+    messageContext: { id: 123, createdAt: new Date("2026-06-08T00:00:00.000Z") },
+    authState: {
+      key: {
+        id: 10,
+        limit5hResetMode: "rolling",
+        dailyResetTime: "00:00",
+        dailyResetMode: "fixed",
+      },
+      user: {
+        id: 20,
+        limit5hResetMode: "rolling",
+        dailyResetTime: "00:00",
+        dailyResetMode: "fixed",
+      },
+    },
     getEndpoint: () => "/v1/responses",
     getOriginalModel: () => "winner-default-model",
     getCurrentModel: () => "winner-default-model",
-    getContext1mApplied: () => false,
+    getContext1mApplied: () => overrides.context1mApplied ?? false,
     setContext1mApplied: vi.fn(),
-    getGroupCostMultiplier: () => 1,
+    getGroupCostMultiplier: () => overrides.groupCostMultiplier ?? 1,
     getSpecialSettings: () => [],
     addSpecialSetting: vi.fn(),
     shouldTrackSessionObservability: () => false,
@@ -151,6 +183,9 @@ describe("finalizeHedgeLoserBilling Codex priority snapshot", () => {
     mocks.addMessageRequestHedgeLoserCost.mockClear();
     mocks.detectUpstreamErrorFromSseOrJsonText.mockReturnValue({ isError: false });
     mocks.isNonBillingEndpoint.mockReturnValue(false);
+    mocks.trackCost.mockClear();
+    mocks.trackUserDailyCost.mockClear();
+    mocks.decrementLeaseBudget.mockClear();
   });
 
   it("uses the initial loser's captured requested service tier after winner session sync", async () => {
@@ -183,5 +218,67 @@ describe("finalizeHedgeLoserBilling Codex priority snapshot", () => {
     expect(billed).toBe("400");
     expect(mocks.addMessageRequestHedgeLoserCost).toHaveBeenCalledTimes(1);
     expect(mocks.addMessageRequestHedgeLoserCost.mock.calls[0]?.[1].toString()).toBe("400");
+  });
+
+  it("tracks Redis loser cost with the captured billing provider and multiplier", async () => {
+    const loserProvider = createCodexProvider({
+      id: 11,
+      name: "initial-codex-loser",
+      costMultiplier: 2,
+    });
+    const winnerProvider = createCodexProvider({
+      id: 99,
+      name: "winner-polluted-provider",
+      costMultiplier: 10,
+    });
+    const loserSession = createLoserSession(winnerProvider, {
+      context1mApplied: true,
+      groupCostMultiplier: 99,
+    });
+    const responseBody = JSON.stringify({
+      usage: {
+        input_tokens: 100,
+        output_tokens: 10,
+      },
+    });
+
+    const billed = await finalizeHedgeLoserBilling({
+      messageRequestId: 123,
+      loserSession: loserSession as any,
+      provider: loserProvider,
+      attemptNumber: 1,
+      upstreamStatusCode: 200,
+      allContent: responseBody,
+      drainComplete: true,
+      billingContext: {
+        originalModel: "gpt-5.5",
+        redirectedModel: "gpt-5.5",
+        requestedServiceTier: "priority",
+        context1mApplied: false,
+        groupCostMultiplier: 3,
+      },
+    });
+
+    expect(billed).toBe("2400");
+    expect(mocks.trackCost).toHaveBeenCalledTimes(1);
+    expect(mocks.trackCost).toHaveBeenCalledWith(
+      10,
+      loserProvider.id,
+      "session-1",
+      2400,
+      expect.objectContaining({
+        userId: 20,
+        requestId: 123,
+      })
+    );
+    expect(mocks.trackUserDailyCost).toHaveBeenCalledWith(
+      20,
+      2400,
+      "00:00",
+      "fixed",
+      expect.objectContaining({
+        requestId: 123,
+      })
+    );
   });
 });

--- a/tests/unit/proxy/response-handler-hedge-loser-priority.test.ts
+++ b/tests/unit/proxy/response-handler-hedge-loser-priority.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  addMessageRequestHedgeLoserCost: vi.fn(async () => {}),
+  detectUpstreamErrorFromSseOrJsonText: vi.fn(() => ({ isError: false })),
+  isNonBillingEndpoint: vi.fn(() => false),
+}));
+
+vi.mock("@/repository/message", () => ({
+  addMessageRequestHedgeLoserCost: mocks.addMessageRequestHedgeLoserCost,
+  updateMessageRequestCostWithBreakdown: vi.fn(),
+  updateMessageRequestDetails: vi.fn(),
+  updateMessageRequestDuration: vi.fn(),
+  updateMessageRequestWinnerCost: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/async-task-manager", () => ({
+  AsyncTaskManager: {
+    register: () => new AbortController(),
+    cleanup: vi.fn(),
+    cancel: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/utils/upstream-error-detection", () => ({
+  detectUpstreamErrorFromSseOrJsonText: mocks.detectUpstreamErrorFromSseOrJsonText,
+  inferUpstreamErrorStatusCodeFromText: vi.fn(() => null),
+}));
+
+vi.mock(import("@/lib/utils/performance-formatter"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    isNonBillingEndpoint: mocks.isNonBillingEndpoint,
+  };
+});
+
+import { finalizeHedgeLoserBilling } from "@/app/v1/_lib/proxy/response-handler";
+import type { Provider } from "@/types/provider";
+
+function createCodexProvider(): Provider {
+  return {
+    id: 11,
+    name: "initial-codex-loser",
+    url: "https://codex.example.com/v1",
+    key: "sk-test",
+    providerVendorId: null,
+    isEnabled: true,
+    weight: 1,
+    priority: 0,
+    groupPriorities: null,
+    costMultiplier: 1,
+    groupTag: null,
+    providerType: "codex",
+    preserveClientIp: false,
+    modelRedirects: null,
+    allowedModels: null,
+    mcpPassthroughType: "none",
+    mcpPassthroughUrl: null,
+    limit5hUsd: null,
+    limitDailyUsd: null,
+    dailyResetMode: "fixed",
+    dailyResetTime: "00:00",
+    limitWeeklyUsd: null,
+    limitMonthlyUsd: null,
+    limitTotalUsd: null,
+    totalCostResetAt: null,
+    limitConcurrentSessions: 0,
+    maxRetryAttempts: 1,
+    circuitBreakerFailureThreshold: 5,
+    circuitBreakerOpenDuration: 1_800_000,
+    circuitBreakerHalfOpenSuccessThreshold: 2,
+    proxyUrl: null,
+    proxyFallbackToDirect: false,
+    firstByteTimeoutStreamingMs: 0,
+    streamingIdleTimeoutMs: 0,
+    requestTimeoutNonStreamingMs: 0,
+    websiteUrl: null,
+    faviconUrl: null,
+    cacheTtlPreference: null,
+    context1mPreference: null,
+    codexReasoningEffortPreference: null,
+    codexReasoningSummaryPreference: null,
+    codexTextVerbosityPreference: null,
+    codexParallelToolCallsPreference: null,
+    codexServiceTierPreference: null,
+    anthropicMaxTokensPreference: null,
+    anthropicThinkingBudgetPreference: null,
+    anthropicAdaptiveThinking: null,
+    geminiGoogleSearchPreference: null,
+    tpm: 0,
+    rpm: 0,
+    rpd: 0,
+    cc: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+}
+
+function createLoserSession(provider: Provider) {
+  return {
+    provider,
+    request: {
+      model: "winner-default-model",
+      message: {
+        model: "winner-default-model",
+        service_tier: "default",
+      },
+    },
+    sessionId: null,
+    messageContext: null,
+    authState: { key: null, user: null },
+    getEndpoint: () => "/v1/responses",
+    getOriginalModel: () => "winner-default-model",
+    getCurrentModel: () => "winner-default-model",
+    getContext1mApplied: () => false,
+    setContext1mApplied: vi.fn(),
+    getGroupCostMultiplier: () => 1,
+    getSpecialSettings: () => [],
+    addSpecialSetting: vi.fn(),
+    shouldTrackSessionObservability: () => false,
+    getCodexPriorityBillingSource: vi.fn(async () => "requested"),
+    getResolvedPricingByBillingSource: vi.fn(async () => ({
+      resolvedModelName: "gpt-5.5",
+      resolvedPricingProviderKey: "openai",
+      source: "official_fallback",
+      priceData: {
+        input_cost_per_token: 1,
+        output_cost_per_token: 10,
+        input_cost_per_token_priority: 2,
+        output_cost_per_token_priority: 20,
+      },
+    })),
+  };
+}
+
+describe("finalizeHedgeLoserBilling Codex priority snapshot", () => {
+  beforeEach(() => {
+    mocks.addMessageRequestHedgeLoserCost.mockClear();
+    mocks.detectUpstreamErrorFromSseOrJsonText.mockReturnValue({ isError: false });
+    mocks.isNonBillingEndpoint.mockReturnValue(false);
+  });
+
+  it("uses the initial loser's captured requested service tier after winner session sync", async () => {
+    const provider = createCodexProvider();
+    const loserSession = createLoserSession(provider);
+    const responseBody = JSON.stringify({
+      usage: {
+        input_tokens: 100,
+        output_tokens: 10,
+      },
+    });
+
+    const billed = await finalizeHedgeLoserBilling({
+      messageRequestId: 123,
+      loserSession: loserSession as any,
+      provider,
+      attemptNumber: 1,
+      upstreamStatusCode: 200,
+      allContent: responseBody,
+      drainComplete: true,
+      billingContext: {
+        originalModel: "gpt-5.5",
+        redirectedModel: "gpt-5.5",
+        requestedServiceTier: "priority",
+        context1mApplied: false,
+        groupCostMultiplier: 1,
+      },
+    });
+
+    expect(billed).toBe("400");
+    expect(mocks.addMessageRequestHedgeLoserCost).toHaveBeenCalledTimes(1);
+    expect(mocks.addMessageRequestHedgeLoserCost.mock.calls[0]?.[1].toString()).toBe("400");
+  });
+});


### PR DESCRIPTION
## Summary

- Preserve the initial Codex hedge loser's requested `service_tier` before the shared session is synced to the winning attempt
- Use the loser's provider and captured requested tier when resolving priority billing for hedge loser cost calculation
- Add a regression test covering an initial Codex `priority` loser after winner-session sync pollution

## Root cause

`finalizeHedgeLoserBilling` already accepts a pre-sync billing context so the initial provider loser is priced with its own model and multipliers. However, Codex priority billing still called `resolveCodexPriorityBillingDecision(loserSession, ...)`, which reads `service_tier` from the session after `syncWinningAttemptSession` may have overwritten it with the winner request. In a hedge race where the initial Codex attempt requested `priority` but the winner did not, the loser could be under-billed at default-tier rates.

**Related PRs:**
- Follow-up to #1247 — introduced hedge loser billing; this PR fixes a gap where Codex priority tier was not captured in the billing snapshot
- Related to #992 — same class of session-sync pollution bug (preserving per-attempt data across winner sync)
- Related to #960 — added the Codex priority billing source setting that this fix relies on
- Related to #870 — added codex service tier provider overrides

## Changes

### Core Changes
- **`forwarder.ts`**: Capture `requestedServiceTier` from the loser's request message into `billingSnapshot` before the winner session can overwrite it
- **`response-handler.ts`**: Thread `provider` and `requestedServiceTier` from `billingContext` through `resolveCodexPriorityBillingDecision` so priority billing uses the loser's own tier, not the winner's
- **`response-handler.ts`**: Extend `getRequestedCodexServiceTier` to accept an optional provider override

### Supporting Changes
- **`StreamingHedgeAttempt.billingSnapshot` type**: Add `requestedServiceTier: string | null` field
- **`finalizeHedgeLoserBilling` params**: Add `requestedServiceTier` to `billingContext` type

## Testing

### Automated Tests
- [x] Unit test added: `tests/unit/proxy/response-handler-hedge-loser-priority.test.ts` (187 lines) — verifies that an initial Codex loser with `priority` service tier is correctly billed at priority rates after winner session sync

### Validation
- `bun run typecheck`
- `bun run test tests/unit/proxy/response-handler-hedge-loser-priority.test.ts tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts tests/integration/billing-model-source.test.ts`
- `bunx biome check src/app/v1/_lib/proxy/response-handler.ts src/app/v1/_lib/proxy/forwarder.ts tests/unit/proxy/response-handler-hedge-loser-priority.test.ts`

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an under-billing bug in the Codex hedge-loser path where `syncWinningAttemptSession` could overwrite the shared session's `service_tier` before `resolveCodexPriorityBillingDecision` read it, causing an initial Codex loser that requested `priority` to be billed at default rates.

- **`forwarder.ts`**: Captures `requestedServiceTier` from the loser's request message into `billingSnapshot` before the winner session sync, extending the existing snapshot mechanism that already preserved model and cost-multiplier state.
- **`response-handler.ts`**: Threads `provider` and the captured `requestedServiceTier` through `resolveCodexPriorityBillingDecision` and `trackCostToRedis` so both the DB cost record and Redis rate-limit counters use the loser's pre-sync tier, not the winner's.
- **Test**: Adds a focused regression test verifying that an initial Codex loser with `requestedServiceTier: \"priority\"` in its billing snapshot is billed at priority rates even after the shared session has been polluted with the winner's default-tier request.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrow, well-scoped billing snapshot extension with no mutations to the hot path and a dedicated regression test.

The fix captures `requestedServiceTier` into the billing snapshot before session-sync can overwrite it, then consistently threads both the provider and the captured tier through cost calculation and Redis tracking. Shadow-session losers preserve existing behavior, and the tests verify the arithmetic end-to-end.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/forwarder.ts | Adds `requestedServiceTier` to the billing snapshot captured before `syncWinningAttemptSession`; snapshot logic and the type definition are correctly extended in lockstep. |
| src/app/v1/_lib/proxy/response-handler.ts | Correctly threads `provider` and `requestedServiceTier` through `resolveCodexPriorityBillingDecision` and `trackCostToRedis`; both the DB cost and Redis counters now consistently use the loser's pre-sync billing parameters. |
| tests/unit/proxy/response-handler-hedge-loser-priority.test.ts | New regression tests cover the priority-tier snapshot path and verify both DB cost (priority x costMultiplier x groupCostMultiplier) and Redis trackCost call. Session-pollution simulation is accurate. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant FW as forwarder.ts (commitWinner)
    participant SS as syncWinningAttemptSession
    participant FHL as finalizeHedgeLoserBilling
    participant RCPBD as resolveCodexPriorityBillingDecision
    participant TCR as trackCostToRedis

    FW->>FW: Capture billingSnapshot
    FW->>SS: syncWinningAttemptSession(session, winner.session)
    Note over SS: Overwrites session.request.message with winner's tier
    FW->>FHL: "finalizeHedgeLoserBilling({billingContext: billingSnapshot})"
    FHL->>RCPBD: "resolveCodexPriorityBillingDecision(loserSession, actualTier, {provider, requestedServiceTier})"
    Note over RCPBD: Uses captured tier instead of polluted session value
    RCPBD-->>FHL: "{effectivePriority: true}"
    FHL->>TCR: "trackCostToRedis(..., {provider, context1mApplied, groupCostMultiplier})"
    Note over TCR: Redis counters use loser's cost parameters
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(proxy): track hedge loser Redis cost..."](https://github.com/ding113/claude-code-hub/commit/fb63194ade8686c8ee17923917bdae19395ea937) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36251743)</sub>

<!-- /greptile_comment -->