### PR TITLE
feat: document MiniMax provider setup

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -214,6 +214,8 @@ Once started:
 - **API Docs (Scalar UI)**: `http://localhost:23000/api/actions/scalar`
 - **API Docs (Swagger UI)**: `http://localhost:23000/api/actions/docs`
 
+For a dual-region, dual-protocol provider setup, see the [MiniMax provider guide](docs/providers/minimax.md).
+
 > 💡 **Tip**: To change the port, edit the `ports` section in `docker-compose.yml`.
 
 ## 🖼️ Screenshots

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -1,0 +1,52 @@
+# MiniMax Provider Guide
+
+Claude Code Hub can route MiniMax models through its existing Anthropic-compatible and OpenAI-compatible provider types. Create separate provider entries for each protocol and region so that routing and failover remain explicit.
+
+## Endpoint Matrix
+
+| Region | OpenAI-compatible base URL | Anthropic-compatible base URL |
+| --- | --- | --- |
+| Global | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+| China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
+Use the URLs exactly as shown. The OpenAI-compatible URL includes `/v1`. The Anthropic-compatible URL ends at `/anthropic`; do not append `/v1`. Claude Code Hub appends the request path, including `/v1/messages`, when forwarding an Anthropic request.
+
+Official documentation:
+
+- Global: https://platform.minimax.io/docs/api-reference/api-overview
+- China: https://platform.minimaxi.com/docs/api-reference/api-overview
+
+## Provider Entries
+
+Create one `claude` provider entry and one `openai-compatible` provider entry for each region. Set the provider URL to the matching value from the endpoint matrix and set the provider's allowed model list to the exact model IDs below.
+
+Do not reuse an OpenAI-compatible URL for an Anthropic provider entry or an Anthropic-compatible URL for an OpenAI-compatible entry. Keep the API key in the provider secret field and never place it in documentation or model redirect rules.
+
+## Model Catalog
+
+Prices are in USD per one million tokens.
+
+### MiniMax-M3
+
+- Context window: `1,000,000` tokens
+- Input modalities: text, image, and video
+- Thinking: adaptive or disabled
+- Standard tier, up to `512,000` input tokens: input `$0.30`, output `$1.20`, cache read `$0.06`
+- Standard tier, above `512,000` input tokens: input `$0.60`, output `$2.40`, cache read `$0.12`
+- Priority tier, up to `512,000` input tokens: input `$0.45`, output `$1.80`, cache read `$0.09`
+- Priority tier, above `512,000` input tokens: input `$0.90`, output `$3.60`, cache read `$0.18`
+- Cache write pricing: not specified
+
+### MiniMax-M2.7
+
+- Context window: `204,800` tokens
+- Input modalities: text
+- Thinking: always on
+- Input: `$0.30`
+- Output: `$1.20`
+- Cache read: `$0.06`
+- Cache write: `$0.375`
+
+## Request Routing
+
+Use `MiniMax-M3` or `MiniMax-M2.7` as the requested model ID. If the provider's allowed model list is configured, use exact-match entries for both IDs and keep both models available for routing. Existing model redirect rules can still map an application-specific name to either target model without changing the upstream provider URL.

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -31,10 +31,9 @@ Prices are in USD per one million tokens.
 - Context window: `1,000,000` tokens
 - Input modalities: text, image, and video
 - Thinking: adaptive or disabled
-- Standard tier, up to `512,000` input tokens: input `$0.30`, output `$1.20`, cache read `$0.06`
-- Standard tier, above `512,000` input tokens: input `$0.60`, output `$2.40`, cache read `$0.12`
-- Priority tier, up to `512,000` input tokens: input `$0.45`, output `$1.80`, cache read `$0.09`
-- Priority tier, above `512,000` input tokens: input `$0.90`, output `$3.60`, cache read `$0.18`
+- Input: `$0.60`
+- Output: `$2.40`
+- Cache read: `$0.12`
 - Cache write pricing: not specified
 
 ### MiniMax-M2.7

--- a/src/lib/model-vendor-icons.test.ts
+++ b/src/lib/model-vendor-icons.test.ts
@@ -19,6 +19,8 @@ describe("getModelVendor", () => {
     { modelId: "doubao-pro-32k", expectedVendor: "bytedance" },
     { modelId: "glm-4-plus", expectedVendor: "zhipuai" },
     { modelId: "kimi-k2", expectedVendor: "moonshotai" },
+    { modelId: "MiniMax-M3", expectedVendor: "minimax" },
+    { modelId: "MiniMax-M2.7", expectedVendor: "minimax" },
     { modelId: "yi-lightning", expectedVendor: "01-ai" },
     { modelId: "hunyuan-pro", expectedVendor: "tencent" },
     { modelId: "ernie-4.0-8k", expectedVendor: "baidu" },

--- a/src/lib/model-vendor/vendor-inference.test.ts
+++ b/src/lib/model-vendor/vendor-inference.test.ts
@@ -45,6 +45,8 @@ describe("inferVendorFromModelName", () => {
     { modelId: "glm-4-plus", expected: "zhipuai" },
     { modelId: "minimax-pro", expected: "minimax" },
     { modelId: "abab-6.5", expected: "minimax" },
+    { modelId: "MiniMax-M3", expected: "minimax" },
+    { modelId: "MiniMax-M2.7", expected: "minimax" },
     { modelId: "kimi-k2", expected: "moonshotai" },
     { modelId: "moonshot-v1-8k", expected: "moonshotai" },
     { modelId: "yi-lightning", expected: "01-ai" },

--- a/tests/unit/app/v1/url.test.ts
+++ b/tests/unit/app/v1/url.test.ts
@@ -16,6 +16,35 @@ function expectBuiltUrl(baseUrl: string, requestPath: string, expectedUrl: strin
 }
 
 describe("buildProxyUrl", () => {
+  test("preserves regional MiniMax protocol base paths", () => {
+    const cases = [
+      {
+        baseUrl: "https://api.minimax.io/v1",
+        requestPath: "/v1/chat/completions",
+        expectedUrl: "https://api.minimax.io/v1/chat/completions",
+      },
+      {
+        baseUrl: "https://api.minimaxi.com/v1",
+        requestPath: "/v1/chat/completions",
+        expectedUrl: "https://api.minimaxi.com/v1/chat/completions",
+      },
+      {
+        baseUrl: "https://api.minimax.io/anthropic",
+        requestPath: "/v1/messages",
+        expectedUrl: "https://api.minimax.io/anthropic/v1/messages",
+      },
+      {
+        baseUrl: "https://api.minimaxi.com/anthropic",
+        requestPath: "/v1/messages",
+        expectedUrl: "https://api.minimaxi.com/anthropic/v1/messages",
+      },
+    ];
+
+    for (const { baseUrl, requestPath, expectedUrl } of cases) {
+      expectBuiltUrl(baseUrl, requestPath, expectedUrl);
+    }
+  });
+
   test("标准拼接：baseUrl 无路径时使用 requestPath + search", () => {
     expectBuiltUrl(
       "https://api.example.com",


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry.

## Summary
Adds comprehensive documentation for configuring MiniMax models (MiniMax-M3 and MiniMax-M2.7) through the repository's existing provider types, including regional endpoint support for both Global and China regions.

## Problem
**Related Issues:**
- Related to #1013 - Provides setup documentation for MiniMax provider configuration

MiniMax offers dual-region, dual-protocol endpoints that need explicit configuration guidance. Users need to understand:
- How to configure separate provider entries for each region and protocol
- Exact endpoint URLs and model IDs
- Pricing tiers and context window limits
- Multimodal capabilities and thinking settings

## Solution
Created a new provider documentation structure under `docs/providers/` with a comprehensive MiniMax setup guide that covers:
- Endpoint matrix for both Global and China regions
- OpenAI-compatible and Anthropic-compatible protocol URLs
- Complete model catalog with pricing, context limits, and capabilities
- Provider entry configuration guidelines
- Request routing instructions

## Changes

### Documentation
- **README.en.md**: Added link to MiniMax provider guide
- **docs/providers/minimax.md**: New comprehensive guide with endpoint matrix, model catalog, and configuration instructions

### Test Coverage
Added regression tests for MiniMax models (MiniMax-M3, MiniMax-M2.7):
- **src/lib/model-vendor-icons.test.ts**: Vendor icon inference tests
- **src/lib/model-vendor/vendor-inference.test.ts**: Vendor inference from model name tests
- **tests/unit/app/v1/url.test.ts**: Regional endpoint URL routing tests covering all four endpoint combinations (Global/China x OpenAI/Anthropic protocols)

## Testing

### Automated Tests
- Focused Vitest passes: `bunx vitest run tests/unit/app/v1/url.test.ts src/lib/model-vendor/vendor-inference.test.ts src/lib/model-vendor-icons.test.ts`
- Changed-file Biome check passes: `bunx biome check tests/unit/app/v1/url.test.ts src/lib/model-vendor/vendor-inference.test.ts src/lib/model-vendor-icons.test.ts`
- TypeScript compilation passes: `bun run typecheck`
- Full lint reports pre-existing repository diagnostics outside this change: `bun run lint`

### Manual Testing
Documentation review:
1. Verify endpoint URLs match official MiniMax documentation
2. Confirm model IDs, pricing, and capabilities are accurate
3. Check that configuration instructions are clear and complete

## Notes
- This PR creates a new documentation structure: `docs/providers/` directory for provider-specific guides
- No code changes to runtime logic - purely documentation and test coverage additions
- Preserves existing provider implementation; documents how to use existing capabilities

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [x] Documentation added
- [x] No breaking changes

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds documentation and tests for the MiniMax provider (models `MiniMax-M3` and `MiniMax-M2.7`), covering dual-region (Global/China) and dual-protocol (OpenAI-compatible/Anthropic-compatible) endpoint configuration. No runtime logic is changed.

- **`docs/providers/minimax.md`**: New guide with endpoint matrix, model catalog (pricing, context window, modalities), and provider entry instructions. Provider type names (`claude`, `openai-compatible`) correctly match the codebase.
- **`tests/unit/app/v1/url.test.ts`**: Four new cases confirm existing `buildProxyUrl` routing handles both the `/v1` (version-root) and `/anthropic` (non-version prefix) base URL shapes correctly.
- **Vendor inference / icon tests**: Two new parametrised cases in each file verify that `MiniMax-M3` and `MiniMax-M2.7` resolve to the `\"minimax\"` vendor via the existing `/minimax|\\babab/` keyword rule.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — documentation and tests only, no runtime logic is touched.

All changes are documentation and tests. The new test cases exercise existing `buildProxyUrl` paths that are already well-covered, vendor inference tests match the existing keyword rule correctly, and the documented provider type names (`claude`, `openai-compatible`) align with what the codebase actually uses.

**Files Needing Attention:** No files require special attention; the README link placement is a minor style point.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.en.md | Adds one-line link to new MiniMax guide; link placement sits inside the "Once started" server-URL list rather than a configuration section. |
| docs/providers/minimax.md | New documentation-only file with endpoint matrix, model catalog, and provider entry guidance; content is well-structured and provider type names match the codebase (`claude`, `openai-compatible`). |
| tests/unit/app/v1/url.test.ts | Adds four MiniMax endpoint URL routing cases exercising existing `buildProxyUrl` logic; all expected outputs are consistent with the function's path-deduplication and version-root behaviour. |
| src/lib/model-vendor/vendor-inference.test.ts | Adds `MiniMax-M3` and `MiniMax-M2.7` inference test cases; both IDs lower-case to strings matched by the existing `/minimax|\babab/` keyword rule. |
| src/lib/model-vendor-icons.test.ts | Adds vendor-icon test cases for `MiniMax-M3` and `MiniMax-M2.7`; consistent with vendor-inference additions and follows the existing `it.each` parametrised pattern in the file. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{Protocol?}
    B -->|OpenAI-compatible| C{Region?}
    B -->|Anthropic-compatible| D{Region?}

    C -->|Global| E["Provider: openai-compatible\nBase URL: api.minimax.io/v1\nResult: /v1/chat/completions"]
    C -->|China| F["Provider: openai-compatible\nBase URL: api.minimaxi.com/v1\nResult: /v1/chat/completions"]

    D -->|Global| G["Provider: claude\nBase URL: api.minimax.io/anthropic\nResult: /anthropic/v1/messages"]
    D -->|China| H["Provider: claude\nBase URL: api.minimaxi.com/anthropic\nResult: /anthropic/v1/messages"]

    E --> I[buildProxyUrl: version-root branch]
    F --> I
    G --> J[buildProxyUrl: standard concat]
    H --> J
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: correct MiniMax M3 pricing"](https://github.com/ding113/claude-code-hub/commit/23d41fe97f02836961bfbb4dc49d5053ec567320) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44389238)</sub>

<!-- /greptile_comment -->