### PR TITLE
fix: Bull 队列未解码 REDIS_URL 密码且忽略 URL 中的 DB 序号

### DIFF
--- a/src/lib/log-cleanup/cleanup-queue.ts
+++ b/src/lib/log-cleanup/cleanup-queue.ts
@@ -46,8 +46,14 @@ function getCleanupQueue(): Queue.Queue {
     const url = new URL(redisUrl);
     redisQueueOptions.host = url.hostname;
     redisQueueOptions.port = parseInt(url.port || (useTls ? "6379" : "6379"), 10);
-    redisQueueOptions.password = url.password;
-    redisQueueOptions.username = url.username; // 传递用户名
+    // WHATWG URL 不会自动解码 userinfo 中的百分号编码，需显式 decode
+    redisQueueOptions.password = decodeURIComponent(url.password);
+    redisQueueOptions.username = decodeURIComponent(url.username); // 传递用户名
+    // 支持 redis://host:port/15 形式的 DB 选择
+    const dbFromPath = parseInt(url.pathname.slice(1), 10);
+    if (!Number.isNaN(dbFromPath)) {
+      redisQueueOptions.db = dbFromPath;
+    }
 
     if (useTls) {
       const rejectUnauthorized = process.env.REDIS_TLS_REJECT_UNAUTHORIZED !== "false";

--- a/src/lib/notification/notification-queue.ts
+++ b/src/lib/notification/notification-queue.ts
@@ -189,8 +189,14 @@ function getNotificationQueue(): Queue.Queue<NotificationJobData> {
     const url = new URL(redisUrl);
     redisQueueOptions.host = url.hostname;
     redisQueueOptions.port = parseInt(url.port || (useTls ? "6379" : "6379"), 10);
-    redisQueueOptions.password = url.password;
-    redisQueueOptions.username = url.username; // 传递用户名
+    // WHATWG URL 不会自动解码 userinfo 中的百分号编码，需显式 decode
+    redisQueueOptions.password = decodeURIComponent(url.password);
+    redisQueueOptions.username = decodeURIComponent(url.username); // 传递用户名
+    // 支持 redis://host:port/15 形式的 DB 选择
+    const dbFromPath = parseInt(url.pathname.slice(1), 10);
+    if (!Number.isNaN(dbFromPath)) {
+      redisQueueOptions.db = dbFromPath;
+    }
 
     if (useTls) {
       const rejectUnauthorized = process.env.REDIS_TLS_REJECT_UNAUTHORIZED !== "false";


### PR DESCRIPTION
## Related Issues

Fixes #1312

---

## 背景

使用外部共享 Redis 部署时，若密码包含 `/`、`=` 等特殊字符，按 URL 规范只能以百分号编码写入 `REDIS_URL`（明文会破坏 URL 解析）。当前版本下这样的配置会导致容器启动即崩溃。

## 问题复现

1. 配置 `REDIS_URL=redis://:pass%2Fword%3D@host:6379/15`（密码原文为 `pass/word=`）
2. 启动服务，日志出现：

```
ERR action=schedule_auto_cleanup_error error=WRONGPASS invalid username-password pair or user is disabled.
ReplyError: WRONGPASS invalid username-password pair or user is disabled.
  command: { name: 'auth', args: [ 'pass%2Fword%3D' ] }
fatal msg=[Lifecycle] unhandledRejection
```

AUTH 参数里是未解码的 `%2F`/`%3D` 原文，进程随即因 unhandledRejection 退出。

3. 此外：即使认证能通过（无特殊字符密码），URL 路径中 `/15` 的 DB 序号也会被忽略，Bull 键全部写入 DB 0——与共享 Redis 场景下的隔离预期不符。

## 根因

`src/lib/notification/notification-queue.ts` 与 `src/lib/log-cleanup/cleanup-queue.ts` 用 `new URL()` 解析连接串后，直接取 `url.password`/`url.username` 传给 Bull 的 redis options。WHATWG URL 规范不会对 userinfo 中的百分号编码自动解码，且这段代码未读取 `url.pathname` 中的 DB 序号。

主客户端（`src/lib/redis/client.ts`）走 ioredis 内置 `parseURL`，已正确解码 userinfo 并支持 db 路径（ioredis ≥5.x），两条路径行为不一致——同一个 `REDIS_URL`，主客户端连接正常，Bull 队列崩溃。

## 改动

两处队列的 URL 解析：对 userinfo 做 `decodeURIComponent` + 从 pathname 解析 DB 序号传入 Bull redis options，与 ioredis `parseURL` 行为对齐。共 +16/−4 行，不改变无特殊字符密码/无 DB 路径场景下的现有行为。

## 验证

实机环境：共享 Redis 7（密码含 `/` 与 `=`）+ `REDIS_URL=redis://:<encoded>@host:6379/15`。

修复前（v0.8.8 官方镜像）：启动即 `WRONGPASS` + `[Lifecycle] unhandledRejection` fatal，容器反复重启。

修复后（本补丁构建镜像）：

```
[Redis] Connected successfully  redisUrl=redis://:****@172.16.20.236:6379/15
action=cleanup_queue_initializing  redisUrl=redis://:***@172.16.20.236:6379/15
action=cleanup_queue_initialized
action=notification_queue_initializing
action=notification_queue_initialized
```

- `/api/actions/health`：database / redis / proxy 全部 `up`
- Redis DB 15 中出现 `bull:notifications:stalled-check`、`bull:log-cleanup:stalled-check`；DB 0 无任何 `bull:*` 键
- 管理员登录正常（HTTP 200 + 签名会话 Cookie）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related bugs in Bull queue initialization when parsing `REDIS_URL`: percent-encoded characters in the password (`%2F`, `%3D`, etc.) were passed raw to Redis AUTH, and the DB number in the URL path (e.g., `/15`) was silently ignored. The fix adds `decodeURIComponent` for userinfo fields and extracts the DB index from `url.pathname`, aligning the two Bull queue paths with how `src/lib/redis/client.ts` already handles `REDIS_URL` via ioredis `parseURL`.

- **Password decode**: `decodeURIComponent(url.password)` and `decodeURIComponent(url.username)` are added in both `cleanup-queue.ts` and `notification-queue.ts`, fixing the crash caused by WHATWG URL preserving percent-encoding verbatim in the `password` accessor.
- **DB selection**: `parseInt(url.pathname.slice(1), 10)` is parsed and passed as `redisQueueOptions.db` when the path contains a valid integer, ensuring Bull queues write keys to the correct Redis database instead of always defaulting to DB 0.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the changes are narrowly scoped to URL parsing in two queue initializers, with all edge cases (empty password, missing DB path, malformed percent-sequences) handled correctly by existing try-catch blocks.

Both changed files receive identical, symmetric treatment: decodeURIComponent is applied to credentials that WHATWG URL preserves in percent-encoded form, and the DB index is extracted from url.pathname with a Number.isNaN guard so URLs without a path segment are unaffected. The fix aligns the two Bull queue paths with how src/lib/redis/client.ts already handles the same REDIS_URL via ioredis parseURL. No business logic, schema changes, or new async paths are introduced.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/log-cleanup/cleanup-queue.ts | Adds decodeURIComponent for username/password and DB-from-pathname extraction; fix is correct and all edge cases (empty password, no DB path) are handled safely within the existing try-catch. |
| src/lib/notification/notification-queue.ts | Identical fix applied symmetrically; same correctness and safety properties as cleanup-queue.ts. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 修复 Bull 队列 REDIS\_URL 密码未解码与 DB 序号丢失..."](https://github.com/ding113/claude-code-hub/commit/e8c88e24432f90545e5bf1195eab685084532e62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42022295)</sub>

<!-- /greptile_comment -->