### PR TITLE
fix: compact combined fast and 1M cost badge

### DIFF
--- a/messages/en/dashboard.json
+++ b/messages/en/dashboard.json
@@ -621,6 +621,7 @@
       "totalCost": "Total Cost",
       "unitPricePer1M": "@ {price} / 1M",
       "fast": "fast",
+      "combinedFastContext": "{fast} + {context} context",
       "fastPriority": "Priority service tier (fast mode)",
       "context1m": "1M Context",
       "context1mEnabled": "1M context window enabled",

--- a/messages/ja/dashboard.json
+++ b/messages/ja/dashboard.json
@@ -621,6 +621,7 @@
       "totalCost": "合計費用",
       "unitPricePer1M": "@ {price} / 1M",
       "fast": "fast",
+      "combinedFastContext": "{fast} + {context} コンテキスト",
       "fastPriority": "Priority service tier (fast モード)",
       "context1m": "1M コンテキスト",
       "context1mEnabled": "1Mコンテキストウィンドウ有効",

--- a/messages/ru/dashboard.json
+++ b/messages/ru/dashboard.json
@@ -621,6 +621,7 @@
       "totalCost": "Общая стоимость",
       "unitPricePer1M": "@ {price} / 1M",
       "fast": "fast",
+      "combinedFastContext": "{fast} + контекст {context}",
       "fastPriority": "Приоритетный уровень обслуживания (режим fast)",
       "context1m": "1M Контекст",
       "context1mEnabled": "Окно контекста 1M включено",

--- a/messages/zh-CN/dashboard.json
+++ b/messages/zh-CN/dashboard.json
@@ -621,6 +621,7 @@
       "totalCost": "总费用",
       "unitPricePer1M": "@ {price} / 1M",
       "fast": "fast",
+      "combinedFastContext": "{fast} + {context} 上下文",
       "fastPriority": "优先服务等级（fast 模式）",
       "context1m": "1M 上下文",
       "context1mEnabled": "1M 上下文窗口已启用",

--- a/messages/zh-TW/dashboard.json
+++ b/messages/zh-TW/dashboard.json
@@ -621,6 +621,7 @@
       "totalCost": "總費用",
       "unitPricePer1M": "@ {price} / 1M",
       "fast": "fast",
+      "combinedFastContext": "{fast} + {context} 上下文",
       "fastPriority": "優先服務層級（fast 模式）",
       "context1m": "1M 上下文長度",
       "context1mEnabled": "1M 上下文視窗已啟用",

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
@@ -460,6 +460,29 @@ describe("virtualized-logs-table multiplier badge", () => {
     expect(html).toContain("x0.20");
   });
 
+  test("combines fast and 1M into one compact cost badge", () => {
+    const html = renderTableWithLog({
+      context1mApplied: true,
+      specialSettings: [
+        {
+          type: "codex_service_tier_result",
+          scope: "response",
+          hit: true,
+          requestedServiceTier: "priority",
+          actualServiceTier: "priority",
+          billingSourcePreference: "actual",
+          resolvedFrom: "actual",
+          effectivePriority: true,
+        },
+      ],
+    });
+
+    expect(html).toContain("logs.billingDetails.fast");
+    expect(html).toContain(">·<");
+    expect(html).toContain(">1M<");
+    expect(html).toContain("gap-0 px-0.5 text-[9px] leading-3");
+  });
+
   test("keeps the winner multiplier visible after multiple Discovery attempts", () => {
     const html = renderTableWithLog({
       costMultiplier: "0.01",

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx
@@ -483,6 +483,30 @@ describe("virtualized-logs-table multiplier badge", () => {
     expect(html).toContain("gap-0 px-0.5 text-[9px] leading-3");
   });
 
+  test("keeps fast-only and 1M-only badges independent", () => {
+    for (const overrides of [
+      {
+        specialSettings: [
+          {
+            type: "codex_service_tier_result" as const,
+            scope: "response" as const,
+            hit: true,
+            requestedServiceTier: "priority",
+            actualServiceTier: "priority",
+            billingSourcePreference: "actual" as const,
+            resolvedFrom: "actual" as const,
+            effectivePriority: true,
+          },
+        ],
+        context1mApplied: false,
+      },
+      { specialSettings: null, context1mApplied: true },
+    ]) {
+      const html = renderTableWithLog(overrides);
+      expect(html).not.toContain("gap-0 px-0.5 text-[9px] leading-3");
+    }
+  });
+
   test("keeps the winner multiplier visible after multiple Discovery attempts", () => {
     const html = renderTableWithLog({
       costMultiplier: "0.01",

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -1216,7 +1216,10 @@ export function VirtualizedLogsTable({
                                         <Badge
                                           variant="outline"
                                           className="gap-0 px-0.5 text-[9px] leading-3"
-                                          title={`${t("logs.billingDetails.fastPriority")} + ${t("logs.billingDetails.context1m")}`}
+                                          title={t("logs.billingDetails.combinedFastContext", {
+                                            fast: t("logs.billingDetails.fast"),
+                                            context: "1M",
+                                          })}
                                         >
                                           <span className="text-orange-700 dark:text-orange-300">
                                             {t("logs.billingDetails.fast")}

--- a/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
+++ b/src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx
@@ -1206,23 +1206,48 @@ export function VirtualizedLogsTable({
                               <TooltipTrigger asChild>
                                 <span className="cursor-help inline-flex items-center gap-1">
                                   {formatCurrency(log.costUsd, currencyCode, 6)}
-                                  {hasPriorityServiceTierSpecialSetting(log.specialSettings) && (
-                                    <Badge
-                                      variant="outline"
-                                      className="text-[10px] leading-tight px-1 bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-950/30 dark:text-orange-300 dark:border-orange-800"
-                                      title={t("logs.billingDetails.fastPriority")}
-                                    >
-                                      {t("logs.billingDetails.fast")}
-                                    </Badge>
-                                  )}
-                                  {log.context1mApplied && (
-                                    <Badge
-                                      variant="outline"
-                                      className="text-[10px] leading-tight px-1 bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-950/30 dark:text-purple-300 dark:border-purple-800"
-                                    >
-                                      1M
-                                    </Badge>
-                                  )}
+                                  {(() => {
+                                    const hasFast = hasPriorityServiceTierSpecialSetting(
+                                      log.specialSettings
+                                    );
+                                    const hasContext1m = Boolean(log.context1mApplied);
+                                    if (hasFast && hasContext1m) {
+                                      return (
+                                        <Badge
+                                          variant="outline"
+                                          className="gap-0 px-0.5 text-[9px] leading-3"
+                                          title={`${t("logs.billingDetails.fastPriority")} + ${t("logs.billingDetails.context1m")}`}
+                                        >
+                                          <span className="text-orange-700 dark:text-orange-300">
+                                            {t("logs.billingDetails.fast")}
+                                          </span>
+                                          <span className="text-muted-foreground">·</span>
+                                          <span className="text-purple-700 dark:text-purple-300">1M</span>
+                                        </Badge>
+                                      );
+                                    }
+                                    return (
+                                      <>
+                                        {hasFast && (
+                                          <Badge
+                                            variant="outline"
+                                            className="text-[10px] leading-tight px-1 bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-950/30 dark:text-orange-300 dark:border-orange-800"
+                                            title={t("logs.billingDetails.fastPriority")}
+                                          >
+                                            {t("logs.billingDetails.fast")}
+                                          </Badge>
+                                        )}
+                                        {hasContext1m && (
+                                          <Badge
+                                            variant="outline"
+                                            className="text-[10px] leading-tight px-1 bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-950/30 dark:text-purple-300 dark:border-purple-800"
+                                          >
+                                            1M
+                                          </Badge>
+                                        )}
+                                      </>
+                                    );
+                                  })()}
                                 </span>
                               </TooltipTrigger>
                               {renderCostTooltip(log)}


### PR DESCRIPTION
## Summary
- Combine the `fast` and `1M` badges into one compact badge when both states are active in the usage logs cost column
- Preserve independent rendering when only one state is active
- Keep backend fields and the detailed cost tooltip unchanged

## Problem
When a log entry has both the priority service tier ("fast") and the 1M context window applied, the cost column rendered two separate badges side by side after the amount, making the cell unnecessarily wide (branch: `fix/log-cost-column-spacing`).

**Related Issues / PRs:**
- No open issue reports this directly
- Follow-up to #870 - introduced the orange "fast" badge in the cost column
- Related to #1038 - last refined the cost-cell badge and tooltip rendering

## Solution
When both `hasPriorityServiceTierSpecialSetting(specialSettings)` and `context1mApplied` are true, render a single outline `Badge` containing `fast · 1M`:
- Each label keeps its semantic color (orange for fast, purple for 1M) in light and dark modes
- Tighter sizing (`gap-0 px-0.5 text-[9px] leading-3`) versus the standalone badge (`text-[10px] leading-tight px-1`)
- Combined `title` attribute joins the existing i18n keys `logs.billingDetails.fastPriority` and `logs.billingDetails.context1m` (present in all 5 locales - no new strings needed)

When only one state is active, the previous standalone badge rendering is kept unchanged.

## Changes

### Core Changes
- `src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx`: wrap the two badge conditions in an IIFE that renders the combined compact badge when both flags are set, otherwise the original standalone badges

### Supporting Changes
- `src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx`: new test `combines fast and 1M into one compact cost badge` asserting the combined markup, the `·` separator, and the compact class string

## Testing

### Automated Tests
- [x] Unit test added (`virtualized-logs-table.test.tsx`)
- Author verification: `bun run typecheck` passed; targeted test run passed (37 tests); `git diff --check` clean

### Manual Testing
1. Trigger a request with both priority service tier and 1M context enabled
2. Open Dashboard -> Logs
3. Expected: cost cell shows a single compact `fast · 1M` badge with a combined hover title; single-state rows render exactly as before

## Screenshots
TODO (before/after of the cost column with both badges active)

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [x] Tests pass locally
- [ ] Documentation updated (if needed) - not needed, UI-only change

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR compacts simultaneous fast-service and 1M-context indicators into one localized usage-log cost badge while preserving standalone rendering.
- Adds a combined badge title across all five supported locale catalogs.
- Adds coverage for combined and independent badge states.
- Leaves cost calculation and detailed cost-tooltip behavior unchanged.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.tsx | Combines the two cost indicators only when both established state checks are active and preserves the prior standalone branches. |
| src/app/[locale]/dashboard/logs/_components/virtualized-logs-table.test.tsx | Covers compact combined rendering and verifies that single-state rows do not use the combined styling. |
| messages/en/dashboard.json | Adds the English combined badge title with placeholders consistent across supported locales. |
| messages/ja/dashboard.json | Adds the Japanese combined badge title with matching interpolation placeholders. |
| messages/ru/dashboard.json | Adds the Russian combined badge title with matching interpolation placeholders. |
| messages/zh-CN/dashboard.json | Adds the Simplified Chinese combined badge title with matching interpolation placeholders. |
| messages/zh-TW/dashboard.json | Adds the Traditional Chinese combined badge title with matching interpolation placeholders. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: localize combined cost badge toolti..."](https://github.com/ding113/claude-code-hub/commit/c18375a73c70baeadee67982e45d1744096bcbcc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56323928)</sub>

<!-- /greptile_comment -->