### PR TITLE
fix(proxy): decode ArrayBuffer bodies for Responses WebSocket

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -163,6 +163,8 @@ function decodeRequestBodyAsJson(body: BodyInit | undefined): Record<string, unk
     text = body;
   } else if (Buffer.isBuffer(body)) {
     text = body.toString("utf8");
+  } else if (body instanceof ArrayBuffer) {
+    text = Buffer.from(body).toString("utf8");
   } else if (body instanceof Uint8Array) {
     text = Buffer.from(body).toString("utf8");
   }

--- a/tests/unit/proxy/proxy-forwarder-raw-passthrough-regression.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-raw-passthrough-regression.test.ts
@@ -11,6 +11,11 @@ const mocks = vi.hoisted(() => ({
     getAgent: vi.fn(),
     markOriginUnhealthy: vi.fn(),
   })),
+  evaluateResponsesWsEligibility: vi.fn(async () => ({
+    isWebsocketClient: false,
+    eligible: false,
+  })),
+  tryResponsesWebsocketUpstream: vi.fn(),
 }));
 
 vi.mock("@/lib/config", async (importOriginal) => {
@@ -26,6 +31,24 @@ vi.mock("@/lib/proxy-agent", () => ({
   getProxyAgentForProvider: mocks.getProxyAgentForProvider,
   getGlobalAgentPool: mocks.getGlobalAgentPool,
 }));
+
+vi.mock("@/app/v1/_lib/responses-ws/eligibility", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/v1/_lib/responses-ws/eligibility")>();
+  return {
+    ...actual,
+    evaluateResponsesWsEligibility: mocks.evaluateResponsesWsEligibility,
+    getResponsesWsSessionId: vi.fn(() => "client-ws-session"),
+  };
+});
+
+vi.mock("@/app/v1/_lib/responses-ws/upstream-adapter", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/app/v1/_lib/responses-ws/upstream-adapter")>();
+  return {
+    ...actual,
+    tryResponsesWebsocketUpstream: mocks.tryResponsesWebsocketUpstream,
+  };
+});
 
 import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
 import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
@@ -124,6 +147,11 @@ function readBodyText(body: BodyInit | undefined): string | null {
 describe("ProxyForwarder raw passthrough regression", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.evaluateResponsesWsEligibility.mockResolvedValue({
+      isWebsocketClient: false,
+      eligible: false,
+    });
+    mocks.tryResponsesWebsocketUpstream.mockReset();
   });
 
   it("raw passthrough 应优先保留原始请求体字节，而不是重新 JSON.stringify", async () => {
@@ -186,6 +214,56 @@ describe("ProxyForwarder raw passthrough regression", () => {
     expect(new URL(capturedUrl as string).searchParams.get("transport")).toBe("http");
     expect(readBodyText(capturedBody)).toBe(originalBody);
     expect(capturedHeaders?.get("x-codex-beta-features")).toBe("remote_compaction_v2");
+    expect(await response.text()).toBe(upstreamSse);
+  });
+
+  it("remote compaction v2 ArrayBuffer 请求体仍通过上游 Responses WebSocket", async () => {
+    const requestBody = {
+      model: "gpt-5.5",
+      stream: true,
+      previous_response_id: "resp_previous",
+      input: [{ type: "compaction_trigger" }],
+    };
+    const originalBody = JSON.stringify(requestBody);
+    const upstreamSse =
+      'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_compact","status":"completed"}}\n\n';
+    const session = createRawPassthroughSession(originalBody, {
+      "x-codex-beta-features": "remote_compaction_v2",
+    });
+    session.requestUrl = new URL("https://proxy.example.com/v1/responses");
+    const provider = createProvider();
+
+    mocks.evaluateResponsesWsEligibility.mockResolvedValue({
+      isWebsocketClient: true,
+      eligible: true,
+      endpointId: null,
+    });
+    mocks.tryResponsesWebsocketUpstream.mockResolvedValue({
+      response: new Response(upstreamSse, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+      connected: true,
+      reused: true,
+    });
+
+    const fetchWithoutAutoDecode = vi.spyOn(ProxyForwarder as any, "fetchWithoutAutoDecode");
+    fetchWithoutAutoDecode.mockImplementationOnce(
+      async () => new Response("unexpected HTTP fallback", { status: 500 })
+    );
+    const { doForward } = ProxyForwarder as unknown as {
+      doForward: (session: ProxySession, provider: Provider, baseUrl: string) => Promise<Response>;
+    };
+
+    const response = await doForward(session, provider, provider.url);
+
+    expect(mocks.tryResponsesWebsocketUpstream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: requestBody,
+        sessionId: "client-ws-session",
+      })
+    );
+    expect(fetchWithoutAutoDecode).not.toHaveBeenCalled();
     expect(await response.text()).toBe(upstreamSse);
   });
 


### PR DESCRIPTION
## Summary

- Decode raw `ArrayBuffer` request bodies before Responses WebSocket forwarding.
- Add regression coverage proving Remote Compaction v2 remains on WebSocket.

## Problem

Remote Compaction v2 requests carrying `previous_response_id` could skip upstream Responses WebSocket forwarding and fall back to HTTP. The upstream HTTP endpoint rejects that continuation parameter.

## Related

- Follow-up to #1404 - introduced Remote Compaction v2 raw passthrough and the regression suite extended here; this PR fixes a gap in that path.
- Related to #1101 - introduced OpenAI Responses WebSocket upstream support, the forwarding path restored by this fix.

## Root cause

Raw passthrough bodies are stored as `ArrayBuffer` values, while `decodeRequestBodyAsJson` only handled strings, Buffers, and Uint8Arrays. Decoding therefore returned `null` and the WebSocket attempt was skipped.

## Impact

Eligible Remote Compaction v2 requests continue through the upstream Responses WebSocket path instead of failing after HTTP fallback. Other request-body shapes retain existing behavior.

## Validation

- `bun run build` — passed
- `bun run lint` — passed
- `bun run lint:fix` — passed; no fixes
- `bun run typecheck` — passed
- `bunx vitest run tests/unit/proxy/proxy-forwarder-raw-passthrough-regression.test.ts` — passed (5 tests)
- `bun run test` — 8529 passed, 13 skipped, 1 failed. The failure is the existing `LanguageSwitcher > keeps the pending refresh after remount when sessionStorage is blocked` assertion; its test file is unchanged from `upstream/dev`, and the isolated rerun reproduces the same failure.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds JSON decoding for raw `ArrayBuffer` request bodies so eligible Remote Compaction v2 requests can continue through the Responses WebSocket path instead of falling back to HTTP.
- Decodes `ArrayBuffer` bodies as UTF-8 alongside existing string, Buffer, and Uint8Array handling.
- Adds regression coverage verifying the decoded body reaches the Responses WebSocket adapter and HTTP fallback is not invoked.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the focused change correctly restoring WebSocket forwarding for raw ArrayBuffer request bodies.

Raw-passthrough bodies are normalized to native ArrayBuffers, the new branch decodes their complete byte range consistently with existing body types, and the regression test verifies that the resulting JSON reaches the WebSocket adapter without HTTP fallback.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/forwarder.ts | Adds the missing ArrayBuffer decoding branch using the same UTF-8 behavior as the existing binary body variants; no actionable issue found. |
| tests/unit/proxy/proxy-forwarder-raw-passthrough-regression.test.ts | Adds focused WebSocket-path regression coverage that exercises the real body decoder and asserts HTTP fallback is avoided. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(proxy): decode ArrayBuffer bodies fo..."](https://github.com/ding113/claude-code-hub/commit/40a2d9de33f796962e2c3e808ddb2024dd1c3dc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53343357)</sub>

**Context used:**

- Knowledge Base — [Proxy request pipeline](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/proxy-pipeline.md)

<!-- /greptile_comment -->