### PR TITLE
fix(proxy): Gemini function id 触发词兼容 JSON 转义引号并整段匹配路径，修复生产漏检

### DIFF
--- a/src/app/v1/_lib/proxy/gemini-function-id-rectifier.ts
+++ b/src/app/v1/_lib/proxy/gemini-function-id-rectifier.ts
@@ -20,7 +20,20 @@ export type GeminiFunctionIdRectifierResult = {
 // 逐条提取 `unknown name "id" at <path>` 违规中的 path，引号路径与无引号路径分开捕获
 // （兼容网关改写文案）：引号路径在闭合引号截断，无引号路径在空白/冒号/换行截断，
 // 防止多条违规被合并到一行时跨违规误捕获。
-const ID_VIOLATION_PATTERN = /unknown name "id" at\s+(?:'([^':\n]+)'|([^\s':\n]+))/g;
+// `id` 两侧允许任意个反斜杠：转发链路常把上游 JSON body 原样拼进错误消息
+// （如 `... | Upstream: {"error":{"message":"... Unknown name \"id\" ..."}}`），
+// 此时消息字段内层引号处于 JSON 转义形态，裸引号正则会漏检。
+const ID_VIOLATION_PATTERN = /unknown name \\*"id\\*" at\s+(?:'([^':\n]+)'|([^\s':\n]+))/g;
+
+// 函数字段的路径段全名（小写化后）。必须整段精确匹配而非子串包含：
+// `tool_config.function_calling_config` 等真实 Gemini 路径含 `function_call` 子串，
+// 子串匹配会把无关违规误判为函数字段 id 违规。
+const FUNCTION_FIELD_SEGMENTS = new Set([
+  "function_call",
+  "function_response",
+  "functioncall",
+  "functionresponse",
+]);
 
 export function detectGeminiFunctionIdRectifierTrigger(
   errorMessage: string | null | undefined
@@ -34,12 +47,11 @@ export function detectGeminiFunctionIdRectifierTrigger(
   // 兼容 snake_case（Vertex 错误文案）与 camelCase（部分兼容网关）两种路径写法。
   for (const match of lower.matchAll(ID_VIOLATION_PATTERN)) {
     const path = match[1] ?? match[2] ?? "";
-    if (
-      path.includes("function_call") ||
-      path.includes("function_response") ||
-      path.includes("functioncall") ||
-      path.includes("functionresponse")
-    ) {
+    const hasFunctionFieldSegment = path
+      .split(".")
+      .some((segment) => FUNCTION_FIELD_SEGMENTS.has(segment.replace(/\[\d+\]$/, "")));
+
+    if (hasFunctionFieldSegment) {
       return "unknown_function_id_field";
     }
   }

--- a/tests/unit/proxy/gemini-function-id-rectifier.test.ts
+++ b/tests/unit/proxy/gemini-function-id-rectifier.test.ts
@@ -42,6 +42,27 @@ Invalid JSON payload received. Unknown name "id" at 'contents[2].parts[0].functi
       expect(trigger).toBe("unknown_function_id_field");
     });
 
+    it("should detect JSON-escaped quotes in forwarder detailed error messages", () => {
+      // 转发链路把上游 JSON body 原样拼进错误消息，message 字段内层引号为 \" 转义形态
+      const trigger = detectGeminiFunctionIdRectifierTrigger(
+        `Provider Vertex AI returned 400: Provider returned 400: Bad Request | Upstream: {
+  "error": {
+    "code": 400,
+    "message": "Invalid JSON payload received. Unknown name \\"id\\" at 'contents[2].parts[0].function_call': Cannot find field.\\nInvalid JSON payload received. Unknown name \\"id\\" at 'contents[3].parts[0].function_response': Cannot find field.",
+    "status": "INVALID_ARGUMENT"
+  }
+}`
+      );
+      expect(trigger).toBe("unknown_function_id_field");
+    });
+
+    it("should not detect JSON-escaped id violation on unrelated path", () => {
+      const trigger = detectGeminiFunctionIdRectifierTrigger(
+        `Provider returned 400 | Upstream: {"error":{"message":"Invalid JSON payload received. Unknown name \\"id\\" at 'generation_config': Cannot find field."}}`
+      );
+      expect(trigger).toBeNull();
+    });
+
     it("should not cross-match id violation on one path with function field on another", () => {
       const trigger = detectGeminiFunctionIdRectifierTrigger(
         `Invalid JSON payload received. Unknown name "id" at 'generation_config': Cannot find field.
@@ -62,6 +83,19 @@ Invalid JSON payload received. Unknown name "foo" at 'contents[0].parts[0].funct
         `Unknown name "foo" at generation_config Unknown name "id" at contents[0].parts[0].function_call`
       );
       expect(trigger).toBe("unknown_function_id_field");
+    });
+
+    it("should not match function_calling_config paths via substring", () => {
+      expect(
+        detectGeminiFunctionIdRectifierTrigger(
+          `Invalid JSON payload received. Unknown name "id" at 'tool_config.function_calling_config': Cannot find field.`
+        )
+      ).toBeNull();
+      expect(
+        detectGeminiFunctionIdRectifierTrigger(
+          `Unknown name "id" at 'toolConfig.functionCallingConfig'`
+        )
+      ).toBeNull();
     });
 
     it("should return null when unknown field is not id", () => {

--- a/tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts
+++ b/tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts
@@ -465,7 +465,8 @@ describe("Endpoint circuit breaker isolation", () => {
     setDeferredMeta(session, 42);
 
     const response = createOpenAIResponsesFailedStreamResponse();
-    await ProxyResponseHandler.dispatch(session, response);
+    const clientResponse = await ProxyResponseHandler.dispatch(session, response);
+    await clientResponse.text();
     await drainAsyncTasks();
 
     expect(mockRecordFailure).toHaveBeenCalledWith(
@@ -474,15 +475,16 @@ describe("Endpoint circuit breaker isolation", () => {
     );
     expect(mockRecordEndpointSuccess).not.toHaveBeenCalled();
     expect(mockRecordEndpointFailure).not.toHaveBeenCalled();
-    expect(SessionManager.clearSessionProvider).toHaveBeenCalledWith("fake-session");
-    expect(updateMessageRequestDetails).toHaveBeenCalledWith(
+    expect(SessionManager.clearSessionProvider).toHaveBeenCalledWith("fake-session", 1);
+    expect(updateMessageRequestDetailsDurably).toHaveBeenCalledWith(
       1,
       expect.objectContaining({
         statusCode: 502,
         errorMessage:
           "FAKE_200_OPENAI_RESPONSE_FAILED: Concurrency limit exceeded for user, please retry later",
         providerId: 1,
-      })
+      }),
+      expect.objectContaining({ onCommitted: expect.any(Function) })
     );
     expect(RateLimitService.trackCost).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## 问题

#1308 的 Gemini function id 整流器在生产环境（v0.8.10 + Vertex 直连）实测**不触发**：Vertex 400 依旧透传给客户端，重试发送的是原始未整流请求体，且无任何 rectifier 日志。

根因：`tryApplyReactiveRectifier` 收到的 `errorMessage` 来自 `getDetailedErrorMessage()`，其中上游 JSON body 被**原样拼入**：

```
Provider Vertex AI - wulf returned 400: ... | Upstream: {
  "error": {
    "message": "Invalid JSON payload received. Unknown name \"id\" at 'contents[2].parts[0].function_call': Cannot find field.\n...",
    ...
```

`message` 字段内层引号处于 **JSON 转义形态**（`\"id\"`），而触发词正则匹配的是裸引号 `"id"`，因此永远检测不到。既有 thinking 系列整流器的触发词均不含引号，此形态差异此前未暴露过（`smartTruncate` 对 JSON body 走 `JSON.stringify(parsed)` 完整保留，转义形态是结构性保证）。

## 修复（两处）

1. **转义兼容**：`ID_VIOLATION_PATTERN` 中 `id` 两侧允许任意个反斜杠，兼容裸引号（解码后文本）与 `\"`/多重转义形态：

```diff
-const ID_VIOLATION_PATTERN = /unknown name "id" at\s+(?:'([^':\n]+)'|([^\s':\n]+))/g;
+const ID_VIOLATION_PATTERN = /unknown name \\*"id\\*" at\s+(?:'([^':\n]+)'|([^\s':\n]+))/g;
```

2. **路径段精确匹配**：函数字段判断由子串 `includes` 改为按 `.` 分段、剥数组下标后**整段比对**。避免 `tool_config.function_calling_config` / `toolConfig.functionCallingConfig` 等真实 Gemini 路径因含 `function_call` 子串被误判——误判 + 剥离无效（`applied=false`）会把错误强改为 `NON_RETRYABLE_CLIENT_ERROR`，压制正常供应商故障转移。

## 验证

- **生产实测**（修复 1 已以 hotpatch 形式在生产验证）：直连 Vertex → 400 → `Gemini function id rectifier applied, retrying` → attempt 2 → 200，功能闭环
- 单测 21/21 全过，含 3 例新增回归：生产 forwarder 详细错误消息**原样形态**（`| Upstream: {...}` + `\"` 转义 + 字面量 `\n` 分隔多violations）、转义形态无关路径不触发、`function_calling_config` 两种命名不误判
- 仍接受的路径形态：`contents[2].parts[0].function_call`、camelCase、网关追加 `.id` 后缀的变体
- `bun run typecheck` 通过，biome 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two root causes that prevented the Gemini function-`id` rectifier from triggering in production (Vertex AI direct mode): the trigger regex failed to match JSON-escaped quotes (`\"id\"`) that appear when the forwarder embeds the raw upstream JSON body in the error message, and path matching used substring `.includes()` which could false-positive on `tool_config.function_calling_config` and similar Gemini paths.

- **Fix 1 – Regex escape compatibility**: `ID_VIOLATION_PATTERN` now uses `\\*"id\\*"` (zero-or-more literal backslashes on each side of the quote), covering bare `"id"` and every JSON-escaped depth.
- **Fix 2 – Exact segment matching**: path checking switches from `path.includes(...)` to splitting on `.`, stripping trailing array indices, and looking up each segment in a `FUNCTION_FIELD_SEGMENTS` Set — preventing `function_calling_config` (which contains `function_call` as a substring) from being mistakenly treated as a function-field violation.
- **Test sync in `response-handler-endpoint-circuit-isolation.test.ts`**: one existing test is updated to consume the `Response` returned by `dispatch` and to match renamed/re-signatured production helpers (`clearSessionProvider`, `updateMessageRequestDetailsDurably`).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — both changes are narrowly scoped to the trigger-detection function, have production-verified behavior, and are covered by 21 unit tests including three new regression cases.

Both changes are narrowly scoped to the trigger-detection function with no data mutations or new async paths. The regex change correctly uses `\\*` to match zero-or-more literal backslashes, and the segment-set replacement is strictly more precise than substring includes.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/gemini-function-id-rectifier.ts | Two targeted fixes: regex `\\*` quantifier to match JSON-escaped backslash-quote forms, and a Set-based exact-segment check replacing substring includes to prevent false positives on `function_calling_config` paths. |
| tests/unit/proxy/gemini-function-id-rectifier.test.ts | Adds three regression tests: production forwarder error format with `\"` escaping and literal `\n` delimiters, JSON-escaped quote on an unrelated path (must not trigger), and `function_calling_config`/`functionCallingConfig` substring paths (must not trigger). |
| tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts | Syncs one test to match changed production API: `dispatch` now returns a `Response` that must be consumed before `drainAsyncTasks`; `clearSessionProvider` now takes a second numeric argument; `updateMessageRequestDetails` renamed to `updateMessageRequestDetailsDurably` with an extra options arg. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(proxy): consume Responses failure s..."](https://github.com/ding113/claude-code-hub/commit/c7db8a5162c53ca3d64237c8244c24309dcb8655) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42256273)</sub>

<!-- /greptile_comment -->