### PR TITLE
fix(fake-streaming): persist terminal request state via lifecycle hook

### DIFF
--- a/src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts
@@ -1,14 +1,21 @@
 import { logger } from "@/lib/logger";
+import { ProxyStatusTracker } from "@/lib/proxy-status-tracker";
+import { updateMessageRequestDetails, updateMessageRequestDuration } from "@/repository/message";
+import type { ProviderType } from "@/types/provider";
 import type { SystemSettings } from "@/types/system-config";
+import { extractActualResponseModelForProvider } from "../actual-response-model";
 import type { ClientFormat } from "../format-mapper";
 import { ProxyForwarder } from "../forwarder";
+import { parseUsageFromResponseText } from "../response-handler";
 import type { ProxySession } from "../session";
 import { isFakeStreamingEligible } from "./eligibility";
+import type { OrchestrateResult } from "./orchestrator";
 import type { ProtocolFamily } from "./response-validator";
 import {
   type AttemptPerformer,
   buildFakeStreamingNonStreamResponse,
   buildFakeStreamingResponse,
+  type FakeStreamingCompletionHook,
 } from "./runner";
 import { cloneRequestForInternalNonStreamAttempt, detectClientStreamIntent } from "./stream-intent";
 
@@ -80,6 +87,7 @@ export async function tryFakeStreamingPath(
     });
   }
   const abortSignal = session.clientAbortSignal ?? new AbortController().signal;
+  const onCompletion = buildCompletionHook(session);
 
   if (isStream) {
     logger.debug("[FakeStreaming] taking stream path", {
@@ -94,6 +102,7 @@ export async function tryFakeStreamingPath(
       abortSignal,
       maxAttempts: MAX_ATTEMPTS,
       heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+      onCompletion,
     });
   }
 
@@ -107,7 +116,146 @@ export async function tryFakeStreamingPath(
     performAttempt,
     abortSignal,
     maxAttempts: MAX_ATTEMPTS,
+    onCompletion,
   });
+}
+
+/**
+ * Build the lifecycle-completion hook that persists the terminal state of a
+ * fake-streaming request. Fake streaming bypasses both ProxyResponseHandler
+ * and ProxyErrorHandler, so without this hook the message_request row stays
+ * with status_code=NULL / provider_chain=NULL forever and the proxy-status
+ * tracker keeps the request in "in progress" state (see #1310).
+ *
+ * Mirrors the write set of ProxyResponseHandler success + ProxyErrorHandler
+ * failure paths so the usage-log UI and the tracker converge to the same
+ * terminal shape as the non-fake-streaming path.
+ */
+function buildCompletionHook(session: ProxySession): FakeStreamingCompletionHook {
+  return async ({ result }) => {
+    const messageContext = session.messageContext;
+    if (!messageContext) return;
+
+    const durationMs = Date.now() - session.startTime;
+    const providerChain = session.getProviderChain();
+    const currentModel = session.getCurrentModel() ?? undefined;
+    const specialSettings = session.getSpecialSettings() ?? undefined;
+    const provider = session.provider ?? null;
+    const providerType = provider?.providerType;
+
+    const { statusCode, errorMessage, usageDetails } = resolveTerminalOutcome({
+      result,
+      providerType,
+    });
+
+    try {
+      await updateMessageRequestDuration(messageContext.id, durationMs);
+    } catch (err) {
+      logger.error("[FakeStreaming] Failed to persist request duration", {
+        error: err,
+        messageRequestId: messageContext.id,
+      });
+    }
+
+    try {
+      await updateMessageRequestDetails(messageContext.id, {
+        statusCode,
+        errorMessage: errorMessage ?? undefined,
+        providerChain,
+        model: currentModel,
+        providerId: provider?.id,
+        context1mApplied: session.getContext1mApplied(),
+        swapCacheTtlApplied: provider?.swapCacheTtlBilling ?? false,
+        specialSettings,
+        ttfbMs: session.ttfbMs ?? durationMs,
+        inputTokens: usageDetails?.inputTokens,
+        outputTokens: usageDetails?.outputTokens,
+        cacheCreationInputTokens: usageDetails?.cacheCreationInputTokens,
+        cacheReadInputTokens: usageDetails?.cacheReadInputTokens,
+        cacheCreation5mInputTokens: usageDetails?.cacheCreation5mInputTokens,
+        cacheCreation1hInputTokens: usageDetails?.cacheCreation1hInputTokens,
+        cacheTtlApplied: usageDetails?.cacheTtl ?? null,
+        actualResponseModel: usageDetails?.actualResponseModel ?? undefined,
+      });
+    } catch (err) {
+      logger.error("[FakeStreaming] Failed to persist terminal request details", {
+        error: err,
+        messageRequestId: messageContext.id,
+      });
+    }
+
+    try {
+      const tracker = ProxyStatusTracker.getInstance();
+      tracker.endRequest(messageContext.user.id, messageContext.id);
+    } catch (err) {
+      logger.error("[FakeStreaming] Failed to end tracker request", {
+        error: err,
+        messageRequestId: messageContext.id,
+      });
+    }
+  };
+}
+
+interface TerminalUsageDetails {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheCreation5mInputTokens?: number;
+  cacheCreation1hInputTokens?: number;
+  cacheTtl?: string | null;
+  actualResponseModel?: string | null;
+}
+
+interface TerminalOutcome {
+  statusCode: number;
+  errorMessage: string | null;
+  usageDetails: TerminalUsageDetails | null;
+}
+
+function resolveTerminalOutcome(input: {
+  result: OrchestrateResult;
+  providerType: ProviderType | undefined;
+}): TerminalOutcome {
+  const { result, providerType } = input;
+
+  if (result.ok && typeof result.finalBody === "string") {
+    let usageDetails: TerminalUsageDetails | null = null;
+    try {
+      const parsed = parseUsageFromResponseText(result.finalBody, providerType);
+      const metrics = parsed.usageMetrics ?? null;
+      const actualResponseModel = providerType
+        ? extractActualResponseModelForProvider(providerType, false, result.finalBody)
+        : null;
+      usageDetails = {
+        inputTokens: metrics?.input_tokens,
+        outputTokens: metrics?.output_tokens,
+        cacheCreationInputTokens: metrics?.cache_creation_input_tokens,
+        cacheReadInputTokens: metrics?.cache_read_input_tokens,
+        cacheCreation5mInputTokens: metrics?.cache_creation_5m_input_tokens,
+        cacheCreation1hInputTokens: metrics?.cache_creation_1h_input_tokens,
+        cacheTtl: metrics?.cache_ttl ?? null,
+        actualResponseModel,
+      };
+    } catch (err) {
+      logger.warn("[FakeStreaming] Failed to parse usage from final body", { error: err });
+    }
+    return { statusCode: 200, errorMessage: null, usageDetails };
+  }
+
+  if (result.errorCode === "client_abort") {
+    return {
+      statusCode: 499,
+      errorMessage: result.errorMessage ?? "client disconnected",
+      usageDetails: null,
+    };
+  }
+
+  return {
+    statusCode: 502,
+    errorMessage: result.errorMessage ?? "all upstream attempts failed",
+    usageDetails: null,
+  };
 }
 
 function applyNonStreamMutation(session: ProxySession): void {

--- a/src/app/v1/_lib/proxy/fake-streaming/runner.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/runner.ts
@@ -89,16 +89,18 @@ function buildStreamResponse(input: FakeStreamingRunInput): Response {
 
       const cleanupHeartbeat = () => clearInterval(heartbeatTimer);
 
-      const onAbort = () => {
-        cleanupHeartbeat();
-        safeClose();
-      };
-      input.abortSignal.addEventListener("abort", onAbort, { once: true });
-
+      // The completion hook must fire EXACTLY once per run: either from the
+      // orchestrator's terminal state, or — if orchestrator never settles
+      // (upstream fetch hung with no provider-level timeout) — from the abort
+      // listener as soon as the client disconnects. `completionFired` guards
+      // the once-only contract across both paths.
+      let completionFired = false;
       const invokeCompletion = async (
         result: OrchestrateResult,
         errorFromRunner?: unknown
       ): Promise<void> => {
+        if (completionFired) return;
+        completionFired = true;
         if (!input.onCompletion) return;
         try {
           await input.onCompletion({ result, errorFromRunner });
@@ -106,6 +108,24 @@ function buildStreamResponse(input: FakeStreamingRunInput): Response {
           // Lifecycle persistence errors must not leak into the SSE stream.
         }
       };
+
+      const onAbort = () => {
+        cleanupHeartbeat();
+        safeClose();
+        // Do NOT block on the persistence write — the response stream must
+        // close immediately for abort semantics. `invokeCompletion` returns
+        // void here, and its own body is fully try/catched so it cannot
+        // reject synchronously or via an unhandled rejection.
+        if (!completionFired) {
+          void invokeCompletion({
+            ok: false,
+            attempts: [],
+            errorCode: "client_abort",
+            errorMessage: "client disconnected before upstream settled",
+          });
+        }
+      };
+      input.abortSignal.addEventListener("abort", onAbort, { once: true });
 
       void orchestrateFakeStreamingAttempts({
         family: input.family,

--- a/src/app/v1/_lib/proxy/fake-streaming/runner.ts
+++ b/src/app/v1/_lib/proxy/fake-streaming/runner.ts
@@ -1,10 +1,30 @@
 import { emitFinalNonStream, emitFinalStream, emitStreamError } from "./emitters";
-import { type AttemptPerformer, orchestrateFakeStreamingAttempts } from "./orchestrator";
+import {
+  type AttemptPerformer,
+  type OrchestrateResult,
+  orchestrateFakeStreamingAttempts,
+} from "./orchestrator";
 import type { ProtocolFamily } from "./response-validator";
 
 export type { AttemptPerformer } from "./orchestrator";
 
 const HEARTBEAT_FRAME = ": ping\n\n";
+
+/**
+ * Optional lifecycle hook fired ONCE per fake-streaming run, regardless of
+ * outcome (success / all-failed / client_abort / runner error). Wired by
+ * `tryFakeStreamingPath` so it can persist the terminal status_code,
+ * provider_chain, tokens, and tracker.endRequest that the normal
+ * ProxyResponseHandler / ProxyErrorHandler path would have written — since
+ * fake streaming bypasses both handlers.
+ *
+ * The callback MUST NOT throw; runner swallows any errors from it to avoid
+ * leaking into the SSE stream or breaking the non-stream response.
+ */
+export type FakeStreamingCompletionHook = (outcome: {
+  result: OrchestrateResult;
+  errorFromRunner?: unknown;
+}) => void | Promise<void>;
 
 export interface FakeStreamingRunInput {
   family: ProtocolFamily;
@@ -13,6 +33,7 @@ export interface FakeStreamingRunInput {
   abortSignal: AbortSignal;
   maxAttempts: number;
   heartbeatIntervalMs: number;
+  onCompletion?: FakeStreamingCompletionHook;
 }
 
 /**
@@ -74,6 +95,18 @@ function buildStreamResponse(input: FakeStreamingRunInput): Response {
       };
       input.abortSignal.addEventListener("abort", onAbort, { once: true });
 
+      const invokeCompletion = async (
+        result: OrchestrateResult,
+        errorFromRunner?: unknown
+      ): Promise<void> => {
+        if (!input.onCompletion) return;
+        try {
+          await input.onCompletion({ result, errorFromRunner });
+        } catch {
+          // Lifecycle persistence errors must not leak into the SSE stream.
+        }
+      };
+
       void orchestrateFakeStreamingAttempts({
         family: input.family,
         performAttempt: input.performAttempt,
@@ -81,11 +114,12 @@ function buildStreamResponse(input: FakeStreamingRunInput): Response {
         maxAttempts: input.maxAttempts,
         isStream: false,
       })
-        .then((result) => {
+        .then(async (result) => {
           cleanupHeartbeat();
           input.abortSignal.removeEventListener("abort", onAbort);
           if (input.abortSignal.aborted) {
             safeClose();
+            await invokeCompletion(result);
             return;
           }
           if (result.ok && typeof result.finalBody === "string") {
@@ -112,8 +146,9 @@ function buildStreamResponse(input: FakeStreamingRunInput): Response {
             );
           }
           safeClose();
+          await invokeCompletion(result);
         })
-        .catch((error: unknown) => {
+        .catch(async (error: unknown) => {
           cleanupHeartbeat();
           input.abortSignal.removeEventListener("abort", onAbort);
           if (!input.abortSignal.aborted) {
@@ -127,6 +162,15 @@ function buildStreamResponse(input: FakeStreamingRunInput): Response {
             );
           }
           safeClose();
+          await invokeCompletion(
+            {
+              ok: false,
+              attempts: [],
+              errorCode: "upstream_all_attempts_failed",
+              errorMessage: error instanceof Error ? error.message : "fake streaming runner failed",
+            },
+            error
+          );
         });
     },
   });
@@ -149,6 +193,18 @@ function buildStreamResponse(input: FakeStreamingRunInput): Response {
 export async function buildFakeStreamingNonStreamResponse(
   input: Omit<FakeStreamingRunInput, "isStream" | "heartbeatIntervalMs">
 ): Promise<Response> {
+  const invokeCompletion = async (
+    result: OrchestrateResult,
+    errorFromRunner?: unknown
+  ): Promise<void> => {
+    if (!input.onCompletion) return;
+    try {
+      await input.onCompletion({ result, errorFromRunner });
+    } catch {
+      // Lifecycle persistence errors must not affect the HTTP response.
+    }
+  };
+
   let result: Awaited<ReturnType<typeof orchestrateFakeStreamingAttempts>>;
   try {
     result = await orchestrateFakeStreamingAttempts({
@@ -162,6 +218,15 @@ export async function buildFakeStreamingNonStreamResponse(
     // failures). Surface a structured 502 here so non-stream clients get the
     // same JSON contract they would for "all attempts failed", instead of the
     // outer ProxyErrorHandler turning this into a different shape.
+    await invokeCompletion(
+      {
+        ok: false,
+        attempts: [],
+        errorCode: "upstream_all_attempts_failed",
+        errorMessage: error instanceof Error ? error.message : "fake streaming runner failed",
+      },
+      error
+    );
     return new Response(
       JSON.stringify({
         error: {
@@ -175,6 +240,8 @@ export async function buildFakeStreamingNonStreamResponse(
       }
     );
   }
+
+  await invokeCompletion(result);
 
   if (result.ok && typeof result.finalBody === "string") {
     return new Response(emitFinalNonStream({ family: input.family, finalBody: result.finalBody }), {

--- a/tests/unit/proxy/response-handler-fake-streaming.test.ts
+++ b/tests/unit/proxy/response-handler-fake-streaming.test.ts
@@ -461,4 +461,79 @@ describe("onCompletion lifecycle hook", () => {
     const body = await response.text();
     expect(body).toBe(validBody);
   });
+
+  test("stream: hook fires with client_abort even when upstream fetch NEVER settles", async () => {
+    // Repro for the real-world bug where sw-sub2api-style upstreams accept
+    // stream:false but never send a response body, provider has
+    // request_timeout_non_streaming_ms=0, so the orchestrator promise stays
+    // pending forever. Without an abort-triggered fallback, the completion
+    // hook never fires and the message_request row stays with status_code
+    // = NULL / provider_chain = NULL forever.
+    const abortController = new AbortController();
+    // Never-resolving performAttempt, and it also does NOT reject on abort
+    // (simulating the case where undici's fetch abort is ineffective / the
+    // upstream socket is stuck in a half-open state).
+    const performAttempt: AttemptPerformer = () => new Promise<never>(() => {});
+    const onCompletion = vi.fn(async () => undefined);
+
+    const response = buildFakeStreamingResponse({
+      family: "anthropic",
+      isStream: true,
+      performAttempt,
+      abortSignal: abortController.signal,
+      maxAttempts: 1,
+      heartbeatIntervalMs: 5000,
+      onCompletion,
+    });
+
+    // Wait for the first heartbeat so we know the stream started.
+    await readUntilFirstChunk(response.body);
+
+    // Client disconnects while orchestrator is still hung.
+    abortController.abort();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onCompletion).toHaveBeenCalledTimes(1);
+    const arg = onCompletion.mock.calls[0][0];
+    expect(arg.result.ok).toBe(false);
+    expect(arg.result.errorCode).toBe("client_abort");
+  });
+
+  test("stream: hook fires exactly once even if orchestrator resolves after abort", async () => {
+    // Belt-and-braces: if a slow orchestrator eventually resolves after the
+    // abort listener has already fired the hook, the .then() branch must not
+    // fire it a second time. Verifies the completionFired guard.
+    const abortController = new AbortController();
+    let releaseAttempt: (() => void) | null = null;
+    const performAttempt: AttemptPerformer = () =>
+      new Promise((resolve) => {
+        releaseAttempt = () => resolve({ status: 200, body: validBody, providerId: "p1" });
+      });
+    const onCompletion = vi.fn(async () => undefined);
+
+    const response = buildFakeStreamingResponse({
+      family: "anthropic",
+      isStream: true,
+      performAttempt,
+      abortSignal: abortController.signal,
+      maxAttempts: 1,
+      heartbeatIntervalMs: 5000,
+      onCompletion,
+    });
+
+    await readUntilFirstChunk(response.body);
+    // Abort fires the hook via the abort listener.
+    abortController.abort();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onCompletion).toHaveBeenCalledTimes(1);
+
+    // Orchestrator wakes up *after* the abort — must NOT fire hook again.
+    releaseAttempt?.();
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onCompletion).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/proxy/response-handler-fake-streaming.test.ts
+++ b/tests/unit/proxy/response-handler-fake-streaming.test.ts
@@ -258,3 +258,207 @@ describe("buildFakeStreamingNonStreamResponse — non-stream path", () => {
     expect(body.error.code).toBe("upstream_all_attempts_failed");
   });
 });
+
+describe("onCompletion lifecycle hook", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("stream: fires once with ok=true after successful attempt", async () => {
+    const performAttempt: AttemptPerformer = async () => ({
+      status: 200,
+      body: validBody,
+      providerId: "p1",
+    });
+    const onCompletion = vi.fn(async () => undefined);
+
+    const response = buildFakeStreamingResponse({
+      family: "anthropic",
+      isStream: true,
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 1,
+      heartbeatIntervalMs: 5000,
+      onCompletion,
+    });
+
+    await vi.runAllTimersAsync();
+    await consumeStream(response.body);
+    // Give the microtask queue a chance to drain (onCompletion runs after
+    // the terminator emission has been enqueued to the stream).
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onCompletion).toHaveBeenCalledTimes(1);
+    const arg = onCompletion.mock.calls[0][0];
+    expect(arg.result.ok).toBe(true);
+    expect(arg.result.finalBody).toBe(validBody);
+    expect(arg.errorFromRunner).toBeUndefined();
+  });
+
+  test("stream: fires once with ok=false + errorCode on terminal failure", async () => {
+    const performAttempt: AttemptPerformer = async () => ({
+      status: 200,
+      body: emptyBody,
+      providerId: "p1",
+    });
+    const onCompletion = vi.fn(async () => undefined);
+
+    const response = buildFakeStreamingResponse({
+      family: "anthropic",
+      isStream: true,
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 1,
+      heartbeatIntervalMs: 5000,
+      onCompletion,
+    });
+
+    await vi.runAllTimersAsync();
+    await consumeStream(response.body);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onCompletion).toHaveBeenCalledTimes(1);
+    const arg = onCompletion.mock.calls[0][0];
+    expect(arg.result.ok).toBe(false);
+    expect(arg.result.errorCode).toBeDefined();
+  });
+
+  test("stream: fires with client_abort when signal aborts before completion", async () => {
+    const abortController = new AbortController();
+    const performAttempt: AttemptPerformer = async (_index, signal) => {
+      return new Promise<never>((_resolve, reject) => {
+        signal.addEventListener("abort", () => {
+          reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+        });
+      });
+    };
+    const onCompletion = vi.fn(async () => undefined);
+
+    const response = buildFakeStreamingResponse({
+      family: "anthropic",
+      isStream: true,
+      performAttempt,
+      abortSignal: abortController.signal,
+      maxAttempts: 1,
+      heartbeatIntervalMs: 5000,
+      onCompletion,
+    });
+
+    const { reader } = await readUntilFirstChunk(response.body);
+    abortController.abort();
+    await vi.runAllTimersAsync();
+    // Drain any remaining bytes so the underlying promise chain settles.
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onCompletion).toHaveBeenCalledTimes(1);
+    const arg = onCompletion.mock.calls[0][0];
+    expect(arg.result.ok).toBe(false);
+    expect(arg.result.errorCode).toBe("client_abort");
+  });
+
+  test("stream: onCompletion throw does not leak into SSE stream", async () => {
+    const performAttempt: AttemptPerformer = async () => ({
+      status: 200,
+      body: validBody,
+      providerId: "p1",
+    });
+    const onCompletion = vi.fn(async () => {
+      throw new Error("persistence blew up");
+    });
+
+    const response = buildFakeStreamingResponse({
+      family: "anthropic",
+      isStream: true,
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 1,
+      heartbeatIntervalMs: 5000,
+      onCompletion,
+    });
+
+    await vi.runAllTimersAsync();
+    // Must not throw; must not surface the persistence error in the stream.
+    const body = await consumeStream(response.body);
+    expect(body).toContain("event: message_stop");
+    expect(body).not.toContain("persistence blew up");
+  });
+
+  test("non-stream: fires once with ok=true and the final body", async () => {
+    const performAttempt: AttemptPerformer = async () => ({
+      status: 200,
+      body: validBody,
+      providerId: "p1",
+    });
+    const onCompletion = vi.fn(async () => undefined);
+
+    await buildFakeStreamingNonStreamResponse({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 1,
+      onCompletion,
+    });
+
+    expect(onCompletion).toHaveBeenCalledTimes(1);
+    const arg = onCompletion.mock.calls[0][0];
+    expect(arg.result.ok).toBe(true);
+    expect(arg.result.finalBody).toBe(validBody);
+  });
+
+  test("non-stream: fires once on all-failed with errorCode surfaced", async () => {
+    const performAttempt: AttemptPerformer = async () => ({
+      status: 200,
+      body: emptyBody,
+      providerId: "p1",
+    });
+    const onCompletion = vi.fn(async () => undefined);
+
+    const response = await buildFakeStreamingNonStreamResponse({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 1,
+      onCompletion,
+    });
+
+    expect(response.status).toBe(502);
+    expect(onCompletion).toHaveBeenCalledTimes(1);
+    const arg = onCompletion.mock.calls[0][0];
+    expect(arg.result.ok).toBe(false);
+    expect(arg.result.errorCode).toBeDefined();
+  });
+
+  test("non-stream: onCompletion throw does not affect the HTTP response", async () => {
+    const performAttempt: AttemptPerformer = async () => ({
+      status: 200,
+      body: validBody,
+      providerId: "p1",
+    });
+    const onCompletion = vi.fn(async () => {
+      throw new Error("persistence blew up");
+    });
+
+    const response = await buildFakeStreamingNonStreamResponse({
+      family: "anthropic",
+      performAttempt,
+      abortSignal: new AbortController().signal,
+      maxAttempts: 1,
+      onCompletion,
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toBe(validBody);
+  });
+});


### PR DESCRIPTION
## 问题描述

Fake streaming 命中白名单的请求在完成/失败后,`message_request` 行永远不会被 finalize:

- `status_code` 永远为 `NULL`
- `provider_chain` 永远为 `NULL`
- `duration_ms` / `ttfb_ms` / `input_tokens` / `output_tokens` 永远为 `NULL`
- `ProxyStatusTracker` 永远不会收到 `endRequest`,导致管理页显示的"进行中请求"永久卡住

线上表现:web 端使用日志里对应会话出现大量"请求中"的孤儿行,即便客户端早已收到完整的响应或错误。

**Related Issues:**
- Related to #854 - 相同症状(请求卡在"请求中"、字段为 NULL),但根因不同:本 PR 修复 fake-streaming 路径问题,#854/#858 修复异步写缓冲问题
- Related to #858 - 针对 #854 的修复,与本 PR 互补(不同代码路径的相同症状修复)
- Follow-up to #1132 - 修复 fake streaming whitelist 功能引入的持久化缺陷

## 根因

`tryFakeStreamingPath` 走的两条路径:

- `buildFakeStreamingResponse` (stream) — 返回同步 `Response`,内部 `void orchestrateFakeStreamingAttempts(...).then(...)` 后台异步执行,主 handler 立即 return。
- `buildFakeStreamingNonStreamResponse` (non-stream) — `await` orchestrator 后 return `Response`。

两条路径都**绕过了** `ProxyResponseHandler.dispatch` 和 `ProxyErrorHandler.handle` —— 而这两处才是把 `providerChain / statusCode / usage / duration / tracker.endRequest` 写回的地方。

grep 证据:
```
$ grep -rn 'updateMessageRequestDetails\|ProxyStatusTracker' src/app/v1/_lib/proxy/fake-streaming/
# (无匹配)
```

`ProxyForwarder.send` 内部只 update `specialSettings` 一个字段,不覆盖 status/tokens/providerChain。

## 修复

给 `buildFakeStreamingResponse` 和 `buildFakeStreamingNonStreamResponse` 增加**可选** `onCompletion` 生命周期钩子:

- Runner 保证 **每次调用有且仅一次** 触发 `onCompletion`,无论成功 / 全部失败 / client_abort / runner throw。
- `tryFakeStreamingPath` 用该钩子 finalize 请求,写入与 `ProxyResponseHandler` 成功路径 + `ProxyErrorHandler` 失败路径**完全对齐**的字段集合(duration、status_code、providerChain、model、providerId、context1mApplied、swapCacheTtlApplied、specialSettings、ttfbMs、input/output/cache tokens、cacheTtl、actualResponseModel、tracker.endRequest)。
- 钩子内的任何异常都会被 runner 吞掉,不会污染 SSE 流或影响 HTTP 响应。

### 兼容性

- 新参数 `onCompletion` 是可选的,现有调用点无需改动。
- 运行时行为对**未接入 hook 的调用者**完全不变(runner 直接跳过 `invokeCompletion`)。
- 所有 114 个既有 fake-streaming 单测继续通过。

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts` (+148 lines) - 新增 `buildCompletionHook` 构造持久化生命周期钩子,对齐 ProxyResponseHandler/ProxyErrorHandler 写入字段
- `src/app/v1/_lib/proxy/fake-streaming/runner.ts` (+70/-3) - 为 stream 和 non-stream 路径注入 `onCompletion` 调用点,保证 exactly-once 语义

### Supporting Changes  
- `tests/unit/proxy/response-handler-fake-streaming.test.ts` (+204 lines) - 7 个新测试覆盖 stream/non-stream 路径的成功/失败/client_abort/hook-throw 场景

## 测试

新增 7 个测试(`tests/unit/proxy/response-handler-fake-streaming.test.ts`):

1. stream 路径成功时 hook fire 一次 且携带正确 result
2. stream 路径 terminal failure 时 hook fire 一次 且 errorCode 正确
3. stream 路径 client_abort 时 hook fire 一次 且 errorCode=client_abort
4. stream 路径 hook throw 时,SSE 流仍正常输出 message_stop,错误信息不泄漏
5. non-stream 路径成功时 hook fire 一次 且拿到 finalBody
6. non-stream 路径 all-failed 时 hook fire 一次 且返回 502
7. non-stream 路径 hook throw 时,HTTP 200 + finalBody 依然正常

`bun run vitest run tests/unit/proxy/*.ts` 全部通过。

## Test plan

- [x] 单元测试:`bun run vitest run tests/unit/proxy/response-handler-fake-streaming.test.ts` (14/14 passed)
- [x] 全量 fake-streaming 单测:6 files / 114 tests passed
- [x] Lint:`bun run lint` clean (仅 1 条 preexisting warning 与本 PR 无关)
- [x] Typecheck:fake-streaming 相关 0 errors(仓库另有 2 处 preexisting error 与本 PR 无关)
- [ ] 部署到线上验证:`message_request.status_code` / `provider_chain` / `duration_ms` 在白名单命中场景下能正确写回,web 端"进行中请求"不再出现孤儿行

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed  
- [x] Tests pass locally (14/14 new tests + 114 existing fake-streaming tests)
- [x] No breaking changes (optional parameter, backward compatible)

---
*Description enhanced by Claude Code*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a persistent data bug where fake-streaming requests that bypassed `ProxyResponseHandler`/`ProxyErrorHandler` never had their `message_request` row finalized — leaving `status_code`, `provider_chain`, and token fields as NULL and orphaning entries in the proxy-status tracker indefinitely.

- **`proxy-integration.ts`**: Adds `buildCompletionHook` which mirrors the write set of `ProxyResponseHandler` + `ProxyErrorHandler`, firing exactly once per request via the new `onCompletion` lifecycle hook to persist status code, provider chain, tokens, and call `tracker.endRequest`.
- **`runner.ts`**: Injects `onCompletion` call-sites into both the stream and non-stream paths, using a `completionFired` boolean guard to guarantee exactly-once semantics across the abort-listener and orchestrator-settle paths, with all hook errors swallowed to prevent bleedthrough into the SSE stream or HTTP response.
- **Tests**: 9 new tests covering stream/non-stream success, terminal failure, `client_abort`, hook-throw isolation, the never-settling upstream scenario, and the double-fire guard.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is backward-compatible (optional parameter), exactly-once hook semantics are correctly implemented with a synchronously-set completionFired guard, and all hook errors are isolated so they cannot affect the SSE stream or HTTP response.

The completionFired guard is set synchronously at the top of invokeCompletion before any await, which correctly serializes the abort-listener and orchestrator-settle race without any window for double invocation. All session reads in buildCompletionHook are captured before the first await, so suspended DB writes cannot observe stale state. The hook is optional and existing call sites are unchanged. Nine new tests cover all critical paths including the never-settling upstream scenario and the double-fire guard.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/fake-streaming/runner.ts | Adds FakeStreamingCompletionHook type and onCompletion call-sites to both stream and non-stream paths. The completionFired boolean guard correctly serializes the abort-listener path and the orchestrator-settle path, ensuring exactly-once hook invocation. The stream path fires the hook fire-and-forget; the non-stream path awaits it before returning the Response. |
| src/app/v1/_lib/proxy/fake-streaming/proxy-integration.ts | Adds buildCompletionHook and resolveTerminalOutcome to wire persistent state writes mirroring ProxyResponseHandler/ProxyErrorHandler. All session reads are captured synchronously before any await. Error paths have isolated try/catch blocks so a DB failure on duration write does not prevent the details write or tracker call. |
| tests/unit/proxy/response-handler-fake-streaming.test.ts | Adds 9 new lifecycle-hook tests covering stream/non-stream success, terminal failure, client_abort, hook-throw isolation, never-settling upstream abort, and the double-fire guard. Coverage is thorough for the exactly-once contract. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(fake-streaming): fire completion hoo..."](https://github.com/ding113/claude-code-hub/commit/c2e0db4e2e103f41465a25fcd513b35301c3e276) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41324512)</sub>

<!-- /greptile_comment -->