### PR TITLE
fix(message): restore indexed reserved session request lookup

### DIFF
--- a/src/repository/message.ts
+++ b/src/repository/message.ts
@@ -77,12 +77,13 @@ function messageSessionLookup(identityOrPhysicalId: string, ownerUserId?: number
 
 function messageCanonicalSessionLookup(identity: string, ownerUserId?: number) {
   const canonicalCondition = isReservedSessionIdentity(identity)
-    ? ownerUserId !== undefined
-      ? or(
-          eq(messageRequest.sessionIdentity, identity),
-          and(isNull(messageRequest.sessionIdentity), eq(messageRequest.sessionId, identity))
-        )
-      : eq(messageRequest.sessionIdentity, identity)
+    ? and(
+        // 保留 expression index 入口，同时避免 reserved identity 混入同名物理 Session。
+        eq(messageSessionIdentity, identity),
+        ownerUserId !== undefined
+          ? or(eq(messageRequest.sessionIdentity, identity), isNull(messageRequest.sessionIdentity))
+          : eq(messageRequest.sessionIdentity, identity)
+      )
     : eq(messageSessionIdentity, identity);
 
   return and(

--- a/src/repository/message.ts
+++ b/src/repository/message.ts
@@ -78,7 +78,7 @@ function messageSessionLookup(identityOrPhysicalId: string, ownerUserId?: number
 function messageCanonicalSessionLookup(identity: string, ownerUserId?: number) {
   const canonicalCondition = isReservedSessionIdentity(identity)
     ? and(
-        // 保留 expression index 入口，同时避免 reserved identity 混入同名物理 Session。
+        // 保留 expression index 入口, 同时避免 reserved identity 混入同名物理 Session.
         eq(messageSessionIdentity, identity),
         ownerUserId !== undefined
           ? or(eq(messageRequest.sessionIdentity, identity), isNull(messageRequest.sessionIdentity))

--- a/tests/api/v1/sessions/sessions.test.ts
+++ b/tests/api/v1/sessions/sessions.test.ts
@@ -137,6 +137,16 @@ describe("v1 session endpoints", () => {
     expect(requests.response.status).toBe(200);
     expect(getSessionRequestsMock).toHaveBeenCalledWith("s1", 2, 5, "desc");
 
+    for (const identity of ["pfx:scope:fingerprint", "sid:canonical-session"]) {
+      const encodedRequests = await callV1Route({
+        method: "GET",
+        pathname: `/api/v1/sessions/${encodeURIComponent(identity)}/requests?page=1&pageSize=20&order=desc`,
+        headers,
+      });
+      expect(encodedRequests.response.status).toBe(200);
+      expect(getSessionRequestsMock).toHaveBeenLastCalledWith(identity, 1, 20, "desc");
+    }
+
     await callV1Route({
       method: "GET",
       pathname: "/api/v1/sessions/s1/requests",

--- a/tests/unit/repository/message-session-request-query.test.ts
+++ b/tests/unit/repository/message-session-request-query.test.ts
@@ -252,7 +252,7 @@ describe("message repository session request queries", () => {
     }
   });
 
-  test("does not add the legacy physical fallback for unscoped reserved identities", async () => {
+  test("uses the canonical expression index without adding an unscoped physical fallback", async () => {
     const count = createDrizzleQuery([{ count: 1 }]);
     const rows = createDrizzleQuery<readonly RequestRow[]>([]);
     boundary.select.mockReturnValueOnce(count).mockReturnValueOnce(rows);
@@ -260,8 +260,10 @@ describe("message repository session request queries", () => {
     await findRequestsBySessionIdentity("pfx:canonical", {} as never);
 
     for (const where of [sqlText(count.trace.where), sqlText(rows.trace.where)]) {
+      expect(where).toContain("coalesce");
+      expect(where).toContain("session_identity");
       expect(where).not.toContain("session_identity is null");
-      expect(where.match(/pfx:canonical/g)).toHaveLength(1);
+      expect(where.match(/pfx:canonical/g)).toHaveLength(2);
     }
   });
 

--- a/tests/unit/repository/message-session-request-query.test.ts
+++ b/tests/unit/repository/message-session-request-query.test.ts
@@ -245,6 +245,7 @@ describe("message repository session request queries", () => {
     await findRequestsBySessionIdentity("pfx:legacy-client", { ownerUserId: 17 } as never);
 
     for (const where of [sqlText(count.trace.where), sqlText(rows.trace.where)]) {
+      expect(where).toContain("coalesce");
       expect(where).toContain("user_id");
       expect(where).toContain("is null");
       expect(where).toContain("session_id");

--- a/tests/unit/repository/message-session-request-query.test.ts
+++ b/tests/unit/repository/message-session-request-query.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { messageRequest } from "@/drizzle/schema";
 import { keys as keysTable } from "@/drizzle/schema";
 import {
@@ -50,6 +51,12 @@ type RequestRow = Pick<
 
 const firstCreatedAt = new Date("2026-05-04T10:00:00.000Z");
 const secondCreatedAt = new Date("2026-05-04T10:01:00.000Z");
+const dialect = new PgDialect();
+
+function compileWhere(values: readonly unknown[]) {
+  const query = dialect.sqlToQuery(values.at(0) as never);
+  return { sql: query.sql.toLowerCase(), params: query.params };
+}
 
 describe("message repository session request queries", () => {
   beforeEach(() => {
@@ -237,36 +244,50 @@ describe("message repository session request queries", () => {
     expect(rowsWhere.match(/shared-session/g)).toHaveLength(1);
   });
 
-  test("includes a legacy null-identity physical fallback for owner-scoped reserved identities", async () => {
-    const count = createDrizzleQuery([{ count: 1 }]);
-    const rows = createDrizzleQuery<readonly RequestRow[]>([]);
-    boundary.select.mockReturnValueOnce(count).mockReturnValueOnce(rows);
+  test.each(["pfx:legacy-client", "sid:legacy-client"])(
+    "includes an owner-scoped legacy fallback without aliasing a non-null identity: %s",
+    async (identity) => {
+      const count = createDrizzleQuery([{ count: 1 }]);
+      const rows = createDrizzleQuery<readonly RequestRow[]>([]);
+      boundary.select.mockReturnValueOnce(count).mockReturnValueOnce(rows);
 
-    await findRequestsBySessionIdentity("pfx:legacy-client", { ownerUserId: 17 } as never);
+      await findRequestsBySessionIdentity(identity, { ownerUserId: 17 } as never);
 
-    for (const where of [sqlText(count.trace.where), sqlText(rows.trace.where)]) {
-      expect(where).toContain("coalesce");
-      expect(where).toContain("user_id");
-      expect(where).toContain("is null");
-      expect(where).toContain("session_id");
-      expect(where.match(/pfx:legacy-client/g)).toHaveLength(2);
+      for (const where of [count.trace.where, rows.trace.where]) {
+        const compiled = compileWhere(where);
+        expect(compiled.sql).toContain(
+          'coalesce("message_request"."session_identity", "message_request"."session_id") ='
+        );
+        expect(compiled.sql).toContain(
+          '("message_request"."session_identity" = $2 or "message_request"."session_identity" is null)'
+        );
+        expect(compiled.sql).not.toContain('or "message_request"."session_id" =');
+        expect(compiled.sql).toContain('"message_request"."user_id" = $3');
+        expect(compiled.params.slice(0, 3)).toEqual([identity, identity, 17]);
+      }
     }
-  });
+  );
 
-  test("uses the canonical expression index without adding an unscoped physical fallback", async () => {
-    const count = createDrizzleQuery([{ count: 1 }]);
-    const rows = createDrizzleQuery<readonly RequestRow[]>([]);
-    boundary.select.mockReturnValueOnce(count).mockReturnValueOnce(rows);
+  test.each(["pfx:canonical", "sid:canonical"])(
+    "uses the canonical expression index with an explicit unscoped identity guard: %s",
+    async (identity) => {
+      const count = createDrizzleQuery([{ count: 1 }]);
+      const rows = createDrizzleQuery<readonly RequestRow[]>([]);
+      boundary.select.mockReturnValueOnce(count).mockReturnValueOnce(rows);
 
-    await findRequestsBySessionIdentity("pfx:canonical", {} as never);
+      await findRequestsBySessionIdentity(identity, {} as never);
 
-    for (const where of [sqlText(count.trace.where), sqlText(rows.trace.where)]) {
-      expect(where).toContain("coalesce");
-      expect(where).toContain("session_identity");
-      expect(where).not.toContain("session_identity is null");
-      expect(where.match(/pfx:canonical/g)).toHaveLength(2);
+      for (const where of [count.trace.where, rows.trace.where]) {
+        const compiled = compileWhere(where);
+        expect(compiled.sql).toContain(
+          'coalesce("message_request"."session_identity", "message_request"."session_id") = $1 and "message_request"."session_identity" = $2'
+        );
+        expect(compiled.sql).not.toContain('"message_request"."session_identity" is null');
+        expect(compiled.sql).not.toContain('or "message_request"."session_id" =');
+        expect(compiled.params.slice(0, 2)).toEqual([identity, identity]);
+      }
     }
-  });
+  );
 
   test("does not treat a reserved canonical identity as a physical Session alias", async () => {
     const locator = createDrizzleQuery([


### PR DESCRIPTION
## Summary

- restore the `COALESCE(session_identity, session_id)` predicate for reserved `pfx:` / `sid:` session request timelines so PostgreSQL can use `idx_message_request_session_identity_created_at`
- retain an explicit `session_identity = identity` guard for unscoped lookups, preserving reserved namespace isolation from same-named physical Session IDs
- retain owner-scoped compatibility for legacy rows with `session_identity IS NULL`
- add compiled-SQL regression coverage for both reserved prefixes and route coverage for URL-encoded identities

## Production symptom

`GET /api/v1/sessions/{encoded-pfx-identity}/requests?page=1&pageSize=20&order=desc` returned `400 session.action_failed`.

The route and query parameters are valid. The action wraps internal failures as this 400 response, while the underlying failure is the session request query timing out on a large `message_request` table.

## Root cause

The reserved-identity request-list path generated only:

```sql
session_identity = $1
```

The existing index starts with:

```sql
COALESCE(session_identity, session_id)
```

The bare predicate could not become the expression index's `Index Cond`, so an admin/unscoped request could scan the large table until `statement_timeout`.

The repaired predicate is:

```sql
COALESCE(session_identity, session_id) = $1
AND session_identity = $2
```

For owner-scoped legacy compatibility, the second term is:

```sql
(session_identity = $2 OR session_identity IS NULL)
AND user_id = $3
```

Local PostgreSQL `EXPLAIN` changed from a filter-only plan to an index scan with:

```text
Index Cond: (COALESCE(session_identity, session_id) = ...)
Filter: (session_identity = ...)
```

## Validation

- focused regression after rebase: 3 files, 23 tests passed
- full Vitest suite before the final rebase: 858 files passed, 8370 tests passed, 13 skipped
- `bun run build`: passed before the final rebase
- `bun run lint`: passed after rebase
- `bun run typecheck`: passed after rebase
- `git diff --check origin/dev...HEAD`: passed
- independent Standards and Spec reviews: no remaining findings

The intervening `dev` commit only changes dashboard usage-log time-filter UI and tests. The focused session tests, lint, and typecheck were rerun after rebase.

## Deployment note

This PR does not change the action's broad error classification. Production recovery requires this PR to be merged and deployed; the reported remote URL has not been re-tested against a deployment from this branch.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores the expression-index predicate for reserved session request lookups while preserving owner-scoped legacy-row support and preventing reserved identities from aliasing physical sessions.
- Rewrites the reserved canonical lookup into an index-compatible conjunction without changing its result set.
- Adds SQL-shape tests for owner-scoped and unscoped `pfx:` and `sid:` identities.
- Adds API coverage for URL-encoded reserved session identities.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or compatibility regressions identified.

The new predicate is logically equivalent to the prior lookup for all nullable column combinations, matches the existing PostgreSQL expression index, and preserves the deliberate distinction between owner-scoped legacy fallback and unscoped canonical lookup.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/repository/message.ts | Restores the expression-index-compatible reserved-session predicate while retaining the existing scoped and unscoped result semantics. |
| tests/unit/repository/message-session-request-query.test.ts | Verifies compiled SQL and parameter ordering for scoped and unscoped `pfx:` and `sid:` lookups. |
| tests/api/v1/sessions/sessions.test.ts | Confirms URL-encoded reserved identities are decoded and forwarded correctly by the session request endpoint. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Reserved session identity] --> B[Match COALESCE of session identity and session ID]
  B --> C{Owner scoped?}
  C -->|Yes| D[Require matching identity or legacy NULL identity]
  C -->|No| E[Require explicit matching session identity]
  D --> F[Apply owner and request filters]
  E --> F
  F --> G[Count and return session requests]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["style(message): normalize comment punctu..."](https://github.com/ding113/claude-code-hub/commit/9696f449dd78c17ab9bdc30b9cecf522d5391b10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49597295)</sub>

**Context used:**

- Knowledge Base — [Database Schema & Repository Layer](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/database-schema.md)

<!-- /greptile_comment -->