### PR TITLE
fix: apply matched provider group billing multiplier

### DIFF
--- a/src/app/v1/_lib/proxy/provider-selector.ts
+++ b/src/app/v1/_lib/proxy/provider-selector.ts
@@ -4,7 +4,11 @@ import { PROVIDER_GROUP } from "@/lib/constants/provider.constants";
 import { logger } from "@/lib/logger";
 import { RateLimitService } from "@/lib/rate-limit";
 import { SessionManager } from "@/lib/session-manager";
-import { parseProviderGroups, resolveProviderGroupsWithDefault } from "@/lib/utils/provider-group";
+import {
+  parseProviderGroups,
+  resolveBillingProviderGroups,
+  resolveProviderGroupsWithDefault,
+} from "@/lib/utils/provider-group";
 import { isProviderActiveNow } from "@/lib/utils/provider-schedule";
 import { resolveSystemTimezone } from "@/lib/utils/timezone";
 import { isVendorTypeCircuitOpen } from "@/lib/vendor-type-circuit-breaker";
@@ -61,6 +65,46 @@ function checkProviderGroupMatch(providerGroupTag: string | null, userGroups: st
   const providerTags = resolveProviderGroupsWithDefault(providerGroupTag);
 
   return providerTags.some((tag) => groups.includes(tag));
+}
+
+async function resolveGroupCostMultiplierForProvider(session: ProxySession): Promise<void> {
+  const effectiveGroup = getEffectiveProviderGroup(session);
+  const provider = session.provider;
+
+  if (!effectiveGroup || !provider) {
+    session.setGroupCostMultiplier(1.0);
+    return;
+  }
+
+  const billingGroups = resolveBillingProviderGroups(provider.groupTag, effectiveGroup);
+  if (billingGroups.length === 0) {
+    logger.warn(
+      "[ProviderResolver] Selected provider has no billing group intersection, falling back to 1.0",
+      {
+        providerId: provider.id,
+        providerName: provider.name,
+        providerGroups: provider.groupTag,
+        effectiveGroup,
+      }
+    );
+    session.setGroupCostMultiplier(1.0);
+    return;
+  }
+
+  const billingGroup = billingGroups.join(",");
+
+  try {
+    const multiplier = await getGroupCostMultiplier(billingGroup);
+    session.setGroupCostMultiplier(multiplier);
+  } catch (error) {
+    logger.warn("[ProviderResolver] Failed to resolve group cost multiplier, falling back to 1.0", {
+      billingGroup,
+      effectiveGroup,
+      providerId: provider.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    session.setGroupCostMultiplier(1.0);
+  }
 }
 
 /**
@@ -184,26 +228,6 @@ export class ProxyProviderResolver {
       );
       session.setProvider(provider);
       session.setLastSelectionContext(context); // 保存用于后续记录
-    }
-
-    // === Resolve group cost multiplier ===
-    // Fail soft: if the lookup throws (Redis/DB hiccup), fall back to 1.0 so
-    // request handling proceeds without billing disruption.
-    const effectiveGroup = getEffectiveProviderGroup(session);
-    if (effectiveGroup) {
-      try {
-        const multiplier = await getGroupCostMultiplier(effectiveGroup);
-        session.setGroupCostMultiplier(multiplier);
-      } catch (error) {
-        logger.warn(
-          "[ProviderResolver] Failed to resolve group cost multiplier, falling back to 1.0",
-          {
-            effectiveGroup,
-            error: error instanceof Error ? error.message : String(error),
-          }
-        );
-        session.setGroupCostMultiplier(1.0);
-      }
     }
 
     // === 故障转移循环 ===
@@ -341,11 +365,13 @@ export class ProxyProviderResolver {
         // 修复：延迟到 forwarder 请求成功后统一更新（见 forwarder.ts:75-80）
         // void SessionManager.updateSessionProvider(...); // ❌ 已移除
 
+        await resolveGroupCostMultiplierForProvider(session);
         return null; // 成功
       }
 
       // sessionId 为空的情况（理论上不应该发生）
       logger.warn("ProviderSelector: sessionId is null, skipping concurrent check");
+      await resolveGroupCostMultiplierForProvider(session);
       return null;
     }
 

--- a/src/lib/utils/provider-group.test.ts
+++ b/src/lib/utils/provider-group.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeProviderGroup,
   normalizeProviderGroupTag,
   parseProviderGroups,
+  resolveBillingProviderGroups,
   resolveProviderGroupsWithDefault,
 } from "./provider-group";
 
@@ -32,5 +33,34 @@ describe("provider-group utils", () => {
   test("keeps raw parse semantics unchanged for empty input", () => {
     expect(parseProviderGroups(null)).toEqual([]);
     expect(parseProviderGroups("   ")).toEqual([]);
+  });
+
+  test("计费分组应取用户分组与已选供应商标签的交集", () => {
+    expect(
+      resolveBillingProviderGroups("cus_gpt,gpt_test", "cus_claude_pro,cus_grok,gpt_test,mimo")
+    ).toEqual(["gpt_test"]);
+  });
+
+  test("计费分组应保留用户分组声明顺序", () => {
+    expect(resolveBillingProviderGroups("group-b,group-a", "group-a,group-b")).toEqual([
+      "group-a",
+      "group-b",
+    ]);
+  });
+
+  test("通配分组应按供应商标签解析倍率", () => {
+    expect(resolveBillingProviderGroups("group-b,group-a", "*")).toEqual(["group-b", "group-a"]);
+  });
+
+  test("显式匹配分组应优先于通配分组", () => {
+    expect(resolveBillingProviderGroups("group-b,group-a", "*,group-a")).toEqual(["group-a"]);
+  });
+
+  test("未分组供应商在通配访问下应使用 default 计费分组", () => {
+    expect(resolveBillingProviderGroups(null, "*")).toEqual(["default"]);
+  });
+
+  test("无交集且无通配权限时不应选择无关分组倍率", () => {
+    expect(resolveBillingProviderGroups("group-b", "group-a")).toEqual([]);
   });
 });

--- a/src/lib/utils/provider-group.ts
+++ b/src/lib/utils/provider-group.ts
@@ -59,3 +59,33 @@ export function resolveProviderGroupsWithDefault(value: unknown): string[] {
 
   return groups;
 }
+
+/**
+ * Resolve the provider groups that should participate in billing.
+ *
+ * Explicit user/key groups are intersected with the selected provider's tags,
+ * preserving the user/key declaration order. A wildcard grants access to all
+ * providers but only falls back to the provider's own tag order when there is
+ * no explicit matching group.
+ */
+export function resolveBillingProviderGroups(
+  providerGroupTag: unknown,
+  userGroupsValue: unknown
+): string[] {
+  const providerGroups = resolveProviderGroupsWithDefault(providerGroupTag);
+  const userGroups = parseProviderGroups(userGroupsValue);
+  const providerGroupSet = new Set(providerGroups);
+
+  const explicitMatches = userGroups.filter(
+    (group) => group !== PROVIDER_GROUP.ALL && providerGroupSet.has(group)
+  );
+  if (explicitMatches.length > 0) {
+    return explicitMatches;
+  }
+
+  if (userGroups.includes(PROVIDER_GROUP.ALL)) {
+    return providerGroups;
+  }
+
+  return [];
+}

--- a/tests/unit/proxy/provider-selector-select-provider-by-type.test.ts
+++ b/tests/unit/proxy/provider-selector-select-provider-by-type.test.ts
@@ -3,6 +3,8 @@ import type { Provider } from "@/types/provider";
 import { ProxyProviderResolver } from "@/app/v1/_lib/proxy/provider-selector";
 
 const findAllProvidersMock = vi.hoisted(() => vi.fn<[], Promise<Provider[]>>());
+const getGroupCostMultiplierMock = vi.hoisted(() => vi.fn());
+const checkAndTrackProviderSessionMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/repository/provider", () => {
   return {
@@ -10,6 +12,16 @@ vi.mock("@/repository/provider", () => {
     findProviderById: vi.fn(),
   };
 });
+
+vi.mock("@/repository/provider-groups", () => ({
+  getGroupCostMultiplier: getGroupCostMultiplierMock,
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  RateLimitService: {
+    checkAndTrackProviderSession: checkAndTrackProviderSessionMock,
+  },
+}));
 
 describe("ProxyProviderResolver.selectProviderByType - /v1/models 分组隔离", () => {
   beforeEach(() => {
@@ -87,5 +99,164 @@ describe("ProxyProviderResolver.selectProviderByType - /v1/models 分组隔离",
     );
 
     expect(provider?.id).toBe(inGroup.id);
+  });
+});
+
+describe("ProxyProviderResolver.ensure - 分组倍率", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("按当前供应商与 Key 分组交集解析倍率", async () => {
+    const provider = {
+      id: 56,
+      name: "gpt-test-provider",
+      isEnabled: true,
+      providerType: "openai-compatible",
+      groupTag: "cus_gpt,gpt_test",
+      weight: 1,
+      priority: 0,
+      costMultiplier: 1,
+      limitConcurrentSessions: 0,
+    } as unknown as Provider;
+
+    getGroupCostMultiplierMock.mockResolvedValueOnce(10);
+
+    const findReusableSpy = vi
+      .spyOn(ProxyProviderResolver as never, "findReusable" as never)
+      .mockResolvedValue(null as never);
+    const pickRandomProviderSpy = vi
+      .spyOn(ProxyProviderResolver as never, "pickRandomProvider" as never)
+      .mockResolvedValue({
+        provider,
+        context: {
+          totalProviders: 1,
+          enabledProviders: 1,
+          targetType: "openai-compatible",
+          requestedModel: "gpt-5.5",
+          groupFilterApplied: true,
+          userGroup: "cus_claude_pro,cus_grok,gpt_test,mimo",
+          beforeHealthCheck: 1,
+          afterHealthCheck: 1,
+          priorityLevels: [0],
+          selectedPriority: 0,
+          candidatesAtPriority: [],
+        },
+      } as never);
+
+    const setGroupCostMultiplier = vi.fn();
+    const session = {
+      provider: null as Provider | null,
+      sessionId: null,
+      authState: {
+        user: { providerGroup: "cus_claude_pro,cus_grok,gpt_test,mimo" },
+        key: { providerGroup: "cus_claude_pro,cus_grok,gpt_test,mimo" },
+      },
+      setProvider(selected: Provider | null) {
+        this.provider = selected;
+      },
+      setLastSelectionContext: vi.fn(),
+      getLastSelectionContext: vi.fn(() => null),
+      setGroupCostMultiplier,
+      addProviderToChain: vi.fn(),
+      getOriginalModel: vi.fn(() => "gpt-5.5"),
+    } as unknown as Parameters<typeof ProxyProviderResolver.ensure>[0];
+
+    try {
+      await expect(ProxyProviderResolver.ensure(session)).resolves.toBeNull();
+    } finally {
+      findReusableSpy.mockRestore();
+      pickRandomProviderSpy.mockRestore();
+    }
+
+    expect(getGroupCostMultiplierMock).toHaveBeenCalledWith("gpt_test");
+    expect(setGroupCostMultiplier).toHaveBeenCalledWith(10);
+  });
+
+  test("故障切换后应按最终供应商重新解析倍率", async () => {
+    const firstProvider = {
+      id: 1,
+      name: "group-a-provider",
+      providerType: "openai-compatible",
+      groupTag: "group-a",
+      weight: 1,
+      priority: 0,
+      costMultiplier: 1,
+      limitConcurrentSessions: 1,
+    } as unknown as Provider;
+    const fallbackProvider = {
+      ...firstProvider,
+      id: 2,
+      name: "group-b-provider",
+      groupTag: "group-b",
+      limitConcurrentSessions: 0,
+    } as Provider;
+
+    getGroupCostMultiplierMock.mockResolvedValueOnce(10);
+    checkAndTrackProviderSessionMock
+      .mockResolvedValueOnce({
+        allowed: false,
+        count: 1,
+        referenced: false,
+        reason: "limit reached",
+      })
+      .mockResolvedValueOnce({
+        allowed: true,
+        count: 1,
+        referenced: false,
+      });
+
+    const context = {
+      totalProviders: 2,
+      enabledProviders: 2,
+      targetType: "openai-compatible",
+      requestedModel: "gpt-5.5",
+      groupFilterApplied: true,
+      userGroup: "group-a,group-b",
+      beforeHealthCheck: 2,
+      afterHealthCheck: 2,
+      priorityLevels: [0],
+      selectedPriority: 0,
+      candidatesAtPriority: [],
+    };
+
+    const findReusableSpy = vi
+      .spyOn(ProxyProviderResolver as never, "findReusable" as never)
+      .mockResolvedValue(null as never);
+    const pickRandomProviderSpy = vi
+      .spyOn(ProxyProviderResolver as never, "pickRandomProvider" as never)
+      .mockResolvedValueOnce({ provider: firstProvider, context } as never)
+      .mockResolvedValueOnce({ provider: fallbackProvider, context } as never);
+
+    const setGroupCostMultiplier = vi.fn();
+    const session = {
+      provider: null as Provider | null,
+      sessionId: "session-1",
+      authState: {
+        user: { providerGroup: "group-a,group-b" },
+        key: { providerGroup: "group-a,group-b" },
+      },
+      setProvider(selected: Provider | null) {
+        this.provider = selected;
+      },
+      setLastSelectionContext: vi.fn(),
+      getLastSelectionContext: vi.fn(() => context),
+      setGroupCostMultiplier,
+      addProviderToChain: vi.fn(),
+      getOriginalModel: vi.fn(() => "gpt-5.5"),
+      recordProviderSessionRef: vi.fn(),
+    } as unknown as Parameters<typeof ProxyProviderResolver.ensure>[0];
+
+    try {
+      await expect(ProxyProviderResolver.ensure(session)).resolves.toBeNull();
+    } finally {
+      findReusableSpy.mockRestore();
+      pickRandomProviderSpy.mockRestore();
+    }
+
+    expect(checkAndTrackProviderSessionMock).toHaveBeenCalledTimes(2);
+    expect(getGroupCostMultiplierMock).toHaveBeenCalledTimes(1);
+    expect(getGroupCostMultiplierMock).toHaveBeenCalledWith("group-b");
+    expect(setGroupCostMultiplier).toHaveBeenCalledWith(10);
   });
 });


### PR DESCRIPTION
## Summary

Fix provider group billing multiplier resolution so billing uses the group that actually matches the selected provider, rather than the first group in the user's/key's group list.

## Root cause

Provider selection filters by the intersection between the request's effective provider groups and the selected provider's `groupTag`, but the billing multiplier was resolved earlier from the raw effective group string. For users/keys with multiple groups, `getGroupCostMultiplier()` returns the first existing group in declaration order. That can underbill when the selected provider matches a later group with a higher multiplier.

Example:

- user/key groups: `cus_claude_pro,cus_grok,gpt_test,mimo`
- selected provider tags: `cus_gpt,gpt_test`
- `gpt_test` multiplier: `10`

Before this change, billing could resolve `cus_claude_pro` first and use multiplier `1`.

## Changes

- Add `resolveBillingProviderGroups()` to compute the billing group intersection between provider tags and effective user/key groups.
- Resolve the group multiplier after final provider selection, including after provider fallback.
- Add regression coverage for multi-group billing and fallback provider recalculation.

## Related

- Follow-up to #1025 — introduced the provider group cost multiplier and the provider-selector resolution that this PR fixes (billing could resolve the wrong group for multi-group users/keys).
- Related to #1255 — same billing multiplier subsystem; another billing-correctness fix in the proxy pipeline.

## Validation

```bash
env DSN= REDIS_URL= AUTO_CLEANUP_TEST_DATA=false bunx vitest run src/lib/utils/provider-group.test.ts tests/unit/proxy/provider-selector-select-provider-by-type.test.ts
```

Result: 16 tests passed.

Note: `bun run typecheck` currently fails on upstream/dev due to an unrelated Langfuse type mismatch in `src/lib/langfuse/trace-proxy-request.ts` (`LangfuseSpan.setTraceIO`), outside this PR's diff.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a billing correctness bug where the group cost multiplier was resolved from the user's raw effective group string before provider selection. For users/keys with multiple groups, `getGroupCostMultiplier` would return the multiplier of the first-declared group regardless of which group actually matched the chosen provider, potentially causing under-billing.

- **`resolveBillingProviderGroups()`** is added to `provider-group.ts` and computes the intersection of the selected provider's group tags with the user/key's declared groups, preserving user declaration order (with wildcards falling back to provider tag order).
- Billing multiplier resolution is moved from before the failover loop (using the raw effective group string) to inside the loop, called only after a provider is successfully selected — including after fallback provider switches.
- New unit tests cover the six key `resolveBillingProviderGroups` cases, and two integration tests verify end-to-end billing multiplier resolution for normal selection and fallback-provider scenarios.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The fix is logically sound and the 503-path (all providers exhausted) correctly skips multiplier resolution since no billing is applied on failed requests.

The core billing logic change is correct across all primary code paths. The only unexercised scenario is when the provider-user group intersection yields multiple groups simultaneously; in that case the join-then-first-match behavior silently defers to user declaration order without test coverage.

src/app/v1/_lib/proxy/provider-selector.ts — specifically the multi-group billing join at line 94 and the missing test for that path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/utils/provider-group.ts | Adds resolveBillingProviderGroups() — computes the intersection of provider group tags and user/key groups, preserving user declaration order; wildcard falls back to provider tag order. Logic is correct and well-tested in isolation. |
| src/app/v1/_lib/proxy/provider-selector.ts | Moves billing multiplier resolution from before the failover loop to inside it (after final provider selection). Adds resolveGroupCostMultiplierForProvider(). Multi-element billing-group intersections are joined and passed to getGroupCostMultiplier() whose first-match policy applies — consistent with existing design but no end-to-end test covers this path. |
| src/lib/utils/provider-group.test.ts | Adds six unit tests for resolveBillingProviderGroups() covering exact intersection, wildcard, explicit-over-wildcard priority, null provider tag, and empty intersection. Good coverage for the pure function. |
| tests/unit/proxy/provider-selector-select-provider-by-type.test.ts | Adds integration tests for the billing multiplier path: one for normal provider selection (single-group intersection) and one for the fallback-provider scenario verifying the multiplier is recalculated against the final provider, not the first attempted one. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ensure called] --> B{findReusable?}
    B -- yes --> C[session.setProvider reused]
    B -- no --> D[pickRandomProvider]
    D --> E[session.setProvider selected]
    C --> F
    E --> F[Failover loop]

    F --> G{session.provider?}
    G -- no --> Z[Return 503]

    G -- yes --> H{session.sessionId?}
    H -- no --> I[resolveGroupCostMultiplierForProvider]
    I --> S[return null]

    H -- yes --> J[checkAndTrackProviderSession]
    J --> K{allowed?}
    K -- no --> L[add to excludedProviders, pickRandomProvider fallback]
    L --> M{fallback found?}
    M -- no --> Z
    M -- yes --> F

    K -- yes --> N[resolveBillingProviderGroups provider.groupTag x effectiveGroup]
    N --> O{intersection empty?}
    O -- yes --> P[warn + setGroupCostMultiplier 1.0]
    O -- no --> Q[billingGroups.join, getGroupCostMultiplier first-match]
    Q --> R[setGroupCostMultiplier result]
    P --> S
    R --> S
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/app/v1/_lib/proxy/provider-selector.ts:94-97
**Multi-group intersection joined before lookup**

When a provider carries multiple group tags that all appear in the user's declared groups (e.g. provider `"group-a,group-b"`, user `"group-a,group-b"`), `resolveBillingProviderGroups` returns `["group-a","group-b"]` and `billingGroups.join(",")` produces `"group-a,group-b"`. `getGroupCostMultiplier` then applies first-match on the parsed list, so `group-a`'s multiplier wins regardless of which group carries the higher rate.

This is consistent with `getGroupCostMultiplier`'s documented "first declared group wins" contract, so it isn't a new regression. However, neither the integration tests in this PR nor the unit tests for `resolveBillingProviderGroups` exercise the end-to-end billing path when the intersection contains more than one element. A case where both groups match the provider but have different multipliers would silently use user-declaration order as the tiebreaker without any test cover.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: apply matched provider group billin..."](https://github.com/ding113/claude-code-hub/commit/ca2b7b9bb8feadd03c74b0c35759193d69b9fa50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46430307)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->