### PR TITLE
fix(ui): keep Radix button client-side

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";


### PR DESCRIPTION
## Summary

- mark the shared `Button` wrapper as a Client Component
- keep `@radix-ui/react-slot` out of React Server Component module evaluation
- restore clean Next.js 16.2.11 production builds

## Root cause

A fresh dependency install resolves the current Radix Slot implementation, which creates a React context during module initialization. The shared `Button` wrapper was evaluated as a Server Component, where React's `react-server` export does not provide `createContext`, causing page-data collection to fail with `TypeError: c.createContext is not a function` on nondeterministic dashboard routes.

## Validation

- `bun run test` (781 files passed, 7132 tests passed)
- `bun run typecheck`
- `bun run build` (187/187 static pages)
- `bun run lint`
- `bun run lint:fix`
- `bunx biome check src/components/ui/button.tsx`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a production build failure in Next.js 16.2.11 by adding `"use client"` to the shared `Button` wrapper, preventing `@radix-ui/react-slot`'s `createContext` call from being evaluated inside the React Server Component module graph.

- **One-line diff, correct fix**: marking the component as a client module is the standard Next.js resolution for third-party packages that call `createContext` at module-init time.
- **`buttonVariants` is now client-boundary-coupled**: the pure `cva` helper is exported from the same file, so server components importing it for class generation will now pull in the client runtime — not a problem today, but worth noting if that pattern grows.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a single directive addition with a clear, well-understood root cause, and all 187 static pages build cleanly.

The diff is one line: adding `"use client"` to prevent a Radix Slot `createContext` call from running in the RSC module graph. The fix is minimal, well-validated by the author's build and test runs, and aligns with standard Next.js patterns for third-party UI libraries. The only non-critical observation is that `buttonVariants` now lives behind the client boundary, which could affect future server-side class generation but causes no current defect.

No files require special attention; `src/components/ui/button.tsx` is the sole changed file and the change is minimal.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/components/ui/button.tsx | Added `"use client"` directive to prevent `@radix-ui/react-slot`'s `createContext` call from being evaluated in the React Server Component module graph; otherwise correct and minimal. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Server Component / Page] -->|imports Button| B{Module boundary}
    B -->|before fix - no 'use client'| C[RSC module evaluator\nuses react-server export]
    C --> D["❌ TypeError: c.createContext\nis not a function\n(Radix Slot calls createContext\nat module init)"]
    B -->|after fix - 'use client' present| E[Client Component bundle]
    E --> F["✅ Full React API available\ncreateContext works\nbuild succeeds 187/187 pages"]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/ui/button.tsx`, line 60 ([link](https://github.com/ding113/claude-code-hub/blob/a5dd4c725f8b8f74445c180835942451d64749dd/src/components/ui/button.tsx#L60)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> <a href="#"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/partners/vercel-dark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/partners/vercel.svg?v=1"><img alt="partner" src="https://greptile-static-assets.s3.amazonaws.com/partners/vercel.svg?v=1" align="top"></picture></a> `buttonVariants` co-located with a client boundary

   `buttonVariants` is a pure `cva` helper with no React dependency. Now that this file is a Client Component module, any Server Component that imports `buttonVariants` solely for CSS class generation (e.g. to style an `<a>` or `next/link` element to look like a button) will silently pull the Radix Slot and client runtime into the server bundle. There's no breakage today, but splitting `buttonVariants` into its own file (e.g. `button.variants.ts`) would keep it tree-shakeable from both boundaries if that pattern ever appears.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/ui/button.tsx
   Line: 60

   Comment:
   `buttonVariants` co-located with a client boundary

   `buttonVariants` is a pure `cva` helper with no React dependency. Now that this file is a Client Component module, any Server Component that imports `buttonVariants` solely for CSS class generation (e.g. to style an `<a>` or `next/link` element to look like a button) will silently pull the Radix Slot and client runtime into the server bundle. There's no breakage today, but splitting `buttonVariants` into its own file (e.g. `button.variants.ts`) would keep it tree-shakeable from both boundaries if that pattern ever appears.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/components/ui/button.tsx:60
`buttonVariants` co-located with a client boundary

`buttonVariants` is a pure `cva` helper with no React dependency. Now that this file is a Client Component module, any Server Component that imports `buttonVariants` solely for CSS class generation (e.g. to style an `<a>` or `next/link` element to look like a button) will silently pull the Radix Slot and client runtime into the server bundle. There's no breakage today, but splitting `buttonVariants` into its own file (e.g. `button.variants.ts`) would keep it tree-shakeable from both boundaries if that pattern ever appears.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): keep Radix button client-side"](https://github.com/ding113/claude-code-hub/commit/a5dd4c725f8b8f74445c180835942451d64749dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46471586)</sub>

<!-- /greptile_comment -->