### PR TITLE
fix(proxy): recognize DeepSeek reasoning stream content

### DIFF
--- a/src/app/v1/_lib/proxy/stream-gate/frame-classifier.ts
+++ b/src/app/v1/_lib/proxy/stream-gate/frame-classifier.ts
@@ -97,9 +97,10 @@ const STREAM_SIGNALS: Record<ProtocolFamily, StreamSignal> = {
   "openai-chat": {
     contentRules: [
       {
-        // chunk 无事件名；delta 携带 content/tool_calls/refusal/audio 即内容
+        // chunk 无事件名；delta 携带 content/reasoning/tool_calls/refusal/audio 即内容
         anyPaths: [
           "choices.#.delta.content",
+          "choices.#.delta.reasoning_content",
           "choices.#.delta.tool_calls.#.function.arguments",
           "choices.#.delta.function_call.arguments",
           "choices.#.delta.refusal",

--- a/tests/unit/proxy/stream-gate-content-gate.test.ts
+++ b/tests/unit/proxy/stream-gate-content-gate.test.ts
@@ -216,6 +216,24 @@ describe("runStreamContentGate", () => {
     }
   });
 
+  it("openai-chat: DeepSeek reasoning_content commits before the default event cap", async () => {
+    const reasoningFrames = Array.from(
+      { length: 65 },
+      (_, index) =>
+        `data: {"choices":[{"delta":{"reasoning_content":"reasoning step ${index}"}}]}\n\n`
+    );
+    const reader = readerFromChunks(reasoningFrames);
+    const result = await runStreamContentGate(reader, {
+      ...GATE_OPTIONS,
+      family: "openai-chat",
+    });
+
+    expect(result.committed).toBe(true);
+    if (!result.committed) return;
+    expect(await drainPrefix(result.prefixChunks)).toBe(reasoningFrames[0]);
+    expect(result.readerDone).toBe(false);
+  });
+
   it("gemini: usage-only chunks buffer until content commits", async () => {
     const reader = readerFromChunks([
       'data: {"usageMetadata":{"totalTokenCount":1}}\n\n',

--- a/tests/unit/proxy/stream-gate-forwarder-integration.test.ts
+++ b/tests/unit/proxy/stream-gate-forwarder-integration.test.ts
@@ -606,6 +606,31 @@ describe("F1 stream content gate x ProxyForwarder sequential path", () => {
       }
     );
 
+    test("Replay owner 将 OpenAI-compatible DeepSeek reasoning_content 视为首个有效内容", async () => {
+      const provider = createProvider({
+        id: 1,
+        name: "deepseek-reasoning",
+        providerType: "openai-compatible",
+      });
+      const session = createSession();
+      session.setProvider(provider);
+      attachReplayOwner(session, REPLAY_GATE_CASES[1]);
+
+      const reasoningFrames = Array.from({ length: 65 }, (_, index) =>
+        sseFrame(null, { choices: [{ delta: { reasoning_content: `reasoning step ${index}` } }] })
+      );
+      const doForward = spyOnDoForward();
+      doForward.mockImplementationOnce(async () => createSseResponse(reasoningFrames));
+
+      const response = await ProxyForwarder.send(session);
+      const text = await response.text();
+
+      expect(doForward).toHaveBeenCalledTimes(1);
+      expect(text).toBe(reasoningFrames.join(""));
+      expect(mocks.pickRandomProviderWithExclusion).not.toHaveBeenCalled();
+      expect(mocks.recordFailure).not.toHaveBeenCalled();
+    });
+
     test("Replay owner 在所有 precommit attempt 失败后立即释放所有权", async () => {
       const provider = createProvider({ id: 1, name: "replay-only", providerType: "codex" });
       const session = createSession();

--- a/tests/unit/proxy/stream-gate-frame-classifier.test.ts
+++ b/tests/unit/proxy/stream-gate-frame-classifier.test.ts
@@ -159,10 +159,17 @@ describe("classifyFrame: anthropic", () => {
 });
 
 describe("classifyFrame: openai-chat", () => {
-  it("content: delta content / tool arguments / refusal / audio", () => {
+  it("content: delta content / reasoning / tool arguments / refusal / audio", () => {
     expect(classifyFrame("openai-chat", null, '{"choices":[{"delta":{"content":"hi"}}]}')).toBe(
       "content"
     );
+    expect(
+      classifyFrame(
+        "openai-chat",
+        null,
+        '{"choices":[{"delta":{"reasoning_content":"reasoning step"}}]}'
+      )
+    ).toBe("content");
     expect(
       classifyFrame(
         "openai-chat",
@@ -197,10 +204,13 @@ describe("classifyFrame: openai-chat", () => {
     ).toBe("neutral");
   });
 
-  it("neutral: empty string content delta", () => {
+  it("neutral: empty string content or reasoning delta", () => {
     expect(classifyFrame("openai-chat", null, '{"choices":[{"delta":{"content":""}}]}')).toBe(
       "neutral"
     );
+    expect(
+      classifyFrame("openai-chat", null, '{"choices":[{"delta":{"reasoning_content":""}}]}')
+    ).toBe("neutral");
   });
 
   it("error: in-stream error payload", () => {


### PR DESCRIPTION
Fixes #1394

## Summary

- Classify non-empty `choices[].delta.reasoning_content` as valid OpenAI Chat stream content.
- Preserve empty reasoning chunks as neutral and keep existing error/content precedence unchanged.
- Cover the 65-frame DeepSeek reasoning stream and the Request Replay owner path that still gates streams while `STREAM_GATE_MODE=off`.

## Validation

- `bunx vitest run tests/unit/proxy/stream-gate-frame-classifier.test.ts tests/unit/proxy/stream-gate-content-gate.test.ts tests/unit/proxy/stream-gate-forwarder-integration.test.ts` (79 passed)
- `bun run typecheck`
- `bun run lint`
- `bun run lint:fix`
- `bun run build`
- `bun run test`
- `bun run test:coverage`

## Review

- Local Standards review: no actionable findings.
- Local Spec review against #1394: no actionable findings.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the OpenAI Chat stream classifier so non-empty DeepSeek `reasoning_content` deltas count as valid content while empty deltas remain neutral.

- Adds `choices.#.delta.reasoning_content` to the existing OpenAI Chat content paths.
- Adds classifier coverage for non-empty and empty reasoning deltas.
- Adds content-gate and replay-owner integration coverage for a 65-frame reasoning stream.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new path uses the classifier’s existing non-empty-value semantics, preserves error-before-content precedence, and is covered at classifier, gate, and forwarding integration levels.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/stream-gate/frame-classifier.ts | Adds DeepSeek reasoning deltas to the established OpenAI Chat content classification without changing error precedence or empty-value semantics. |
| tests/unit/proxy/stream-gate-frame-classifier.test.ts | Verifies non-empty reasoning deltas classify as content and empty reasoning deltas remain neutral. |
| tests/unit/proxy/stream-gate-content-gate.test.ts | Verifies a reasoning-only stream commits immediately rather than reaching the event cap. |
| tests/unit/proxy/stream-gate-forwarder-integration.test.ts | Verifies the replay-owner forwarding path accepts and returns a reasoning-only DeepSeek stream without failover. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(proxy): recognize DeepSeek reasoning..."](https://github.com/ding113/claude-code-hub/commit/06abb52cbfbf3c3dd4efbc7910431d6399f34ec5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49908881)</sub>

**Context used:**

- Knowledge Base — [Proxy request pipeline](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/proxy-pipeline.md)

<!-- /greptile_comment -->