### PR TITLE
fix(logs): declare subquery column alias for raw SQL session identity suggestions

### DIFF
--- a/src/repository/usage-logs.ts
+++ b/src/repository/usage-logs.ts
@@ -1,7 +1,6 @@
 import "server-only";
 
-import type { SQL } from "drizzle-orm";
-import { and, desc, eq, gte, inArray, isNull, lt, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, is, isNull, lt, SQL, sql } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { keys as keysTable, messageRequest, providers, usageLedger, users } from "@/drizzle/schema";
 import { TTLMap } from "@/lib/cache/ttl-map";
@@ -1981,9 +1980,11 @@ export async function findUsageLogSessionIdSuggestions(
 
       const subqueryLimit = Math.max(500, limit * 25);
 
+      const candidateColumn = is(candidate, SQL) ? candidate.as("session_id") : candidate;
+
       const baseInnerQuery = db
         .select({
-          sessionId: candidate,
+          sessionId: candidateColumn,
           createdAt: usageLedger.createdAt,
           id: usageLedger.id,
         })
@@ -2045,9 +2046,11 @@ export async function findUsageLogSessionIdSuggestions(
 
       const subqueryLimit = Math.max(500, limit * 25);
 
+      const candidateColumn = is(candidate, SQL) ? candidate.as("session_id") : candidate;
+
       const baseInnerQuery = db
         .select({
-          sessionId: candidate,
+          sessionId: candidateColumn,
           createdAt: messageRequest.createdAt,
           id: messageRequest.id,
         })

--- a/tests/unit/repository/usage-logs-sessionid-suggestions.test.ts
+++ b/tests/unit/repository/usage-logs-sessionid-suggestions.test.ts
@@ -396,4 +396,52 @@ describe("Usage logs sessionId suggestions", () => {
     expect(limitArgs).toContain(500);
     expect(limitArgs).toContain(20);
   });
+
+  test.each([false, true])(
+    "builds valid Drizzle queries without SelectionProxy errors for raw SQL candidate expressions (ledgerOnly=%s)",
+    async (ledgerOnly) => {
+      vi.resetModules();
+      isLedgerOnlyModeMock.mockResolvedValue(ledgerOnly);
+
+      const generatedQueries: string[] = [];
+      const fakeClient: any = Object.assign(() => Promise.resolve([]), {
+        options: { parsers: {}, serializers: {} },
+        unsafe: () => ({ values: () => Promise.resolve([]) }),
+      });
+      const { drizzle } = await import("drizzle-orm/postgres-js");
+      const realDb = drizzle(fakeClient);
+
+      const dummy = realDb
+        .select()
+        .from(
+          realDb._.schema ? (realDb as any) : (await import("@/drizzle/schema")).messageRequest
+        );
+      const proto = Object.getPrototypeOf(dummy);
+      const origThen = proto.then;
+      // biome-ignore lint/suspicious/noThenProperty: test spy intercepts query execution to assert generated SQL
+      proto.then = function (onfulfilled: any, onrejected: any) {
+        generatedQueries.push(this.toSQL().sql);
+        return Promise.resolve([]).then(onfulfilled, onrejected);
+      };
+
+      vi.doMock("@/drizzle/db", () => ({
+        db: realDb,
+      }));
+
+      try {
+        const { findUsageLogSessionIdSuggestions } = await import("@/repository/usage-logs");
+        const result = await findUsageLogSessionIdSuggestions({ term: "b44", limit: 20 });
+
+        expect(result).toEqual([]);
+        expect(generatedQueries.length).toBe(2);
+        for (const sql of generatedQueries) {
+          expect(sql.toLowerCase()).toContain("session_id");
+          expect(sql.toLowerCase()).toContain("max(");
+        }
+      } finally {
+        // biome-ignore lint/suspicious/noThenProperty: restore original then implementation
+        proto.then = origThen;
+      }
+    }
+  );
 });


### PR DESCRIPTION
## Summary

Fixes a `SelectionProxy` runtime error in `findUsageLogSessionIdSuggestions` introduced in #1447 where raw `SQL` expressions (`messageSessionIdentity` / `ledgerSessionIdentity`) were referenced from subquery selections without an explicit alias.

### Problem
- In #1447, bounded subqueries (`.as("sub")`) were introduced to optimize aggregation queries.
- When `candidate` is a raw SQL expression (`COALESCE(sessionIdentity, sessionId)`), Drizzle ORM's `SelectionProxy` throws at query build time when referencing `subquery.sessionId`:
  ```
  Error: You tried to reference "sessionId" field from a subquery, which is a raw SQL field, but it doesn't have an alias declared. Please add an alias to the field using ".as('alias')" method.
  ```
- This broke `/api/v1/usage-logs/session-id-suggestions` for all searches (both Prefix ID and physical Session ID candidates), displaying "No matching Session or Prefix IDs found" in the dashboard.
- The unit test mocked `query.as` directly with a plain object, masking this runtime validation error.

### Solution
- Use `is(candidate, SQL) ? candidate.as("session_id") : candidate` to declare an explicit column alias for raw SQL candidates before selecting into the inner subquery.
- Add test coverage using real Drizzle query builder instances to assert AST compilation across both `message_request` and `usage_ledger` paths without `SelectionProxy` errors.

### Verification
- `bun run lint` passed cleanly.
- `bun run typecheck` passed cleanly.
- `bunx vitest run tests/unit/repository/usage-logs-sessionid-suggestions.test.ts` all 16 tests passed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes session-identity suggestion queries by assigning raw Drizzle SQL expressions an explicit alias before exposing them through bounded subqueries.

- Applies the alias consistently to the normal request-record and ledger-only query paths.
- Adds real Drizzle query-builder coverage for both storage modes and verifies that the generated aggregate queries compile with the alias.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The alias is applied to both reachable raw SQL candidates while physical columns remain unchanged, and the added tests exercise query construction through both storage modes.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/repository/usage-logs.ts | Correctly distinguishes raw SQL session-identity expressions from physical columns and aliases the former in both query paths. |
| tests/unit/repository/usage-logs-sessionid-suggestions.test.ts | Adds focused compilation coverage using real Drizzle builders for both normal and ledger-only modes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(logs): declare subquery column alias..."](https://github.com/ding113/claude-code-hub/commit/65cd959ec2dd04b7e58290865d531d1fe04fffdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56981632)</sub>

**Context used:**

- Knowledge Base — [Usage persistence and ledger](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/usage-persistence-and-ledger.md)
- Knowledge Base — [Operational analytics and alerts](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/operational-analytics-and-alerts.md)

<!-- /greptile_comment -->