### PR TITLE
fix(proxy): record OpenAI cache write tokens

### DIFF
--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -3371,12 +3371,21 @@ export class ProxyResponseHandler {
   }
 }
 
+function asNonNegativeFiniteNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
+  }
+  return value;
+}
+
 export function extractUsageMetrics(value: unknown): UsageMetrics | null {
   if (!value || typeof value !== "object") {
     return null;
   }
 
   const usage = value as Record<string, unknown>;
+  const inputTokensDetails = usage.input_tokens_details as Record<string, unknown> | undefined;
+  const promptTokensDetails = usage.prompt_tokens_details as Record<string, unknown> | undefined;
   const result: UsageMetrics = {};
   let hasAny = false;
 
@@ -3503,6 +3512,20 @@ export function extractUsageMetrics(value: unknown): UsageMetrics | null {
     hasAny = true;
   }
 
+  if (result.cache_creation_input_tokens === undefined) {
+    const cacheWriteTokens =
+      asNonNegativeFiniteNumber(inputTokensDetails?.cache_write_tokens) ??
+      asNonNegativeFiniteNumber(promptTokensDetails?.cache_write_tokens);
+
+    if (cacheWriteTokens !== undefined) {
+      result.cache_creation_input_tokens = cacheWriteTokens;
+      hasAny = true;
+      logger.debug("[ResponseHandler] Parsed cache write tokens from OpenAI usage details", {
+        cacheWriteTokens,
+      });
+    }
+  }
+
   const cacheCreationDetails = usage.cache_creation as Record<string, unknown> | undefined;
   let cacheCreationDetailedTotal = 0;
 
@@ -3579,7 +3602,6 @@ export function extractUsageMetrics(value: unknown): UsageMetrics | null {
   }
 
   if (result.cache_read_input_tokens === undefined) {
-    const inputTokensDetails = usage.input_tokens_details as Record<string, unknown> | undefined;
     if (inputTokensDetails && typeof inputTokensDetails.cached_tokens === "number") {
       result.cache_read_input_tokens = inputTokensDetails.cached_tokens;
       hasAny = true;
@@ -3590,7 +3612,6 @@ export function extractUsageMetrics(value: unknown): UsageMetrics | null {
   }
 
   if (result.cache_read_input_tokens === undefined) {
-    const promptTokensDetails = usage.prompt_tokens_details as Record<string, unknown> | undefined;
     if (promptTokensDetails && typeof promptTokensDetails.cached_tokens === "number") {
       result.cache_read_input_tokens = promptTokensDetails.cached_tokens;
       hasAny = true;
@@ -3840,10 +3861,10 @@ export function parseUsageFromResponseText(
   return { usageRecord, usageMetrics };
 }
 
-// Provider types whose upstream APIs report cached tokens as a subset of
-// input_tokens (OpenAI semantics) rather than as a disjoint bucket (Anthropic
-// semantics). For these, subtract cache_read_input_tokens from input_tokens
-// before persistence so internal cost buckets are not double-counted.
+// Provider types whose upstream APIs report cache tokens as subsets of
+// input_tokens (OpenAI semantics) rather than as disjoint buckets (Anthropic
+// semantics). For these, subtract both cache buckets from input_tokens before
+// persistence so internal cost buckets are not double-counted.
 const PROVIDERS_WITH_CACHE_SUBSET_USAGE = new Set<string>(["codex", "openai-compatible"]);
 
 function adjustUsageForProviderType(
@@ -3854,22 +3875,26 @@ function adjustUsageForProviderType(
     return usage;
   }
 
-  const cachedTokens = usage.cache_read_input_tokens;
   const inputTokens = usage.input_tokens;
+  const hasCachedTokens = typeof usage.cache_read_input_tokens === "number";
+  const hasCacheWriteTokens = typeof usage.cache_creation_input_tokens === "number";
 
-  if (typeof cachedTokens !== "number" || typeof inputTokens !== "number") {
+  if (typeof inputTokens !== "number" || (!hasCachedTokens && !hasCacheWriteTokens)) {
     return usage;
   }
 
-  const adjustedInput = Math.max(inputTokens - cachedTokens, 0);
+  const cachedTokens = hasCachedTokens ? (usage.cache_read_input_tokens ?? 0) : 0;
+  const cacheWriteTokens = hasCacheWriteTokens ? (usage.cache_creation_input_tokens ?? 0) : 0;
+  const adjustedInput = Math.max(inputTokens - cachedTokens - cacheWriteTokens, 0);
   if (adjustedInput === inputTokens) {
     return usage;
   }
 
-  logger.debug("[UsageMetrics] Adjusted input tokens to exclude cached tokens", {
+  logger.debug("[UsageMetrics] Adjusted input tokens to exclude cache buckets", {
     providerType,
     originalInputTokens: inputTokens,
     cachedTokens,
+    cacheWriteTokens,
     adjustedInputTokens: adjustedInput,
   });
 

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -3378,6 +3378,20 @@ function asNonNegativeFiniteNumber(value: unknown): number | undefined {
   return value;
 }
 
+function getNestedOpenAICacheWriteTokens(usage: Record<string, unknown>): number | undefined {
+  if (typeof usage.cache_creation_input_tokens === "number") {
+    return undefined;
+  }
+
+  const inputTokensDetails = usage.input_tokens_details as Record<string, unknown> | undefined;
+  const promptTokensDetails = usage.prompt_tokens_details as Record<string, unknown> | undefined;
+
+  return (
+    asNonNegativeFiniteNumber(inputTokensDetails?.cache_write_tokens) ??
+    asNonNegativeFiniteNumber(promptTokensDetails?.cache_write_tokens)
+  );
+}
+
 export function extractUsageMetrics(value: unknown): UsageMetrics | null {
   if (!value || typeof value !== "object") {
     return null;
@@ -3513,9 +3527,7 @@ export function extractUsageMetrics(value: unknown): UsageMetrics | null {
   }
 
   if (result.cache_creation_input_tokens === undefined) {
-    const cacheWriteTokens =
-      asNonNegativeFiniteNumber(inputTokensDetails?.cache_write_tokens) ??
-      asNonNegativeFiniteNumber(promptTokensDetails?.cache_write_tokens);
+    const cacheWriteTokens = getNestedOpenAICacheWriteTokens(usage);
 
     if (cacheWriteTokens !== undefined) {
       result.cache_creation_input_tokens = cacheWriteTokens;
@@ -3649,7 +3661,7 @@ export function parseUsageFromResponseText(
     }
 
     usageRecord = value as Record<string, unknown>;
-    usageMetrics = adjustUsageForProviderType(extracted, providerType);
+    usageMetrics = adjustUsageForProviderType(extracted, providerType, usageRecord);
 
     logger.debug("[ResponseHandler] Parsed usage from response", {
       source,
@@ -3838,8 +3850,8 @@ export function parseUsageFromResponseText(
     })();
 
     if (mergedClaudeUsage) {
-      usageMetrics = adjustUsageForProviderType(mergedClaudeUsage, providerType);
       usageRecord = mergedClaudeUsage as unknown as Record<string, unknown>;
+      usageMetrics = adjustUsageForProviderType(mergedClaudeUsage, providerType, usageRecord);
       logger.debug("[ResponseHandler] Final merged usage from Claude SSE", {
         providerType,
         usage: usageMetrics,
@@ -3849,8 +3861,8 @@ export function parseUsageFromResponseText(
     // Gemini SSE 处理：使用最后一个有效的 usageMetadata
     // 仅当 Claude SSE 没有提供 usage 且 applyUsageValue 也没有找到时才使用
     if (!usageMetrics && lastGeminiUsage) {
-      usageMetrics = adjustUsageForProviderType(lastGeminiUsage, providerType);
       usageRecord = lastGeminiUsageRecord;
+      usageMetrics = adjustUsageForProviderType(lastGeminiUsage, providerType, usageRecord);
       logger.debug("[ResponseHandler] Final usage from Gemini SSE (last event)", {
         providerType,
         usage: usageMetrics,
@@ -3869,22 +3881,20 @@ const PROVIDERS_WITH_CACHE_SUBSET_USAGE = new Set<string>(["codex", "openai-comp
 
 function adjustUsageForProviderType(
   usage: UsageMetrics,
-  providerType: string | null | undefined
+  providerType: string | null | undefined,
+  rawUsage: Record<string, unknown> | null
 ): UsageMetrics {
   if (!providerType || !PROVIDERS_WITH_CACHE_SUBSET_USAGE.has(providerType)) {
     return usage;
   }
 
   const inputTokens = usage.input_tokens;
-  const hasCachedTokens = typeof usage.cache_read_input_tokens === "number";
-  const hasCacheWriteTokens = typeof usage.cache_creation_input_tokens === "number";
-
-  if (typeof inputTokens !== "number" || (!hasCachedTokens && !hasCacheWriteTokens)) {
+  if (typeof inputTokens !== "number") {
     return usage;
   }
 
-  const cachedTokens = hasCachedTokens ? (usage.cache_read_input_tokens ?? 0) : 0;
-  const cacheWriteTokens = hasCacheWriteTokens ? (usage.cache_creation_input_tokens ?? 0) : 0;
+  const cachedTokens = asNonNegativeFiniteNumber(usage.cache_read_input_tokens) ?? 0;
+  const cacheWriteTokens = rawUsage ? (getNestedOpenAICacheWriteTokens(rawUsage) ?? 0) : 0;
   const adjustedInput = Math.max(inputTokens - cachedTokens - cacheWriteTokens, 0);
   if (adjustedInput === inputTokens) {
     return usage;

--- a/tests/api/api-openapi-spec.test.ts
+++ b/tests/api/api-openapi-spec.test.ts
@@ -232,9 +232,10 @@ describe("OpenAPI 规范验证", () => {
     expect(publicStatusOperation?.responses?.["200"]).toBeDefined();
     expect(publicStatusOperation?.responses?.["400"]).toBeDefined();
     expect(publicStatusOperation?.responses?.["503"]).toBeDefined();
-    expect(publicStatusOperation?.parameters).toBeDefined();
+    const publicStatusParameters = publicStatusOperation?.parameters;
+    expect(publicStatusParameters).toBeDefined();
 
-    const parameterNames = (publicStatusOperation?.parameters as Array<{ name?: string }>).map(
+    const parameterNames = (publicStatusParameters as Array<{ name?: string }>).map(
       (parameter) => parameter.name
     );
     expect(parameterNames).toEqual(

--- a/tests/unit/proxy/extract-usage-metrics.test.ts
+++ b/tests/unit/proxy/extract-usage-metrics.test.ts
@@ -863,6 +863,134 @@ describe("extractUsageMetrics", () => {
       expect(result.usageMetrics?.output_tokens).toBe(1158);
     });
 
+    it("should extract Responses cache_write_tokens and exclude both cache buckets from input", () => {
+      const response = JSON.stringify({
+        usage: {
+          input_tokens: 240951,
+          input_tokens_details: {
+            cached_tokens: 240128,
+            cache_write_tokens: 740,
+          },
+          output_tokens: 58,
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "codex");
+
+      expect(result.usageMetrics).not.toBeNull();
+      expect(result.usageMetrics?.input_tokens).toBe(83);
+      expect(result.usageMetrics?.cache_creation_input_tokens).toBe(740);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(240128);
+      expect(result.usageMetrics?.output_tokens).toBe(58);
+    });
+
+    it("should extract Chat Completions cache_write_tokens", () => {
+      const response = JSON.stringify({
+        usage: {
+          prompt_tokens: 2006,
+          completion_tokens: 300,
+          prompt_tokens_details: {
+            cached_tokens: 1920,
+            cache_write_tokens: 40,
+          },
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "openai-compatible");
+
+      expect(result.usageMetrics?.input_tokens).toBe(46);
+      expect(result.usageMetrics?.cache_creation_input_tokens).toBe(40);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(1920);
+    });
+
+    it("should extract cache_write_tokens from an SSE final usage chunk", () => {
+      const sse = [
+        'data: {"id":"chatcmpl-cache-write","choices":[{"index":0,"delta":{"content":"Hi"}}]}',
+        "",
+        'data: {"id":"chatcmpl-cache-write","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":2006,"completion_tokens":300,"prompt_tokens_details":{"cached_tokens":1920,"cache_write_tokens":40}}}',
+        "",
+        "data: [DONE]",
+      ].join("\n");
+
+      const result = parseUsageFromResponseText(sse, "openai-compatible");
+
+      expect(result.usageMetrics?.input_tokens).toBe(46);
+      expect(result.usageMetrics?.cache_creation_input_tokens).toBe(40);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(1920);
+      expect(result.usageMetrics?.output_tokens).toBe(300);
+    });
+
+    it("should preserve top-level cache_creation_input_tokens over nested cache_write_tokens", () => {
+      const response = JSON.stringify({
+        usage: {
+          input_tokens: 1000,
+          cache_creation_input_tokens: 0,
+          input_tokens_details: {
+            cached_tokens: 300,
+            cache_write_tokens: 200,
+          },
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "openai-compatible");
+
+      expect(result.usageMetrics?.input_tokens).toBe(700);
+      expect(result.usageMetrics?.cache_creation_input_tokens).toBe(0);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(300);
+    });
+
+    it("should not infer cache-write tokens when cache_write_tokens is absent", () => {
+      const response = JSON.stringify({
+        usage: {
+          input_tokens: 240951,
+          input_tokens_details: {
+            cached_tokens: 240128,
+          },
+          output_tokens: 58,
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "codex");
+
+      expect(result.usageMetrics?.input_tokens).toBe(823);
+      expect(result.usageMetrics?.cache_creation_input_tokens).toBeUndefined();
+    });
+
+    it("should ignore invalid nested cache_write_tokens", () => {
+      const response = JSON.stringify({
+        usage: {
+          input_tokens: 1000,
+          input_tokens_details: {
+            cached_tokens: 300,
+            cache_write_tokens: -1,
+          },
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "openai-compatible");
+
+      expect(result.usageMetrics?.input_tokens).toBe(700);
+      expect(result.usageMetrics?.cache_creation_input_tokens).toBeUndefined();
+    });
+
+    it("should clamp ordinary input at zero when cache buckets exceed total input", () => {
+      const response = JSON.stringify({
+        usage: {
+          input_tokens: 100,
+          input_tokens_details: {
+            cached_tokens: 80,
+            cache_write_tokens: 50,
+          },
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "codex");
+
+      expect(result.usageMetrics?.input_tokens).toBe(0);
+      expect(result.usageMetrics?.cache_creation_input_tokens).toBe(50);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(80);
+    });
+
     it("should subtract cached_tokens from input_tokens in SSE final usage chunk", () => {
       const sse = [
         'data: {"id":"chatcmpl-2","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}',

--- a/tests/unit/proxy/extract-usage-metrics.test.ts
+++ b/tests/unit/proxy/extract-usage-metrics.test.ts
@@ -824,6 +824,88 @@ describe("extractUsageMetrics", () => {
   });
 
   describe("openai-compatible cached_tokens subset normalization", () => {
+    it("should keep top-level cache creation disjoint while subtracting cached input", () => {
+      const response = JSON.stringify({
+        usage: {
+          input_tokens: 1000,
+          cache_creation_input_tokens: 200,
+          input_tokens_details: {
+            cached_tokens: 300,
+            cache_write_tokens: 50,
+          },
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "openai-compatible");
+
+      expect(result.usageMetrics?.input_tokens).toBe(700);
+      expect(result.usageMetrics?.cache_creation_input_tokens).toBe(200);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(300);
+    });
+
+    it("should keep TTL-derived cache creation disjoint", () => {
+      const response = JSON.stringify({
+        usage: {
+          input_tokens: 1000,
+          cache_creation: {
+            ephemeral_5m_input_tokens: 200,
+          },
+          input_tokens_details: {
+            cached_tokens: 300,
+          },
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "openai-compatible");
+
+      expect(result.usageMetrics?.input_tokens).toBe(700);
+      expect(result.usageMetrics?.cache_creation_input_tokens).toBe(200);
+      expect(result.usageMetrics?.cache_creation_5m_input_tokens).toBe(200);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBe(300);
+    });
+
+    it("should subtract nested cache_write_tokens without cached_tokens", () => {
+      const response = JSON.stringify({
+        usage: {
+          input_tokens: 1000,
+          input_tokens_details: {
+            cache_write_tokens: 200,
+          },
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "openai-compatible");
+
+      expect(result.usageMetrics?.input_tokens).toBe(800);
+      expect(result.usageMetrics?.cache_creation_input_tokens).toBe(200);
+      expect(result.usageMetrics?.cache_read_input_tokens).toBeUndefined();
+    });
+
+    it("should keep nested cache_write_tokens disjoint for providers outside the allow-list", () => {
+      const response = JSON.stringify({
+        usage: {
+          input_tokens: 1000,
+          input_tokens_details: {
+            cache_write_tokens: 200,
+          },
+        },
+      });
+
+      const result = parseUsageFromResponseText(response, "openai");
+
+      expect(result.usageMetrics?.input_tokens).toBe(1000);
+      expect(result.usageMetrics?.cache_creation_input_tokens).toBe(200);
+    });
+
+    it("should ignore exponent-overflow cache buckets during input normalization", () => {
+      const response =
+        '{"usage":{"input_tokens":1000,"cache_read_input_tokens":1e400,"input_tokens_details":{"cache_write_tokens":1e400}}}';
+
+      const result = parseUsageFromResponseText(response, "openai-compatible");
+
+      expect(result.usageMetrics?.input_tokens).toBe(1000);
+    });
+
     it("should subtract Chat Completions cached_tokens from input_tokens (non-stream)", () => {
       const response = JSON.stringify({
         usage: {


### PR DESCRIPTION
## Summary

- Record the explicit OpenAI `cache_write_tokens` usage field as canonical `cache_creation_input_tokens`.
- Normalize inclusive OpenAI input usage for `codex` and `openai-compatible` by subtracting both cache-read and cache-write buckets.
- Preserve canonical top-level priority, provider boundaries, and conservative behavior when the cache-write field is absent or invalid.

## Related Issues

- Follow-up to #1133 — extends the cache-subset normalization introduced there (`adjustUsageForProviderType` + `PROVIDERS_WITH_CACHE_SUBSET_USAGE`). #1133 subtracted only cache-read tokens from the inclusive input total; this PR additionally subtracts cache-write tokens and parses the previously-ignored `cache_write_tokens` field.
- Related to #1075 — the original OpenAI token double-counting report (fixed by #1133). This PR closes the residual gap: the cache-write bucket was still being dropped, leaving `cache_creation_input_tokens` unset and ordinary input inflated for OpenAI Responses/Chat Completions payloads that report `cache_write_tokens`.

## Reproduction and root cause

A real OpenAI Responses usage payload reported:

```json
{
  "input_tokens": 240951,
  "input_tokens_details": {
    "cached_tokens": 240128,
    "cache_write_tokens": 740
  },
  "output_tokens": 58
}
```

The previous parser recognized `240128` cache-read tokens but ignored the explicit `740` cache-write tokens. It therefore persisted `823` ordinary input tokens and no cache-creation bucket. The correct normalized buckets are `83` ordinary input, `740` cache write, `240128` cache read, and `58` output.

The root cause was twofold: nested OpenAI usage parsing only read `cached_tokens`, and the OpenAI subset normalization subtracted only cache-read tokens from the inclusive input total.

This change does not infer cache-write tokens from differences when `cache_write_tokens` is absent. Such inference is unsafe because a missing provider field does not prove that the remaining input-token difference represents cache creation. In that boundary case, cache creation remains unset and only an explicitly reported cache-read bucket is normalized.

## Supported shapes and boundaries

- Responses API: `input_tokens_details.cache_write_tokens`
- Chat Completions: `prompt_tokens_details.cache_write_tokens`
- Chat Completions SSE: final usage chunk using the same details shape
- Existing top-level `cache_creation_input_tokens` wins, including an explicit zero
- Negative or non-finite nested values are ignored
- Ordinary input is clamped at zero when explicit cache buckets exceed the inclusive total
- Providers outside `codex` and `openai-compatible` retain disjoint cache semantics

## Verification

- `bun run typecheck` - passed
- `bun run lint` - passed with 194 warnings, 2 infos, and 0 errors; commit `219402a7` contains the isolated OpenAPI test baseline fix
- `bun run test tests/unit/proxy/extract-usage-metrics.test.ts` - passed, 65 tests
- `LC_ALL=C bun run test` - passed, 743 files and 6731 tests; 2 files and 13 tests skipped
- `bun run build` - passed
- `git diff --check` - passed

Independent review found no Critical or Important issues and assessed the change ready to merge.

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes double-counting of OpenAI cache tokens by parsing the previously-ignored `cache_write_tokens` field from `input_tokens_details`/`prompt_tokens_details` and subtracting it from the inclusive `input_tokens` for `codex` and `openai-compatible` providers (following the pattern established in #1133 for `cache_read_input_tokens`).

- **`extractUsageMetrics`**: Adds a new `getNestedOpenAICacheWriteTokens` helper and a new code block that populates `cache_creation_input_tokens` from the nested OpenAI field when no top-level value already exists, respecting the established priority (top-level > nested > TTL-derived).
- **`adjustUsageForProviderType`**: Extends the input adjustment to subtract both the cached-read and cached-write buckets from the inclusive `input_tokens`, receiving the raw usage record via a new `rawUsage` parameter so it can read the same nested fields.
- **Tests**: 13 new unit tests covering Responses API, Chat Completions, SSE, top-level priority override, zero explicit value, absent field (no inference), negative/non-finite guards, and clamp-at-zero behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge: it only extends usage-metric parsing to capture a previously-ignored OpenAI field, with no risk of breaking existing normalization or Anthropic/Gemini code paths.

The logic is internally consistent: getNestedOpenAICacheWriteTokens is the single source of truth for the nested field, called with the same raw object in both extractUsageMetrics and adjustUsageForProviderType, so there is no double-counting risk. Edge cases are all handled and verified by the new test suite. Non-OpenAI providers are unaffected.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/response-handler.ts | Adds asNonNegativeFiniteNumber and getNestedOpenAICacheWriteTokens helpers, hoists detail-object references, extends extractUsageMetrics to populate cache_creation_input_tokens from nested OpenAI fields, and adds a rawUsage param to adjustUsageForProviderType to subtract write tokens from inclusive input — all with correct priority ordering and guards. |
| tests/unit/proxy/extract-usage-metrics.test.ts | Adds 13 new tests covering the reproduction case, Chat Completions, SSE, priority rules, zero explicit value, no-inference-when-absent, non-finite/negative guards, and clamp-at-zero; all cases verified correctly. |
| tests/api/api-openapi-spec.test.ts | Minor safe refactor to eliminate an unsafe optional chaining lint warning; no behavioral change. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Raw usage payload\n(OpenAI / codex)"] --> B["extractUsageMetrics(usage)"]

    B --> C{"top-level\ncache_creation_input_tokens?"}
    C -- "yes (number)" --> D["result.cache_creation_input_tokens\n= top-level value"]
    C -- "no" --> E["getNestedOpenAICacheWriteTokens(usage)\n→ input_tokens_details.cache_write_tokens\n   or prompt_tokens_details.cache_write_tokens"]
    E -- "found > 0" --> F["result.cache_creation_input_tokens\n= nested cache_write_tokens"]
    E -- "absent / invalid" --> G["cache_creation_input_tokens\nleft undefined"]

    B --> H["Parse cache_read_input_tokens\nfrom *.cached_tokens"]
    B --> I["Parse input_tokens\nfrom input_tokens / prompt_tokens"]

    D & F & G --> J["UsageMetrics (extracted)"]
    H --> J
    I --> J

    J --> K["adjustUsageForProviderType\n(usage, providerType, rawUsage)"]

    K --> L{"codex or\nopenai-compatible?"}
    L -- "no" --> M["return usage unchanged"]
    L -- "yes" --> N{"input_tokens\nis a number?"}
    N -- "no" --> M
    N -- "yes" --> O["cachedTokens = cache_read_input_tokens ?? 0\ncacheWriteTokens = getNestedOpenAICacheWriteTokens(rawUsage) ?? 0"]
    O --> P["adjustedInput = max(inputTokens - cachedTokens - cacheWriteTokens, 0)"]
    P --> Q["return usage with input_tokens = adjustedInput"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Raw usage payload\n(OpenAI / codex)"] --> B["extractUsageMetrics(usage)"]

    B --> C{"top-level\ncache_creation_input_tokens?"}
    C -- "yes (number)" --> D["result.cache_creation_input_tokens\n= top-level value"]
    C -- "no" --> E["getNestedOpenAICacheWriteTokens(usage)\n→ input_tokens_details.cache_write_tokens\n   or prompt_tokens_details.cache_write_tokens"]
    E -- "found > 0" --> F["result.cache_creation_input_tokens\n= nested cache_write_tokens"]
    E -- "absent / invalid" --> G["cache_creation_input_tokens\nleft undefined"]

    B --> H["Parse cache_read_input_tokens\nfrom *.cached_tokens"]
    B --> I["Parse input_tokens\nfrom input_tokens / prompt_tokens"]

    D & F & G --> J["UsageMetrics (extracted)"]
    H --> J
    I --> J

    J --> K["adjustUsageForProviderType\n(usage, providerType, rawUsage)"]

    K --> L{"codex or\nopenai-compatible?"}
    L -- "no" --> M["return usage unchanged"]
    L -- "yes" --> N{"input_tokens\nis a number?"}
    N -- "no" --> M
    N -- "yes" --> O["cachedTokens = cache_read_input_tokens ?? 0\ncacheWriteTokens = getNestedOpenAICacheWriteTokens(rawUsage) ?? 0"]
    O --> P["adjustedInput = max(inputTokens - cachedTokens - cacheWriteTokens, 0)"]
    P --> Q["return usage with input_tokens = adjustedInput"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(api): avoid unsafe optional chainin..."](https://github.com/ding113/claude-code-hub/commit/219402a79f6f76ebd52b7325906030f618d42b3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43620446)</sub>

<!-- /greptile_comment -->