### PR TITLE
fix(k8s): 修正 fetch 超时配置单位

### DIFF
--- a/deploy/k8s/app/deployment.yaml
+++ b/deploy/k8s/app/deployment.yaml
@@ -57,12 +57,13 @@ spec:
               value: "20"
             - name: DB_POOL_CONNECT_TIMEOUT
               value: "10"
+            # Fetch 超时单位为毫秒,需与 .env.example 和 env.schema.ts 保持一致。
             - name: FETCH_CONNECT_TIMEOUT
-              value: "30"
-            #- name: FETCH_HEADERS_TIMEOUT
-            #  value: "600"
-            #- name: FETCH_BODY_TIMEOUT
-            #  value: "600"
+              value: "30000"
+            - name: FETCH_HEADERS_TIMEOUT
+              value: "600000"
+            - name: FETCH_BODY_TIMEOUT
+              value: "600000"
             - name: ENABLE_RATE_LIMIT
               value: "true"
             - name: ENABLE_API_KEY_REDIS_CACHE


### PR DESCRIPTION
## Summary
Corrects the timeout configuration units in the K8s deployment manifest to match the application's millisecond-based expectations (undici interprets all timeout values in milliseconds).

## Problem
The K8s deployment manifest configured undici timeout values incorrectly:
- `FETCH_CONNECT_TIMEOUT`: `"30"` (interpreted as 30ms instead of 30000ms = 30s)
- `FETCH_HEADERS_TIMEOUT` and `FETCH_BODY_TIMEOUT`: were commented out in #1174 with a note to fix `FETCH_CONNECT_TIMEOUT` separately

This caused a high probability of 503 errors in K8s deployments because connections would timeout before upstream providers could respond.

**Related Issues/PRs:**
- Follow-up to #1174 — Completes the timeout unit fix. PR #1174 commented out `FETCH_HEADERS_TIMEOUT` and `FETCH_BODY_TIMEOUT` and noted that `FETCH_CONNECT_TIMEOUT` needed a follow-up fix (was set to `"30"` instead of `"30000"`).
- Completes fix for #1173 — Issue reported that k8s deployment timeout values were 1000x too small. This PR completes the resolution by correcting all three timeout values.

## Solution
Updates `deploy/k8s/app/deployment.yaml` to use correct millisecond-based values that match `.env.example` and `src/lib/config/env.schema.ts`:
- `FETCH_CONNECT_TIMEOUT`: `"30"` → `"30000"` (30 seconds in milliseconds)
- `FETCH_HEADERS_TIMEOUT`: uncommented with `"600000"` (600 seconds in milliseconds)
- `FETCH_BODY_TIMEOUT`: uncommented with `"600000"` (600 seconds in milliseconds)

## Changes

### Core Changes
- `deploy/k8s/app/deployment.yaml` — Fixed all three fetch timeout environment variables to use correct millisecond values

## Testing

### Manual Testing
1. Deploy with the updated manifest
2. Verify undici logs show correct timeout values (30000, 600000, 600000) instead of the incorrect values (30, 600, 600)
3. Confirm LLM requests complete without premature timeout errors

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed

---
*Description enhanced by Claude AI*