### PR TITLE
fix(request-filters): preserve advanced mode when rebinding

### DIFF
--- a/src/actions/request-filters.ts
+++ b/src/actions/request-filters.ts
@@ -364,6 +364,9 @@ export async function updateRequestFilterAction(
       updates.providerIds !== undefined ? updates.providerIds : existing!.providerIds;
     const effectiveGroupTags =
       updates.groupTags !== undefined ? updates.groupTags : existing!.groupTags;
+    const effectiveRuleMode = updates.ruleMode ?? existing!.ruleMode;
+    const effectiveOperations =
+      updates.operations !== undefined ? updates.operations : existing!.operations;
 
     const validationError = validatePayload({
       name: existing!.name,
@@ -373,6 +376,8 @@ export async function updateRequestFilterAction(
       bindingType: effectiveBindingType,
       providerIds: effectiveProviderIds,
       groupTags: effectiveGroupTags,
+      ruleMode: effectiveRuleMode,
+      operations: effectiveOperations,
     });
 
     if (validationError) {

--- a/tests/unit/actions/request-filters-cache-reload.test.ts
+++ b/tests/unit/actions/request-filters-cache-reload.test.ts
@@ -5,6 +5,7 @@ const reloadMock = vi.fn(async () => {});
 const createRequestFilterMock = vi.fn();
 const updateRequestFilterMock = vi.fn();
 const deleteRequestFilterMock = vi.fn();
+const getRequestFilterByIdMock = vi.fn(async () => null);
 
 vi.mock("@/lib/auth", () => ({
   getSession: getSessionMock,
@@ -29,7 +30,7 @@ vi.mock("@/repository/request-filters", () => ({
   createRequestFilter: createRequestFilterMock,
   deleteRequestFilter: deleteRequestFilterMock,
   getAllRequestFilters: vi.fn(async () => []),
-  getRequestFilterById: vi.fn(async () => null),
+  getRequestFilterById: getRequestFilterByIdMock,
   updateRequestFilter: updateRequestFilterMock,
 }));
 
@@ -110,6 +111,66 @@ describe("request-filters actions reload the engine on mutation", () => {
 
     expect(res.ok).toBe(true);
     expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows updating provider bindings on an advanced final filter with an empty target", async () => {
+    const advancedFilter = {
+      ...baseFilter,
+      target: "",
+      bindingType: "providers" as const,
+      providerIds: [5, 4, 6],
+      ruleMode: "advanced" as const,
+      executionPhase: "final" as const,
+      operations: [
+        {
+          op: "remove" as const,
+          scope: "body" as const,
+          path: "tools",
+          matcher: { field: "type", value: "image_generation", matchType: "exact" as const },
+        },
+      ],
+    };
+    getRequestFilterByIdMock.mockResolvedValue(advancedFilter);
+    updateRequestFilterMock.mockResolvedValue({ ...advancedFilter, providerIds: [5, 4, 6, 24] });
+
+    const { updateRequestFilterAction } = await import("@/actions/request-filters");
+    const res = await updateRequestFilterAction(1, { providerIds: [5, 4, 6, 24] });
+
+    expect(res.ok).toBe(true);
+    expect(updateRequestFilterMock).toHaveBeenCalledWith(1, { providerIds: [5, 4, 6, 24] });
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates binding updates against the effective updated rule mode", async () => {
+    const advancedFilter = {
+      ...baseFilter,
+      target: "",
+      bindingType: "providers" as const,
+      providerIds: [5, 4, 6],
+      ruleMode: "advanced" as const,
+      executionPhase: "final" as const,
+      operations: [
+        {
+          op: "remove" as const,
+          scope: "body" as const,
+          path: "tools",
+          matcher: { field: "type", value: "image_generation", matchType: "exact" as const },
+        },
+      ],
+    };
+    getRequestFilterByIdMock.mockResolvedValue(advancedFilter);
+
+    const { updateRequestFilterAction } = await import("@/actions/request-filters");
+    const res = await updateRequestFilterAction(1, {
+      providerIds: [5, 4, 6, 24],
+      ruleMode: "simple",
+      operations: null,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("目标字段不能为空");
+    expect(updateRequestFilterMock).not.toHaveBeenCalled();
+    expect(reloadMock).not.toHaveBeenCalled();
   });
 
   it("deleteRequestFilterAction reloads the engine after a successful delete", async () => {


### PR DESCRIPTION
## Summary
Preserve the existing `ruleMode` and `operations` when validating provider/group binding-only updates, preventing advanced-mode filters with an empty `target` from being incorrectly rejected.

## Problem

This is a regression from #912 (advanced mode operations). When updating **only binding fields** (`providerIds`, `groupTags`) on an advanced-mode filter, the binding-validation path at `src/actions/request-filters.ts:368` constructs a `validatePayload` call that omits `ruleMode` and `operations`. Without `ruleMode`, the validator defaults to `"simple"` mode, which enforces a non-empty `target` — but advanced-mode filters legitimately have empty `target` fields since they use `operations` instead. This makes binding-only updates on advanced filters fail with "目标字段不能为空".

## Solution

Forward the existing filter's `ruleMode` and `operations` into the `validatePayload` call so the validator correctly recognizes advanced-mode filters and skips the empty-target check.

**Follow-up to #912** — the advanced-mode validation path for binding-only updates was missed in the original implementation.

## Changes

### Core Fix
- `src/actions/request-filters.ts` — Pass `existing.ruleMode` and `existing.operations` to `validatePayload` in the binding-update validation block

### Tests
- `tests/unit/actions/request-filters-cache-reload.test.ts` — Regression test: updating provider bindings on an advanced final filter with an empty `target` succeeds and calls the repository correctly

## Testing
- `bun run test tests/unit/actions/request-filters-cache-reload.test.ts`
- `bunx biome check src/actions/request-filters.ts tests/unit/actions/request-filters-cache-reload.test.ts`

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression introduced in #912 where binding-only updates (`providerIds`, `groupTags`) on advanced-mode filters incorrectly failed with "目标字段不能为空". The root cause was the binding-validation call inside `updateRequestFilterAction` omitting `ruleMode` and `operations`, causing `validatePayload` to default to simple mode and enforce a non-empty `target` check that advanced filters legitimately bypass.

- **Core fix** (`src/actions/request-filters.ts`): `effectiveRuleMode` and `effectiveOperations` are now computed and forwarded to `validatePayload` in the binding-update validation block, so the validator correctly recognises advanced-mode filters and skips the empty-target check.
- **Regression tests** (`tests/unit/actions/request-filters-cache-reload.test.ts`): Two new tests cover the primary fix (binding update on advanced filter with empty `target` succeeds) and the boundary case (transitioning to simple mode without a target still fails correctly).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrow, well-targeted, and covered by regression tests; no existing behaviour outside the advanced-mode binding path is affected.

The fix touches only two new lines in a single conditional block, correctly mirrors how every other effective-value computation in that block already works, and is guarded by two new tests covering both the happy path and the failure boundary.

No files require special attention beyond the noted pre-existing gap in the binding validation's target handling.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/actions/request-filters.ts | Adds effectiveRuleMode and effectiveOperations to the binding-update validatePayload call, fixing the advanced-mode regression; existing!.target passed to that same call (rather than updates.target ?? existing!.target) is a pre-existing gap for combined target+binding updates. |
| tests/unit/actions/request-filters-cache-reload.test.ts | Extracts getRequestFilterById mock for reuse and adds two well-scoped regression tests covering both the fixed path and the mode-transition boundary. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[updateRequestFilterAction called] --> B{binding fields in updates?}
    B -- No --> G[other validation / DB write]
    B -- Yes --> C[compute effectiveBindingType\neffectiveProviderIds\neffectiveGroupTags]
    C --> D["compute effectiveRuleMode\n(updates.ruleMode ?? existing.ruleMode)\n[NEW]"]
    D --> E["compute effectiveOperations\n(updates.operations ?? existing.operations)\n[NEW]"]
    E --> F["validatePayload(name, scope, action,\ntarget, bindingType, providerIds, groupTags,\nruleMode, operations)"]
    F -- ruleMode=advanced --> H[validateOperations → skip empty-target check]
    F -- ruleMode=simple --> I{target empty?}
    I -- Yes --> J[return error]
    I -- No --> K[check binding constraints]
    H --> K
    K --> G
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/actions/request-filters.ts:371-381
The binding validation block now correctly computes `effectiveRuleMode` and `effectiveOperations`, but still passes `existing!.target` instead of the effective target. For a combined update such as `{ ruleMode: "simple", target: "new-value", providerIds: [...] }` on an existing advanced-mode filter (which has an empty `target`), the validator receives the old empty target alongside `ruleMode: "simple"` and rejects the request with "目标字段不能为空" even though the final state would be valid. Using the effective target here is consistent with how every other field in this block is computed.

```suggestion
    const effectiveTarget = updates.target ?? existing!.target;
    const validationError = validatePayload({
      name: existing!.name,
      scope: existing!.scope,
      action: existing!.action,
      target: effectiveTarget,
      bindingType: effectiveBindingType,
      providerIds: effectiveProviderIds,
      groupTags: effectiveGroupTags,
      ruleMode: effectiveRuleMode,
      operations: effectiveOperations,
    });
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(request-filters): preserve advanced ..."](https://github.com/ding113/claude-code-hub/commit/9a783319456d9cb1764f270b3be1180c60796f9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36635943)</sub>

<!-- /greptile_comment -->