### PR TITLE
fix(proxy): confirm Claude Code on count_tokens without metadata.user_id

### DIFF
--- a/src/app/v1/_lib/proxy/client-detector.ts
+++ b/src/app/v1/_lib/proxy/client-detector.ts
@@ -1,3 +1,4 @@
+import { isCountTokensEndpointPath } from "./endpoint-paths";
 import type { ProxySession } from "./session";
 
 export const CLAUDE_CODE_KEYWORD_PREFIX = "claude-code";
@@ -114,6 +115,24 @@ const ENTRYPOINT_MAP: Record<string, string> = {
   "claude-code-github-action": "claude-code-gh-action",
 };
 
+function resolveRequestPathname(session: ProxySession): string | null {
+  if (typeof session.getEndpoint === "function") {
+    return session.getEndpoint();
+  }
+
+  const pathname = session.requestUrl?.pathname;
+  return typeof pathname === "string" ? pathname : null;
+}
+
+function isCountTokensRequest(session: ProxySession): boolean {
+  if (typeof session.isCountTokensRequest === "function") {
+    return session.isCountTokensRequest();
+  }
+
+  const pathname = resolveRequestPathname(session);
+  return pathname !== null && isCountTokensEndpointPath(pathname);
+}
+
 function confirmClaudeCodeSignals(session: ProxySession): {
   confirmed: boolean;
   signals: string[];
@@ -148,8 +167,18 @@ function confirmClaudeCodeSignals(session: ProxySession): {
     supplementary.push("dangerous-browser-access");
   }
 
+  // count_tokens payloads intentionally omit metadata.user_id (Anthropic API + Claude Code CLI).
+  // Confirm with the 3 header signals so client restrictions do not false-reject these requests.
+  const hasHeaderSignals =
+    signals.includes("x-app-cli") &&
+    signals.includes("ua-prefix") &&
+    signals.includes("betas-present");
+  const confirmed = isCountTokensRequest(session)
+    ? hasHeaderSignals
+    : signals.includes("metadata-user-id") && hasHeaderSignals;
+
   return {
-    confirmed: signals.length === 4,
+    confirmed,
     signals,
     supplementary,
   };

--- a/tests/unit/proxy/client-detector.test.ts
+++ b/tests/unit/proxy/client-detector.test.ts
@@ -24,6 +24,7 @@ type SessionOptions = {
   dangerousBrowserAccess?: string | null;
   anthropicBeta?: string | null;
   metadataUserId?: string | null;
+  pathname?: string;
 };
 
 function createMockSession(options: SessionOptions = {}): ProxySession {
@@ -43,12 +44,19 @@ function createMockSession(options: SessionOptions = {}): ProxySession {
     message.metadata = { user_id: options.metadataUserId };
   }
 
+  const pathname = options.pathname ?? "/v1/messages";
+  const requestUrl = new URL(`https://cch.example.com${pathname}`);
+  const isCountTokensRequest = pathname === "/v1/messages/count_tokens";
+
   return {
     userAgent: options.userAgent ?? null,
     headers,
+    requestUrl,
     request: {
       message,
     },
+    getEndpoint: () => pathname,
+    isCountTokensRequest: () => isCountTokensRequest,
   } as unknown as ProxySession;
 }
 
@@ -85,13 +93,12 @@ describe("client-detector", () => {
       expect(isBuiltinKeyword(pattern)).toBe(true);
     });
 
-    test.each([
-      "gemini-cli",
-      "codex-cli",
-      "custom-pattern",
-    ])("should return false for non-builtin keyword: %s", (pattern) => {
-      expect(isBuiltinKeyword(pattern)).toBe(false);
-    });
+    test.each(["gemini-cli", "codex-cli", "custom-pattern"])(
+      "should return false for non-builtin keyword: %s",
+      (pattern) => {
+        expect(isBuiltinKeyword(pattern)).toBe(false);
+      }
+    );
   });
 
   describe("confirmClaudeCodeSignals via detectClientFull", () => {
@@ -189,6 +196,35 @@ describe("client-detector", () => {
       const result = detectClientFull(session, "claude-code");
       expect(result.hubConfirmed).toBe(false);
       expect(result.signals.length).toBe(3);
+    });
+
+    test("should confirm count_tokens with 3 header signals without metadata.user_id", () => {
+      const session = createMockSession({
+        userAgent: "claude-cli/2.1.220 (external, cli)",
+        xApp: "cli",
+        anthropicBeta:
+          "claude-code-20250219,interleaved-thinking-2025-05-14,context-management-2025-06-27,token-counting-2024-11-01",
+        pathname: "/v1/messages/count_tokens",
+      });
+
+      const result = detectClientFull(session, "claude-code");
+      expect(result.hubConfirmed).toBe(true);
+      expect(result.matched).toBe(true);
+      expect(result.subClient).toBe("claude-code-cli");
+      expect(result.signals).toEqual(["x-app-cli", "ua-prefix", "betas-present"]);
+    });
+
+    test("should still require header signals on count_tokens when metadata.user_id is absent", () => {
+      const session = createMockSession({
+        userAgent: "claude-cli/2.1.220 (external, cli)",
+        xApp: "cli",
+        pathname: "/v1/messages/count_tokens",
+      });
+
+      const result = detectClientFull(session, "claude-code");
+      expect(result.hubConfirmed).toBe(false);
+      expect(result.matched).toBe(false);
+      expect(result.signals).toEqual(["x-app-cli", "ua-prefix"]);
     });
 
     test("should not confirm with 0 strong signals", () => {
@@ -293,6 +329,18 @@ describe("client-detector", () => {
         anthropicBeta: "non-claude-code",
       });
       expect(matchClientPattern(session, "claude-code")).toBe(false);
+    });
+
+    test("should match claude-code on count_tokens without metadata.user_id", () => {
+      const session = createMockSession({
+        userAgent: "claude-cli/2.1.220 (external, cli)",
+        xApp: "cli",
+        anthropicBeta:
+          "claude-code-20250219,interleaved-thinking-2025-05-14,context-management-2025-06-27,token-counting-2024-11-01",
+        pathname: "/v1/messages/count_tokens",
+      });
+      expect(matchClientPattern(session, "claude-code")).toBe(true);
+      expect(matchClientPattern(session, "claude-code-cli")).toBe(true);
     });
   });
 
@@ -567,6 +615,35 @@ describe("client-detector", () => {
         "betas-present",
         "metadata-user-id",
       ]);
+      expect(result.hubConfirmed).toBe(true);
+    });
+
+    test("should allow count_tokens Claude Code CLI when allowlist is claude-code", () => {
+      const session = createMockSession({
+        userAgent: "claude-cli/2.1.220 (external, cli)",
+        xApp: "cli",
+        anthropicBeta: "claude-code-20250219,token-counting-2024-11-01",
+        pathname: "/v1/messages/count_tokens",
+      });
+      const result = isClientAllowedDetailed(session, ["claude-code", "claude-code-cli"], []);
+      expect(result.allowed).toBe(true);
+      expect(result.matchType).toBe("allowed");
+      expect(result.matchedPattern).toBe("claude-code");
+      expect(result.detectedClient).toBe("claude-code-cli");
+      expect(result.hubConfirmed).toBe(true);
+      expect(result.signals).toEqual(["x-app-cli", "ua-prefix", "betas-present"]);
+    });
+
+    test("should reject count_tokens when allowlisted sub-client does not match", () => {
+      const session = createMockSession({
+        userAgent: "claude-cli/2.1.220 (external, cli)",
+        xApp: "cli",
+        anthropicBeta: "claude-code-20250219,token-counting-2024-11-01",
+        pathname: "/v1/messages/count_tokens",
+      });
+      const result = isClientAllowedDetailed(session, ["claude-code-vscode"], []);
+      expect(result.allowed).toBe(false);
+      expect(result.matchType).toBe("allowlist_miss");
       expect(result.hubConfirmed).toBe(true);
     });
 


### PR DESCRIPTION
## Summary

- Fix Claude Code CLI false-rejection on `/v1/messages/count_tokens` when providers use `claude-code` / `claude-code-cli` client allowlists
- `count_tokens` payloads intentionally omit `metadata.user_id`, so `confirmClaudeCodeSignals` never reached 4/4 and providers were filtered as `client_restriction` (503 `no_available_providers`)
- Confirm count_tokens with the same 3 header signals used by `/v1/messages` (`x-app-cli`, `ua-prefix`, `betas-present`); chat endpoints still require `metadata-user-id`

Fixes #1363

## Test plan

- [x] `bunx vitest run tests/unit/proxy/client-detector.test.ts` (104 passed)
- [x] `bun run typecheck`
- [x] biome check on touched files
- [ ] Manual: Claude Code CLI `/v1/messages/count_tokens` against a provider allowlisting `claude-code` no longer returns 503 `client_restriction`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes Claude Code client detection for token-counting requests.
- Recognizes `/v1/messages/count_tokens` using the three available Claude Code header signals when `metadata.user_id` is absent.
- Preserves the four-signal requirement for other endpoints.
- Adds unit coverage for detection, allowlist matching, and sub-client rejection.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The endpoint check uses the existing ProxySession count-tokens classification, relaxes only the unavailable metadata signal for that endpoint, and keeps the prior four-signal behavior elsewhere.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/client-detector.ts | Adds count-tokens-aware Claude Code confirmation while retaining the existing confirmation requirements for other endpoints. |
| tests/unit/proxy/client-detector.test.ts | Extends session mocks with endpoint information and covers count_tokens detection and client-restriction behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(proxy): confirm Claude Code on count..."](https://github.com/ding113/claude-code-hub/commit/e8200922d64cf31c65764799ba3b575d45d1d736) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47529557)</sub>

<!-- /greptile_comment -->