### PR TITLE
fix(stream-gate): preserve 4xx status code for non-retryable client errors

### DIFF
--- a/src/app/v1/_lib/proxy/stream-gate/stream-content-gate.ts
+++ b/src/app/v1/_lib/proxy/stream-gate/stream-content-gate.ts
@@ -32,10 +32,11 @@ export type StreamGateFailureReason =
   | "idle_timeout";
 
 /**
- * 门控 precommit 错误。继承 ProxyError（statusCode 502）——
- * categorizeErrorAsync 将其归为 PROVIDER_ERROR：计入熔断器并切换供应商，
- * 无需改动现有错误分类逻辑。gate_error 时把上游错误帧原文带入
- * upstreamError.body，供错误规则匹配（如不可重试的客户端输入错误）与审计。
+ * 门控 precommit 错误。继承 ProxyError——
+ * gate_error 时如果上游错误帧携带明确的 4xx 客户端错误特征（例如 cyber_policy、
+ * invalid_request、400 状态码等），则使用真实的 4xx 状态码，使下游错误分类器能正确
+ * 判定为不可重试的客户端错误（NON_RETRYABLE_CLIENT_ERROR），避免无意义的切商重试并
+ * 正常触发 error_rules 覆写；其余情况默认使用 502（PROVIDER_ERROR）触发切商。
  */
 export class StreamPrecommitError extends ProxyError {
   readonly gateReason: StreamGateFailureReason;
@@ -53,7 +54,8 @@ export class StreamPrecommitError extends ProxyError {
     }
   ) {
     const message = `Stream content gate rejected upstream before first valid content (${reason})`;
-    super(message, 502, {
+    const statusCode = resolveGateErrorStatusCode(reason, detail.frameData);
+    super(message, statusCode, {
       body: buildGateErrorBody(reason, detail),
       providerId: detail.providerId,
       providerName: detail.providerName,
@@ -61,6 +63,80 @@ export class StreamPrecommitError extends ProxyError {
     this.name = "StreamPrecommitError";
     this.gateReason = reason;
   }
+}
+
+function resolveGateErrorStatusCode(reason: StreamGateFailureReason, frameData?: string): number {
+  if (reason !== "gate_error" || !frameData) {
+    return 502;
+  }
+
+  try {
+    const trimmed = frameData.trim();
+    if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+      return 502;
+    }
+    const json = JSON.parse(trimmed) as Record<string, unknown>;
+    if (!json || typeof json !== "object") {
+      return 502;
+    }
+
+    // 1. 尝试从常见 status 字段直接提取 4xx 状态码
+    const candidates = [
+      json.status,
+      json.status_code,
+      json.statusCode,
+      (json.error as Record<string, unknown> | undefined)?.status,
+      (json.error as Record<string, unknown> | undefined)?.status_code,
+      (json.error as Record<string, unknown> | undefined)?.statusCode,
+      (json.response as { error?: Record<string, unknown> } | undefined)?.error?.status,
+      (json.response as { error?: Record<string, unknown> } | undefined)?.error?.status_code,
+      (json.response as { error?: Record<string, unknown> } | undefined)?.error?.statusCode,
+    ];
+    for (const code of candidates) {
+      if (typeof code === "number" && code >= 400 && code < 500) {
+        return code;
+      }
+    }
+
+    // 2. 检查常见客户端错误类型及错误码
+    const errType = String(
+      (json.error as Record<string, unknown> | undefined)?.type ||
+        (json.response as { error?: Record<string, unknown> } | undefined)?.error?.type ||
+        json.type ||
+        ""
+    ).toLowerCase();
+
+    const errCode = String(
+      (json.error as Record<string, unknown> | undefined)?.code ||
+        (json.response as { error?: Record<string, unknown> } | undefined)?.error?.code ||
+        json.code ||
+        ""
+    ).toLowerCase();
+
+    const errStatus = String(
+      (json.error as Record<string, unknown> | undefined)?.status || json.status || ""
+    ).toUpperCase();
+
+    if (
+      errType === "invalid_request_error" ||
+      errType === "invalid_request" ||
+      errType === "bad_request_error" ||
+      errCode === "cyber_policy" ||
+      errCode === "invalid_prompt" ||
+      errCode === "invalid_value" ||
+      errCode === "unsupported_value" ||
+      errCode === "context_length_exceeded" ||
+      errCode === "message_too_big" ||
+      errCode === "string_above_max_length" ||
+      errStatus === "INVALID_ARGUMENT"
+    ) {
+      return 400;
+    }
+  } catch {
+    // 忽略非 JSON 解析异常
+  }
+
+  return 502;
 }
 
 function buildGateErrorBody(

--- a/src/components/ui/__tests__/language-switcher.test.tsx
+++ b/src/components/ui/__tests__/language-switcher.test.tsx
@@ -131,11 +131,13 @@ describe("LanguageSwitcher", () => {
   });
 
   test("keeps the pending refresh after remount when sessionStorage is blocked", () => {
-    // happy-dom 的 sessionStorage 是 Proxy 且原型并非全局 Storage,
-    // 实例级 spy 会被当成存储项写入而不生效,需在实际原型上拦截 setItem
-    const storagePrototype = Object.getPrototypeOf(window.sessionStorage) as Storage;
-    const setItemSpy = vi.spyOn(storagePrototype, "setItem").mockImplementation(() => {
-      throw new Error("blocked storage");
+    const originalSetItem = window.sessionStorage.setItem;
+    Object.defineProperty(window.sessionStorage, "setItem", {
+      value: vi.fn(() => {
+        throw new Error("blocked storage");
+      }),
+      configurable: true,
+      writable: true,
     });
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -157,7 +159,11 @@ describe("LanguageSwitcher", () => {
 
     view.unmount();
     view = null;
-    setItemSpy.mockRestore();
+    Object.defineProperty(window.sessionStorage, "setItem", {
+      value: originalSetItem,
+      configurable: true,
+      writable: true,
+    });
 
     testState.currentLocale = "en";
     view = render(<LanguageSwitcher />);

--- a/src/repository/error-rules.ts
+++ b/src/repository/error-rules.ts
@@ -436,6 +436,22 @@ const DEFAULT_ERROR_RULES = [
       },
     },
   },
+  {
+    pattern: "cyber_policy|flagged for possible cybersecurity risk",
+    category: "content_filter",
+    description: "OpenAI cyber policy violation (non-retryable)",
+    matchType: "regex" as const,
+    isDefault: true,
+    isEnabled: true,
+    priority: 90,
+    overrideResponse: {
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "内容触发了安全策略拦截 (cyber_policy)，请调整输入后重试",
+      },
+    },
+  },
   // Tool use validation errors (non-retryable)
   {
     pattern: "`tool_use` ids must be unique|tool_use.*ids must be unique",

--- a/tests/unit/proxy/stream-gate-content-gate.test.ts
+++ b/tests/unit/proxy/stream-gate-content-gate.test.ts
@@ -321,6 +321,55 @@ describe("StreamPrecommitError classification", () => {
     expect(error.statusCode).toBe(502);
     expect(error).not.toBeInstanceOf(EmptyResponseError);
   });
+
+  it("extracts 400 status code for cyber_policy error frames", () => {
+    const error = new StreamPrecommitError("gate_error", {
+      family: "openai-responses",
+      providerId: 1,
+      providerName: "p",
+      frameData: JSON.stringify({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          code: "cyber_policy",
+          message: "This content was flagged for possible cybersecurity risk.",
+        },
+      }),
+    });
+    expect(error.statusCode).toBe(400);
+    expect(error.gateReason).toBe("gate_error");
+  });
+
+  it("extracts explicit 4xx status code when provided in the error frame", () => {
+    const error = new StreamPrecommitError("gate_error", {
+      family: "openai-responses",
+      providerId: 1,
+      providerName: "p",
+      frameData: JSON.stringify({
+        status: 422,
+        error: {
+          message: "Unprocessable entity",
+        },
+      }),
+    });
+    expect(error.statusCode).toBe(422);
+  });
+
+  it("extracts 400 status code for invalid_request_error and invalid_prompt", () => {
+    const error = new StreamPrecommitError("gate_error", {
+      family: "anthropic",
+      providerId: 1,
+      providerName: "p",
+      frameData: JSON.stringify({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message: "Invalid request body",
+        },
+      }),
+    });
+    expect(error.statusCode).toBe(400);
+  });
 });
 
 describe("request echo frame byte-cap exclusion", () => {

--- a/tests/unit/proxy/stream-gate-forwarder-integration.test.ts
+++ b/tests/unit/proxy/stream-gate-forwarder-integration.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
+import { ProxyError } from "@/app/v1/_lib/proxy/errors";
 
 /**
  * F1 流式内容门控（stream content gate）在 ProxyForwarder 顺序路径中的接线集成测试。
@@ -595,6 +596,48 @@ describe("F1 stream content gate x ProxyForwarder sequential path", () => {
         .find((item) => item.id === provider1.id && item.reason === "retry_failed");
       expect(emptyStreamEntry?.statusCode).toBe(502);
       expect(emptyStreamEntry?.errorMessage).toContain("empty_stream");
+    });
+
+    test("上游返回 4xx / cyber_policy 错误帧时不触发切商重试，按不可重试客户端错误退出", async () => {
+      const provider1 = createProvider({ id: 1, name: "gate-p1", providerType: "codex" });
+      const session = createSession();
+      session.setProvider(provider1);
+      Object.assign(session, {
+        requestUrl: new URL("https://example.com/v1/responses"),
+        originalFormat: "response",
+        endpointPolicy: resolveEndpointPolicy("/v1/responses"),
+      });
+
+      mocks.categorizeErrorAsync.mockImplementationOnce(async (err: Error) => {
+        if (err instanceof ProxyError && err.statusCode === 400) {
+          return 3; // NON_RETRYABLE_CLIENT_ERROR
+        }
+        return 0;
+      });
+
+      const cyberPolicyFrame = `event: error\ndata: ${JSON.stringify({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          code: "cyber_policy",
+          message: "This content was flagged for possible cybersecurity risk.",
+        },
+      })}\n\n`;
+
+      const doForward = spyOnDoForward();
+      doForward.mockImplementationOnce(async () => createSseResponse([cyberPolicyFrame]));
+
+      await expect(ProxyForwarder.send(session)).rejects.toThrow(
+        /Stream content gate rejected upstream before first valid content/
+      );
+
+      expect(doForward).toHaveBeenCalledTimes(1);
+      expect(mocks.pickRandomProviderWithExclusion).not.toHaveBeenCalled();
+
+      const chainEntries = session.getProviderChain();
+      const failureEntry = chainEntries.find((item) => item.id === provider1.id);
+      expect(failureEntry?.statusCode).toBe(400);
+      expect(failureEntry?.reason).toBe("client_error_non_retryable");
     });
   });
 


### PR DESCRIPTION
## 问题

Fixes #1448

在开启流式内容门控（`STREAM_GATE_MODE=enforce`）时，当上游（如 OpenAI / CPA / Codex）在首个有效内容 chunk 到达前返回了属于 **4xx 客户端请求错误** 的 SSE 事件帧（例如 `cyber_policy`、`invalid_request`、`context_length_exceeded` 等）时：

1. `StreamPrecommitError` 在门控拦截阶段将 `statusCode` **硬编码写死为了 `502`**。
2. 错误分类器（`categorizeErrorAsync`）在处理该异常时，因 `statusCode === 502` 处于 `[500, 599]` 区间，直接将其归类为 **`PROVIDER_ERROR`（供应商节点故障）**。
3. 进而触发了供应商对冲/切换重试（Hedge/Retry），无意义地把同组内所有可用供应商遍历重试一遍。
4. 重试耗尽后对外返回 `503: 所有供应商暂时不可用，请稍后重试`，导致上游真实的 400 业务错误被掩盖，且管理员在后台配置的 `error_rules` 无法提前生效拦截。

## 改动

1. **`stream-content-gate.ts`**：
   - 新增 `resolveGateErrorStatusCode(reason, frameData)`：当 `reason === "gate_error"` 且 `frameData` 包含 4xx 状态码或已知客户端错误特征（`cyber_policy`、`invalid_request_error`、`context_length_exceeded`、`invalid_prompt`、`INVALID_ARGUMENT` 等）时，提取并赋予其真实的 4xx 状态码（默认 400）；
   - 真实供应商异常、空流或未知错误继续保持 502 兜底。
2. **`error-rules.ts`**：
   - 在 `DEFAULT_ERROR_RULES` 中补齐 `cyber_policy` 对应的不可重试拦截规则（`category: "content_filter"`, `priority: 90`）。
3. **单元测试与集成测试**：
   - `tests/unit/proxy/stream-gate-content-gate.test.ts`：增加门控针对 `cyber_policy`、`invalid_request_error` 及显式 4xx 的状态码提取单测；
   - `tests/unit/proxy/stream-gate-forwarder-integration.test.ts`：增加流门控遇到 `cyber_policy` 时立即以 `client_error_non_retryable` 终止且不切商重试的集成测试。

## 验收

```bash
bun run typecheck    # clean
bun run lint         # clean
bun run build        # clean
bun run test         # 869/869 passed
```

## 关联 PR

- Related to #1443 — 同为 `StreamPrecommitError` 错误归因的互补修正：#1443 处理 `empty_stream` 的熔断记账豁免，本 PR 处理 `gate_error` 携带 4xx 客户端错误帧时的真实状态码保留。两者均修改 `stream-content-gate.ts` 及 `stream-gate-content-gate.test.ts`、`stream-gate-forwarder-integration.test.ts`，合并时需注意冲突协调。

## 补充说明

- **`src/components/ui/__tests__/language-switcher.test.tsx`**：随本 PR 附带修复 happy-dom 环境下 `sessionStorage.setItem` 的 mock 方式（由原型级 `vi.spyOn` 改为实例级 `Object.defineProperty`），纯测试基建调整，不涉及生产代码。
- **默认规则自动生效**：新增的 `cyber_policy` 默认规则会随启动时 `syncDefaultErrorRules()`（`instrumentation.ts`）自动同步到数据库；若已存在同 pattern 的用户自定义规则则保留用户版本，无需手动迁移。
- **行为变化说明**：`gate_error` 帧带 4xx 特征时不再触发切商/对冲重试，直接以 `NON_RETRYABLE_CLIENT_ERROR` 终止并返回真实状态码（即本 PR 的修复目标）；空流、超时与未知错误的 502 兜底路径保持不变，无破坏性变更。

---
*Description enhanced by Claude AI*