### PR TITLE
fix(provider-endpoints): allow disabling scheduled probes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,17 +182,20 @@ ENABLE_SMART_PROBING=false
 PROBE_INTERVAL_MS=30000
 PROBE_TIMEOUT_MS=5000
 
-# Provider Endpoint Probing (always enabled)
-# Probes all enabled endpoints based on dynamic intervals and refreshes endpoint selection ranking.
-# Note: No ENABLE switch, enabled by default; tune via parameters below.
+# Provider Endpoint Probing
+# Scheduled probing is enabled by default and refreshes endpoint selection ranking.
+# Set to false to disable only the background scheduler. Manual probe APIs and request-driven
+# health/circuit-breaker behavior remain available.
+ENDPOINT_PROBE_SCHEDULER_ENABLED=true
 #
 # Dynamic Interval Rules (in priority order):
-# 1. Timeout Override (10s): If endpoint's lastProbeErrorType === "timeout" and not recovered (lastProbeOk !== true)
+# 1. Timeout Override (default 10s): If endpoint's lastProbeErrorType === "timeout" and not recovered (lastProbeOk !== true)
 # 2. Single-Vendor (10min): If vendor has only 1 enabled endpoint
 # 3. Base Interval (default): All other endpoints
 #
-# ENDPOINT_PROBE_INTERVAL_MS controls the base interval. Single-vendor and timeout intervals are fixed.
+# ENDPOINT_PROBE_INTERVAL_MS controls the base interval. Single-vendor interval is fixed.
 ENDPOINT_PROBE_INTERVAL_MS=60000
+ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS=10000
 # When no endpoints are due, scheduler will still poll DB periodically to pick up config changes.
 # Default: min(ENDPOINT_PROBE_INTERVAL_MS, 30000)
 ENDPOINT_PROBE_IDLE_DB_POLL_INTERVAL_MS=30000

--- a/src/lib/provider-endpoints/probe-scheduler.ts
+++ b/src/lib/provider-endpoints/probe-scheduler.ts
@@ -14,11 +14,73 @@ import {
 
 const LOCK_KEY = "locks:endpoint-probe-scheduler";
 
+function warnInvalidEnvironmentVariable(
+  name: string,
+  value: string,
+  defaultValue: boolean | number
+): void {
+  logger.warn("[EndpointProbeScheduler] Invalid environment variable, using default", {
+    name,
+    value,
+    defaultValue,
+  });
+}
+
+function parseBooleanWithDefault(
+  value: string | undefined,
+  fallback: boolean,
+  name: string
+): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  switch (value) {
+    case "true":
+    case "1":
+      return true;
+    case "false":
+    case "0":
+      return false;
+    default:
+      warnInvalidEnvironmentVariable(name, value, fallback);
+      return fallback;
+  }
+}
+
+function parsePositiveIntWithDefault(
+  value: string | undefined,
+  fallback: number,
+  name: string
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    warnInvalidEnvironmentVariable(name, value, fallback);
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    warnInvalidEnvironmentVariable(name, value, fallback);
+    return fallback;
+  }
+
+  return parsed;
+}
+
 function parseIntWithDefault(value: string | undefined, fallback: number): number {
   const n = value ? Number.parseInt(value, 10) : Number.NaN;
   return Number.isFinite(n) ? n : fallback;
 }
 
+const SCHEDULER_ENABLED = parseBooleanWithDefault(
+  process.env.ENDPOINT_PROBE_SCHEDULER_ENABLED,
+  true,
+  "ENDPOINT_PROBE_SCHEDULER_ENABLED"
+);
 // Base interval (default 60s)
 const BASE_INTERVAL_MS = Math.max(
   1,
@@ -26,8 +88,12 @@ const BASE_INTERVAL_MS = Math.max(
 );
 // Single-vendor interval (10 minutes)
 const SINGLE_VENDOR_INTERVAL_MS = 600_000;
-// Timeout override interval (10 seconds)
-const TIMEOUT_OVERRIDE_INTERVAL_MS = 10_000;
+// Timeout override interval (default 10 seconds)
+const TIMEOUT_OVERRIDE_INTERVAL_MS = parsePositiveIntWithDefault(
+  process.env.ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS,
+  10_000,
+  "ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS"
+);
 // Scheduler tick interval - use shortest possible interval to support timeout override
 const TICK_INTERVAL_MS = Math.min(BASE_INTERVAL_MS, TIMEOUT_OVERRIDE_INTERVAL_MS);
 // Max idle DB polling interval (bounded by base interval)
@@ -325,6 +391,13 @@ async function runProbeCycle(): Promise<void> {
 }
 
 export function startEndpointProbeScheduler(): void {
+  if (!SCHEDULER_ENABLED) {
+    logger.info("[EndpointProbeScheduler] Disabled by configuration", {
+      name: "ENDPOINT_PROBE_SCHEDULER_ENABLED",
+    });
+    return;
+  }
+
   if (schedulerState.__CCH_ENDPOINT_PROBE_SCHEDULER_STARTED__) {
     return;
   }
@@ -372,6 +445,7 @@ export function stopEndpointProbeScheduler(): void {
 }
 
 export function getEndpointProbeSchedulerStatus(): {
+  enabled: boolean;
   started: boolean;
   running: boolean;
   baseIntervalMs: number;
@@ -385,6 +459,7 @@ export function getEndpointProbeSchedulerStatus(): {
   lockTtlMs: number;
 } {
   return {
+    enabled: SCHEDULER_ENABLED,
     started: schedulerState.__CCH_ENDPOINT_PROBE_SCHEDULER_STARTED__ === true,
     running: schedulerState.__CCH_ENDPOINT_PROBE_SCHEDULER_RUNNING__ === true,
     baseIntervalMs: BASE_INTERVAL_MS,

--- a/tests/unit/lib/provider-endpoints/probe-scheduler.test.ts
+++ b/tests/unit/lib/provider-endpoints/probe-scheduler.test.ts
@@ -49,6 +49,15 @@ let renewLeaderLockMock: ReturnType<typeof vi.fn>;
 let releaseLeaderLockMock: ReturnType<typeof vi.fn>;
 let findEnabledEndpointsMock: ReturnType<typeof vi.fn>;
 let probeByEndpointMock: ReturnType<typeof vi.fn>;
+const loggerInfoMock = vi.fn();
+const loggerWarnMock = vi.fn();
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: loggerInfoMock,
+    warn: loggerWarnMock,
+  },
+}));
 
 vi.mock("@/lib/provider-endpoints/leader-lock", () => ({
   acquireLeaderLock: (...args: unknown[]) => acquireLeaderLockMock(...args),
@@ -70,6 +79,131 @@ describe("provider-endpoints: probe scheduler", () => {
     vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe("environment configuration", () => {
+    test("uses backward-compatible defaults when variables are unset", async () => {
+      vi.resetModules();
+      vi.stubEnv("ENDPOINT_PROBE_SCHEDULER_ENABLED", undefined);
+      vi.stubEnv("ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS", undefined);
+
+      const { getEndpointProbeSchedulerStatus } = await import(
+        "@/lib/provider-endpoints/probe-scheduler"
+      );
+
+      expect(getEndpointProbeSchedulerStatus()).toEqual(
+        expect.objectContaining({
+          enabled: true,
+          timeoutOverrideIntervalMs: 10_000,
+        })
+      );
+      expect(loggerWarnMock).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      { value: "true", expected: true },
+      { value: "1", expected: true },
+      { value: "false", expected: false },
+      { value: "0", expected: false },
+    ])("parses ENDPOINT_PROBE_SCHEDULER_ENABLED=$value", async ({ value, expected }) => {
+      vi.resetModules();
+      vi.stubEnv("ENDPOINT_PROBE_SCHEDULER_ENABLED", value);
+      vi.stubEnv("ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS", undefined);
+
+      const { getEndpointProbeSchedulerStatus } = await import(
+        "@/lib/provider-endpoints/probe-scheduler"
+      );
+
+      expect(getEndpointProbeSchedulerStatus().enabled).toBe(expected);
+      expect(loggerWarnMock).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      "enabled",
+      "TRUE",
+      " false ",
+    ])("invalid scheduler switch %s warns and falls back to enabled", async (value) => {
+      vi.resetModules();
+      vi.stubEnv("ENDPOINT_PROBE_SCHEDULER_ENABLED", value);
+      vi.stubEnv("ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS", undefined);
+
+      const { getEndpointProbeSchedulerStatus } = await import(
+        "@/lib/provider-endpoints/probe-scheduler"
+      );
+
+      expect(getEndpointProbeSchedulerStatus().enabled).toBe(true);
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        "[EndpointProbeScheduler] Invalid environment variable, using default",
+        {
+          name: "ENDPOINT_PROBE_SCHEDULER_ENABLED",
+          value,
+          defaultValue: true,
+        }
+      );
+    });
+
+    test.each([
+      "10000ms",
+      "0",
+      "-1",
+      "1.5",
+    ])("invalid timeout retry interval %s warns and falls back to 10000", async (value) => {
+      vi.resetModules();
+      vi.stubEnv("ENDPOINT_PROBE_SCHEDULER_ENABLED", undefined);
+      vi.stubEnv("ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS", value);
+
+      const { getEndpointProbeSchedulerStatus } = await import(
+        "@/lib/provider-endpoints/probe-scheduler"
+      );
+
+      expect(getEndpointProbeSchedulerStatus().timeoutOverrideIntervalMs).toBe(10_000);
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        "[EndpointProbeScheduler] Invalid environment variable, using default",
+        {
+          name: "ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS",
+          value,
+          defaultValue: 10_000,
+        }
+      );
+    });
+
+    test("disabled scheduler does not create a timer, acquire a lock, or query endpoints", async () => {
+      vi.resetModules();
+      vi.stubEnv("ENDPOINT_PROBE_SCHEDULER_ENABLED", "false");
+      vi.stubEnv("ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS", undefined);
+
+      acquireLeaderLockMock = vi.fn(async () => null);
+      renewLeaderLockMock = vi.fn(async () => false);
+      releaseLeaderLockMock = vi.fn(async () => {});
+      findEnabledEndpointsMock = vi.fn(async () => [makeEndpoint(1)]);
+      probeByEndpointMock = vi.fn(async () => makeOkResult());
+      const setIntervalMock = vi.fn();
+      vi.stubGlobal("setInterval", setIntervalMock);
+
+      const { getEndpointProbeSchedulerStatus, startEndpointProbeScheduler } = await import(
+        "@/lib/provider-endpoints/probe-scheduler"
+      );
+
+      startEndpointProbeScheduler();
+      await flushMicrotasks();
+
+      expect(getEndpointProbeSchedulerStatus()).toEqual(
+        expect.objectContaining({
+          enabled: false,
+          started: false,
+          running: false,
+        })
+      );
+      expect(setIntervalMock).not.toHaveBeenCalled();
+      expect(acquireLeaderLockMock).not.toHaveBeenCalled();
+      expect(findEnabledEndpointsMock).not.toHaveBeenCalled();
+      expect(probeByEndpointMock).not.toHaveBeenCalled();
+      expect(loggerInfoMock).toHaveBeenCalledWith(
+        "[EndpointProbeScheduler] Disabled by configuration",
+        { name: "ENDPOINT_PROBE_SCHEDULER_ENABLED" }
+      );
+    });
   });
 
   test("not leader: scheduled probing does nothing", async () => {
@@ -315,6 +449,69 @@ describe("provider-endpoints: probe scheduler", () => {
       // Only timeout endpoint should be probed
       expect(probeByEndpointMock).toHaveBeenCalledTimes(1);
       expect(probeByEndpointMock.mock.calls[0][0].endpoint.id).toBe(1);
+
+      stopEndpointProbeScheduler();
+    });
+
+    test.each([
+      {
+        scenario: "before the configured threshold",
+        now: "2024-01-01T12:00:15Z",
+        expectedProbeCount: 0,
+      },
+      {
+        scenario: "at the configured threshold",
+        now: "2024-01-01T12:00:30Z",
+        expectedProbeCount: 1,
+      },
+    ])("custom timeout retry interval $scenario", async ({ now, expectedProbeCount }) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(now));
+
+      vi.resetModules();
+      vi.stubEnv("ENDPOINT_PROBE_INTERVAL_MS", "60000");
+      vi.stubEnv("ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS", "30000");
+      vi.stubEnv("ENDPOINT_PROBE_CYCLE_JITTER_MS", "0");
+
+      acquireLeaderLockMock = vi.fn(async () => ({
+        key: "locks:endpoint-probe-scheduler",
+        lockId: "test",
+        lockType: "memory" as const,
+      }));
+      renewLeaderLockMock = vi.fn(async () => true);
+      releaseLeaderLockMock = vi.fn(async () => {});
+
+      const timeoutEndpoint = makeEndpoint(1, {
+        vendorId: 1,
+        lastProbedAt: new Date("2024-01-01T12:00:00Z"),
+        lastProbeOk: false,
+        lastProbeErrorType: "timeout",
+      });
+      const normalEndpoint = makeEndpoint(2, {
+        vendorId: 1,
+        lastProbedAt: new Date("2024-01-01T12:00:00Z"),
+        lastProbeOk: true,
+      });
+
+      findEnabledEndpointsMock = vi.fn(async () => [timeoutEndpoint, normalEndpoint]);
+      probeByEndpointMock = vi.fn(async () => makeOkResult());
+
+      const {
+        getEndpointProbeSchedulerStatus,
+        startEndpointProbeScheduler,
+        stopEndpointProbeScheduler,
+      } = await import("@/lib/provider-endpoints/probe-scheduler");
+
+      expect(getEndpointProbeSchedulerStatus().timeoutOverrideIntervalMs).toBe(30_000);
+
+      startEndpointProbeScheduler();
+      await flushMicrotasks();
+
+      expect(findEnabledEndpointsMock).toHaveBeenCalledTimes(1);
+      expect(probeByEndpointMock).toHaveBeenCalledTimes(expectedProbeCount);
+      if (expectedProbeCount === 1) {
+        expect(probeByEndpointMock.mock.calls[0][0].endpoint.id).toBe(1);
+      }
 
       stopEndpointProbeScheduler();
     });

--- a/tests/unit/lib/provider-endpoints/probe.test.ts
+++ b/tests/unit/lib/provider-endpoints/probe.test.ts
@@ -36,6 +36,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.useRealTimers();
   delete process.env.ENDPOINT_PROBE_METHOD;
+  delete process.env.ENDPOINT_PROBE_SCHEDULER_ENABLED;
 });
 
 describe("provider-endpoints: probe", () => {
@@ -268,8 +269,9 @@ describe("provider-endpoints: probe", () => {
     expect(recordFailureMock).not.toHaveBeenCalled();
   });
 
-  test("probeProviderEndpointAndRecord: 记录入库字段包含 source/ok/statusCode/latency/probedAt", async () => {
+  test("probeProviderEndpointAndRecord: scheduler 关闭时 manual 探测仍正常入库", async () => {
     process.env.ENDPOINT_PROBE_METHOD = "HEAD";
+    process.env.ENDPOINT_PROBE_SCHEDULER_ENABLED = "false";
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
 


### PR DESCRIPTION
## Summary

Adds a global switch (`ENDPOINT_PROBE_SCHEDULER_ENABLED`) to disable the background endpoint probe scheduler, and makes the previously-hardcoded 10s timeout-retry interval configurable (`ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS`). Both default to current behavior, so this change is fully backward-compatible.

## Problem

The endpoint probe scheduler currently starts unconditionally (from `src/instrumentation.ts`) with no global off switch. In deployments with many endpoints (e.g. 100+ single-vendor endpoints), the scheduler keeps probing and writing to the probe-history table even with zero business traffic, competing for DB connections and contributing to the `Something went wrong!` / `CONNECT_TIMEOUT postgres:5432` errors reported under load.

Separately, the 10s timeout-retry interval was a hardcoded constant, so endpoints in the timeout-retry category could not be tuned via environment variables.

**Related Issues:**
- Partially addresses #1326 — delivers the minimal global switch the issue explicitly accepts as a first step, plus the configurable timeout interval. The full passive mode envisioned there (business-request-driven probe-health updates, exponential-backoff recovery probing, history sampling) is **not** implemented and remains open.
- Related to #802 — both stem from the dynamic interval system: fixed single-vendor / timeout intervals bypassed `ENDPOINT_PROBE_INTERVAL_MS`. This PR makes the timeout interval tunable; the single-vendor interval remains fixed.
- Related to #660 — predecessor request to disable / tune endpoint health checks.

## Solution

- The guard lives **inside** `startEndpointProbeScheduler()`: when `ENDPOINT_PROBE_SCHEDULER_ENABLED=false`, it logs `"Disabled by configuration"` and returns early — no timer, no leader lock, no endpoint query. Existing call sites are unchanged.
- Added strict env parsers (`parseBooleanWithDefault`, `parsePositiveIntWithDefault`) that warn and fall back to the default on invalid input, rather than silently coercing.
- `getEndpointProbeSchedulerStatus()` now exposes an `enabled` field so the active mode is observable.
- Manual probe APIs and request-driven circuit-breaker behavior are untouched and remain available when the scheduler is off — real traffic still drives circuit-breaker failover, matching #1326's expected behavior.

## Changes

### Core Changes
- `src/lib/provider-endpoints/probe-scheduler.ts`: new `SCHEDULER_ENABLED` switch with early-return guard; `TIMEOUT_OVERRIDE_INTERVAL_MS` now read from `ENDPOINT_PROBE_TIMEOUT_RETRY_INTERVAL_MS`; validated env parsers with warn-on-invalid; status API gains `enabled`.

### Supporting Changes
- `.env.example`: documented both new variables and refreshed the surrounding comments.
- `tests/unit/lib/provider-endpoints/probe-scheduler.test.ts` (+197): env-parsing defaults / truthy / falsy / invalid-warning cases, disabled-scheduler no-op verification, custom timeout-interval probing behavior.
- `tests/unit/lib/provider-endpoints/probe.test.ts`: regression ensuring manual probe still records to history when the scheduler is disabled.

## Breaking Changes

None. Both new variables default to the previous behavior (`true` and `10000ms`). The scheduler status endpoint gains an additive `enabled` field.

## Testing

### Automated Tests
- [x] Unit tests added — env config parsing, disabled-scheduler no-op, custom timeout interval
- [x] Regression: manual probe still records when scheduler is disabled

### Manual Testing
1. Set `ENDPOINT_PROBE_SCHEDULER_ENABLED=false` and start the app.
2. Confirm the startup log shows `[EndpointProbeScheduler] Disabled by configuration`.
3. Confirm no `source=scheduled` probe records appear in the history table while idle.
4. Trigger a manual probe via the management API — confirm it still records.
5. Confirm normal proxy traffic still drives circuit-breaker failover.

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] Documentation updated (`.env.example`)

---
*Description enhanced by Claude AI*