### PR TITLE
fix(proxy): recognize terminal Responses compaction streams (#1410)

### DIFF
--- a/src/app/v1/_lib/proxy/stream-gate/frame-classifier.ts
+++ b/src/app/v1/_lib/proxy/stream-gate/frame-classifier.ts
@@ -356,7 +356,7 @@ function classifyFrameInner(
     return "malformed";
   }
 
-  const outerVerdict = classifyParsedFrame(signal, eventName, parsed);
+  const outerVerdict = classifyParsedFrame(family, signal, eventName, parsed);
   if (outerVerdict !== "neutral" || family !== "gemini" || Array.isArray(parsed)) {
     return outerVerdict;
   }
@@ -365,11 +365,12 @@ function classifyFrameInner(
   // 只有外层中性时才解包，供所有门控与 observer 共用同一分类结果。
   const response = (parsed as Record<string, unknown>).response;
   return response && typeof response === "object" && !Array.isArray(response)
-    ? classifyParsedFrame(signal, eventName, response)
+    ? classifyParsedFrame(family, signal, eventName, response)
     : outerVerdict;
 }
 
 function classifyParsedFrame(
+  family: ProtocolFamily,
   signal: StreamSignal,
   eventName: string | null,
   parsed: object
@@ -385,6 +386,9 @@ function classifyParsedFrame(
   for (const rule of signal.errorRules) {
     if (frameRuleMatches(rule, effective, parsed)) return "error";
   }
+  if (family === "openai-responses" && isCompletedResponsesCompaction(effective, parsed)) {
+    return "content";
+  }
   for (const rule of signal.contentRules) {
     if (frameRuleMatches(rule, effective, parsed)) return "content";
   }
@@ -395,6 +399,27 @@ function classifyParsedFrame(
     return "terminal";
   }
   return "neutral";
+}
+
+/**
+ * 部分 Responses 上游只在 response.completed 中返回 compaction output，
+ * 不会先发送 response.output_item.done。逐项关联 type 与 opaque state，
+ * 避免不同 output item 的字段组合造成误提交。
+ */
+function isCompletedResponsesCompaction(eventType: string, parsed: object): boolean {
+  if (eventType !== "response.completed" || Array.isArray(parsed)) return false;
+
+  const response = (parsed as Record<string, unknown>).response;
+  if (response === null || typeof response !== "object" || Array.isArray(response)) return false;
+
+  const output = (response as Record<string, unknown>).output;
+  if (!Array.isArray(output)) return false;
+
+  return output.some((item) => {
+    if (item === null || typeof item !== "object" || Array.isArray(item)) return false;
+    const record = item as Record<string, unknown>;
+    return record.type === "compaction" && isNonEmptyValue(record.encrypted_content);
+  });
 }
 
 /** 单条帧规则 AND 语义；空规则永不命中（防目录笔误把所有帧判成内容/错误）。 */

--- a/src/app/v1/_lib/proxy/stream-gate/frame-classifier.ts
+++ b/src/app/v1/_lib/proxy/stream-gate/frame-classifier.ts
@@ -168,12 +168,6 @@ const STREAM_SIGNALS: Record<ProtocolFamily, StreamSignal> = {
         anyPaths: ["code"],
       },
       {
-        // Remote/server-side compaction 的 opaque state 是完整协议 payload，只有非空且类型精确匹配才提交。
-        eventTypes: ["response.output_item.done"],
-        anyPaths: ["item.encrypted_content"],
-        valueMatches: [{ path: "item.type", values: ["compaction"] }],
-      },
-      {
         // output_item.added 的 name/id/status 只是结构元数据；真实 payload 到达前不能提交，
         // 否则紧随其后的 response.failed / 断流将失去透明 fallback 机会。
         // fake-streaming 的完整 item 会在 added/done 中携带 arguments/input/action，仍可提交。
@@ -386,7 +380,7 @@ function classifyParsedFrame(
   for (const rule of signal.errorRules) {
     if (frameRuleMatches(rule, effective, parsed)) return "error";
   }
-  if (family === "openai-responses" && isCompletedResponsesCompaction(effective, parsed)) {
+  if (family === "openai-responses" && isResponsesCompactionContent(effective, parsed)) {
     return "content";
   }
   for (const rule of signal.contentRules) {
@@ -402,24 +396,36 @@ function classifyParsedFrame(
 }
 
 /**
- * 部分 Responses 上游只在 response.completed 中返回 compaction output，
- * 不会先发送 response.output_item.done。逐项关联 type 与 opaque state，
- * 避免不同 output item 的字段组合造成误提交。
+ * Remote/server-side compaction 的 opaque state 是完整协议 payload。部分上游只在
+ * response.completed 中返回 output, 不会先发送 response.output_item.done。
  */
-function isCompletedResponsesCompaction(eventType: string, parsed: object): boolean {
-  if (eventType !== "response.completed" || Array.isArray(parsed)) return false;
+function isResponsesCompactionContent(eventType: string, parsed: object): boolean {
+  if (Array.isArray(parsed)) return false;
 
-  const response = (parsed as Record<string, unknown>).response;
+  const record = parsed as Record<string, unknown>;
+  if (eventType === "response.output_item.done") {
+    return isNonEmptyCompactionItem(record.item);
+  }
+  if (eventType !== "response.completed") return false;
+
+  const response = record.response;
   if (response === null || typeof response !== "object" || Array.isArray(response)) return false;
 
   const output = (response as Record<string, unknown>).output;
   if (!Array.isArray(output)) return false;
 
-  return output.some((item) => {
-    if (item === null || typeof item !== "object" || Array.isArray(item)) return false;
-    const record = item as Record<string, unknown>;
-    return record.type === "compaction" && isNonEmptyValue(record.encrypted_content);
-  });
+  return output.some(isNonEmptyCompactionItem);
+}
+
+/** 同一 output item 内的 type 与 opaque state 必须同时满足协议类型约束。 */
+function isNonEmptyCompactionItem(item: unknown): boolean {
+  if (item === null || typeof item !== "object" || Array.isArray(item)) return false;
+  const record = item as Record<string, unknown>;
+  return (
+    record.type === "compaction" &&
+    typeof record.encrypted_content === "string" &&
+    record.encrypted_content !== ""
+  );
 }
 
 /** 单条帧规则 AND 语义；空规则永不命中（防目录笔误把所有帧判成内容/错误）。 */

--- a/tests/unit/proxy/stream-gate-content-gate.test.ts
+++ b/tests/unit/proxy/stream-gate-content-gate.test.ts
@@ -254,6 +254,42 @@ describe("runStreamContentGate", () => {
     expect(new TextDecoder().decode(rest.value)).toBe(completed);
   });
 
+  it("openai-responses: commits compaction carried only by response.completed", async () => {
+    const completed =
+      'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed","output":[{"type":"compaction","encrypted_content":"opaque-state"}]}}\n\n';
+    const reader = readerFromChunks([completed]);
+
+    const result = await runStreamContentGate(reader, {
+      ...GATE_OPTIONS,
+      family: "openai-responses",
+    });
+
+    expect(result.committed).toBe(true);
+    if (!result.committed) return;
+    expect(await drainPrefix(result.prefixChunks)).toBe(completed);
+    expect(result.readerDone).toBe(false);
+  });
+
+  it("openai-responses: commits custom tool-call input before response.completed", async () => {
+    const toolInput =
+      'event: response.custom_tool_call_input.delta\ndata: {"type":"response.custom_tool_call_input.delta","delta":"{\\"path\\":\\"README.md\\"}"}\n\n';
+    const completed =
+      'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n';
+    const reader = readerFromChunks([toolInput, completed]);
+
+    const result = await runStreamContentGate(reader, {
+      ...GATE_OPTIONS,
+      family: "openai-responses",
+    });
+
+    expect(result.committed).toBe(true);
+    if (!result.committed) return;
+    expect(await drainPrefix(result.prefixChunks)).toBe(toolInput);
+    expect(result.readerDone).toBe(false);
+    const rest = await reader.read();
+    expect(new TextDecoder().decode(rest.value)).toBe(completed);
+  });
+
   it("gemini: usage-only chunks buffer until content commits", async () => {
     const reader = readerFromChunks([
       'data: {"usageMetadata":{"totalTokenCount":1}}\n\n',

--- a/tests/unit/proxy/stream-gate-forwarder-integration.test.ts
+++ b/tests/unit/proxy/stream-gate-forwarder-integration.test.ts
@@ -224,6 +224,35 @@ const OPENAI_RESPONSES_WINNER_FRAMES = [
   }),
 ];
 
+const VALID_OPENAI_RESPONSES_STREAMS = [
+  {
+    name: "terminal compaction output",
+    frames: [
+      sseFrame("response.completed", {
+        type: "response.completed",
+        response: {
+          id: "resp_compaction",
+          status: "completed",
+          output: [{ id: "cmp_1", type: "compaction", encrypted_content: "opaque-state" }],
+        },
+      }),
+    ],
+  },
+  {
+    name: "custom tool-call input deltas",
+    frames: [
+      sseFrame("response.custom_tool_call_input.delta", {
+        type: "response.custom_tool_call_input.delta",
+        delta: '{"path":"README.md"}',
+      }),
+      sseFrame("response.completed", {
+        type: "response.completed",
+        response: { id: "resp_tool", status: "completed" },
+      }),
+    ],
+  },
+] as const;
+
 type ReplayGateCase = {
   name: string;
   providerType: Provider["providerType"];
@@ -516,6 +545,30 @@ describe("F1 stream content gate x ProxyForwarder sequential path", () => {
       expect(mocks.recordFailure).not.toHaveBeenCalled();
     });
 
+    test("Responses terminal compaction 在 enforce 模式下直接提交且不计入熔断", async () => {
+      const provider = createProvider({ id: 1, name: "compaction", providerType: "codex" });
+      const session = createSession();
+      session.setProvider(provider);
+      Object.assign(session, {
+        requestUrl: new URL("https://example.com/v1/responses"),
+        originalFormat: "response",
+        endpointPolicy: resolveEndpointPolicy("/v1/responses"),
+      });
+
+      const frames = VALID_OPENAI_RESPONSES_STREAMS[0].frames.slice();
+      const doForward = spyOnDoForward();
+      doForward.mockImplementationOnce(async () => createSseResponse(frames));
+
+      const response = await ProxyForwarder.send(session);
+      const text = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(text).toBe(frames.join(""));
+      expect(doForward).toHaveBeenCalledTimes(1);
+      expect(mocks.pickRandomProviderWithExclusion).not.toHaveBeenCalled();
+      expect(mocks.recordFailure).not.toHaveBeenCalled();
+    });
+
     test("terminal-only 流（message_stop 即终止）按 empty_stream 失败并切换供应商", async () => {
       const provider1 = createProvider({ id: 1, name: "gate-p1" });
       const provider2 = createProvider({ id: 2, name: "gate-p2" });
@@ -630,6 +683,29 @@ describe("F1 stream content gate x ProxyForwarder sequential path", () => {
       expect(mocks.pickRandomProviderWithExclusion).not.toHaveBeenCalled();
       expect(mocks.recordFailure).not.toHaveBeenCalled();
     });
+
+    test.each(VALID_OPENAI_RESPONSES_STREAMS)(
+      "Replay owner 将 $name 视为有效内容，不触发 502/failover/熔断",
+      async ({ frames }) => {
+        const provider = createProvider({ id: 1, name: "responses-valid", providerType: "codex" });
+        const session = createSession();
+        session.setProvider(provider);
+        attachReplayOwner(session, REPLAY_GATE_CASES[0]);
+
+        const streamFrames = frames.slice();
+        const doForward = spyOnDoForward();
+        doForward.mockImplementationOnce(async () => createSseResponse(streamFrames));
+
+        const response = await ProxyForwarder.send(session);
+        const text = await response.text();
+
+        expect(response.status).toBe(200);
+        expect(text).toBe(streamFrames.join(""));
+        expect(doForward).toHaveBeenCalledTimes(1);
+        expect(mocks.pickRandomProviderWithExclusion).not.toHaveBeenCalled();
+        expect(mocks.recordFailure).not.toHaveBeenCalled();
+      }
+    );
 
     test("Replay owner 在所有 precommit attempt 失败后立即释放所有权", async () => {
       const provider = createProvider({ id: 1, name: "replay-only", providerType: "codex" });

--- a/tests/unit/proxy/stream-gate-frame-classifier.test.ts
+++ b/tests/unit/proxy/stream-gate-frame-classifier.test.ts
@@ -270,6 +270,40 @@ describe("classifyFrame: openai-responses", () => {
     ).toBe("content");
   });
 
+  it("content: custom tool-call input delta and done payloads", () => {
+    expect(
+      classifyFrame(
+        "openai-responses",
+        "response.custom_tool_call_input.delta",
+        '{"type":"response.custom_tool_call_input.delta","delta":"{\\"path\\":\\"README.md\\"}"}'
+      )
+    ).toBe("content");
+    expect(
+      classifyFrame(
+        "openai-responses",
+        "response.custom_tool_call_input.done",
+        '{"type":"response.custom_tool_call_input.done","input":"{\\"path\\":\\"README.md\\"}"}'
+      )
+    ).toBe("content");
+  });
+
+  it("neutral: empty custom tool-call input delta and done payloads", () => {
+    expect(
+      classifyFrame(
+        "openai-responses",
+        "response.custom_tool_call_input.delta",
+        '{"type":"response.custom_tool_call_input.delta","delta":""}'
+      )
+    ).toBe("neutral");
+    expect(
+      classifyFrame(
+        "openai-responses",
+        "response.custom_tool_call_input.done",
+        '{"type":"response.custom_tool_call_input.done","input":""}'
+      )
+    ).toBe("neutral");
+  });
+
   it("neutral: output_item.added carrying only tool metadata", () => {
     expect(
       classifyFrame(
@@ -298,6 +332,40 @@ describe("classifyFrame: openai-responses", () => {
         '{"type":"response.output_item.done","item":{"type":"compaction","encrypted_content":"opaque-state"}}'
       )
     ).toBe("content");
+  });
+
+  it("content: response.completed carrying compaction output with opaque state", () => {
+    expect(
+      classifyFrame(
+        "openai-responses",
+        "response.completed",
+        '{"type":"response.completed","response":{"status":"completed","output":[{"type":"compaction","encrypted_content":"opaque-state"}]}}'
+      )
+    ).toBe("content");
+  });
+
+  it("terminal: response.completed without a non-empty compaction output", () => {
+    expect(
+      classifyFrame(
+        "openai-responses",
+        "response.completed",
+        '{"type":"response.completed","response":{"status":"completed","output":[{"type":"compaction","encrypted_content":""}]}}'
+      )
+    ).toBe("terminal");
+    expect(
+      classifyFrame(
+        "openai-responses",
+        "response.completed",
+        '{"type":"response.completed","response":{"status":"completed","output":[{"type":"reasoning","encrypted_content":"opaque-state"}]}}'
+      )
+    ).toBe("terminal");
+    expect(
+      classifyFrame(
+        "openai-responses",
+        "response.completed",
+        '{"type":"response.completed","response":{"status":"completed","output":[{"type":"compaction","encrypted_content":""},{"type":"reasoning","encrypted_content":"opaque-state"}]}}'
+      )
+    ).toBe("terminal");
   });
 
   it("neutral: empty or non-compaction encrypted output item", () => {

--- a/tests/unit/proxy/stream-gate-frame-classifier.test.ts
+++ b/tests/unit/proxy/stream-gate-frame-classifier.test.ts
@@ -368,6 +368,34 @@ describe("classifyFrame: openai-responses", () => {
     ).toBe("terminal");
   });
 
+  it("rejects non-string compaction encrypted content", () => {
+    for (const encryptedContent of [true, 42, { opaque: "state" }]) {
+      expect(
+        classifyFrame(
+          "openai-responses",
+          "response.output_item.done",
+          JSON.stringify({
+            type: "response.output_item.done",
+            item: { type: "compaction", encrypted_content: encryptedContent },
+          })
+        )
+      ).toBe("neutral");
+      expect(
+        classifyFrame(
+          "openai-responses",
+          "response.completed",
+          JSON.stringify({
+            type: "response.completed",
+            response: {
+              status: "completed",
+              output: [{ type: "compaction", encrypted_content: encryptedContent }],
+            },
+          })
+        )
+      ).toBe("terminal");
+    }
+  });
+
   it("neutral: empty or non-compaction encrypted output item", () => {
     expect(
       classifyFrame(


### PR DESCRIPTION
## 问题

OpenAI Responses API 的合法流不一定包含 `response.output_text.delta`。当上游只在 terminal `response.completed` 的 `response.output[]` 中返回 `type: "compaction"` 和非空 `encrypted_content` 时, stream gate 会先看到 terminal 而没有识别到有效内容, 最终以 `empty_stream` 返回 502, 并错误触发 provider failover 与 circuit breaker failure recording.

`response.custom_tool_call_input.delta` / `.done` 在当前 `dev` 已有非空内容识别规则, 但此前缺少覆盖 #1410 实际 Replay owner 与 forwarder 路径的直接回归测试.

Fixes #1410

## 修改

- 将 classifier 的 protocol family 传入 parsed-frame 判定, 仅为 `openai-responses` 启用 terminal compaction 识别.
- 对 `response.completed` 的 `response.output[]` 逐项检查, 只在同一个 item 同时满足 `type === "compaction"` 且 `encrypted_content` 非空时判为 `content`.
- `response.output_item.done` 与 `response.completed` 共享同一个 exact predicate, `encrypted_content` 只接受官方 schema 定义的非空 string; boolean、number、array/object 不再误提交.
- 保持 error rule 优先级、其他 protocol family、空密文、非 compaction item 和普通 terminal-only 流的既有行为.
- 补充 classifier、content gate 和 ProxyForwarder 集成回归, 覆盖 compaction-only terminal stream 与 custom tool-call input stream.

## Replay owner 语义

本 PR 不移除 Replay owner 的 precommit gate。`stream_gate_mode=off` 仍只关闭普通请求 gate; Replay owner 继续执行 pre-content safety check, 防止错误或畸形前缀进入共享 Replay spool 并污染 attach follower.

修复后的行为是: 即使 `stream_gate_mode=off` 且请求为 Replay owner, 合法 terminal compaction 与 custom tool-call input stream 也会被识别为有效内容, 原样返回 HTTP 200, 不发生 502、failover 或 circuit breaker failure recording.

## 验收

- 聚焦回归: 3 files, 92 tests passed.
- `bun run lint:fix`: passed.
- `bun run lint`: passed.
- `bun run typecheck`: passed.
- `bun run build`: passed.
- `git diff --check`: passed.
- 完整 Vitest: 首次并发运行在无关 `keys-edit-key-expires-at-clear.test.ts` 出现 2 个 flaky failures; 该文件单独重跑 6/6 passed; 修复前完整复验为 860 files / 8453 tests passed; review 修复后完整复验为 860 files / 8454 tests passed, 0 failures, exit 0.
- 独立规格、正确性与 review-fix 复审: No findings.
- CodeRabbit 的 `encrypted_content` 类型契约 finding 已按官方 OpenAI API schema 修复并补 TDD 负例.

结构化验收报告:

- [Acceptance: aggregated delivery history](https://app.lobehub.com/acceptance/0e2dc464-76e5-4fa6-b5e5-7c5b6791df43)
- [Round 1: initial 4/4 acceptance](https://app.lobehub.com/verify/d3c65746-5d28-42d1-8ebc-527db0c3f842)
- [Round 2: review repair 5/5 acceptance](https://app.lobehub.com/verify/581f6bbc-c072-4b9c-98f1-64d9659ba6ac)

## 风险边界

本次没有单独新增 hedge-path 的 compaction fixture、同帧 `response.error` + compaction 组合或无 SSE `event:` 行组合。实现仍通过共享 content gate、embedded `data.type` 推导和 error-first 顺序覆盖这些路径; 独立审查未发现缺陷.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the OpenAI Responses stream classifier to recognize non-empty compaction payloads in both output-item and terminal completion frames.
- Passes the protocol family into parsed-frame classification so the new behavior remains isolated to OpenAI Responses.
- Preserves error-first classification and requires compaction type and encrypted content to coexist in the same output item.
- Adds classifier, content-gate, sequential-forwarder, and Replay-owner regression coverage for compaction and custom tool-call input streams.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/stream-gate/frame-classifier.ts | Adds family-scoped recognition of non-empty Responses compaction payloads while retaining error-rule precedence and existing classifications. |
| tests/unit/proxy/stream-gate-content-gate.test.ts | Adds direct gate regressions for terminal compaction and custom tool-call input content. |
| tests/unit/proxy/stream-gate-forwarder-integration.test.ts | Verifies sequential and Replay-owner forwarding succeeds without failover or circuit-breaker failure recording. |
| tests/unit/proxy/stream-gate-frame-classifier.test.ts | Covers accepted compaction shapes and rejects empty, mismatched, and non-string encrypted content. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[OpenAI Responses SSE frame] --> B[Parse event name and data]
  B --> C{Error rule matches?}
  C -->|Yes| D[Classify as error]
  C -->|No| E{Compaction item with non-empty encrypted content?}
  E -->|Yes| F[Classify as content and commit stream]
  E -->|No| G{Existing content rule matches?}
  G -->|Yes| F
  G -->|No| H{Terminal event?}
  H -->|Yes| I[Classify as terminal]
  H -->|No| J[Classify as neutral]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(stream-gate): require non-empty stri..."](https://github.com/ding113/claude-code-hub/commit/2856cd74cf624c8cae03a32f8964878ac158e322) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51755209)</sub>

**Context used:**

- Knowledge Base — [Proxy request pipeline](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/proxy-pipeline.md)
- Knowledge Base — [Provider Management](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/provider-management.md)

<!-- /greptile_comment -->