### PR TITLE
fix(proxy): detect Responses failed fake-200 streams

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -1502,7 +1502,8 @@ export class ProxyForwarder {
               detected.isError &&
               (detected.code === "FAKE_200_HTML_BODY" ||
                 detected.code === "FAKE_200_JSON_ERROR_NON_EMPTY" ||
-                detected.code === "FAKE_200_JSON_ERROR_MESSAGE_NON_EMPTY");
+                detected.code === "FAKE_200_JSON_ERROR_MESSAGE_NON_EMPTY" ||
+                detected.code === "FAKE_200_OPENAI_RESPONSE_FAILED");
 
             if (isStrongFake200) {
               const inferredStatus = inferUpstreamErrorStatusCodeFromText(inspectedText);

--- a/src/lib/utils/upstream-error-detection.ts
+++ b/src/lib/utils/upstream-error-detection.ts
@@ -81,6 +81,8 @@ const FAKE_200_CODES = {
 // 注意：这里必须是 `"key"\s*:` 形式，避免误命中 JSON 字符串内容里的 `\"key\"`。
 const MAY_HAVE_JSON_ERROR_KEY = /"error"\s*:/;
 const MAY_HAVE_JSON_MESSAGE_KEY = /"message"\s*:/;
+const MAY_HAVE_OPENAI_RESPONSES_FAILED_SIGNAL =
+  /(?:event:\s*response\.failed|"type"\s*:\s*"response\.failed"|"status"\s*:\s*"failed")/;
 
 const HTML_DOC_SNIFF_MAX_CHARS = 1024;
 const HTML_DOCTYPE_RE = /^<!doctype\s+html[\s>]/i;
@@ -237,45 +239,56 @@ function hasNonEmptyValue(value: unknown): boolean {
   return true;
 }
 
-function extractOpenAIResponsesFailedDetail(obj: Record<string, unknown>): string | null {
+type OpenAIResponsesFailedDetection = {
+  detail?: string;
+};
+
+function detectOpenAIResponsesFailed(
+  obj: Record<string, unknown>
+): OpenAIResponsesFailedDetection | null {
   const eventType = typeof obj.type === "string" ? obj.type.trim() : "";
+  const sseEventType = typeof obj.__sseEvent === "string" ? obj.__sseEvent.trim() : "";
   const response = isPlainRecord(obj.response) ? obj.response : obj;
   const responseStatus = typeof response.status === "string" ? response.status.trim() : "";
   const responseObject = typeof response.object === "string" ? response.object.trim() : "";
   const responseId = typeof response.id === "string" ? response.id.trim() : "";
 
   const looksLikeOpenAIResponse =
+    sseEventType.startsWith("response.") ||
     eventType.startsWith("response.") ||
     responseObject === "response" ||
     responseId.startsWith("resp_");
-  const isFailedResponse = eventType === "response.failed" || responseStatus === "failed";
-  if (!looksLikeOpenAIResponse || !isFailedResponse || !hasNonEmptyValue(response.error)) {
+  const isFailedResponse =
+    sseEventType === "response.failed" ||
+    eventType === "response.failed" ||
+    responseStatus === "failed";
+  if (!looksLikeOpenAIResponse || !isFailedResponse) {
     return null;
   }
 
   const responseError = response.error;
   if (typeof responseError === "string" && responseError.trim()) {
-    return truncateForDetail(responseError);
+    return { detail: truncateForDetail(responseError) };
   }
 
   if (isPlainRecord(responseError)) {
     const message = typeof responseError.message === "string" ? responseError.message : "";
     if (message.trim()) {
-      return truncateForDetail(message);
+      return { detail: truncateForDetail(message) };
     }
 
     const code = typeof responseError.code === "string" ? responseError.code : "";
     if (code.trim()) {
-      return truncateForDetail(code);
+      return { detail: truncateForDetail(code) };
     }
   }
 
   const topLevelMessage = typeof obj.message === "string" ? obj.message : "";
   if (topLevelMessage.trim()) {
-    return truncateForDetail(topLevelMessage);
+    return { detail: truncateForDetail(topLevelMessage) };
   }
 
-  return null;
+  return {};
 }
 
 export function sanitizeErrorTextForDetail(text: string): string {
@@ -322,12 +335,12 @@ function detectFromJsonObject(
   rawJsonChars: number,
   options: Required<Pick<DetectionOptions, "maxJsonCharsForMessageCheck" | "messageKeyword">>
 ): UpstreamErrorDetectionResult {
-  const openAIResponsesFailedDetail = extractOpenAIResponsesFailedDetail(obj);
-  if (openAIResponsesFailedDetail !== null) {
+  const openAIResponsesFailed = detectOpenAIResponsesFailed(obj);
+  if (openAIResponsesFailed !== null) {
     return {
       isError: true,
       code: FAKE_200_CODES.OPENAI_RESPONSE_FAILED,
-      detail: openAIResponsesFailedDetail,
+      ...(openAIResponsesFailed.detail ? { detail: openAIResponsesFailed.detail } : {}),
     };
   }
 
@@ -438,9 +451,13 @@ export function detectUpstreamErrorFromSseOrJsonText(
     return { isError: false };
   }
 
-  // 情况 2：SSE 文本。快速过滤：既无 "error"/"message" key 时跳过解析
+  // 情况 2：SSE 文本。快速过滤：既无 "error"/"message" key，也无 Responses failed 信号时跳过解析
   // 注意：这里要求 key 命中 `"key"\s*:`，尽量避免误命中 JSON 字符串内容里的 `\"error\"`。
-  if (!MAY_HAVE_JSON_ERROR_KEY.test(text) && !MAY_HAVE_JSON_MESSAGE_KEY.test(text)) {
+  if (
+    !MAY_HAVE_JSON_ERROR_KEY.test(text) &&
+    !MAY_HAVE_JSON_MESSAGE_KEY.test(text) &&
+    !MAY_HAVE_OPENAI_RESPONSES_FAILED_SIGNAL.test(text)
+  ) {
     return { isError: false };
   }
 
@@ -448,17 +465,21 @@ export function detectUpstreamErrorFromSseOrJsonText(
   const events = parseSSEData(text);
   for (const evt of events) {
     if (!isPlainRecord(evt.data)) continue;
+    const eventData =
+      typeof evt.event === "string" && evt.event.trim().length > 0
+        ? { ...evt.data, __sseEvent: evt.event.trim() }
+        : evt.data;
     // 性能优化：只有在 message 是字符串、且“看起来足够小”时才需要精确计算 JSON 字符数。
     // 对大多数 SSE 事件（message 为对象、或没有 message），无需 JSON.stringify。
     let chars = 0;
-    const errorValue = evt.data.error;
-    const messageValue = evt.data.message;
+    const errorValue = eventData.error;
+    const messageValue = eventData.message;
     if (!hasNonEmptyValue(errorValue) && typeof messageValue === "string") {
       if (messageValue.length >= merged.maxJsonCharsForMessageCheck) {
         chars = merged.maxJsonCharsForMessageCheck; // >= 阈值即可跳过 message 关键字判定
       } else {
         try {
-          chars = JSON.stringify(evt.data).length;
+          chars = JSON.stringify(eventData).length;
         } catch {
           // stringify 失败时回退为近似值（仍保持“仅小体积 JSON 才做 message 检测”的意图）
           chars = messageValue.length;
@@ -466,7 +487,7 @@ export function detectUpstreamErrorFromSseOrJsonText(
       }
     }
 
-    const res = detectFromJsonObject(evt.data, chars, merged);
+    const res = detectFromJsonObject(eventData, chars, merged);
     if (res.isError) return res;
   }
 

--- a/src/lib/utils/upstream-error-detection.ts
+++ b/src/lib/utils/upstream-error-detection.ts
@@ -74,6 +74,7 @@ const FAKE_200_CODES = {
   JSON_ERROR_NON_EMPTY: "FAKE_200_JSON_ERROR_NON_EMPTY",
   JSON_ERROR_MESSAGE_NON_EMPTY: "FAKE_200_JSON_ERROR_MESSAGE_NON_EMPTY",
   JSON_MESSAGE_KEYWORD_MATCH: "FAKE_200_JSON_MESSAGE_KEYWORD_MATCH",
+  OPENAI_RESPONSE_FAILED: "FAKE_200_OPENAI_RESPONSE_FAILED",
 } as const;
 
 // SSE 快速过滤：仅当文本里“看起来存在 JSON key”时才进入 parseSSEData（避免无谓解析）。
@@ -236,6 +237,47 @@ function hasNonEmptyValue(value: unknown): boolean {
   return true;
 }
 
+function extractOpenAIResponsesFailedDetail(obj: Record<string, unknown>): string | null {
+  const eventType = typeof obj.type === "string" ? obj.type.trim() : "";
+  const response = isPlainRecord(obj.response) ? obj.response : obj;
+  const responseStatus = typeof response.status === "string" ? response.status.trim() : "";
+  const responseObject = typeof response.object === "string" ? response.object.trim() : "";
+  const responseId = typeof response.id === "string" ? response.id.trim() : "";
+
+  const looksLikeOpenAIResponse =
+    eventType.startsWith("response.") ||
+    responseObject === "response" ||
+    responseId.startsWith("resp_");
+  const isFailedResponse = eventType === "response.failed" || responseStatus === "failed";
+  if (!looksLikeOpenAIResponse || !isFailedResponse || !hasNonEmptyValue(response.error)) {
+    return null;
+  }
+
+  const responseError = response.error;
+  if (typeof responseError === "string" && responseError.trim()) {
+    return truncateForDetail(responseError);
+  }
+
+  if (isPlainRecord(responseError)) {
+    const message = typeof responseError.message === "string" ? responseError.message : "";
+    if (message.trim()) {
+      return truncateForDetail(message);
+    }
+
+    const code = typeof responseError.code === "string" ? responseError.code : "";
+    if (code.trim()) {
+      return truncateForDetail(code);
+    }
+  }
+
+  const topLevelMessage = typeof obj.message === "string" ? obj.message : "";
+  if (topLevelMessage.trim()) {
+    return truncateForDetail(topLevelMessage);
+  }
+
+  return null;
+}
+
 export function sanitizeErrorTextForDetail(text: string): string {
   // 注意：这里的目的不是“完美脱敏”，而是尽量降低上游错误信息中意外夹带敏感内容的风险。
   // 若后续发现更多敏感模式，可在不改变检测语义的前提下补充。
@@ -280,6 +322,15 @@ function detectFromJsonObject(
   rawJsonChars: number,
   options: Required<Pick<DetectionOptions, "maxJsonCharsForMessageCheck" | "messageKeyword">>
 ): UpstreamErrorDetectionResult {
+  const openAIResponsesFailedDetail = extractOpenAIResponsesFailedDetail(obj);
+  if (openAIResponsesFailedDetail !== null) {
+    return {
+      isError: true,
+      code: FAKE_200_CODES.OPENAI_RESPONSE_FAILED,
+      detail: openAIResponsesFailedDetail,
+    };
+  }
+
   // 判定优先级：
   // 1) `error` 非空：直接判定为错误（强信号）
   // 2) 小体积 JSON 下，`message` 命中关键字：判定为错误（弱信号，但能覆盖部分“错误只写在 message”场景）

--- a/tests/unit/proxy/proxy-forwarder-fake-200-html.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-fake-200-html.test.ts
@@ -371,6 +371,78 @@ describe("ProxyForwarder - fake 200 HTML body", () => {
     expect(mocks.recordSuccess).not.toHaveBeenCalledWith(1);
   });
 
+  test("200 + application/json 的非流式 Responses failed 应视为失败并切换供应商", async () => {
+    const provider1 = createProvider({ id: 1, name: "p1", key: "k1", maxRetryAttempts: 1 });
+    const provider2 = createProvider({ id: 2, name: "p2", key: "k2", maxRetryAttempts: 1 });
+
+    const session = createSession();
+    session.requestUrl = new URL("https://example.com/v1/responses");
+    session.originalUrlPathname = "/v1/responses";
+    session.endpointPolicy = resolveEndpointPolicy("/v1/responses");
+    session.setProvider(provider1);
+
+    mocks.pickRandomProviderWithExclusion.mockResolvedValueOnce(provider2);
+
+    const doForward = vi.spyOn(ProxyForwarder as any, "doForward");
+
+    const failedResponseBody = JSON.stringify({
+      id: "resp_failed",
+      object: "response",
+      status: "failed",
+      error: {
+        type: "rate_limit_error",
+        message: "Concurrency limit exceeded for user, please retry later",
+      },
+    });
+    const okJson = JSON.stringify({
+      id: "resp_ok",
+      object: "response",
+      status: "completed",
+      output: [],
+    });
+
+    doForward.mockResolvedValueOnce(
+      new Response(failedResponseBody, {
+        status: 200,
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+          "content-length": String(failedResponseBody.length),
+        },
+      })
+    );
+
+    doForward.mockResolvedValueOnce(
+      new Response(okJson, {
+        status: 200,
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+          "content-length": String(okJson.length),
+        },
+      })
+    );
+
+    const response = await ProxyForwarder.send(session);
+    expect(await response.text()).toContain("resp_ok");
+
+    expect(doForward).toHaveBeenCalledTimes(2);
+    expect(doForward.mock.calls[0][1].id).toBe(1);
+    expect(doForward.mock.calls[1][1].id).toBe(2);
+
+    expect(mocks.pickRandomProviderWithExclusion).toHaveBeenCalledWith(session, [1]);
+    expect(mocks.recordFailure).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ message: "FAKE_200_OPENAI_RESPONSE_FAILED" })
+    );
+
+    const failure = mocks.recordFailure.mock.calls[0]?.[1];
+    expect(failure).toBeInstanceOf(ProxyError);
+    expect((failure as ProxyError).statusCode).toBe(502);
+    expect((failure as ProxyError).upstreamError?.rawBody).toBe(failedResponseBody);
+    expect((failure as ProxyError).upstreamError?.rawBodyTruncated).toBe(false);
+    expect(mocks.recordSuccess).toHaveBeenCalledWith(2);
+    expect(mocks.recordSuccess).not.toHaveBeenCalledWith(1);
+  });
+
   test("假200 JSON error 命中 rate limit 关键字时，应推断为 429 并在决策链中标记为推断", async () => {
     const provider1 = createProvider({ id: 1, name: "p1", key: "k1", maxRetryAttempts: 1 });
     const provider2 = createProvider({ id: 2, name: "p2", key: "k2", maxRetryAttempts: 1 });

--- a/tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts
+++ b/tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts
@@ -274,6 +274,37 @@ function createFake200StreamResponse(errorMessage: string = "invalid api key"): 
   });
 }
 
+/** Create an OpenAI Responses SSE stream that reports a terminal response.failed event. */
+function createOpenAIResponsesFailedStreamResponse(): Response {
+  const body = [
+    "event: response.failed",
+    `data: ${JSON.stringify({
+      type: "response.failed",
+      response: {
+        id: "resp_123",
+        object: "response",
+        status: "failed",
+        error: {
+          code: "rate_limit_exceeded",
+          message: "Concurrency limit exceeded for user, please retry later",
+        },
+      },
+    })}`,
+    "",
+  ].join("\n");
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
 /** Create an SSE stream that returns non-200 HTTP status with error body. */
 function createNon200StreamResponse(statusCode: number): Response {
   const body = `data: ${JSON.stringify({ error: "rate limit exceeded" })}\n\n`;
@@ -327,6 +358,7 @@ function setupCommonMocks() {
   });
   vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
   vi.mocked(updateMessageRequestDuration).mockResolvedValue(undefined);
+  vi.mocked(SessionManager.updateSessionUsage).mockResolvedValue(undefined);
   vi.mocked(SessionManager.storeSessionResponse).mockResolvedValue(undefined);
   vi.mocked(SessionManager.clearSessionProvider).mockResolvedValue(undefined);
   vi.mocked(RateLimitService.trackCost).mockResolvedValue(undefined);
@@ -376,6 +408,33 @@ describe("Endpoint circuit breaker isolation", () => {
           item.statusCodeInferred === true
       )
     ).toBe(true);
+  });
+
+  it("OpenAI Responses response.failed with HTTP 200 should be treated as provider failure", async () => {
+    const session = createSession();
+    setDeferredMeta(session, 42);
+
+    const response = createOpenAIResponsesFailedStreamResponse();
+    await ProxyResponseHandler.dispatch(session, response);
+    await drainAsyncTasks();
+
+    expect(mockRecordFailure).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ message: "FAKE_200_OPENAI_RESPONSE_FAILED" })
+    );
+    expect(mockRecordEndpointSuccess).not.toHaveBeenCalled();
+    expect(mockRecordEndpointFailure).not.toHaveBeenCalled();
+    expect(SessionManager.clearSessionProvider).toHaveBeenCalledWith("fake-session");
+    expect(updateMessageRequestDetails).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        statusCode: 502,
+        errorMessage:
+          "FAKE_200_OPENAI_RESPONSE_FAILED: Concurrency limit exceeded for user, please retry later",
+        providerId: 1,
+      })
+    );
+    expect(RateLimitService.trackCost).not.toHaveBeenCalled();
   });
 
   it("高并发模式下，fake-200 流式错误仍应记录核心失败，但跳过 session 观测写入", async () => {

--- a/tests/unit/proxy/response-handler-non200.test.ts
+++ b/tests/unit/proxy/response-handler-non200.test.ts
@@ -258,6 +258,90 @@ describe("Non-200 Status Code Handling", () => {
       expect(result.code).toBe("FAKE_200_EMPTY_BODY");
     });
 
+    it("should detect OpenAI Responses response.failed SSE event", () => {
+      const sse = [
+        "event: response.failed",
+        'data: {"type":"response.failed","response":{"id":"resp_123","status":"failed","error":{"code":"rate_limit_exceeded","message":"Concurrency limit exceeded for user, please retry later"}}}',
+        "",
+      ].join("\n");
+
+      const result = detectUpstreamErrorFromSseOrJsonText(sse);
+
+      expect(result.isError).toBe(true);
+      if (result.isError) {
+        expect(result.code).toBe("FAKE_200_OPENAI_RESPONSE_FAILED");
+        expect(result.detail).toBe("Concurrency limit exceeded for user, please retry later");
+      }
+    });
+
+    it("should detect wrapped OpenAI Responses failed JSON object", () => {
+      const body = JSON.stringify({
+        type: "response.failed",
+        response: {
+          id: "resp_456",
+          status: "failed",
+          error: {
+            code: "server_error",
+            message: "Upstream worker failed",
+          },
+        },
+      });
+
+      const result = detectUpstreamErrorFromSseOrJsonText(body);
+
+      expect(result.isError).toBe(true);
+      if (result.isError) {
+        expect(result.code).toBe("FAKE_200_OPENAI_RESPONSE_FAILED");
+        expect(result.detail).toBe("Upstream worker failed");
+      }
+    });
+
+    it("should detect flat OpenAI Responses failed JSON object", () => {
+      const body = JSON.stringify({
+        id: "resp_789",
+        object: "response",
+        status: "failed",
+        error: {
+          code: "rate_limit_exceeded",
+          message: "Too many concurrent requests",
+        },
+      });
+
+      const result = detectUpstreamErrorFromSseOrJsonText(body);
+
+      expect(result.isError).toBe(true);
+      if (result.isError) {
+        expect(result.code).toBe("FAKE_200_OPENAI_RESPONSE_FAILED");
+        expect(result.detail).toBe("Too many concurrent requests");
+      }
+    });
+
+    it("should not treat successful OpenAI Responses completed event as fake 200", () => {
+      const sse = [
+        "event: response.completed",
+        'data: {"type":"response.completed","response":{"id":"resp_ok","status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}',
+        "",
+      ].join("\n");
+
+      const result = detectUpstreamErrorFromSseOrJsonText(sse);
+
+      expect(result.isError).toBe(false);
+    });
+
+    it("should not classify normal OpenAI chat completion SSE chunks as Responses failures", () => {
+      const sse = [
+        'data: {"id":"chatcmpl_123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hello"}}]}',
+        "",
+        'data: {"id":"chatcmpl_123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}',
+        "",
+        "data: [DONE]",
+      ].join("\n");
+
+      const result = detectUpstreamErrorFromSseOrJsonText(sse);
+
+      expect(result.isError).toBe(false);
+    });
+
     it("should return isError=false for successful JSON without error field", () => {
       const result = detectUpstreamErrorFromSseOrJsonText(
         '{"choices":[{"message":{"content":"hi"}}]}'

--- a/tests/unit/proxy/response-handler-non200.test.ts
+++ b/tests/unit/proxy/response-handler-non200.test.ts
@@ -274,6 +274,38 @@ describe("Non-200 Status Code Handling", () => {
       }
     });
 
+    it("should detect OpenAI Responses failure when only the SSE event name says response.failed", () => {
+      const sse = [
+        "event: response.failed",
+        'data: {"response":{"error":{"message":"Concurrency limit exceeded for user, please retry later"}}}',
+        "",
+      ].join("\n");
+
+      const result = detectUpstreamErrorFromSseOrJsonText(sse);
+
+      expect(result.isError).toBe(true);
+      if (result.isError) {
+        expect(result.code).toBe("FAKE_200_OPENAI_RESPONSE_FAILED");
+        expect(result.detail).toBe("Concurrency limit exceeded for user, please retry later");
+      }
+    });
+
+    it("should detect OpenAI Responses failure when SSE event name is response.failed but data type is generic", () => {
+      const sse = [
+        "event: response.failed",
+        'data: {"type":"response","response":{"error":{"message":"Concurrency limit exceeded for user, please retry later"}}}',
+        "",
+      ].join("\n");
+
+      const result = detectUpstreamErrorFromSseOrJsonText(sse);
+
+      expect(result.isError).toBe(true);
+      if (result.isError) {
+        expect(result.code).toBe("FAKE_200_OPENAI_RESPONSE_FAILED");
+        expect(result.detail).toBe("Concurrency limit exceeded for user, please retry later");
+      }
+    });
+
     it("should detect wrapped OpenAI Responses failed JSON object", () => {
       const body = JSON.stringify({
         type: "response.failed",
@@ -313,6 +345,62 @@ describe("Non-200 Status Code Handling", () => {
       if (result.isError) {
         expect(result.code).toBe("FAKE_200_OPENAI_RESPONSE_FAILED");
         expect(result.detail).toBe("Too many concurrent requests");
+      }
+    });
+
+    it("should detect OpenAI Responses failed event when error detail is not extractable", () => {
+      const body = JSON.stringify({
+        type: "response.failed",
+        response: {
+          id: "resp_numeric_code",
+          status: "failed",
+          error: {
+            code: 429,
+            type: "rate_limit_error",
+          },
+        },
+      });
+
+      const result = detectUpstreamErrorFromSseOrJsonText(body);
+
+      expect(result.isError).toBe(true);
+      if (result.isError) {
+        expect(result.code).toBe("FAKE_200_OPENAI_RESPONSE_FAILED");
+        expect(result.detail).toBeUndefined();
+      }
+    });
+
+    it("should detect OpenAI Responses failed event without error payload", () => {
+      const body = JSON.stringify({
+        type: "response.failed",
+        response: {
+          id: "resp_missing_error",
+          status: "failed",
+        },
+      });
+
+      const result = detectUpstreamErrorFromSseOrJsonText(body);
+
+      expect(result.isError).toBe(true);
+      if (result.isError) {
+        expect(result.code).toBe("FAKE_200_OPENAI_RESPONSE_FAILED");
+        expect(result.detail).toBeUndefined();
+      }
+    });
+
+    it("should detect OpenAI Responses failed SSE event without error payload", () => {
+      const sse = [
+        "event: response.failed",
+        'data: {"type":"response.failed","response":{"id":"resp_sse_missing_error","status":"failed"}}',
+        "",
+      ].join("\n");
+
+      const result = detectUpstreamErrorFromSseOrJsonText(sse);
+
+      expect(result.isError).toBe(true);
+      if (result.isError) {
+        expect(result.code).toBe("FAKE_200_OPENAI_RESPONSE_FAILED");
+        expect(result.detail).toBeUndefined();
       }
     });
 


### PR DESCRIPTION
## Summary

- Detect OpenAI Responses API `response.failed` SSE payloads as fake-200 upstream failures.
- Reuse the existing deferred streaming finalizer so HTTP 200 streams with failed Responses terminal events are recorded as provider failures, not successful requests.
- Add regression coverage for flat/wrapped Responses failures, normal completed Responses events, and Chat Completions SSE chunks.

## Why

Some OpenAI-compatible Responses providers return HTTP 200 while the SSE stream contains a terminal `response.failed` event, such as a concurrency or rate-limit failure. Before this change, CCH could finalize those requests as successful because the fake-200 detector did not inspect nested `response.error` payloads.

This PR fixes accounting, circuit-breaker state, and session binding after a failed Responses stream is observed. Transparent in-flight failover before bytes are committed to the client is tracked separately.

## Related Issues & PRs

- Follow-up to #735 - extends the fake-200 detection utility (`src/lib/utils/upstream-error-detection.ts`) and the deferred-stream finalization that PR introduced.
- Related to #763 - sibling extension that added `FAKE_200_HTML_BODY`; this PR adds the analogous `FAKE_200_OPENAI_RESPONSE_FAILED` code for nested Responses error payloads.
- Related to #749 - original "recorded as 200 success" report that motivated fake-200 detection.
- Related to #1134 - builds on the accounting model it established: a fake-200 triggers core `recordFailure` but not endpoint circuit recording, and clears the session provider binding.
- Related to #1249 - complementary Responses terminal-event handling. #1249 fixes false 499 on Codex streams via a client-path terminal tracker; this PR fixes false 200 on OpenAI Responses streams via the `allContent` fake-200 detector. They address different manifestations through different code paths.

## Changes

Additive detection logic; no API, schema, or signature changes.

### Core Changes
- `src/lib/utils/upstream-error-detection.ts` (+51) - New `FAKE_200_OPENAI_RESPONSE_FAILED` code and `extractOpenAIResponsesFailedDetail()`, wired into `detectFromJsonObject()` ahead of the generic top-level `error`/`message` checks. Requires the object to look like an OpenAI Response (`type` prefix `response.`, `object === "response"`, or `id` prefix `resp_`), be in a failed state (`response.failed` / `status === "failed"`), and carry a non-empty nested `response.error`; extracts message, then code, then top-level message. The existing detector only inspected top-level `error`, so the nested `response.error` in the SSE/wrapped `response.failed` payload was previously invisible.

### Supporting Changes (Tests)
- `tests/unit/proxy/response-handler-non200.test.ts` (+84) - Detection cases for SSE `response.failed`, wrapped JSON, and flat JSON, plus negative cases confirming `response.completed` and Chat Completions chunks are not misclassified.
- `tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts` (+59) - End-to-end case asserting a 200 + `response.failed` stream is recorded as a 502 core failure, skips endpoint success/failure recording and cost tracking, and clears the session provider binding.

## Testing

- `bun run test -- tests/unit/proxy/response-handler-non200.test.ts tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts tests/unit/proxy/extract-usage-metrics.test.ts`
- `bun run typecheck`
- `bun run lint` (passes with pre-existing warnings)
- `bun run test -- tests/unit/proxy`

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the fake-200 upstream error detector to recognise OpenAI Responses API `response.failed` SSE events, which embed the error under a nested `response.error` field that the previous top-level `error` inspector never reached. The deferred streaming finaliser is wired to the new `FAKE_200_OPENAI_RESPONSE_FAILED` code so that HTTP 200 streams carrying a terminal failure are correctly recorded as provider failures, circuit-breaker state is updated, and the session provider binding is cleared.

- **New `detectOpenAIResponsesFailed()` in `upstream-error-detection.ts`**: handles both the wrapped SSE format (`obj.response.error`) and the flat JSON format (`obj.error` with OpenAI Response object markers); returns an empty sentinel `{}` rather than `null` for confirmed failures with no extractable detail string, so every `response.failed` event is recorded as an error even when the nested error object carries only numeric codes.
- **`__sseEvent` injection in the SSE loop**: the SSE event name is added to the parsed data object before detection so `detectOpenAIResponsesFailed` can use the SSE event line (e.g. `event: response.failed`) as a primary detection signal alongside `type`/`status` fields.
- **Fast-filter regex updated** to include `"status"\\s*:\\s*"failed"` and both SSE and JSON `response.failed` patterns, ensuring the new path is not skipped by the pre-parse guard.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Additive detection logic only; no existing behaviour changes for Chat Completions or non-Responses streams.

The change is purely additive: a new detection branch fires before existing generic checks and a new code string is appended to an existing safe-list. The prior thread's concern about null vs. confirmed-failure sentinel is resolved — the function now returns {} for failures with non-extractable error detail, so every response.failed event is recorded as an error. Test coverage spans SSE, wrapped JSON, flat JSON, missing-error, numeric-code, and the critical negative cases (completed events and Chat Completions chunks are unaffected).

The fast-filter regex in upstream-error-detection.ts now includes "status"\s*:\s*"failed" which is broader than the existing key-only patterns; worth a second read to confirm it cannot match inside model-generated string values at scale.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/utils/upstream-error-detection.ts | Adds FAKE_200_OPENAI_RESPONSE_FAILED detection: new detectOpenAIResponsesFailed() handles both wrapped SSE (error under response.error) and flat (top-level error) formats; correctly returns {} instead of null for confirmed failures with no extractable detail; SSE event name injected via __sseEvent spread; fast filter regex updated. |
| src/app/v1/_lib/proxy/forwarder.ts | One-line additive change: adds FAKE_200_OPENAI_RESPONSE_FAILED to the isStrongFake200 predicate, allowing the new detection code to trigger retry/failover in the deferred streaming finalizer path. |
| tests/unit/proxy/response-handler-non200.test.ts | Adds 10 new unit tests covering SSE response.failed detection (with/without error payload, numeric code, SSE-only event name), wrapped/flat JSON formats, and negative cases for response.completed and Chat Completions chunks. |
| tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts | Adds end-to-end test asserting that a 200+response.failed SSE stream triggers core recordFailure (502), skips endpoint circuit recording and cost tracking, and clears session provider binding; also adds missing SessionManager.updateSessionUsage mock to setupCommonMocks. |
| tests/unit/proxy/proxy-forwarder-fake-200-html.test.ts | Adds integration test for non-streaming application/json response with response.failed flat format, verifying provider failover to provider2 and correct FAKE_200_OPENAI_RESPONSE_FAILED error recording. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SSE or JSON text] --> B{Starts with curly brace?}
    B -->|Yes| C[JSON.parse → detectFromJsonObject]
    B -->|No| D{Fast filter passes?\nerror / message /\nresponse.failed signal}
    D -->|No| Z[isError: false]
    D -->|Yes| E[parseSSEData]
    E --> F{Named evt.event?}
    F -->|Yes| G[eventData = spread with __sseEvent]
    F -->|No| H[eventData = evt.data as-is]
    G --> C
    H --> C
    C --> I[detectOpenAIResponsesFailed]
    I --> J{looksLikeOpenAIResponse AND isFailedResponse?}
    J -->|No, returns null| K[Generic error/message checks]
    J -->|Yes| L{Extract detail from response.error}
    L -->|string or object message/code| M[FAKE_200_OPENAI_RESPONSE_FAILED + detail]
    L -->|not extractable, returns empty obj| M
    K --> O{obj.error non-empty?}
    O -->|Yes| P[FAKE_200_JSON_ERROR_NON_EMPTY or MESSAGE]
    O -->|No| Q{Small JSON + message keyword?}
    Q -->|Yes| R[FAKE_200_JSON_MESSAGE_KEYWORD_MATCH]
    Q -->|No| Z
    M --> S[isStrongFake200 = true]
    P --> S
    S --> T[recordFailure 502, clearSessionProvider, skip endpoint circuit]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[SSE or JSON text] --> B{Starts with curly brace?}
    B -->|Yes| C[JSON.parse → detectFromJsonObject]
    B -->|No| D{Fast filter passes?\nerror / message /\nresponse.failed signal}
    D -->|No| Z[isError: false]
    D -->|Yes| E[parseSSEData]
    E --> F{Named evt.event?}
    F -->|Yes| G[eventData = spread with __sseEvent]
    F -->|No| H[eventData = evt.data as-is]
    G --> C
    H --> C
    C --> I[detectOpenAIResponsesFailed]
    I --> J{looksLikeOpenAIResponse AND isFailedResponse?}
    J -->|No, returns null| K[Generic error/message checks]
    J -->|Yes| L{Extract detail from response.error}
    L -->|string or object message/code| M[FAKE_200_OPENAI_RESPONSE_FAILED + detail]
    L -->|not extractable, returns empty obj| M
    K --> O{obj.error non-empty?}
    O -->|Yes| P[FAKE_200_JSON_ERROR_NON_EMPTY or MESSAGE]
    O -->|No| Q{Small JSON + message keyword?}
    Q -->|Yes| R[FAKE_200_JSON_MESSAGE_KEYWORD_MATCH]
    Q -->|No| Z
    M --> S[isStrongFake200 = true]
    P --> S
    S --> T[recordFailure 502, clearSessionProvider, skip endpoint circuit]
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(proxy): flag failed Responses withou..."](https://github.com/ding113/claude-code-hub/commit/50a88a762af64d29d241a63762a27bf80609668f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41073974)</sub>

<!-- /greptile_comment -->