### PR TITLE
fix(codex): strip image_gen namespace tools

### DIFF
--- a/src/lib/codex/provider-overrides.ts
+++ b/src/lib/codex/provider-overrides.ts
@@ -435,9 +435,6 @@ export function applyCodexProviderOverridesWithAudit(
   const serviceTier = normalizeStringPreference(provider.codexServiceTierPreference);
 
   const beforeServiceTier = toAuditValue(request.service_tier);
-  const beforeImageGeneration = hasImageGenerationTool(request.tools);
-  const beforeInputImageGeneration = hasInputImageGenerationTool(request.input);
-
   const hit =
     parallelToolCalls !== null ||
     imageGeneration !== null ||
@@ -451,6 +448,8 @@ export function applyCodexProviderOverridesWithAudit(
     return { request, audit: null };
   }
 
+  const beforeImageGeneration = hasImageGenerationTool(request.tools);
+  const beforeInputImageGeneration = hasInputImageGenerationTool(request.input);
   const beforeParallelToolCalls = toAuditValue(request.parallel_tool_calls);
   const beforeReasoning = isPlainObject(request.reasoning) ? request.reasoning : null;
   const beforeReasoningEffort = toAuditValue(beforeReasoning?.effort);

--- a/src/lib/codex/provider-overrides.ts
+++ b/src/lib/codex/provider-overrides.ts
@@ -375,12 +375,14 @@ export function applyCodexProviderOverrides(
   const imageGeneration = normalizeImageGenerationPreference(
     provider.codexImageGenerationPreference
   );
-  applyImageGenerationToolPreference(output, ensureCloned, imageGeneration);
-  applyInputImageGenerationToolPreference(output, ensureCloned, imageGeneration);
-  applyImageGenerationToolChoicePreference(output, ensureCloned, imageGeneration, {
-    imageGenerationToolReference: findImageGenerationToolReference(output),
-    hasAvailableTools: hasAvailableTool(output),
-  });
+  if (imageGeneration !== null) {
+    applyImageGenerationToolPreference(output, ensureCloned, imageGeneration);
+    applyInputImageGenerationToolPreference(output, ensureCloned, imageGeneration);
+    applyImageGenerationToolChoicePreference(output, ensureCloned, imageGeneration, {
+      imageGenerationToolReference: findImageGenerationToolReference(output),
+      hasAvailableTools: hasAvailableTool(output),
+    });
+  }
 
   const reasoningEffort = normalizeStringPreference(provider.codexReasoningEffortPreference);
   const reasoningSummary = normalizeStringPreference(provider.codexReasoningSummaryPreference);

--- a/src/lib/codex/provider-overrides.ts
+++ b/src/lib/codex/provider-overrides.ts
@@ -51,12 +51,82 @@ function normalizeImageGenerationPreference(
   return value === "true";
 }
 
-function isImageGenerationTool(value: unknown): value is Record<string, unknown> {
-  return isPlainObject(value) && value.type === "image_generation";
+function toImageGenerationToolReference(value: unknown): Record<string, unknown> | null {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+  if (value.type === "image_generation") {
+    return { type: "image_generation" };
+  }
+  if (value.type === "namespace" && value.name === "image_gen") {
+    return { type: "namespace", name: "image_gen" };
+  }
+  return null;
+}
+
+function isImageGenerationTool(value: unknown): boolean {
+  return toImageGenerationToolReference(value) !== null;
 }
 
 function hasImageGenerationTool(value: unknown): boolean {
   return Array.isArray(value) && value.some((tool) => isImageGenerationTool(tool));
+}
+
+function hasInputImageGenerationTool(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.some(
+      (item) =>
+        isPlainObject(item) &&
+        item.type === "additional_tools" &&
+        hasImageGenerationTool(item.tools)
+    )
+  );
+}
+
+function findImageGenerationToolReference(
+  request: Record<string, unknown>
+): Record<string, unknown> | null {
+  if (Array.isArray(request.tools)) {
+    for (const tool of request.tools) {
+      const reference = toImageGenerationToolReference(tool);
+      if (reference) {
+        return reference;
+      }
+    }
+  }
+
+  if (!Array.isArray(request.input)) {
+    return null;
+  }
+  for (const item of request.input) {
+    if (!isPlainObject(item) || item.type !== "additional_tools" || !Array.isArray(item.tools)) {
+      continue;
+    }
+    for (const tool of item.tools) {
+      const reference = toImageGenerationToolReference(tool);
+      if (reference) {
+        return reference;
+      }
+    }
+  }
+  return null;
+}
+
+function hasAvailableTool(request: Record<string, unknown>): boolean {
+  if (Array.isArray(request.tools) && request.tools.length > 0) {
+    return true;
+  }
+  return (
+    Array.isArray(request.input) &&
+    request.input.some(
+      (item) =>
+        isPlainObject(item) &&
+        item.type === "additional_tools" &&
+        Array.isArray(item.tools) &&
+        item.tools.length > 0
+    )
+  );
 }
 
 function applyImageGenerationToolPreference(
@@ -70,7 +140,10 @@ function applyImageGenerationToolPreference(
 
   const existingTools = Array.isArray(request.tools) ? request.tools : null;
   if (enabled) {
-    if (existingTools?.some((tool) => isImageGenerationTool(tool))) {
+    if (
+      existingTools?.some((tool) => isImageGenerationTool(tool)) ||
+      hasInputImageGenerationTool(request.input)
+    ) {
       return;
     }
     const target = ensureCloned();
@@ -97,15 +170,83 @@ function applyImageGenerationToolPreference(
   }
 }
 
+function applyInputImageGenerationToolPreference(
+  request: Record<string, unknown>,
+  ensureCloned: () => Record<string, unknown>,
+  enabled: boolean | null
+): void {
+  if (enabled !== false || !Array.isArray(request.input)) {
+    return;
+  }
+
+  const nextInput: unknown[] = [];
+  let changed = false;
+  for (const item of request.input) {
+    if (!isPlainObject(item) || item.type !== "additional_tools" || !Array.isArray(item.tools)) {
+      nextInput.push(item);
+      continue;
+    }
+
+    const nextTools = item.tools.filter((tool) => !isImageGenerationTool(tool));
+    if (nextTools.length === item.tools.length) {
+      nextInput.push(item);
+      continue;
+    }
+
+    changed = true;
+    if (nextTools.length > 0) {
+      nextInput.push({ ...item, tools: nextTools });
+    }
+  }
+
+  if (changed) {
+    ensureCloned().input = nextInput;
+  }
+}
+
+function isImageGenerationToolChoice(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value === "image_generation";
+  }
+  if (!isPlainObject(value)) {
+    return false;
+  }
+  if (isImageGenerationTool(value)) {
+    return true;
+  }
+  if (value.type === "namespace" && value.namespace === "image_gen") {
+    return true;
+  }
+  if (isImageGenerationToolChoice(value.tool)) {
+    return true;
+  }
+  return isPlainObject(value.function) && value.function.name === "image_generation";
+}
+
 function summarizeImageGenerationToolChoice(value: unknown): string | null {
   if (typeof value === "string") {
     return value;
   }
-  if (!isPlainObject(value) || typeof value.type !== "string") {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+  if (isImageGenerationToolChoice(value.tool)) {
+    return "tool:image_generation";
+  }
+  if (isPlainObject(value.function) && value.function.name === "image_generation") {
+    return "function:image_generation";
+  }
+  if (typeof value.type !== "string") {
     return null;
   }
   if (value.type === "image_generation") {
     return "image_generation";
+  }
+  if (
+    value.type === "namespace" &&
+    (value.name === "image_gen" || value.namespace === "image_gen")
+  ) {
+    return "namespace:image_gen";
   }
   if (value.type !== "allowed_tools") {
     return value.type;
@@ -127,7 +268,7 @@ function applyImageGenerationToolChoicePreference(
   ensureCloned: () => Record<string, unknown>,
   enabled: boolean | null,
   context: {
-    hadImageGenerationTool: boolean;
+    imageGenerationToolReference: Record<string, unknown> | null;
     hasAvailableTools: boolean;
   }
 ): void {
@@ -146,7 +287,10 @@ function applyImageGenerationToolChoicePreference(
     const target = ensureCloned();
     target.tool_choice = {
       ...toolChoice,
-      tools: [...toolChoice.tools, { type: "image_generation" }],
+      tools: [
+        ...toolChoice.tools,
+        context.imageGenerationToolReference ?? { type: "image_generation" },
+      ],
     };
     return;
   }
@@ -163,18 +307,18 @@ function applyImageGenerationToolChoicePreference(
     return;
   }
 
-  if (!isPlainObject(toolChoice)) {
-    return;
-  }
-
-  if (toolChoice.type === "image_generation") {
+  if (isImageGenerationToolChoice(toolChoice)) {
     const target = ensureCloned();
     // 只剩非图像工具时改成 none，避免回退到 auto 后放宽客户端原本的工具限制。
     target.tool_choice = "none";
     return;
   }
 
-  if (toolChoice.type !== "allowed_tools" || !Array.isArray(toolChoice.tools)) {
+  if (
+    !isPlainObject(toolChoice) ||
+    toolChoice.type !== "allowed_tools" ||
+    !Array.isArray(toolChoice.tools)
+  ) {
     return;
   }
 
@@ -200,7 +344,7 @@ function applyImageGenerationToolChoicePreference(
  * - 偏好值为 null/undefined/"inherit" 表示“遵循客户端”
  * - 覆写仅影响以下字段：
  *   - parallel_tool_calls
- *   - tools / tool_choice 中与 image_generation 相关的能力声明
+ *   - tools / input.additional_tools / tool_choice 中与 image_generation 相关的能力声明
  *   - reasoning.effort / reasoning.summary
  *   - service_tier
  *   - text.verbosity
@@ -231,11 +375,11 @@ export function applyCodexProviderOverrides(
   const imageGeneration = normalizeImageGenerationPreference(
     provider.codexImageGenerationPreference
   );
-  const hadImageGenerationTool = hasImageGenerationTool(output.tools);
   applyImageGenerationToolPreference(output, ensureCloned, imageGeneration);
+  applyInputImageGenerationToolPreference(output, ensureCloned, imageGeneration);
   applyImageGenerationToolChoicePreference(output, ensureCloned, imageGeneration, {
-    hadImageGenerationTool,
-    hasAvailableTools: Array.isArray(output.tools) && output.tools.length > 0,
+    imageGenerationToolReference: findImageGenerationToolReference(output),
+    hasAvailableTools: hasAvailableTool(output),
   });
 
   const reasoningEffort = normalizeStringPreference(provider.codexReasoningEffortPreference);
@@ -290,6 +434,7 @@ export function applyCodexProviderOverridesWithAudit(
 
   const beforeServiceTier = toAuditValue(request.service_tier);
   const beforeImageGeneration = hasImageGenerationTool(request.tools);
+  const beforeInputImageGeneration = hasInputImageGenerationTool(request.input);
 
   const hit =
     parallelToolCalls !== null ||
@@ -318,6 +463,7 @@ export function applyCodexProviderOverridesWithAudit(
 
   const afterParallelToolCalls = toAuditValue(nextRequest.parallel_tool_calls);
   const afterImageGeneration = hasImageGenerationTool(nextRequest.tools);
+  const afterInputImageGeneration = hasInputImageGenerationTool(nextRequest.input);
   const afterReasoning = isPlainObject(nextRequest.reasoning) ? nextRequest.reasoning : null;
   const afterReasoningEffort = toAuditValue(afterReasoning?.effort);
   const afterReasoningSummary = toAuditValue(afterReasoning?.summary);
@@ -337,6 +483,12 @@ export function applyCodexProviderOverridesWithAudit(
       before: beforeImageGeneration,
       after: afterImageGeneration,
       changed: !Object.is(beforeImageGeneration, afterImageGeneration),
+    },
+    {
+      path: "input.additional_tools.image_generation",
+      before: beforeInputImageGeneration,
+      after: afterInputImageGeneration,
+      changed: !Object.is(beforeInputImageGeneration, afterInputImageGeneration),
     },
     {
       path: "reasoning.effort",

--- a/src/lib/codex/provider-overrides.ts
+++ b/src/lib/codex/provider-overrides.ts
@@ -58,8 +58,13 @@ function toImageGenerationToolReference(value: unknown): Record<string, unknown>
   if (value.type === "image_generation") {
     return { type: "image_generation" };
   }
-  if (value.type === "namespace" && value.name === "image_gen") {
-    return { type: "namespace", name: "image_gen" };
+  if (value.type === "namespace") {
+    if (value.name === "image_gen") {
+      return { type: "namespace", name: "image_gen" };
+    }
+    if (value.namespace === "image_gen") {
+      return { type: "namespace", namespace: "image_gen" };
+    }
   }
   return null;
 }
@@ -214,13 +219,7 @@ function isImageGenerationToolChoice(value: unknown): boolean {
   if (isImageGenerationTool(value)) {
     return true;
   }
-  if (value.type === "namespace" && value.namespace === "image_gen") {
-    return true;
-  }
-  if (isImageGenerationToolChoice(value.tool)) {
-    return true;
-  }
-  return isPlainObject(value.function) && value.function.name === "image_generation";
+  return isImageGenerationTool(value.tool);
 }
 
 function summarizeImageGenerationToolChoice(value: unknown): string | null {
@@ -230,11 +229,8 @@ function summarizeImageGenerationToolChoice(value: unknown): string | null {
   if (!isPlainObject(value)) {
     return null;
   }
-  if (isImageGenerationToolChoice(value.tool)) {
+  if (isImageGenerationTool(value.tool)) {
     return "tool:image_generation";
-  }
-  if (isPlainObject(value.function) && value.function.name === "image_generation") {
-    return "function:image_generation";
   }
   if (typeof value.type !== "string") {
     return null;

--- a/tests/api/api-openapi-spec.test.ts
+++ b/tests/api/api-openapi-spec.test.ts
@@ -232,9 +232,10 @@ describe("OpenAPI 规范验证", () => {
     expect(publicStatusOperation?.responses?.["200"]).toBeDefined();
     expect(publicStatusOperation?.responses?.["400"]).toBeDefined();
     expect(publicStatusOperation?.responses?.["503"]).toBeDefined();
-    expect(publicStatusOperation?.parameters).toBeDefined();
+    const publicStatusParameters = publicStatusOperation?.parameters;
+    expect(publicStatusParameters).toBeDefined();
 
-    const parameterNames = (publicStatusOperation?.parameters as Array<{ name?: string }>).map(
+    const parameterNames = (publicStatusParameters as Array<{ name?: string }>).map(
       (parameter) => parameter.name
     );
     expect(parameterNames).toEqual(

--- a/tests/unit/proxy/codex-provider-overrides.test.ts
+++ b/tests/unit/proxy/codex-provider-overrides.test.ts
@@ -425,7 +425,6 @@ describe("Codex 供应商级参数覆写", () => {
     ["字符串", "image_generation", "image_generation"],
     ["namespace 字段", { type: "namespace", namespace: "image_gen" }, "namespace:image_gen"],
     ["嵌套 tool", { tool: { type: "namespace", name: "image_gen" } }, "tool:image_generation"],
-    ["function.name", { function: { name: "image_generation" } }, "function:image_generation"],
   ])("当强制 image_generation=false 时，应移除%s形式的 tool_choice 并记录审计", (_, toolChoice, auditValue) => {
     const provider = {
       providerType: "codex",
@@ -446,6 +445,60 @@ describe("Codex 供应商级参数覆写", () => {
       after: null,
       changed: true,
     });
+  });
+
+  it("不应把名为 image_generation 的普通函数选择误判为内置图片工具", () => {
+    const provider = {
+      providerType: "codex",
+      codexImageGenerationPreference: "false",
+    };
+    const input: Record<string, unknown> = {
+      model: "gpt-5.5",
+      input: [],
+      tools: [
+        {
+          type: "function",
+          name: "image_generation",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      tool_choice: {
+        type: "function",
+        function: { name: "image_generation" },
+      },
+    };
+
+    const result = applyCodexProviderOverridesWithAudit(provider as any, input);
+
+    expect(result.request).toBe(input);
+    expect(result.request.tool_choice).toEqual(input.tool_choice);
+    expect(result.audit?.changes.find((change) => change.path === "tool_choice")).toEqual({
+      path: "tool_choice",
+      before: "function",
+      after: "function",
+      changed: false,
+    });
+  });
+
+  it("不应递归解析多层嵌套的 tool_choice.tool", () => {
+    const provider = {
+      providerType: "codex",
+      codexImageGenerationPreference: "false",
+    };
+    const nestedToolChoice: Record<string, unknown> = {
+      tool: { tool: { type: "image_generation" } },
+    };
+    const input: Record<string, unknown> = {
+      model: "gpt-5.5",
+      input: [],
+      tools: [{ type: "function", name: "lookup_weather" }],
+      tool_choice: nestedToolChoice,
+    };
+
+    const output = applyCodexProviderOverrides(provider as any, input);
+
+    expect(output).toBe(input);
+    expect(output.tool_choice).toBe(nestedToolChoice);
   });
 
   it("不应把其他 namespace 中名为 imagegen 的普通函数误判为图片工具", () => {
@@ -569,6 +622,35 @@ describe("Codex 供应商级参数覆写", () => {
         mode: "auto",
         tools: [
           { type: "namespace", name: "image_gen" },
+          { type: "function", name: "lookup_weather" },
+        ],
+      },
+    };
+
+    const output = applyCodexProviderOverrides(provider as any, input);
+
+    expect(output.tool_choice).toEqual({
+      type: "allowed_tools",
+      mode: "auto",
+      tools: [{ type: "function", name: "lookup_weather" }],
+    });
+  });
+
+  it("当 allowed_tools 使用 namespace 字段声明 image_gen 时，也应剔除该项", () => {
+    const provider = {
+      providerType: "codex",
+      codexImageGenerationPreference: "false",
+    };
+
+    const input: Record<string, unknown> = {
+      model: "gpt-5.5",
+      input: [],
+      tools: [{ type: "function", name: "lookup_weather" }],
+      tool_choice: {
+        type: "allowed_tools",
+        mode: "auto",
+        tools: [
+          { type: "namespace", namespace: "image_gen" },
           { type: "function", name: "lookup_weather" },
         ],
       },

--- a/tests/unit/proxy/codex-provider-overrides.test.ts
+++ b/tests/unit/proxy/codex-provider-overrides.test.ts
@@ -74,6 +74,38 @@ describe("Codex 供应商级参数覆写", () => {
     expect(input).toEqual(snapshot);
   });
 
+  it("当 image_generation 偏好为 inherit 时，不应扫描工具声明", () => {
+    const provider = {
+      providerType: "codex",
+      codexImageGenerationPreference: "inherit",
+    };
+    let toolsReadCount = 0;
+    let inputReadCount = 0;
+    const input: Record<string, unknown> = { model: "gpt-5.5" };
+    Object.defineProperties(input, {
+      tools: {
+        enumerable: true,
+        get: () => {
+          toolsReadCount += 1;
+          return [{ type: "namespace", name: "image_gen" }];
+        },
+      },
+      input: {
+        enumerable: true,
+        get: () => {
+          inputReadCount += 1;
+          return [];
+        },
+      },
+    });
+
+    const output = applyCodexProviderOverrides(provider as any, input);
+
+    expect(output).toBe(input);
+    expect(toolsReadCount).toBe(0);
+    expect(inputReadCount).toBe(0);
+  });
+
   it("当强制 parallel_tool_calls 时，应覆写为对应布尔值", () => {
     const provider = {
       providerType: "codex",

--- a/tests/unit/proxy/codex-provider-overrides.test.ts
+++ b/tests/unit/proxy/codex-provider-overrides.test.ts
@@ -161,6 +161,101 @@ describe("Codex 供应商级参数覆写", () => {
     });
   });
 
+  it("当强制 image_generation=true 且请求已声明 image_gen namespace 时，不应重复注入图像工具", () => {
+    const provider = {
+      providerType: "codex",
+      codexImageGenerationPreference: "true",
+    };
+
+    const input: Record<string, unknown> = {
+      model: "gpt-5.5",
+      input: [],
+      tools: [
+        {
+          type: "namespace",
+          name: "image_gen",
+          tools: [{ type: "function", name: "imagegen" }],
+        },
+      ],
+    };
+
+    const output = applyCodexProviderOverrides(provider as any, input);
+
+    expect(output).toBe(input);
+    expect(output.tools).toEqual(input.tools);
+  });
+
+  it("当强制 image_generation=true 且 Responses Lite 已声明 image_gen namespace 时，不应重复注入顶层工具", () => {
+    const provider = {
+      providerType: "codex",
+      codexImageGenerationPreference: "true",
+    };
+
+    const input: Record<string, unknown> = {
+      model: "gpt-5.5",
+      input: [
+        {
+          type: "additional_tools",
+          tools: [{ type: "namespace", name: "image_gen" }],
+        },
+      ],
+    };
+
+    const output = applyCodexProviderOverrides(provider as any, input);
+
+    expect(output).toBe(input);
+    expect(output.tools).toBeUndefined();
+  });
+
+  it.each([
+    [
+      "顶层 tools",
+      {
+        tools: [{ type: "namespace", name: "image_gen" }],
+        input: [],
+      },
+    ],
+    [
+      "Responses Lite",
+      {
+        input: [
+          {
+            type: "additional_tools",
+            tools: [{ type: "namespace", name: "image_gen" }],
+          },
+        ],
+      },
+    ],
+  ])("当强制 image_generation=true 且%s已声明 namespace 时，allowed_tools 应使用同形引用", (_, request) => {
+    const provider = {
+      providerType: "codex",
+      codexImageGenerationPreference: "true",
+    };
+    const input: Record<string, unknown> = {
+      model: "gpt-5.5",
+      ...request,
+      tool_choice: {
+        type: "allowed_tools",
+        mode: "auto",
+        tools: [{ type: "function", name: "lookup_weather" }],
+      },
+    };
+
+    const output = applyCodexProviderOverrides(provider as any, input);
+
+    expect(output.tool_choice).toEqual({
+      type: "allowed_tools",
+      mode: "auto",
+      tools: [
+        { type: "function", name: "lookup_weather" },
+        { type: "namespace", name: "image_gen" },
+      ],
+    });
+    expect(output.tools).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "image_generation" })])
+    );
+  });
+
   it("当强制 image_generation=false 时，应从 tools 中移除对应工具", () => {
     const provider = {
       providerType: "codex",
@@ -180,6 +275,166 @@ describe("Codex 供应商级参数覆写", () => {
       { type: "image_generation" },
       { type: "function", name: "lookup_weather" },
     ]);
+  });
+
+  it("当强制 image_generation=false 时，应完整移除 namespace 和 Responses Lite 图片工具声明", () => {
+    const provider = {
+      id: 90,
+      name: "codex-provider",
+      providerType: "codex",
+      codexImageGenerationPreference: "false",
+    };
+
+    const imageNamespace = {
+      type: "namespace",
+      name: "image_gen",
+      tools: [{ type: "function", name: "imagegen" }],
+    };
+    const codeNamespace = {
+      type: "namespace",
+      name: "code_tools",
+      tools: [{ type: "function", name: "run" }],
+    };
+    const input: Record<string, unknown> = {
+      model: "gpt-5.5",
+      tools: [{ type: "function", name: "shell" }, imageNamespace, codeNamespace],
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+        { type: "additional_tools", tools: [imageNamespace] },
+        { type: "additional_tools", tools: [imageNamespace, codeNamespace] },
+      ],
+      tool_choice: { type: "namespace", name: "image_gen" },
+    };
+    const snapshot = structuredClone(input);
+
+    const result = applyCodexProviderOverridesWithAudit(provider as any, input);
+
+    expect(result.request.tools).toEqual([{ type: "function", name: "shell" }, codeNamespace]);
+    expect(result.request.input).toEqual([
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+      { type: "additional_tools", tools: [codeNamespace] },
+    ]);
+    expect(result.request.tool_choice).toBe("none");
+    expect(input).toEqual(snapshot);
+
+    expect(
+      result.audit?.changes.find((change) => change.path === "tools.image_generation")
+    ).toEqual({
+      path: "tools.image_generation",
+      before: true,
+      after: false,
+      changed: true,
+    });
+    expect(
+      result.audit?.changes.find(
+        (change) => change.path === "input.additional_tools.image_generation"
+      )
+    ).toEqual({
+      path: "input.additional_tools.image_generation",
+      before: true,
+      after: false,
+      changed: true,
+    });
+  });
+
+  it("当强制 image_generation=false 且只有 Responses Lite 图片工具时，应独立清理并正确审计", () => {
+    const provider = {
+      id: 90,
+      name: "codex-provider",
+      providerType: "codex",
+      codexImageGenerationPreference: "false",
+    };
+    const input: Record<string, unknown> = {
+      model: "gpt-5.5",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+        { type: "image_generation_call", id: "ig_123", result: "preserve" },
+        {
+          type: "additional_tools",
+          tools: [{ type: "namespace", name: "image_gen" }],
+        },
+      ],
+      include: ["image_generation_call.results"],
+      tool_choice: "auto",
+    };
+    const snapshot = structuredClone(input);
+
+    const result = applyCodexProviderOverridesWithAudit(provider as any, input);
+
+    expect(result.request.input).toEqual([
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+      { type: "image_generation_call", id: "ig_123", result: "preserve" },
+    ]);
+    expect(result.request.include).toEqual(["image_generation_call.results"]);
+    expect(result.request.tool_choice).toBeUndefined();
+    expect(input).toEqual(snapshot);
+    expect(
+      result.audit?.changes.find((change) => change.path === "tools.image_generation")
+    ).toEqual({
+      path: "tools.image_generation",
+      before: false,
+      after: false,
+      changed: false,
+    });
+    expect(
+      result.audit?.changes.find(
+        (change) => change.path === "input.additional_tools.image_generation"
+      )
+    ).toEqual({
+      path: "input.additional_tools.image_generation",
+      before: true,
+      after: false,
+      changed: true,
+    });
+  });
+
+  it.each([
+    ["字符串", "image_generation", "image_generation"],
+    ["namespace 字段", { type: "namespace", namespace: "image_gen" }, "namespace:image_gen"],
+    ["嵌套 tool", { tool: { type: "namespace", name: "image_gen" } }, "tool:image_generation"],
+    ["function.name", { function: { name: "image_generation" } }, "function:image_generation"],
+  ])("当强制 image_generation=false 时，应移除%s形式的 tool_choice 并记录审计", (_, toolChoice, auditValue) => {
+    const provider = {
+      providerType: "codex",
+      codexImageGenerationPreference: "false",
+    };
+    const input: Record<string, unknown> = {
+      model: "gpt-5.5",
+      input: [],
+      tool_choice: toolChoice,
+    };
+
+    const result = applyCodexProviderOverridesWithAudit(provider as any, input);
+
+    expect(result.request.tool_choice).toBeUndefined();
+    expect(result.audit?.changes.find((change) => change.path === "tool_choice")).toEqual({
+      path: "tool_choice",
+      before: auditValue,
+      after: null,
+      changed: true,
+    });
+  });
+
+  it("不应把其他 namespace 中名为 imagegen 的普通函数误判为图片工具", () => {
+    const provider = {
+      providerType: "codex",
+      codexImageGenerationPreference: "false",
+    };
+    const input: Record<string, unknown> = {
+      model: "gpt-5.5",
+      input: [],
+      tools: [
+        {
+          type: "namespace",
+          name: "media_tools",
+          tools: [{ type: "function", name: "imagegen" }],
+        },
+      ],
+    };
+
+    const output = applyCodexProviderOverrides(provider as any, input);
+
+    expect(output).toBe(input);
   });
 
   it("当强制 image_generation=false 且 tool_choice 直接指向 image_generation 时，应移除该选择", () => {
@@ -259,6 +514,35 @@ describe("Codex 供应商级参数覆写", () => {
     const output = applyCodexProviderOverrides(provider as any, input);
 
     expect(output.tools).toEqual([{ type: "function", name: "lookup_weather" }]);
+    expect(output.tool_choice).toEqual({
+      type: "allowed_tools",
+      mode: "auto",
+      tools: [{ type: "function", name: "lookup_weather" }],
+    });
+  });
+
+  it("当强制 image_generation=false 且 allowed_tools 包含 image_gen namespace 时，应剔除该项", () => {
+    const provider = {
+      providerType: "codex",
+      codexImageGenerationPreference: "false",
+    };
+
+    const input: Record<string, unknown> = {
+      model: "gpt-5.5",
+      input: [],
+      tools: [{ type: "function", name: "lookup_weather" }],
+      tool_choice: {
+        type: "allowed_tools",
+        mode: "auto",
+        tools: [
+          { type: "namespace", name: "image_gen" },
+          { type: "function", name: "lookup_weather" },
+        ],
+      },
+    };
+
+    const output = applyCodexProviderOverrides(provider as any, input);
+
     expect(output.tool_choice).toEqual({
       type: "allowed_tools",
       mode: "auto",

--- a/tests/unit/proxy/codex-provider-overrides.test.ts
+++ b/tests/unit/proxy/codex-provider-overrides.test.ts
@@ -99,9 +99,10 @@ describe("Codex 供应商级参数覆写", () => {
       },
     });
 
-    const output = applyCodexProviderOverrides(provider as any, input);
+    const result = applyCodexProviderOverridesWithAudit(provider as any, input);
 
-    expect(output).toBe(input);
+    expect(result.request).toBe(input);
+    expect(result.audit).toBeNull();
     expect(toolsReadCount).toBe(0);
     expect(inputReadCount).toBe(0);
   });


### PR DESCRIPTION
## Summary

- recognize Codex image generation tools declared as the `image_gen` namespace
- strip image declarations from both top-level `tools` and Responses Lite `input[].additional_tools` when a provider forces image generation off
- normalize related `tool_choice` and `allowed_tools` references while preserving unrelated tools and response history
- add audit coverage for embedded additional tools

## Problem

CCH's provider override only recognized the legacy `{ "type": "image_generation" }` declaration. Newer Codex requests can expose image generation as `{ "type": "namespace", "name": "image_gen" }`, including inside Responses Lite `additional_tools` carriers. As a result, a provider configured to force image generation off could still receive the image namespace and forward it upstream, where accounts without image access reject the request.

## Related

- Follow-up to #1307 - fixes a gap in the Codex image generation provider override introduced there. #1307 only matched the legacy `{ "type": "image_generation" }` declaration, so newer Codex requests exposing image generation as a `namespace` tool (including inside Responses Lite `additional_tools`) bypassed the force-off path and leaked upstream.
- Related to #870 - the broader Codex provider-override system (`service_tier`) that #1307 extended and that this fix operates within.

## Solution

When image generation is forced off, this change removes only image tool declarations and matching tool choices. It keeps other namespaces, ordinary tools, historical `image_generation_call` input items, and `include` fields intact. Empty `additional_tools` carriers are removed. The transformation remains copy-on-write.

When image generation is forced on, existing namespace declarations are reused for `allowed_tools` instead of injecting a mismatched legacy reference.

Key implementation points in `src/lib/codex/provider-overrides.ts`:
- `toImageGenerationToolReference` now recognizes both `{ type: "image_generation" }` and `{ type: "namespace", name: "image_gen" }`.
- `applyInputImageGenerationToolPreference` strips image tools from `input[].additional_tools` and drops emptied carriers.
- `isImageGenerationToolChoice` covers additional `tool_choice` shapes (namespace object, nested `tool`, `function.name`), and `summarizeImageGenerationToolChoice` emits matching audit values.
- Force-on path reuses the existing same-shape reference (via `findImageGenerationToolReference`) for `allowed_tools` injection rather than always inserting the legacy form.

This follows the complete-blocking behavior introduced in Sub2API v0.1.151 (`d3a1835e`).

## Changes

- `src/lib/codex/provider-overrides.ts` (+168/-16) - namespace detection, Responses Lite `additional_tools` stripping, expanded `tool_choice` handling, and a new `input.additional_tools.image_generation` audit path.
- `tests/unit/proxy/codex-provider-overrides.test.ts` (+284) - force-on idempotency, same-shape `allowed_tools` reuse, force-off stripping across top-level and Responses Lite carriers, multiple `tool_choice` forms, and a negative test ensuring an unrelated `imagegen` function is not misidentified.

No breaking changes - internal helpers only; no exported signatures, schema, or migrations affected.

## Testing

### Automated Tests
- [x] Unit tests added (`tests/unit/proxy/codex-provider-overrides.test.ts`, +284)
- Focused provider override tests: 33/33 passed

### Validation
- `bun run lint`
- `bun run lint:fix`
- `bun run typecheck`
- `LC_ALL=C bun run test` (743 files passed, 6731 tests passed, 13 skipped)
- `bun run build`

### Manual Testing
No UI changes; this is proxy-pipeline logic. To verify end-to-end: send a Codex Responses request carrying `{ type: "namespace", name: "image_gen" }` (in `tools` or `input[].additional_tools`) through a provider with `codexImageGenerationPreference=false`, and confirm the namespace (and any matching `tool_choice`) is stripped before the request is forwarded upstream.

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [ ] Documentation updated (if needed)

---
*Description enhanced by Claude AI*

## Follow-up fixes

- skip image-tool scans in both the direct override path and the production audit wrapper when image generation is inherited, before reading `tools` or `input`
- add a getter-based regression test through `applyCodexProviderOverridesWithAudit` to cover the real forwarding path
- include the existing OpenAPI optional-chaining safety fix required by Biome 2.5.3 CI (`tests/api/api-openapi-spec.test.ts`)

Follow-up validation: full Biome 2.5.3 check passed; local full suite `6732` passed / `13` skipped; production build passed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes a gap in the Codex provider image-generation override: the existing logic only recognised the legacy `{ type: "image_generation" }` declaration, so requests using the newer `{ type: "namespace", name: "image_gen" }` form — including inside Responses Lite `input[].additional_tools` carriers — could slip through a force-off provider and reach upstream accounts that reject image access. The fix adds namespace detection across all relevant shapes, strips image tools from both the top-level `tools` array and embedded `additional_tools` carriers, normalises associated `tool_choice` references, and reuses the same-shape reference (legacy or namespace) when force-on injects into `allowed_tools`.

- **`toImageGenerationToolReference` / `isImageGenerationTool`**: now recognises `{ type: \"image_generation\" }`, `{ type: \"namespace\", name: \"image_gen\" }`, and `{ type: \"namespace\", namespace: \"image_gen\" }`, covering both field spellings for the namespace form.
- **`applyInputImageGenerationToolPreference`**: new function that strips image tools from `input[].additional_tools` carriers on force-off; carriers with no remaining tools are dropped, others are preserved.
- **`isImageGenerationToolChoice` / `summarizeImageGenerationToolChoice`**: extended to handle namespace objects and the nested-`tool` wrapping; the depth check is a single one-level unwrap (calls `isImageGenerationTool`, not itself), so there is no recursive risk.
- **Audit path**: `beforeInputImageGeneration` / `afterInputImageGeneration` scans are now guarded behind the early-exit `hit` check, eliminating unnecessary property reads when all preferences are inherited.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is scoped entirely to internal helper functions, preserves copy-on-write semantics, and carries comprehensive test coverage across all new code paths.

Both gaps flagged in the previous review round are correctly addressed. `isImageGenerationToolChoice` calls `isImageGenerationTool` (not itself), eliminating any recursive risk. `toImageGenerationToolReference` handles both `name` and `namespace` field spellings uniformly so filtering is consistent everywhere. The 284 new test lines cover force-on idempotency, force-off stripping across both carriers, same-shape reference reuse, multiple tool_choice shapes, and the inherit-path early-exit. No exported API, schema, or migration is touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/codex/provider-overrides.ts | Extended image-generation override logic to strip namespace tools from both top-level tools and Responses Lite input[].additional_tools, normalize multiple tool_choice shapes, and reuse same-shape references on force-on. Copy-on-write discipline maintained throughout. |
| tests/unit/proxy/codex-provider-overrides.test.ts | +284 lines of new unit tests covering force-on idempotency, same-shape allowed_tools reuse, force-off stripping across both carriers, multiple tool_choice shapes, negative test for unrelated namespace, and a getter-based regression for the inherit early-exit path. |
| tests/api/api-openapi-spec.test.ts | Minor Biome 2.5.3 lint fix: extracts publicStatusOperation?.parameters into a local variable to satisfy optional-chaining rules before the map call. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(codex): narrow image tool choice mat..."](https://github.com/ding113/claude-code-hub/commit/7639110875d5ffdc30a257cb0836ef2708097b50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43599825)</sub>

<!-- /greptile_comment -->