### PR TITLE
feat(leaderboard): 缓存系数列增加 tooltip 与分层上色

### DIFF
--- a/messages/en/dashboard.json
+++ b/messages/en/dashboard.json
@@ -704,6 +704,7 @@
       "cacheHitRequests": "Cache-eligible Requests",
       "cacheHitRate": "Cache Hit Rate",
       "cacheCoefficient": "Cache Coefficient",
+      "cacheCoefficientTooltip": "A higher cache coefficient means fewer provider account switches and less noticeable cache degradation. 0.9+ is excellent, 0.8+ is good.",
       "cacheReadTokens": "Cache Read Tokens",
       "totalTokens": "Total Tokens",
       "cacheCreationConsumedAmount": "Cache Creation Spend",

--- a/messages/ja/dashboard.json
+++ b/messages/ja/dashboard.json
@@ -704,6 +704,7 @@
       "cacheHitRequests": "キャッシュ対象リクエスト数(命中率計算対象)",
       "cacheHitRate": "キャッシュ命中率",
       "cacheCoefficient": "キャッシュ係数",
+      "cacheCoefficientTooltip": "キャッシュ係数が大きいほど、プロバイダーのアカウント切り替えが少なく、キャッシュ劣化が目立ちにくくなります。0.9 以上は優秀、0.8 以上は良好です。",
       "cacheReadTokens": "キャッシュ読取トークン数",
       "totalTokens": "総トークン数",
       "cacheCreationConsumedAmount": "キャッシュ作成消費額",

--- a/messages/ru/dashboard.json
+++ b/messages/ru/dashboard.json
@@ -704,6 +704,7 @@
       "cacheHitRequests": "Запросы (учтены в hit rate)",
       "cacheHitRate": "Попадания в кэш",
       "cacheCoefficient": "Коэффициент кэша",
+      "cacheCoefficientTooltip": "Чем выше коэффициент кэша, тем реже переключаются аккаунты поставщика и тем менее заметна деградация кэша. 0.9 и выше — отлично, 0.8 и выше — хорошо.",
       "cacheReadTokens": "Токены чтения из кэша",
       "totalTokens": "Всего токенов",
       "cacheCreationConsumedAmount": "Расход на создание кэша",

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -704,6 +704,7 @@
       "cacheHitRequests": "缓存触发请求数",
       "cacheHitRate": "缓存命中率",
       "cacheCoefficient": "缓存系数",
+      "cacheCoefficientTooltip": "缓存系数越大，供应商切号越少，失缓现象越不明显。0.9 以上为优秀，0.8 以上为良好。",
       "cacheReadTokens": "缓存读取 Token 数",
       "totalTokens": "总 Token 数",
       "cacheCreationConsumedAmount": "缓存创建消耗金额",

--- a/messages/zh-TW/dashboard.json
+++ b/messages/zh-TW/dashboard.json
@@ -704,6 +704,7 @@
       "cacheHitRequests": "快取命中請求數（納入快取命中率計算的請求總數）",
       "cacheHitRate": "快取命中率",
       "cacheCoefficient": "快取係數",
+      "cacheCoefficientTooltip": "快取係數越大，供應商切號越少，失緩現象越不明顯。0.9 以上為優秀，0.8 以上為良好。",
       "cacheReadTokens": "快取讀取 Token 數",
       "totalTokens": "總 Token 數",
       "cacheCreationConsumedAmount": "快取建立消耗金額",

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
@@ -252,12 +252,14 @@ export function LeaderboardTable<TParent, TSub = TParent>({
                         {col.headerTooltip && (
                           <Tooltip>
                             <TooltipTrigger asChild>
-                              <span
+                              <button
+                                type="button"
+                                aria-label={col.headerTooltip}
                                 className="ml-1 inline-flex cursor-help items-center text-muted-foreground/70 hover:text-muted-foreground"
                                 onClick={(e) => e.stopPropagation()}
                               >
                                 <CircleHelp className="h-3.5 w-3.5" />
-                              </span>
+                              </button>
                             </TooltipTrigger>
                             <TooltipContent className="max-w-64">
                               {col.headerTooltip}

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
@@ -7,6 +7,7 @@ import {
   Award,
   ChevronDown,
   ChevronRight,
+  CircleHelp,
   Medal,
   Trophy,
 } from "lucide-react";
@@ -22,11 +23,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { LeaderboardPeriod } from "@/repository/leaderboard";
 
 // 支持动态列定义
 export interface ColumnDef<T> {
   header: string;
+  /** 表头帮助图标悬停时展示的说明文案 */
+  headerTooltip?: string;
   className?: string;
   /**
    * index 语义：
@@ -245,6 +249,21 @@ export function LeaderboardTable<TParent, TSub = TParent>({
                         className={`flex items-center ${col.className?.includes("text-right") ? "justify-end" : ""} ${shouldBold ? "font-bold" : ""}`}
                       >
                         {col.header}
+                        {col.headerTooltip && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span
+                                className="ml-1 inline-flex cursor-help items-center text-muted-foreground/70 hover:text-muted-foreground"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <CircleHelp className="h-3.5 w-3.5" />
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-64">
+                              {col.headerTooltip}
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
                         {col.sortKey && getSortIcon(col.sortKey)}
                       </div>
                     </TableHead>

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
@@ -101,6 +101,21 @@ function renderSuccessRateCell(
 
 const VALID_PERIODS: LeaderboardPeriod[] = ["daily", "weekly", "monthly", "allTime", "custom"];
 
+// 缓存系数分层配色（与缓存命中率同档）：>=0.9 优秀（绿），>=0.8 良好（黄），其余橙色
+function renderCacheCoefficientCell(bp: number | null) {
+  if (bp == null) {
+    return <span className="text-muted-foreground">–</span>;
+  }
+  const value = bp / 10000;
+  const colorClass =
+    value >= 0.9
+      ? "text-green-600 dark:text-green-400"
+      : value >= 0.8
+        ? "text-yellow-600 dark:text-yellow-400"
+        : "text-orange-600 dark:text-orange-400";
+  return <span className={colorClass}>{value.toFixed(2)}</span>;
+}
+
 export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
   const t = useTranslations("dashboard.leaderboard");
   const searchParams = useSearchParams();
@@ -385,11 +400,10 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     },
     {
       header: t("columns.cacheCoefficient"),
+      headerTooltip: t("columns.cacheCoefficientTooltip"),
       className: "text-right",
-      cell: (row) => {
-        const bp = "cacheCoefficientBp" in row ? row.cacheCoefficientBp : null;
-        return bp == null ? "–" : (bp / 10000).toFixed(2);
-      },
+      cell: (row) =>
+        renderCacheCoefficientCell("cacheCoefficientBp" in row ? row.cacheCoefficientBp : null),
       sortKey: "cacheCoefficientBp",
       getValue: (row) => ("cacheCoefficientBp" in row ? row.cacheCoefficientBp : null),
     },
@@ -430,11 +444,10 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     },
     {
       header: t("columns.cacheCoefficient"),
+      headerTooltip: t("columns.cacheCoefficientTooltip"),
       className: "text-right",
-      cell: (row) => {
-        const bp = "cacheCoefficientBp" in row ? row.cacheCoefficientBp : null;
-        return bp == null ? "–" : (bp / 10000).toFixed(2);
-      },
+      cell: (row) =>
+        renderCacheCoefficientCell("cacheCoefficientBp" in row ? row.cacheCoefficientBp : null),
       sortKey: "cacheCoefficientBp",
       getValue: (row) => ("cacheCoefficientBp" in row ? row.cacheCoefficientBp : null),
     },

--- a/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx
@@ -349,7 +349,7 @@ export function SummaryTab({
                       </span>
                       <Link
                         href={buildLogsFilterHref(identity.value)}
-                        className="text-xs font-mono break-all underline-offset-2 hover:underline"
+                        className="text-xs font-mono truncate min-w-0 underline-offset-2 hover:underline"
                       >
                         {identity.value}
                       </Link>

--- a/tests/unit/dashboard/leaderboard-view-cache-coefficient.test.tsx
+++ b/tests/unit/dashboard/leaderboard-view-cache-coefficient.test.tsx
@@ -140,8 +140,46 @@ describe("LeaderboardView cache coefficient column", () => {
       root!.render(<LeaderboardView isAdmin />);
     });
 
-    const trigger = container!.querySelector('[data-slot="tooltip-trigger"]');
+    const coefficientHeader = Array.from(container!.querySelectorAll("th")).find((th) =>
+      th.textContent?.includes("columns.cacheCoefficient")
+    );
+    expect(coefficientHeader).toBeDefined();
+    const trigger = coefficientHeader!.querySelector('[data-slot="tooltip-trigger"]');
     expect(trigger).not.toBeNull();
+  });
+
+  it("does not trigger column sorting when the help icon is clicked", async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("scope=providerCacheHitRate")) {
+        return {
+          ok: true,
+          json: async () => [
+            cacheHitEntry({ providerId: 1, providerName: "high-first", cacheCoefficientBp: 9500 }),
+            cacheHitEntry({ providerId: 2, providerName: "low-second", cacheCoefficientBp: 5000 }),
+          ],
+        } as Response;
+      }
+      return { ok: true, json: async () => [] } as Response;
+    });
+
+    await act(async () => {
+      root!.render(<LeaderboardView isAdmin />);
+    });
+
+    const coefficientHeader = Array.from(container!.querySelectorAll("th")).find((th) =>
+      th.textContent?.includes("columns.cacheCoefficient")
+    );
+    const trigger = coefficientHeader!.querySelector('[data-slot="tooltip-trigger"]');
+    expect(trigger).not.toBeNull();
+
+    await act(async () => {
+      trigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // 行顺序保持默认（未触发升序排序，否则 low-second 会排到第一行）
+    const bodyText = container!.querySelector("tbody")?.textContent ?? "";
+    expect(bodyText.indexOf("high-first")).toBeLessThan(bodyText.indexOf("low-second"));
   });
 
   it("colors the coefficient by tier: >=0.9 green, >=0.8 yellow, else orange", async () => {
@@ -152,8 +190,15 @@ describe("LeaderboardView cache coefficient column", () => {
           ok: true,
           json: async () => [
             cacheHitEntry({ providerId: 1, providerName: "excellent", cacheCoefficientBp: 9500 }),
-            cacheHitEntry({ providerId: 2, providerName: "good", cacheCoefficientBp: 8600 }),
-            cacheHitEntry({ providerId: 3, providerName: "poor", cacheCoefficientBp: 5000 }),
+            cacheHitEntry({
+              providerId: 2,
+              providerName: "edge-excellent",
+              cacheCoefficientBp: 9000,
+            }),
+            cacheHitEntry({ providerId: 3, providerName: "good", cacheCoefficientBp: 8600 }),
+            cacheHitEntry({ providerId: 4, providerName: "edge-good", cacheCoefficientBp: 8000 }),
+            cacheHitEntry({ providerId: 5, providerName: "poor", cacheCoefficientBp: 5000 }),
+            cacheHitEntry({ providerId: 6, providerName: "missing", cacheCoefficientBp: null }),
           ],
         } as Response;
       }
@@ -167,8 +212,14 @@ describe("LeaderboardView cache coefficient column", () => {
     const hasColoredValue = (selector: string, text: string) =>
       Array.from(container!.querySelectorAll(selector)).some((el) => el.textContent === text);
     expect(hasColoredValue("span.text-green-600", "0.95")).toBe(true);
+    // 边界值：0.90 仍属优秀档
+    expect(hasColoredValue("span.text-green-600", "0.90")).toBe(true);
     expect(hasColoredValue("span.text-yellow-600", "0.86")).toBe(true);
+    // 边界值：0.80 仍属良好档
+    expect(hasColoredValue("span.text-yellow-600", "0.80")).toBe(true);
     expect(hasColoredValue("span.text-orange-600", "0.50")).toBe(true);
+    // 缺失值：muted 样式展示占位符
+    expect(hasColoredValue("span.text-muted-foreground", "–")).toBe(true);
   });
 
   it("renders the coefficient column on the provider usage board too", async () => {

--- a/tests/unit/dashboard/leaderboard-view-cache-coefficient.test.tsx
+++ b/tests/unit/dashboard/leaderboard-view-cache-coefficient.test.tsx
@@ -124,6 +124,53 @@ describe("LeaderboardView cache coefficient column", () => {
     expect(text).toContain("–");
   });
 
+  it("shows a tooltip trigger on the cache coefficient column header", async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("scope=providerCacheHitRate")) {
+        return {
+          ok: true,
+          json: async () => [cacheHitEntry({ providerId: 1, cacheCoefficientBp: 9000 })],
+        } as Response;
+      }
+      return { ok: true, json: async () => [] } as Response;
+    });
+
+    await act(async () => {
+      root!.render(<LeaderboardView isAdmin />);
+    });
+
+    const trigger = container!.querySelector('[data-slot="tooltip-trigger"]');
+    expect(trigger).not.toBeNull();
+  });
+
+  it("colors the coefficient by tier: >=0.9 green, >=0.8 yellow, else orange", async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("scope=providerCacheHitRate")) {
+        return {
+          ok: true,
+          json: async () => [
+            cacheHitEntry({ providerId: 1, providerName: "excellent", cacheCoefficientBp: 9500 }),
+            cacheHitEntry({ providerId: 2, providerName: "good", cacheCoefficientBp: 8600 }),
+            cacheHitEntry({ providerId: 3, providerName: "poor", cacheCoefficientBp: 5000 }),
+          ],
+        } as Response;
+      }
+      return { ok: true, json: async () => [] } as Response;
+    });
+
+    await act(async () => {
+      root!.render(<LeaderboardView isAdmin />);
+    });
+
+    const hasColoredValue = (selector: string, text: string) =>
+      Array.from(container!.querySelectorAll(selector)).some((el) => el.textContent === text);
+    expect(hasColoredValue("span.text-green-600", "0.95")).toBe(true);
+    expect(hasColoredValue("span.text-yellow-600", "0.86")).toBe(true);
+    expect(hasColoredValue("span.text-orange-600", "0.50")).toBe(true);
+  });
+
   it("renders the coefficient column on the provider usage board too", async () => {
     searchParamsState.value = new URLSearchParams("scope=provider");
     fetchMock.mockImplementation(async (input) => {


### PR DESCRIPTION
## 变更内容

- **表头 tooltip**：排行榜中「缓存系数」列（供应商成本榜 + 缓存命中榜）新增帮助图标，悬停解释字段含义：缓存系数越大，供应商切号越少，失缓现象越不明显；并标注分档阈值（0.9 优秀 / 0.8 良好）
- **分层上色**：与缓存命中率同档配色 —— ≥0.9 绿色（优秀）、≥0.8 黄色（良好）、其余橙色；无数据仍显示 `–`
- **基础设施**：`ColumnDef` 新增 `headerTooltip` 字段，tooltip 触发处 `stopPropagation`，不影响表头排序
- **i18n**：5 种语言（zh-CN / zh-TW / en / ja / ru）文案齐备
- **测试**：新增 tooltip 触发器与三档配色断言，共 4 个用例全部通过

## 验证

- `bun run typecheck` / `biome check` / `bun run build` 通过
- `bunx vitest run tests/unit/dashboard/leaderboard-view-cache-coefficient.test.tsx`：4 passed
- `tests/unit/dashboard/` 全套 31 个文件 174 个用例通过
- 真实页面截图核验（种子数据 0.95 / 0.86 / 0.50 三档）：tooltip 悬停展示正常，两张榜单配色正确

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds localized cache-coefficient guidance and tier-based coloring to both provider leaderboards, while preserving sorting and missing-data behavior.
- Adds a focusable tooltip control to sortable cache-coefficient headers.
- Applies green, yellow, and orange coefficient tiers with localized explanations in all five supported locales.
- Adds coverage for tooltip rendering, sort-event isolation, threshold colors, and null values.
- Truncates long identity values in the error-details summary.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported inaccessible tooltip trigger is now a native focusable button.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx | Adds reusable tooltip metadata and a keyboard-focusable button trigger that prevents its click from activating header sorting. |
| src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx | Adds shared cache-coefficient tier rendering and localized tooltip content to both applicable provider tables. |
| tests/unit/dashboard/leaderboard-view-cache-coefficient.test.tsx | Covers tooltip presence, sort isolation, exact tier boundaries, missing data, and both provider leaderboard variants. |
| src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx | Changes long identity links from wrapping to constrained truncation within the existing flex layout. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(leaderboard,logs): address review fe..."](https://github.com/ding113/claude-code-hub/commit/85b37bc3d9c9ccc519b875116419de1fb7bb06b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49577279)</sub>

**Context used:**

- Knowledge Base — [Dashboard UI (Next.js App Router)](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/dashboard-ui.md)

<!-- /greptile_comment -->