### PR TITLE
fix(responses-ws): encode multiline events as valid SSE

### DIFF
--- a/src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts
+++ b/src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts
@@ -1,6 +1,7 @@
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
+import { parseSseBody } from "@/app/v1/_lib/proxy/stream-gate/sse-frames";
 import type { Provider } from "@/types/provider";
 import {
   clearResponsesWsSessionsForTests,
@@ -195,6 +196,39 @@ describe("tryResponsesWebsocketUpstream", () => {
     expect(body).toContain('"type":"response.created"');
     expect(body).toContain('"type":"response.output_text.delta"');
     expect(body).toContain('"type":"response.completed"');
+  });
+
+  it("preserves pretty-printed multiline JSON as complete SSE events", async () => {
+    const events = [
+      { type: "response.created", response: { id: "resp_pretty" } },
+      { type: "response.output_text.delta", delta: "hello" },
+      {
+        type: "response.completed",
+        response: { id: "resp_pretty", usage: { input_tokens: 2, output_tokens: 1 } },
+      },
+    ];
+    server = await startMockServer((socket) => {
+      socket.on("message", () => {
+        for (const event of events) {
+          socket.send(JSON.stringify(event, null, 2).replace(/\n/g, "\r\n"));
+        }
+      });
+    });
+
+    const result = await tryResponsesWebsocketUpstream({
+      provider: codexProvider(),
+      upstreamUrl: `http://127.0.0.1:${server.port}/v1/responses`,
+      upstreamHeaders: new Headers({ authorization: "Bearer sk-mock" }),
+      body: { model: "gpt-5.5", input: "hi" },
+    });
+
+    expect("response" in result).toBe(true);
+    if (!("response" in result)) return;
+
+    const body = await collectSseBody(result.response);
+    const frames = parseSseBody(body);
+    expect(frames.map((frame) => JSON.parse(frame.data))).toEqual(events);
+    expect(body.match(/^data:/gm)?.length).toBeGreaterThan(events.length);
   });
 
   it("returns failure when upstream rejects the WS upgrade", async () => {

--- a/src/app/v1/_lib/responses-ws/upstream-adapter.ts
+++ b/src/app/v1/_lib/responses-ws/upstream-adapter.ts
@@ -776,12 +776,21 @@ export async function tryResponsesWebsocketUpstream(options: {
     async start(controller) {
       let sawTerminalEvent = false;
 
-      const writeLine = (obj: string) => {
-        controller.enqueue(encoder.encode(`data: ${obj}\n\n`));
+      const writeEvent = (payload: string) => {
+        // SSE requires every physical payload line to carry its own `data:`
+        // prefix. Upstream WebSocket implementations may pretty-print JSON;
+        // wrapping that text in a single `data:` line would dispatch only the
+        // opening `{` and make downstream parsers report malformed JSON.
+        const normalizedPayload = payload.replace(/\r\n?/g, "\n");
+        const dataLines = normalizedPayload
+          .split("\n")
+          .map((line) => `data: ${line}`)
+          .join("\n");
+        controller.enqueue(encoder.encode(`${dataLines}\n\n`));
       };
 
       const processText = (text: string): boolean => {
-        writeLine(text);
+        writeEvent(text);
         try {
           const parsed = JSON.parse(text);
           if (parsed && typeof parsed.type === "string" && TERMINAL_EVENT_TYPES.has(parsed.type)) {


### PR DESCRIPTION
## Summary

- encode every physical WebSocket payload line as an SSE `data:` line
- normalize CRLF and CR line endings before emitting an event
- add a regression test for pretty-printed multiline JSON frames

## Problem

Some Responses WebSocket providers send JSON frames formatted across multiple lines. The adapter wrapped the whole frame with a single `data:` prefix, so SSE consumers treated only the opening line as event data and attempted to parse incomplete JSON.

## Related

- Related to #1432 — complementary fix in the Responses WebSocket subsystem; #1432 addresses the request path (decoding ArrayBuffer bodies), while this PR fixes the response path (SSE encoding)

## Root cause

SSE requires each physical payload line to be prefixed with `data:`. The previous adapter only prefixed the first line of a WebSocket text frame.

## Impact

Multiline and CRLF-formatted Responses WebSocket events now remain one complete SSE event downstream. Compact single-line JSON behavior is unchanged.

## Validation

- `bunx vitest run src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts` (25 passed)
- `bun run build`
- `bun run lint`
- `bun run lint:fix`
- `bun run typecheck`
- `bun run test` (8529 passed, 13 skipped; one unrelated existing failure in `LanguageSwitcher > keeps the pending refresh after remount when sessionStorage is blocked`)
- isolated rerun of the unrelated LanguageSwitcher file reproduces the same failure

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects Responses WebSocket-to-SSE serialization so every physical payload line receives an SSE `data:` prefix while CRLF and CR endings are normalized. It also adds regression coverage proving that pretty-printed multiline JSON remains a complete downstream event.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable regressions identified in the changed SSE serialization or its regression test.

The adapter now preserves multiline WebSocket payloads as single SSE events, while single-line events and raw-payload terminal detection retain their existing behavior.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/responses-ws/upstream-adapter.ts | Replaces single-prefix serialization with standards-compliant multiline SSE encoding without changing terminal-event detection. |
| src/app/v1/_lib/responses-ws/__tests__/upstream-adapter.test.ts | Adds focused coverage for CRLF-formatted, pretty-printed JSON frames and verifies complete event reconstruction. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(responses-ws): encode multiline even..."](https://github.com/ding113/claude-code-hub/commit/e9061155c81fe7b1c6cc3bf8a8af0501473f9c60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53929211)</sub>

**Context used:**

- Knowledge Base — [Proxy request pipeline](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/proxy-pipeline.md)

<!-- /greptile_comment -->