### PR TITLE
fix(models): add Codex manifest fallback

### DIFF
--- a/src/app/v1/_lib/models/available-models.ts
+++ b/src/app/v1/_lib/models/available-models.ts
@@ -547,7 +547,7 @@ export async function handleAvailableModels(c: Context): Promise<Response> {
   try {
     const { user, key } = await authenticateRequest(c);
 
-    if (c.req.query("client_version")?.trim()) {
+    if (c.req.path === "/v1/models" && c.req.query("client_version")?.trim()) {
       c.header("ETag", CODEX_MODELS_MANIFEST_ETAG);
       if (c.req.header("if-none-match") === CODEX_MODELS_MANIFEST_ETAG) {
         return c.body(null, 304);

--- a/src/app/v1/_lib/models/available-models.ts
+++ b/src/app/v1/_lib/models/available-models.ts
@@ -557,10 +557,12 @@ export async function handleAvailableModels(c: Context): Promise<Response> {
   try {
     const { user, key } = await authenticateRequest(c);
     const responseFormat = detectResponseFormat(c);
+    const clientFormatOverride = detectClientFormatOverride(c);
 
     if (
       c.req.path === "/v1/models" &&
       responseFormat === "openai" &&
+      clientFormatOverride === null &&
       c.req.query("client_version")?.trim()
     ) {
       c.header("ETag", CODEX_MODELS_MANIFEST_ETAG);
@@ -571,7 +573,6 @@ export async function handleAvailableModels(c: Context): Promise<Response> {
       return c.json({ models: [] });
     }
 
-    const clientFormatOverride = detectClientFormatOverride(c);
     const clientFormat = clientFormatOverride || mapResponseFormatToClientFormat(responseFormat);
 
     logger.debug("[AvailableModels] Request received", {

--- a/src/app/v1/_lib/models/available-models.ts
+++ b/src/app/v1/_lib/models/available-models.ts
@@ -556,8 +556,13 @@ export const handleOpenAICompatibleModels = createFixedProviderTypesModelsHandle
 export async function handleAvailableModels(c: Context): Promise<Response> {
   try {
     const { user, key } = await authenticateRequest(c);
+    const responseFormat = detectResponseFormat(c);
 
-    if (c.req.path === "/v1/models" && c.req.query("client_version")?.trim()) {
+    if (
+      c.req.path === "/v1/models" &&
+      responseFormat === "openai" &&
+      c.req.query("client_version")?.trim()
+    ) {
       c.header("ETag", CODEX_MODELS_MANIFEST_ETAG);
       c.header("Cache-Control", "no-cache");
       if (matchesIfNoneMatch(c.req.header("if-none-match"), CODEX_MODELS_MANIFEST_ETAG)) {
@@ -566,7 +571,6 @@ export async function handleAvailableModels(c: Context): Promise<Response> {
       return c.json({ models: [] });
     }
 
-    const responseFormat = detectResponseFormat(c);
     const clientFormatOverride = detectClientFormatOverride(c);
     const clientFormat = clientFormatOverride || mapResponseFormatToClientFormat(responseFormat);
 

--- a/src/app/v1/_lib/models/available-models.ts
+++ b/src/app/v1/_lib/models/available-models.ts
@@ -32,6 +32,16 @@ const DEFAULT_MODELS_TIMEOUT_MS = 10000;
 /** Codex CLI 使用空远端清单时会回退到内置模型目录。 */
 const CODEX_MODELS_MANIFEST_ETAG = 'W/"cch-codex-bundled-v1"';
 
+function matchesIfNoneMatch(value: string | undefined, etag: string): boolean {
+  if (!value) return false;
+
+  const opaqueTag = etag.replace(/^W\//, "");
+  return value.split(",").some((candidate) => {
+    const normalized = candidate.trim();
+    return normalized === "*" || normalized.replace(/^W\//, "") === opaqueTag;
+  });
+}
+
 /**
  * 获取 provider 的请求超时配置
  */
@@ -549,7 +559,8 @@ export async function handleAvailableModels(c: Context): Promise<Response> {
 
     if (c.req.path === "/v1/models" && c.req.query("client_version")?.trim()) {
       c.header("ETag", CODEX_MODELS_MANIFEST_ETAG);
-      if (c.req.header("if-none-match") === CODEX_MODELS_MANIFEST_ETAG) {
+      c.header("Cache-Control", "no-cache");
+      if (matchesIfNoneMatch(c.req.header("if-none-match"), CODEX_MODELS_MANIFEST_ETAG)) {
         return c.body(null, 304);
       }
       return c.json({ models: [] });

--- a/src/app/v1/_lib/models/available-models.ts
+++ b/src/app/v1/_lib/models/available-models.ts
@@ -29,6 +29,9 @@ export interface FetchedModel {
 /** 模型列表请求的默认超时（毫秒） */
 const DEFAULT_MODELS_TIMEOUT_MS = 10000;
 
+/** Codex CLI 使用空远端清单时会回退到内置模型目录。 */
+const CODEX_MODELS_MANIFEST_ETAG = 'W/"cch-codex-bundled-v1"';
+
 /**
  * 获取 provider 的请求超时配置
  */
@@ -543,6 +546,14 @@ export const handleOpenAICompatibleModels = createFixedProviderTypesModelsHandle
 export async function handleAvailableModels(c: Context): Promise<Response> {
   try {
     const { user, key } = await authenticateRequest(c);
+
+    if (c.req.query("client_version")?.trim()) {
+      c.header("ETag", CODEX_MODELS_MANIFEST_ETAG);
+      if (c.req.header("if-none-match") === CODEX_MODELS_MANIFEST_ETAG) {
+        return c.body(null, 304);
+      }
+      return c.json({ models: [] });
+    }
 
     const responseFormat = detectResponseFormat(c);
     const clientFormatOverride = detectClientFormatOverride(c);

--- a/tests/unit/models/codex-models-manifest-fallback.test.ts
+++ b/tests/unit/models/codex-models-manifest-fallback.test.ts
@@ -81,20 +81,18 @@ describe("Codex models manifest fallback", () => {
     expect(findAllProviders).not.toHaveBeenCalled();
   });
 
-  it.each([
-    CODEX_MODELS_ETAG,
-    `"other", ${CODEX_MODELS_ETAG}`,
-    "*",
-  ])("returns 304 when If-None-Match is %s", async (ifNoneMatch) => {
-    const response = await authenticatedRequest("/v1/models?client_version=0.144.1", {
-      "if-none-match": ifNoneMatch,
-    });
+  it("returns 304 for matching If-None-Match validators", async () => {
+    for (const ifNoneMatch of [CODEX_MODELS_ETAG, `"other", ${CODEX_MODELS_ETAG}`, "*"]) {
+      const response = await authenticatedRequest("/v1/models?client_version=0.144.1", {
+        "if-none-match": ifNoneMatch,
+      });
 
-    expect(response.status).toBe(304);
-    expect(response.headers.get("etag")).toBe(CODEX_MODELS_ETAG);
-    expect(response.headers.get("cache-control")).toBe("no-cache");
-    expect(await response.text()).toBe("");
-    expect(findAllProviders).not.toHaveBeenCalled();
+      expect(response.status).toBe(304);
+      expect(response.headers.get("etag")).toBe(CODEX_MODELS_ETAG);
+      expect(response.headers.get("cache-control")).toBe("no-cache");
+      expect(await response.text()).toBe("");
+      expect(findAllProviders).not.toHaveBeenCalled();
+    }
   });
 
   it("keeps the OpenAI models response for requests without client_version", async () => {

--- a/tests/unit/models/codex-models-manifest-fallback.test.ts
+++ b/tests/unit/models/codex-models-manifest-fallback.test.ts
@@ -123,6 +123,17 @@ describe("Codex models manifest fallback", () => {
     expect(findAllProviders).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps Gemini model discovery for x-goog-api-key requests with client_version", async () => {
+    const response = await authenticatedRequest("/v1/models?client_version=0.144.1", {
+      "x-goog-api-key": "gemini-key",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ models: [] });
+    expect(response.headers.get("etag")).toBeNull();
+    expect(findAllProviders).toHaveBeenCalledTimes(1);
+  });
+
   it("still requires authentication before returning the fallback manifest", async () => {
     const response = await createApp().request("http://localhost/v1/models?client_version=0.144.1");
 

--- a/tests/unit/models/codex-models-manifest-fallback.test.ts
+++ b/tests/unit/models/codex-models-manifest-fallback.test.ts
@@ -1,0 +1,135 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/repository/key", () => ({
+  resolveApiKeyAuthOutcome: vi.fn(),
+}));
+
+vi.mock("@/repository/provider", () => ({
+  findAllProviders: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/proxy-agent", () => ({
+  createProxyAgentForProvider: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/timezone", () => ({
+  resolveSystemTimezone: vi.fn().mockResolvedValue("UTC"),
+}));
+
+vi.mock("@/lib/utils/provider-schedule", () => ({
+  isProviderActiveNow: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("@/app/v1/_lib/proxy/provider-selector", () => ({
+  checkProviderGroupMatch: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("next-intl/server", () => ({
+  getLocale: vi.fn().mockResolvedValue("en"),
+}));
+
+vi.mock("@/lib/utils/error-messages", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils/error-messages")>(
+    "@/lib/utils/error-messages"
+  );
+  return {
+    ...actual,
+    getErrorMessageServer: vi.fn(async (_locale: string, code: string) => code),
+  };
+});
+
+import { handleAvailableModels } from "@/app/v1/_lib/models/available-models";
+import { resolveApiKeyAuthOutcome } from "@/repository/key";
+import { findAllProviders } from "@/repository/provider";
+
+const CODEX_MODELS_ETAG = 'W/"cch-codex-bundled-v1"';
+
+function createApp() {
+  const app = new Hono();
+  app.get("/v1/models", handleAvailableModels);
+  return app;
+}
+
+function authenticatedRequest(path: string, headers?: Record<string, string>) {
+  return createApp().request(`http://localhost${path}`, {
+    headers: {
+      authorization: "Bearer sk-test",
+      ...headers,
+    },
+  });
+}
+
+describe("Codex models manifest fallback", () => {
+  beforeEach(() => {
+    vi.mocked(resolveApiKeyAuthOutcome).mockResolvedValue({
+      ok: true,
+      user: { id: 1, providerGroup: null, isEnabled: true, expiresAt: null },
+      key: { providerGroup: null, name: "test-key" },
+    } as never);
+    vi.mocked(findAllProviders).mockResolvedValue([]);
+  });
+
+  it("returns an empty Codex manifest for a non-empty client_version", async () => {
+    const response = await authenticatedRequest("/v1/models?client_version=0.144.1");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ models: [] });
+    expect(response.headers.get("etag")).toBe(CODEX_MODELS_ETAG);
+    expect(findAllProviders).not.toHaveBeenCalled();
+  });
+
+  it("returns 304 when If-None-Match matches the fallback manifest", async () => {
+    const response = await authenticatedRequest("/v1/models?client_version=0.144.1", {
+      "if-none-match": CODEX_MODELS_ETAG,
+    });
+
+    expect(response.status).toBe(304);
+    expect(response.headers.get("etag")).toBe(CODEX_MODELS_ETAG);
+    expect(await response.text()).toBe("");
+    expect(findAllProviders).not.toHaveBeenCalled();
+  });
+
+  it("keeps the OpenAI models response for requests without client_version", async () => {
+    const response = await authenticatedRequest("/v1/models");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ object: "list", data: [] });
+    expect(response.headers.get("etag")).toBeNull();
+    expect(findAllProviders).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a whitespace-only client_version", async () => {
+    const response = await authenticatedRequest("/v1/models?client_version=%20%20");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ object: "list", data: [] });
+    expect(findAllProviders).toHaveBeenCalledTimes(1);
+  });
+
+  it("still requires authentication before returning the fallback manifest", async () => {
+    const response = await createApp().request("http://localhost/v1/models?client_version=0.144.1");
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: { message: "未提供认证凭据", type: "authentication_error" },
+    });
+    expect(resolveApiKeyAuthOutcome).not.toHaveBeenCalled();
+    expect(findAllProviders).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid API key before returning the fallback manifest", async () => {
+    vi.mocked(resolveApiKeyAuthOutcome).mockResolvedValueOnce({
+      ok: false,
+      reason: "not_found",
+    });
+
+    const response = await authenticatedRequest("/v1/models?client_version=0.144.1");
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: { message: "PROXY_INVALID_API_KEY", type: "invalid_api_key" },
+    });
+    expect(findAllProviders).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/models/codex-models-manifest-fallback.test.ts
+++ b/tests/unit/models/codex-models-manifest-fallback.test.ts
@@ -77,16 +77,22 @@ describe("Codex models manifest fallback", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ models: [] });
     expect(response.headers.get("etag")).toBe(CODEX_MODELS_ETAG);
+    expect(response.headers.get("cache-control")).toBe("no-cache");
     expect(findAllProviders).not.toHaveBeenCalled();
   });
 
-  it("returns 304 when If-None-Match matches the fallback manifest", async () => {
+  it.each([
+    CODEX_MODELS_ETAG,
+    `"other", ${CODEX_MODELS_ETAG}`,
+    "*",
+  ])("returns 304 when If-None-Match is %s", async (ifNoneMatch) => {
     const response = await authenticatedRequest("/v1/models?client_version=0.144.1", {
-      "if-none-match": CODEX_MODELS_ETAG,
+      "if-none-match": ifNoneMatch,
     });
 
     expect(response.status).toBe(304);
     expect(response.headers.get("etag")).toBe(CODEX_MODELS_ETAG);
+    expect(response.headers.get("cache-control")).toBe("no-cache");
     expect(await response.text()).toBe("");
     expect(findAllProviders).not.toHaveBeenCalled();
   });

--- a/tests/unit/models/codex-models-manifest-fallback.test.ts
+++ b/tests/unit/models/codex-models-manifest-fallback.test.ts
@@ -134,6 +134,19 @@ describe("Codex models manifest fallback", () => {
     expect(findAllProviders).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    ["/v1/models?client_version=0.144.1&format=gemini", undefined],
+    ["/v1/models?client_version=0.144.1&api_type=gemini", undefined],
+    ["/v1/models?client_version=0.144.1", { "x-cch-api-type": "gemini" }],
+  ])("keeps explicit model format override for %s", async (path, headers) => {
+    const response = await authenticatedRequest(path, headers);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ object: "list", data: [] });
+    expect(response.headers.get("etag")).toBeNull();
+    expect(findAllProviders).toHaveBeenCalledTimes(1);
+  });
+
   it("still requires authentication before returning the fallback manifest", async () => {
     const response = await createApp().request("http://localhost/v1/models?client_version=0.144.1");
 

--- a/tests/unit/models/codex-models-manifest-fallback.test.ts
+++ b/tests/unit/models/codex-models-manifest-fallback.test.ts
@@ -48,6 +48,7 @@ const CODEX_MODELS_ETAG = 'W/"cch-codex-bundled-v1"';
 function createApp() {
   const app = new Hono();
   app.get("/v1/models", handleAvailableModels);
+  app.get("/v1beta/models", handleAvailableModels);
   return app;
 }
 
@@ -104,6 +105,15 @@ describe("Codex models manifest fallback", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ object: "list", data: [] });
+    expect(findAllProviders).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Gemini model discovery for /v1beta/models with client_version", async () => {
+    const response = await authenticatedRequest("/v1beta/models?client_version=0.144.1");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ models: [] });
+    expect(response.headers.get("etag")).toBeNull();
     expect(findAllProviders).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

- return a Codex-compatible `{"models":[]}` envelope for authenticated `GET /v1/models` requests with a non-empty `client_version`
- add a stable weak ETag, standard `If-None-Match` handling, and `Cache-Control: no-cache`
- preserve the existing OpenAI `{"object":"list","data":[...]}` response for all other model-list requests

## Why

Codex manifest consumers use `client_version` to distinguish their model-catalog request and require a top-level `models` array. CCH currently routes these requests through its OpenAI model aggregator, so strict gateways reject the `{object,data}` response as an invalid manifest.

The empty manifest is intentional. Codex falls back to its bundled model catalog when the remote manifest is empty, retaining the client's complete capability metadata. CCH's aggregated model shape only contains a small subset of that metadata, so synthesizing non-empty entries would be unsafe. See the upstream Codex regression coverage: https://github.com/openai/codex/blob/44918ea10c0f99151c6710411b4322c2f5c96bea/codex-rs/models-manager/src/manager_tests.rs#L592-L608

Authentication remains ahead of the compatibility response, so missing, invalid, disabled, or expired credentials keep their existing `401` behavior.

**Related Issues:** No tracking issue exists for this fallback. Searched open and closed issues/PRs across `codex`, `client_version`, `manifest`, and `/v1/models`; this is a self-contained compatibility fix and does not map to a reported bug.

## Changes

### Core Changes
- `src/app/v1/_lib/models/available-models.ts` (+29/-1) — in `handleAvailableModels`, after `authenticateRequest`, branch only for exact `/v1/models` requests in OpenAI format, without an explicit format override, and with a non-empty `client_version`: set a stable weak `ETag` (`W/"cch-codex-bundled-v1"`) and `Cache-Control: no-cache`, return `304` for matching, multi-value, weak-equivalent, or wildcard `If-None-Match`, otherwise return `{"models":[]}`. Ordinary `/v1/models`, Gemini `/v1beta/models`, `x-goog-api-key`, and explicit format-override requests fall through unchanged to the existing aggregator.

### Supporting Changes
- `tests/unit/models/codex-models-manifest-fallback.test.ts` (+173, new) — covers the empty manifest, ETag/cache headers, exact/list/wildcard validators, unchanged OpenAI and Gemini discovery (including `x-goog-api-key` and explicit format overrides), whitespace-only parameters, and authentication failures.

## Scope

This is deliberately a compatibility fallback only. It does not proxy provider-specific manifests, synthesize capability fields, change `/v1/responses/models`, or alter ordinary OpenAI model discovery.

## Breaking Changes

None. The new branch is purely additive and runs only for exact `/v1/models` requests in OpenAI format, without an explicit format override, when `client_version` is present and non-empty; every other model-list request is unchanged. No schema, migration, or exported-signature changes.

## Testing

### Automated Tests
- [x] Unit tests added (`tests/unit/models/codex-models-manifest-fallback.test.ts`, +173)
- [ ] Integration tests — N/A (single handler branch, fully covered by unit tests)

### Manual Testing
1. `GET /v1/models?client_version=0.144.1` with a valid key → expect `200 {"models":[]}` and `ETag: W/"cch-codex-bundled-v1"`.
2. Repeat with a matching, multi-value, or wildcard `If-None-Match` → expect `304` with an empty body.
3. `GET /v1/models` (no `client_version`) → expect the unchanged OpenAI `{object,data}` response and no `ETag`.
4. `GET /v1beta/models?client_version=0.144.1` → expect unchanged Gemini model discovery.
5. `GET /v1/models?client_version=0.144.1` with `x-goog-api-key` → expect unchanged Gemini model discovery.
6. `GET /v1/models?client_version=0.144.1&format=gemini` (or equivalent header/query override) → expect unchanged explicit provider selection.
7. `GET /v1/models?client_version=0.144.1` with no/invalid credentials → expect `401`, no manifest returned.

### Validation
- `bun run test tests/unit/models/codex-models-manifest-fallback.test.ts tests/unit/proxy/available-models.test.ts tests/unit/models/available-models-auth-outcome.test.ts tests/unit/models/available-models-gemini-key.test.ts` (45 passed)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bunx @biomejs/biome@2.5.4 check src/app/v1/_lib/models/available-models.ts tests/unit/models/codex-models-manifest-fallback.test.ts`

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Tests pass locally
- [ ] Documentation updated (if needed)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a Codex-manifest compatibility branch to `handleAvailableModels`: when a request targets exactly `/v1/models` in OpenAI format (no `x-goog-api-key`, no `/v1beta/` path, no explicit format override) and supplies a non-empty `client_version`, the handler short-circuits to return `{"models":[]}` with a stable weak ETag and `Cache-Control: no-cache` instead of routing through the OpenAI model aggregator. Authentication still runs first, so 401 handling is unaffected.

- **Codex branch gating** (`available-models.ts`): five conditions must all be true — exact path, `responseFormat === "openai"`, no `clientFormatOverride`, non-whitespace `client_version` — before the early return fires; all other requests reach the existing aggregator unchanged.
- **RFC 7232 compliance**: `matchesIfNoneMatch` implements correct weak comparison (strips `W/` from both sides), handles comma-separated validators and wildcards, and attaches ETag/Cache-Control to both the 200 and 304 responses.
- **Test coverage** (`codex-models-manifest-fallback.test.ts`): 8 test cases covering the empty manifest, 304 with exact/multi-value/wildcard validators, Gemini and explicit-override fall-throughs, whitespace `client_version` truncation, and both authentication-failure scenarios.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the new branch is strictly additive, authentication is enforced before it fires, and all existing model-list paths are unchanged.

The Codex branch is guarded by five independent conditions, so the risk of accidental activation is low. The matchesIfNoneMatch helper correctly follows RFC 7232 weak-comparison rules (wildcard, comma-separated, and weak-prefixed ETags all tested). ETag and Cache-Control headers are set before both the 200 and 304 responses. The test suite exercises every documented edge case including authentication failures, Gemini fall-throughs, whitespace client_version, and explicit format overrides. No schema changes, no migration, no exported-signature changes.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/models/available-models.ts | Adds a matchesIfNoneMatch helper and a Codex-manifest early-return branch in handleAvailableModels; authentication still runs first and all existing paths are unchanged. |
| tests/unit/models/codex-models-manifest-fallback.test.ts | New test file covering the empty manifest, ETag/Cache-Control headers, wildcard and multi-value If-None-Match, Gemini and explicit-override fall-throughs, whitespace client_version, and both auth-failure scenarios. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as Codex CLI / OpenAI Client
    participant H as handleAvailableModels
    participant Auth as authenticateRequest
    participant Agg as Model Aggregator

    Client->>H: "GET /v1/models?client_version=0.144.1"
    H->>Auth: authenticateRequest(c)
    Auth-->>H: "{user, key} or throws 401"
    H->>H: "detectResponseFormat -> openai"
    H->>H: "detectClientFormatOverride -> null"
    H->>H: "path===/v1/models and client_version non-empty?"
    alt Codex manifest branch
        H->>H: set ETag + Cache-Control headers
        alt If-None-Match matches
            H-->>Client: 304 Not Modified + ETag + Cache-Control
        else No match
            H-->>Client: 200 models[] + ETag + Cache-Control
        end
    else Normal aggregator path
        H->>Agg: getAvailableModels
        Agg-->>H: models + providerName
        H-->>Client: 200 OpenAI or Gemini or Anthropic shape
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as Codex CLI / OpenAI Client
    participant H as handleAvailableModels
    participant Auth as authenticateRequest
    participant Agg as Model Aggregator

    Client->>H: "GET /v1/models?client_version=0.144.1"
    H->>Auth: authenticateRequest(c)
    Auth-->>H: "{user, key} or throws 401"
    H->>H: "detectResponseFormat -> openai"
    H->>H: "detectClientFormatOverride -> null"
    H->>H: "path===/v1/models and client_version non-empty?"
    alt Codex manifest branch
        H->>H: set ETag + Cache-Control headers
        alt If-None-Match matches
            H-->>Client: 304 Not Modified + ETag + Cache-Control
        else No match
            H-->>Client: 200 models[] + ETag + Cache-Control
        end
    else Normal aggregator path
        H->>Agg: getAvailableModels
        Agg-->>H: models + providerName
        H-->>Client: 200 OpenAI or Gemini or Anthropic shape
    end
```

</a>
</details>

<sub>Reviews (5): Last reviewed commit: ["test(models): stabilize formatter output"](https://github.com/ding113/claude-code-hub/commit/f2eeff3232fd587ef16fcd47546eca98b04da53b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44957114)</sub>

<!-- /greptile_comment -->