### PR TITLE
release v0.9.1

### DIFF
--- a/messages/en/dashboard.json
+++ b/messages/en/dashboard.json
@@ -704,6 +704,7 @@
       "cacheHitRequests": "Cache-eligible Requests",
       "cacheHitRate": "Cache Hit Rate",
       "cacheCoefficient": "Cache Coefficient",
+      "cacheCoefficientTooltip": "A higher cache coefficient means fewer provider account switches and less noticeable cache degradation. 0.9+ is excellent, 0.8+ is good.",
       "cacheReadTokens": "Cache Read Tokens",
       "totalTokens": "Total Tokens",
       "cacheCreationConsumedAmount": "Cache Creation Spend",

--- a/messages/ja/dashboard.json
+++ b/messages/ja/dashboard.json
@@ -704,6 +704,7 @@
       "cacheHitRequests": "キャッシュ対象リクエスト数(命中率計算対象)",
       "cacheHitRate": "キャッシュ命中率",
       "cacheCoefficient": "キャッシュ係数",
+      "cacheCoefficientTooltip": "キャッシュ係数が大きいほど、プロバイダーのアカウント切り替えが少なく、キャッシュ劣化が目立ちにくくなります。0.9 以上は優秀、0.8 以上は良好です。",
       "cacheReadTokens": "キャッシュ読取トークン数",
       "totalTokens": "総トークン数",
       "cacheCreationConsumedAmount": "キャッシュ作成消費額",

--- a/messages/ru/dashboard.json
+++ b/messages/ru/dashboard.json
@@ -704,6 +704,7 @@
       "cacheHitRequests": "Запросы (учтены в hit rate)",
       "cacheHitRate": "Попадания в кэш",
       "cacheCoefficient": "Коэффициент кэша",
+      "cacheCoefficientTooltip": "Чем выше коэффициент кэша, тем реже переключаются аккаунты поставщика и тем менее заметна деградация кэша. 0.9 и выше — отлично, 0.8 и выше — хорошо.",
       "cacheReadTokens": "Токены чтения из кэша",
       "totalTokens": "Всего токенов",
       "cacheCreationConsumedAmount": "Расход на создание кэша",

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -704,6 +704,7 @@
       "cacheHitRequests": "缓存触发请求数",
       "cacheHitRate": "缓存命中率",
       "cacheCoefficient": "缓存系数",
+      "cacheCoefficientTooltip": "缓存系数越大，供应商切号越少，失缓现象越不明显。0.9 以上为优秀，0.8 以上为良好。",
       "cacheReadTokens": "缓存读取 Token 数",
       "totalTokens": "总 Token 数",
       "cacheCreationConsumedAmount": "缓存创建消耗金额",

--- a/messages/zh-TW/dashboard.json
+++ b/messages/zh-TW/dashboard.json
@@ -704,6 +704,7 @@
       "cacheHitRequests": "快取命中請求數（納入快取命中率計算的請求總數）",
       "cacheHitRate": "快取命中率",
       "cacheCoefficient": "快取係數",
+      "cacheCoefficientTooltip": "快取係數越大，供應商切號越少，失緩現象越不明顯。0.9 以上為優秀，0.8 以上為良好。",
       "cacheReadTokens": "快取讀取 Token 數",
       "totalTokens": "總 Token 數",
       "cacheCreationConsumedAmount": "快取建立消耗金額",

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx
@@ -7,6 +7,7 @@ import {
   Award,
   ChevronDown,
   ChevronRight,
+  CircleHelp,
   Medal,
   Trophy,
 } from "lucide-react";
@@ -22,11 +23,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { LeaderboardPeriod } from "@/repository/leaderboard";
 
 // 支持动态列定义
 export interface ColumnDef<T> {
   header: string;
+  /** 表头帮助图标悬停时展示的说明文案 */
+  headerTooltip?: string;
   className?: string;
   /**
    * index 语义：
@@ -245,6 +249,23 @@ export function LeaderboardTable<TParent, TSub = TParent>({
                         className={`flex items-center ${col.className?.includes("text-right") ? "justify-end" : ""} ${shouldBold ? "font-bold" : ""}`}
                       >
                         {col.header}
+                        {col.headerTooltip && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                type="button"
+                                aria-label={col.headerTooltip}
+                                className="ml-1 inline-flex cursor-help items-center text-muted-foreground/70 hover:text-muted-foreground"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <CircleHelp className="h-3.5 w-3.5" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-64">
+                              {col.headerTooltip}
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
                         {col.sortKey && getSortIcon(col.sortKey)}
                       </div>
                     </TableHead>

--- a/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
+++ b/src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx
@@ -101,6 +101,21 @@ function renderSuccessRateCell(
 
 const VALID_PERIODS: LeaderboardPeriod[] = ["daily", "weekly", "monthly", "allTime", "custom"];
 
+// 缓存系数分层配色（与缓存命中率同档）：>=0.9 优秀（绿），>=0.8 良好（黄），其余橙色
+function renderCacheCoefficientCell(bp: number | null) {
+  if (bp == null) {
+    return <span className="text-muted-foreground">–</span>;
+  }
+  const value = bp / 10000;
+  const colorClass =
+    value >= 0.9
+      ? "text-green-600 dark:text-green-400"
+      : value >= 0.8
+        ? "text-yellow-600 dark:text-yellow-400"
+        : "text-orange-600 dark:text-orange-400";
+  return <span className={colorClass}>{value.toFixed(2)}</span>;
+}
+
 export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
   const t = useTranslations("dashboard.leaderboard");
   const searchParams = useSearchParams();
@@ -385,11 +400,10 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     },
     {
       header: t("columns.cacheCoefficient"),
+      headerTooltip: t("columns.cacheCoefficientTooltip"),
       className: "text-right",
-      cell: (row) => {
-        const bp = "cacheCoefficientBp" in row ? row.cacheCoefficientBp : null;
-        return bp == null ? "–" : (bp / 10000).toFixed(2);
-      },
+      cell: (row) =>
+        renderCacheCoefficientCell("cacheCoefficientBp" in row ? row.cacheCoefficientBp : null),
       sortKey: "cacheCoefficientBp",
       getValue: (row) => ("cacheCoefficientBp" in row ? row.cacheCoefficientBp : null),
     },
@@ -430,11 +444,10 @@ export function LeaderboardView({ isAdmin }: LeaderboardViewProps) {
     },
     {
       header: t("columns.cacheCoefficient"),
+      headerTooltip: t("columns.cacheCoefficientTooltip"),
       className: "text-right",
-      cell: (row) => {
-        const bp = "cacheCoefficientBp" in row ? row.cacheCoefficientBp : null;
-        return bp == null ? "–" : (bp / 10000).toFixed(2);
-      },
+      cell: (row) =>
+        renderCacheCoefficientCell("cacheCoefficientBp" in row ? row.cacheCoefficientBp : null),
       sortKey: "cacheCoefficientBp",
       getValue: (row) => ("cacheCoefficientBp" in row ? row.cacheCoefficientBp : null),
     },

--- a/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx
@@ -349,7 +349,7 @@ export function SummaryTab({
                       </span>
                       <Link
                         href={buildLogsFilterHref(identity.value)}
-                        className="text-xs font-mono break-all underline-offset-2 hover:underline"
+                        className="text-xs font-mono truncate min-w-0 underline-offset-2 hover:underline"
                       >
                         {identity.value}
                       </Link>

--- a/src/app/[locale]/dashboard/logs/_components/filters/quick-filters-bar.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/filters/quick-filters-bar.tsx
@@ -8,12 +8,16 @@ import { cn } from "@/lib/utils";
 export type FilterPreset = "today" | "this-week" | "errors-only" | "show-retries";
 
 interface QuickFiltersBarProps {
-  activePreset: FilterPreset | null;
+  activePresets: ReadonlySet<FilterPreset>;
   onPresetToggle: (preset: FilterPreset) => void;
   className?: string;
 }
 
-export function QuickFiltersBar({ activePreset, onPresetToggle, className }: QuickFiltersBarProps) {
+export function QuickFiltersBar({
+  activePresets,
+  onPresetToggle,
+  className,
+}: QuickFiltersBarProps) {
   const t = useTranslations("dashboard.logs.filters");
 
   const timePresets: Array<{ id: FilterPreset; label: string; icon: typeof Calendar }> = [
@@ -40,10 +44,11 @@ export function QuickFiltersBar({ activePreset, onPresetToggle, className }: Qui
         <Button
           key={id}
           type="button"
-          variant={activePreset === id ? "default" : "outline"}
+          variant={activePresets.has(id) ? "default" : "outline"}
           size="sm"
           onClick={() => onPresetToggle(id)}
           className="shrink-0"
+          aria-pressed={activePresets.has(id)}
         >
           <Icon className="h-4 w-4 mr-1.5" />
           {label}
@@ -58,10 +63,11 @@ export function QuickFiltersBar({ activePreset, onPresetToggle, className }: Qui
         <Button
           key={id}
           type="button"
-          variant={activePreset === id ? "default" : "outline"}
+          variant={activePresets.has(id) ? "default" : "outline"}
           size="sm"
           onClick={() => onPresetToggle(id)}
           className="shrink-0"
+          aria-pressed={activePresets.has(id)}
         >
           <Icon className="h-4 w-4 mr-1.5" />
           {label}

--- a/src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/logs-date-range-picker.tsx
@@ -106,10 +106,15 @@ export function LogsDateRangePicker({
 
   const handleQuickPeriodClick = useCallback(
     (period: QuickPeriod) => {
+      // Toggle: clicking the active period again clears the date range
+      if (activeQuickPeriod === period) {
+        onDateRangeChange({ startDate: undefined, endDate: undefined });
+        return;
+      }
       const range = getDateRangeForPeriod(period, serverTimeZone);
       onDateRangeChange(range);
     },
-    [onDateRangeChange, serverTimeZone]
+    [activeQuickPeriod, onDateRangeChange, serverTimeZone]
   );
 
   const handleNavigate = useCallback(

--- a/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { format, startOfDay, startOfWeek } from "date-fns";
+import { format } from "date-fns";
 import { ChevronDown, Clock, Download, Network, Server, User } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -22,6 +22,7 @@ import {
 import { getErrorMessage } from "@/lib/utils/error-messages";
 import type { Key } from "@/types/key";
 import type { ProviderDisplay } from "@/types/provider";
+import { detectQuickTimePreset, getQuickTimeRange } from "../_utils/time-range";
 import { ActiveFiltersDisplay } from "./filters/active-filters-display";
 import { FilterSection } from "./filters/filter-section";
 import { IdentityFilters } from "./filters/identity-filters";
@@ -87,7 +88,6 @@ export function UsageLogsFilters({
   const [localFilters, setLocalFilters] = useState<UsageLogFilters>(filters);
   const [isExporting, setIsExporting] = useState(false);
   const [exportStatus, setExportStatus] = useState<UsageLogsExportStatus | null>(null);
-  const [activePreset, setActivePreset] = useState<FilterPreset | null>(null);
   const exportRunIdRef = useRef(0);
 
   // Track users and keys for display name resolution
@@ -159,6 +159,30 @@ export function UsageLogsFilters({
     localFilters.replayFilter,
   ]);
 
+  // Quick filter highlight states are derived from the actual filter values, so the quick
+  // filters bar, date range picker and time inputs always stay in sync no matter which
+  // control changed the underlying range.
+  const activePresets = useMemo<ReadonlySet<FilterPreset>>(() => {
+    const presets = new Set<FilterPreset>();
+    const timePreset = detectQuickTimePreset(
+      localFilters.startTime,
+      localFilters.endTime,
+      serverTimeZone
+    );
+    if (timePreset) presets.add(timePreset);
+    if (localFilters.excludeStatusCode200) presets.add("errors-only");
+    if (localFilters.minRetryCount !== undefined && localFilters.minRetryCount > 0) {
+      presets.add("show-retries");
+    }
+    return presets;
+  }, [
+    localFilters.startTime,
+    localFilters.endTime,
+    localFilters.excludeStatusCode200,
+    localFilters.minRetryCount,
+    serverTimeZone,
+  ]);
+
   useEffect(() => {
     setLocalFilters(filters);
   }, [filters]);
@@ -177,7 +201,6 @@ export function UsageLogsFilters({
     exportRunIdRef.current += 1;
     setLocalFilters({});
     setKeys([]);
-    setActivePreset(null);
     setIsExporting(false);
     setExportStatus(null);
     onReset();
@@ -291,58 +314,40 @@ export function UsageLogsFilters({
 
   const handlePresetToggle = useCallback(
     (preset: FilterPreset) => {
-      const now = new Date();
+      const isActive = activePresets.has(preset);
 
-      if (preset === activePreset) {
-        // Toggle off - clear the preset-related filters
-        setActivePreset(null);
-        setLocalFilters((prev) => {
-          const next = { ...prev };
-          if (preset === "today" || preset === "this-week") {
+      setLocalFilters((prev) => {
+        const next = { ...prev };
+
+        if (preset === "today" || preset === "this-week") {
+          if (isActive) {
             delete next.startTime;
             delete next.endTime;
-          } else if (preset === "errors-only") {
-            delete next.excludeStatusCode200;
-          } else if (preset === "show-retries") {
-            delete next.minRetryCount;
+          } else {
+            const range = getQuickTimeRange(preset, serverTimeZone);
+            if (!range) return prev;
+            next.startTime = range.startTime;
+            next.endTime = range.endTime;
           }
-          return next;
-        });
-        return;
-      }
+        } else if (preset === "errors-only") {
+          if (isActive) {
+            delete next.excludeStatusCode200;
+          } else {
+            next.excludeStatusCode200 = true;
+            next.statusCode = undefined;
+          }
+        } else if (preset === "show-retries") {
+          if (isActive) {
+            delete next.minRetryCount;
+          } else {
+            next.minRetryCount = 1;
+          }
+        }
 
-      setActivePreset(preset);
-
-      if (preset === "today") {
-        const todayStart = startOfDay(now).getTime();
-        const todayEnd = todayStart + 24 * 60 * 60 * 1000;
-        setLocalFilters((prev) => ({
-          ...prev,
-          startTime: todayStart,
-          endTime: todayEnd,
-        }));
-      } else if (preset === "this-week") {
-        const weekStart = startOfWeek(now, { weekStartsOn: 1 }).getTime();
-        const weekEnd = weekStart + 7 * 24 * 60 * 60 * 1000;
-        setLocalFilters((prev) => ({
-          ...prev,
-          startTime: weekStart,
-          endTime: weekEnd,
-        }));
-      } else if (preset === "errors-only") {
-        setLocalFilters((prev) => ({
-          ...prev,
-          excludeStatusCode200: true,
-          statusCode: undefined,
-        }));
-      } else if (preset === "show-retries") {
-        setLocalFilters((prev) => ({
-          ...prev,
-          minRetryCount: 1,
-        }));
-      }
+        return next;
+      });
     },
-    [activePreset]
+    [activePresets, serverTimeZone]
   );
 
   const handleRemoveFilter = useCallback((key: keyof UsageLogFilters) => {
@@ -351,13 +356,12 @@ export function UsageLogsFilters({
       delete next[key];
       return next;
     });
-    setActivePreset(null);
   }, []);
 
   return (
     <div className="space-y-4">
       {/* Quick Filters Bar */}
-      <QuickFiltersBar activePreset={activePreset} onPresetToggle={handlePresetToggle} />
+      <QuickFiltersBar activePresets={activePresets} onPresetToggle={handlePresetToggle} />
 
       {/* Active Filters Display */}
       <ActiveFiltersDisplay

--- a/src/app/[locale]/dashboard/logs/_utils/time-range.ts
+++ b/src/app/[locale]/dashboard/logs/_utils/time-range.ts
@@ -1,4 +1,4 @@
-import { format, subDays } from "date-fns";
+import { addDays, format, startOfWeek, subDays } from "date-fns";
 import { fromZonedTime, toZonedTime } from "date-fns-tz";
 
 export interface ClockParts {
@@ -94,4 +94,61 @@ export function getQuickDateRange(
         endDate: formatDate(baseDate),
       };
   }
+}
+
+export type QuickTimePreset = "today" | "this-week";
+
+const QUICK_TIME_PRESETS: QuickTimePreset[] = ["today", "this-week"];
+
+function getDateRangeForTimePreset(
+  preset: QuickTimePreset,
+  timeZone?: string,
+  now: Date = new Date()
+): { startDate: string; endDate: string } {
+  if (preset === "this-week") {
+    const baseDate = timeZone ? toZonedTime(now, timeZone) : now;
+    const weekStart = startOfWeek(baseDate, { weekStartsOn: 1 });
+    return {
+      startDate: format(weekStart, "yyyy-MM-dd"),
+      endDate: format(addDays(weekStart, 6), "yyyy-MM-dd"),
+    };
+  }
+  return getQuickDateRange("today", timeZone, now);
+}
+
+/**
+ * Exclusive-end timestamp range ([start 00:00:00, end+1day 00:00:00)) for a quick time preset,
+ * resolved in the same timezone the time filter UI displays dates in.
+ */
+export function getQuickTimeRange(
+  preset: QuickTimePreset,
+  timeZone?: string,
+  now: Date = new Date()
+): { startTime: number; endTime: number } | null {
+  const { startDate, endDate } = getDateRangeForTimePreset(preset, timeZone, now);
+  const startTime = dateStringWithClockToTimestamp(startDate, "00:00:00", timeZone);
+  const endInclusive = dateStringWithClockToTimestamp(endDate, "23:59:59", timeZone);
+  if (startTime === undefined || endInclusive === undefined) return null;
+  return { startTime, endTime: endInclusive + 1000 };
+}
+
+/**
+ * Inverse of getQuickTimeRange: returns the preset whose range exactly matches the given
+ * timestamps, or null when the range is custom (or incomplete).
+ */
+export function detectQuickTimePreset(
+  startTime?: number,
+  endTime?: number,
+  timeZone?: string,
+  now: Date = new Date()
+): QuickTimePreset | null {
+  if (startTime === undefined || endTime === undefined) return null;
+
+  for (const preset of QUICK_TIME_PRESETS) {
+    const range = getQuickTimeRange(preset, timeZone, now);
+    if (range && range.startTime === startTime && range.endTime === endTime) {
+      return preset;
+    }
+  }
+  return null;
 }

--- a/src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-messages-client-actions.test.tsx
+++ b/src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-messages-client-actions.test.tsx
@@ -28,9 +28,10 @@ vi.mock("next-intl", () => {
 });
 
 let seqParamValue: string | null = null;
+let sessionIdParamValue = "0123456789abcdef";
 vi.mock("next/navigation", () => {
   return {
-    useParams: () => ({ sessionId: "0123456789abcdef" }),
+    useParams: () => ({ sessionId: sessionIdParamValue }),
     useSearchParams: () => ({
       get: (key: string) => {
         if (key !== "seq") return null;
@@ -57,7 +58,7 @@ vi.mock("@/i18n/routing", () => {
 
 const getSessionDetailsMock = vi.fn();
 const terminateActiveSessionMock = vi.fn();
-vi.mock("@/actions/active-sessions", () => {
+vi.mock("@/lib/api-client/v1/actions/active-sessions", () => {
   return {
     getSessionDetails: (...args: unknown[]) => getSessionDetailsMock(...args),
     terminateActiveSession: (...args: unknown[]) => terminateActiveSessionMock(...args),
@@ -267,9 +268,30 @@ afterEach(() => {
   routerBackMock.mockReset();
   vi.useRealTimers();
   seqParamValue = null;
+  sessionIdParamValue = "0123456789abcdef";
 });
 
 describe("SessionMessagesClient (request export actions)", () => {
+  test("decodes an URL-encoded canonical Session ID before loading details", async () => {
+    sessionIdParamValue = "pfx%3A9d403aeabe1f236d%3A1ee9a5d1bd4d98ce4bed39daca4b943e";
+    getSessionDetailsMock.mockResolvedValue({
+      ok: true,
+      data: buildDetailsData(),
+    });
+
+    const { unmount } = renderClient(<SessionMessagesClient />);
+    await flushEffects();
+
+    expect(getSessionDetailsMock).toHaveBeenCalledWith(
+      "pfx:9d403aeabe1f236d:1ee9a5d1bd4d98ce4bed39daca4b943e",
+      undefined,
+      undefined,
+      undefined
+    );
+
+    unmount();
+  });
+
   test("selected seq in URL overrides currentSequence for request export", async () => {
     seqParamValue = "3";
     getSessionDetailsMock.mockResolvedValue({

--- a/src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-messages-client.tsx
+++ b/src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-messages-client.tsx
@@ -53,15 +53,24 @@ import { SessionMessagesDetailsTabs } from "./session-details-tabs";
 import { hasSnapshotData } from "./session-messages-guards";
 import { SessionStats } from "./session-stats";
 
+function normalizeCanonicalSessionRouteParam(sessionId: string): string {
+  try {
+    const decoded = decodeURIComponent(sessionId);
+    return decoded.startsWith("pfx:") || decoded.startsWith("sid:") ? decoded : sessionId;
+  } catch {
+    return sessionId;
+  }
+}
+
 export function SessionMessagesClient() {
   const t = useTranslations("dashboard.sessions");
   const tErrors = useTranslations("errors");
 
-  const params = useParams();
+  const params = useParams<{ sessionId: string }>();
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
-  const sessionId = params.sessionId as string;
+  const sessionId = normalizeCanonicalSessionRouteParam(params.sessionId);
 
   // URL state
   const seqParam = searchParams.get("seq");

--- a/src/repository/message.ts
+++ b/src/repository/message.ts
@@ -77,12 +77,13 @@ function messageSessionLookup(identityOrPhysicalId: string, ownerUserId?: number
 
 function messageCanonicalSessionLookup(identity: string, ownerUserId?: number) {
   const canonicalCondition = isReservedSessionIdentity(identity)
-    ? ownerUserId !== undefined
-      ? or(
-          eq(messageRequest.sessionIdentity, identity),
-          and(isNull(messageRequest.sessionIdentity), eq(messageRequest.sessionId, identity))
-        )
-      : eq(messageRequest.sessionIdentity, identity)
+    ? and(
+        // 保留 expression index 入口, 同时避免 reserved identity 混入同名物理 Session.
+        eq(messageSessionIdentity, identity),
+        ownerUserId !== undefined
+          ? or(eq(messageRequest.sessionIdentity, identity), isNull(messageRequest.sessionIdentity))
+          : eq(messageRequest.sessionIdentity, identity)
+      )
     : eq(messageSessionIdentity, identity);
 
   return and(

--- a/tests/api/v1/sessions/sessions.test.ts
+++ b/tests/api/v1/sessions/sessions.test.ts
@@ -137,6 +137,16 @@ describe("v1 session endpoints", () => {
     expect(requests.response.status).toBe(200);
     expect(getSessionRequestsMock).toHaveBeenCalledWith("s1", 2, 5, "desc");
 
+    for (const identity of ["pfx:scope:fingerprint", "sid:canonical-session"]) {
+      const encodedRequests = await callV1Route({
+        method: "GET",
+        pathname: `/api/v1/sessions/${encodeURIComponent(identity)}/requests?page=1&pageSize=20&order=desc`,
+        headers,
+      });
+      expect(encodedRequests.response.status).toBe(200);
+      expect(getSessionRequestsMock).toHaveBeenLastCalledWith(identity, 1, 20, "desc");
+    }
+
     await callV1Route({
       method: "GET",
       pathname: "/api/v1/sessions/s1/requests",

--- a/tests/unit/dashboard-logs-quick-filters-linkage.test.tsx
+++ b/tests/unit/dashboard-logs-quick-filters-linkage.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { format } from "date-fns";
+import type { ReactNode } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, test } from "vitest";
+import { UsageLogsFilters } from "@/app/[locale]/dashboard/logs/_components/usage-logs-filters";
+import commonMessages from "../../messages/en/common.json";
+import dashboardMessages from "../../messages/en/dashboard.json";
+
+function renderWithIntl(node: ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <NextIntlClientProvider
+        locale="en"
+        messages={{ dashboard: dashboardMessages, common: commonMessages }}
+        timeZone="UTC"
+      >
+        {node}
+      </NextIntlClientProvider>
+    );
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+async function actClick(el: Element | null) {
+  if (!el) throw new Error("element not found");
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+/**
+ * The quick filters bar and the date range picker both render a "Today" button.
+ * They are told apart by the icon: quick filter buttons carry a lucide icon,
+ * picker quick-period buttons are text-only.
+ */
+function findButton(
+  container: Element,
+  text: string,
+  options?: { withIcon?: boolean }
+): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll("button")).find((button) => {
+    if ((button.textContent || "").trim() !== text) return false;
+    if (options?.withIcon === undefined) return true;
+    const hasIcon = button.querySelector("svg") !== null;
+    return hasIcon === options.withIcon;
+  });
+}
+
+function isPressed(button: HTMLButtonElement | undefined): boolean {
+  return button?.getAttribute("aria-pressed") === "true";
+}
+
+function getTimeInputs(container: Element): HTMLInputElement[] {
+  return Array.from(container.querySelectorAll("input[type='time']"));
+}
+
+async function changeInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  if (!setter) throw new Error("missing native input value setter");
+  await act(async () => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function renderFilters() {
+  return renderWithIntl(
+    <UsageLogsFilters
+      isAdmin={false}
+      providers={[]}
+      initialKeys={[]}
+      filters={{}}
+      onChange={() => {}}
+      onReset={() => {}}
+    />
+  );
+}
+
+describe("UsageLogsFilters - quick filter linkage", () => {
+  test("quick bar Today lights up the picker Today and fills the date/time display", async () => {
+    const { container, unmount } = renderFilters();
+
+    const quickToday = findButton(container, "Today", { withIcon: true });
+    const pickerToday = findButton(container, "Today", { withIcon: false });
+    expect(quickToday).toBeDefined();
+    expect(pickerToday).toBeDefined();
+    expect(isPressed(quickToday)).toBe(false);
+    expect(isPressed(pickerToday)).toBe(false);
+
+    await actClick(quickToday ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+    expect(isPressed(findButton(container, "Today", { withIcon: false }))).toBe(true);
+
+    const today = format(new Date(), "yyyy-MM-dd");
+    const rangeTrigger = findButton(container, today);
+    expect(rangeTrigger).toBeDefined();
+
+    const [startInput, endInput] = getTimeInputs(container);
+    expect(startInput?.value).toBe("00:00");
+    expect(endInput?.value).toBe("23:59:59");
+
+    unmount();
+  });
+
+  test("selecting Today in the date range picker lights up the quick bar Today", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Today", { withIcon: false }) ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: false }))).toBe(true);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+
+    const [startInput, endInput] = getTimeInputs(container);
+    expect(startInput?.value).toBe("00:00");
+    expect(endInput?.value).toBe("23:59:59");
+
+    unmount();
+  });
+
+  test("selecting Yesterday in the picker does not light up the quick bar Today", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Yesterday", { withIcon: false }) ?? null);
+
+    expect(isPressed(findButton(container, "Yesterday", { withIcon: false }))).toBe(true);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(false);
+    expect(isPressed(findButton(container, "Today", { withIcon: false }))).toBe(false);
+
+    unmount();
+  });
+
+  test("clicking the active quick bar preset again clears the time range", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Today", { withIcon: true }) ?? null);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+
+    await actClick(findButton(container, "Today", { withIcon: true }) ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(false);
+    expect(isPressed(findButton(container, "Today", { withIcon: false }))).toBe(false);
+
+    const [startInput, endInput] = getTimeInputs(container);
+    expect(startInput?.value).toBe("");
+    expect(endInput?.value).toBe("");
+
+    unmount();
+  });
+
+  test("clicking the active picker period again clears the range and the quick bar highlight", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Today", { withIcon: false }) ?? null);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+
+    await actClick(findButton(container, "Today", { withIcon: false }) ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: false }))).toBe(false);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(false);
+
+    const [startInput, endInput] = getTimeInputs(container);
+    expect(startInput?.value).toBe("");
+    expect(endInput?.value).toBe("");
+
+    unmount();
+  });
+
+  test("time presets and status presets can stay highlighted at the same time", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Today", { withIcon: true }) ?? null);
+    await actClick(findButton(container, "Errors Only") ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+    expect(isPressed(findButton(container, "Errors Only"))).toBe(true);
+
+    await actClick(findButton(container, "With Retries") ?? null);
+
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+    expect(isPressed(findButton(container, "Errors Only"))).toBe(true);
+    expect(isPressed(findButton(container, "With Retries"))).toBe(true);
+
+    unmount();
+  });
+
+  test("changing the start clock breaks the exact Today preset highlight", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "Today", { withIcon: true }) ?? null);
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(true);
+
+    const [startInput] = getTimeInputs(container);
+    if (!startInput) throw new Error("start time input not found");
+    await changeInputValue(startInput, "08:00:00");
+
+    expect(isPressed(findButton(container, "Today", { withIcon: true }))).toBe(false);
+
+    unmount();
+  });
+
+  test("quick bar This Week fills a Monday-Sunday range and toggles off", async () => {
+    const { container, unmount } = renderFilters();
+
+    await actClick(findButton(container, "This Week", { withIcon: true }) ?? null);
+
+    expect(isPressed(findButton(container, "This Week", { withIcon: true }))).toBe(true);
+
+    const [startInput, endInput] = getTimeInputs(container);
+    expect(startInput?.value).toBe("00:00");
+    expect(endInput?.value).toBe("23:59:59");
+
+    await actClick(findButton(container, "This Week", { withIcon: true }) ?? null);
+
+    expect(isPressed(findButton(container, "This Week", { withIcon: true }))).toBe(false);
+    expect(getTimeInputs(container)[0]?.value).toBe("");
+
+    unmount();
+  });
+});

--- a/tests/unit/dashboard-logs-time-range-utils.test.ts
+++ b/tests/unit/dashboard-logs-time-range-utils.test.ts
@@ -2,8 +2,10 @@ import { format } from "date-fns";
 import { describe, expect, test } from "vitest";
 import {
   dateStringWithClockToTimestamp,
+  detectQuickTimePreset,
   formatClockFromTimestamp,
   getQuickDateRange,
+  getQuickTimeRange,
   inclusiveEndTimestampFromExclusive,
   parseClockString,
   type QuickPeriod,
@@ -114,5 +116,58 @@ describe("dashboard logs time range utils", () => {
 
     expect([before, after]).toContain(range.startDate);
     expect(range.endDate).toBe(range.startDate);
+  });
+
+  test("getQuickTimeRange returns today's full-day range with exclusive end", () => {
+    const now = new Date("2024-01-15T12:00:00Z");
+
+    expect(getQuickTimeRange("today", "UTC", now)).toEqual({
+      startTime: Date.UTC(2024, 0, 15, 0, 0, 0),
+      endTime: Date.UTC(2024, 0, 16, 0, 0, 0),
+    });
+  });
+
+  test("getQuickTimeRange resolves today in the given timezone", () => {
+    const now = new Date("2024-01-02T02:00:00Z");
+    const tz = "America/Los_Angeles"; // still 2024-01-01 (PST, UTC-8) there
+
+    const range = getQuickTimeRange("today", tz, now);
+    expect(range).toEqual({
+      startTime: Date.UTC(2024, 0, 1, 8, 0, 0),
+      endTime: Date.UTC(2024, 0, 2, 8, 0, 0),
+    });
+  });
+
+  test("getQuickTimeRange returns this-week as Monday through next Monday (exclusive)", () => {
+    const now = new Date("2024-01-17T12:00:00Z"); // Wednesday
+
+    expect(getQuickTimeRange("this-week", "UTC", now)).toEqual({
+      startTime: Date.UTC(2024, 0, 15, 0, 0, 0), // Monday 00:00:00
+      endTime: Date.UTC(2024, 0, 22, 0, 0, 0), // next Monday 00:00:00
+    });
+  });
+
+  test("detectQuickTimePreset round-trips getQuickTimeRange", () => {
+    const now = new Date("2024-01-17T12:00:00Z");
+
+    for (const preset of ["today", "this-week"] as const) {
+      const range = getQuickTimeRange(preset, "UTC", now);
+      expect(range).not.toBeNull();
+      expect(detectQuickTimePreset(range?.startTime, range?.endTime, "UTC", now)).toBe(preset);
+    }
+  });
+
+  test("detectQuickTimePreset returns null for custom or incomplete ranges", () => {
+    const now = new Date("2024-01-17T12:00:00Z");
+    const today = getQuickTimeRange("today", "UTC", now);
+    expect(today).not.toBeNull();
+    if (!today) return;
+
+    // A shifted start clock breaks the exact full-day preset
+    expect(
+      detectQuickTimePreset(today.startTime + 3_600_000, today.endTime, "UTC", now)
+    ).toBeNull();
+    expect(detectQuickTimePreset(undefined, today.endTime, "UTC", now)).toBeNull();
+    expect(detectQuickTimePreset(today.startTime, undefined, "UTC", now)).toBeNull();
   });
 });

--- a/tests/unit/dashboard/leaderboard-view-cache-coefficient.test.tsx
+++ b/tests/unit/dashboard/leaderboard-view-cache-coefficient.test.tsx
@@ -124,6 +124,104 @@ describe("LeaderboardView cache coefficient column", () => {
     expect(text).toContain("–");
   });
 
+  it("shows a tooltip trigger on the cache coefficient column header", async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("scope=providerCacheHitRate")) {
+        return {
+          ok: true,
+          json: async () => [cacheHitEntry({ providerId: 1, cacheCoefficientBp: 9000 })],
+        } as Response;
+      }
+      return { ok: true, json: async () => [] } as Response;
+    });
+
+    await act(async () => {
+      root!.render(<LeaderboardView isAdmin />);
+    });
+
+    const coefficientHeader = Array.from(container!.querySelectorAll("th")).find((th) =>
+      th.textContent?.includes("columns.cacheCoefficient")
+    );
+    expect(coefficientHeader).toBeDefined();
+    const trigger = coefficientHeader!.querySelector('[data-slot="tooltip-trigger"]');
+    expect(trigger).not.toBeNull();
+  });
+
+  it("does not trigger column sorting when the help icon is clicked", async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("scope=providerCacheHitRate")) {
+        return {
+          ok: true,
+          json: async () => [
+            cacheHitEntry({ providerId: 1, providerName: "high-first", cacheCoefficientBp: 9500 }),
+            cacheHitEntry({ providerId: 2, providerName: "low-second", cacheCoefficientBp: 5000 }),
+          ],
+        } as Response;
+      }
+      return { ok: true, json: async () => [] } as Response;
+    });
+
+    await act(async () => {
+      root!.render(<LeaderboardView isAdmin />);
+    });
+
+    const coefficientHeader = Array.from(container!.querySelectorAll("th")).find((th) =>
+      th.textContent?.includes("columns.cacheCoefficient")
+    );
+    const trigger = coefficientHeader!.querySelector('[data-slot="tooltip-trigger"]');
+    expect(trigger).not.toBeNull();
+
+    await act(async () => {
+      trigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    // 行顺序保持默认（未触发升序排序，否则 low-second 会排到第一行）
+    const bodyText = container!.querySelector("tbody")?.textContent ?? "";
+    expect(bodyText.indexOf("high-first")).toBeLessThan(bodyText.indexOf("low-second"));
+  });
+
+  it("colors the coefficient by tier: >=0.9 green, >=0.8 yellow, else orange", async () => {
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("scope=providerCacheHitRate")) {
+        return {
+          ok: true,
+          json: async () => [
+            cacheHitEntry({ providerId: 1, providerName: "excellent", cacheCoefficientBp: 9500 }),
+            cacheHitEntry({
+              providerId: 2,
+              providerName: "edge-excellent",
+              cacheCoefficientBp: 9000,
+            }),
+            cacheHitEntry({ providerId: 3, providerName: "good", cacheCoefficientBp: 8600 }),
+            cacheHitEntry({ providerId: 4, providerName: "edge-good", cacheCoefficientBp: 8000 }),
+            cacheHitEntry({ providerId: 5, providerName: "poor", cacheCoefficientBp: 5000 }),
+            cacheHitEntry({ providerId: 6, providerName: "missing", cacheCoefficientBp: null }),
+          ],
+        } as Response;
+      }
+      return { ok: true, json: async () => [] } as Response;
+    });
+
+    await act(async () => {
+      root!.render(<LeaderboardView isAdmin />);
+    });
+
+    const hasColoredValue = (selector: string, text: string) =>
+      Array.from(container!.querySelectorAll(selector)).some((el) => el.textContent === text);
+    expect(hasColoredValue("span.text-green-600", "0.95")).toBe(true);
+    // 边界值：0.90 仍属优秀档
+    expect(hasColoredValue("span.text-green-600", "0.90")).toBe(true);
+    expect(hasColoredValue("span.text-yellow-600", "0.86")).toBe(true);
+    // 边界值：0.80 仍属良好档
+    expect(hasColoredValue("span.text-yellow-600", "0.80")).toBe(true);
+    expect(hasColoredValue("span.text-orange-600", "0.50")).toBe(true);
+    // 缺失值：muted 样式展示占位符
+    expect(hasColoredValue("span.text-muted-foreground", "–")).toBe(true);
+  });
+
   it("renders the coefficient column on the provider usage board too", async () => {
     searchParamsState.value = new URLSearchParams("scope=provider");
     fetchMock.mockImplementation(async (input) => {

--- a/tests/unit/repository/message-session-request-query.test.ts
+++ b/tests/unit/repository/message-session-request-query.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { messageRequest } from "@/drizzle/schema";
 import { keys as keysTable } from "@/drizzle/schema";
 import {
@@ -50,6 +51,12 @@ type RequestRow = Pick<
 
 const firstCreatedAt = new Date("2026-05-04T10:00:00.000Z");
 const secondCreatedAt = new Date("2026-05-04T10:01:00.000Z");
+const dialect = new PgDialect();
+
+function compileWhere(values: readonly unknown[]) {
+  const query = dialect.sqlToQuery(values.at(0) as never);
+  return { sql: query.sql.toLowerCase(), params: query.params };
+}
 
 describe("message repository session request queries", () => {
   beforeEach(() => {
@@ -237,33 +244,50 @@ describe("message repository session request queries", () => {
     expect(rowsWhere.match(/shared-session/g)).toHaveLength(1);
   });
 
-  test("includes a legacy null-identity physical fallback for owner-scoped reserved identities", async () => {
-    const count = createDrizzleQuery([{ count: 1 }]);
-    const rows = createDrizzleQuery<readonly RequestRow[]>([]);
-    boundary.select.mockReturnValueOnce(count).mockReturnValueOnce(rows);
+  test.each(["pfx:legacy-client", "sid:legacy-client"])(
+    "includes an owner-scoped legacy fallback without aliasing a non-null identity: %s",
+    async (identity) => {
+      const count = createDrizzleQuery([{ count: 1 }]);
+      const rows = createDrizzleQuery<readonly RequestRow[]>([]);
+      boundary.select.mockReturnValueOnce(count).mockReturnValueOnce(rows);
 
-    await findRequestsBySessionIdentity("pfx:legacy-client", { ownerUserId: 17 } as never);
+      await findRequestsBySessionIdentity(identity, { ownerUserId: 17 } as never);
 
-    for (const where of [sqlText(count.trace.where), sqlText(rows.trace.where)]) {
-      expect(where).toContain("user_id");
-      expect(where).toContain("is null");
-      expect(where).toContain("session_id");
-      expect(where.match(/pfx:legacy-client/g)).toHaveLength(2);
+      for (const where of [count.trace.where, rows.trace.where]) {
+        const compiled = compileWhere(where);
+        expect(compiled.sql).toContain(
+          'coalesce("message_request"."session_identity", "message_request"."session_id") ='
+        );
+        expect(compiled.sql).toContain(
+          '("message_request"."session_identity" = $2 or "message_request"."session_identity" is null)'
+        );
+        expect(compiled.sql).not.toContain('or "message_request"."session_id" =');
+        expect(compiled.sql).toContain('"message_request"."user_id" = $3');
+        expect(compiled.params.slice(0, 3)).toEqual([identity, identity, 17]);
+      }
     }
-  });
+  );
 
-  test("does not add the legacy physical fallback for unscoped reserved identities", async () => {
-    const count = createDrizzleQuery([{ count: 1 }]);
-    const rows = createDrizzleQuery<readonly RequestRow[]>([]);
-    boundary.select.mockReturnValueOnce(count).mockReturnValueOnce(rows);
+  test.each(["pfx:canonical", "sid:canonical"])(
+    "uses the canonical expression index with an explicit unscoped identity guard: %s",
+    async (identity) => {
+      const count = createDrizzleQuery([{ count: 1 }]);
+      const rows = createDrizzleQuery<readonly RequestRow[]>([]);
+      boundary.select.mockReturnValueOnce(count).mockReturnValueOnce(rows);
 
-    await findRequestsBySessionIdentity("pfx:canonical", {} as never);
+      await findRequestsBySessionIdentity(identity, {} as never);
 
-    for (const where of [sqlText(count.trace.where), sqlText(rows.trace.where)]) {
-      expect(where).not.toContain("session_identity is null");
-      expect(where.match(/pfx:canonical/g)).toHaveLength(1);
+      for (const where of [count.trace.where, rows.trace.where]) {
+        const compiled = compileWhere(where);
+        expect(compiled.sql).toContain(
+          'coalesce("message_request"."session_identity", "message_request"."session_id") = $1 and "message_request"."session_identity" = $2'
+        );
+        expect(compiled.sql).not.toContain('"message_request"."session_identity" is null');
+        expect(compiled.sql).not.toContain('or "message_request"."session_id" =');
+        expect(compiled.params.slice(0, 2)).toEqual([identity, identity]);
+      }
     }
-  });
+  );
 
   test("does not treat a reserved canonical identity as a physical Session alias", async () => {
     const locator = createDrizzleQuery([


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This release improves dashboard filtering and presentation while correcting canonical session lookup and navigation behavior.
- Synchronizes usage-log quick filters with date, time, error, and retry controls.
- Adds localized cache-coefficient guidance and visual quality tiers to leaderboard tables.
- Decodes encoded canonical session route parameters and aligns client calls with the REST API wrapper.
- Reworks the reserved-session query to use the existing COALESCE expression index without changing its result set.
- Expands regression coverage for session queries, filter linkage, time ranges, and leaderboard rendering.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

The new filter ranges match the backend’s exclusive-end timestamp contract, canonical session normalization covers the generated reserved identity formats, and the repository predicate remains logically equivalent while improving index eligibility.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/logs/_utils/time-range.ts | Adds timezone-aware, exclusive-end ranges and exact preset detection consistent with repository query semantics. |
| src/app/[locale]/dashboard/logs/_components/usage-logs-filters.tsx | Derives quick-filter highlights from actual filter state and permits independent time, error, and retry presets. |
| src/app/[locale]/dashboard/leaderboard/_components/leaderboard-table.tsx | Adds an accessible optional tooltip trigger to reusable leaderboard column headers. |
| src/app/[locale]/dashboard/leaderboard/_components/leaderboard-view.tsx | Adds localized cache-coefficient guidance and threshold-based cell coloring. |
| src/app/[locale]/dashboard/sessions/[sessionId]/messages/_components/session-messages-client.tsx | Normalizes URL-encoded reserved canonical identities before invoking session API wrappers. |
| src/repository/message.ts | Re-expresses reserved canonical-session matching through the indexed COALESCE expression while preserving prior row-selection semantics. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(message): restore indexed reserved s..."](https://github.com/ding113/claude-code-hub/commit/8baef8be7f0eff9674e724e1d59e0bb0df084941) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49598179)</sub>

**Context used:**

- Knowledge Base — [Dashboard UI (Next.js App Router)](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/dashboard-ui.md)
- Knowledge Base — [Database Schema & Repository Layer](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/database-schema.md)

<!-- /greptile_comment -->