### PR TITLE
feat(proxy): 竞速赢家无条件改绑 Session 复用绑定

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -4419,7 +4419,9 @@ export class ProxyForwarder {
             attempt.provider.priority || 0,
             launchedProviderCount === 1 && attempt.provider.id === initialProvider.id,
             attempt.provider.id !== initialProvider.id,
-            session.authState?.key?.id ?? null
+            session.authState?.key?.id ?? null,
+            // 产生了真实竞速赢家时，无条件把 Session 复用绑定改绑到赢家。
+            isActualHedgeWin
           );
 
           if (bindingResult.updated) {

--- a/src/lib/session-manager.ts
+++ b/src/lib/session-manager.ts
@@ -743,7 +743,7 @@ export class SessionManager {
   /**
    * 智能更新 Session 绑定
    *
-   * 策略：首次绑定用 SET NX；故障转移后无条件更新；其他情况按优先级和熔断状态决策
+   * 策略：首次绑定用 SET NX；故障转移成功或竞速赢家强制改绑时无条件更新；其他情况按优先级和熔断状态决策
    */
   static async updateSessionBindingSmart(
     sessionId: string,

--- a/src/lib/session-manager.ts
+++ b/src/lib/session-manager.ts
@@ -751,7 +751,8 @@ export class SessionManager {
     newProviderPriority: number,
     isFirstAttempt: boolean = false,
     isFailoverSuccess: boolean = false,
-    keyId?: number | null
+    keyId?: number | null,
+    forceUpdate: boolean = false
   ): Promise<{ updated: boolean; reason: string; details?: string }> {
     const redis = getRedisClient();
     if (!redis || redis.status !== "ready") {
@@ -801,8 +802,9 @@ export class SessionManager {
 
       // ========== 情况 2：重试成功（需要智能决策）==========
 
-      // 2.0 故障转移成功：无条件更新绑定（减少缓存切换）
-      if (isFailoverSuccess) {
+      // 2.0 故障转移成功 或 竞速赢家强制改绑：无条件更新绑定
+      // forceUpdate 在读取当前绑定/优先级/熔断状态之前短路，确保竞速赢家一定成为复用绑定。
+      if (isFailoverSuccess || forceUpdate) {
         const pipeline = redis.pipeline();
         pipeline.setex(
           `session:${sessionId}:provider`,
@@ -814,16 +816,24 @@ export class SessionManager {
         }
         await pipeline.exec();
 
-        logger.info("SessionManager: Updated binding after failover", {
-          sessionId,
-          newProviderId,
-          newPriority: newProviderPriority,
-        });
+        const reason = isFailoverSuccess ? "failover_success" : "race_winner_forced";
+        logger.info(
+          isFailoverSuccess
+            ? "SessionManager: Updated binding after failover"
+            : "SessionManager: Forced binding to race winner",
+          {
+            sessionId,
+            newProviderId,
+            newPriority: newProviderPriority,
+          }
+        );
 
         return {
           updated: true,
-          reason: "failover_success",
-          details: `故障转移成功，绑定到供应商 ${newProviderId}`,
+          reason,
+          details: isFailoverSuccess
+            ? `故障转移成功，绑定到供应商 ${newProviderId}`
+            : `竞速赢家强制改绑到供应商 ${newProviderId}`,
         };
       }
 

--- a/tests/unit/lib/session-manager-binding-smart.test.ts
+++ b/tests/unit/lib/session-manager-binding-smart.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for SessionManager.updateSessionBindingSmart forceUpdate semantics.
+ *
+ * Hedge race winners must unconditionally rebind the session-reuse binding to
+ * the winner. forceUpdate short-circuits the smart-decision path (priority /
+ * circuit health) that would otherwise keep a healthy higher-priority binding.
+ */
+
+let redisClientRef: {
+  status: string;
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  setex: ReturnType<typeof vi.fn>;
+  pipeline: ReturnType<typeof vi.fn>;
+} | null;
+
+let lastPipeline: {
+  setex: ReturnType<typeof vi.fn>;
+  exec: ReturnType<typeof vi.fn>;
+};
+
+const makePipeline = () => {
+  const pipeline = {
+    setex: vi.fn(() => pipeline),
+    exec: vi.fn(async () => []),
+  };
+  lastPipeline = pipeline;
+  return pipeline;
+};
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/redis", () => ({
+  getRedisClient: () => redisClientRef,
+}));
+
+// Both are loaded via `await import(...)` inside updateSessionBindingSmart; the
+// static vi.mock still intercepts the dynamic import.
+vi.mock("@/repository/provider", () => ({
+  findProviderById: vi.fn(),
+}));
+
+vi.mock("@/lib/circuit-breaker", () => ({
+  isCircuitOpen: vi.fn(),
+}));
+
+import { isCircuitOpen } from "@/lib/circuit-breaker";
+import { SessionManager } from "@/lib/session-manager";
+import { findProviderById } from "@/repository/provider";
+
+const SID = "sess-binding";
+const TTL = 300;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  redisClientRef = {
+    status: "ready",
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => "OK"),
+    setex: vi.fn(async () => "OK"),
+    pipeline: vi.fn(() => makePipeline()),
+  };
+});
+
+describe("SessionManager.updateSessionBindingSmart forceUpdate", () => {
+  it("forceUpdate=true overrides a healthy higher-priority existing binding", async () => {
+    // Existing binding -> provider 1 (healthy, higher priority than the winner)
+    redisClientRef!.get.mockResolvedValue("1");
+    vi.mocked(findProviderById).mockResolvedValue({ id: 1, name: "main", priority: 5 } as never);
+    vi.mocked(isCircuitOpen).mockResolvedValue(false);
+
+    const result = await SessionManager.updateSessionBindingSmart(
+      SID,
+      2, // winner id
+      10, // winner priority (lower priority than current's 5)
+      false, // isFirstAttempt
+      false, // isFailoverSuccess
+      null,
+      true // forceUpdate
+    );
+
+    expect(result).toMatchObject({ updated: true, reason: "race_winner_forced" });
+    expect(lastPipeline.setex).toHaveBeenCalledWith(`session:${SID}:provider`, TTL, "2");
+  });
+
+  it("forceUpdate=false keeps the healthy higher-priority binding (documents the gap)", async () => {
+    redisClientRef!.get.mockResolvedValue("1");
+    vi.mocked(findProviderById).mockResolvedValue({ id: 1, name: "main", priority: 5 } as never);
+    vi.mocked(isCircuitOpen).mockResolvedValue(false);
+
+    const result = await SessionManager.updateSessionBindingSmart(
+      SID,
+      2,
+      10,
+      false,
+      false,
+      null,
+      false // forceUpdate
+    );
+
+    expect(result).toMatchObject({ updated: false, reason: "keep_healthy_higher_priority" });
+  });
+
+  it("forceUpdate=true short-circuits before consulting provider/circuit state", async () => {
+    redisClientRef!.get.mockResolvedValue("1");
+
+    await SessionManager.updateSessionBindingSmart(SID, 2, 10, false, false, null, true);
+
+    expect(findProviderById).not.toHaveBeenCalled();
+    expect(isCircuitOpen).not.toHaveBeenCalled();
+    // forceUpdate goes straight to the unconditional pipeline path.
+    expect(redisClientRef!.get).not.toHaveBeenCalled();
+  });
+
+  it("forceUpdate=true also persists the keyId binding with TTL", async () => {
+    const result = await SessionManager.updateSessionBindingSmart(
+      SID,
+      2,
+      10,
+      false,
+      false,
+      42, // keyId
+      true
+    );
+
+    expect(result.updated).toBe(true);
+    expect(lastPipeline.setex).toHaveBeenCalledWith(`session:${SID}:provider`, TTL, "2");
+    expect(lastPipeline.setex).toHaveBeenCalledWith(`session:${SID}:key`, TTL, "42");
+  });
+
+  it("isFailoverSuccess=true keeps reason failover_success even when forceUpdate=true", async () => {
+    const result = await SessionManager.updateSessionBindingSmart(
+      SID,
+      2,
+      10,
+      false,
+      true, // isFailoverSuccess
+      null,
+      true // forceUpdate
+    );
+
+    expect(result).toMatchObject({ updated: true, reason: "failover_success" });
+  });
+
+  it("returns redis_not_ready regardless of forceUpdate when redis is unavailable", async () => {
+    redisClientRef!.status = "connecting";
+
+    const result = await SessionManager.updateSessionBindingSmart(
+      SID,
+      2,
+      10,
+      false,
+      false,
+      null,
+      true
+    );
+
+    expect(result).toMatchObject({ updated: false, reason: "redis_not_ready" });
+  });
+});

--- a/tests/unit/lib/session-manager-binding-smart.test.ts
+++ b/tests/unit/lib/session-manager-binding-smart.test.ts
@@ -91,6 +91,29 @@ describe("SessionManager.updateSessionBindingSmart forceUpdate", () => {
 
     expect(result).toMatchObject({ updated: true, reason: "race_winner_forced" });
     expect(lastPipeline.setex).toHaveBeenCalledWith(`session:${SID}:provider`, TTL, "2");
+    // Guard against a regression that queues setex but forgets to flush the pipeline.
+    expect(lastPipeline.exec).toHaveBeenCalledTimes(1);
+  });
+
+  it("forceUpdate=true rebinds even when the winner equals the current binding", async () => {
+    // Production winner==initialProvider race: the bound provider is already the winner,
+    // but the race result must still (re)write the binding and refresh its TTL.
+    redisClientRef!.get.mockResolvedValue("2");
+
+    const result = await SessionManager.updateSessionBindingSmart(
+      SID,
+      2, // winner id == currently bound id
+      10,
+      false,
+      false,
+      null,
+      true // forceUpdate
+    );
+
+    expect(result).toMatchObject({ updated: true, reason: "race_winner_forced" });
+    expect(redisClientRef!.get).not.toHaveBeenCalled();
+    expect(lastPipeline.setex).toHaveBeenCalledWith(`session:${SID}:provider`, TTL, "2");
+    expect(lastPipeline.exec).toHaveBeenCalledTimes(1);
   });
 
   it("forceUpdate=false keeps the healthy higher-priority binding (documents the gap)", async () => {
@@ -136,6 +159,7 @@ describe("SessionManager.updateSessionBindingSmart forceUpdate", () => {
     expect(result.updated).toBe(true);
     expect(lastPipeline.setex).toHaveBeenCalledWith(`session:${SID}:provider`, TTL, "2");
     expect(lastPipeline.setex).toHaveBeenCalledWith(`session:${SID}:key`, TTL, "42");
+    expect(lastPipeline.exec).toHaveBeenCalledTimes(1);
   });
 
   it("isFailoverSuccess=true keeps reason failover_success even when forceUpdate=true", async () => {

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -968,13 +968,16 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
       expect(mocks.recordFailure).not.toHaveBeenCalled();
       expect(mocks.recordSuccess).not.toHaveBeenCalled();
       expect(session.provider?.id).toBe(2);
+      // Actual hedge win (launchedProviderCount > 1) forces the session-reuse
+      // binding to the winner (forceUpdate=true, the trailing arg).
       expect(mocks.updateSessionBindingSmart).toHaveBeenCalledWith(
         "sess-hedge",
         2,
         0,
         false,
         true,
-        null
+        null,
+        true
       );
       expect(mocks.releaseProviderSession).toHaveBeenCalledWith(1, "sess-hedge");
     } finally {
@@ -1267,6 +1270,18 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
       expect(mocks.recordFailure).not.toHaveBeenCalled();
       expect(mocks.recordSuccess).not.toHaveBeenCalled();
       expect(session.provider?.id).toBe(1);
+      // Initial provider won the race (launchedProviderCount > 1): the binding
+      // must still be force-updated to the winner (forceUpdate=true), closing
+      // the gap where the smart path could keep a stale/higher-priority binding.
+      expect(mocks.updateSessionBindingSmart).toHaveBeenCalledWith(
+        "sess-hedge",
+        1,
+        0,
+        false,
+        false,
+        null,
+        true
+      );
       expect(mocks.releaseProviderSession).toHaveBeenCalledWith(2, "sess-hedge");
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
## 背景

供应商竞速(hedge,首字节超时对冲)中,首个读到首字节的供应商成为**竞速赢家**。`commitWinner()` 已经会 `setProvider(winner)`、写决策链 `hedge_winner`、取消输家,并调用 `SessionManager.updateSessionBindingSmart(...)` 更新「Session 复用绑定」(`session:<id>:provider`,后续同会话请求据此复用同一供应商)。

但绑定走的是「智能决策」,存在一个 gap:
- 赢家 **= 备选供应商**(winner ≠ initialProvider)→ `isFailoverSuccess=true` → 已无条件改绑;
- 赢家 **= 初始供应商**,但确实发生了竞速(`launchedProviderCount > 1`)→ `isFirstAttempt=false`、`isFailoverSuccess=false` → 落入「智能决策」分支。生产中若存在一个**健康且优先级更高/相同**的旧绑定,会返回 `keep_healthy_higher_priority`(`updated:false`)而**拒绝把绑定更新为竞速赢家**。

## 改动

只要产生竞速赢家(`launchedProviderCount > 1`),就**无条件**把 Session 复用绑定设为该赢家。

- `src/lib/session-manager.ts` — `updateSessionBindingSmart` 新增可选参 `forceUpdate`(末位,后向兼容)。`forceUpdate=true` 时并入既有「故障转移无条件更新」分支,在读取当前绑定 / 查优先级 / 熔断状态**之前短路**,reason 记为 `race_winner_forced`(failover 仍优先记为 `failover_success`)。
- `src/app/v1/_lib/proxy/forwarder.ts` — `commitWinner` 调用追加第 7 实参 `isActualHedgeWin`。
- deferred finalization(`response-handler.ts`)对 hedge 赢家本就跳过绑定,无重复/冲突,未改动。

## 测试(TDD,红 → 绿)

- 新增 `tests/unit/lib/session-manager-binding-smart.test.ts`:直跑真实 `updateSessionBindingSmart`,覆盖 forceUpdate 覆盖健康高优先级旧绑定、短路不查 provider/熔断、keyId+TTL 写入、failover label 优先、redis 未就绪等 6 个用例。
- 改 `proxy-forwarder-hedge-first-byte.test.ts`:为「赢家=初始且发生竞速」场景新增 `forceUpdate=true` 断言;为「赢家=备选」既有断言补尾参。

## 本地验证(全绿)

- `bun run typecheck`(exit 0)
- `bun run lint`(exit 0,仅既有 warning)
- `bun run test` — 727 文件 / 6516 测试通过,13 skipped
- `bun run build`(exit 0)

## 相关 PR / Related Work

- Follow-up to #220 — #220 引入 `isFailoverSuccess` 无条件改绑分支;本 PR 在同一分支新增 `forceUpdate`,把「无条件改绑」从故障转移扩展到竞速赢家。
- Related to #894 — #894 引入 hedge 竞速与 `commitWinner`;本 PR 在 `commitWinner` 追加 `isActualHedgeWin`,对真实竞速赢家强制改绑。
- Related to #980 — 同处 Session 复用绑定子系统(`updateSessionBindingSmart`),其「按供应商禁用复用」与本处的「竞速赢家强制改绑」共同影响绑定生命周期。

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a gap in the hedge-race session-reuse binding: when the **initial provider** wins a hedge race (`launchedProviderCount > 1`), the old "smart decision" path could keep a higher-priority existing binding instead of rebinding to the actual race winner. The fix adds a `forceUpdate: boolean = false` parameter to `updateSessionBindingSmart` that short-circuits all Redis reads and priority comparisons, unconditionally writing the winner.

- `session-manager.ts`: new `forceUpdate` param merges into the existing `isFailoverSuccess` unconditional branch; returns `race_winner_forced` reason (failover label still takes priority when both flags are true).
- `forwarder.ts`: `commitWinner` now passes `isActualHedgeWin` (`launchedProviderCount > 1`) as the trailing arg, which is mutually exclusive with `isFirstAttempt=true` by construction.
- Tests cover six `forceUpdate` scenarios including the TTL-refresh edge case (winner equals current binding), short-circuit verification, and Redis-not-ready guard.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, backward-compatible extension to a single decision branch with no impact on non-hedge call sites.

The `forceUpdate` flag is appended at the end with a `false` default, so all existing callers are unaffected. The flag is only activated in `commitWinner` when a real hedge race occurred, a condition that is mutually exclusive with `isFirstAttempt=true` by construction, so there is no path where the new branch conflicts with the SET-NX first-attempt logic. The six new unit tests directly verify the short-circuit behavior, TTL refresh, keyId persistence, and the Redis-not-ready guard.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/session-manager.ts | Adds optional `forceUpdate` param to `updateSessionBindingSmart`; when true (or `isFailoverSuccess` is true), unconditionally rewrites the session binding before any Redis reads, returning `race_winner_forced` reason. Logic is clean and backward-compatible. |
| src/app/v1/_lib/proxy/forwarder.ts | In `commitWinner`, passes `isActualHedgeWin` (`launchedProviderCount > 1`) as the new trailing arg. Since `launchedProviderCount > 1` also makes `isFirstAttempt` false, the `forceUpdate` branch is always correctly reached. One-line change, no other logic altered. |
| tests/unit/lib/session-manager-binding-smart.test.ts | New unit test covering 6 forceUpdate scenarios: overrides healthy high-priority binding, rebinds same winner (TTL refresh), documents the pre-fix gap, short-circuit verification (no get/findProvider/isCircuitOpen), keyId persistence, failover_success label priority, and Redis-not-ready guard. |
| tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts | Updated existing hedge test to assert the trailing `true` (`forceUpdate`) arg for alternate-provider winner, and adds a new assertion for initial-provider-wins-race scenario, validating the full call signature in both paths. |

</details>

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["commitWinner(attempt, launchedProviderCount)"] --> B["isActualHedgeWin = launchedProviderCount > 1"]
    B --> C["updateSessionBindingSmart(...)"]
    C --> D{"isFirstAttempt?"}
    D -- "yes (no hedge)" --> E["SET NX — first_success"]
    D -- "no" --> F{"isFailoverSuccess OR forceUpdate?"}
    F -- "yes" --> G{"isFailoverSuccess?"}
    G -- "yes (alternate won)" --> H["pipeline.setex / reason: failover_success"]
    G -- "no (initial won hedge)" --> I["pipeline.setex / reason: race_winner_forced"]
    F -- "no" --> J["Smart decision: read Redis, priority/circuit check"]
    J --> K{"Higher priority or circuit open?"}
    K -- "rebind" --> L["pipeline.setex"]
    K -- "keep" --> M["keep_healthy_higher_priority (updated: false)"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(session): assert pipeline flush and..."](https://github.com/ding113/claude-code-hub/commit/a58ac253076449bb26df7ddabce6c40d94cda382) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37416500)</sub>

<!-- /greptile_comment -->