### PR TITLE
fix(proxy): preserve Codex Responses streams without SSE header

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -117,7 +117,10 @@ import {
 import { ProxyProviderResolver } from "./provider-selector";
 import { abortReplayOwnership, releaseReplayOwnership } from "./replay/replay-spool";
 import { isJsonResponseContentType, isMalformedJsonResponseBody } from "./response-content-type";
-import { finalizeHedgeLoserBilling } from "./response-handler";
+import {
+  finalizeHedgeLoserBilling,
+  shouldForceCodexResponsesStreamHandling,
+} from "./response-handler";
 import type { ProxySession } from "./session";
 import {
   type DeferredStreamingHedgeBindingAuthority,
@@ -1932,7 +1935,12 @@ export class ProxyForwarder {
           // ========== 空响应检测（仅非流式）==========
           const contentType = response.headers.get("content-type") || "";
           const normalizedContentType = contentType.toLowerCase();
-          const isSSE = normalizedContentType.includes("text/event-stream");
+          const forceCodexResponsesStream = shouldForceCodexResponsesStreamHandling(
+            session,
+            response
+          );
+          const isSSE =
+            normalizedContentType.includes("text/event-stream") || forceCodexResponsesStream;
           const isHtml =
             normalizedContentType.includes("text/html") ||
             normalizedContentType.includes("application/xhtml+xml");
@@ -1957,12 +1965,17 @@ export class ProxyForwarder {
             let streamingResponse = response;
             let gateChainAudit: ProviderChainItem["streamGate"];
             const gateMode = resolveStreamGateMode();
+            // Missing or misleading MIME is not enough to distinguish SSE from a headerless
+            // JSON fake-200. Always use the bounded precommit gate for this compatibility path,
+            // even when ordinary stream gating is off or shadow-only.
             const shouldRunPrecommitGate =
-              gateMode === "enforce" || session.replayState?.role === "owner";
+              gateMode === "enforce" ||
+              session.replayState?.role === "owner" ||
+              forceCodexResponsesStream;
             if (
               shouldRunPrecommitGate &&
               response.body &&
-              session.getEndpointPolicy().kind !== "raw_passthrough"
+              (session.getEndpointPolicy().kind !== "raw_passthrough" || forceCodexResponsesStream)
             ) {
               const gateFamily = mapProviderTypeToFamily(currentProvider.providerType);
               if (gateFamily) {
@@ -5083,9 +5096,18 @@ export class ProxyForwarder {
             // F1 门控（enforce 或 Replay owner）：胜者判定从「首个非空字节」升级为
             // 「首个有效内容帧」。
             // 级联阈值计时器保持不动——内容慢的 attempt 不提交，自动触发下一候选竞速。
+            const forceCodexResponsesStream = shouldForceCodexResponsesStreamHandling(
+              attempt.session,
+              response
+            );
+            const shouldRunHedgePrecommitGate =
+              resolveStreamGateMode() === "enforce" ||
+              attempt.session.replayState?.role === "owner" ||
+              forceCodexResponsesStream;
             const hedgeGateFamily =
-              (resolveStreamGateMode() === "enforce" || session.replayState?.role === "owner") &&
-              session.getEndpointPolicy().kind !== "raw_passthrough"
+              shouldRunHedgePrecommitGate &&
+              (attempt.session.getEndpointPolicy().kind !== "raw_passthrough" ||
+                forceCodexResponsesStream)
                 ? mapProviderTypeToFamily(attempt.provider.providerType)
                 : null;
 

--- a/src/app/v1/_lib/proxy/response-handler.ts
+++ b/src/app/v1/_lib/proxy/response-handler.ts
@@ -78,7 +78,7 @@ import {
   createReplaySpoolIfOwner,
   releaseReplayOwnership,
 } from "./replay/replay-spool";
-import { isMalformedJsonResponseBody } from "./response-content-type";
+import { isJsonResponseContentType, isMalformedJsonResponseBody } from "./response-content-type";
 import type { ProxySession } from "./session";
 import {
   consumeDeferredStreamingFinalization,
@@ -104,6 +104,33 @@ const STREAM_STATS_TAIL_BYTES = STREAM_STATS_MAX_BUFFER_BYTES - STREAM_STATS_HEA
 const STREAM_STATS_SLAB_BYTES = 64 * 1024;
 const STREAM_STATS_TRUNCATED_MARKER = "\n\n: [cch_truncated]\n\n";
 const RESPONSE_TEXT_ENCODER = new TextEncoder();
+
+function isCodexResponsesStreamRequest(session: ProxySession): boolean {
+  return (
+    session.provider?.providerType === "codex" &&
+    (session.originalFormat === "response" || session.getEndpoint() === "/v1/responses") &&
+    session.request.message.stream === true
+  );
+}
+
+export function shouldForceCodexResponsesStreamHandling(
+  session: ProxySession,
+  response: Response
+): boolean {
+  const contentType = response.headers.get("content-type");
+  const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+
+  return (
+    isCodexResponsesStreamRequest(session) &&
+    !!response.body &&
+    response.status >= 200 &&
+    response.status < 300 &&
+    mediaType !== "text/event-stream" &&
+    mediaType !== "text/html" &&
+    mediaType !== "application/xhtml+xml" &&
+    !isJsonResponseContentType(contentType)
+  );
+}
 
 function protocolObservationFromMetering(
   snapshot: ClientAbortMeteringSnapshot
@@ -2675,13 +2702,16 @@ export class ProxyResponseHandler {
     const snapshotSession = session as ProxySession & {
       detailSnapshotResponseBeforeSource?: Response | null;
     };
-    const isStreamingResponse = response.headers.get("content-type")?.includes("text/event-stream");
+    const forceCodexResponsesStream = shouldForceCodexResponsesStreamHandling(session, response);
+    const isStreamingResponse =
+      forceCodexResponsesStream ||
+      response.headers.get("content-type")?.includes("text/event-stream");
     if (!isStreamingResponse && session.sessionId && session.shouldPersistSessionDebugArtifacts()) {
       snapshotSession.detailSnapshotResponseBeforeSource = response.clone();
     }
 
     let fixedResponse = response;
-    if (!session.getEndpointPolicy().bypassResponseRectifier) {
+    if (!forceCodexResponsesStream && !session.getEndpointPolicy().bypassResponseRectifier) {
       try {
         // raw passthrough 端点跳过 ResponseFixer，也跳过其中的 Responses 输出归一化。
         fixedResponse = await ResponseFixer.process(session, response);
@@ -2702,8 +2732,22 @@ export class ProxyResponseHandler {
     const contentType = fixedResponse.headers.get("content-type") || "";
     const isSSE = contentType.includes("text/event-stream");
 
-    if (!isSSE) {
+    if (!isSSE && !forceCodexResponsesStream) {
       return await ProxyResponseHandler.handleNonStream(session, fixedResponse);
+    }
+
+    if (forceCodexResponsesStream && !isSSE) {
+      logger.debug(
+        "[ResponseHandler] Forcing Codex Responses stream handling without SSE content-type",
+        {
+          sessionId: session.sessionId ?? null,
+          requestSequence: session.requestSequence ?? null,
+          messageId: session.messageContext?.id ?? null,
+          providerId: session.provider?.id ?? null,
+          httpStatusCode: fixedResponse.status,
+          contentType: contentType || null,
+        }
+      );
     }
 
     return await ProxyResponseHandler.handleStream(session, fixedResponse);
@@ -5719,6 +5763,9 @@ export class ProxyResponseHandler {
     // ⭐ 修复 Bun 运行时的 Transfer-Encoding 重复问题
     // 清理上游的传输 headers，让 Response API 自动管理
     const finalStreamHeaders = cleanResponseHeaders(response.headers);
+    if (shouldForceCodexResponsesStreamHandling(session, response)) {
+      finalStreamHeaders.set("content-type", "text/event-stream; charset=utf-8");
+    }
     if (session.sessionId && session.shouldPersistSessionDebugArtifacts()) {
       const responseAfterMetaTask = SessionManager.storeSessionResponsePhaseSnapshot?.(
         session.sessionId,

--- a/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
+++ b/tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts
@@ -8,11 +8,12 @@ const testState = vi.hoisted(() => ({
   asyncTasks: [] as Promise<void>[],
   cancelTask: vi.fn(),
   cleanupTask: vi.fn(),
+  responseFixerProcess: vi.fn(async (_session: unknown, response: Response) => response),
 }));
 
 vi.mock("@/app/v1/_lib/proxy/response-fixer", () => ({
   ResponseFixer: {
-    process: async (_session: unknown, response: Response) => response,
+    process: testState.responseFixerProcess,
   },
 }));
 
@@ -223,11 +224,61 @@ function makeSession(clientAbortSignal: AbortSignal | null, stream: boolean): Pr
   return session as unknown as ProxySession;
 }
 
+function makeCodexResponsesSession(stream = true): ProxySession {
+  const session = makeSession(null, stream) as ProxySession & {
+    endpointPolicy: ReturnType<typeof resolveEndpointPolicy>;
+  };
+  const endpointPolicy = resolveEndpointPolicy("/v1/responses");
+  session.provider = makeProvider({ providerType: "codex" });
+  session.providerType = "codex";
+  session.originalFormat = "response";
+  session.originalUrlPathname = "/v1/responses";
+  session.requestUrl = new URL("http://localhost/v1/responses");
+  session.endpointPolicy = endpointPolicy;
+  session.getEndpointPolicy = () => endpointPolicy;
+  session.getEndpoint = () => "/v1/responses";
+  return session;
+}
+
+function makeRemoteCompactionV2Session(): ProxySession {
+  const session = makeCodexResponsesSession() as ProxySession & {
+    endpointPolicy: ReturnType<typeof resolveEndpointPolicy>;
+  };
+  const endpointPolicy = resolveEndpointPolicy("/v1/responses/compact");
+  session.endpointPolicy = endpointPolicy;
+  session.getEndpointPolicy = () => endpointPolicy;
+  session.request.message.input = [{ type: "compaction_trigger" }];
+  return session;
+}
+
+const CODEX_RESPONSES_SSE = [
+  'event: response.created\ndata: {"response":{"id":"resp_missing_header"}}\n\n',
+  [
+    'event: response.completed\ndata: {"response":{"id":"resp_missing_header",',
+    '"status":"completed","usage":{"input_tokens":1,"output_tokens":2}},',
+    '"sequence_number":3}\n\n',
+  ].join(""),
+].join("");
+
+const REMOTE_COMPACTION_V2_SSE = [
+  [
+    'event: response.output_item.done\ndata: {"type":"response.output_item.done",',
+    '"output_index":0,"item":{"type":"compaction",',
+    '"encrypted_content":"opaque-state"}}\n\n',
+  ].join(""),
+  [
+    'event: response.completed\ndata: {"type":"response.completed",',
+    '"response":{"id":"resp_compact","status":"completed",',
+    '"output":[{"type":"compaction","encrypted_content":"opaque-state"}]}}\n\n',
+  ].join(""),
+].join("");
+
 describe("ProxyResponseHandler client abort listener cleanup", () => {
   beforeEach(() => {
     testState.asyncTasks = [];
     testState.cancelTask.mockClear();
     testState.cleanupTask.mockClear();
+    testState.responseFixerProcess.mockClear();
     vi.restoreAllMocks();
   });
 
@@ -273,6 +324,102 @@ describe("ProxyResponseHandler client abort listener cleanup", () => {
     const abortAddCalls = addSpy.mock.calls.filter(([type]) => type === "abort");
     expect(abortAddCalls).toHaveLength(1);
     expect(removeSpy).toHaveBeenCalledWith("abort", abortAddCalls[0][1]);
+  });
+
+  it("preserves Codex Responses SSE without cloning a missing-header stream", async () => {
+    const session = makeCodexResponsesSession();
+    session.sessionId = "session-debug-artifacts";
+    session.shouldPersistSessionDebugArtifacts = () => true;
+    const upstreamResponse = new Response(new TextEncoder().encode(CODEX_RESPONSES_SSE));
+    const cloneSpy = vi.spyOn(upstreamResponse, "clone");
+    expect(upstreamResponse.headers.get("content-type")).toBeNull();
+
+    const response = await ProxyResponseHandler.dispatch(session, upstreamResponse);
+    const responseText = await response.text();
+    await drainAsyncTasks();
+
+    expect(testState.responseFixerProcess).not.toHaveBeenCalled();
+    expect(cloneSpy).not.toHaveBeenCalled();
+    expect(response.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
+    expect(responseText).toBe(CODEX_RESPONSES_SSE);
+  });
+
+  it("preserves headerless Remote Compaction v2 SSE under raw passthrough", async () => {
+    const session = makeRemoteCompactionV2Session();
+    session.sessionId = "session-debug-artifacts-compact";
+    session.shouldPersistSessionDebugArtifacts = () => true;
+    const upstreamResponse = new Response(new TextEncoder().encode(REMOTE_COMPACTION_V2_SSE));
+    const cloneSpy = vi.spyOn(upstreamResponse, "clone");
+    expect(session.getEndpointPolicy().kind).toBe("raw_passthrough");
+    expect(upstreamResponse.headers.get("content-type")).toBeNull();
+
+    const response = await ProxyResponseHandler.dispatch(session, upstreamResponse);
+    const responseText = await response.text();
+    await drainAsyncTasks();
+
+    expect(testState.responseFixerProcess).not.toHaveBeenCalled();
+    expect(cloneSpy).not.toHaveBeenCalled();
+    expect(response.headers.get("content-type")).toBe("text/event-stream; charset=utf-8");
+    expect(responseText).toBe(REMOTE_COMPACTION_V2_SSE);
+  });
+
+  it.each(["application/json", "application/problem+json"])(
+    "keeps explicit %s responses on non-stream handling",
+    async (contentType) => {
+      const session = makeCodexResponsesSession();
+      const upstreamText = JSON.stringify({ id: "resp_json", status: "completed", output: [] });
+      const upstreamResponse = new Response(upstreamText, {
+        headers: { "content-type": contentType },
+      });
+
+      const response = await ProxyResponseHandler.dispatch(session, upstreamResponse);
+      const responseText = await response.text();
+      await drainAsyncTasks();
+
+      expect(testState.responseFixerProcess).toHaveBeenCalledOnce();
+      expect(response.headers.get("content-type")).toBe(contentType);
+      expect(responseText).toBe(upstreamText);
+    }
+  );
+
+  it("does not force a non-Codex response without content-type into stream handling", async () => {
+    const session = makeSession(null, true);
+    const upstreamResponse = new Response(new TextEncoder().encode(JSON.stringify({ output: [] })));
+
+    const response = await ProxyResponseHandler.dispatch(session, upstreamResponse);
+    await response.text();
+    await drainAsyncTasks();
+
+    expect(testState.responseFixerProcess).toHaveBeenCalledOnce();
+    expect(response.headers.get("content-type")).toBeNull();
+  });
+
+  it("does not force a non-stream Codex request without content-type", async () => {
+    const session = makeCodexResponsesSession(false);
+    const upstreamResponse = new Response(new TextEncoder().encode(JSON.stringify({ output: [] })));
+
+    const response = await ProxyResponseHandler.dispatch(session, upstreamResponse);
+    await response.text();
+    await drainAsyncTasks();
+
+    expect(testState.responseFixerProcess).toHaveBeenCalledOnce();
+    expect(response.headers.get("content-type")).toBeNull();
+  });
+
+  it("does not force a non-success Codex response without content-type", async () => {
+    const session = makeCodexResponsesSession();
+    const upstreamResponse = new Response(
+      new TextEncoder().encode(JSON.stringify({ error: { message: "bad request" } })),
+      { status: 400 }
+    );
+
+    const response = await ProxyResponseHandler.dispatch(session, upstreamResponse);
+    await response.text();
+    await drainAsyncTasks();
+
+    expect(testState.responseFixerProcess).toHaveBeenCalledOnce();
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toBeNull();
   });
 
   it("uses no-op cleanup when client abort signal is null", async () => {

--- a/tests/unit/proxy/stream-gate-forwarder-integration.test.ts
+++ b/tests/unit/proxy/stream-gate-forwarder-integration.test.ts
@@ -3,11 +3,12 @@ import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
 import { ProxyError } from "@/app/v1/_lib/proxy/errors";
 
 /**
- * F1 流式内容门控（stream content gate）在 ProxyForwarder 顺序路径中的接线集成测试。
+ * F1 流式内容门控（stream content gate）在 ProxyForwarder 中的接线集成测试。
  *
- * 顺序路径进入条件：provider.firstByteTimeoutStreamingMs = 0（关闭 first-byte hedge），
+ * 默认顺序路径进入条件：provider.firstByteTimeoutStreamingMs = 0（关闭 first-byte hedge），
  * shouldUseStreamingHedge() 返回 false，ProxyForwarder.send() 走顺序重试循环，
  * 在 isSSE 分支对 response.body 执行真实的 runStreamContentGate（本文件不 mock 门控本体）。
+ * 专用回归用例会将该值设为正数，以覆盖 Legacy Hedge 的同一门控接线。
  *
  * STREAM_GATE_MODE 由 getEnvConfig() 读取（模块级缓存 _envConfig，首次调用即固化），
  * 因此这里 mock "@/lib/config/env.schema"，通过 vi.hoisted 的 envControl 注入模式值：
@@ -469,6 +470,17 @@ function createSession(clientAbortSignal: AbortSignal | null = null): ProxySessi
   return session as ProxySession;
 }
 
+function configureCodexResponsesRequest(session: ProxySession): void {
+  session.requestUrl = new URL("https://example.com/v1/responses");
+  session.originalFormat = "response";
+  session.endpointPolicy = resolveEndpointPolicy("/v1/responses");
+  session.request.message = {
+    model: "gpt-5.5",
+    stream: true,
+    input: "hi",
+  };
+}
+
 function attachReplayOwner(session: ProxySession, testCase: ReplayGateCase): void {
   Object.assign(session, {
     requestUrl: new URL(`https://example.com${testCase.endpoint}`),
@@ -533,7 +545,7 @@ function attachAttemptRuntime(
   runtime.releaseAgent = cleanup.releaseAgent;
 }
 
-describe("F1 stream content gate x ProxyForwarder sequential path", () => {
+describe("F1 stream content gate x ProxyForwarder paths", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.categorizeErrorAsync.mockResolvedValue(ProxyErrorCategory.PROVIDER_ERROR);
@@ -788,6 +800,267 @@ describe("F1 stream content gate x ProxyForwarder sequential path", () => {
     beforeEach(() => {
       envControl.streamGateMode = "off";
     });
+
+    test("缺少 Content-Type 的 Codex Responses 流在 EOF 前返回且不被克隆检查", async () => {
+      const provider = createProvider({ id: 1, name: "codex-headerless", providerType: "codex" });
+      const session = createSession();
+      configureCodexResponsesRequest(session);
+      session.setProvider(provider);
+
+      const encoder = new TextEncoder();
+      const firstFrames = [
+        sseFrame("response.created", {
+          type: "response.created",
+          response: { id: "resp_headerless", status: "in_progress" },
+        }),
+        sseFrame("response.output_text.delta", {
+          type: "response.output_text.delta",
+          delta: "hello",
+        }),
+      ].join("");
+      const completedFrame = sseFrame("response.completed", {
+        type: "response.completed",
+        response: { id: "resp_headerless", status: "completed" },
+      });
+      let upstreamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+      const upstreamResponse = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            upstreamController = controller;
+            controller.enqueue(encoder.encode(firstFrames));
+          },
+        })
+      );
+      const cloneSpy = vi.spyOn(upstreamResponse, "clone");
+      const doForward = spyOnDoForward();
+      doForward.mockResolvedValueOnce(upstreamResponse);
+
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const response = await Promise.race([
+        ProxyForwarder.send(session),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("ProxyForwarder.send waited for headerless stream EOF")),
+            1_000
+          );
+        }),
+      ]).finally(() => {
+        if (timeout) clearTimeout(timeout);
+        upstreamController?.enqueue(encoder.encode(completedFrame));
+        upstreamController?.close();
+      });
+
+      expect(upstreamResponse.headers.get("content-type")).toBeNull();
+      expect(cloneSpy).not.toHaveBeenCalled();
+      expect(await response.text()).toBe(firstFrames + completedFrame);
+      expect(mocks.recordSuccess).not.toHaveBeenCalled();
+    });
+
+    test("raw passthrough 的缺头 Remote Compaction v2 流在 EOF 前提交且完整透传", async () => {
+      const provider = createProvider({ id: 1, name: "codex-compact", providerType: "codex" });
+      const session = createSession();
+      configureCodexResponsesRequest(session);
+      session.request.message.input = [{ type: "compaction_trigger" }];
+      session.endpointPolicy = resolveEndpointPolicy("/v1/responses/compact");
+      session.setProvider(provider);
+
+      const encoder = new TextEncoder();
+      const compactionFrame = sseFrame("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          type: "compaction",
+          encrypted_content: "opaque-state",
+        },
+      });
+      const completedFrame = sseFrame("response.completed", {
+        type: "response.completed",
+        response: {
+          id: "resp_compact",
+          status: "completed",
+          output: [{ type: "compaction", encrypted_content: "opaque-state" }],
+        },
+      });
+      let upstreamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+      const upstreamResponse = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            upstreamController = controller;
+            controller.enqueue(encoder.encode(compactionFrame));
+          },
+        })
+      );
+      const cloneSpy = vi.spyOn(upstreamResponse, "clone");
+      const doForward = spyOnDoForward();
+      doForward.mockResolvedValueOnce(upstreamResponse);
+
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const response = await Promise.race([
+        ProxyForwarder.send(session),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("ProxyForwarder.send waited for raw compaction stream EOF")),
+            1_000
+          );
+        }),
+      ]).finally(() => {
+        if (timeout) clearTimeout(timeout);
+        upstreamController?.enqueue(encoder.encode(completedFrame));
+        upstreamController?.close();
+      });
+
+      expect(session.getEndpointPolicy().kind).toBe("raw_passthrough");
+      expect(upstreamResponse.headers.get("content-type")).toBeNull();
+      expect(cloneSpy).not.toHaveBeenCalled();
+      expect(await response.text()).toBe(compactionFrame + completedFrame);
+      expect(mocks.recordSuccess).not.toHaveBeenCalled();
+      expect(mocks.pickRandomProviderWithExclusion).not.toHaveBeenCalled();
+    });
+
+    test("缺少 Content-Type 的 JSON 假 200 在提交前被拦截并切换供应商", async () => {
+      const provider1 = createProvider({ id: 1, name: "codex-json-1", providerType: "codex" });
+      const provider2 = createProvider({ id: 2, name: "codex-json-2", providerType: "codex" });
+      const session = createSession();
+      configureCodexResponsesRequest(session);
+      session.setProvider(provider1);
+
+      mocks.pickRandomProviderWithExclusion.mockResolvedValueOnce(provider2);
+      const doForward = spyOnDoForward();
+      const headerlessJsonError = new Response(
+        new TextEncoder().encode(
+          JSON.stringify({ error: { type: "server_error", message: "upstream failed" } })
+        )
+      );
+      expect(headerlessJsonError.headers.get("content-type")).toBeNull();
+      doForward.mockResolvedValueOnce(headerlessJsonError);
+      doForward.mockImplementationOnce(async () =>
+        createSseResponse(OPENAI_RESPONSES_WINNER_FRAMES)
+      );
+
+      const response = await ProxyForwarder.send(session);
+
+      expect(await response.text()).toBe(OPENAI_RESPONSES_WINNER_FRAMES.join(""));
+      expect(doForward).toHaveBeenCalledTimes(2);
+      expect(mocks.recordFailure).toHaveBeenCalledWith(provider1.id, expect.any(Error));
+      expect(mocks.recordSuccess).not.toHaveBeenCalledWith(provider1.id);
+      expect(session.provider?.id).toBe(provider2.id);
+    });
+
+    test("raw passthrough 的缺头 JSON 在补 SSE 头前仍执行有界嗅探", async () => {
+      const provider = createProvider({ id: 1, name: "codex-compact", providerType: "codex" });
+      const session = createSession();
+      configureCodexResponsesRequest(session);
+      session.endpointPolicy = resolveEndpointPolicy("/v1/responses/compact");
+      session.setProvider(provider);
+
+      const doForward = spyOnDoForward();
+      const headerlessJson = new Response(
+        new TextEncoder().encode(
+          JSON.stringify({ error: { type: "server_error", message: "upstream failed" } })
+        )
+      );
+      expect(headerlessJson.headers.get("content-type")).toBeNull();
+      doForward.mockResolvedValueOnce(headerlessJson);
+
+      await expect(ProxyForwarder.send(session)).rejects.toThrow(
+        /Stream content gate rejected upstream before first valid content/
+      );
+
+      expect(doForward).toHaveBeenCalledTimes(1);
+      expect(mocks.pickRandomProviderWithExclusion).not.toHaveBeenCalled();
+      expect(mocks.recordSuccess).not.toHaveBeenCalled();
+    });
+
+    test("Legacy Hedge 的缺头 JSON 不会抢先成为 Codex Responses 流赢家", async () => {
+      const provider1 = createProvider({
+        id: 1,
+        name: "codex-hedge-json",
+        providerType: "codex",
+        firstByteTimeoutStreamingMs: 100,
+      });
+      const provider2 = createProvider({
+        id: 2,
+        name: "codex-hedge-sse",
+        providerType: "codex",
+        firstByteTimeoutStreamingMs: 100,
+      });
+      const session = createSession();
+      configureCodexResponsesRequest(session);
+      session.setProvider(provider1);
+
+      mocks.pickRandomProviderWithExclusion.mockResolvedValueOnce(provider2);
+      const doForward = spyOnDoForward();
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        attachAttemptRuntime(attemptSession, {
+          clearResponseTimeout: vi.fn(),
+          releaseAgent: vi.fn(),
+        });
+        return new Response(
+          new TextEncoder().encode(
+            JSON.stringify({ error: { type: "server_error", message: "upstream failed" } })
+          )
+        );
+      });
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        attachAttemptRuntime(attemptSession, {
+          clearResponseTimeout: vi.fn(),
+          releaseAgent: vi.fn(),
+        });
+        return createSseResponse(OPENAI_RESPONSES_WINNER_FRAMES);
+      });
+
+      const response = await ProxyForwarder.send(session);
+
+      expect(await response.text()).toBe(OPENAI_RESPONSES_WINNER_FRAMES.join(""));
+      expect(doForward).toHaveBeenCalledTimes(2);
+      expect(mocks.recordFailure).toHaveBeenCalledWith(provider1.id, expect.any(Error));
+      expect(session.provider?.id).toBe(provider2.id);
+    });
+
+    test.each(["text/html", "application/xhtml+xml"])(
+      "Codex Responses 流的 %s 网关页保留 fake-200 检测和供应商切换",
+      async (contentType) => {
+        const provider1 = createProvider({ id: 1, name: "codex-html-1", providerType: "codex" });
+        const provider2 = createProvider({ id: 2, name: "codex-html-2", providerType: "codex" });
+        const session = createSession();
+        configureCodexResponsesRequest(session);
+        session.setProvider(provider1);
+
+        mocks.pickRandomProviderWithExclusion.mockResolvedValueOnce(provider2);
+        const doForward = spyOnDoForward();
+        const htmlBody = "<!doctype html><html><body>blocked</body></html>";
+        const jsonBody = JSON.stringify({ id: "resp_ok", status: "completed", output: [] });
+        doForward.mockResolvedValueOnce(
+          new Response(htmlBody, {
+            status: 200,
+            headers: {
+              "content-type": `${contentType}; charset=utf-8`,
+              "content-length": String(htmlBody.length),
+            },
+          })
+        );
+        doForward.mockResolvedValueOnce(
+          new Response(jsonBody, {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              "content-length": String(jsonBody.length),
+            },
+          })
+        );
+
+        const response = await ProxyForwarder.send(session);
+
+        expect(await response.text()).toBe(jsonBody);
+        expect(doForward).toHaveBeenCalledTimes(2);
+        expect(mocks.recordFailure).toHaveBeenCalledWith(
+          provider1.id,
+          expect.objectContaining({ message: "FAKE_200_HTML_BODY" })
+        );
+        expect(mocks.recordSuccess).not.toHaveBeenCalledWith(provider1.id);
+        expect(mocks.recordSuccess).toHaveBeenCalledWith(provider2.id);
+      }
+    );
 
     test("默认 off：含 error 帧的 200 SSE 原样透传，不触发 failover", async () => {
       const provider1 = createProvider({ id: 1, name: "gate-p1" });


### PR DESCRIPTION
## 问题

部分 Codex-compatible 上游在 `/v1/responses` 且请求明确 `stream: true` 时，会返回成功的有效 SSE 正文，但省略或错误设置响应 `Content-Type`。当前响应分发仅依赖 `text/event-stream` 响应头识别流，因此会将这类响应送入 `ResponseFixer` 和非流式路径，缓冲原本应实时转发的 SSE。

## 修复

- 对 Codex Responses 的显式流请求，在上游返回 2xx、存在 body，且 MIME 既不是 SSE、JSON，也不是 HTML/XHTML 时，复用现有流处理路径。
- 在 forwarder 的非流正文检查前复用同一判定，避免克隆读取延迟首字节，并保持流式延迟结算。
- 对 MIME 缺失或误标的候选流始终执行现有有界 precommit gate，即使普通 gate 为 off/shadow，也会在零字节提交前拒绝 headerless JSON 假 200 并保留 provider failover。
- 命中该兼容路径时跳过 `ResponseFixer`，保持状态码和正文不变，并为下游补齐 `text/event-stream; charset=utf-8`。
- 复用现有 JSON Content-Type 判断，显式保留 `application/json` 和 `application/*+json` 的非流式处理。
- 仅增加 debug 日志，不增加指标、持久化记录或运行时配置。

## 相关 PRs

- Related to #1435 — complementary SSE handling; #1435 fixed WebSocket-to-SSE encoding for multiline events, while this PR fixes HTTP stream detection when Content-Type header is missing
- Related to #1304 — sibling Responses stream fix; #1304 added fake-200 detection for `response.failed` events, while this PR ensures valid SSE streams aren't misrouted to non-stream handling
- Related to #1443 — Responses stream handling context; #1443 excluded empty Responses streams from circuit breaker

## 安全边界

以下情况保持现有行为：

- 非 Codex provider
- 非 Responses 端点/格式
- `stream` 未明确为 `true`
- 无响应正文或非 2xx 响应
- 已正确标记为 SSE 的响应
- JSON 和 `+json` 响应
- HTML/XHTML 网关响应（继续走既有 fake-200 检测及 provider failover）

## 验证

- [x] 定向 ResponseHandler / forwarder 生命周期回归：28 tests passed
- [x] `bun run lint:fix`
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] 完整 Vitest：872 files / 8704 tests passed，13 skipped
- [x] `bun run test:v1`：91 files / 391 tests passed，critical coverage check passed
- [x] `bun run format:check`
- [x] `bun run validate:migrations`
- [x] `bun run openapi:check`
- [x] `bun run openapi:lint`
- [x] `git diff --check`












<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves explicitly requested Codex Responses streams when successful upstreams omit or misstate the SSE Content-Type.

- Adds a narrowly scoped compatibility predicate for successful Codex Responses streaming requests.
- Forces headerless candidates through the bounded precommit stream gate to retain fake-200 detection and provider failover.
- Skips non-stream response rectification for accepted compatibility streams and supplies the downstream SSE Content-Type.
- Covers sequential, legacy-hedge, raw-passthrough, JSON, HTML, abort-cleanup, and response-preservation behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/forwarder.ts | Extends sequential and legacy-hedge stream detection and mandatory precommit gating to qualifying headerless Codex Responses streams. |
| src/app/v1/_lib/proxy/response-handler.ts | Defines the compatibility predicate, bypasses non-stream rectification, preserves stream processing, and repairs the downstream SSE Content-Type. |
| tests/unit/proxy/response-handler-abort-listener-cleanup.test.ts | Adds response-handler coverage for headerless streams, raw passthrough, excluded MIME/status cases, and unchanged body delivery. |
| tests/unit/proxy/stream-gate-forwarder-integration.test.ts | Adds integration coverage for precommit gating, failover, raw passthrough, MIME exclusions, and legacy hedging. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Codex Responses request with stream true] --> B[Receive successful upstream response]
  B --> C{Content-Type}
  C -->|SSE| D[Existing stream path]
  C -->|JSON or HTML| E[Existing non-stream and fake-200 handling]
  C -->|Missing or other MIME| F[Forced bounded precommit gate]
  F -->|Valid Responses SSE frames| G[Managed stream path]
  F -->|Invalid or error body| H[Reject before commit and permit failover]
  G --> I[Set downstream SSE Content-Type]
  I --> J[Preserve status and body]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(proxy): preserve Codex Responses str..."](https://github.com/ding113/claude-code-hub/commit/7a70446b7c73e18475af4a797f2a899d48081c0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57588217)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Provider protocol adapters](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/provider-protocol-adapters.md)
- Knowledge Base — [Request sessions and streaming](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/request-sessions-and-streaming.md)
- Knowledge Base — [Provider routing and failover](https://app.greptile.com/ygxz/-/custom-context/knowledge-base/ding113/claude-code-hub/-/docs/provider-routing-and-failover.md)
</details>


<!-- /greptile_comment -->