### PR TITLE
fix(dashboard): sync usage log quick filters with time range state

### DIFF
--- a/src/app/[locale]/dashboard/logs/_components/filters/quick-filters-bar.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/filters/quick-filters-bar.tsx
@@ -8,12 +8,16 @@ import { cn } from "@/lib/utils";
 export type FilterPreset = "today" | "this-week" | "errors-only" | "show-retries";
 
 interface QuickFiltersBarProps {
-  activePreset: FilterPreset | null;
+  activePresets: ReadonlySet<FilterPreset>;
   onPresetToggle: (preset: FilterPreset) => void;
   className?: string;
 }
 
-export function QuickFiltersBar({ activePreset, onPresetToggle, className }: QuickFiltersBarProps) {
+export function QuickFiltersBar({
+  activePresets,
+  onPresetToggle,
+  className,
+}: QuickFiltersBarProps) {
   const t = useTranslations("dashboard.logs.filters");
 
   const timePresets: Array<{ id: FilterPreset; label: string; icon: typeof Calendar }> = [
@@ -40,10 +44,11 @@ export function QuickFiltersBar({ activePreset, onPresetToggle, className }: Qui
         <Button
           key={id}
           type="button"
-          variant={activePreset === id ? "default" : "outline"}
+          variant={activePresets.has(id) ? "default" : "outline"}
           size="sm"
           onClick={() => onPresetToggle(id)}
           className="shrink-0"
+          aria-pressed={activePresets.has(id)}
         >
           <Icon className="h-4 w-4 mr-1.5" />
           {label}
@@ -58,10 +63,11 @@ export function QuickFiltersBar({ activePreset, onPresetToggle, className }: Qui
         <Button
           key={id}
           type="button"
-          variant={activePreset === id ? "default" : "outline"}
+          variant={activePresets.has(id) ? "default" : "outline"}
           size="sm"
           onClick={() => onPresetToggle(id)}
           className="shrink-0"
+          aria-pressed={activePresets.has(id)}
         >
           <Icon className="h-4 w-4 mr-1.5" />
           {label}

--- a/src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx
@@ -106,10 +106,15 @@ export function LogsDateRangePicker({
 
   const handleQuickPeriodClick = useCallback(
     (period: QuickPeriod) => {
+      // Toggle: clicking the active period again clears the date range
+      if (activeQuickPeriod === period) {
+        onDateRangeChange({ startDate: undefined, endDate: undefined });
+        return;
+      }
       const range = getDateRangeForPeriod(period, serverTimeZone);
       onDateRangeChange(range);
     },
-    [onDateRangeChange, serverTimeZone]
+    [activeQuickPeriod, onDateRangeChange, serverTimeZone]
   );
 
   const handleNavigate = useCallback(

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { format, startOfDay, startOfWeek } from "date-fns";
+import { format } from "date-fns";
 import { ChevronDown, Clock, Download, Network, Server, User } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -22,6 +22,7 @@ import {
 import { getErrorMessage } from "@/lib/utils/error-messages";
 import type { Key } from "@/types/key";
 import type { ProviderDisplay } from "@/types/provider";
+import { detectQuickTimePreset, getQuickTimeRange } from "../_utils/time-range";
 import { ActiveFiltersDisplay } from "./filters/active-filters-display";
 import { FilterSection } from "./filters/filter-section";
 import { IdentityFilters } from "./filters/identity-filters";
@@ -87,7 +88,6 @@ export function UsageLogsFilters({
   const [localFilters, setLocalFilters] = useState<UsageLogFilters>(filters);
   const [isExporting, setIsExporting] = useState(false);
   const [exportStatus, setExportStatus] = useState<UsageLogsExportStatus | null>(null);
-  const [activePreset, setActivePreset] = useState<FilterPreset | null>(null);
   const exportRunIdRef = useRef(0);
 
   // Track users and keys for display name resolution
@@ -159,6 +159,30 @@ export function UsageLogsFilters({
     localFilters.replayFilter,
   ]);
 
+  // Quick filter highlight states are derived from the actual filter values, so the quick
+  // filters bar, date range picker and time inputs always stay in sync no matter which
+  // control changed the underlying range.
+  const activePresets = useMemo<ReadonlySet<FilterPreset>>(() => {
+    const presets = new Set<FilterPreset>();
+    const timePreset = detectQuickTimePreset(
+      localFilters.startTime,
+      localFilters.endTime,
+      serverTimeZone
+    );
+    if (timePreset) presets.add(timePreset);
+    if (localFilters.excludeStatusCode200) presets.add("errors-only");
+    if (localFilters.minRetryCount !== undefined && localFilters.minRetryCount > 0) {
+      presets.add("show-retries");
+    }
+    return presets;
+  }, [
+    localFilters.startTime,
+    localFilters.endTime,
+    localFilters.excludeStatusCode200,
+    localFilters.minRetryCount,
+    serverTimeZone,
+  ]);
+
   useEffect(() => {
     setLocalFilters(filters);
   }, [filters]);
@@ -177,7 +201,6 @@ export function UsageLogsFilters({
     exportRunIdRef.current += 1;
     setLocalFilters({});
     setKeys([]);
-    setActivePreset(null);
     setIsExporting(false);
     setExportStatus(null);
     onReset();
@@ -291,58 +314,40 @@ export function UsageLogsFilters({
 
   const handlePresetToggle = useCallback(
     (preset: FilterPreset) => {
-      const now = new Date();
+      const isActive = activePresets.has(preset);
 
-      if (preset === activePreset) {
-        // Toggle off - clear the preset-related filters
-        setActivePreset(null);
-        setLocalFilters((prev) => {
-          const next = { ...prev };
-          if (preset === "today" || preset === "this-week") {
+      setLocalFilters((prev) => {
+        const next = { ...prev };
+
+        if (preset === "today" || preset === "this-week") {
+          if (isActive) {
             delete next.startTime;
             delete next.endTime;
-          } else if (preset === "errors-only") {
-            delete next.excludeStatusCode200;
-          } else if (preset === "show-retries") {
-            delete next.minRetryCount;
+          } else {
+            const range = getQuickTimeRange(preset, serverTimeZone);
+            if (!range) return prev;
+            next.startTime = range.startTime;
+            next.endTime = range.endTime;
           }
-          return next;
-        });
-        return;
-      }
+        } else if (preset === "errors-only") {
+          if (isActive) {
+            delete next.excludeStatusCode200;
+          } else {
+            next.excludeStatusCode200 = true;
+            next.statusCode = undefined;
+          }
+        } else if (preset === "show-retries") {
+          if (isActive) {
+            delete next.minRetryCount;
+          } else {
+            next.minRetryCount = 1;
+          }
+        }
 
-      setActivePreset(preset);
-
-      if (preset === "today") {
-        const todayStart = startOfDay(now).getTime();
-        const todayEnd = todayStart + 24 * 60 * 60 * 1000;
-        setLocalFilters((prev) => ({
-          ...prev,
-          startTime: todayStart,
-          endTime: todayEnd,
-        }));
-      } else if (preset === "this-week") {
-        const weekStart = startOfWeek(now, { weekStartsOn: 1 }).getTime();
-        const weekEnd = weekStart + 7 * 24 * 60 * 60 * 1000;
-        setLocalFilters((prev) => ({
-          ...prev,
-          startTime: weekStart,
-          endTime: weekEnd,
-        }));
-      } else if (preset === "errors-only") {
-        setLocalFilters((prev) => ({
-          ...prev,
-          excludeStatusCode200: true,
-          statusCode: undefined,
-        }));
-      } else if (preset === "show-retries") {
-        setLocalFilters((prev) => ({
-          ...prev,
-          minRetryCount: 1,
-        }));
-      }
+        return next;
+      });
     },
-    [activePreset]
+    [activePresets, serverTimeZone]
   );
 
   const handleRemoveFilter = useCallback((key: keyof UsageLogFilters) => {
@@ -351,13 +356,12 @@ export function UsageLogsFilters({
       delete next[key];
       return next;
     });
-    setActivePreset(null);
   }, []);
 
   return (
     <div className="space-y-4">
       {/* Quick Filters Bar */}
-      <QuickFiltersBar activePreset={activePreset} onPresetToggle={handlePresetToggle} />
+      <QuickFiltersBar activePresets={activePresets} onPresetToggle={handlePresetToggle} />
 
       {/* Active Filters Display */}
       <ActiveFiltersDisplay

--- a/src/app/[locale]/dashboard/logs/_utils/time-range.ts
+++ b/src/app/[locale]/dashboard/logs/_utils/time-range.ts
@@ -1,4 +1,4 @@
-import { format, subDays } from "date-fns";
+import { addDays, format, startOfWeek, subDays } from "date-fns";
 import { fromZonedTime, toZonedTime } from "date-fns-tz";
 
 export interface ClockParts {
@@ -94,4 +94,61 @@ export function getQuickDateRange(
         endDate: formatDate(baseDate),
       };
   }
+}
+
+export type QuickTimePreset = "today" | "this-week";
+
+const QUICK_TIME_PRESETS: QuickTimePreset[] = ["today", "this-week"];
+
+function getDateRangeForTimePreset(
+  preset: QuickTimePreset,
+  timeZone?: string,
+  now: Date = new Date()
+): { startDate: string; endDate: string } {
+  if (preset === "this-week") {
+    const baseDate = timeZone ? toZonedTime(now, timeZone) : now;
+    const weekStart = startOfWeek(baseDate, { weekStartsOn: 1 });
+    return {
+      startDate: format(weekStart, "yyyy-MM-dd"),
+      endDate: format(addDays(weekStart, 6), "yyyy-MM-dd"),
+    };
+  }
+  return getQuickDateRange("today", timeZone, now);
+}
+
+/**
+ * Exclusive-end timestamp range ([start 00:00:00, end+1day 00:00:00)) for a quick time preset,
+ * resolved in the same timezone the time filter UI displays dates in.
+ */
+export function getQuickTimeRange(
+  preset: QuickTimePreset,
+  timeZone?: string,
+  now: Date = new Date()
+): { startTime: number; endTime: number } | null {
+  const { startDate, endDate } = getDateRangeForTimePreset(preset, timeZone, now);
+  const startTime = dateStringWithClockToTimestamp(startDate, "00:00:00", timeZone);
+  const endInclusive = dateStringWithClockToTimestamp(endDate, "23:59:59", timeZone);
+  if (startTime === undefined || endInclusive === undefined) return null;
+  return { startTime, endTime: endInclusive + 1000 };
+}
+
+/**
+ * Inverse of getQuickTimeRange: returns the preset whose range exactly matches the given
+ * timestamps, or null when the range is custom (or incomplete).
+ */
+export function detectQuickTimePreset(
+  startTime?: number,
+  endTime?: number,
+  timeZone?: string,
+  now: Date = new Date()
+): QuickTimePreset | null {
+  if (startTime === undefined || endTime === undefined) return null;
+
+  for (const preset of QUICK_TIME_PRESETS) {
+    const range = getQuickTimeRange(preset, timeZone, now);
+    if (range && range.startTime === startTime && range.endTime === endTime) {
+      return preset;
+    }
+  }
+  return null;
 }

--- a/tests/unit/dashboard-logs-quick-filters-linkage.test.tsx
+++ b/tests/unit/dashboard-logs-quick-filters-linkage.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { format } from "date-fns";
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, test } from "vitest";
+import { UsageLogsFilters } from "@/app/[locale]/dashboard/logs/_components/usage-logs-filters";
+import commonMessages from "../../messages/en/common.json";
+import dashboardMessages from "../../messages/en/dashboard.json";
+
+function renderWithIntl(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <NextIntlClientProvider
+        locale="en"
+        messages={{ dashboard: dashboardMessages, common: commonMessages }}
+        timeZone="UTC"
+      >
+        {node}
+      </NextIntlClientProvider>
+    );
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+async function actClick(el: Element | null) {
+  if (!el) throw new Error("element not found");
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+/**
+ * The quick filters bar and the date range picker both render a "Today" button.
+ * They are told apart by the icon: quick filter buttons carry a lucide icon,
+ * picker quick-period buttons are text-only.
+ */
+function findButton(
+  container: Element,
+  text: string,
+  options?: { withIcon?: boolean }
+): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find((button) => {
+    if ((button.textContent || "").trim() !== text) return false;
+    if (options?.withIcon === undefined) return true;
+    const hasIcon = button.querySelector("svg") !== null;
+    return hasIcon === options.withIcon;
+  });
+}
+
+function isPressed(button: HTMLButtonElement | undefined): boolean {
+  return button?.getAttribute("aria-pressed") === "true";
+}
+
+function getTimeInputs(container: Element): HTMLInputElement[] {
+  return Array.from(container.querySelectorAll("input[type='time']"));
+}
+
+async function changeInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  if (!setter) throw new Error("missing native input value setter");
+  await act(async () => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function renderFilters() {
+  return renderWithIntl(
+    <UsageLogsFilters
+      isAdmin={false}
+      providers={[]}
+      initialKeys={[]}
+      filters={{}}
+      onChange={() => {}}
+      onReset={() => {}}
+    />
+  );
+}
+
+describe("UsageLogsFilters - quick filter linkage", () => {
+  test("quick bar Today lights up the picker Today and fills the date/time display", async () => {
+    const { container, unmount } = renderFilters();
+
+    const quickToday = findButton(container, "Today", { withIcon: true });
+    const pickerToday = findButton(container, "Today", { withIcon: false });
+    expect(quickToday).toBeDefined();
+    expect(pickerToday).toBeDefined();
+    expect(isPressed(quickToday)).toBe(false);
+    expect(isPressed(pickerToday)).toBe(false);
+
+    await actClick(quickToday ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+    expect(isPressed(findButton(container, "Today", { withIcon: false }))).toBe(true);
+
+    const today = format(new Date(), "yyyy-MM-dd");
+    const rangeTrigger = findButton(container, today);
+    expect(rangeTrigger).toBeDefined();
+
+    const [startInput, endInput] = getTimeInputs(container);
+    expect(startInput?.value).toBe("00:00");
+    expect(endInput?.value).toBe("23:59:59");
+
+    unmount();
+  });
+
+  test("selecting Today in the date range picker lights up the quick bar Today", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Today", { withIcon: false }) ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: false }))).toBe(true);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+
+    const [startInput, endInput] = getTimeInputs(container);
+    expect(startInput?.value).toBe("00:00");
+    expect(endInput?.value).toBe("23:59:59");
+
+    unmount();
+  });
+
+  test("selecting Yesterday in the picker does not light up the quick bar Today", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Yesterday", { withIcon: false }) ?? null);
+
+    expect(isPressed(findButton(container, "Yesterday", { withIcon: false }))).toBe(true);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(false);
+    expect(isPressed(findButton(container, "Today", { withIcon: false }))).toBe(false);
+
+    unmount();
+  });
+
+  test("clicking the active quick bar preset again clears the time range", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Today", { withIcon: true }) ?? null);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+
+    await actClick(findButton(container, "Today", { withIcon: true }) ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(false);
+    expect(isPressed(findButton(container, "Today", { withIcon: false }))).toBe(false);
+
+    const [startInput, endInput] = getTimeInputs(container);
+    expect(startInput?.value).toBe("");
+    expect(endInput?.value).toBe("");
+
+    unmount();
+  });
+
+  test("clicking the active picker period again clears the range and the quick bar highlight", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Today", { withIcon: false }) ?? null);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+
+    await actClick(findButton(container, "Today", { withIcon: false }) ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: false }))).toBe(false);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(false);
+
+    const [startInput, endInput] = getTimeInputs(container);
+    expect(startInput?.value).toBe("");
+    expect(endInput?.value).toBe("");
+
+    unmount();
+  });
+
+  test("time presets and status presets can stay highlighted at the same time", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Today", { withIcon: true }) ?? null);
+    await actClick(findButton(container, "Errors Only") ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+    expect(isPressed(findButton(container, "Errors Only"))).toBe(true);
+
+    await actClick(findButton(container, "With Retries") ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+    expect(isPressed(findButton(container, "Errors Only"))).toBe(true);
+    expect(isPressed(findButton(container, "With Retries"))).toBe(true);
+
+    unmount();
+  });
+
+  test("changing the start clock breaks the exact Today preset highlight", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Today", { withIcon: true }) ?? null);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+
+    const [startInput] = getTimeInputs(container);
+    if (!startInput) throw new Error("start time input not found");
+    await changeInputValue(startInput, "08:00:00");
+
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(false);
+
+    unmount();
+  });
+
+  test("quick bar This Week fills a Monday-Sunday range and toggles off", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "This Week", { withIcon: true }) ?? null);
+
+    expect(isPressed(findButton(container, "This Week", { withIcon: true }))).toBe(true);
+
+    const [startInput, endInput] = getTimeInputs(container);
+    expect(startInput?.value).toBe("00:00");
+    expect(endInput?.value).toBe("23:59:59");
+
+    await actClick(findButton(container, "This Week", { withIcon: true }) ?? null);
+
+    expect(isPressed(findButton(container, "This Week", { withIcon: true }))).toBe(false);
+    expect(getTimeInputs(container)[0]?.value).toBe("");
+
+    unmount();
+  });
+});

--- a/tests/unit/dashboard-logs-time-range-utils.test.ts
+++ b/tests/unit/dashboard-logs-time-range-utils.test.ts
@@ -2,8 +2,10 @@ import { format } from "date-fns";
 import { describe, expect, test } from "vitest";
 import {
   dateStringWithClockToTimestamp,
+  detectQuickTimePreset,
   formatClockFromTimestamp,
   getQuickDateRange,
+  getQuickTimeRange,
   inclusiveEndTimestampFromExclusive,
   parseClockString,
   type QuickPeriod,
@@ -114,5 +116,58 @@ describe("dashboard logs time range utils", () => {
 
     expect([before, after]).toContain(range.startDate);
     expect(range.endDate).toBe(range.startDate);
+  });
+
+  test("getQuickTimeRange returns today's full-day range with exclusive end", () => {
+    const now = new Date("2024-01-15T12:00:00Z");
+
+    expect(getQuickTimeRange("today", "UTC", now)).toEqual({
+      startTime: Date.UTC(2024, 0, 15, 0, 0, 0),
+      endTime: Date.UTC(2024, 0, 16, 0, 0, 0),
+    });
+  });
+
+  test("getQuickTimeRange resolves today in the given timezone", () => {
+    const now = new Date("2024-01-02T02:00:00Z");
+    const tz = "America/Los_Angeles"; // still 2024-01-01 (PST, UTC-8) there
+
+    const range = getQuickTimeRange("today", tz, now);
+    expect(range).toEqual({
+      startTime: Date.UTC(2024, 0, 1, 8, 0, 0),
+      endTime: Date.UTC(2024, 0, 2, 8, 0, 0),
+    });
+  });
+
+  test("getQuickTimeRange returns this-week as Monday through next Monday (exclusive)", () => {
+    const now = new Date("2024-01-17T12:00:00Z"); // Wednesday
+
+    expect(getQuickTimeRange("this-week", "UTC", now)).toEqual({
+      startTime: Date.UTC(2024, 0, 15, 0, 0, 0), // Monday 00:00:00
+      endTime: Date.UTC(2024, 0, 22, 0, 0, 0), // next Monday 00:00:00
+    });
+  });
+
+  test("detectQuickTimePreset round-trips getQuickTimeRange", () => {
+    const now = new Date("2024-01-17T12:00:00Z");
+
+    for (const preset of ["today", "this-week"] as const) {
+      const range = getQuickTimeRange(preset, "UTC", now);
+      expect(range).not.toBeNull();
+      expect(detectQuickTimePreset(range?.startTime, range?.endTime, "UTC", now)).toBe(preset);
+    }
+  });
+
+  test("detectQuickTimePreset returns null for custom or incomplete ranges", () => {
+    const now = new Date("2024-01-17T12:00:00Z");
+    const today = getQuickTimeRange("today", "UTC", now);
+    expect(today).not.toBeNull();
+    if (!today) return;
+
+    // A shifted start clock breaks the exact full-day preset
+    expect(
+      detectQuickTimePreset(today.startTime + 3_600_000, today.endTime, "UTC", now)
+    ).toBeNull();
+    expect(detectQuickTimePreset(undefined, today.endTime, "UTC", now)).toBeNull();
+    expect(detectQuickTimePreset(today.startTime, undefined, "UTC", now)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

使用记录页筛选面板中，四个快捷筛选条件（今天/本周/仅错误/有重试）与时间范围的日期范围、自定义范围、开始/结束时间之间没有联动：高亮状态是独立的 `activePreset` state，与实际筛选值脱钩。

本 PR 将高亮状态改为从 `localFilters` 派生（单一数据源），实现双向联动点亮，并统一所有快捷条件为「点击选中、再点取消」。

## Root Cause

- 快捷筛选条的高亮是独立 useState：在日期范围选择器里选「今天」不会点亮快捷条，改日期后快捷条仍残留高亮。
- 高亮位只有一个：选「今天」再点「仅错误」，「今天」高亮被顶掉，但时间筛选其实仍在生效。
- 快捷条的「今天/本周」用浏览器本地时区 `startOfDay` 计算，与时间筛选区使用的 `serverTimeZone` 口径不一致。
- 日期范围选择器内的快捷周期（今天/昨天/近7天/近30天）不支持再点取消。

## Changes

- `_utils/time-range.ts`：新增 `getQuickTimeRange` / `detectQuickTimePreset`，快捷条与时间筛选区共用同一时区口径的预设区间计算与反查。
- `usage-logs-filters.tsx`：移除 `activePreset` state，高亮从 `localFilters` 派生 —— 时间预设精确匹配整天/整周区间，「仅错误」↔ `excludeStatusCode200`，「有重试」↔ `minRetryCount > 0`，支持多预设同时点亮。
- `quick-filters-bar.tsx`：props 改为 `activePresets: ReadonlySet`，补充 `aria-pressed`。
- `logs-date-range-picker.tsx`：快捷周期支持 toggle，再点已激活周期即清空日期范围。

## Behavior

- 任一处（快捷条/日期快捷周期/日历自定义范围）选择「今天」，其余控件同步点亮并回填日期与时间条。
- 所有快捷条件点击选中、再点取消；时间预设与状态预设可同时点亮，互不顶掉。
- 手动修改开始/结束时刻后，语义为「整天」的快捷条预设自动熄灭，避免上下状态假同步。

## Testing

- 新增 8 个联动组件测试（`dashboard-logs-quick-filters-linkage.test.tsx`，使用真实 `LogsDateRangePicker`）与 5 个 time-range 工具函数测试。
- 全量 `bun run test`：859 个测试文件 8377 个用例全部通过；`bun run lint`、`bun run typecheck`、`bun run build` 干净。
- 用本分支生产构建在真实浏览器实测：正/反向联动点亮、再点取消、三预设共存、取消时间预设不影响状态预设，均有截图佐证（验收轮次：https://app.lobehub.com/verify/7e8d8b6b-497c-46e3-a739-c244c01b310e ）。

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces independent quick-filter highlighting with state derived from the actual usage-log filters and adds consistent toggle behavior.
- Shares timezone-aware Today and This Week range calculation and detection.
- Allows time, error, and retry presets to remain active independently.
- Adds toggle-off behavior and accessibility state to quick-filter controls.
- Adds component and utility coverage for bidirectional synchronization.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The filter controls now derive their highlights from the underlying filter values, use consistent timezone-aware ranges, and preserve independent status and time selections without introducing a concrete failure.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx | Derives all active quick-filter states from local filter values and updates each preset independently. |
| src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx | Adds toggle-off behavior when the selected calendar quick period is clicked again. |
| src/app/[locale]/dashboard/logs/_components/filters/quick-filters-bar.tsx | Supports multiple simultaneous active presets and exposes their pressed state accessibly. |
| src/app/[locale]/dashboard/logs/_utils/time-range.ts | Adds timezone-aware full-range generation and exact preset detection for Today and This Week. |
| tests/unit/dashboard-logs-quick-filters-linkage.test.tsx | Covers synchronization, independent preset activation, toggle-off behavior, and clock-edit invalidation. |
| tests/unit/dashboard-logs-time-range-utils.test.ts | Covers preset range boundaries, timezone conversion, round trips, and custom-range rejection. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Controls["Quick filters / date picker / clock inputs"] --> LocalFilters["localFilters"]
  LocalFilters --> Detection["Detect exact time and status presets"]
  Detection --> Highlights["Derived activePresets"]
  LocalFilters --> Apply["Apply filters"]
  Apply --> URL["Usage-log URL/query state"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): sync usage log quick fil..."](https://github.com/ding113/claude-code-hub/commit/ed2399fc5bc67d5472d58287655b7b2cc4b7d9f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49594629)</sub>

**Context used:**

- Knowledge Base — [Dashboard UI (Next.js App Router)](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/dashboard-ui.md)

<!-- /greptile_comment -->