### PR TITLE
fix(dashboard): 避免会话消息链接重复预取

### DIFF
--- a/src/app/[locale]/dashboard/logs/_components/error-details-dialog.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/error-details-dialog.test.tsx
@@ -36,8 +36,18 @@ beforeEach(() => {
 });
 
 vi.mock("@/i18n/routing", () => ({
-  Link: ({ href, children }: { href: string; children: ReactNode }) => (
-    <a href={href}>{children}</a>
+  Link: ({
+    href,
+    children,
+    prefetch,
+  }: {
+    href: string;
+    children: ReactNode;
+    prefetch?: boolean;
+  }) => (
+    <a href={href} data-prefetch={String(prefetch)}>
+      {children}
+    </a>
   ),
 }));
 
@@ -497,6 +507,11 @@ describe("error-details-dialog layout", () => {
     expect(container.querySelector('a[href*="sessionId=pfx%3Ascope%3Aroot"]')).toBeTruthy();
     expect(container.querySelector('a[href*="sessionId=physical-a"]')).toBeTruthy();
     expect(container.querySelector('a[href*="requestId=203"]')).toBeTruthy();
+    expect(
+      container
+        .querySelector('a[href*="/dashboard/sessions/pfx%3Ascope%3Aroot/messages"]')
+        ?.getAttribute("data-prefetch")
+    ).toBe("false");
     expect(container.textContent).toContain("Canonical Session ID: pfx:scope:root");
     expect(container.textContent).toContain("Client Session ID: physical-a");
     unmount();

--- a/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx
@@ -361,7 +361,7 @@ export function SummaryTab({
                     </div>
                   </div>
                   {identity.value === sessionId && hasMessages && !checkingMessages && (
-                    <Link href={sessionMessagesHref}>
+                    <Link href={sessionMessagesHref} prefetch={false}>
                       <Button variant="outline" size="sm">
                         <ExternalLink className="h-4 w-4 mr-2" />
                         {t("viewDetails")}


### PR DESCRIPTION
## 问题

错误详情弹窗会为带消息的会话记录渲染详情链接。Next.js `Link` 默认会在链接进入视口时预取目标页面，多条记录同时出现时，会在短时间内触发大量会话消息请求。

**相关 Issue / PR：**
- Related to #1068 — 该链接预取的目标页面（会话消息详情视图）由该特性引入，本 PR 仅关闭其自动预取行为。

## 修改

- 关闭错误详情弹窗中会话消息详情链接的自动预取（`prefetch={false}`）。
- 保留用户点击后的正常跳转行为。
- 补充回归测试，确保该链接不会再次启用自动预取。

## 变更范围

| 文件 | 说明 |
| --- | --- |
| `SummaryTab.tsx` | 为会话消息详情链接添加 `prefetch={false}`。 |
| `error-details-dialog.test.tsx` | mock `Link` 透出 `prefetch` 属性，并断言该链接 `data-prefetch="false"`。 |

无 schema / 迁移 / API / 导出签名变更，无破坏性改动。

## 验证

- 聚焦回归测试：52/52 passed。
- `bun run lint`：passed。
- `bun run typecheck`：passed。
- `bun run build`：passed。
- `git diff --check`：passed。
- 完整 `bun run test` 在未改动的 `language-switcher.test.tsx` 中有 1 个既有失败；单独运行该文件仍可复现。

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables automatic prefetching for session-message detail links in the dashboard error dialog while preserving click navigation.
- Adds `prefetch={false}` to the locale-aware session-message link.
- Extends the dialog regression test to verify that prefetching remains disabled.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The production change narrowly disables automatic prefetching on the intended locale-aware link, and the updated test exercises that specific session-message URL and verifies the disabled value.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/logs/_components/error-details-dialog/components/SummaryTab.tsx | Disables automatic prefetching on the existing session-message detail link without changing its destination or visibility conditions. |
| src/app/[locale]/dashboard/logs/_components/error-details-dialog.test.tsx | Updates the routing-link mock to expose the prefetch prop and adds a focused regression assertion for the changed link. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): disable session message ..."](https://github.com/ding113/claude-code-hub/commit/65a35e8e179f66e584673718080e46b6c32417af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52108670)</sub>

<!-- /greptile_comment -->