### PR TITLE
feat(logs): show live upstream providers

### DIFF
--- a/src/app/[locale]/dashboard/logs/_components/thinking-effort-display.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/thinking-effort-display.test.tsx
@@ -70,6 +70,7 @@ describe("ThinkingEffortDisplay", () => {
     expect(html).toContain("max");
     expect(html).toContain("reasoningEffort.overridden");
     expect(html).toContain("lucide-arrow-right");
+    expect(html).toContain("relative z-20");
   });
 
   test("显示 Anthropic 请求中的思考强度", () => {

--- a/src/app/[locale]/dashboard/logs/_components/thinking-effort-display.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/thinking-effort-display.tsx
@@ -34,7 +34,7 @@ export function ThinkingEffortDisplay({ specialSettings }: ThinkingEffortDisplay
       <Tooltip delayDuration={250}>
         <TooltipTrigger asChild>
           <span
-            className="inline-flex items-center gap-1 whitespace-nowrap"
+            className="relative z-20 inline-flex items-center gap-1 whitespace-nowrap"
             data-slot="thinking-effort"
           >
             {effortInfo.requestedEffort && (

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-table.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-table.test.tsx
@@ -187,7 +187,7 @@ describe("usage-logs-table thinking effort", () => {
     expect(cells[6]?.textContent).toContain("gpt-5.4");
     expect(cells[7]?.textContent).toContain("low");
     expect(cells[7]?.textContent).toContain("max");
-    expect(cells[7]?.className).toContain("overflow-hidden");
+    expect(cells[7]?.className).toContain("overflow-visible");
   });
 
   test("显示 Anthropic 请求的思考强度", () => {

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx
@@ -317,7 +317,7 @@ export function UsageLogsTable({
                       </TooltipProvider>
                     </TableCell>
                     {hideReasoningEffortColumn ? null : (
-                      <TableCell className="font-mono text-xs w-[84px] max-w-[84px] overflow-hidden">
+                      <TableCell className="relative z-20 w-[84px] max-w-[84px] overflow-visible font-mono text-xs">
                         <ThinkingEffortDisplay specialSettings={log.specialSettings} />
                       </TableCell>
                     )}

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
@@ -279,7 +279,7 @@ describe("virtualized-logs-table thinking effort", () => {
     const effortDisplay = container.querySelector('[data-slot="thinking-effort"]');
     expect(effortDisplay?.textContent).toContain("low");
     expect(effortDisplay?.textContent).toContain("max");
-    expect(effortDisplay?.closest(".overflow-hidden")).not.toBeNull();
+    expect(effortDisplay?.closest(".overflow-visible")).not.toBeNull();
   });
 
   test("显示 Anthropic 请求的思考强度", () => {
@@ -941,6 +941,64 @@ describe("virtualized-logs-table live chain display", () => {
       <VirtualizedLogsTable filters={{}} autoRefreshEnabled={false} />
     );
     expect(html).toContain("text-indigo-500");
+  });
+
+  test("stacks every currently connected racing provider and exposes the full list", () => {
+    setupLiveChainDefaults();
+    mockLogs = [
+      makeLog({
+        id: 1,
+        statusCode: null,
+        providerChain: null,
+        _liveChain: {
+          chain: [],
+          activeProviders: [
+            { id: 1, name: "openai-east-with-a-long-name" },
+            { id: 2, name: "anthropic-west-with-a-long-name" },
+            { id: 3, name: "gemini-central-with-a-long-name" },
+          ],
+          phase: "hedge_racing",
+          updatedAt: Date.now(),
+        },
+      }),
+    ];
+
+    const html = renderToStaticMarkup(
+      <VirtualizedLogsTable filters={{}} autoRefreshEnabled={false} />
+    );
+
+    expect(html).toContain('data-slot="live-provider-stack"');
+    expect(html).toContain("openai-east-with-a-long-name");
+    expect(html).toContain("anthropic-west-with-a-long-name");
+    expect(html).toContain("gemini-central-with-a-long-name");
+    expect(html).toContain('data-slot="live-provider-tooltip"');
+  });
+
+  test("shows only the newly active provider after fallback switches", () => {
+    setupLiveChainDefaults();
+    mockLogs = [
+      makeLog({
+        id: 1,
+        statusCode: null,
+        providerChain: null,
+        _liveChain: {
+          chain: [
+            { id: 1, name: "primary-provider", reason: "retry_failed" },
+            { id: 2, name: "fallback-provider", reason: "initial_selection" },
+          ],
+          activeProviders: [{ id: 2, name: "fallback-provider" }],
+          phase: "provider_selected",
+          updatedAt: Date.now(),
+        },
+      }),
+    ];
+
+    const html = renderToStaticMarkup(
+      <VirtualizedLogsTable filters={{}} autoRefreshEnabled={false} />
+    );
+
+    expect(html).toContain("fallback-provider");
+    expect(html).not.toContain("primary-provider");
   });
 
   test("renders generic in-progress when live chain is empty", () => {

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -97,6 +97,47 @@ function StatusBadgeOnly({ statusCode }: { statusCode: number | null }) {
   );
 }
 
+function LiveProviderStack({ providers }: { providers: Array<{ id: number; name: string }> }) {
+  const visibleProviders = providers.slice(0, 3);
+  const hiddenProviderCount = providers.length - visibleProviders.length;
+
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={250}>
+        <TooltipTrigger asChild>
+          <span
+            className="flex min-w-0 items-center -space-x-2 cursor-help"
+            data-slot="live-provider-stack"
+          >
+            {visibleProviders.map((provider) => (
+              <span
+                key={provider.id}
+                className="relative max-w-[68px] truncate rounded-md border bg-background px-1.5 py-0.5 text-xs text-foreground shadow-sm"
+              >
+                {provider.name}
+              </span>
+            ))}
+            {hiddenProviderCount > 0 && (
+              <span className="relative rounded-md border bg-muted px-1.5 py-0.5 text-xs text-muted-foreground shadow-sm">
+                +{hiddenProviderCount}
+              </span>
+            )}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-[320px]" side="bottom" align="start">
+          <div data-slot="live-provider-tooltip">
+            <ul className="space-y-1 text-xs whitespace-normal break-words">
+              {providers.map((provider) => (
+                <li key={provider.id}>{provider.name}</li>
+              ))}
+            </ul>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 interface VirtualizedLogsTableProps {
   filters: VirtualizedLogsTableFilters;
   currencyCode?: CurrencyCode;
@@ -887,11 +928,21 @@ export function VirtualizedLogsTable({
                           log._liveChain ? (
                             <div className="flex items-center gap-1.5 min-w-0">
                               <Loader2 className="h-3 w-3 animate-spin text-blue-500 shrink-0" />
-                              <span className="text-xs text-muted-foreground truncate">
-                                {log._liveChain.chain.length > 0
-                                  ? log._liveChain.chain[log._liveChain.chain.length - 1].name
-                                  : t("logs.details.inProgress")}
-                              </span>
+                              {log._liveChain.activeProviders ? (
+                                log._liveChain.activeProviders.length > 0 ? (
+                                  <LiveProviderStack providers={log._liveChain.activeProviders} />
+                                ) : (
+                                  <span className="text-xs text-muted-foreground truncate">
+                                    {t("logs.details.inProgress")}
+                                  </span>
+                                )
+                              ) : (
+                                <span className="text-xs text-muted-foreground truncate">
+                                  {log._liveChain.chain.length > 0
+                                    ? log._liveChain.chain[log._liveChain.chain.length - 1].name
+                                    : t("logs.details.inProgress")}
+                                </span>
+                              )}
                               {log._liveChain.phase === "retrying" && (
                                 <Badge
                                   variant="outline"
@@ -1016,7 +1067,7 @@ export function VirtualizedLogsTable({
 
                     {/* Thinking Effort */}
                     {hideReasoningEffortColumn ? null : (
-                      <div className="flex-[0.6] min-w-[64px] overflow-hidden px-1.5 font-mono text-xs">
+                      <div className="relative z-20 flex-[0.6] min-w-[64px] overflow-visible px-1.5 font-mono text-xs">
                         <ThinkingEffortDisplay specialSettings={log.specialSettings} />
                       </div>
                     )}

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -4558,6 +4558,7 @@ export class ProxyForwarder {
         attempt.thresholdTimer = null;
       }
       attempts.delete(attempt);
+      session.removeLiveActiveProvider(attempt.provider.id);
 
       // 竞速输家计费开启：仅标记 + 记录决策链，不取消连接、不释放 agent。
       // 实际的后台 drain 由 runAttempt 的 .then 流程发起（它独占 reader，避免并发读）。
@@ -4855,6 +4856,9 @@ export class ProxyForwarder {
     };
 
     const handleAttemptFailure = async (attempt: StreamingHedgeAttempt, error: Error) => {
+      if (attempt !== winnerAttempt) {
+        session.removeLiveActiveProvider(attempt.provider.id);
+      }
       // 已被标记为计费输家、billing 尚未启动、却在此失败（如首块读取出错 / 赢家已提交）：
       // 此时 abortAttempt 已早退（未取消连接/未释放 agent），由这里兜底清理，避免 reader/agent 泄漏。
       if (
@@ -5344,6 +5348,7 @@ export class ProxyForwarder {
       };
 
       attempts.add(attempt);
+      session.addLiveActiveProvider(provider);
 
       // Record hedge participant launch in decision chain
       // (first provider is already recorded via initial_selection or session_reuse)

--- a/src/app/v1/_lib/proxy/session.ts
+++ b/src/app/v1/_lib/proxy/session.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import { logger } from "@/lib/logger";
 import {
   deleteLiveChain,
+  type LiveProviderSnapshot,
   writeLiveChain,
   writeLiveRoutingTrace,
 } from "@/lib/redis/live-chain-store";
@@ -206,6 +207,8 @@ export class ProxySession {
 
   // 上游决策链（记录尝试的供应商列表）
   private providerChain: ProviderChainItem[];
+  private liveActiveProviders = new Map<number, LiveProviderSnapshot>();
+  private liveActiveProviderCounts = new Map<number, number>();
 
   // Request-level routing observability. Discovery attempts live here rather
   // than providerChain because providerChain is also a billing/retry contract.
@@ -423,6 +426,45 @@ export class ProxySession {
     if (provider) {
       this.providerType = provider.providerType as ProviderType;
     }
+    if (!this.liveActiveProviders) {
+      this.liveActiveProviders = new Map<number, LiveProviderSnapshot>();
+    }
+    if (!this.liveActiveProviderCounts) {
+      this.liveActiveProviderCounts = new Map<number, number>();
+    }
+    this.liveActiveProviders.clear();
+    this.liveActiveProviderCounts.clear();
+    if (provider) {
+      this.liveActiveProviders.set(provider.id, { id: provider.id, name: provider.name });
+      this.liveActiveProviderCounts.set(provider.id, 1);
+    }
+    this.persistLiveChain();
+  }
+
+  addLiveActiveProvider(provider: Pick<Provider, "id" | "name">): void {
+    if (!this.liveActiveProviders) {
+      this.liveActiveProviders = new Map<number, LiveProviderSnapshot>();
+    }
+    if (!this.liveActiveProviderCounts) {
+      this.liveActiveProviderCounts = new Map<number, number>();
+    }
+    this.liveActiveProviders.set(provider.id, { id: provider.id, name: provider.name });
+    this.liveActiveProviderCounts.set(
+      provider.id,
+      (this.liveActiveProviderCounts.get(provider.id) ?? 0) + 1
+    );
+    this.persistLiveChain();
+  }
+
+  removeLiveActiveProvider(providerId: number): void {
+    const count = this.liveActiveProviderCounts?.get(providerId) ?? 0;
+    if (count <= 1) {
+      this.liveActiveProviderCounts?.delete(providerId);
+      if (this.liveActiveProviders?.delete(providerId)) this.persistLiveChain();
+      return;
+    }
+    this.liveActiveProviderCounts.set(providerId, count - 1);
+    this.persistLiveChain();
   }
 
   setSessionBindingSnapshot(snapshot: SessionBindingSnapshot | null): void {
@@ -862,11 +904,19 @@ export class ProxySession {
       this.liveRoutingTraceDirty = false;
 
       const chain = writeChain ? structuredClone(this.providerChain) : null;
+      const activeProviders = writeChain
+        ? structuredClone([...this.liveActiveProviders.values()])
+        : null;
       const routingTrace = writeRoutingTrace ? structuredClone(this.routingTrace) : null;
       const writes: Promise<void>[] = [];
       if (chain) {
         writes.push(
-          writeLiveChain(this.sessionId as string, this.requestSequence as number, chain)
+          writeLiveChain(
+            this.sessionId as string,
+            this.requestSequence as number,
+            chain,
+            activeProviders ?? []
+          )
         );
       }
       if (routingTrace) {

--- a/src/lib/redis/live-chain-store.storage.test.ts
+++ b/src/lib/redis/live-chain-store.storage.test.ts
@@ -102,6 +102,71 @@ describe("live-chain routing trace storage", () => {
     });
   });
 
+  it("derives all currently connected Discovery providers from attempt lifecycle events", async () => {
+    const trace = makeTrace({
+      updatedAt: 240,
+      events: [
+        {
+          type: "attempt_started",
+          at: 200,
+          elapsedMs: 100,
+          round: 1,
+          attemptId: "11:1",
+          attemptKind: "normal",
+          provider: { id: 11, name: "provider-a" },
+        },
+        {
+          type: "attempt_started",
+          at: 210,
+          elapsedMs: 110,
+          round: 1,
+          attemptId: "12:1",
+          attemptKind: "normal",
+          provider: { id: 12, name: "provider-b" },
+        },
+        {
+          type: "attempt_finished",
+          at: 220,
+          elapsedMs: 120,
+          round: 1,
+          attemptId: "11:1",
+          attemptKind: "normal",
+          provider: { id: 11, name: "provider-a" },
+          outcome: "failed",
+        },
+        {
+          type: "attempt_started",
+          at: 230,
+          elapsedMs: 130,
+          round: 1,
+          attemptId: "13:1",
+          attemptKind: "fallback",
+          provider: { id: 13, name: "provider-c" },
+        },
+      ],
+    });
+    await writeLiveRoutingTrace("racing", 1, trace);
+
+    await expect(readLiveChain("racing", 1)).resolves.toMatchObject({
+      activeProviders: [
+        { id: 12, name: "provider-b" },
+        { id: 13, name: "provider-c" },
+      ],
+    });
+  });
+
+  it("switches the active legacy provider after a serial fallback", async () => {
+    await writeLiveChain("fallback", 1, [
+      { id: 21, name: "primary", reason: "initial_selection", timestamp: 100 },
+      { id: 21, name: "primary", reason: "retry_failed", timestamp: 200 },
+      { id: 22, name: "fallback", reason: "initial_selection", timestamp: 210 },
+    ]);
+
+    await expect(readLiveChain("fallback", 1)).resolves.toMatchObject({
+      activeProviders: [{ id: 22, name: "fallback" }],
+    });
+  });
+
   it("returns an early trace before the provider chain snapshot exists", async () => {
     const trace = makeTrace({
       updatedAt: 150,

--- a/src/lib/redis/live-chain-store.ts
+++ b/src/lib/redis/live-chain-store.ts
@@ -4,10 +4,16 @@ import type { ProviderChainItem } from "@/types/message";
 import { normalizeRoutingTrace, type RoutingTraceV1 } from "@/types/routing-trace";
 import { RedisKVStore } from "./redis-kv-store";
 
+export interface LiveProviderSnapshot {
+  id: number;
+  name: string;
+}
+
 export interface LiveChainSnapshot {
   chain: ProviderChainItem[];
   phase: string;
   updatedAt: number;
+  activeProviders?: LiveProviderSnapshot[];
   routingTrace?: RoutingTraceV1 | null;
 }
 
@@ -78,6 +84,80 @@ function inferDiscoveryPhase(trace: RoutingTraceV1): string {
   return "discovery_racing";
 }
 
+function deriveDiscoveryActiveProviders(trace: RoutingTraceV1): LiveProviderSnapshot[] | undefined {
+  const activeAttempts = new Map<string, LiveProviderSnapshot>();
+  let sawAttemptLifecycle = false;
+
+  for (const event of trace.events) {
+    if (event.type === "attempt_started" && event.attemptId && event.provider) {
+      sawAttemptLifecycle = true;
+      activeAttempts.set(event.attemptId, {
+        id: event.provider.id,
+        name: event.provider.name ?? String(event.provider.id),
+      });
+      continue;
+    }
+
+    if (event.type === "attempt_finished" && event.attemptId) {
+      sawAttemptLifecycle = true;
+      activeAttempts.delete(event.attemptId);
+      continue;
+    }
+
+    if (event.type === "winner_committed" && event.attemptId && event.provider) {
+      sawAttemptLifecycle = true;
+      activeAttempts.clear();
+      activeAttempts.set(event.attemptId, {
+        id: event.provider.id,
+        name: event.provider.name ?? String(event.provider.id),
+      });
+      continue;
+    }
+
+    if (event.type === "request_finished") {
+      sawAttemptLifecycle = true;
+      activeAttempts.clear();
+    }
+  }
+
+  if (!sawAttemptLifecycle) return undefined;
+  return [
+    ...new Map([...activeAttempts.values()].map((provider) => [provider.id, provider])).values(),
+  ];
+}
+
+function deriveLegacyActiveProviders(chain: ProviderChainItem[]): LiveProviderSnapshot[] {
+  const activeProviders = new Map<number, LiveProviderSnapshot>();
+
+  for (const item of chain) {
+    const provider = { id: item.id, name: item.name };
+    switch (item.reason) {
+      case "initial_selection":
+      case "session_reuse":
+      case "affinity_hit":
+      case "hedge_launched":
+        activeProviders.set(item.id, provider);
+        break;
+      case "hedge_winner":
+      case "request_success":
+      case "retry_success":
+        activeProviders.clear();
+        activeProviders.set(item.id, provider);
+        break;
+      case "retry_failed":
+      case "system_error":
+      case "resource_not_found":
+      case "hedge_loser_cancelled":
+      case "hedge_loser_billed":
+      case "client_abort":
+        activeProviders.delete(item.id);
+        break;
+    }
+  }
+
+  return [...activeProviders.values()];
+}
+
 export function inferPhase(
   chain: ProviderChainItem[],
   routingTrace?: RoutingTraceV1 | null
@@ -122,6 +202,8 @@ function mergeSnapshot(
   // snapshot shape. Prefer the independently updated trace when both exist.
   const routingTrace =
     normalizeRoutingTrace(storedRoutingTrace) ?? normalizeRoutingTrace(snapshot?.routingTrace);
+  const activeProviders =
+    routingTrace?.mode === "discovery" ? deriveDiscoveryActiveProviders(routingTrace) : undefined;
 
   // Trace recording starts before provider selection can append to the legacy
   // chain. Keep that earliest Discovery state visible instead of waiting for a
@@ -132,6 +214,7 @@ function mergeSnapshot(
       chain: [],
       phase: inferPhase([], routingTrace),
       updatedAt: routingTrace.updatedAt,
+      ...(activeProviders ? { activeProviders } : {}),
       routingTrace,
     };
   }
@@ -139,6 +222,7 @@ function mergeSnapshot(
   return {
     ...snapshot,
     phase: inferPhase(snapshot.chain, routingTrace),
+    ...(activeProviders ? { activeProviders } : {}),
     routingTrace,
   };
 }
@@ -146,12 +230,14 @@ function mergeSnapshot(
 export async function writeLiveChain(
   sessionId: string,
   requestSequence: number,
-  chain: ProviderChainItem[]
+  chain: ProviderChainItem[],
+  activeProviders: LiveProviderSnapshot[] = deriveLegacyActiveProviders(chain)
 ): Promise<void> {
   const snapshot: LiveChainSnapshot = {
     chain,
     phase: inferPhase(chain),
     updatedAt: Date.now(),
+    activeProviders,
   };
   await store.set(buildKey(sessionId, requestSequence), snapshot);
 }

--- a/src/repository/usage-logs.ts
+++ b/src/repository/usage-logs.ts
@@ -113,6 +113,7 @@ export interface UsageLogRow {
     chain: ProviderChainItem[];
     phase: string;
     updatedAt: number;
+    activeProviders?: Array<{ id: number; name: string }>;
     routingTrace?: RoutingTraceV1 | null;
   } | null;
   anthropicEffort?: string | null;


### PR DESCRIPTION
## Summary
- Persist active upstream providers in the existing Redis live usage snapshot.
- Reconstruct Discovery racing providers from routing lifecycle events and track legacy hedge/fallback activity.
- Stack live racing providers with a full Tooltip list; switch to the active fallback provider in real time.
- Allow reasoning-effort override badges to overflow into the next column without changing column widths.

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run build` (passes; existing Edge/Node compatibility warnings remain)
- Focused Vitest: 69 passed
- Full Vitest completed 8,189 tests before the final test-only assertion adjustment; final full rerun was interrupted with exit 143 after an unrelated provider action test timed out under suite contention
- The timed-out provider action test passed independently in 2.6s
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds live upstream-provider snapshots to Redis and renders active racing or fallback providers in the virtualized logs table.

- Tracks legacy hedge participants through attempt launch and cleanup.
- Reconstructs Discovery participants by replaying routing lifecycle events.
- Adds a stacked provider display with a complete tooltip list.
- Allows reasoning-effort badges to overflow their fixed-width column.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The Discovery lifecycle gap should be fixed before merging because live logs can identify a failed sticky provider as still connected during the replacement race.

The new event replay assumes every started Discovery attempt receives an immediate terminal event, but two reachable sticky fallback branches continue routing after removing an attempt without recording its completion.

**Files Needing Attention:** src/lib/redis/live-chain-store.ts and the Discovery cleanup branches in src/app/v1/_lib/proxy/forwarder.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/redis/live-chain-store.ts | Adds active-provider snapshot storage and Discovery event replay, but unmatched sticky-probe start events can temporarily retain disconnected providers. |
| src/app/v1/_lib/proxy/forwarder.ts | Adds legacy hedge provider lifecycle updates; those paths are balanced, while existing Discovery sticky fallback behavior exposes a gap in the new replay model. |
| src/app/v1/_lib/proxy/session.ts | Adds ref-counted active-provider state and includes it in serialized live-chain snapshots. |
| src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx | Renders up to three active providers as a stack and exposes the complete list through a tooltip. |
| src/app/[locale]/dashboard/logs/_components/usage-logs-table.tsx | Allows the fixed-width reasoning-effort cell to visibly overflow without changing its width. |
| src/repository/usage-logs.ts | Extends the live-chain row contract with the optional active-provider list. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant F as ProxyForwarder
  participant S as ProxySession
  participant R as Redis live snapshot
  participant U as Usage Logs UI
  F->>S: attempt_started / active-provider update
  S->>R: persist chain, trace, and active providers
  F->>S: attempt_finished / winner_committed
  S->>R: persist updated snapshot
  U->>R: poll live request state
  R-->>U: activeProviders
  U-->>U: render provider stack and tooltip
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/lib/redis/live-chain-store.ts:92-99
**Unmatched attempts remain active**

When a Discovery sticky probe fails or enters sticky-timeout fallback, the forwarder removes the attempt without immediately emitting `attempt_finished`; this replay therefore retains the disconnected provider until the request settles or commits a winner, causing live logs to show it alongside the replacement round.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(logs): show live upstream providers"](https://github.com/ding113/claude-code-hub/commit/69f164feb5bfb987346df1134eb7f28d6760eb8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49366942)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Proxy request pipeline](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/proxy-pipeline.md)
- Knowledge Base — [Redis Caching and Session Tracking](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/redis-caching-and-sessions.md)
- Knowledge Base — [Dashboard UI (Next.js App Router)](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/dashboard-ui.md)
</details>

<!-- /greptile_comment -->