### PR TITLE
fix(usage-logs): filter blank model options

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/app/[locale]/dashboard/logs/_components/filters/request-filters.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/filters/request-filters.tsx
@@ -71,6 +71,7 @@ export function RequestFilters({
     () => new Map(providers.map((provider) => [provider.id, provider.name])),
     [providers]
   );
+  const modelOptions = useMemo(() => models.filter((model) => model.trim().length > 0), [models]);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -256,7 +257,7 @@ export function RequestFilters({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">{t("logs.filters.allModels")}</SelectItem>
-            {models.map((model) => (
+            {modelOptions.map((model) => (
               <SelectItem key={model} value={model}>
                 {model}
               </SelectItem>

--- a/src/app/[locale]/dashboard/logs/_hooks/use-lazy-filter-options.ts
+++ b/src/app/[locale]/dashboard/logs/_hooks/use-lazy-filter-options.ts
@@ -120,6 +120,6 @@ export const useLazyStatusCodes: () => UseLazyFilterOptionsReturn<number> =
 export const useLazyEndpoints: () => UseLazyFilterOptionsReturn<string> =
   createLazyFilterHook<string>(getEndpointList);
 
-function isNonBlankString(value: string): boolean {
-  return value.trim().length > 0;
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
 }

--- a/src/app/[locale]/dashboard/logs/_hooks/use-lazy-filter-options.ts
+++ b/src/app/[locale]/dashboard/logs/_hooks/use-lazy-filter-options.ts
@@ -98,8 +98,13 @@ function createLazyFilterHook<T>(
  * 惰性加载 Models 列表
  * 用于 Model 筛选器下拉，展开时才加载数据
  */
-export const useLazyModels: () => UseLazyFilterOptionsReturn<string> =
-  createLazyFilterHook<string>(getModelList);
+export const useLazyModels: () => UseLazyFilterOptionsReturn<string> = createLazyFilterHook<string>(
+  async () => {
+    const result = await getModelList();
+    if (!result.ok) return result;
+    return { ...result, data: result.data.filter(isNonBlankString) };
+  }
+);
 
 /**
  * 惰性加载 StatusCodes 列表
@@ -114,3 +119,7 @@ export const useLazyStatusCodes: () => UseLazyFilterOptionsReturn<number> =
  */
 export const useLazyEndpoints: () => UseLazyFilterOptionsReturn<string> =
   createLazyFilterHook<string>(getEndpointList);
+
+function isNonBlankString(value: string): boolean {
+  return value.trim().length > 0;
+}

--- a/src/repository/usage-logs.ts
+++ b/src/repository/usage-logs.ts
@@ -1469,10 +1469,20 @@ export async function getUsedModels(): Promise<string[]> {
   const results = await db
     .selectDistinct({ model: messageRequest.model })
     .from(messageRequest)
-    .where(and(isNull(messageRequest.deletedAt), sql`${messageRequest.model} IS NOT NULL`))
+    .where(
+      and(
+        isNull(messageRequest.deletedAt),
+        sql`${messageRequest.model} IS NOT NULL`,
+        sql`btrim(${messageRequest.model}) <> ''`
+      )
+    )
     .orderBy(messageRequest.model);
 
-  return results.map((r) => r.model).filter((m): m is string => m !== null);
+  return results.map((r) => r.model).filter(isNonBlankString);
+}
+
+function isNonBlankString(value: string | null): value is string {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 /**

--- a/tests/unit/dashboard-logs-lazy-filter-options.test.tsx
+++ b/tests/unit/dashboard-logs-lazy-filter-options.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { ReactNode } from "react";
+import { act, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { useLazyModels } from "@/app/[locale]/dashboard/logs/_hooks/use-lazy-filter-options";
+
+const getModelListMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api-client/v1/actions/usage-logs", () => ({
+  getEndpointList: vi.fn(async () => ({ ok: true, data: [] })),
+  getModelList: getModelListMock,
+  getStatusCodeList: vi.fn(async () => ({ ok: true, data: [] })),
+}));
+
+type HookSnapshot = ReturnType<typeof useLazyModels>;
+
+function HookProbe({ onSnapshot }: { onSnapshot: (snapshot: HookSnapshot) => void }) {
+  const snapshot = useLazyModels();
+
+  useEffect(() => {
+    onSnapshot(snapshot);
+  }, [snapshot, onSnapshot]);
+
+  return null;
+}
+
+function renderHookProbe(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(node);
+  });
+
+  return () => {
+    act(() => root.unmount());
+    container.remove();
+  };
+}
+
+async function waitForLoaded(read: () => HookSnapshot | null): Promise<HookSnapshot> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < 1000) {
+    const snapshot = read();
+    if (snapshot?.isLoaded) return snapshot;
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+  }
+
+  throw new Error("Timed out waiting for useLazyModels to load.");
+}
+
+describe("useLazyModels", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    getModelListMock.mockReset();
+  });
+
+  test("drops malformed model options instead of failing the lazy load", async () => {
+    getModelListMock.mockResolvedValue({
+      ok: true,
+      data: ["", null, 42, "   ", "claude-sonnet-4-5"] as unknown as string[],
+    });
+
+    let latest: HookSnapshot | null = null;
+    const unmount = renderHookProbe(
+      <HookProbe
+        onSnapshot={(snapshot) => {
+          latest = snapshot;
+        }}
+      />
+    );
+
+    await act(async () => {
+      latest?.onOpenChange(true);
+    });
+
+    const loaded = await waitForLoaded(() => latest);
+
+    expect(loaded.error).toBeNull();
+    expect(loaded.data).toEqual(["claude-sonnet-4-5"]);
+
+    unmount();
+  });
+});

--- a/tests/unit/dashboard-logs-sessionid-suggestions-ui.test.tsx
+++ b/tests/unit/dashboard-logs-sessionid-suggestions-ui.test.tsx
@@ -5,7 +5,7 @@
 import type { ReactNode } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -37,6 +37,12 @@ const usersActionMocks = vi.hoisted(() => ({
     ok: true,
     data: [] as Array<{ id: number; name: string }>,
   })),
+}));
+
+const lazyFilterOptionMocks = vi.hoisted(() => ({
+  models: [] as string[],
+  endpoints: [] as string[],
+  statusCodes: [] as number[],
 }));
 
 vi.mock("@/actions/usage-logs", () => ({
@@ -132,7 +138,11 @@ vi.mock("@/components/ui/select", () => ({
   Select: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   SelectTrigger: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   SelectContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-  SelectItem: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children, value }: { children?: ReactNode; value: string }) => (
+    <div data-select-item="" data-select-value={value}>
+      {children}
+    </div>
+  ),
   SelectValue: () => <span />,
 }));
 
@@ -160,17 +170,17 @@ vi.mock("@/components/ui/command", () => ({
 // Mock lazy filter hooks
 vi.mock("@/app/[locale]/dashboard/logs/_hooks/use-lazy-filter-options", () => ({
   useLazyModels: () => ({
-    data: [],
+    data: lazyFilterOptionMocks.models,
     isLoading: false,
     onOpenChange: vi.fn(),
   }),
   useLazyEndpoints: () => ({
-    data: [],
+    data: lazyFilterOptionMocks.endpoints,
     isLoading: false,
     onOpenChange: vi.fn(),
   }),
   useLazyStatusCodes: () => ({
-    data: [],
+    data: lazyFilterOptionMocks.statusCodes,
     isLoading: false,
     onOpenChange: vi.fn(),
   }),
@@ -197,7 +207,49 @@ function setReactInputValue(input: HTMLInputElement, value: string) {
   input.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
+beforeEach(() => {
+  lazyFilterOptionMocks.models = [];
+  lazyFilterOptionMocks.endpoints = [];
+  lazyFilterOptionMocks.statusCodes = [];
+});
+
 describe("UsageLogsFilters sessionId suggestions", () => {
+  test("should ignore empty model options before rendering Select items", async () => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+    lazyFilterOptionMocks.models = ["", "   ", "claude-sonnet-4-5", "gpt-4o"];
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <UsageLogsFilters
+          isAdmin={false}
+          providers={[]}
+          initialKeys={[]}
+          filters={{}}
+          onChange={() => {}}
+          onReset={() => {}}
+        />
+      );
+    });
+
+    const values = Array.from(container.querySelectorAll("[data-select-value]")).map((el) =>
+      el.getAttribute("data-select-value")
+    );
+    expect(values).toContain("claude-sonnet-4-5");
+    expect(values).toContain("gpt-4o");
+    expect(values).not.toContain("");
+    expect(values).not.toContain("   ");
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
   test("should debounce and require min length (>=2)", async () => {
     vi.useFakeTimers();
     vi.clearAllMocks();

--- a/tests/unit/repository/usage-logs-model-filter-options.test.ts
+++ b/tests/unit/repository/usage-logs-model-filter-options.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test, vi } from "vitest";
+
+function createThenableQuery<T>(result: T) {
+  const query: any = Promise.resolve(result);
+  query.from = vi.fn(() => query);
+  query.where = vi.fn(() => query);
+  query.orderBy = vi.fn(() => query);
+  return query;
+}
+
+describe("usage log model filter options", () => {
+  test("getUsedModels omits empty or blank model names", async () => {
+    vi.resetModules();
+
+    const selectDistinctMock = vi.fn(() =>
+      createThenableQuery([
+        { model: "" },
+        { model: "   " },
+        { model: "claude-sonnet-4-5" },
+        { model: "gpt-4o" },
+        { model: null },
+      ])
+    );
+
+    vi.doMock("@/drizzle/db", () => ({
+      db: { selectDistinct: selectDistinctMock },
+    }));
+
+    const { getUsedModels } = await import("@/repository/usage-logs");
+
+    await expect(getUsedModels()).resolves.toEqual(["claude-sonnet-4-5", "gpt-4o"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Filter empty and whitespace-only model names from usage log model filter options at the repository/API source.
- Defensively filter model options in the lazy UI hook and model Select rendering so old or malformed responses cannot create empty Select.Item values.
- Align the Biome schema reference with the locked Biome CLI version so lint can run locally.

Fixes #1285

## Tests
- bunx vitest run tests/unit/repository/usage-logs-model-filter-options.test.ts
- bunx vitest run tests/unit/dashboard-logs-sessionid-suggestions-ui.test.tsx
- bunx vitest run tests/api/v1/usage-logs/usage-logs.test.ts tests/api/v1/me/me.test.ts tests/unit/api/v1/usage-logs-hooks.test.ts
- bun run build
- bun run lint
- bun run lint:fix
- bun run typecheck
- bun run test

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds layered, defensive filtering of blank/whitespace-only model names that could otherwise create empty `<SelectItem>` values in the usage-log model filter dropdown. Filtering is applied at three independent layers: the SQL query (`btrim`), the API-response hook, and the UI component's `useMemo`.

- **Repository layer** (`usage-logs.ts`): adds a `btrim(model) <> ''` SQL predicate and a JS-level `isNonBlankString` fallback so the DB query never returns blank strings.
- **Hook layer** (`use-lazy-filter-options.ts`): wraps `getModelList()` with an `isNonBlankString` guard so malformed API responses are stripped before reaching state.
- **UI layer** (`request-filters.tsx`): computes `modelOptions` via `useMemo` to prevent any remaining blanks from being rendered as `<SelectItem>` nodes, and `biome.json` is bumped to match the locked CLI version.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change only adds filtering guards at multiple layers, with no mutations to data writes or auth paths.

The change is purely additive: blank-string filtering is applied at the SQL predicate, the API hook, and the UI rendering stage. No existing data is modified, no auth or write paths are touched, and each new layer has a corresponding test.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/repository/usage-logs.ts | Adds btrim(model) <> '' SQL predicate and JS-level isNonBlankString fallback to strip blank model entries from filter options. |
| src/app/[locale]/dashboard/logs/_hooks/use-lazy-filter-options.ts | Wraps getModelList() with an isNonBlankString post-filter as a defensive layer against malformed API responses; adds a file-level isNonBlankString helper. |
| src/app/[locale]/dashboard/logs/_components/filters/request-filters.tsx | Adds a modelOptions memo that strips blank strings from the models array before rendering SelectItem nodes. |
| tests/unit/repository/usage-logs-model-filter-options.test.ts | New unit test verifying the JS-level isNonBlankString filter in getUsedModels; SQL WHERE conditions are not asserted (noted in prior review). |
| tests/unit/dashboard-logs-lazy-filter-options.test.tsx | New hook-level test confirming that blank, null, and non-string values returned from getModelList are dropped by useLazyModels. |
| tests/unit/dashboard-logs-sessionid-suggestions-ui.test.tsx | Extends existing UI test with a case asserting blank model strings are excluded from rendered SelectItem values; upgrades SelectItem mock to expose data-select-value. |
| biome.json | Schema reference bumped from 2.4.15 to 2.4.16 to match the locked Biome CLI version. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(logs): drop non-string entries from ..."](https://github.com/ding113/claude-code-hub/commit/543a5b25108d667be525609979fe70116aa597e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39030326)</sub>

<!-- /greptile_comment -->