### PR TITLE
fix(test): run durable commit callbacks in response handler tests

### DIFF
--- a/tests/integration/proxy-hedge-lifecycle.test.ts
+++ b/tests/integration/proxy-hedge-lifecycle.test.ts
@@ -518,7 +518,8 @@ describe("proxy hedge transport/lifecycle integration (persistence and control-p
           outputTokens: 3,
           providerId: 2,
           statusCode: 200,
-        })
+        }),
+        expect.objectContaining({ onCommitted: expect.any(Function) })
       );
       expect(state.updateMessageRequestDetailsIfUnfinalized).not.toHaveBeenCalled();
 
@@ -615,7 +616,8 @@ describe("proxy hedge transport/lifecycle integration (persistence and control-p
       expect(state.durableTerminal).toHaveBeenCalledOnce();
       expect(state.durableTerminal).toHaveBeenCalledWith(
         MESSAGE.id,
-        expect.objectContaining({ statusCode: 502 })
+        expect.objectContaining({ statusCode: 502 }),
+        expect.objectContaining({ onCommitted: expect.any(Function) })
       );
       expect(agents.release).toHaveBeenCalledOnce();
       expect(agents.pool.getPoolStats().activeRequests).toBe(0);

--- a/tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts
+++ b/tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts
@@ -357,7 +357,12 @@ function setupCommonMocks() {
     updatedAt: new Date(),
   });
   vi.mocked(updateMessageRequestDetails).mockResolvedValue(undefined);
-  vi.mocked(updateMessageRequestDetailsDurably).mockResolvedValue(true);
+  vi.mocked(updateMessageRequestDetailsDurably).mockImplementation(
+    async (_id, details, options) => {
+      await options?.onCommitted?.(details);
+      return true;
+    }
+  );
   vi.mocked(updateMessageRequestDuration).mockResolvedValue(undefined);
   vi.mocked(SessionManager.storeSessionResponse).mockResolvedValue(undefined);
   vi.mocked(SessionManager.clearSessionProvider).mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

- 修正 response handler 单测中的 durable writer mock, 使其执行真实契约里的 `onCommitted` callback
- 更新 Hedge lifecycle 集成测试, 匹配 durable terminal writer 新增的第三个 options 参数
- 恢复当前 `dev` 上 5 个 Unit 失败和 2 个 Integration 失败的测试基线

## Root cause

终态副作用已移动到 durable commit callback 中, 但测试 mock 只返回成功, 没有调用 `onCommitted`. 因此 circuit breaker, session binding 和成功/失败记录相关 spy 始终为 0 次. 两个集成测试也仍按旧的双参数签名断言 durable writer.

## Validation

- `bunx vitest run tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts tests/integration/proxy-hedge-lifecycle.test.ts`: 10/10 passed
- `bun run typecheck`: passed
- `bun run test`: 7023 passed, 13 skipped
- `bun run build`: passed
- changed-file Biome check: passed
- `git diff --check`: passed

## Existing repository-wide checks

`bun run format:check` and `bun run lint` still report the existing repository-wide Biome 2.4.16 baseline outside these two files: 30 format errors and 196 warnings. This PR adds no changed-file Biome finding.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates response-handler tests to follow the durable commit callback contract. The main changes are:

- Runs `onCommitted` from the durable writer mock.
- Checks the durable writer options in hedge success and failure tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after aligning the mock's callback timing with production.

- The updated hedge assertions match the production call shape.
- The unit-test mock awaits a callback that production runs without waiting, which can mask ordering differences.

tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/integration/proxy-hedge-lifecycle.test.ts | Updates hedge lifecycle assertions to require the durable writer's commit callback option. |
| tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts | Runs the durable commit callback, but awaits it unlike the production writer. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/unit/proxy/response-handler-endpoint-circuit-isolation.test.ts:362
**Commit Callback Is Incorrectly Awaited**

The real durable writer invokes `onCommitted` without awaiting it and contains callback failures, but this mock awaits the callback and propagates rejection. An asynchronous callback therefore finishes before the response handler returns in these tests even though it may still be pending in production, which can hide lifecycle-order bugs and makes callback-failure behavior differ from the real writer.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): run durable commit callbacks ..."](https://github.com/ding113/claude-code-hub/commit/fc02ceb96be432294bbc8ef72932c3cf8ac19421) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46420708)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->