### PR TITLE
fix(keys): 非 admin 自助建 key 403 + errors.auth.forbidden 原始键名显示 (#1259)

### DIFF
--- a/src/app/api/v1/resources/keys/handlers.ts
+++ b/src/app/api/v1/resources/keys/handlers.ts
@@ -66,6 +66,45 @@ export async function createUserKey(c: Context): Promise<Response> {
   return createdResponse(result.data, location, { headers: withNoStoreHeaders() });
 }
 
+// NOTE(#1259): self-service write endpoint — the per-user route above is
+// admin-only, so non-admin dashboard users create keys through this route.
+// The target user id always comes from the authenticated session.
+export async function createSelfKey(c: Context): Promise<Response> {
+  const auth = c.get("auth");
+  const sessionUserId = auth?.session?.user?.id;
+  if (!sessionUserId) {
+    return createProblemResponse({
+      status: 401,
+      instance: new URL(c.req.url).pathname,
+      errorCode: "auth.missing",
+      detail: "Authentication is required.",
+    });
+  }
+  // Read-tier auth admits canLoginWebUi=false keys as read-only sessions; a
+  // key write here would let them mint a Web-UI-capable key, so reject them.
+  if (auth?.session?.key?.canLoginWebUi === false) {
+    return createProblemResponse({
+      status: 403,
+      instance: new URL(c.req.url).pathname,
+      errorCode: "auth.forbidden",
+      detail: "Read-only sessions cannot create keys.",
+    });
+  }
+  const body = await parseHonoJsonBody(c, KeyCreateSchema);
+  if (!body.ok) return body.response;
+  const actions = await import("@/actions/keys");
+  const result = await callAction(
+    c,
+    actions.addKey,
+    [{ userId: sessionUserId, ...body.data }] as never[],
+    c.get("auth")
+  );
+  if (!result.ok) return actionError(c, result);
+  const createdKeyId = (result.data as { id?: number }).id;
+  const location = createdKeyId ? `/api/v1/keys/${createdKeyId}` : "/api/v1/users:self/keys";
+  return createdResponse(result.data, location, { headers: withNoStoreHeaders() });
+}
+
 export async function getKey(c: Context): Promise<Response> {
   const params = parseKeyParams(c);
   if (params instanceof Response) return params;

--- a/src/app/api/v1/resources/keys/handlers.ts
+++ b/src/app/api/v1/resources/keys/handlers.ts
@@ -81,8 +81,9 @@ export async function createSelfKey(c: Context): Promise<Response> {
     });
   }
   // Read-tier auth admits canLoginWebUi=false keys as read-only sessions; a
-  // key write here would let them mint a Web-UI-capable key, so reject them.
-  if (auth?.session?.key?.canLoginWebUi === false) {
+  // key write here would let them mint a Web-UI-capable key. Deny-by-default
+  // (only an explicit canLoginWebUi=true session may proceed).
+  if (auth?.session?.key?.canLoginWebUi !== true) {
     return createProblemResponse({
       status: 403,
       instance: new URL(c.req.url).pathname,
@@ -93,10 +94,12 @@ export async function createSelfKey(c: Context): Promise<Response> {
   const body = await parseHonoJsonBody(c, KeyCreateSchema);
   if (!body.ok) return body.response;
   const actions = await import("@/actions/keys");
+  // Session user id is spread last so a future schema change can never let the
+  // request body steer the target user.
   const result = await callAction(
     c,
     actions.addKey,
-    [{ userId: sessionUserId, ...body.data }] as never[],
+    [{ ...body.data, userId: sessionUserId }] as never[],
     c.get("auth")
   );
   if (!result.ok) return actionError(c, result);

--- a/src/app/api/v1/resources/keys/router.ts
+++ b/src/app/api/v1/resources/keys/router.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/api/v1/schemas/keys";
 import {
   batchUpdateKeys,
+  createSelfKey,
   createUserKey,
   deleteKey,
   enableKey,
@@ -109,6 +110,31 @@ keysRouter.openapi(
     },
   }),
   createUserKey as never
+);
+
+keysRouter.openapi(
+  createRoute({
+    method: "post",
+    path: "/users:self/keys",
+    middleware: requireAuth("read"),
+    tags: ["Keys"],
+    summary: "Create own key",
+    description:
+      "Creates a key for the current session user. The target user id always comes from the authenticated session; read-only sessions (keys without Web UI access) are rejected.",
+    "x-required-access": "read",
+    security,
+    request: {
+      body: { required: true, content: { "application/json": { schema: KeyCreateSchema } } },
+    },
+    responses: {
+      201: {
+        description: "Created key.",
+        content: { "application/json": { schema: GenericKeyResponseSchema } },
+      },
+      ...problemResponses,
+    },
+  }),
+  createSelfKey as never
 );
 
 // Custom-method routes (`/keys/{id}:reveal` etc.) must register before the

--- a/src/lib/api-client/v1/actions/_compat.ts
+++ b/src/lib/api-client/v1/actions/_compat.ts
@@ -1,9 +1,12 @@
 "use client";
 
 import { apiClient } from "@/lib/api-client/v1/client";
-import { ApiError } from "@/lib/api-client/v1/errors";
+import { ApiError, getApiErrorMessageKey } from "@/lib/api-client/v1/errors";
 import type { ActionResult } from "./types";
 
+// NOTE(#1259): errorCode is pre-mapped to an errors-namespace key so forms can
+// pass it straight to getErrorMessage(); raw REST codes like "auth.forbidden"
+// have no translation and would render as the literal key path.
 export function toActionResult<T = any>(promise: Promise<T>): Promise<ActionResult<T>> {
   return promise
     .then((data) => ({ ok: true as const, data }) as ActionResult<T>)
@@ -11,7 +14,7 @@ export function toActionResult<T = any>(promise: Promise<T>): Promise<ActionResu
       (error): ActionResult<T> => ({
         ok: false as const,
         error: error instanceof Error ? error.message : "Request failed",
-        errorCode: error instanceof ApiError ? error.errorCode : undefined,
+        errorCode: error instanceof ApiError ? getApiErrorMessageKey(error) : undefined,
         errorParams: error instanceof ApiError ? toActionErrorParams(error.errorParams) : undefined,
       })
     );
@@ -24,7 +27,7 @@ export function toVoidActionResult(promise: Promise<unknown>): Promise<ActionRes
       (error): ActionResult => ({
         ok: false as const,
         error: error instanceof Error ? error.message : "Request failed",
-        errorCode: error instanceof ApiError ? error.errorCode : undefined,
+        errorCode: error instanceof ApiError ? getApiErrorMessageKey(error) : undefined,
         errorParams: error instanceof ApiError ? toActionErrorParams(error.errorParams) : undefined,
       })
     );

--- a/src/lib/api-client/v1/actions/keys.ts
+++ b/src/lib/api-client/v1/actions/keys.ts
@@ -1,4 +1,5 @@
 import type { BatchUpdateKeysParams, PatchKeyLimitField } from "@/actions/keys";
+import { isAdminForbidden } from "@/lib/api-client/v1/errors";
 import type { Key } from "@/types/key";
 import {
   apiDelete,
@@ -15,7 +16,17 @@ export type { Key } from "@/types/key";
 
 export function addKey(data: { userId: number } & Record<string, unknown>) {
   const { userId, ...body } = data;
-  return toActionResult(apiPost(`/api/v1/users/${userId}/keys`, body));
+  // NOTE(#1259): the per-user route is admin-only. Non-admin self-service runs
+  // into auth.forbidden there, so retry via the read-tier self endpoint, which
+  // derives the target user from the session (mirrors getUsers()'s fallback).
+  return toActionResult(
+    apiPost(`/api/v1/users/${userId}/keys`, body).catch((error: unknown) => {
+      if (isAdminForbidden(error)) {
+        return apiPost("/api/v1/users:self/keys", body);
+      }
+      throw error;
+    })
+  );
 }
 
 export function editKey(keyId: number, data: unknown) {

--- a/src/lib/api-client/v1/actions/users.ts
+++ b/src/lib/api-client/v1/actions/users.ts
@@ -1,6 +1,6 @@
 import type { BatchUpdateUsersParams, GetUsersBatchParams } from "@/actions/users";
 import { DASHBOARD_COMPAT_HEADER } from "@/lib/api/v1/_shared/constants";
-import { ApiError } from "@/lib/api-client/v1/errors";
+import { isAdminForbidden } from "@/lib/api-client/v1/errors";
 import type { UserDisplay } from "@/types/user";
 import {
   apiDelete,
@@ -182,8 +182,4 @@ function toUserListQuery(params?: GetUsersBatchParams): string {
     sortBy: params?.sortBy,
     sortOrder: params?.sortOrder,
   });
-}
-
-function isAdminForbidden(error: unknown): boolean {
-  return error instanceof ApiError && error.status === 403 && error.errorCode === "auth.forbidden";
 }

--- a/src/lib/api-client/v1/errors.ts
+++ b/src/lib/api-client/v1/errors.ts
@@ -23,6 +23,12 @@ export function isApiError(error: unknown): error is ApiError {
   return error instanceof ApiError;
 }
 
+// Admin-only routes reject non-admin sessions with this exact pair; clients
+// use it to decide whether to retry through a read-tier self endpoint.
+export function isAdminForbidden(error: unknown): boolean {
+  return isApiError(error) && error.status === 403 && error.errorCode === "auth.forbidden";
+}
+
 const API_ERROR_MESSAGE_KEYS: Record<string, string> = {
   "api.error": "INTERNAL_ERROR",
   "api.malformed_error_body": "INTERNAL_ERROR",
@@ -39,6 +45,10 @@ const API_ERROR_MESSAGE_KEYS: Record<string, string> = {
   "provider_endpoint.action_failed": "OPERATION_FAILED",
   "provider_vendor.not_found": "NOT_FOUND",
   "provider_vendor.action_failed": "OPERATION_FAILED",
+  "key.not_found": "KEY_NOT_FOUND",
+  "key.action_failed": "OPERATION_FAILED",
+  "user.not_found": "USER_NOT_FOUND",
+  "user.action_failed": "OPERATION_FAILED",
 };
 
 export function getApiErrorMessageKey(error: ApiError): string {

--- a/src/lib/api-client/v1/openapi-types.gen.ts
+++ b/src/lib/api-client/v1/openapi-types.gen.ts
@@ -2468,6 +2468,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/users:self/keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create own key
+         * @description Creates a key for the current session user. The target user id always comes from the authenticated session; read-only sessions (keys without Web UI access) are rejected.
+         */
+        post: operations["postUsersSelfKeys"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/keys/{keyId}:enable": {
         parameters: {
             query?: never;
@@ -32605,6 +32625,223 @@ export interface operations {
                 /** @description User id. */
                 userId: number;
             };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Key name. */
+                    name: string;
+                    /** @description Expiration date or null. */
+                    expiresAt?: string | null;
+                    /** @description Whether the key is enabled. */
+                    isEnabled?: boolean;
+                    /** @description Whether this key can login to the Web UI. */
+                    canLoginWebUi?: boolean;
+                    /** @description Five-hour USD quota. */
+                    limit5hUsd?: number | null;
+                    /**
+                     * @description Five-hour reset mode.
+                     * @enum {string}
+                     */
+                    limit5hResetMode?: "fixed" | "rolling";
+                    /** @description Daily USD quota. */
+                    limitDailyUsd?: number | null;
+                    /**
+                     * @description Daily reset mode.
+                     * @enum {string}
+                     */
+                    dailyResetMode?: "fixed" | "rolling";
+                    /** @description Daily reset time in HH:mm. */
+                    dailyResetTime?: string;
+                    /** @description Weekly USD quota. */
+                    limitWeeklyUsd?: number | null;
+                    /** @description Monthly USD quota. */
+                    limitMonthlyUsd?: number | null;
+                    /** @description Total USD quota. */
+                    limitTotalUsd?: number | null;
+                    /** @description Concurrent session limit. */
+                    limitConcurrentSessions?: number;
+                    /** @description Provider group expression. */
+                    providerGroup?: string | null;
+                    /**
+                     * @description Cache TTL preference.
+                     * @enum {string}
+                     */
+                    cacheTtlPreference?: "inherit" | "5m" | "1h";
+                };
+            };
+        };
+        responses: {
+            /** @description Created key. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Invalid request. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Access denied. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description Key not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": {
+                        /** @description Stable problem type URI or URN. */
+                        type: string;
+                        /** @description Short problem title. */
+                        title: string;
+                        /** @description HTTP status code. */
+                        status: number;
+                        /** @description Human-readable error detail. */
+                        detail: string;
+                        /** @description Request path that produced the problem. */
+                        instance: string;
+                        /** @description Application error code for frontend i18n. */
+                        errorCode: string;
+                        /** @description Optional i18n parameters. */
+                        errorParams?: {
+                            [key: string]: unknown;
+                        };
+                        /** @description Optional request trace identifier. */
+                        traceId?: string;
+                        /** @description Validation failure details. */
+                        invalidParams?: {
+                            /** @description Path to the invalid input field. */
+                            path: (string | number)[];
+                            /** @description Machine-readable validation error code. */
+                            code: string;
+                            /** @description Validation error message. */
+                            message: string;
+                        }[];
+                    };
+                };
+            };
+        };
+    };
+    postUsersSelfKeys: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description Required only when authenticating with the auth-token cookie on mutation requests. */
+                "X-CCH-CSRF"?: string;
+            };
+            path?: never;
             cookie?: never;
         };
         requestBody: {

--- a/tests/api/v1/keys/keys.self.test.ts
+++ b/tests/api/v1/keys/keys.self.test.ts
@@ -1,0 +1,153 @@
+import type { AuthSession } from "@/lib/auth";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const validateAuthTokenMock = vi.hoisted(() => vi.fn());
+const addKeyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return { ...actual, validateAuthToken: validateAuthTokenMock };
+});
+
+vi.mock("@/actions/keys", () => ({
+  addKey: addKeyMock,
+}));
+
+const { callV1Route } = await import("../test-utils");
+
+const adminSession = {
+  user: { id: 1, role: "admin", isEnabled: true },
+  key: { id: 1, userId: 1, key: "admin-token", canLoginWebUi: true },
+} as AuthSession;
+
+const userSession = {
+  user: { id: 2, role: "user", isEnabled: true },
+  key: { id: 2, userId: 2, key: "user-token", canLoginWebUi: true },
+} as AuthSession;
+
+// Read-tier auth admits canLoginWebUi=false keys as read-only sessions; the
+// self key-creation endpoint must reject them (issue #1259 / privilege fence).
+const readOnlySession = {
+  user: { id: 3, role: "user", isEnabled: true },
+  key: { id: 3, userId: 3, key: "readonly-token", canLoginWebUi: false },
+} as AuthSession;
+
+describe("POST /api/v1/users:self/keys", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addKeyMock.mockResolvedValue({
+      ok: true,
+      data: { id: 77, generatedKey: "sk-new", name: "self-key" },
+    });
+  });
+
+  test("creates a key for the session user without admin access", async () => {
+    validateAuthTokenMock.mockResolvedValue(userSession);
+
+    const created = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/users:self/keys",
+      headers: { Authorization: "Bearer user-token" },
+      body: { name: "self-key", providerGroup: "default" },
+    });
+
+    expect(created.response.status).toBe(201);
+    expect(created.response.headers.get("Location")).toBe("/api/v1/keys/77");
+    expect(created.response.headers.get("Cache-Control")).toContain("no-store");
+    expect(addKeyMock).toHaveBeenCalledWith({
+      userId: 2,
+      name: "self-key",
+      providerGroup: "default",
+    });
+  });
+
+  test("derives the target user from the session for admins too", async () => {
+    validateAuthTokenMock.mockResolvedValue(adminSession);
+
+    const created = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/users:self/keys",
+      headers: { Authorization: "Bearer admin-token" },
+      body: { name: "self-key" },
+    });
+
+    expect(created.response.status).toBe(201);
+    expect(addKeyMock).toHaveBeenCalledWith({ userId: 1, name: "self-key" });
+  });
+
+  test("rejects body attempts to choose another user id via the strict schema", async () => {
+    validateAuthTokenMock.mockResolvedValue(userSession);
+
+    const response = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/users:self/keys",
+      headers: { Authorization: "Bearer user-token" },
+      body: { name: "self-key", userId: 999 },
+    });
+
+    expect(response.response.status).toBe(400);
+    expect(response.json).toMatchObject({ errorCode: "request.validation_failed" });
+    expect(addKeyMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects read-only sessions that cannot log into the Web UI", async () => {
+    validateAuthTokenMock.mockResolvedValue(readOnlySession);
+
+    const response = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/users:self/keys",
+      headers: { Authorization: "Bearer readonly-token" },
+      body: { name: "escalation-attempt" },
+    });
+
+    expect(response.response.status).toBe(403);
+    expect(response.json).toMatchObject({ errorCode: "auth.forbidden" });
+    expect(addKeyMock).not.toHaveBeenCalled();
+  });
+
+  test("requires authentication", async () => {
+    const response = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/users:self/keys",
+      body: { name: "anonymous" },
+    });
+
+    expect(response.response.status).toBe(401);
+    expect(response.json).toMatchObject({ errorCode: "auth.missing" });
+    expect(addKeyMock).not.toHaveBeenCalled();
+  });
+
+  test("surfaces action failures through the problem envelope", async () => {
+    validateAuthTokenMock.mockResolvedValue(userSession);
+    addKeyMock.mockResolvedValue({
+      ok: false,
+      error: "duplicate name",
+      errorCode: "DUPLICATE_NAME",
+    });
+
+    const response = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/users:self/keys",
+      headers: { Authorization: "Bearer user-token" },
+      body: { name: "self-key" },
+    });
+
+    expect(response.response.status).toBe(400);
+    expect(response.json).toMatchObject({ errorCode: "DUPLICATE_NAME" });
+  });
+
+  test("keeps the per-user admin route admin-only", async () => {
+    validateAuthTokenMock.mockResolvedValue(userSession);
+
+    const response = await callV1Route({
+      method: "POST",
+      pathname: "/api/v1/users/2/keys",
+      headers: { Authorization: "Bearer user-token" },
+      body: { name: "self-key" },
+    });
+
+    expect(response.response.status).toBe(403);
+    expect(response.json).toMatchObject({ errorCode: "auth.forbidden" });
+    expect(addKeyMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/api/v1/api-client-actions.test.ts
+++ b/tests/unit/api/v1/api-client-actions.test.ts
@@ -6,12 +6,14 @@ import { ApiError } from "@/lib/api-client/v1/errors";
 const getMock = vi.hoisted(() => vi.fn());
 const patchMock = vi.hoisted(() => vi.fn());
 const postMock = vi.hoisted(() => vi.fn());
+const deleteMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/api-client/v1/client", () => ({
   apiClient: {
     get: getMock,
     patch: patchMock,
     post: postMock,
+    delete: deleteMock,
   },
 }));
 
@@ -471,6 +473,70 @@ describe("v1 action compatibility client", () => {
       errorCode: "DUPLICATE_NAME",
       errorParams: undefined,
     });
+  });
+
+  test("preserves business delete codes through toVoidActionResult (removeKey)", async () => {
+    // The #1266 contract: CANNOT_DELETE_LAST_KEY must survive the void wrapper
+    // unchanged (not collapsed to a generic code) so the toast shows the reason.
+    deleteMock.mockRejectedValueOnce(
+      new ApiError({
+        status: 400,
+        errorCode: "CANNOT_DELETE_LAST_KEY",
+        detail: "Bad request",
+      })
+    );
+
+    const result = await keys.removeKey(7);
+
+    expect(deleteMock).toHaveBeenCalledWith("/api/v1/keys/7");
+    expect(result).toEqual({
+      ok: false,
+      error: "Bad request",
+      errorCode: "CANNOT_DELETE_LAST_KEY",
+      errorParams: undefined,
+    });
+  });
+
+  test("maps key.action_failed through toVoidActionResult to OPERATION_FAILED", async () => {
+    deleteMock.mockRejectedValueOnce(
+      new ApiError({ status: 400, errorCode: "key.action_failed", detail: "Bad request" })
+    );
+
+    const result = await keys.removeKey(7);
+
+    expect(result).toMatchObject({ ok: false, errorCode: "OPERATION_FAILED" });
+  });
+
+  test("surfaces PERMISSION_DENIED when both admin and self key creation are forbidden", async () => {
+    // Readonly self-service user: admin route 403s, fallback self route also 403s.
+    postMock
+      .mockRejectedValueOnce(
+        new ApiError({ status: 403, errorCode: "auth.forbidden", detail: "Admin access required." })
+      )
+      .mockRejectedValueOnce(
+        new ApiError({
+          status: 403,
+          errorCode: "auth.forbidden",
+          detail: "Read-only sessions cannot create keys.",
+        })
+      );
+
+    const result = await keys.addKey({ userId: 2, name: "self-key" });
+
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(postMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/v1/users/2/keys",
+      { name: "self-key" },
+      undefined
+    );
+    expect(postMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/v1/users:self/keys",
+      { name: "self-key" },
+      undefined
+    );
+    expect(result).toMatchObject({ ok: false, errorCode: "PERMISSION_DENIED" });
   });
 
   test("maps resource action_failed codes to translatable error codes", async () => {

--- a/tests/unit/api/v1/api-client-actions.test.ts
+++ b/tests/unit/api/v1/api-client-actions.test.ts
@@ -33,6 +33,9 @@ const providerEndpoints = await vi.importActual<
 const usageLogs = await vi.importActual<typeof import("@/lib/api-client/v1/actions/usage-logs")>(
   "@/lib/api-client/v1/actions/usage-logs"
 );
+const keys = await vi.importActual<typeof import("@/lib/api-client/v1/actions/keys")>(
+  "@/lib/api-client/v1/actions/keys"
+);
 
 describe("v1 action compatibility client", () => {
   beforeEach(() => {
@@ -408,10 +411,83 @@ describe("v1 action compatibility client", () => {
 
     const result = await providers.getProviderGroupsWithCount();
 
+    // errorCode must arrive pre-mapped to an errors-namespace key so forms can
+    // translate it directly (issue #1259: raw "auth.forbidden" rendered as the
+    // literal fallback string "errors.auth.forbidden").
     expect(result).toEqual({
       ok: false,
       error: "Admin access is required.",
-      errorCode: "auth.forbidden",
+      errorCode: "PERMISSION_DENIED",
+      errorParams: undefined,
+    });
+  });
+
+  test("falls back to the self key-creation endpoint for non-admin key creation", async () => {
+    postMock
+      .mockRejectedValueOnce(
+        new ApiError({
+          status: 403,
+          errorCode: "auth.forbidden",
+          detail: "Admin access is required.",
+        })
+      )
+      .mockResolvedValueOnce({ id: 77, generatedKey: "sk-new", name: "self-key" });
+
+    const result = await keys.addKey({ userId: 2, name: "self-key", providerGroup: "default" });
+
+    expect(postMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/v1/users/2/keys",
+      { name: "self-key", providerGroup: "default" },
+      undefined
+    );
+    expect(postMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/v1/users:self/keys",
+      { name: "self-key", providerGroup: "default" },
+      undefined
+    );
+    expect(result).toEqual({
+      ok: true,
+      data: { id: 77, generatedKey: "sk-new", name: "self-key" },
+    });
+  });
+
+  test("does not retry key creation for non-authorization failures", async () => {
+    postMock.mockRejectedValue(
+      new ApiError({
+        status: 400,
+        errorCode: "DUPLICATE_NAME",
+        detail: "Key name already exists.",
+      })
+    );
+
+    const result = await keys.addKey({ userId: 2, name: "self-key" });
+
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      ok: false,
+      error: "Key name already exists.",
+      errorCode: "DUPLICATE_NAME",
+      errorParams: undefined,
+    });
+  });
+
+  test("maps resource action_failed codes to translatable error codes", async () => {
+    getMock.mockRejectedValue(
+      new ApiError({
+        status: 400,
+        errorCode: "key.action_failed",
+        detail: "Bad request",
+      })
+    );
+
+    const result = await keys.getKeys(2);
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Bad request",
+      errorCode: "OPERATION_FAILED",
       errorParams: undefined,
     });
   });

--- a/tests/unit/api/v1/api-client-actions.test.ts
+++ b/tests/unit/api/v1/api-client-actions.test.ts
@@ -508,6 +508,9 @@ describe("v1 action compatibility client", () => {
   });
 
   test("surfaces PERMISSION_DENIED when both admin and self key creation are forbidden", async () => {
+    // Drop any persistent implementation a prior test left on postMock so the
+    // two Once-rejections below are the only behaviors in play.
+    postMock.mockReset();
     // Readonly self-service user: admin route 403s, fallback self route also 403s.
     postMock
       .mockRejectedValueOnce(

--- a/tests/unit/frontend/api-error-i18n.test.ts
+++ b/tests/unit/frontend/api-error-i18n.test.ts
@@ -58,4 +58,30 @@ describe("v1 API error i18n mapping", () => {
       )
     ).toBe("OPERATION_FAILED");
   });
+
+  test("maps key and user REST codes to existing translation keys", () => {
+    expect(
+      getApiErrorMessageKey(
+        new ApiError({ status: 404, errorCode: "key.not_found", detail: "Not found" })
+      )
+    ).toBe("KEY_NOT_FOUND");
+
+    expect(
+      getApiErrorMessageKey(
+        new ApiError({ status: 400, errorCode: "key.action_failed", detail: "Bad request" })
+      )
+    ).toBe("OPERATION_FAILED");
+
+    expect(
+      getApiErrorMessageKey(
+        new ApiError({ status: 404, errorCode: "user.not_found", detail: "Not found" })
+      )
+    ).toBe("USER_NOT_FOUND");
+
+    expect(
+      getApiErrorMessageKey(
+        new ApiError({ status: 400, errorCode: "user.action_failed", detail: "Bad request" })
+      )
+    ).toBe("OPERATION_FAILED");
+  });
 });


### PR DESCRIPTION
Closes #1259

## 问题(两个缺陷)

1. **功能缺陷**:非 admin 用户(持 `canLoginWebUi` key)在「用户管理」页给自己建 key 时,请求走 `POST /api/v1/users/{userId}/keys`(`requireAuth("admin")`),在中间件层被 403 拦截,根本到不了已自带 self 校验的 `addKey` action(`src/actions/keys.ts`)。读路径有 `users:self` 兜底,写路径没有——#1140 引入的回归。
2. **显示缺陷**:`_compat.toActionResult` 原样回传 REST errorCode(`auth.forbidden`),表单 `getErrorMessage()` 查不到该翻译键,toast 显示字面量 `errors.auth.forbidden`。

## 修复(issue 推荐的方案 A)

### 自助建 key 写路径
- 新增 read-tier `POST /api/v1/users:self/keys`(`keys/router.ts`),目标 userId **始终取自会话**,复用现有 `addKey` action(其内部仍做 self 校验)
- 安全围栏:read tier 会放行 `canLoginWebUi=false` 的只读会话,而该端点是写操作且可铸造出能登录 Web UI 的新 key——handler 显式拒绝只读会话(403 `auth.forbidden`)
- `KeyCreateSchema` 为 `.strict()`:body 夹带 `userId` 直接 400,无法指定他人
- api-client `addKey()` 仿照 `getUsers()`:admin 路由 403 `auth.forbidden` 时回退 self 端点;其他错误不重试
- `isAdminForbidden` 下沉到 `api-client/v1/errors.ts` 统一复用(users.ts 原本地实现移除)

### errorCode 显示
- `_compat.toActionResult` / `toVoidActionResult` 统一过 `getApiErrorMessageKey()` 映射(`auth.forbidden` → `PERMISSION_DENIED`),所有表单一次性修复
- 映射表补充 `key.not_found→KEY_NOT_FOUND` / `key.action_failed→OPERATION_FAILED` / `user.not_found→USER_NOT_FOUND` / `user.action_failed→OPERATION_FAILED`
- 更新既有契约断言(provider group counts 失败用例:期望值从原始 `auth.forbidden` 改为映射后的 `PERMISSION_DENIED`)

### OpenAPI
- `openapi:generate` 重新生成 `openapi-types.gen.ts`;`openapi:check` / `openapi:lint` 通过

## 测试(TDD,先红后绿)

- `tests/api/v1/keys/keys.self.test.ts`(7 用例):非 admin 201 且 userId 取自会话 / admin 同样可用 / body 夹带 userId 400 / 只读会话 403 / 未认证 401 / action 失败透传 / **admin 路由保持 admin-only 回归守卫**
- `tests/unit/api/v1/api-client-actions.test.ts`:403 回退 self 端点、非授权错误不重试、`key.action_failed` 映射
- `tests/unit/frontend/api-error-i18n.test.ts`:key/user REST 码映射断言

## 验证

- `bun run build` / `typecheck` / `lint` / `test`(根配置全量)/ `test:v1` / 4 个绿基线覆盖率配置全部通过
- 其余 4 个覆盖率配置(my-usage 等)为 dev 存量失败(已在 #1266 中以干净基线逐项核实),与本 PR 无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two bugs from #1259: non-admin users with `canLoginWebUi` keys could not create keys for themselves (the `POST /api/v1/users/{userId}/keys` route is admin-only at the middleware tier, so requests were 403'd before reaching the self-check in `addKey`), and raw REST error codes like `auth.forbidden` were leaking into the UI as untranslated strings.

- Adds a new `POST /api/v1/users:self/keys` endpoint at the `read` auth tier that always derives the target user from the session, with an explicit fence blocking `canLoginWebUi=false` sessions from escalating. The frontend `addKey()` client function falls back to this endpoint when the admin route returns 403.
- Routes `toActionResult` / `toVoidActionResult` through `getApiErrorMessageKey()` so all REST error codes are pre-mapped to i18n-namespace keys before reaching form error handlers.
- Extracts `isAdminForbidden` into `errors.ts` for shared use, and extends the error-code mapping table with `key.*` / `user.*` entries.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The new self-service key endpoint is correctly fenced at the handler level (canLoginWebUi check), the KeyCreateSchema is already .strict() so request bodies cannot inject a userId, and the client-side retry is scoped strictly to 403 auth.forbidden responses from the admin route.

The changes are well-scoped: a new read-tier endpoint with explicit privilege checks, a client-side fallback that cannot be triggered by any error other than a genuine 403 from the admin route, and a pre-mapping fix for error codes that had no translation. The existing addKey action's own self-check remains in place as a second layer. Tests cover the privilege fence, the strict-schema 400, the dual-403 PERMISSION_DENIED path, and a regression guard confirming the admin-only route stays admin-only. No existing behaviour is changed for admin callers.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/api/v1/resources/keys/handlers.ts | Adds createSelfKey handler; derives userId from session and explicitly rejects canLoginWebUi=false sessions to prevent privilege escalation. |
| src/app/api/v1/resources/keys/router.ts | Registers the new POST /users:self/keys route at the read auth tier using KeyCreateSchema (already .strict()) to prevent body-injected userId. |
| src/lib/api-client/v1/actions/keys.ts | addKey now retries via /users:self/keys when the admin route returns 403 auth.forbidden; non-auth errors are re-thrown without retry. |
| src/lib/api-client/v1/actions/_compat.ts | toActionResult and toVoidActionResult now map ApiError.errorCode through getApiErrorMessageKey() before returning, fixing untranslated error display. |
| src/lib/api-client/v1/errors.ts | Adds isAdminForbidden helper and extends API_ERROR_MESSAGE_KEYS with key.* and user.* entries. |
| src/lib/api-client/v1/actions/users.ts | Removed local isAdminForbidden in favour of the shared version from errors.ts; no behavioural change. |
| src/lib/api-client/v1/openapi-types.gen.ts | Generated type additions for the new /users:self/keys POST operation; no hand-authored changes. |
| tests/api/v1/keys/keys.self.test.ts | New integration tests covering 7 scenarios including the read-only 403 fence, strict-schema 400, and admin-route regression guard. |
| tests/unit/api/v1/api-client-actions.test.ts | Extended with tests for the 403 fallback, non-auth no-retry, errorCode mapping, and the dual-403 PERMISSION_DENIED path. |
| tests/unit/frontend/api-error-i18n.test.ts | Adds assertions for the newly added key.* and user.* REST-code-to-i18n-key mappings. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as "Dashboard UI"
    participant AC as "addKey() client"
    participant AR as "POST /users/{id}/keys (admin)"
    participant SR as "POST /users:self/keys (read)"
    participant ACT as "addKey action"

    UI->>AC: "addKey({ userId, name })"
    AC->>AR: "POST /api/v1/users/{userId}/keys"
    alt "user is admin"
        AR->>ACT: "callAction"
        ACT-->>AR: "ok: true, key"
        AR-->>AC: "201 Created"
        AC-->>UI: "ok: true, key"
    else "user is non-admin"
        AR-->>AC: "403 auth.forbidden"
        AC->>SR: "retry POST /api/v1/users:self/keys"
        SR->>ACT: "callAction with session userId"
        ACT-->>SR: "ok: true, key"
        SR-->>AC: "201 Created"
        AC-->>UI: "ok: true, key"
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(api-client): reset postMock in doub..."](https://github.com/ding113/claude-code-hub/commit/70b7c96256a90f1829bb08268083952006ac069b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36900557)</sub>

<!-- /greptile_comment -->