### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -387,7 +387,7 @@ This project builds on [zsio/claude-code-hub](https://github.com/zsio/claude-cod
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ding113/claude-code-hub&type=Date)](https://star-history.com/#ding113/claude-code-hub&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ding113/claude-code-hub&type=Date)](https://star-history.dera.page/#ding113/claude-code-hub&Date)
 
 ## 📜 License
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ cch doctor            # 诊断集群与部署状态
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ding113/claude-code-hub&type=Date)](https://star-history.com/#ding113/claude-code-hub&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ding113/claude-code-hub&type=Date)](https://star-history.dera.page/#ding113/claude-code-hub&Date)
 
 ## 📜 许可证 License
 


### PR DESCRIPTION
## Summary
Fixes the broken star history chart in README files by switching from `api.star-history.com` to `star-history.dera.page`.

## Problem
The current star history chart provider (`api.star-history.com`) is affected by GitHub stargazer API restrictions and no longer displays the chart correctly.

## Solution
Switch to `star-history.dera.page`, an alternative provider that works without requiring an API token.

## Changes
- `README.md`: Update star history chart URLs
- `README.en.md`: Update star history chart URLs

**Before:**
```
https://api.star-history.com/svg?repos=ding113/claude-code-hub&type=Date
```

**After:**
```
https://star-history.dera.page/svg?repos=ding113/claude-code-hub&type=Date
```

## Verification
The chart should now display properly at both URLs:
- [Chinese README](https://github.com/ding113/claude-code-hub/blob/fix/star-history-chart/README.md#-star-history)
- [English README](https://github.com/ding113/claude-code-hub/blob/fix/star-history-chart/README.en.md#-star-history)

---
**Note**: This PR targets `main` but per CLAUDE.md, PRs should typically target `dev` branch.

---
*Description enhanced by Claude AI*
