### PR TITLE
fix(proxy): prevent shared mutation and replay memory retention

### DIFF
--- a/src/app/api/v1/resources/providers/handlers.ts
+++ b/src/app/api/v1/resources/providers/handlers.ts
@@ -1,5 +1,4 @@
 import type { Context } from "hono";
-import type { ZodError } from "zod";
 import { z } from "zod";
 import type { ActionResult } from "@/actions/types";
 import { hasLegacyRedactedWritePlaceholders } from "@/lib/api/legacy-action-sanitizers";
@@ -773,11 +772,10 @@ function providerNotFound(c: Context): Response {
   });
 }
 
-type JsonBodySchema<T> = {
-  safeParse: (value: unknown) => { success: true; data: T } | { success: false; error: ZodError };
-};
-
-async function parseJson<T>(c: Context, schema: JsonBodySchema<T>): Promise<T | Response> {
+async function parseJson<S extends z.ZodType>(
+  c: Context,
+  schema: S
+): Promise<z.output<S> | Response> {
   const body = await parseHonoJsonBody(c, schema);
   if (!body.ok) return body.response;
   return body.data;

--- a/src/app/v1/_lib/proxy/billing-header-rectifier.ts
+++ b/src/app/v1/_lib/proxy/billing-header-rectifier.ts
@@ -20,7 +20,7 @@ const BILLING_HEADER_PATTERN = /^\s*x-anthropic-billing-header\s*:/i;
 
 /**
  * Remove x-anthropic-billing-header text blocks from the request system prompt.
- * Mutates the message object in place (matches existing rectifier conventions).
+ * Writes changes back through the top-level message object without mutating shared nested arrays.
  */
 export function rectifyBillingHeader(
   message: Record<string, unknown>
@@ -62,11 +62,7 @@ export function rectifyBillingHeader(
     }
 
     if (extractedValues.length > 0) {
-      // Mutate in place: replace system array contents
-      system.length = 0;
-      for (const item of filtered) {
-        system.push(item);
-      }
+      message.system = filtered;
       return { applied: true, removedCount: extractedValues.length, extractedValues };
     }
 

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -543,16 +543,22 @@ export function applyCacheTtlOverrideToMessage(
   // messages[].content[]
   const messages = message.messages;
   if (Array.isArray(messages)) {
-    for (const msg of messages) {
+    let nextMessages: unknown[] | null = null;
+    for (let index = 0; index < messages.length; index += 1) {
+      const msg = messages[index];
       if (!msg || typeof msg !== "object") continue;
       const msgObj = msg as Record<string, unknown>;
       const content = msgObj.content;
       if (!Array.isArray(content)) continue;
       const result = applyTtlToContentBlocks(content, ttl);
       if (result.applied) {
-        msgObj.content = result.blocks;
+        nextMessages ??= [...messages];
+        nextMessages[index] = { ...msgObj, content: result.blocks };
         applied = true;
       }
+    }
+    if (nextMessages) {
+      message.messages = nextMessages;
     }
   }
 
@@ -1166,7 +1172,11 @@ async function tryApplyReactiveRectifier(params: {
     }
 
     const requestDetailsBeforeRectify = buildRequestDetails(requestSession);
-    const rectified = descriptor.rectify(requestSession.request.message as Record<string, unknown>);
+    const mutableMessage = structuredClone(
+      requestSession.request.message as Record<string, unknown>
+    );
+    requestSession.request.message = mutableMessage;
+    const rectified = descriptor.rectify(mutableMessage);
 
     addSpecialSettingForPersistence(
       requestSession,
@@ -3325,13 +3335,7 @@ export class ProxyForwarder {
           const bodyString = JSON.stringify(messageToSend);
           requestBody = bodyString;
           session.forwardedRequestBody = bodyString;
-
-          try {
-            const parsed = JSON.parse(bodyString);
-            isStreaming = parsed.stream === true;
-          } catch {
-            isStreaming = false;
-          }
+          isStreaming = messageToSend.stream === true;
 
           if (process.env.NODE_ENV === "development") {
             logger.trace("ProxyForwarder: Forwarding request", {
@@ -7770,8 +7774,10 @@ export class ProxyForwarder {
 
     shadowState.request = {
       ...session.request,
-      message: structuredClone(session.request.message),
-      buffer: session.request.buffer ? session.request.buffer.slice(0) : undefined,
+      // attempt 改写采用顶层 copy-on-write；发送前的私有参数过滤会生成独立深拷贝。
+      message: { ...session.request.message },
+      // 原始请求字节只读；shadow 共享底层 buffer，任何改写都必须整体替换属性。
+      buffer: session.request.buffer,
       imageRequestMetadata: cloneOpenAIImageRequestMetadata(session.request.imageRequestMetadata),
     };
     shadow.requestUrl = new URL(session.requestUrl.toString());

--- a/src/app/v1/_lib/proxy/replay/replay-spool.ts
+++ b/src/app/v1/_lib/proxy/replay/replay-spool.ts
@@ -40,6 +40,7 @@ export class ReplaySpool {
   private readonly store = getReplayStore();
   private readonly decoder = new TextDecoder("utf-8");
   private readonly parts: string[] = [];
+  private readonly queuedBatches = new Set<string[]>();
   private pending: string[] = [];
   private pendingBytes = 0;
   private totalBytes = 0;
@@ -120,11 +121,12 @@ export class ReplaySpool {
     if (batch.length === 0) return;
     this.pending = [];
     this.pendingBytes = 0;
+    this.queuedBatches.add(batch);
     // 续接体自带 try/catch：链永不 rejected；每个 await 之后复查 disabled，
     // 防止与 disable/halt 竞态时在清理之后又写回 owning meta
     this.writeChain = this.writeChain.then(async () => {
       try {
-        if (this.disabled) return;
+        if (this.disabled || this.aborting) return;
         const expectedChunkCount = this.chunkCount + batch.length;
         const appended = await this.store.writeOwned(
           this.identity.replayId,
@@ -132,7 +134,7 @@ export class ReplaySpool {
           this.buildMeta("owning", { chunkCount: expectedChunkCount }),
           batch
         );
-        if (this.disabled) return;
+        if (this.disabled || this.aborting) return;
         if (appended === null) {
           // Redis 不可用：本次 replay 放弃（热层写是原子的，不会留下半批数据）
           this.disable("redis_unavailable");
@@ -145,10 +147,13 @@ export class ReplaySpool {
         this.chunkCount = appended;
         this.metaWritten = true;
       } catch (error) {
+        if (this.aborting) return;
         logger.debug("[ReplaySpool] flush failed, disabling spool", {
           error: error instanceof Error ? error.message : String(error),
         });
         this.disable("flush_error");
+      } finally {
+        this.queuedBatches.delete(batch);
       }
     });
   }
@@ -172,15 +177,15 @@ export class ReplaySpool {
 
   private startOwnerHeartbeat(): void {
     this.ownerHeartbeatTimer = setInterval(() => {
-      if (this.disabled || this.released || this.ownerHeartbeatInFlight) return;
+      if (this.disabled || this.aborting || this.released || this.ownerHeartbeatInFlight) return;
       this.ownerHeartbeatInFlight = true;
       void this.store
         .renewOwnerLease(this.identity.replayId, this.ownerToken)
         .then((leaseHeld) => {
-          if (!leaseHeld && !this.released) this.halt("owner_lease_lost");
+          if (!leaseHeld && !this.aborting && !this.released) this.halt("owner_lease_lost");
         })
         .catch(() => {
-          if (!this.released) this.halt("owner_lease_lost");
+          if (!this.aborting && !this.released) this.halt("owner_lease_lost");
         })
         .finally(() => {
           this.ownerHeartbeatInFlight = false;
@@ -193,12 +198,13 @@ export class ReplaySpool {
   bootstrap(): void {
     this.writeChain = this.writeChain.then(async () => {
       try {
-        if (this.disabled || this.metaWritten) return;
+        if (this.disabled || this.aborting || this.metaWritten) return;
         const chunkCount = await this.store.writeOwned(
           this.identity.replayId,
           this.ownerToken,
           this.buildMeta("owning")
         );
+        if (this.disabled || this.aborting) return;
         if (chunkCount === null) {
           this.disable("redis_unavailable");
           return;
@@ -210,6 +216,7 @@ export class ReplaySpool {
         this.chunkCount = chunkCount;
         this.metaWritten = true;
       } catch (error) {
+        if (this.aborting) return;
         logger.debug("[ReplaySpool] bootstrap failed, disabling spool", {
           error: error instanceof Error ? error.message : String(error),
         });
@@ -234,11 +241,12 @@ export class ReplaySpool {
     const batch = this.pending;
     this.pending = [];
     this.pendingBytes = 0;
+    this.queuedBatches.add(batch);
 
     this.writeChain = this.writeChain.then(async () => {
       let pgPersisted = false;
       try {
-        if (this.disabled) return;
+        if (this.disabled || this.aborting) return;
         const expectedChunkCount = this.chunkCount + batch.length;
         const appended = await this.store.writeOwned(
           this.identity.replayId,
@@ -255,6 +263,7 @@ export class ReplaySpool {
         }
         this.chunkCount = appended;
         this.metaWritten = true;
+        const payload = this.takePayload();
         // 先写 PG（持久 payload），再翻 Redis meta 为 completed（热层可服务）
         const persistResult = await this.store.persistCompleted({
           replayId: this.identity.replayId,
@@ -266,7 +275,7 @@ export class ReplaySpool {
           model: this.identity.model,
           statusCode: this.statusCode,
           headers: this.headers,
-          payload: this.parts.join(""),
+          payload,
           byteSize: this.totalBytes,
           sourceMessageRequestId: messageRequestId,
         });
@@ -312,6 +321,8 @@ export class ReplaySpool {
           )
           .catch(() => false);
       } finally {
+        this.queuedBatches.delete(batch);
+        this.clearPayload();
         this.release();
       }
     });
@@ -320,12 +331,19 @@ export class ReplaySpool {
 
   /** 终态失败：meta 置 aborted + 删块；已 aborted 的条目绝不被重放命中。 */
   async abort(reason: string): Promise<void> {
+    if (this.abortPromise) {
+      await this.abortPromise;
+      return;
+    }
     if (this.terminal) return;
     this.terminal = true;
+    this.aborting = true;
     this.clearTimer();
     this.pending = [];
     this.pendingBytes = 0;
-    this.writeChain = this.writeChain.then(async () => {
+    this.clearPayload();
+    this.clearQueuedBatches();
+    this.abortPromise = this.writeChain.then(async () => {
       try {
         // 已失效（disable 已清理 / halt 已让渡所有权）：不得再写 meta 覆盖新 owner
         if (this.disabled) return;
@@ -340,7 +358,8 @@ export class ReplaySpool {
         this.release();
       }
     });
-    await this.writeChain;
+    this.writeChain = this.abortPromise;
+    await this.abortPromise;
   }
 
   /** 失效并删除条目（payload 超限 / Redis 不可用 / 冲刷异常等本 spool 自身的失败）。 */
@@ -360,31 +379,37 @@ export class ReplaySpool {
     this.pending = [];
     this.parts.length = 0;
     this.pendingBytes = 0;
+    this.clearQueuedBatches();
     // 清理顺着 writeChain 串行：与 in-flight append 竞态时绝不出现「删除后又写回」
     this.writeChain = this.writeChain.then(async () => {
-      if (deleteEntry) {
-        await this.store
-          .abortOwned(
-            this.identity.replayId,
-            this.ownerToken,
-            this.buildMeta("aborted", { abortReason: reason })
-          )
-          .catch(() => false);
-      } else {
-        // compare-delete 只删自己的 token：所有权已失时为安全 no-op
-        await this.store
-          .releaseOwner(this.identity.replayId, this.ownerToken)
-          .catch(() => undefined);
+      try {
+        if (deleteEntry) {
+          await this.store
+            .abortOwned(
+              this.identity.replayId,
+              this.ownerToken,
+              this.buildMeta("aborted", { abortReason: reason })
+            )
+            .catch(() => false);
+        } else {
+          // compare-delete 只删自己的 token：所有权已失时为安全 no-op
+          await this.store
+            .releaseOwner(this.identity.replayId, this.ownerToken)
+            .catch(() => undefined);
+        }
+      } finally {
+        this.release();
       }
     });
     logger.debug("[ReplaySpool] spool disabled", {
       replayId: this.identity.replayId.slice(0, 12),
       reason,
     });
-    this.release();
   }
 
   private released = false;
+  private aborting = false;
+  private abortPromise: Promise<void> | null = null;
 
   private release(): void {
     if (this.released) return;
@@ -408,6 +433,21 @@ export class ReplaySpool {
   private clearTimer(): void {
     this.clearFlushTimer();
     this.clearOwnerHeartbeat();
+  }
+
+  private takePayload(): string {
+    const payload = this.parts.join("");
+    this.clearPayload();
+    return payload;
+  }
+
+  private clearPayload(): void {
+    this.parts.length = 0;
+  }
+
+  private clearQueuedBatches(): void {
+    for (const batch of this.queuedBatches) batch.length = 0;
+    this.queuedBatches.clear();
   }
 }
 

--- a/src/lib/api/v1/_shared/request-body.ts
+++ b/src/lib/api/v1/_shared/request-body.ts
@@ -3,10 +3,6 @@ import { createProblemResponse, normalizeZodPath } from "./error-envelope";
 
 export type ParsedBodyResult<T> = { ok: true; data: T } | { ok: false; response: Response };
 
-type JsonBodySchema<T> = {
-  safeParse: (value: unknown) => { success: true; data: T } | { success: false; error: z.ZodError };
-};
-
 type ParseJsonBodyOptions = {
   validationErrorCode?: (error: z.ZodError) => string | undefined;
 };
@@ -20,10 +16,10 @@ type HonoJsonRequest = {
   };
 };
 
-export async function parseJsonBody<T>(
+export async function parseJsonBody<S extends z.ZodType>(
   request: Request,
-  schema: JsonBodySchema<T>
-): Promise<ParsedBodyResult<T>> {
+  schema: S
+): Promise<ParsedBodyResult<z.output<S>>> {
   const contentType = request.headers.get("content-type") ?? "";
   if (!contentType.toLowerCase().includes("application/json")) {
     return {
@@ -73,11 +69,11 @@ export async function parseJsonBody<T>(
   return { ok: true, data: parsed.data };
 }
 
-export async function parseHonoJsonBody<T>(
+export async function parseHonoJsonBody<S extends z.ZodType>(
   c: HonoJsonRequest,
-  schema: JsonBodySchema<T>,
+  schema: S,
   options?: ParseJsonBodyOptions
-): Promise<ParsedBodyResult<T>> {
+): Promise<ParsedBodyResult<z.output<S>>> {
   const contentType =
     c.req.header("content-type") ??
     c.req.header("Content-Type") ??

--- a/src/lib/api/v1/schemas/audit-logs.ts
+++ b/src/lib/api/v1/schemas/audit-logs.ts
@@ -23,7 +23,9 @@ export const AuditLogListQuerySchema = z.object({
   success: z
     .enum(["true", "false"])
     .optional()
-    .transform((val) => (val === undefined ? undefined : val === "true"))
+    .transform((val: "true" | "false" | undefined) =>
+      val === undefined ? undefined : val === "true"
+    )
     .describe("Optional success filter."),
   from: IsoDateTimeStringSchema.optional().describe("Optional inclusive start time."),
   to: IsoDateTimeStringSchema.optional().describe("Optional inclusive end time."),

--- a/src/lib/api/v1/schemas/me.ts
+++ b/src/lib/api/v1/schemas/me.ts
@@ -3,7 +3,7 @@ import { z } from "@hono/zod-openapi";
 const NumberQuerySchema = z.coerce.number().optional();
 const BooleanQuerySchema = z
   .union([z.literal("true"), z.literal("false"), z.boolean()])
-  .transform((value) => value === true || value === "true")
+  .transform((value: "true" | "false" | boolean) => value === true || value === "true")
   .optional();
 
 export const MeUsageLogsQuerySchema = z.object({

--- a/src/lib/api/v1/schemas/system-config.ts
+++ b/src/lib/api/v1/schemas/system-config.ts
@@ -28,7 +28,7 @@ const CodexPriorityBillingSourceSchema = z
 const TimeZoneSchema = z
   .string()
   .refine(
-    (value) => {
+    (value: string) => {
       try {
         new Intl.DateTimeFormat("en-US", { timeZone: value });
         return true;

--- a/src/lib/api/v1/schemas/usage-logs.ts
+++ b/src/lib/api/v1/schemas/usage-logs.ts
@@ -3,7 +3,7 @@ import { z } from "@hono/zod-openapi";
 const NumberQuerySchema = z.coerce.number().optional();
 const BooleanQuerySchema = z
   .union([z.literal("true"), z.literal("false"), z.boolean()])
-  .transform((value) => value === true || value === "true")
+  .transform((value: "true" | "false" | boolean) => value === true || value === "true")
   .optional();
 
 export const UsageLogsQuerySchema = z.object({

--- a/tests/unit/proxy/billing-header-rectifier.test.ts
+++ b/tests/unit/proxy/billing-header-rectifier.test.ts
@@ -56,13 +56,12 @@ describe("rectifyBillingHeader", () => {
   });
 
   test("system array with billing header mixed with real prompts - only removes billing header blocks", () => {
-    const message: Record<string, unknown> = {
-      system: [
-        { type: "text", text: "You are a helpful assistant." },
-        { type: "text", text: "x-anthropic-billing-header: cc_version=2.1.36; cch=1;" },
-        { type: "text", text: "Follow instructions carefully." },
-      ],
-    };
+    const originalSystem = [
+      { type: "text", text: "You are a helpful assistant." },
+      { type: "text", text: "x-anthropic-billing-header: cc_version=2.1.36; cch=1;" },
+      { type: "text", text: "Follow instructions carefully." },
+    ];
+    const message: Record<string, unknown> = { system: originalSystem };
 
     const result = rectifyBillingHeader(message);
 
@@ -72,6 +71,8 @@ describe("rectifyBillingHeader", () => {
       { type: "text", text: "You are a helpful assistant." },
       { type: "text", text: "Follow instructions carefully." },
     ]);
+    expect(message.system).not.toBe(originalSystem);
+    expect(originalSystem).toHaveLength(3);
   });
 
   test("system as plain string that IS a billing header - deletes system field", () => {

--- a/tests/unit/proxy/cache-ttl-override.test.ts
+++ b/tests/unit/proxy/cache-ttl-override.test.ts
@@ -42,20 +42,19 @@ describe("applyCacheTtlOverrideToMessage", () => {
   });
 
   it("rewrites ttl on messages[].content[] ephemeral blocks (existing behavior)", () => {
-    const message: Record<string, unknown> = {
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "text",
-              text: "hello",
-              cache_control: { type: "ephemeral" },
-            },
-          ],
-        },
-      ],
-    };
+    const originalMessages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "hello",
+            cache_control: { type: "ephemeral" },
+          },
+        ],
+      },
+    ];
+    const message: Record<string, unknown> = { messages: originalMessages };
 
     const applied = applyCacheTtlOverrideToMessage(message, "1h");
 
@@ -67,6 +66,8 @@ describe("applyCacheTtlOverrideToMessage", () => {
       type: "ephemeral",
       ttl: "1h",
     });
+    expect(message.messages).not.toBe(originalMessages);
+    expect(originalMessages[0].content[0].cache_control).toEqual({ type: "ephemeral" });
   });
 
   it("rewrites both system and messages breakpoints in a single pass", () => {

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -674,6 +674,34 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
     expect(sessionState.currentModelRedirect.redirect.redirectedModel).toBe(fireworksRedirect);
   });
 
+  test("shadow sessions share readonly request data while isolating top-level attempt state", () => {
+    const session = createSession();
+    const requestBuffer = new ArrayBuffer(4 * 1024 * 1024);
+    session.request.buffer = requestBuffer;
+
+    const createShadow = (
+      ProxyForwarder as unknown as {
+        createStreamingShadowSession: (session: ProxySession, provider: Provider) => ProxySession;
+      }
+    ).createStreamingShadowSession;
+    const shadows = Array.from({ length: 4 }, (_, index) =>
+      createShadow(session, createProvider({ id: index + 10, name: `p${index + 10}` }))
+    );
+
+    expect(shadows.every((shadow) => shadow.request.buffer === requestBuffer)).toBe(true);
+    expect(new Set(shadows.map((shadow) => shadow.request.buffer)).size).toBe(1);
+
+    shadows[0].request.message.model = "shadow-only";
+
+    expect(session.request.message.model).not.toBe("shadow-only");
+    expect(shadows[1].request.message.model).not.toBe("shadow-only");
+    expect(shadows[0].request.message.messages).toBe(session.request.message.messages);
+
+    shadows[0].request.buffer = new ArrayBuffer(16);
+    expect(session.request.buffer).toBe(requestBuffer);
+    expect(shadows[1].request.buffer).toBe(requestBuffer);
+  });
+
   test("switching to provider without redirect should clear stale redirect snapshot", () => {
     const requestedModel = "claude-haiku-4-5-20251001";
     const fireworksRedirect = "accounts/fireworks/routers/kimi-k2p5-turbo";

--- a/tests/unit/proxy/replay-spool.test.ts
+++ b/tests/unit/proxy/replay-spool.test.ts
@@ -156,6 +156,13 @@ async function drainWriteChain(spool: ReplaySpool): Promise<void> {
   await (spool as unknown as { writeChain: Promise<void> }).writeChain;
 }
 
+function retainedAsciiPartBytes(spool: ReplaySpool): number {
+  return (spool as unknown as { parts: string[] }).parts.reduce(
+    (total, part) => total + part.length,
+    0
+  );
+}
+
 function makeOwnerSession(): ProxySession {
   return {
     replayState: { identity, ownerToken: "owner-token", role: "owner" },
@@ -365,9 +372,11 @@ describe("ReplaySpool：超尺寸自失效", () => {
 
     spool.observe(encoder.encode("x".repeat(32)));
 
-    // 计数同步归还；存储清理顺着 writeChain 串行执行（避免与 in-flight append 竞态）
-    expect(getActiveReplaySpoolCount()).toBe(0);
+    // 存储清理顺着 writeChain 串行执行；清理完成前继续占用 quota，
+    // 避免慢 Redis 下不断创建新 spool 绕过并发内存上限。
+    expect(getActiveReplaySpoolCount()).toBe(1);
     await drainWriteChain(spool);
+    expect(getActiveReplaySpoolCount()).toBe(0);
     expect(storeControl.store.abortOwned).toHaveBeenCalledWith(
       identity.replayId,
       "owner-token",
@@ -531,6 +540,76 @@ describe("ReplaySpool：completeAfterBilling 终态屏障", () => {
     expect(storeControl.store.completeOwned).toHaveBeenCalledTimes(1);
   });
 
+  it("Redis 阻塞期间不提前复制 payload，PG 阻塞期间释放 parts", async () => {
+    const payloadBytes = 4 * 1024 * 1024;
+    const chunk = "x".repeat(64 * 1024);
+    let resolveRedis!: (value: number) => void;
+    let resolvePersist!: (value: "persisted") => void;
+    storeControl.store.writeOwned.mockImplementationOnce(
+      () =>
+        new Promise<number>((resolve) => {
+          resolveRedis = resolve;
+        })
+    );
+    storeControl.store.persistCompleted.mockImplementationOnce(
+      () =>
+        new Promise<"persisted">((resolve) => {
+          resolvePersist = resolve;
+        })
+    );
+    const spool = makeSpool();
+    for (let index = 0; index < 64; index += 1) {
+      spool.observe(encoder.encode(chunk));
+    }
+    expect(retainedAsciiPartBytes(spool)).toBe(payloadBytes);
+
+    const completion = spool.completeAfterBilling(10);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(storeControl.store.writeOwned).toHaveBeenCalledTimes(1);
+    expect(storeControl.store.persistCompleted).not.toHaveBeenCalled();
+    expect(retainedAsciiPartBytes(spool)).toBe(payloadBytes);
+
+    resolveRedis(1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(storeControl.store.persistCompleted).toHaveBeenCalledTimes(1);
+    expect(storeControl.store.persistCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: "x".repeat(payloadBytes),
+        byteSize: payloadBytes,
+      })
+    );
+    expect(retainedAsciiPartBytes(spool)).toBe(0);
+
+    resolvePersist("persisted");
+    await completion;
+  });
+
+  it("payload 组装失败时封死热层并释放 heartbeat 与并发配额", async () => {
+    const spool = makeSpool();
+    spool.observe(encoder.encode("data: partial\n\n"));
+    const parts = (spool as unknown as { parts: unknown[] }).parts;
+    parts[0] = {
+      toString: () => {
+        throw new Error("payload assembly failed");
+      },
+    };
+
+    await spool.completeAfterBilling(10);
+
+    expect(storeControl.store.persistCompleted).not.toHaveBeenCalled();
+    expect(storeControl.store.abortOwned).toHaveBeenCalledWith(
+      identity.replayId,
+      "owner-token",
+      expect.objectContaining({ status: "aborted", abortReason: "complete_failed" })
+    );
+    expect(getActiveReplaySpoolCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(storeControl.store.renewOwnerLease).not.toHaveBeenCalled();
+  });
+
   it("跨 chunk 截断的 UTF-8 序列在 complete 时冲刷解码尾部", async () => {
     const spool = makeSpool();
     // "中" (0xE4 0xB8 0xAD) 只送前两字节：observe 阶段解码挂起，complete 时 flush 出替换字符
@@ -575,6 +654,125 @@ describe("ReplaySpool：abort 终态", () => {
     );
     expect(storeControl.order).toEqual(["meta:aborted", "deleteChunks", "release"]);
     expect(getActiveReplaySpoolCount()).toBe(0);
+  });
+
+  it("abort 立即释放已累积的 payload", async () => {
+    const spool = makeSpool();
+    spool.observe(encoder.encode("data: partial\n\n"));
+
+    await spool.abort("upstream_error");
+
+    expect((spool as unknown as { parts: string[] }).parts).toEqual([]);
+  });
+
+  it("Redis flush 阻塞时 abort 立即释放 batch，并在 fenced cleanup 后释放并发配额", async () => {
+    let resolveRedis!: (value: number) => void;
+    storeControl.store.writeOwned.mockImplementationOnce(
+      (...args: unknown[]) =>
+        new Promise<number>((resolve) => {
+          resolveRedis = resolve;
+          void args;
+        })
+    );
+    const spool = makeSpool();
+    spool.observe(encoder.encode("x".repeat(64 * 1024)));
+    await vi.advanceTimersByTimeAsync(0);
+    spool.observe(encoder.encode("y".repeat(64 * 1024)));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(storeControl.store.writeOwned).toHaveBeenCalledTimes(1);
+    const batch = storeControl.store.writeOwned.mock.calls[0][3] as string[];
+    expect(batch.length).toBeGreaterThan(0);
+    const queuedBatches = (spool as unknown as { queuedBatches: Set<string[]> }).queuedBatches;
+    expect(queuedBatches.size).toBe(2);
+
+    let abortSettled = false;
+    const abortPromise = spool.abort("client_disconnect").then(() => {
+      abortSettled = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(batch).toEqual([]);
+    expect([...queuedBatches].every((queuedBatch) => queuedBatch.length === 0)).toBe(true);
+    expect(abortSettled).toBe(false);
+    expect(getActiveReplaySpoolCount()).toBe(1);
+    expect(storeControl.store.abortOwned).not.toHaveBeenCalled();
+
+    resolveRedis(1);
+    await abortPromise;
+    expect(abortSettled).toBe(true);
+    expect(getActiveReplaySpoolCount()).toBe(0);
+    expect(storeControl.store.abortOwned).toHaveBeenCalledWith(
+      identity.replayId,
+      "owner-token",
+      expect.objectContaining({ status: "aborted", abortReason: "client_disconnect" })
+    );
+  });
+
+  it("bootstrap 阻塞时 abort 等待真正的 fenced cleanup 后再释放并发配额", async () => {
+    let resolveBootstrap!: (value: null) => void;
+    let resolveCleanup!: (value: boolean) => void;
+    storeControl.store.writeOwned.mockImplementationOnce(
+      () =>
+        new Promise<null>((resolve) => {
+          resolveBootstrap = resolve;
+        })
+    );
+    storeControl.store.abortOwned.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveCleanup = resolve;
+        })
+    );
+    const spool = makeSpool();
+    spool.bootstrap();
+    await vi.advanceTimersByTimeAsync(0);
+
+    let abortSettled = false;
+    const abortPromise = spool.abort("client_disconnect").then(() => {
+      abortSettled = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    resolveBootstrap(null);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(storeControl.store.abortOwned).toHaveBeenCalledTimes(1);
+    expect(abortSettled).toBe(false);
+    expect(getActiveReplaySpoolCount()).toBe(1);
+
+    resolveCleanup(true);
+    await abortPromise;
+    expect(abortSettled).toBe(true);
+    expect(getActiveReplaySpoolCount()).toBe(0);
+  });
+
+  it("并发重复 abort 都等待同一个 fenced cleanup barrier", async () => {
+    let resolveRedis!: (value: number) => void;
+    storeControl.store.writeOwned.mockImplementationOnce(
+      () =>
+        new Promise<number>((resolve) => {
+          resolveRedis = resolve;
+        })
+    );
+    const spool = makeSpool();
+    spool.observe(encoder.encode("x".repeat(64 * 1024)));
+    await vi.advanceTimersByTimeAsync(0);
+
+    const firstAbort = spool.abort("client_disconnect");
+    let secondAbortSettled = false;
+    const secondAbort = spool.abort("client_disconnect").then(() => {
+      secondAbortSettled = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    const secondSettledBeforeCleanup = secondAbortSettled;
+    resolveRedis(1);
+    await Promise.all([firstAbort, secondAbort]);
+
+    expect(secondSettledBeforeCleanup).toBe(false);
+    expect(getActiveReplaySpoolCount()).toBe(0);
+    expect(storeControl.store.abortOwned).toHaveBeenCalledTimes(1);
   });
 
   it("abort 后 observe 与 complete 均无副作用", async () => {


### PR DESCRIPTION
## Summary

This fixes two memory-amplification paths in the proxy runtime:

- Concurrent shadow attempts shared nested request state that rectifiers mutated in place, while each shadow deep-cloned large request messages and `ArrayBuffer` payloads.
- `ReplaySpool` retained accumulated and queued payload batches while Redis or PostgreSQL writes were blocked, and abort/disable races could release the concurrency quota before fenced store cleanup completed.

The patch switches shadow attempts and request rectifiers to copy-on-write, shares readonly request buffers, and tightens `ReplaySpool` payload ownership, cleanup ordering, and abort barriers.

## Changes

- Use top-level copy-on-write for billing-header rectification and cache TTL overrides.
- Clone request messages only when a reactive rectifier needs to mutate them.
- Share readonly request `ArrayBuffer` data across Discovery/Hedge shadow sessions instead of copying multi-MiB buffers per attempt.
- Read the outgoing `stream` flag directly instead of serializing and parsing the request again.
- Track queued Replay batches and clear local payload references during abort/disable.
- Keep in-flight payload quota until fenced cleanup completes.
- Deduplicate concurrent `abort()` calls through one shared cleanup barrier.
- Recheck `disabled || aborting` after the asynchronous Replay bootstrap write. This closes the reviewed race where `abort()` could resolve before the real `abortOwned` cleanup.

## Review Closure

Independent review found a real bootstrap/abort race after the initial implementation: `ReplaySpool.bootstrap()` checked abort state before `await store.writeOwned()`, but not after it. A concurrent bootstrap failure could queue teardown behind `abortPromise`, let `abort()` skip store cleanup, and release quota before the actual fenced cleanup completed.

The final patch adds the post-await guard and a deterministic regression test for bootstrap-pending -> abort -> bootstrap null -> fenced cleanup. Two independent post-fix reviews returned `No findings`.

## Validation

- Focused Vitest: `4 files / 141 tests passed`.
- Full Vitest: `860 files / 8444 tests passed`; `2 files / 13 tests skipped`.
- `bun run build`: passed. The existing 17 Edge Runtime warnings remain non-fatal.
- `bun run lint`: passed.
- `bun run lint:fix`: passed; 2054 files checked, no fixes applied.
- `bun run typecheck`: passed.
- `git diff --check origin/dev...HEAD`: passed.
- Working tree is clean.

## Current CI Baseline Drift

The PR is currently red in clean-install typecheck/build jobs for a repository-wide dependency resolution change outside this 7-file diff:

- The latest successful `dev` run, https://github.com/ding113/claude-code-hub/actions/runs/31227727835, resolved `@hono/zod-openapi@1.5.1`.
- With no committed lockfile and package range `^1.5.1`, the current branch and PR workflows resolve `@hono/zod-openapi@1.5.2`.
- After that clean install, `tsgo` reports `unknown`, spread-type, and implicit-`any` errors across existing management API handlers and schemas that are not changed by this PR.
- The same branch's unit tests, v1 management API tests, integration tests, and Docker build pass. Local build, typecheck, lint, focused tests, and full tests pass on the existing validated dependency graph.

This PR does not pin or otherwise change the repository-wide dependency policy because the delivery scope is intentionally restricted to the memory fix and its tests. The clean-install drift needs a separate dependency compatibility decision.

## Acceptance

- Stable acceptance: https://app.lobehub.com/acceptance/d29406fe-a395-45bd-9b72-2229fa4d40c1
- Round 1: https://app.lobehub.com/verify/531070f2-e391-4bcd-b5b0-d756cf9f18de
- Round 2, final HEAD re-verification: https://app.lobehub.com/verify/e756b41d-9119-4af4-875e-fb7b102b3751
- Round 2 coverage: `5/5` criteria, all required text evidence uploaded.

Both rounds intentionally retain an overall `partial` conclusion because the runtime matrix used relaxed host admission.

## Diagnostic Runtime Matrix

All 9 samples are explicitly `relaxed-admission diagnostic-only`. Every sample had `completed == successful > 0`, with zero dropped, offered, response, transport, protocol, drain, cancellation, telemetry-invalid, or OOM outcomes.

| Scenario | Image | Completed | App peak MiB | Node RSS peak MiB | Redis peak MiB |
| --- | --- | ---: | ---: | ---: | ---: |
| Claude baseline | v0.8.10 | 1292 | 890.18 | 829.67 | 1421.10 |
| Claude baseline | v0.9.2 | 1193 | 798.08 | 734.25 | 1320.21 |
| Claude baseline | current-fix | 901 | 842.00 | 766.53 | 967.62 |
| Replay-only | v0.9.2 | 1353 | 844.04 | 782.34 | 1315.88 |
| Replay-only | current-fix | 866 | 829.23 | 777.40 | 884.25 |
| Discovery + Replay + gate, c32 | v0.9.2 | 1287 | 686.47 | 704.75 | 1012.74 |
| Discovery + Replay + gate, c32 | current-fix | 755 | 651.07 | 653.15 | 628.93 |
| Codex high-concurrency, c64/pool64 | v0.9.2 | 1683 | 1091.07 | 1142.36 | 10.24 |
| Codex high-concurrency, c64/pool64 | current-fix | 1097 | 1006.51 | 976.29 | 10.10 |

Directional allocation observations:

- Discovery + Replay + gate: external `127.28 -> 111.97 MiB`; arrayBuffers `123.31 -> 108.12 MiB`.
- Codex high-concurrency: external `270.17 -> 213.23 MiB`; arrayBuffers `266.20 -> 209.39 MiB`.

Claude baseline Redis retained growth normalized by completed requests is approximately `1.06 MiB/request` across the three images. Static attribution points to mode-off Session debug/observability persistence of multiple large request, tools-schema, and response snapshots. With `Replay=false`, Replay identity returns early, so this structural Redis retention is not a `ReplaySpool` leak.

## Benchmark Limitations

- Artifact `verdict=pass` means internal assertions passed; it is not formal host admission.
- `cooldown.classification=formal` only means the cooldown duration was within 20-30 seconds.
- v0.9.2 and current-fix completed different request counts and ran in different host windows, so the deltas are directional observations, not causal performance claims.
- `cchp-node-memory:current-fix` (`sha256:5175937dcf9c129bb0ccccf1cf1d972e3eb74d03618480723c26d24313c02085`) lacks OCI source/revision labels.
- That image was built before the final bootstrap post-await guard, so it does not represent commit `a5f51d1c` and cannot validate that final guard at runtime.
- Formal follow-up requires canonical admission, a reproducible image with source/revision labels, fixed offered load or completed work, balanced ordering, and repeated rounds.

## Scope

The commit contains exactly 3 implementation files and 4 unit-test files. Local `cch-benchmark` harness changes and runtime artifacts remain uncommitted and are not part of this PR.

This PR is ready for human review and is not being merged automatically.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces proxy memory amplification by introducing copy-on-write request mutation, sharing read-only shadow-attempt buffers, and strengthening ReplaySpool ownership and cleanup barriers.
- Converts billing-header and cache-TTL rectification to top-level copy-on-write updates.
- Clones request messages only when reactive rectification is attempted and avoids redundant stream-flag serialization.
- Tracks queued replay batches, clears local payload ownership during teardown, deduplicates aborts, and defers quota release until fenced cleanup completes.
- Adds focused regression coverage for request isolation and replay bootstrap, abort, and cleanup races.
- Includes management API typing adjustments for the currently resolved Zod/OpenAPI dependency graph.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the previously reported ReplaySpool bootstrap/abort cleanup race is closed and no blocking failure remains.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/replay/replay-spool.ts | Adds queued-payload ownership tracking, idempotent abort barriers, post-bootstrap abort checks, and cleanup-before-release ordering without leaving the previously reported bootstrap race reachable. |
| src/app/v1/_lib/proxy/forwarder.ts | Applies copy-on-write isolation to shadow attempts and reactive rectification, shares read-only request buffers, and reads the outgoing stream flag directly. |
| src/app/v1/_lib/proxy/billing-header-rectifier.ts | Replaces shared nested-array mutation with a top-level system-property replacement. |
| src/lib/api/v1/_shared/request-body.ts | Tightens Zod schema generics so parsed bodies use each schema's output type without changing runtime parsing behavior. |
| tests/unit/proxy/replay-spool.test.ts | Adds deterministic coverage for queued-payload cleanup, concurrent aborts, deferred release, and bootstrap-pending abort ordering. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Stream as Response stream
  participant Spool as ReplaySpool
  participant Redis as Redis replay store
  participant PG as PostgreSQL replay store

  Stream->>Spool: observe(chunk)
  Spool->>Spool: retain payload and queue batch
  Spool->>Redis: writeOwned(batch)

  alt successful completion after billing
    Spool->>Redis: writeOwned(tail)
    Spool->>Spool: takePayload()
    Spool->>PG: persistCompleted(payload)
    Spool->>Redis: completeOwned()
    Spool->>Spool: clear payload and release quota
  else abort or disable
    Spool->>Spool: mark aborting and clear local payloads
    Spool->>Redis: abortOwned() after queued writes
    Spool->>Spool: release quota after cleanup
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(types): resolve tsgo type inference ..."](https://github.com/ding113/claude-code-hub/commit/81c1c11ecafc75849284ce9c03cf9393b5e5425c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51407477)</sub>

**Context used:**

- Knowledge Base — [Proxy request pipeline](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/proxy-pipeline.md)
- Knowledge Base — [Management API (/api/v1)](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/management-api.md)

<!-- /greptile_comment -->