### PR TITLE
fix(proxy): prevent large session requests from cascading into OOM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,8 @@ SESSION_RESPONSE_BODY_DEDUP_ENABLED=false # response body 单 key 去重 writer�
 SESSION_RESPONSE_BODY_MAX_BYTES=5242880 # 会话响应体 Redis 存储上限（默认 5 MiB，范围 64 KiB-64 MiB）
                                         # 去重关闭时限制每份正文；去重开启时限制所有唯一正文的 UTF-8 总字节数
                                         # 超限正文不落 Redis；before/after snapshot 的 headers/meta 仍保留
+SESSION_REQUEST_ARTIFACT_MAX_BYTES=5242880 # 单份请求调试正文 Redis 存储上限（默认 5 MiB，范围 64 KiB-64 MiB）
+                                        # 超限时跳过 requestBody/messages 和 before/after body，保留 headers/meta
 
 # Dashboard 配置
 DASHBOARD_LOGS_POLL_INTERVAL_MS=5000    # 日志页自动刷新轮询间隔（毫秒，默认 5000，范围 250-60000）

--- a/src/actions/active-sessions.ts
+++ b/src/actions/active-sessions.ts
@@ -1029,11 +1029,8 @@ export async function getSessionDetails(
       locatorResult.locator.keyId
     );
 
-    // 6. 并行获取 messages、requestBody 和 response（不缓存，因为这些数据较大）
+    // 6. 先读取 phase 快照和轻量 metadata；大字段仅在现代快照缺失时读取 legacy key。
     const [
-      requestBody,
-      messages,
-      response,
       requestHeaders,
       responseHeaders,
       clientReqMeta,
@@ -1046,15 +1043,6 @@ export async function getSessionDetails(
       responseSnapshotBefore,
       responseSnapshotAfter,
     ] = await Promise.all([
-      redisArtifactsOwned
-        ? SessionManager.getSessionRequestBody(sourceSessionId, effectiveSequence)
-        : null,
-      redisArtifactsOwned
-        ? SessionManager.getSessionMessages(sourceSessionId, effectiveSequence)
-        : null,
-      redisArtifactsOwned
-        ? SessionManager.getSessionResponse(sourceSessionId, effectiveSequence)
-        : null,
       redisArtifactsOwned
         ? SessionManager.getSessionRequestHeaders(sourceSessionId, effectiveSequence)
         : null,
@@ -1100,21 +1088,6 @@ export async function getSessionDetails(
         : null,
     ]);
 
-    // 兼容：历史/异常数据可能是 JSON 字符串（前端需要根级对象/数组）
-    const normalizedMessages = parseJsonStringOrNull(messages);
-    const normalizedRequestBody = parseJsonStringOrNull(requestBody);
-
-    const requestMeta = {
-      clientUrl: clientReqMeta?.url ?? null,
-      upstreamUrl: upstreamReqMeta?.url ?? null,
-      method: clientReqMeta?.method ?? upstreamReqMeta?.method ?? null,
-    };
-
-    const responseMeta = {
-      upstreamUrl: upstreamResMeta?.url ?? upstreamReqMeta?.url ?? null,
-      statusCode: upstreamResMeta?.statusCode ?? null,
-    };
-
     const snapshots: SessionDetailSnapshots = {
       defaultView: DEFAULT_SESSION_DETAIL_VIEW_MODE,
       request: {
@@ -1134,6 +1107,41 @@ export async function getSessionDetails(
         after: normalizeResponseSnapshot(responseSnapshotAfter ?? null),
       },
     };
+
+    const snapshotRequestBody = snapshots.request.after?.body ?? snapshots.request.before?.body;
+    const snapshotMessages =
+      snapshots.request.before?.messages ?? snapshots.request.after?.messages;
+    const snapshotResponse = snapshots.response.after?.body ?? snapshots.response.before?.body;
+
+    const [legacyRequestBody, legacyMessages, legacyResponse] = await Promise.all([
+      redisArtifactsOwned && snapshotRequestBody == null
+        ? SessionManager.getSessionRequestBody(sourceSessionId, effectiveSequence)
+        : null,
+      redisArtifactsOwned && snapshotMessages == null
+        ? SessionManager.getSessionMessages(sourceSessionId, effectiveSequence)
+        : null,
+      redisArtifactsOwned && snapshotResponse == null
+        ? SessionManager.getSessionResponse(sourceSessionId, effectiveSequence)
+        : null,
+    ]);
+
+    // 兼容：历史/异常数据可能是 JSON 字符串（前端需要根级对象/数组）。
+    const normalizedMessages = snapshotMessages ?? parseJsonStringOrNull(legacyMessages ?? null);
+    const normalizedRequestBody =
+      snapshotRequestBody ?? parseJsonStringOrNull(legacyRequestBody ?? null);
+    const response = snapshotResponse ?? legacyResponse;
+
+    const requestMeta = {
+      clientUrl: clientReqMeta?.url ?? null,
+      upstreamUrl: upstreamReqMeta?.url ?? null,
+      method: clientReqMeta?.method ?? upstreamReqMeta?.method ?? null,
+    };
+
+    const responseMeta = {
+      upstreamUrl: upstreamResMeta?.url ?? upstreamReqMeta?.url ?? null,
+      statusCode: upstreamResMeta?.statusCode ?? null,
+    };
+
     const legacyCompatibilitySnapshots = buildLegacyCompatibilitySnapshots({
       requestBody: normalizedRequestBody,
       messages: normalizedMessages,

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -161,6 +161,7 @@ import {
 export const DEFAULT_CODEX_USER_AGENT =
   "codex_cli_rs/0.93.0 (Windows 10.0.26200; x86_64) vscode/1.108.1";
 const EMPTY_PREFIX_CHUNK = new Uint8Array(0);
+const LEGACY_STREAMING_HEDGE_MAX_CONCURRENCY = 2;
 
 async function runStreamContentGateWithAbortSignals(
   reader: ReadableStreamDefaultReader<Uint8Array>,
@@ -4957,6 +4958,7 @@ export class ProxyForwarder {
 
     const launchAlternative = async () => {
       if (settled || winnerCommitted || noMoreProviders) return;
+      if (attempts.size >= LEGACY_STREAMING_HEDGE_MAX_CONCURRENCY) return;
       if (launchingAlternative) {
         await launchingAlternative;
         return;

--- a/src/app/v1/_lib/proxy/session-guard.ts
+++ b/src/app/v1/_lib/proxy/session-guard.ts
@@ -89,8 +89,15 @@ export class ProxySessionGuard {
       session.setRawCrossProviderFallbackEnabled(rawFallbackEnabled);
       const allowRawSessionContext = session.isRawCrossProviderFallbackEnabled();
       session.setHighConcurrencyModeEnabled(systemSettings.enableHighConcurrencyMode ?? false);
+      const persistSessionRequestArtifacts =
+        session.shouldPersistSessionDebugArtifacts() &&
+        session.shouldPersistSessionRequestArtifacts();
       let requestMessageBeforeProxyMutations = session.request.message as Record<string, unknown>;
-      if (session.request.message && typeof session.request.message === "object") {
+      if (
+        persistSessionRequestArtifacts &&
+        session.request.message &&
+        typeof session.request.message === "object"
+      ) {
         try {
           requestMessageBeforeProxyMutations = structuredClone(
             session.request.message as Record<string, unknown>
@@ -99,7 +106,7 @@ export class ProxySessionGuard {
           requestMessageBeforeProxyMutations = session.request.message as Record<string, unknown>;
         }
       }
-      const originalMessages = session.getMessages();
+      const originalMessages = persistSessionRequestArtifacts ? session.getMessages() : undefined;
 
       // Codex Session ID 补全：在提取 clientSessionId 之前触发，避免落入不稳定的降级方案
       const codexCompletionEnabled = systemSettings.enableCodexSessionIdCompletion ?? true;
@@ -232,23 +239,29 @@ export class ProxySessionGuard {
       // 注意：必须在后续任何格式转换/过滤前触发存储，避免记录被“后处理”污染
       if (session.sessionId && session.shouldPersistSessionDebugArtifacts()) {
         const requestBeforeSnapshot = {
-          body: requestMessageBeforeProxyMutations,
           headers: filterClientRequestSnapshotHeaders(session.headers),
           meta: {
             clientUrl: session.requestUrl.toString(),
             upstreamUrl: null,
             method: session.method,
           },
-          ...(originalMessages !== undefined ? { messages: originalMessages } : {}),
+          ...(persistSessionRequestArtifacts
+            ? {
+                body: requestMessageBeforeProxyMutations,
+                ...(originalMessages !== undefined ? { messages: originalMessages } : {}),
+              }
+            : {}),
         };
 
-        void SessionManager.storeSessionRequestBody(
-          session.sessionId,
-          session.request.message,
-          requestSequence
-        ).catch((err) => {
-          logger.error("[ProxySessionGuard] Failed to store session request body:", err);
-        });
+        if (persistSessionRequestArtifacts) {
+          void SessionManager.storeSessionRequestBody(
+            session.sessionId,
+            session.request.message,
+            requestSequence
+          ).catch((err) => {
+            logger.error("[ProxySessionGuard] Failed to store session request body:", err);
+          });
+        }
 
         void SessionManager.storeSessionClientRequestMeta(
           session.sessionId,
@@ -270,7 +283,7 @@ export class ProxySessionGuard {
         });
 
         // 可选：存储 messages（受环境变量控制，按请求序号独立存储）
-        if (messages !== undefined) {
+        if (persistSessionRequestArtifacts && messages !== undefined) {
           void SessionManager.storeSessionMessages(
             session.sessionId,
             messages,

--- a/src/app/v1/_lib/proxy/session.ts
+++ b/src/app/v1/_lib/proxy/session.ts
@@ -9,6 +9,10 @@ import {
   writeLiveRoutingTrace,
 } from "@/lib/redis/live-chain-store";
 import type { SessionBindingSnapshot } from "@/lib/redis/session-binding";
+import {
+  getSessionRequestArtifactByteSize,
+  getSessionRequestArtifactMaxBytes,
+} from "@/lib/session-request-artifact-limit";
 import { clientRequestsContext1m as clientRequestsContext1mHelper } from "@/lib/special-attributes";
 import { ERROR_CODES, getErrorMessageServer } from "@/lib/utils/error-messages";
 import {
@@ -579,6 +583,22 @@ export class ProxySession {
 
   shouldPersistSessionDebugArtifacts(): boolean {
     return !this.highConcurrencyModeEnabled;
+  }
+
+  shouldPersistSessionRequestArtifacts(): boolean {
+    const byteSize = getSessionRequestArtifactByteSize(
+      this.request.message,
+      this.isOpenAIImageMultipartRequest() ? undefined : this.request.buffer?.byteLength
+    );
+    const maxBytes = getSessionRequestArtifactMaxBytes();
+    if (byteSize <= maxBytes) return true;
+
+    logger.warn("[ProxySession] Skipped oversized session request artifacts", {
+      byteSize,
+      maxBytes,
+      endpoint: this.getEndpoint(),
+    });
+    return false;
   }
 
   shouldTrackSessionObservability(): boolean {

--- a/src/lib/config/env.schema.ts
+++ b/src/lib/config/env.schema.ts
@@ -150,6 +150,13 @@ export const EnvSchema = z.object({
   // - false (默认)：存储请求/响应体但对 message 内容脱敏 [REDACTED]
   // - true：原样存储 message 内容（注意隐私和存储空间影响）
   STORE_SESSION_MESSAGES: z.string().default("false").transform(booleanTransform),
+  // 单份请求调试 artifact（requestBody/messages/before/after body）的 Redis 存储上限。
+  SESSION_REQUEST_ARTIFACT_MAX_BYTES: z.coerce
+    .number()
+    .int()
+    .min(64 * 1024)
+    .max(64 * 1024 * 1024)
+    .default(5 * 1024 * 1024),
   // 会话响应体存储开关
   // - true (默认)：存储响应体（SSE/JSON），用于调试/回放/问题定位（Redis 临时缓存，默认 5 分钟）
   // - false：不存储响应体（注意：不影响本次请求处理；仅影响后续在 UI/诊断中查看 response body）

--- a/src/lib/session-manager-detail-snapshots.test.ts
+++ b/src/lib/session-manager-detail-snapshots.test.ts
@@ -64,12 +64,14 @@ vi.mock("@/lib/redis", () => ({
 
 let mockStoreMessages = false;
 let mockStoreSessionResponseBody = true;
+let mockSessionRequestArtifactMaxBytes = 1024 * 1024;
 let mockSessionResponseBodyMaxBytes = 1024 * 1024;
 
 vi.mock("@/lib/config/env.schema", () => ({
   getEnvConfig: () => ({
     STORE_SESSION_MESSAGES: mockStoreMessages,
     STORE_SESSION_RESPONSE_BODY: mockStoreSessionResponseBody,
+    SESSION_REQUEST_ARTIFACT_MAX_BYTES: mockSessionRequestArtifactMaxBytes,
     SESSION_RESPONSE_BODY_MAX_BYTES: mockSessionResponseBodyMaxBytes,
     SESSION_TTL: 300,
   }),
@@ -84,6 +86,7 @@ describe("SessionManager detail snapshots", () => {
     redisMock.status = "ready";
     mockStoreMessages = false;
     mockStoreSessionResponseBody = true;
+    mockSessionRequestArtifactMaxBytes = 1024 * 1024;
     mockSessionResponseBodyMaxBytes = 1024 * 1024;
   });
 
@@ -427,6 +430,44 @@ describe("SessionManager detail snapshots", () => {
       "SessionManager: Skipped oversized session response body",
       { context: "snapshot:after", byteSize: 5, maxBytes: 4 }
     );
+  });
+
+  it("skips oversized request artifacts while preserving snapshot headers and meta", async () => {
+    mockStoreMessages = true;
+    mockSessionRequestArtifactMaxBytes = 4;
+
+    await SessionManager.storeSessionRequestBody("sess_oversized_request", "12345", 1);
+    await SessionManager.storeSessionMessages("sess_oversized_request", ["12345"], 1);
+    await SessionManager.storeSessionRequestPhaseSnapshot(
+      "sess_oversized_request",
+      "before",
+      {
+        body: "12345",
+        messages: ["12345"],
+        headers: new Headers({ "content-type": "application/json" }),
+        meta: {
+          clientUrl: "https://client.example/v1/messages",
+          upstreamUrl: null,
+          method: "POST",
+        },
+      },
+      1
+    );
+
+    expect(await SessionManager.getSessionRequestBody("sess_oversized_request", 1)).toBeNull();
+    expect(await SessionManager.getSessionMessages("sess_oversized_request", 1)).toBeNull();
+    expect(
+      await SessionManager.getSessionRequestPhaseSnapshot("sess_oversized_request", "before", 1)
+    ).toEqual({
+      body: null,
+      messages: null,
+      headers: { "content-type": "application/json" },
+      meta: {
+        clientUrl: "https://client.example/v1/messages",
+        upstreamUrl: null,
+        method: "POST",
+      },
+    });
   });
 
   it("removes a previous snapshot body when its replacement exceeds the limit", async () => {

--- a/src/lib/session-manager.ts
+++ b/src/lib/session-manager.ts
@@ -9,6 +9,10 @@ import { parseClaudeMetadataUserId } from "@/lib/claude-code/metadata-user-id";
 import { getEnvConfig } from "@/lib/config/env.schema";
 import { logger } from "@/lib/logger";
 import {
+  getSessionRequestArtifactByteSize,
+  getSessionRequestArtifactMaxBytes,
+} from "@/lib/session-request-artifact-limit";
+import {
   redactMessages,
   redactRequestBody,
   redactResponseBody,
@@ -234,6 +238,19 @@ function canStoreSessionResponseBody(value: string, context: string): boolean {
   if (byteSize <= maxBytes) return true;
 
   logger.warn("SessionManager: Skipped oversized session response body", {
+    context,
+    byteSize,
+    maxBytes,
+  });
+  return false;
+}
+
+function canStoreSessionRequestArtifact(value: unknown, context: string): boolean {
+  const byteSize = getSessionRequestArtifactByteSize(value);
+  const maxBytes = getSessionRequestArtifactMaxBytes();
+  if (byteSize <= maxBytes) return true;
+
+  logger.warn("SessionManager: Skipped oversized session request artifact", {
     context,
     byteSize,
     maxBytes,
@@ -1935,6 +1952,10 @@ export class SessionManager {
       const key = requestSequence
         ? `session:${sessionId}:req:${requestSequence}:messages`
         : `session:${sessionId}:messages`;
+      if (!canStoreSessionRequestArtifact(messagesJson, "messages")) {
+        await redis.del(key);
+        return;
+      }
       await redis.setex(key, SessionManager.SESSION_TTL, messagesJson);
       logger.trace("SessionManager: Stored session messages", {
         sessionId,
@@ -2550,6 +2571,10 @@ export class SessionManager {
         ? requestBody
         : redactRequestBody(requestBody);
       const payload = JSON.stringify(bodyToStore);
+      if (!canStoreSessionRequestArtifact(payload, "requestBody")) {
+        await redis.del(key);
+        return;
+      }
       await redis.setex(key, SessionManager.SESSION_TTL, payload);
       logger.trace("SessionManager: Stored session request body", {
         sessionId,
@@ -2950,31 +2975,53 @@ export class SessionManager {
       const writes: Array<Promise<unknown>> = [];
 
       if ("body" in snapshot) {
-        const normalizedBody = parseJsonStringIfPossible(snapshot.body ?? null);
-        const bodyToStore = SessionManager.STORE_MESSAGES
-          ? normalizedBody
-          : redactRequestBody(normalizedBody);
-        writes.push(
-          redis.setex(
-            buildSessionDetailSnapshotKey(sessionId, sequence, "request", phase, "body"),
-            SessionManager.SESSION_TTL,
-            JSON.stringify(bodyToStore)
-          )
+        const rawBody = snapshot.body ?? null;
+        const bodyKey = buildSessionDetailSnapshotKey(
+          sessionId,
+          sequence,
+          "request",
+          phase,
+          "body"
         );
+        if (canStoreSessionRequestArtifact(rawBody, `snapshot:${phase}:body`)) {
+          const normalizedBody = parseJsonStringIfPossible(rawBody);
+          const bodyToStore = SessionManager.STORE_MESSAGES
+            ? normalizedBody
+            : redactRequestBody(normalizedBody);
+          const bodyJson = JSON.stringify(bodyToStore);
+          if (canStoreSessionRequestArtifact(bodyJson, `snapshot:${phase}:body`)) {
+            writes.push(redis.setex(bodyKey, SessionManager.SESSION_TTL, bodyJson));
+          } else {
+            writes.push(redis.del(bodyKey));
+          }
+        } else {
+          writes.push(redis.del(bodyKey));
+        }
       }
 
       if ("messages" in snapshot) {
-        const normalizedMessages = parseJsonStringIfPossible(snapshot.messages ?? null);
-        const messagesToStore = SessionManager.STORE_MESSAGES
-          ? normalizedMessages
-          : redactMessages(normalizedMessages);
-        writes.push(
-          redis.setex(
-            buildSessionDetailSnapshotKey(sessionId, sequence, "request", phase, "messages"),
-            SessionManager.SESSION_TTL,
-            JSON.stringify(messagesToStore)
-          )
+        const rawMessages = snapshot.messages ?? null;
+        const messagesKey = buildSessionDetailSnapshotKey(
+          sessionId,
+          sequence,
+          "request",
+          phase,
+          "messages"
         );
+        if (canStoreSessionRequestArtifact(rawMessages, `snapshot:${phase}:messages`)) {
+          const normalizedMessages = parseJsonStringIfPossible(rawMessages);
+          const messagesToStore = SessionManager.STORE_MESSAGES
+            ? normalizedMessages
+            : redactMessages(normalizedMessages);
+          const messagesJson = JSON.stringify(messagesToStore);
+          if (canStoreSessionRequestArtifact(messagesJson, `snapshot:${phase}:messages`)) {
+            writes.push(redis.setex(messagesKey, SessionManager.SESSION_TTL, messagesJson));
+          } else {
+            writes.push(redis.del(messagesKey));
+          }
+        } else {
+          writes.push(redis.del(messagesKey));
+        }
       }
 
       if ("headers" in snapshot) {

--- a/src/lib/session-request-artifact-limit.ts
+++ b/src/lib/session-request-artifact-limit.ts
@@ -1,0 +1,20 @@
+import { Buffer } from "node:buffer";
+import { getEnvConfig } from "@/lib/config/env.schema";
+
+const DEFAULT_SESSION_REQUEST_ARTIFACT_MAX_BYTES = 5 * 1024 * 1024;
+
+export function getSessionRequestArtifactMaxBytes(): number {
+  const configuredMaxBytes = getEnvConfig().SESSION_REQUEST_ARTIFACT_MAX_BYTES;
+  return Number.isSafeInteger(configuredMaxBytes) && configuredMaxBytes > 0
+    ? configuredMaxBytes
+    : DEFAULT_SESSION_REQUEST_ARTIFACT_MAX_BYTES;
+}
+
+export function getSessionRequestArtifactByteSize(value: unknown, byteSizeHint?: number): number {
+  if (Number.isSafeInteger(byteSizeHint) && byteSizeHint !== undefined && byteSizeHint >= 0) {
+    return byteSizeHint;
+  }
+
+  const serialized = typeof value === "string" ? value : JSON.stringify(value);
+  return serialized === undefined ? 0 : Buffer.byteLength(serialized, "utf8");
+}

--- a/tests/unit/actions/active-sessions-detail-snapshots.test.ts
+++ b/tests/unit/actions/active-sessions-detail-snapshots.test.ts
@@ -400,6 +400,16 @@ describe("getSessionDetails - additive detail snapshots contract", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
+    expect(getSessionRequestBodyMock).not.toHaveBeenCalled();
+    expect(getSessionMessagesMock).not.toHaveBeenCalled();
+    expect(getSessionResponseMock).not.toHaveBeenCalled();
+    expect(result.data.requestBody).toEqual({
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: "after body messages" }],
+    });
+    expect(result.data.messages).toEqual([{ role: "user", content: "before messages" }]);
+    expect(result.data.response).toBe('{"after":true}');
+
     expect(result.data.snapshots).toEqual({
       defaultView: DEFAULT_SESSION_DETAIL_VIEW_MODE,
       request: {

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -1731,7 +1731,7 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
     }
   });
 
-  test("when multiple providers all exceed threshold, hedge scheduler keeps expanding until a later provider wins", async () => {
+  test("legacy hedge caps in-flight attempts and launches a replacement after one fails", async () => {
     vi.useFakeTimers();
 
     try {
@@ -1772,10 +1772,8 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
         const runtime = attemptSession as ProxySession & AttemptRuntime;
         runtime.responseController = controller1;
         runtime.clearResponseTimeout = vi.fn();
-        return createStreamingResponse({
-          label: "p1",
-          firstChunkDelayMs: 400,
-          controller: controller1,
+        return await new Promise<Response>((_resolve, reject) => {
+          setTimeout(() => reject(new Error("p1 failed after hedge launch")), 250);
         });
       });
 
@@ -1804,15 +1802,17 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
       const responsePromise = ProxyForwarder.send(session);
 
       await vi.advanceTimersByTimeAsync(200);
-      expect(doForward).toHaveBeenCalledTimes(3);
+      expect(doForward).toHaveBeenCalledTimes(2);
+      expect(mocks.pickRandomProviderWithExclusion).toHaveBeenCalledTimes(1);
 
-      await vi.advanceTimersByTimeAsync(25);
+      await vi.advanceTimersByTimeAsync(75);
+      expect(doForward).toHaveBeenCalledTimes(3);
       const response = await responsePromise;
       expect(await response.text()).toContain('"provider":"p3"');
-      expect(controller1.signal.aborted).toBe(true);
+      expect(controller1.signal.aborted).toBe(false);
       expect(controller2.signal.aborted).toBe(true);
       expect(controller3.signal.aborted).toBe(false);
-      expect(mocks.recordFailure).not.toHaveBeenCalled();
+      expect(mocks.recordFailure).toHaveBeenCalledWith(1, expect.any(Error));
       expect(mocks.recordSuccess).not.toHaveBeenCalled();
       expect(session.provider?.id).toBe(3);
       expect(mocks.releaseProviderSession).toHaveBeenCalledWith(1, "sess-hedge");

--- a/tests/unit/proxy/session-guard-warmup-intercept.test.ts
+++ b/tests/unit/proxy/session-guard-warmup-intercept.test.ts
@@ -94,6 +94,9 @@ function createMockSession(overrides: Partial<ProxySession> = {}): ProxySession 
     shouldPersistSessionDebugArtifacts() {
       return !this.highConcurrencyModeEnabled;
     },
+    shouldPersistSessionRequestArtifacts() {
+      return true;
+    },
     shouldTrackSessionObservability() {
       return !this.highConcurrencyModeEnabled;
     },
@@ -286,6 +289,41 @@ describe("ProxySessionGuard：warmup 拦截不应计入并发会话", () => {
         headers: { "content-type": "application/json" },
         messages: [{ role: "user", content: "hello" }],
       }),
+      1
+    );
+  });
+
+  test("超限请求跳过 request body/messages，但仍保留轻量 before 快照", async () => {
+    const ProxySessionGuard = await loadGuard();
+    const structuredCloneSpy = vi.spyOn(globalThis, "structuredClone");
+    const getMessages = vi.fn(() => [{ role: "user", content: "oversized" }]);
+    const session = createMockSession({
+      headers: new Headers({ "content-type": "application/json" }),
+      request: {
+        message: { model: "claude-sonnet-4-5-20250929", messages: ["oversized"] },
+        model: "claude-sonnet-4-5-20250929",
+      } as ProxySession["request"],
+      getMessages,
+      shouldPersistSessionRequestArtifacts: () => false,
+      isWarmupRequest: () => false,
+    });
+
+    await ProxySessionGuard.ensure(session);
+
+    expect(structuredCloneSpy).not.toHaveBeenCalled();
+    expect(storeSessionRequestBodyMock).not.toHaveBeenCalled();
+    expect(storeSessionMessagesMock).not.toHaveBeenCalled();
+    expect(storeSessionRequestPhaseSnapshotMock).toHaveBeenCalledWith(
+      "session_assigned",
+      "before",
+      {
+        headers: { "content-type": "application/json" },
+        meta: {
+          clientUrl: "http://localhost/v1/messages",
+          upstreamUrl: null,
+          method: "POST",
+        },
+      },
       1
     );
   });


### PR DESCRIPTION
## Summary

- cap legacy streaming hedge concurrency at two in-flight attempts while retaining failure replacement
- skip request debug artifacts above 5 MiB before structured cloning, while preserving headers and metadata
- prefer phase snapshots in Session details and only fetch legacy large payloads when required for compatibility

## Problem

A roughly 19.36 MB request could fan out across 10-24 legacy hedge attempts. Every attempt cloned, serialized, and transported the full request body, while session debugging persisted several redundant Redis artifacts. Anonymous RSS then reached the 10 GiB pod cgroup limit and the kernel killed Node.

**Related Issues:**
- Related to #1430 - same kernel-level OOM symptom (anonymous RSS growth to the cgroup limit, container restart loops). #1453 already addressed stream lifecycle leaks and bounded detached streams; this PR closes a distinct amplification path it did not cover: large request bodies multiplied across hedge attempts plus redundant per-request Redis debug artifacts.
- Related to #1444 - user-reported memory explosion causing repeated container restarts after upgrade; closed as a duplicate of #1430.

**Fix-chain context:** continues the v0.9.4+ OOM hardening series #1439 / #1440 / #1441 / #1453.

## Solution

Three complementary bounds, each targeting a different amplifier:

1. **Hedge concurrency cap** (`forwarder.ts`): legacy streaming hedge now launches at most 2 concurrent attempts (`LEGACY_STREAMING_HEDGE_MAX_CONCURRENCY`). When an in-flight attempt fails, a replacement is still launched, so failover semantics are preserved - only the fan-out width is bounded, capping the per-request memory multiplier on large bodies.
2. **Request artifact size cap** (new `src/lib/session-request-artifact-limit.ts`): `SESSION_REQUEST_ARTIFACT_MAX_BYTES` (default 5 MiB, range 64 KiB-64 MiB) bounds each request debug artifact (requestBody / messages / before-after snapshot bodies). Oversized artifacts are rejected before `structuredClone` in the session guard (avoiding the clone/serialize spike entirely) and deleted rather than written in `SessionManager` (including stale keys from a previous smaller payload). Headers and meta are always preserved so session debugging still works.
3. **Snapshot-first session details** (`active-sessions.ts`): `getSessionDetails` now derives requestBody/messages/response from the phase snapshots it already loads, and only falls back to the legacy large-payload Redis keys when snapshot content is missing (compatibility with historical data).

## Changes

### Core Changes
- `src/app/v1/_lib/proxy/forwarder.ts`: cap legacy streaming hedge at 2 in-flight attempts, keep failure replacement
- `src/lib/session-request-artifact-limit.ts` (new): shared max-bytes helper plus byte-size computation with a buffer-length hint to avoid re-serializing the body just to measure it
- `src/lib/session-manager.ts`: `canStoreSessionRequestArtifact` guard in `storeSessionRequestBody` / `storeSessionMessages` / request phase-snapshot writes; oversized values skip the write and delete any stale key
- `src/app/v1/_lib/proxy/session-guard.ts` + `session.ts`: new `shouldPersistSessionRequestArtifacts()` gate - oversized requests skip `structuredClone`, `getMessages()`, and body/messages stores, while the lightweight before-snapshot (headers/meta) is still persisted
- `src/actions/active-sessions.ts`: snapshot-first reads with legacy fallback only when snapshot body/messages are absent

### Supporting Changes
- `src/lib/config/env.schema.ts` + `.env.example`: new `SESSION_REQUEST_ARTIFACT_MAX_BYTES` (default 5 MiB, range 64 KiB-64 MiB) with documentation
- Tests: oversized-artifact skip with headers/meta preservation and stale-key cleanup (session-manager); legacy large-payload getters not called when snapshots exist (active-sessions); guard skips clone/store but keeps the lightweight snapshot; hedge test rewritten to assert the cap plus replacement-after-failure

## Behavioral Notes

No migrations or API changes. Two intentional behavior changes reviewers should be aware of:

- Request debug payloads above 5 MiB are no longer stored in Redis or shown in Session details (headers and metadata remain). Tunable via `SESSION_REQUEST_ARTIFACT_MAX_BYTES`.
- Legacy streaming hedge runs at most 2 attempts concurrently instead of expanding across all eligible providers; failed attempts are still replaced.

## Testing

### Automated Tests
- [x] Unit tests added/updated across 4 test files covering each bound
- [x] Focused OOM regression tests: 110 passed
- [x] `bun run typecheck`, `bun run lint`, `bun run build`
- [x] Full Vitest: 8,692 passed, 13 skipped; two host-only failures were isolated and passed with `LC_ALL=C` and a 70-second timeout respectively

### Manual Testing
1. Send a request larger than 5 MiB (e.g., large attachment payload) - verify pod RSS stays bounded, the warn log `Skipped oversized session request artifacts` fires, and Session details still show headers/meta with bodies omitted.
2. Trigger legacy streaming hedge with slow/failing providers - verify at most 2 in-flight attempts and that a replacement launches after a failure.

## Checklist
- [x] Code follows project conventions
- [x] Tests pass locally
- [x] Documentation updated (`.env.example`)

---
*Description enhanced by Claude AI*


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR limits the memory amplification caused by large session requests while retaining routing recovery and lightweight diagnostics.

- Caps legacy streaming hedges at two concurrent upstream attempts and launches replacements after failures.
- Skips oversized request bodies and messages before cloning or Redis persistence while preserving headers and metadata.
- Uses phase snapshots preferentially for session details and reads legacy payloads only when the corresponding snapshot field is unavailable.
- Adds configuration documentation and focused regression coverage for artifact limits, snapshot compatibility, and hedge replacement behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete correctness or security failures identified in the changed paths.

The new limits are applied before the principal cloning path and again at Redis write boundaries, hedge failures continue launching replacement providers, and session-detail fallback remains field-specific when snapshots are absent.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/forwarder.ts | Adds a two-attempt concurrency ceiling to legacy streaming hedges while retaining replacement launches after attempt failures. |
| src/app/v1/_lib/proxy/session.ts | Introduces the request-level persistence gate that avoids expensive diagnostics for oversized inbound bodies. |
| src/app/v1/_lib/proxy/session-guard.ts | Applies the persistence decision before structured cloning and preserves lightweight snapshot headers and metadata when body artifacts are skipped. |
| src/lib/session-manager.ts | Enforces request artifact limits at Redis write boundaries and deletes previously stored oversized values to avoid stale diagnostics. |
| src/lib/session-request-artifact-limit.ts | Centralizes configured request artifact limits and UTF-8 serialized-size measurement. |
| src/actions/active-sessions.ts | Prefers modern phase snapshot fields and conditionally fetches legacy large artifacts only for missing values. |
| src/lib/config/env.schema.ts | Adds validated configuration for the request artifact storage ceiling. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Incoming proxy request] --> B{Request artifact size within limit?}
  B -- Yes --> C[Clone and persist request body/messages]
  B -- No --> D[Persist headers and metadata only]
  C --> E[Forward upstream]
  D --> E
  E --> F[Run at most two legacy hedge attempts]
  F --> G{Attempt succeeds?}
  G -- Yes --> H[Commit winning response]
  G -- No --> I{Another provider available?}
  I -- Yes --> F
  I -- No --> J[Return terminal failure]
  H --> K[Read phase snapshots for session details]
  J --> K
  K --> L{Snapshot field available?}
  L -- Yes --> M[Return snapshot value]
  L -- No --> N[Fetch corresponding legacy artifact]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(forwarder): cap legacy streaming hed..."](https://github.com/ding113/claude-code-hub/commit/ad00c398ed44aa0e9db148610fd5a3e4c7477763) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57435453)</sub>

**Context used:**

- Knowledge Base — [Provider routing and failover](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/provider-routing-and-failover.md)
- Knowledge Base — [Request sessions and streaming](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/request-sessions-and-streaming.md)

<!-- /greptile_comment -->