### PR TITLE
fix(session): decode canonical detail route identities

### DIFF
--- a/src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-messages-client-actions.test.tsx
+++ b/src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-messages-client-actions.test.tsx
@@ -28,9 +28,10 @@ vi.mock("next-intl", () => {
 });
 
 let seqParamValue: string | null = null;
+let sessionIdParamValue = "0123456789abcdef";
 vi.mock("next/navigation", () => {
   return {
-    useParams: () => ({ sessionId: "0123456789abcdef" }),
+    useParams: () => ({ sessionId: sessionIdParamValue }),
     useSearchParams: () => ({
       get: (key: string) => {
         if (key !== "seq") return null;
@@ -57,7 +58,7 @@ vi.mock("@/i18n/routing", () => {
 
 const getSessionDetailsMock = vi.fn();
 const terminateActiveSessionMock = vi.fn();
-vi.mock("@/actions/active-sessions", () => {
+vi.mock("@/lib/api-client/v1/actions/active-sessions", () => {
   return {
     getSessionDetails: (...args: unknown[]) => getSessionDetailsMock(...args),
     terminateActiveSession: (...args: unknown[]) => terminateActiveSessionMock(...args),
@@ -267,9 +268,30 @@ afterEach(() => {
   routerBackMock.mockReset();
   vi.useRealTimers();
   seqParamValue = null;
+  sessionIdParamValue = "0123456789abcdef";
 });
 
 describe("SessionMessagesClient (request export actions)", () => {
+  test("decodes an URL-encoded canonical Session ID before loading details", async () => {
+    sessionIdParamValue = "pfx%3A9d403aeabe1f236d%3A1ee9a5d1bd4d98ce4bed39daca4b943e";
+    getSessionDetailsMock.mockResolvedValue({
+      ok: true,
+      data: buildDetailsData(),
+    });
+
+    const { unmount } = renderClient(<SessionMessagesClient />);
+    await flushEffects();
+
+    expect(getSessionDetailsMock).toHaveBeenCalledWith(
+      "pfx:9d403aeabe1f236d:1ee9a5d1bd4d98ce4bed39daca4b943e",
+      undefined,
+      undefined,
+      undefined
+    );
+
+    unmount();
+  });
+
   test("selected seq in URL overrides currentSequence for request export", async () => {
     seqParamValue = "3";
     getSessionDetailsMock.mockResolvedValue({

--- a/src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-messages-client.tsx
+++ b/src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-messages-client.tsx
@@ -53,15 +53,24 @@ import { SessionMessagesDetailsTabs } from "./session-details-tabs";
 import { hasSnapshotData } from "./session-messages-guards";
 import { SessionStats } from "./session-stats";
 
+function normalizeCanonicalSessionRouteParam(sessionId: string): string {
+  try {
+    const decoded = decodeURIComponent(sessionId);
+    return decoded.startsWith("pfx:") || decoded.startsWith("sid:") ? decoded : sessionId;
+  } catch {
+    return sessionId;
+  }
+}
+
 export function SessionMessagesClient() {
   const t = useTranslations("dashboard.sessions");
   const tErrors = useTranslations("errors");
 
-  const params = useParams();
+  const params = useParams<{ sessionId: string }>();
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
-  const sessionId = params.sessionId as string;
+  const sessionId = normalizeCanonicalSessionRouteParam(params.sessionId);
 
   // URL state
   const seqParam = searchParams.get("seq");


### PR DESCRIPTION
## Summary

- 在 Session 详情页路由边界规范化 URL 编码后的 reserved canonical identity
- 仅接受解码后以 `pfx:` 或 `sid:` 开头的值，避免改变普通 physical Session ID
- 修正组件测试的 stale mock 路径，并用生产中的 `pfx%3A...` 形态补充回归测试

## Root Cause

目标 Session 已成功写入 `message_request` 和 `usage_ledger`，但详情页收到 URL 编码后的 `pfx%3A...` 并原样传给 REST client。REST client 再次执行 `encodeURIComponent` 后请求 `%253A` 键，无法命中数据库中的 `pfx:...` canonical identity，因此返回资源不存在。

## Validation

- `bun run lint`
- `bun run lint:fix`
- `bun run typecheck`
- `bun run build`
- `bun run test` (`858` files passed, `8365` tests passed)
- 聚焦 Session 详情组件回归测试
- API client canonical/physical locator 编码契约测试

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR normalizes URL-encoded reserved canonical session identities at the Session detail route boundary so the REST client does not double-encode them.
- Decodes route parameters only when the decoded identity begins with `pfx:` or `sid:`, preserving ordinary physical Session IDs.
- Updates the client-action mock path to the production API-client module.
- Adds regression coverage for the encoded `pfx%3A...` route form.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the canonical route normalization matching the identity grammar and API-client encoding contract.

Reserved canonical identities use fixed `pfx:` or `sid:` prefixes and hexadecimal components, and the new normalization restores their canonical form before the REST client performs its required path-segment encoding without altering ordinary physical IDs.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-messages-client.tsx | Adds guarded route-boundary decoding for canonical session identities while leaving ordinary physical IDs unchanged. |
| src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-messages-client-actions.test.tsx | Corrects the mocked API-client module and verifies that an encoded canonical route identity is decoded before details are loaded. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Route as Session detail route
  participant Client as SessionMessagesClient
  participant API as REST API client
  participant Server as Session details endpoint
  Route->>Client: pfx%3Ascope%3Afingerprint
  Client->>Client: decode reserved canonical identity
  Client->>API: pfx:scope:fingerprint
  API->>Server: encodeURIComponent(identity)
  Server-->>Client: Matching session details
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(session): decode canonical detail ro..."](https://github.com/ding113/claude-code-hub/commit/631dfc18f557b01d278ebc362630a387b95a8fb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49577210)</sub>

**Context used:**

- Knowledge Base — [Dashboard UI (Next.js App Router)](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/dashboard-ui.md)

<!-- /greptile_comment -->