### PR TITLE
feat(gateway): 增加资源感知的多核心运行模式

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,20 @@ ADMIN_TOKEN=change-me
 # 设置为 false 可禁用自动迁移
 AUTO_MIGRATE=true
 
+# 网关多核心模式（生产启动入口 cluster.js）
+# - auto（默认）：仅在有效 vCPU >= 4 且内存/共享预算足够时启用。4 vCPU 默认 2 个
+#   完整网关进程，8+ vCPU 默认最多 4 个；请求正文始终只由其中一个进程持有，不经 IPC 复制。
+# - on：显式要求至少 2 个进程；off：保持单进程。
+# - CCH_MULTICORE_WORKERS 可显式指定 1~32；1 等价于单进程。显式多进程仍会校验内存和预算。
+# - 多进程依赖 Redis Pub/Sub 同步安全与路由缓存失效；未配置 Redis 或关闭
+#   ENABLE_RATE_LIMIT 时 auto 回退单进程，显式多进程配置会启动失败。
+CCH_MULTICORE_MODE=auto
+# CCH_MULTICORE_WORKERS=4
+CCH_MULTICORE_MEMORY_PER_WORKER_MB=1024
+CCH_MULTICORE_PRIMARY_MEMORY_RESERVE_MB=256
+# CCH_MULTICORE_READY_TIMEOUT_MS=180000
+# CCH_MULTICORE_SHUTDOWN_TIMEOUT_MS=33000  # 未设置时自动取 SHUTDOWN_HARD_EXIT_MS + 5 秒
+
 # 数据库连接字符串（仅用于本地开发或非 Docker Compose 部署）
 DSN="postgres://user:password@host:port/db_name"
 
@@ -20,10 +34,11 @@ ENABLE_API_KEY_VACUUM_FILTER="true"
 
 # PostgreSQL 连接池配置（postgres.js）
 # 说明：
-# - DB_POOL_MAX 是每个应用进程内 data/control/writer 三类 pool 的连接总预算
-# - 默认拆分：生产环境 20 = 15/4/1，开发与测试环境 10 = 7/2/1
+# - DB_POOL_MAX 是一个应用容器内 data/control/writer 三类 pool 的连接总预算；启用内置
+#   多进程时由 launcher 确定性分摊到各网关进程，单进程时保持原语义
+# - 单进程默认拆分：生产环境 20 = 15/4/1，开发与测试环境 10 = 7/2/1
 # - 每条 pool 另有有界 outstanding admission，满载时以 DB_POOL_ADMISSION_EXCEEDED 快速失败
-# - k8s 多副本时仍需按副本数分摊这个总预算
+# - k8s 多 Pod 时每个 Pod 都有一份该预算，仍需按 Pod 数核算数据库总连接数
 DB_POOL_MAX=20
 DB_POOL_IDLE_TIMEOUT=20                  # 空闲连接回收（秒）
 DB_POOL_CONNECT_TIMEOUT=10               # 建立连接超时（秒）
@@ -35,7 +50,7 @@ DB_LOCK_TIMEOUT_MS=5000                   # SQL 等待数据库锁的最长时�
 # - sync：同步写入（兼容旧行为，但高并发下会增加请求尾部阻塞）
 MESSAGE_REQUEST_WRITE_MODE=async
 
-# message_request 异步批量参数（可选）
+# message_request 异步批量参数（可选）；MAX_PENDING 在内置多进程间分摊，避免队列内存倍增
 MESSAGE_REQUEST_ASYNC_FLUSH_INTERVAL_MS=250
 MESSAGE_REQUEST_ASYNC_BATCH_SIZE=200
 MESSAGE_REQUEST_ASYNC_MAX_PENDING=5000
@@ -173,14 +188,15 @@ FETCH_HEADERS_TIMEOUT=600000
 FETCH_BODY_TIMEOUT=600000
 MAX_RETRY_ATTEMPTS_DEFAULT=2                # 单供应商最大尝试次数（含首次调用），范围 1-10，留空使用默认值 2
 
-# 客户端断开后的 detached stream 共享带权进程级资源预算。
+# 客户端断开后的 detached stream 共享带权容器级资源预算（内置多进程间分摊）。
 # Replay owner 申请较重的 replay lease；预算不足时降级为轻量 metering，
 # 两者都无法准入时才终止上游并按 499 结算。
 DETACHED_STREAM_MAX_CONCURRENCY=64
 DETACHED_STREAM_BUDGET_BYTES=67108864
 DETACHED_STREAM_METERING_RESERVE_BYTES=16777216
 
-# 流式内容门禁在所有并发请求间共享的 precommit 原始字节与解析文本预算（默认 256 MiB）。
+# 流式内容门禁在容器内共享的 precommit 原始字节与解析文本预算（默认 256 MiB，
+# 内置多进程间分摊）。
 # 预算不足时请求等待现有前缀被消费，不会关闭门禁或误触发供应商切换。
 # 至少应为 STREAM_GATE_PREBUFFER_BYTE_CAP 的 4 倍。
 STREAM_GATE_GLOBAL_PREBUFFER_BYTE_CAP=268435456

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ AUTO_MIGRATE=true
 #   完整网关进程，8+ vCPU 默认最多 4 个；请求正文始终只由其中一个进程持有，不经 IPC 复制。
 # - on：显式要求至少 2 个进程；off：保持单进程。
 # - CCH_MULTICORE_WORKERS 可显式指定 1~32；1 等价于单进程。显式多进程仍会校验内存和预算。
-# - 多进程依赖 Redis Pub/Sub 同步安全与路由缓存失效；未配置 Redis 或关闭
+# - 多进程依赖 Redis Pub/Sub 同步安全、路由、系统设置与 Provider group 计费倍率失效；未配置 Redis 或关闭
 #   ENABLE_RATE_LIMIT 时 auto 回退单进程，显式多进程配置会启动失败。
 CCH_MULTICORE_MODE=auto
 # CCH_MULTICORE_WORKERS=4

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ RUN mkdir -p /app/reports
 # --report-exclude-env：诊断报告不得持久化 ADMIN_TOKEN、DSN、Redis、Langfuse
 # 与 Provider credentials 等运行时环境变量
 # --report-directory：指向 /app/reports 以便挂卷持久化
-CMD ["node", "--report-on-fatalerror", "--report-uncaught-exception", "--report-exclude-env", "--report-directory=/app/reports", "server.js"]
+CMD ["node", "--report-on-fatalerror", "--report-uncaught-exception", "--report-exclude-env", "--report-directory=/app/reports", "cluster.js"]

--- a/cluster.js
+++ b/cluster.js
@@ -36,6 +36,19 @@ function loadLauncherEnvironment() {
   }
 }
 
+function normalizeStandaloneEnvironment(env = process.env) {
+  // `off` 是紧急回滚入口。即使部署残留了内部 worker 标记，单进程也必须恢复
+  // 完整 owner 角色，不能误跳过迁移、队列 consumer 或后台调度器。
+  env.CCH_MULTICORE_ACTIVE = "0";
+  env.CCH_MULTICORE_WORKER_INDEX = "0";
+  env.CCH_MULTICORE_WORKER_COUNT = "1";
+  env.CCH_MULTICORE_BACKGROUND_OWNER = "1";
+  env.CCH_PROCESS_ROLE = "gateway-control";
+  delete env.CCH_MULTICORE_EFFECTIVE_VCPUS;
+  delete env.CCH_MULTICORE_EFFECTIVE_MEMORY_BYTES;
+  return env;
+}
+
 async function main() {
   if (!cluster.isPrimary) {
     throw new Error("cluster.js must only run as the primary process");
@@ -60,6 +73,7 @@ async function main() {
   });
 
   if (!plan.enabled) {
+    normalizeStandaloneEnvironment(process.env);
     const { main: startServer } = require("./server");
     await startServer();
     return;
@@ -82,7 +96,7 @@ async function main() {
   }).start();
 }
 
-module.exports = { loadLauncherEnvironment, main };
+module.exports = { loadLauncherEnvironment, main, normalizeStandaloneEnvironment };
 
 if (require.main === module) {
   main().catch((error) => {

--- a/cluster.js
+++ b/cluster.js
@@ -1,0 +1,94 @@
+// claude-code-hub 的资源感知型生产启动器。
+//
+// 每个 cluster worker 独占完整的请求生命周期。主进程只分发已接受的 socket
+// 句柄，绝不传递请求正文或解析后的对象图，避免大请求跨越 IPC 序列化边界。
+
+"use strict";
+
+const cluster = require("node:cluster");
+const path = require("node:path");
+const { createClusterSupervisor } = require("./server-lib/cluster-supervisor");
+const {
+  createMulticorePlan,
+  detectRuntimeResources,
+  hasCrossProcessInvalidation,
+} = require("./server-lib/multicore");
+
+function log(level, msg, extra) {
+  const line = { ts: new Date().toISOString(), level, msg, ...(extra || {}) };
+  try {
+    process.stdout.write(`${JSON.stringify(line)}\n`);
+  } catch {
+    // 日志写入失败不应影响启动监督。
+  }
+}
+
+function loadLauncherEnvironment() {
+  try {
+    // worker 数必须在 Next 启动前确定。复用 Next 的 .env 加载语义，确保
+    // `bun run start` 与容器注入环境变量时行为一致。
+    const { loadEnvConfig } = require("@next/env");
+    loadEnvConfig(__dirname, process.env.NODE_ENV !== "production");
+  } catch (error) {
+    log("warn", "multicore_env_load_failed", {
+      error: String(error?.message || error),
+    });
+  }
+}
+
+async function main() {
+  if (!cluster.isPrimary) {
+    throw new Error("cluster.js must only run as the primary process");
+  }
+
+  loadLauncherEnvironment();
+  const resources = detectRuntimeResources();
+  const plan = createMulticorePlan({ env: process.env, resources });
+  log("info", "multicore_plan_resolved", {
+    enabled: plan.enabled,
+    mode: plan.mode,
+    reason: plan.reason,
+    workerCount: plan.workerCount,
+    effectiveVcpus: resources.effectiveCpu,
+    cpuQuota: resources.cpuQuota,
+    cpusetVcpus: resources.cpusetCpu,
+    crossProcessInvalidation: hasCrossProcessInvalidation(process.env),
+    effectiveMemoryMiB: Math.floor(resources.effectiveMemoryBytes / (1024 * 1024)),
+    memoryPerWorkerMiB: plan.memoryPerWorkerBytes
+      ? Math.floor(plan.memoryPerWorkerBytes / (1024 * 1024))
+      : null,
+  });
+
+  if (!plan.enabled) {
+    const { main: startServer } = require("./server");
+    await startServer();
+    return;
+  }
+
+  // 轮询调度比任由少数 keep-alive listener 获得大部分连接更均衡。Windows
+  // 保留原生策略；生产容器运行于 Linux，因此使用 SCHED_RR。
+  cluster.schedulingPolicy = process.platform === "win32" ? cluster.SCHED_NONE : cluster.SCHED_RR;
+  cluster.setupPrimary({
+    exec: path.join(__dirname, "server.js"),
+    execArgv: process.execArgv,
+  });
+
+  createClusterSupervisor({
+    clusterModule: cluster,
+    plan,
+    processRef: process,
+    env: process.env,
+    log,
+  }).start();
+}
+
+module.exports = { loadLauncherEnvironment, main };
+
+if (require.main === module) {
+  main().catch((error) => {
+    log("error", "multicore_bootstrap_failed", {
+      error: String(error?.stack || error),
+    });
+    process.exit(1);
+  });
+}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -68,4 +68,4 @@ RUN mkdir -p /app/reports && chown node:node /app/reports
 USER node
 EXPOSE 3000
 
-CMD ["node", "--report-on-fatalerror", "--report-uncaught-exception", "--report-exclude-env", "--report-directory=/app/reports", "server.js"]
+CMD ["node", "--report-on-fatalerror", "--report-uncaught-exception", "--report-exclude-env", "--report-directory=/app/reports", "cluster.js"]

--- a/deploy/Dockerfile.dev
+++ b/deploy/Dockerfile.dev
@@ -52,4 +52,4 @@ COPY --from=build --chown=node:node /app/.next/static ./.next/static
 USER node
 EXPOSE 3000
 
-CMD ["node", "server.js"]
+CMD ["node", "cluster.js"]

--- a/docs/k8s-deployment.md
+++ b/docs/k8s-deployment.md
@@ -213,6 +213,23 @@ bash scripts/deploy-k8s.sh --replicas 3 --hpa-min 3 --hpa-max 10 -y
 默认模板保留 `replicas=2`,但 `AUTO_MIGRATE` 入口 `src/instrumentation.ts` 会先获取 PostgreSQL advisory lock,
 因此首次多副本启动时迁移会串行执行。如果你更关心首启速度,也可以先用 `--replicas 1` 部署,确认健康后再扩容。
 
+### 单 Pod 多核心模式
+
+生产镜像通过 `cluster.js` 启动。默认 `CCH_MULTICORE_MODE=auto` 只在 cgroup 有效
+vCPU 至少为 4 且内存/共享预算足够时启用；当前 app 模板的 `limits.cpu=4`、
+`limits.memory=4Gi` 会自动运行 2 个完整网关 worker。每个请求始终由一个 worker
+从 socket 处理到 usage/计费写回,正文和 JSON 对象不会通过进程 IPC 复制。
+
+`DB_POOL_MAX`、message writer pending、detached stream、stream gate 和 replay 并发等
+配置在同一 Pod 内作为聚合预算分摊。例如模板的 `DB_POOL_MAX=24` 在 2 worker 下为
+12/12,不会因为多进程把单 Pod 的 PostgreSQL 连接预算翻倍；多个 Pod 之间仍需再按
+`replicas`/HPA 最大值计算总连接数。
+
+HPA 看到的是 Pod 内 primary 与所有 worker 的合计 CPU/内存。少量长 keep-alive 或
+WebSocket 连接仍具有单 worker 亲和性,压测时应同时检查每个进程的负载分布。若希望
+完全由 Pod 横向扩展控制,可在 Deployment 中设置 `CCH_MULTICORE_MODE=off`。详细的
+内存模型、覆盖配置和故障语义见[网关多核心运行模式](./multicore-gateway.md)。
+
 ### Codex `/v1/responses` WebSocket 反代
 
 `/v1/responses` 端点对 Codex 客户端会走 **WebSocket 升级**(其余路径仍是 HTTP)。

--- a/docs/multicore-gateway.md
+++ b/docs/multicore-gateway.md
@@ -8,6 +8,8 @@
 
 请求完成后的 usage、计费、replay complete、亲和绑定和 durable message 写入也保留在同一请求 worker 中。这样既不复制响应正文，也不破坏现有事务顺序；由于请求本身已分布到多个进程，这些终态计算会自然并行。
 
+逐阶段热点、所有可并行化候选、parse-only worker 的内存模型和后续实施门槛见[多核心并行化与热点拆分审计](./research/gateway-multicore-parallelization-analysis.md)。
+
 ## 默认行为
 
 | 环境 | `CCH_MULTICORE_MODE=auto` 的行为 |
@@ -36,7 +38,11 @@ min(4, floor(effective_vCPU / 2), memory_capacity, shared_budget_capacity)
 - 内存：`os.totalmem()` 与 cgroup v2/v1 memory limit 的最小值。
 - 默认每个完整网关预留 1024 MiB，并为轻量 primary/运行时开销预留 256 MiB。
 
-自动模式还要求配置 `REDIS_URL`，且 `ENABLE_RATE_LIMIT` 不能关闭。错误规则、请求过滤器、敏感词、Provider cache 和 API Key Vacuum Filter 等进程本地快照使用 Redis Pub/Sub 接收微小的失效通知；没有这条控制通道时自动回退单进程，避免管理写入只刷新命中它的某一个 worker。显式要求多进程但缺少该通道会直接启动失败。Redis 运行期故障仍沿用现有多实例 fail-open 语义，恢复前应避免修改上述动态配置。
+自动模式还要求配置 `REDIS_URL`，且 `ENABLE_RATE_LIMIT` 不能关闭。错误规则、请求过滤器、敏感词、Provider cache、系统设置、Provider group 计费倍率和 API Key Vacuum Filter 等进程本地快照使用 Redis Pub/Sub 接收微小的失效通知；没有这条控制通道时自动回退单进程，避免管理写入只刷新命中它的某一个 worker。显式要求多进程但缺少该通道会直接启动失败。Redis 运行期故障仍沿用现有多实例 fail-open 语义，恢复前应避免修改上述动态配置。
+
+Provider group 倍率缓存额外使用版本号阻止“更新通知到达后，较早发出的 DB 查询才返回并重新写入旧值”的竞态；更新广播只在数据库提交后发送。每进程缓存最多保留 10,000 个原始 group 表达式，TTL 为 60 秒，避免高基数字符串在多个 V8 heap 中无界累积。多核心 worker 会在报告 ready 前等待首次订阅；Redis 临时不可用时保留 TTL 降级语义并记录告警。
+
+系统设置缓存使用相同的查询版本栅栏，覆盖计费口径、hedge loser、stream gate、replay、限额 lease 和响应策略等热路径开关。保存操作在数据库提交后先清空本进程，再发布不含设置内容的失效消息；其他 worker 收到后只清本地快照。发布失败时仍由 60 秒 TTL 收敛，不会把完整配置对象放进 Redis Pub/Sub。
 
 因此，容器看到宿主机有很多核心但 cgroup 只分配 3.5 vCPU 时，有效值为 3，不会自动启用。没有容器 CPU quota 的 Docker 部署会按宿主机可见核心判断；共享宿主机上建议显式设置容器 quota 或 `CCH_MULTICORE_WORKERS`。
 
@@ -135,6 +141,7 @@ CCH_MULTICORE_PRIMARY_MEMORY_RESERVE_MB=256
 ## 故障与关闭语义
 
 - worker 未在 ready deadline 内启动：先发送 `SIGTERM`，5 秒仍未退出则发送 `SIGKILL`，随后按原 slot 重启。
+- worker 发出异步 `error`：先等待短暂的自然 `exit`；若 Node 未再发出 `exit`，则发送 `SIGKILL`，再经过有界宽限期合成且仅合成一次终态。迟到的真实 `exit` 由 worker record 身份检查忽略，不会重复计数或拉起。
 - worker 意外退出：指数退避重启，slot 和资源预算不变。
 - 同一 slot 在 60 秒内连续失败 5 次：primary 判定 crash loop，终止整个容器，让外层 Docker/Kubernetes supervisor 重新创建干净实例。
 - primary 收到 `SIGTERM`/`SIGINT`：转发到所有 worker；worker 继续使用现有的 readiness flip、HTTP/WS drain、durable writer flush、DB/Redis cleanup 顺序。

--- a/docs/multicore-gateway.md
+++ b/docs/multicore-gateway.md
@@ -1,0 +1,163 @@
+# 网关多核心运行模式
+
+## 目标与结论
+
+生产启动入口 `cluster.js` 可以在一个容器内运行多个完整的 `server.js` 网关进程，把不同请求的 JSON 处理、过滤、格式转换、响应分析、usage 计算和写回工作并行分散到多个 V8 event loop。默认 `auto` 模式只在探测到 **至少 4 个有效 vCPU** 且内存与共享预算足够时启用。
+
+实现刻意没有把“大请求体 -> 单独 JSON worker -> 完整对象返回”作为方案。普通 JavaScript 对象跨 `worker_threads` 或子进程时需要 structured clone/序列化，大字符串、tools schema、base64 图片和深层对象会同时保留字节、字符串、AST 与克隆结果，峰值内存往往比节省的 event-loop 时间更危险。当前模式让一条请求从 socket 读取到最终结算始终归属于同一个 worker；primary 只转交 socket handle，不通过 IPC 发送正文或对象树。
+
+请求完成后的 usage、计费、replay complete、亲和绑定和 durable message 写入也保留在同一请求 worker 中。这样既不复制响应正文，也不破坏现有事务顺序；由于请求本身已分布到多个进程，这些终态计算会自然并行。
+
+## 默认行为
+
+| 环境 | `CCH_MULTICORE_MODE=auto` 的行为 |
+| --- | --- |
+| 非 production 或 CI | 单进程 |
+| 有效 vCPU < 4 | 单进程 |
+| 4 vCPU、内存/预算足够 | 2 个完整网关 worker |
+| 6 vCPU、内存/预算足够 | 3 个完整网关 worker |
+| 8+ vCPU、内存/预算足够 | 最多 4 个完整网关 worker |
+| 未配置 Redis 跨进程缓存失效 | 单进程 |
+| 内存或任一共享预算不足以安全容纳 2 个 worker | 单进程 |
+
+自动数量为以下容量的最小值：
+
+```text
+min(4, floor(effective_vCPU / 2), memory_capacity, shared_budget_capacity)
+```
+
+每个进程预留两个 vCPU 的原因是主 JavaScript 线程之外仍有 GC、异步 zlib/libuv、TLS 和原生代码工作，避免“4 vCPU 启 4 个主线程”把尾延迟和内存推到不可控区间。需要覆盖默认值时可显式设置 worker 数。
+
+## 资源探测
+
+`server-lib/multicore.js` 使用最保守的可见资源值：
+
+- CPU：`os.availableParallelism()`、cgroup v2 `cpu.max`、cgroup v1 CFS quota 和 cpuset 的最小值；小数 quota 向下取整。
+- 内存：`os.totalmem()` 与 cgroup v2/v1 memory limit 的最小值。
+- 默认每个完整网关预留 1024 MiB，并为轻量 primary/运行时开销预留 256 MiB。
+
+自动模式还要求配置 `REDIS_URL`，且 `ENABLE_RATE_LIMIT` 不能关闭。错误规则、请求过滤器、敏感词、Provider cache 和 API Key Vacuum Filter 等进程本地快照使用 Redis Pub/Sub 接收微小的失效通知；没有这条控制通道时自动回退单进程，避免管理写入只刷新命中它的某一个 worker。显式要求多进程但缺少该通道会直接启动失败。Redis 运行期故障仍沿用现有多实例 fail-open 语义，恢复前应避免修改上述动态配置。
+
+因此，容器看到宿主机有很多核心但 cgroup 只分配 3.5 vCPU 时，有效值为 3，不会自动启用。没有容器 CPU quota 的 Docker 部署会按宿主机可见核心判断；共享宿主机上建议显式设置容器 quota 或 `CCH_MULTICORE_WORKERS`。
+
+## 进程拓扑与启动顺序
+
+```text
+                         public :3000
+                              |
+                    cluster primary (轻量)
+                  只分发 socket handle，不读正文
+                     /          |          \
+                    /           |           \
+          worker 0             worker 1      worker N
+       gateway-control          gateway       gateway
+       请求 + 后台任务           仅请求          仅请求
+             |                    |              |
+      127.0.0.1:随机端口   127.0.0.1:随机端口  127.0.0.1:随机端口
+       私有 WS 回环 HTTP      私有 WS 回环 HTTP   私有 WS 回环 HTTP
+```
+
+1. primary 只启动 slot 0。
+2. slot 0 完成 Next prepare、迁移、规则同步、队列和 scheduler 初始化并开始监听。
+3. slot 0 通过一个只有 type/index/pid 的小型 IPC 消息报告 ready。
+4. primary 再启动其余 request-only worker；它们验证数据库并加载各自的本地缓存，不重复启动 singleton 后台任务。
+
+这样可避免多个新进程在迁移和默认数据尚未就绪时同时接流量，也避免 Bull consumer、价格同步、outbox recovery、探测与清理调度器在同一容器内成倍注册。slot 0 异常退出时 supervisor 会用同一角色和同一资源分片重启它。
+
+## WebSocket 正确性
+
+`/v1/responses` WebSocket 的连接队列、per-process secret 和持久上游 WS session 都具有进程归属。若它仍回环到共享的公共端口，cluster 可能把内部 HTTP 请求交给另一个 worker，造成 secret 不匹配或 `store=false + previous_response_id` 续接状态丢失。
+
+每个 worker 现在创建独占的 `127.0.0.1:0` HTTP listener，且显式使用 `exclusive: true`。该 worker 接收的 WS frame 只回到自己的随机端口，因此：
+
+- 客户端 WS 连接、frame queue、内部 HTTP 请求和上游持久 session 始终在同一进程；
+- 不需要在进程间共享 secret；
+- 大 WS 正文不会经过 cluster IPC；
+- shutdown 同时关闭公共 listener、私有 listener 和 WebSocket server。
+
+这里仍保留既有的 WS -> 本机 HTTP 序列化成本。进一步删除这次序列化需要把 Next/Hono proxy core 抽成可直接调用的内部 API，是独立的大型重构；本次实现优先消除跨进程错误路由和新增内存复制。
+
+## 内存与连接预算
+
+完整进程会复制 V8 heap、Next 模块缓存、Redis/DB client、socket pool 和本地 cache。为了不让“2~4 个进程”直接变成“2~4 倍预算”，launcher 将下列已有配置解释为**一个容器内的聚合预算**并按 slot 确定性分摊，余数优先给较低 slot：
+
+| 聚合配置 | 默认总量 | 每个 worker 的最低合法分片 | 目的 |
+| --- | ---: | ---: | --- |
+| `DB_POOL_MAX` | 20 | 1 | 保持容器内数据库连接总上限 |
+| `MESSAGE_REQUEST_ASYNC_MAX_PENDING` | 5000 | 100 | 限制 durable message writer 排队对象 |
+| `DETACHED_STREAM_MAX_CONCURRENCY` | 64 | 1 | 防止 detached stream 数量倍增 |
+| `DETACHED_STREAM_BUDGET_BYTES` | 64 MiB | 3 MiB + 64 KiB | 限制 detached/replay 缓冲 |
+| `DETACHED_STREAM_METERING_RESERVE_BYTES` | 16 MiB | 64 KiB | 保留最小计量空间 |
+| `STREAM_GATE_GLOBAL_PREBUFFER_BYTE_CAP` | 256 MiB | `4 * STREAM_GATE_PREBUFFER_BYTE_CAP` | 限制 stream gate 前缀缓冲 |
+| `REPLAY_MAX_CONCURRENT_SPOOLS` | 64 | 1 | 防止每进程各自获得完整 spool 并发 |
+
+例如默认 2 worker 时，`DB_POOL_MAX=20` 变成 10/10；3 worker 时是 7/7/6。Kubernetes 的多个 Pod 仍各自拥有一份聚合预算，所以数据库总连接上限需要按 Pod 数继续核算。
+
+显式 worker 数超过内存容量或无法为每个 worker 生成合法分片时，launcher 会 fail fast，而不是悄悄启动一个可能 OOM 或配置校验失败的集群。自动模式则安全回退单进程。每请求正文上限、单响应上限等请求级限制不会分摊。
+
+### 为什么不用正文 IPC
+
+- `child_process.send()` 需要序列化与解析；普通对象和字符串不是共享内存。
+- `worker.postMessage()` 的普通对象需要 structured clone；即便 transfer 原始 `ArrayBuffer`，解析后的 AST 返回主线程仍要整树复制。
+- `SharedArrayBuffer` 只能共享字节，不能共享普通 JavaScript 对象。
+- 为保持“同步语义”使用 `Atomics.wait()` 会直接阻塞 gateway event loop。
+- 大请求排队到独立解析池还需要同时限制 task 数与 queued bytes，否则多个接近 100 MiB 的正文会快速放大 RSS。
+
+完整请求分片避免上述复制：worker 从自己的 socket 直接读取，所有中间字符串/AST/转换结果在同一 heap 内产生并尽早释放。
+
+## 配置
+
+```dotenv
+# auto | on | off；多进程要求 REDIS_URL 且 ENABLE_RATE_LIMIT 未关闭
+CCH_MULTICORE_MODE=auto
+
+# 可选精确值。1 强制单进程；production 下 2~32 可覆盖 CPU 门槛，但仍受内存/预算校验。
+# CCH_MULTICORE_WORKERS=4
+
+# worker 数量的内存安全模型
+CCH_MULTICORE_MEMORY_PER_WORKER_MB=1024
+CCH_MULTICORE_PRIMARY_MEMORY_RESERVE_MB=256
+
+# 可选的启动/关闭监督边界；关闭默认值为 SHUTDOWN_HARD_EXIT_MS + 5 秒
+# CCH_MULTICORE_READY_TIMEOUT_MS=180000
+# CCH_MULTICORE_SHUTDOWN_TIMEOUT_MS=33000
+```
+
+常用操作：
+
+- 回滚到旧的单进程拓扑：`CCH_MULTICORE_MODE=off` 或 `CCH_MULTICORE_WORKERS=1`。
+- 4 vCPU 但内存小于默认安全模型：保持单进程，或在压测证明安全后显式下调 `CCH_MULTICORE_MEMORY_PER_WORKER_MB`；最低允许 256 MiB，不代表生产推荐值。
+- 指定更多 worker：同时复核聚合 DB/stream/replay/writer 预算；launcher 最多允许 32，自动模式最多 4。
+- 外部已经为每个容器限制到 1~2 vCPU：维持单进程并通过 Pod/容器副本横向扩展通常更简单。
+
+`CCH_MULTICORE_ACTIVE`、`CCH_MULTICORE_WORKER_INDEX`、`CCH_MULTICORE_WORKER_COUNT` 和 `CCH_MULTICORE_BACKGROUND_OWNER` 由 launcher 写入，不能作为普通部署配置手工拼装。
+
+## 故障与关闭语义
+
+- worker 未在 ready deadline 内启动：先发送 `SIGTERM`，5 秒仍未退出则发送 `SIGKILL`，随后按原 slot 重启。
+- worker 意外退出：指数退避重启，slot 和资源预算不变。
+- 同一 slot 在 60 秒内连续失败 5 次：primary 判定 crash loop，终止整个容器，让外层 Docker/Kubernetes supervisor 重新创建干净实例。
+- primary 收到 `SIGTERM`/`SIGINT`：转发到所有 worker；worker 继续使用现有的 readiness flip、HTTP/WS drain、durable writer flush、DB/Redis cleanup 顺序。
+- 超过 primary shutdown deadline：向残留 worker 发送 `SIGKILL` 并以非零状态退出。
+
+普通 usage/billing 写入没有改成裸 fire-and-forget，也没有移到不耐久的进程内队列；worker 崩溃仍沿用原有请求事务语义。
+
+## 运维与验证
+
+启动日志中的关键事件：
+
+- `multicore_plan_resolved`：有效 CPU/内存、是否启用、worker 数和原因；
+- `multicore_worker_started` / `multicore_worker_ready`：slot 生命周期；
+- `multicore_cluster_ready`：全部 slot 已 ready；
+- `multicore_worker_exited` / `multicore_worker_crash_loop`：异常和重启；
+- `server_listening`：包含 worker index/count 与其私有回环端口。
+
+上线前至少对比单进程、自动模式和显式 worker 数，按请求类型分桶观察：
+
+1. 每进程 CPU、event-loop utilization/delay、GC、RSS、heap、external/ArrayBuffer；
+2. 吞吐、TTFT、p50/p95/p99、错误率；
+3. 1 KiB 到大 body、明文及 gzip/br/zstd、非流式/SSE/WebSocket；
+4. DB pool、Redis、upstream socket、writer pending、detached/stream gate/replay 预算；
+5. worker kill、slot 0 kill、启动超时、优雅关闭和 WS 续接。
+
+Node cluster 主要按连接分流。少数超长 keep-alive、HTTP/2 多路复用或单条 WebSocket 连接仍会固定在一个 worker，不能仅用“总 CPU 未打满”判断实现失效；压测必须同时观察连接数、每连接请求数和各 worker 负载。对大规模 Kubernetes 部署，外部 L7 按请求分流的多 Pod 仍是首选，内置多进程用于充分利用单 Pod 的 4+ vCPU 配额。

--- a/docs/multicore-gateway.md
+++ b/docs/multicore-gateway.md
@@ -38,9 +38,9 @@ min(4, floor(effective_vCPU / 2), memory_capacity, shared_budget_capacity)
 - 内存：`os.totalmem()` 与 cgroup v2/v1 memory limit 的最小值。
 - 默认每个完整网关预留 1024 MiB，并为轻量 primary/运行时开销预留 256 MiB。
 
-自动模式还要求配置 `REDIS_URL`，且 `ENABLE_RATE_LIMIT` 不能关闭。错误规则、请求过滤器、敏感词、Provider cache、系统设置、Provider group 计费倍率和 API Key Vacuum Filter 等进程本地快照使用 Redis Pub/Sub 接收微小的失效通知；没有这条控制通道时自动回退单进程，避免管理写入只刷新命中它的某一个 worker。显式要求多进程但缺少该通道会直接启动失败。Redis 运行期故障仍沿用现有多实例 fail-open 语义，恢复前应避免修改上述动态配置。
+自动模式还要求配置 `REDIS_URL`，且 `ENABLE_RATE_LIMIT` 不能关闭。错误规则、请求过滤器、敏感词、Provider cache、系统设置、Provider group 计费倍率、熔断配置和 API Key Vacuum Filter 等进程本地快照使用 Redis Pub/Sub 接收微小的失效通知；没有这条控制通道时自动回退单进程，避免管理写入只刷新命中它的某一个 worker。显式要求多进程但缺少该通道会直接启动失败。Redis 在启动或运行期间暂时不可用时，订阅登记不会丢失：共享订阅器按 1 秒到 60 秒的指数退避持续重试；首次订阅和每次重连成功后都会向所有登记者合成一次 resync 失效，强制从数据库等权威存储重载，从而覆盖 Pub/Sub 无法补发的断线窗口。恢复前仍沿用现有多实例 fail-open 语义。
 
-Provider group 倍率缓存额外使用版本号阻止“更新通知到达后，较早发出的 DB 查询才返回并重新写入旧值”的竞态；更新广播只在数据库提交后发送。每进程缓存最多保留 10,000 个原始 group 表达式，TTL 为 60 秒，避免高基数字符串在多个 V8 heap 中无界累积。多核心 worker 会在报告 ready 前等待首次订阅；Redis 临时不可用时保留 TTL 降级语义并记录告警。
+Provider group 倍率缓存额外使用版本号阻止“更新通知到达后，较早发出的 DB 查询才返回并重新写入旧值”的竞态；更新广播只在数据库提交后发送。每进程缓存最多保留 10,000 个原始 group 表达式，TTL 为 60 秒，避免高基数字符串在多个 V8 heap 中无界累积。多核心 worker 会在报告 ready 前完成首次订阅尝试；Redis 临时不可用时保留 TTL 降级语义、持续后台恢复且不在请求正文路径排队。
 
 系统设置缓存使用相同的查询版本栅栏，覆盖计费口径、hedge loser、stream gate、replay、限额 lease 和响应策略等热路径开关。保存操作在数据库提交后先清空本进程，再发布不含设置内容的失效消息；其他 worker 收到后只清本地快照。发布失败时仍由 60 秒 TTL 收敛，不会把完整配置对象放进 Redis Pub/Sub。
 

--- a/docs/research/gateway-multicore-parallelization-analysis.md
+++ b/docs/research/gateway-multicore-parallelization-analysis.md
@@ -1,0 +1,264 @@
+# CCH 网关多核心并行化与热点拆分审计
+
+> 审计日期：2026-08-29
+>
+> 基线：最新 dev 加 feat/gateway-multicore
+>
+> 性质：源码与架构审计。生产收益仍须用真实流量分布和固定资源压测确认。
+
+## 执行结论
+
+Node.js 可以让一个应用使用 4 个乃至更多 CPU 核心，但单个 V8 主事件循环不会自动并行执行
+JavaScript。CCH 当前最稳健的并行边界是**完整请求**，而不是 JSON.parse、usage、敏感词或每个
+SSE chunk：多个完整 gateway worker 直接从共享监听端口接收不同连接，每条请求从 socket、正文、
+对象树、上游响应到最终结算始终归同一 worker 所有。
+
+本分支据此实现了资源感知的 Node cluster：
+
+- auto 仅在 production、有效 vCPU 不少于 4、内存和共享预算足够、Redis 失效通道可用时开启；
+- 4 vCPU 默认 2 个 gateway worker，6 vCPU 默认 3 个，8 vCPU 及以上默认最多 4 个；
+- primary 只转交 socket handle，应用 IPC 只有 type、workerIndex、pid 三个 ready 字段；
+- 请求正文和解析后的普通 JavaScript 对象不经过 IPC，不产生第二份跨 isolate 对象树；
+- usage、转换、统计和写回随请求自然分布到多个进程，不额外搬运响应正文；
+- DB、detached stream、replay、prebuffer 和 writer pending 等既有配置被解释为容器聚合预算并按
+  worker 分片，避免进程数直接乘大共享依赖和缓冲上限；
+- 仅 slot 0 运行 singleton 后台任务，其余 worker 只初始化请求必需的本地状态；
+- 每个 worker 有独占的 IPv4 loopback listener，Responses WebSocket 内部请求不会被另一 worker
+  接走；
+- 系统设置与 Provider group 计费倍率缓存使用提交后 Redis 广播和查询版本 fence；倍率缓存
+  另有 60 秒 TTL 与每进程 10,000 项上限，避免跨进程旧值和高基数内存增长；
+- worker error、缺失 exit、启动超时、crash loop 和 shutdown 都有有界监督。
+
+因此，本次没有加入 parse-only worker，也没有把终态 SQL/Redis 写回改成进程内 fire-and-forget。
+这不是保守地少做，而是当前源码约束下同时兼顾吞吐、峰值内存和账务正确性的最优第一阶段。
+
+## 判断原则
+
+评估“能否并行”必须同时回答五个问题：
+
+1. 工作是否真正在 JavaScript 主线程消耗 CPU，还是本来就在等待 DB、Redis、上游网络或 libuv？
+2. 输入和输出跨 isolate 时要复制多少字节、字符串和对象节点？
+3. 是否能转移唯一 ownership，还是主线程仍需保留原始正文或完整 AST？
+4. 任务失败、进程退出、取消或重试时，是否会漏记或重复计费、泄漏 lease、破坏 replay/affinity？
+5. 队列是否同时限制任务数和 queued bytes，并纳入 shutdown、超时和监控？
+
+仅把同步函数包装进 Promise、queueMicrotask、setImmediate 或 AsyncTaskManager 不会使用其他核心。
+worker_threads 能并行 CPU JavaScript，但普通对象使用 structured clone；child_process IPC 还需要进程
+序列化。ArrayBuffer transfer 只能转移原始字节 ownership，不能共享解析后的普通对象图。
+
+## 当前热点与可并行化候选总表
+
+### 请求侧
+
+| 工作 | 性质 | 可选并行边界 | 内存与正确性后果 | 结论 |
+| --- | --- | --- | --- | --- |
+| socket 与正文读取 | 异步 I/O、body ownership | 完整 gateway worker | primary 不读正文即可零应用级复制 | 已按请求分片 |
+| gzip、br、deflate、zstd 解压 | 大正文 CPU 和膨胀分配 | Node 异步 zlib，或粗粒度 request actor | 必须限制解压后大小、in-flight bytes 和线程池竞争 | P1 候选，不单独进程 IPC |
+| UTF-8 decode | O(body) CPU 和字符串分配 | 并入粗粒度 actor | 单独返回大字符串仍复制 | 不单拆 |
+| JSON.parse | 同步 CPU、创建完整 AST | request actor 内继续完成后续转换 | 把 AST 返回主线程会 structured clone 整棵树，峰值最危险 | 禁止 parse-only 默认方案 |
+| pretty JSON 与请求日志正文 | 重复 stringify 和大字符串 | 删除、采样或 actor 内只产小摘要 | 不能把完整 body 再发给日志 worker | P1 先消除工作 |
+| header 鉴权和 API key vacuum | 小 CPU、可能 DB/Redis I/O | 在读取大 body 前完成 | 会改变非法请求的错误优先级，需兼容测试 | P1 前移，不送 worker |
+| input rectifier | 对象树遍历和修改 | 粗粒度 request actor | 必须固定配置版本和执行顺序 | P2 候选，不单拆 |
+| 敏感词提取与匹配 | 随消息长度增长的 CPU | request actor 使用版本化词表 | 返回完整提取文本也可能很大 | 可合并，不单次 IPC |
+| request filters | JSON path、正则、deep merge/replace | request actor 使用规则快照 | provider/group 条件和错误语义必须一致 | 可合并，不单次 IPC |
+| message extraction | 多协议递归遍历 | 与过滤、指纹共同执行 | 只应返回小型摘要 | 可合并 |
+| request/replay identity | stable stringify、hash、全树扫描 | request actor | canonical 字节必须与旧实现完全一致 | 高价值 P1/P2 候选 |
+| affinity fingerprint | conversation、tool、media 规范化和 hash | request actor | 影响路由和 generation fence，需要 golden tests | 高价值 P1/P2 候选 |
+| provider selection | 本地 cache、共享 breaker、DB/Redis | 完整 gateway worker | 实时状态不适合序列化给 CPU worker | 留请求 worker |
+| provider policy、converter、最终 stringify | 对象树 CPU | 选定 provider 后的粗粒度 actor | retry、hedge 和 provider 配置使接口复杂 | profiling 后 P2 |
+| header 构造 | 小 Map 操作 | 无 | IPC 固定成本更高 | 留请求 worker |
+| upstream fetch | 异步网络和 socket pool | 多 gateway 进程 | 自建 worker 只会复制 client 与连接池 | 留请求 worker |
+| hedge、retry、Abort 调度 | timer 与有序状态机 | 完整 gateway worker | winner/loser ownership 不可切碎 | 留请求 worker |
+
+### 响应、usage 与终态
+
+| 工作 | 性质 | 可选并行边界 | 内存与正确性后果 | 结论 |
+| --- | --- | --- | --- | --- |
+| 非流式 response parse/convert/stringify | 明确正文 CPU | 一次性 response actor | transfer 原始 bytes 后应直接返回最终 bytes 和小摘要 | 先去重，profiling 后 P2 |
+| usage、model、tier、error、completion 识别 | 多处重复 parse/scan | 单个 TerminalAnalysis | 各拆一次 IPC 会放大正文和排序问题 | P1 合并为一次分析 |
+| 流式 SSE/NDJSON 分析 | 增量协议 CPU | stream pump 内维护紧凑状态 | 逐 chunk IPC 会增加排队、复制、背压和乱序面 | 禁止逐 chunk worker |
+| 终态 stream snapshot 再扫描 | 最多若干 MiB 的重复 CPU | pump 结束时直接产摘要 | 摘要必须覆盖异常、截断和 client abort | P1 增量化 |
+| Responses WebSocket frame | parse/stringify 与本机 HTTP loopback | 直接调用共享 proxy core | 连接 queue、secret、persistent upstream session 都有进程归属 | 当前用私有 loopback 保正确；P1 删除 loopback |
+| 价格查表与 Decimal 成本计算 | 通常较小 CPU | 并入 TerminalAnalysis | 必须固定 price/config 版本 | 不值得独立 IPC |
+| message/usage ledger durable commit | DB I/O、事务屏障 | transactional outbox consumer | 至少一次投递要求幂等、版本 fence、重试、DLQ、reconcile | 默认留关键路径 |
+| hedge loser 计费 | 并发终态与账务 | durable event 才可外移 | winner/loser 重复和迟到完成风险高 | 不可裸异步 |
+| Redis usage、rate-limit、lease | 网络 I/O 与限额一致性 | 仅耐久事件化 | 延迟会弱化限额，crash 会泄漏 lease | 默认留关键路径 |
+| replay completed | 有序可见性状态 | durable commit 后的小事件 | 绝不能越过 billing/message commit | 保留 commit barrier |
+| affinity/session binding CAS | generation 有序写 | 版本化 durable event | 迟到结果必须被 fence 拒绝 | 默认留关键路径 |
+| session response artifact | redact、parse/stringify 加 Redis I/O | 复用 TerminalAnalysis；可选耐久队列 | 影响续接、dashboard 可见性、TTL | CPU 可复用，写入需单独决策 |
+| routing trace/public rollup | 小事件构造与外部写 | 已提交后 outbox/consumer | 不得携带完整 body；需幂等 | 适合角色拆分 |
+| Langfuse 与详细日志 | 可产生大序列化和网络 I/O | 有界 telemetry queue | 必须有 drop/sample、queued bytes 和脱敏 | 可异步，但不能反压核心请求 |
+
+### 后台与控制面
+
+| 任务 | 多进程风险 | 当前或推荐 owner | 结论 |
+| --- | --- | --- | --- |
+| migrations | 多 worker 同时启动和等待 | slot 0；PG advisory lock | 已 gate |
+| provider vendor/endpoint backfill | 重复扫描 | slot 0；advisory lock | 已 gate |
+| ledger backfill、cache effectiveness、replay cleanup | 重复 timer，虽有 DB lock | slot 0/control | 已 gate，长期可独立 control |
+| endpoint probe/public status/probe log cleanup | 重复 leader 竞争和连接 | slot 0/control | 已 gate |
+| cloud price sync | 进程内标记不能跨进程去重 | slot 0/control | 已 gate |
+| routing trace outbox recovery | 重复扫描/竞争 | slot 0/outbox worker | 已 gate，长期可独立 worker |
+| Bull cleanup、notification、user reset | 多 gateway 注册会放大 Redis 连接 | slot 0/queue-worker | 已 gate，长期可独立扩缩 |
+| session cache cleanup | 每进程自己的 cache | 每个 gateway | 必须每 worker 运行 |
+| provider、filter、sensitive、API key、倍率 cache 订阅 | 每进程自己的只读副本 | 每个 gateway | 必须每 worker 运行并支持失效 |
+| lifecycle、Langfuse、crash diagnostics | 进程本地 | 每个 gateway | 必须每 worker 运行 |
+
+## 为什么完整请求分片优于 parse-only worker
+
+假设一个大请求包含 tools schema、长消息或 base64 图片。parse-only 方案通常同时存活：
+
+1. Fetch/Node 读取的原始字节；
+2. 解码后的 UTF-16 JavaScript 字符串；
+3. worker isolate 内的解析对象树；
+4. structured clone 到 gateway isolate 的第二棵对象树；
+5. rectifier、filter、converter 和 stringify 产生的派生对象或字符串；
+6. 排队期间其他请求的同类副本。
+
+即使输入 ArrayBuffer 可以 transfer，第 4 项仍无法通过 transfer 返回。若主线程同步等待 worker，
+Atomics.wait 还会直接阻塞 gateway event loop；若异步等待，则必须解决取消、worker crash、队列公平性、
+timeout、config snapshot、queued bytes 和 shutdown。parse-only 可能降低主线程 ELU，却增加总 CPU 与 RSS，
+因此不能仅凭“更多核心有占用”判断成功。
+
+真正可能成立的 worker_threads 边界是粗粒度 actor：主线程转移唯一输入 bytes，worker 在同一 isolate
+连续完成解压、parse、纯 CPU 过滤/指纹/转换和最终 stringify，只返回最终出站 bytes 与固定上限的
+TerminalAnalysis。它仍是 P2 实验，因为 CCH 的 DB/Redis/provider/retry 状态会把 actor 切成多个阶段，
+而完整 gateway 进程已经用更低复杂度并行了整条链路。
+
+## 内存与 ownership 约束
+
+任何后续并行化必须维持以下不变量：
+
+- primary 和控制进程不得读取、缓存或序列化请求/响应正文；
+- 一条请求的普通对象树同一时刻只属于一个 isolate；
+- IPC payload 必须是固定上限的小元数据，或 transfer 后失去发送方 ownership 的原始 bytes；
+- 队列同时限制 task count 与 queued/resident bytes，拒绝策略必须可观测；
+- 解压后大小、单任务 bytes、全局 in-flight bytes、worker heap 和结果 bytes 都有硬上限；
+- 大 body 不能因为日志、Langfuse、replay、hedge 或 retry 被无意保留多份；
+- 多 gateway 的 V8 heap、Next 模块、local cache、Redis/DB/upstream client 固定开销必须计入容器 RSS；
+- 所有“每进程上限”都要明确是否需要按 worker 分片，不能把容器预算乘以进程数。
+
+当前实现通过 socket ownership、极小 ready IPC、私有 WS loopback、聚合预算分片、最低每 worker 内存
+预留和倍率 cache 项数上限满足第一阶段约束。它不能消除完整 V8/Next runtime 的固定复制，所以低内存
+容器自动回退单进程；这比在压力下依赖 OOM killer 更可预测。
+
+## 终态正确性边界
+
+请求完成后的工作并非都可无序外移。当前关键顺序可以概括为：
+
+```text
+上游终态
+  -> 协议/usage/成本分析
+  -> durable message 与 billing commit
+  -> 已提交后的 lease、trace、artifact 等副作用
+  -> replay completed 与对外最终可见状态
+```
+
+纯分析可以合并或在粗粒度 actor 中执行；durable commit 和它前后的 fence 不能变成裸 void Promise。
+如果 profiling 最终证明数据库终态写入是主要瓶颈，唯一可靠的跨进程方向是 transactional outbox：
+
+- 与请求权威状态在同一 DB transaction 写入小事件；
+- 使用稳定幂等键和 aggregate version/generation；
+- consumer 支持至少一次投递、重试、DLQ、claim 超时和 reconciliation；
+- crash injection 证明 enqueue 前失败不会对外宣称完成，enqueue 后重投不会重复计费；
+- replay、affinity、lease 和 hedge loser 各自保持现有顺序约束。
+
+这属于事务架构升级，不应仅为让 CPU 图更均匀而实施。
+
+## 实施优先级
+
+### 已完成的 P0
+
+1. 资源感知的完整 gateway 多进程，默认 vCPU 不少于 4 才开启。
+2. cgroup CPU quota、cpuset、memory limit 与 os.availableParallelism 的保守探测。
+3. 内存和共享预算容量校验、确定性分片、显式配置 fail-fast。
+4. slot 0 背景 owner、request-only worker、本地 cache 初始化与 ready 顺序。
+5. 私有 WS loopback，避免 cluster 跨 worker 错路由和正文 IPC。
+6. worker startup/error/exit/crash-loop/shutdown 的有界监督。
+7. standalone 与 Docker 启动入口、server-lib 产物复制和部署文档。
+8. 系统设置与 Provider group 倍率跨进程提交后失效、查询版本栅栏和有界降级。
+
+### 下一阶段 P1：先减少工作和复制
+
+1. 建立真实 CPU profile、ELU、event-loop delay、GC 和 body size 分桶基线。
+2. 将可安全的 header 鉴权、Content-Length 与 byte admission 前移到读取大正文之前。
+3. 评估同步解压改为异步 zlib，并统一限制解压并发和 resident bytes。
+4. 删除不必要的 Request clone、生产 pretty body 和重复 stringify/parse。
+5. 形成一次性 TerminalAnalysis，流式协议在 pump 内增量维护摘要。
+6. 抽取可直接调用的 proxy core，删除 WS 到本机 HTTP 的重复 parse/stringify。
+7. 对 Langfuse、日志与 artifact 明确 body 截断、采样、drop 和 byte budget。
+
+### Profiling 后的 P2
+
+只有 P1 后 profile 仍显示纯 CPU 阶段占主导，才建立固定 worker_threads pool，并要求：
+
+- 复用 worker，不按请求创建；
+- byte-weighted bounded queue 和 worker heap 上限；
+- transferable ArrayBuffer 单一 ownership；
+- 粗粒度 request 或 response actor，不做 parse-only 和逐 chunk IPC；
+- config snapshot version、typed error、Abort、deadline、worker recycle、shutdown drain；
+- standalone worker bundle、source map 和产物契约测试；
+- feature flag、单线程回退和与 baseline 的 golden parity。
+
+### P3/P4
+
+- 将 control、queue-worker、admin、init 从 gateway 角色进一步拆出，独立分配 DB/Redis/CPU 预算；
+- 仅在终态存储延迟被证实为瓶颈时，使用 transactional outbox 外移可重试副作用。
+
+## Benchmark 与验收矩阵
+
+生产结论不能由单元测试或本机总 CPU 推导。至少比较单进程、auto、显式 2/4 worker，并覆盖：
+
+- 请求体：1 KiB、64 KiB、1 MiB、8 MiB、接近上限；文本、深层 JSON、大 tools、base64；
+- encoding：identity、gzip、br、deflate、zstd，以及高压缩比输入；
+- 协议：Anthropic、OpenAI、Gemini；非流式、SSE/NDJSON、Responses WebSocket；
+- 连接：大量短连接、大量 keep-alive、少量 hot keep-alive、H2 终止方式、长 WS；
+- 功能：filters、sensitive、affinity、replay、conversion、hedge、retry、Langfuse；
+- 故障：client abort、slow consumer、worker kill、slot 0 kill、Redis 短断、DB admission、shutdown；
+- 并发：32、128、512 以及真实业务峰值和 body 分布。
+
+必须按 worker 记录 CPU、ELU、event-loop delay、RSS、heap、external、arrayBuffers、GC、连接数和请求数；
+同时观察吞吐、TTFT、p50/p95/p99、错误率、DB pool、Redis latency、upstream sockets、writer pending、
+detached/replay/prebuffer bytes。少量 keep-alive 或 WS 连接可能天然倾斜，不能只看容器总 CPU。
+
+worker 或新异步边界的采用门槛至少是：固定总 CPU 下吞吐显著上升，event-loop delay 下降，p99/TTFT
+不恶化，RSS 与 queued bytes 有硬上限，并且 billing、replay、affinity、session、lease 与 WS 结果和
+baseline 完全一致。parse-only 若只改善 ELU，却增加总 CPU/RSS 或降低吞吐，应直接淘汰。
+
+## 明确不采用的方案
+
+- 每请求创建 Worker 或子进程；
+- 用 child_process IPC 搬运大请求或响应；
+- worker parse 后 structured-clone 完整 AST 回主线程；
+- 将 JSON.parse、敏感词、usage、model、error 各拆成一次 IPC；
+- 逐 SSE/NDJSON chunk 往返 worker；
+- 用 SharedArrayBuffer 试图共享普通 JavaScript object graph；
+- 用 Atomics.wait 保持同步语义并阻塞 gateway；
+- 只有 task count、没有 queued bytes 上限的 worker queue；
+- 无界增加 UV_THREADPOOL_SIZE、worker 数或每进程连接池；
+- 将 DB、Redis、fetch 等异步 I/O 搬到 CPU worker；
+- 将 billing、replay、affinity、lease 写回改为非耐久 fire-and-forget；
+- 未处理 WebSocket 进程归属就让内部 loopback 进入共享 cluster 端口；
+- 让每个 gateway 重复注册 singleton scheduler 和 Bull consumer；
+- 仅看总 CPU 使用率，不看 per-worker 连接倾斜、ELU、RSS 和共享依赖饱和。
+
+## 源码索引
+
+- 启动与资源：cluster.js、server-lib/multicore.js、server-lib/cluster-supervisor.js、server.js
+- 进程角色：src/instrumentation.ts、src/lib/lifecycle/shutdown.ts
+- 请求主链：src/app/v1/_lib/proxy-handler.ts、src/app/v1/_lib/proxy/session.ts、forwarder.ts
+- 请求 CPU：request-body-codec.ts、request-filter-engine.ts、message-extractor.ts、affinity/fingerprint.ts
+- 响应终态：response-handler.ts、client-abort-metering.ts、src/repository/message.ts
+- WebSocket：server.js、src/app/v1/_lib/responses-ws
+- cache 一致性：src/lib/redis/pubsub.ts、src/lib/cache、src/repository/provider-groups.ts
+- 部署：Dockerfile、deploy/Dockerfile、docs/k8s-deployment.md、docs/multicore-gateway.md
+
+## 官方机制参考
+
+- [Node.js Cluster](https://nodejs.org/api/cluster.html)
+- [Node.js Worker threads](https://nodejs.org/api/worker_threads.html)
+- [Node.js Child process](https://nodejs.org/api/child_process.html)
+- [Node.js Zlib](https://nodejs.org/api/zlib.html)
+- [Node.js os.availableParallelism](https://nodejs.org/api/os.html#osavailableparallelism)
+- [Node.js Performance hooks](https://nodejs.org/api/perf_hooks.html)
+- [Fetch Standard body clone](https://fetch.spec.whatwg.org/#concept-body-clone)

--- a/docs/research/gateway-multicore-parallelization-analysis.md
+++ b/docs/research/gateway-multicore-parallelization-analysis.md
@@ -15,7 +15,7 @@ SSE chunk：多个完整 gateway worker 直接从共享监听端口接收不同�
 
 本分支据此实现了资源感知的 Node cluster：
 
-- auto 仅在 production、有效 vCPU 不少于 4、内存和共享预算足够、Redis 失效通道可用时开启；
+- auto 仅在 production、有效 vCPU 不少于 4、内存和共享预算足够、Redis 失效通道已配置时开启；
 - 4 vCPU 默认 2 个 gateway worker，6 vCPU 默认 3 个，8 vCPU 及以上默认最多 4 个；
 - primary 只转交 socket handle，应用 IPC 只有 type、workerIndex、pid 三个 ready 字段；
 - 请求正文和解析后的普通 JavaScript 对象不经过 IPC，不产生第二份跨 isolate 对象树；
@@ -25,8 +25,9 @@ SSE chunk：多个完整 gateway worker 直接从共享监听端口接收不同�
 - 仅 slot 0 运行 singleton 后台任务，其余 worker 只初始化请求必需的本地状态；
 - 每个 worker 有独占的 IPv4 loopback listener，Responses WebSocket 内部请求不会被另一 worker
   接走；
-- 系统设置与 Provider group 计费倍率缓存使用提交后 Redis 广播和查询版本 fence；倍率缓存
-  另有 60 秒 TTL 与每进程 10,000 项上限，避免跨进程旧值和高基数内存增长；
+- 进程本地安全/路由缓存使用持久登记的 Redis 订阅；首次连接失败会指数退避自愈，首次订阅和重连后
+  合成 resync 强制刷新，覆盖断线期间无法补发的消息；系统设置与 Provider group 计费倍率另使用
+  提交后广播和查询版本 fence，倍率缓存有 60 秒 TTL 与每进程 10,000 项上限；
 - worker error、缺失 exit、启动超时、crash loop 和 shutdown 都有有界监督。
 
 因此，本次没有加入 parse-only worker，也没有把终态 SQL/Redis 写回改成进程内 fire-and-forget。
@@ -101,7 +102,7 @@ worker_threads 能并行 CPU JavaScript，但普通对象使用 structured clone
 | routing trace outbox recovery | 重复扫描/竞争 | slot 0/outbox worker | 已 gate，长期可独立 worker |
 | Bull cleanup、notification、user reset | 多 gateway 注册会放大 Redis 连接 | slot 0/queue-worker | 已 gate，长期可独立扩缩 |
 | session cache cleanup | 每进程自己的 cache | 每个 gateway | 必须每 worker 运行 |
-| provider、filter、sensitive、API key、倍率 cache 订阅 | 每进程自己的只读副本 | 每个 gateway | 必须每 worker 运行并支持失效 |
+| provider、filter、sensitive、API key、倍率 cache 订阅 | 每进程自己的只读副本 | 每个 gateway | 必须每 worker 持久登记、断线重试并在恢复后强制刷新 |
 | lifecycle、Langfuse、crash diagnostics | 进程本地 | 每个 gateway | 必须每 worker 运行 |
 
 ## 为什么完整请求分片优于 parse-only worker
@@ -176,7 +177,7 @@ TerminalAnalysis。它仍是 P2 实验，因为 CCH 的 DB/Redis/provider/retry 
 5. 私有 WS loopback，避免 cluster 跨 worker 错路由和正文 IPC。
 6. worker startup/error/exit/crash-loop/shutdown 的有界监督。
 7. standalone 与 Docker 启动入口、server-lib 产物复制和部署文档。
-8. 系统设置与 Provider group 倍率跨进程提交后失效、查询版本栅栏和有界降级。
+8. 全部本地安全/路由缓存的持久订阅、断线恢复 resync，以及系统设置与 Provider group 倍率的提交后失效、查询版本栅栏和有界降级。
 
 ### 下一阶段 P1：先减少工作和复制
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "tsgo -p tsconfig.json --noEmit && next dev --port 13500",
     "dev:server": "NODE_ENV=development node server.js",
     "build": "tsgo -p tsconfig.json --noEmit && next build && (node scripts/copy-version-to-standalone.cjs || bun scripts/copy-version-to-standalone.cjs) && (node scripts/copy-custom-server-to-standalone.cjs || bun scripts/copy-custom-server-to-standalone.cjs)",
-    "start": "node server.js",
+    "start": "node cluster.js",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "typecheck": "tsgo -p tsconfig.json --noEmit",

--- a/scripts/copy-custom-server-to-standalone.cjs
+++ b/scripts/copy-custom-server-to-standalone.cjs
@@ -1,16 +1,14 @@
 /**
- * Copy the custom Node server (with WebSocket upgrade support) into the
- * Next.js standalone output, overwriting the generated server.js so Docker
- * runtime (`CMD ["node", "server.js"]`) boots the custom one instead.
+ * 将支持 WebSocket upgrade 的自定义 Node 服务和资源感知型 cluster 启动器
+ * 复制到 Next.js standalone 产物。
  *
- * Also copies the `server-lib/` helper directory it depends on (e.g. the
- * standalone-config injector). Next's traced files only follow imports from
- * the compiled app, not from our custom server entry, so anything server.js
- * `require()`s from outside node_modules must be copied explicitly.
+ * 同时复制其依赖的 `server-lib/` helper 目录（例如 standalone-config 注入器）。
+ * Next 的文件追踪只跟随编译后应用的 import，不会追踪自定义服务入口，因此
+ * server.js 从 node_modules 之外 `require()` 的内容必须显式复制。
  *
- * The generated standalone server.js is the default Next.js minimal server;
- * ours wraps Next.js programmatically plus adds WebSocket upgrade handling
- * on /v1/responses. See server.js at the repo root for the full rationale.
+ * 自动生成的 standalone server.js 是 Next.js 默认最小服务；本项目入口通过
+ * 编程方式封装 Next.js，并为 /v1/responses 增加 WebSocket upgrade 处理。
+ * 完整设计原因参见仓库根目录的 server.js。
  */
 
 const fs = require("node:fs");
@@ -35,8 +33,17 @@ const serverDst = path.join(dstDir, "server.js");
 fs.copyFileSync(serverSrc, serverDst);
 console.log(`[copy-custom-server] Copied ${serverSrc} -> ${serverDst}`);
 
-// server.js requires from server-lib/, so missing it would yield a standalone
-// artifact that crashes on startup. Fail the build instead of warning.
+const clusterSrc = path.resolve(cwd, "cluster.js");
+if (!fs.existsSync(clusterSrc)) {
+  console.error(`[copy-custom-server] Cluster launcher not found at ${clusterSrc}`);
+  process.exit(1);
+}
+const clusterDst = path.join(dstDir, "cluster.js");
+fs.copyFileSync(clusterSrc, clusterDst);
+console.log(`[copy-custom-server] Copied ${clusterSrc} -> ${clusterDst}`);
+
+// server.js 会从 server-lib/ 加载依赖；缺失它会让 standalone 产物启动即崩溃，
+// 因此直接令构建失败，而不是只告警。
 const libSrc = path.resolve(cwd, "server-lib");
 if (!fs.existsSync(libSrc)) {
   console.error(

--- a/scripts/copy-version-to-standalone.cjs
+++ b/scripts/copy-version-to-standalone.cjs
@@ -25,8 +25,8 @@ fs.mkdirSync(dstDir, { recursive: true });
 fs.copyFileSync(src, dst);
 console.log(`[copy-version] Copied VERSION -> ${dst}`);
 
-// Make standalone output self-contained for local `node .next/standalone/server.js` runs.
-// Next.js standalone requires `.next/static` and `public` to exist next to `server.js`.
+// 让 standalone 产物可直接执行 `node .next/standalone/cluster.js`。
+// Next.js standalone 要求 `.next/static` 和 `public` 与 `server.js` 位于同级目录。
 copyDirIfExists(
   path.resolve(process.cwd(), ".next", "static"),
   path.resolve(dstDir, ".next", "static")

--- a/server-lib/cluster-supervisor.js
+++ b/server-lib/cluster-supervisor.js
@@ -249,6 +249,20 @@ function createClusterSupervisor(options) {
     if (failureCount !== null) scheduleRestart(record.slot, failureCount);
   }
 
+  function handleWorkerError(record, error) {
+    // cluster.Worker 会把异步 spawn/IPC 错误作为 `error` 事件抛出。这里必须
+    // 消费该事件以免 EventEmitter 击穿 primary；崩溃计数与重启仍统一由
+    // `exit` 路径负责，避免同一次故障被重复计数或重复拉起。
+    if (workersBySlot.get(record.slot) !== record) return;
+    emitLog("error", "multicore_worker_error", {
+      workerIndex: record.slot,
+      pid: workerPid(record.worker),
+      ready: record.ready,
+      shuttingDown,
+      error: String(error?.message || error),
+    });
+  }
+
   function handleWorkerReady(record, message) {
     if (
       message?.type !== WORKER_READY_MESSAGE_TYPE ||
@@ -256,6 +270,13 @@ function createClusterSupervisor(options) {
       record.ready ||
       shuttingDown
     ) {
+      return;
+    }
+    if (record.startupTimedOut) {
+      emitLog("warn", "multicore_worker_ready_after_timeout", {
+        workerIndex: record.slot,
+        pid: workerPid(record.worker),
+      });
       return;
     }
     record.ready = true;
@@ -300,12 +321,21 @@ function createClusterSupervisor(options) {
       return null;
     }
 
-    const record = { slot, worker, ready: false, readyTimer: null, readyKillTimer: null };
+    const record = {
+      slot,
+      worker,
+      ready: false,
+      startupTimedOut: false,
+      readyTimer: null,
+      readyKillTimer: null,
+    };
     workersBySlot.set(slot, record);
     worker.on("message", (message) => handleWorkerReady(record, message));
+    worker.on("error", (error) => handleWorkerError(record, error));
     worker.once("exit", (code, signal) => handleWorkerExit(record, code, signal));
     record.readyTimer = setTimer(() => {
       if (workersBySlot.get(slot) !== record || record.ready || shuttingDown) return;
+      record.startupTimedOut = true;
       emitLog("error", "multicore_worker_ready_timeout", {
         workerIndex: slot,
         pid: workerPid(worker),
@@ -313,7 +343,7 @@ function createClusterSupervisor(options) {
       });
       sendWorkerSignal(worker, "SIGTERM");
       record.readyKillTimer = setTimer(() => {
-        if (workersBySlot.get(slot) !== record || record.ready || shuttingDown) return;
+        if (workersBySlot.get(slot) !== record || shuttingDown) return;
         emitLog("error", "multicore_worker_ready_force_kill", {
           workerIndex: slot,
           pid: workerPid(worker),

--- a/server-lib/cluster-supervisor.js
+++ b/server-lib/cluster-supervisor.js
@@ -9,6 +9,7 @@ const DEFAULT_RESTART_BASE_DELAY_MS = 250;
 const DEFAULT_RESTART_MAX_DELAY_MS = 10_000;
 const DEFAULT_FORCE_EXIT_GRACE_MS = 1_000;
 const DEFAULT_READY_KILL_GRACE_MS = 5_000;
+const DEFAULT_WORKER_ERROR_EXIT_GRACE_MS = 1_000;
 
 function parsePositiveInteger(raw, fallback, name) {
   if (raw === undefined || raw === null || String(raw).trim() === "") return fallback;
@@ -48,6 +49,7 @@ function resolveSupervisorSettings(env = process.env) {
     restartBaseDelayMs: DEFAULT_RESTART_BASE_DELAY_MS,
     restartMaxDelayMs: DEFAULT_RESTART_MAX_DELAY_MS,
     forceExitGraceMs: DEFAULT_FORCE_EXIT_GRACE_MS,
+    workerErrorExitGraceMs: DEFAULT_WORKER_ERROR_EXIT_GRACE_MS,
   };
 }
 
@@ -86,6 +88,15 @@ function createClusterSupervisor(options) {
 
   function safeClearTimer(timer) {
     if (timer !== null && timer !== undefined) clearTimer(timer);
+  }
+
+  function clearWorkerTimers(record) {
+    safeClearTimer(record.readyTimer);
+    safeClearTimer(record.terminationTimer);
+    safeClearTimer(record.exitFallbackTimer);
+    record.readyTimer = null;
+    record.terminationTimer = null;
+    record.exitFallbackTimer = null;
   }
 
   function emitLog(level, event, payload = {}) {
@@ -148,10 +159,7 @@ function createClusterSupervisor(options) {
     for (const timer of restartTimers.values()) safeClearTimer(timer);
     restartTimers.clear();
     for (const record of workersBySlot.values()) {
-      safeClearTimer(record.readyTimer);
-      safeClearTimer(record.readyKillTimer);
-      record.readyTimer = null;
-      record.readyKillTimer = null;
+      clearWorkerTimers(record);
       sendWorkerSignal(record.worker, signal);
     }
 
@@ -219,12 +227,9 @@ function createClusterSupervisor(options) {
     restartTimers.set(slot, timer);
   }
 
-  function handleWorkerExit(record, code, signal) {
+  function handleWorkerExit(record, code, signal, metadata = {}) {
     if (workersBySlot.get(record.slot) !== record) return;
-    safeClearTimer(record.readyTimer);
-    safeClearTimer(record.readyKillTimer);
-    record.readyTimer = null;
-    record.readyKillTimer = null;
+    clearWorkerTimers(record);
     workersBySlot.delete(record.slot);
 
     if (shuttingDown) {
@@ -235,6 +240,7 @@ function createClusterSupervisor(options) {
         code: code ?? null,
         signal: signal ?? null,
         shutdownSignal,
+        ...metadata,
       });
       maybeFinishShutdown();
       return;
@@ -245,8 +251,37 @@ function createClusterSupervisor(options) {
       code: code ?? null,
       signal: signal ?? null,
       ready: record.ready,
+      terminationReason: record.terminationReason,
+      ...metadata,
     });
     if (failureCount !== null) scheduleRestart(record.slot, failureCount);
+  }
+
+  function forceKillWorkerAndBoundExit(record, reason, event, payload = {}) {
+    if (workersBySlot.get(record.slot) !== record || shuttingDown) return;
+
+    emitLog("error", event, {
+      workerIndex: record.slot,
+      pid: workerPid(record.worker),
+      ...payload,
+    });
+    sendWorkerSignal(record.worker, "SIGKILL");
+    if (workersBySlot.get(record.slot) !== record || shuttingDown) return;
+    record.exitFallbackTimer = setTimer(() => {
+      if (workersBySlot.get(record.slot) !== record || shuttingDown) return;
+      emitLog("error", "multicore_worker_exit_missing", {
+        workerIndex: record.slot,
+        pid: workerPid(record.worker),
+        reason,
+        graceMs: settings.forceExitGraceMs,
+      });
+      // child_process 不保证 error 后仍触发 exit。强杀后若仍缺少 exit，
+      // 合成一次终态释放 slot；迟到的真实 exit 会被 record 身份检查忽略。
+      handleWorkerExit(record, null, "SIGKILL", {
+        synthetic: true,
+        terminationReason: reason,
+      });
+    }, settings.forceExitGraceMs);
   }
 
   function handleWorkerError(record, error) {
@@ -261,6 +296,21 @@ function createClusterSupervisor(options) {
       shuttingDown,
       error: String(error?.message || error),
     });
+    if (shuttingDown || record.terminationReason !== null) return;
+
+    // Node 不保证 error 之后仍会触发 exit。先给自然 exit 一个短窗口，
+    // 再强杀并由统一 exit 路径有界完成 slot 回收。
+    record.terminationReason = "worker_error";
+    safeClearTimer(record.readyTimer);
+    record.readyTimer = null;
+    record.terminationTimer = setTimer(() => {
+      forceKillWorkerAndBoundExit(
+        record,
+        "worker_error",
+        "multicore_worker_error_force_kill",
+        { graceMs: settings.workerErrorExitGraceMs }
+      );
+    }, settings.workerErrorExitGraceMs);
   }
 
   function handleWorkerReady(record, message) {
@@ -279,11 +329,9 @@ function createClusterSupervisor(options) {
       });
       return;
     }
+    if (record.terminationReason !== null) return;
     record.ready = true;
-    safeClearTimer(record.readyTimer);
-    safeClearTimer(record.readyKillTimer);
-    record.readyTimer = null;
-    record.readyKillTimer = null;
+    clearWorkerTimers(record);
     emitLog("info", "multicore_worker_ready", {
       workerIndex: record.slot,
       pid: workerPid(record.worker),
@@ -326,8 +374,10 @@ function createClusterSupervisor(options) {
       worker,
       ready: false,
       startupTimedOut: false,
+      terminationReason: null,
       readyTimer: null,
-      readyKillTimer: null,
+      terminationTimer: null,
+      exitFallbackTimer: null,
     };
     workersBySlot.set(slot, record);
     worker.on("message", (message) => handleWorkerReady(record, message));
@@ -336,20 +386,20 @@ function createClusterSupervisor(options) {
     record.readyTimer = setTimer(() => {
       if (workersBySlot.get(slot) !== record || record.ready || shuttingDown) return;
       record.startupTimedOut = true;
+      record.terminationReason = "ready_timeout";
       emitLog("error", "multicore_worker_ready_timeout", {
         workerIndex: slot,
         pid: workerPid(worker),
         timeoutMs: settings.readyTimeoutMs,
       });
       sendWorkerSignal(worker, "SIGTERM");
-      record.readyKillTimer = setTimer(() => {
-        if (workersBySlot.get(slot) !== record || shuttingDown) return;
-        emitLog("error", "multicore_worker_ready_force_kill", {
-          workerIndex: slot,
-          pid: workerPid(worker),
-          graceMs: settings.readyKillGraceMs,
-        });
-        sendWorkerSignal(worker, "SIGKILL");
+      record.terminationTimer = setTimer(() => {
+        forceKillWorkerAndBoundExit(
+          record,
+          "ready_timeout",
+          "multicore_worker_ready_force_kill",
+          { graceMs: settings.readyKillGraceMs }
+        );
       }, settings.readyKillGraceMs);
     }, settings.readyTimeoutMs);
 
@@ -399,6 +449,7 @@ module.exports = {
   DEFAULT_RESTART_BASE_DELAY_MS,
   DEFAULT_RESTART_MAX_DELAY_MS,
   DEFAULT_RESTART_WINDOW_MS,
+  DEFAULT_WORKER_ERROR_EXIT_GRACE_MS,
   createClusterSupervisor,
   resolveSupervisorSettings,
 };

--- a/server-lib/cluster-supervisor.js
+++ b/server-lib/cluster-supervisor.js
@@ -1,0 +1,374 @@
+"use strict";
+
+const { WORKER_READY_MESSAGE_TYPE, buildWorkerEnvironment } = require("./multicore");
+
+const DEFAULT_READY_TIMEOUT_MS = 180_000;
+const DEFAULT_RESTART_WINDOW_MS = 60_000;
+const DEFAULT_MAX_RESTARTS_PER_WINDOW = 5;
+const DEFAULT_RESTART_BASE_DELAY_MS = 250;
+const DEFAULT_RESTART_MAX_DELAY_MS = 10_000;
+const DEFAULT_FORCE_EXIT_GRACE_MS = 1_000;
+const DEFAULT_READY_KILL_GRACE_MS = 5_000;
+
+function parsePositiveInteger(raw, fallback, name) {
+  if (raw === undefined || raw === null || String(raw).trim() === "") return fallback;
+  const value = Number(String(raw).trim());
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function resolveSupervisorSettings(env = process.env) {
+  const workerHardExitMs = parsePositiveInteger(
+    env.SHUTDOWN_HARD_EXIT_MS,
+    28_000,
+    "SHUTDOWN_HARD_EXIT_MS"
+  );
+  const shutdownTimeoutMs = parsePositiveInteger(
+    env.CCH_MULTICORE_SHUTDOWN_TIMEOUT_MS,
+    workerHardExitMs + 5_000,
+    "CCH_MULTICORE_SHUTDOWN_TIMEOUT_MS"
+  );
+  if (shutdownTimeoutMs <= workerHardExitMs) {
+    throw new Error(
+      "CCH_MULTICORE_SHUTDOWN_TIMEOUT_MS must exceed SHUTDOWN_HARD_EXIT_MS"
+    );
+  }
+  return {
+    readyTimeoutMs: parsePositiveInteger(
+      env.CCH_MULTICORE_READY_TIMEOUT_MS,
+      DEFAULT_READY_TIMEOUT_MS,
+      "CCH_MULTICORE_READY_TIMEOUT_MS"
+    ),
+    readyKillGraceMs: DEFAULT_READY_KILL_GRACE_MS,
+    shutdownTimeoutMs,
+    restartWindowMs: DEFAULT_RESTART_WINDOW_MS,
+    maxRestartsPerWindow: DEFAULT_MAX_RESTARTS_PER_WINDOW,
+    restartBaseDelayMs: DEFAULT_RESTART_BASE_DELAY_MS,
+    restartMaxDelayMs: DEFAULT_RESTART_MAX_DELAY_MS,
+    forceExitGraceMs: DEFAULT_FORCE_EXIT_GRACE_MS,
+  };
+}
+
+function createClusterSupervisor(options) {
+  if (!options?.clusterModule || typeof options.clusterModule.fork !== "function") {
+    throw new TypeError("clusterModule with fork() is required");
+  }
+  if (!options.plan?.enabled || options.plan.workerCount < 2) {
+    throw new TypeError("An enabled multicore plan with at least two workers is required");
+  }
+
+  const clusterModule = options.clusterModule;
+  const plan = options.plan;
+  const processRef = options.processRef || process;
+  const log = typeof options.log === "function" ? options.log : () => {};
+  const now = typeof options.now === "function" ? options.now : Date.now;
+  const setTimer = options.setTimeoutFn || setTimeout;
+  const clearTimer = options.clearTimeoutFn || clearTimeout;
+  const exit = options.exit || ((code) => processRef.exit(code));
+  const settings = {
+    ...resolveSupervisorSettings(options.env || processRef.env),
+    ...(options.settings || {}),
+  };
+
+  const workersBySlot = new Map();
+  const restartTimers = new Map();
+  const crashTimesBySlot = new Map();
+  let started = false;
+  let shuttingDown = false;
+  let secondaryWorkersStarted = false;
+  let shutdownSignal = null;
+  let requestedExitCode = 0;
+  let shutdownTimer = null;
+  let forceExitTimer = null;
+  let exited = false;
+
+  function safeClearTimer(timer) {
+    if (timer !== null && timer !== undefined) clearTimer(timer);
+  }
+
+  function emitLog(level, event, payload = {}) {
+    log(level, event, payload);
+  }
+
+  function workerPid(worker) {
+    return worker?.process?.pid ?? null;
+  }
+
+  function finishPrimary(code) {
+    if (exited) return;
+    exited = true;
+    safeClearTimer(shutdownTimer);
+    safeClearTimer(forceExitTimer);
+    emitLog(code === 0 ? "info" : "error", "multicore_primary_exit", { code });
+    exit(code);
+  }
+
+  function maybeFinishShutdown() {
+    if (!shuttingDown || workersBySlot.size > 0 || restartTimers.size > 0) return;
+    finishPrimary(requestedExitCode);
+  }
+
+  function sendWorkerSignal(worker, signal) {
+    try {
+      if (worker?.process && typeof worker.process.kill === "function") {
+        worker.process.kill(signal);
+        return true;
+      }
+      if (typeof worker?.kill === "function") {
+        worker.kill(signal);
+        return true;
+      }
+    } catch (error) {
+      emitLog("warn", "multicore_worker_signal_failed", {
+        pid: workerPid(worker),
+        signal,
+        error: String(error?.message || error),
+      });
+    }
+    return false;
+  }
+
+  function beginShutdown(signal, exitCode = 0, reason = "signal") {
+    if (shuttingDown) {
+      requestedExitCode = Math.max(requestedExitCode, exitCode);
+      return;
+    }
+    shuttingDown = true;
+    shutdownSignal = signal;
+    requestedExitCode = exitCode;
+    emitLog("info", "multicore_shutdown_started", {
+      signal,
+      reason,
+      workers: workersBySlot.size,
+      timeoutMs: settings.shutdownTimeoutMs,
+    });
+
+    for (const timer of restartTimers.values()) safeClearTimer(timer);
+    restartTimers.clear();
+    for (const record of workersBySlot.values()) {
+      safeClearTimer(record.readyTimer);
+      safeClearTimer(record.readyKillTimer);
+      record.readyTimer = null;
+      record.readyKillTimer = null;
+      sendWorkerSignal(record.worker, signal);
+    }
+
+    if (workersBySlot.size === 0) {
+      maybeFinishShutdown();
+      return;
+    }
+
+    shutdownTimer = setTimer(() => {
+      requestedExitCode = 1;
+      emitLog("error", "multicore_shutdown_timeout", {
+        timeoutMs: settings.shutdownTimeoutMs,
+        remainingWorkers: workersBySlot.size,
+      });
+      for (const record of workersBySlot.values()) {
+        sendWorkerSignal(record.worker, "SIGKILL");
+      }
+      if (workersBySlot.size === 0) {
+        maybeFinishShutdown();
+        return;
+      }
+      forceExitTimer = setTimer(() => finishPrimary(1), settings.forceExitGraceMs);
+    }, settings.shutdownTimeoutMs);
+  }
+
+  function recordCrash(slot, details) {
+    const cutoff = now() - settings.restartWindowMs;
+    const crashTimes = (crashTimesBySlot.get(slot) || []).filter((value) => value >= cutoff);
+    crashTimes.push(now());
+    crashTimesBySlot.set(slot, crashTimes);
+
+    emitLog("warn", "multicore_worker_exited", {
+      workerIndex: slot,
+      restartCount: crashTimes.length,
+      restartWindowMs: settings.restartWindowMs,
+      ...details,
+    });
+
+    if (crashTimes.length >= settings.maxRestartsPerWindow) {
+      emitLog("error", "multicore_worker_crash_loop", {
+        workerIndex: slot,
+        crashes: crashTimes.length,
+        restartWindowMs: settings.restartWindowMs,
+      });
+      beginShutdown("SIGTERM", 1, "worker_crash_loop");
+      return null;
+    }
+    return crashTimes.length;
+  }
+
+  function scheduleRestart(slot, failureCount) {
+    if (shuttingDown || restartTimers.has(slot)) return;
+    const delayMs = Math.min(
+      settings.restartBaseDelayMs * 2 ** Math.max(0, failureCount - 1),
+      settings.restartMaxDelayMs
+    );
+    emitLog("info", "multicore_worker_restart_scheduled", {
+      workerIndex: slot,
+      delayMs,
+    });
+    const timer = setTimer(() => {
+      restartTimers.delete(slot);
+      forkSlot(slot);
+    }, delayMs);
+    restartTimers.set(slot, timer);
+  }
+
+  function handleWorkerExit(record, code, signal) {
+    if (workersBySlot.get(record.slot) !== record) return;
+    safeClearTimer(record.readyTimer);
+    safeClearTimer(record.readyKillTimer);
+    record.readyTimer = null;
+    record.readyKillTimer = null;
+    workersBySlot.delete(record.slot);
+
+    if (shuttingDown) {
+      if (typeof code === "number" && code !== 0) requestedExitCode = 1;
+      emitLog("info", "multicore_worker_stopped", {
+        workerIndex: record.slot,
+        pid: workerPid(record.worker),
+        code: code ?? null,
+        signal: signal ?? null,
+        shutdownSignal,
+      });
+      maybeFinishShutdown();
+      return;
+    }
+
+    const failureCount = recordCrash(record.slot, {
+      pid: workerPid(record.worker),
+      code: code ?? null,
+      signal: signal ?? null,
+      ready: record.ready,
+    });
+    if (failureCount !== null) scheduleRestart(record.slot, failureCount);
+  }
+
+  function handleWorkerReady(record, message) {
+    if (
+      message?.type !== WORKER_READY_MESSAGE_TYPE ||
+      workersBySlot.get(record.slot) !== record ||
+      record.ready ||
+      shuttingDown
+    ) {
+      return;
+    }
+    record.ready = true;
+    safeClearTimer(record.readyTimer);
+    safeClearTimer(record.readyKillTimer);
+    record.readyTimer = null;
+    record.readyKillTimer = null;
+    emitLog("info", "multicore_worker_ready", {
+      workerIndex: record.slot,
+      pid: workerPid(record.worker),
+      backgroundOwner: record.slot === 0,
+    });
+
+    if (record.slot === 0 && !secondaryWorkersStarted) {
+      secondaryWorkersStarted = true;
+      for (let slot = 1; slot < plan.workerCount; slot += 1) forkSlot(slot);
+    }
+
+    if (workersBySlot.size === plan.workerCount) {
+      const readyCount = Array.from(workersBySlot.values()).filter((item) => item.ready).length;
+      if (readyCount === plan.workerCount) {
+        emitLog("info", "multicore_cluster_ready", { workerCount: plan.workerCount });
+      }
+    }
+  }
+
+  function forkSlot(slot) {
+    if (shuttingDown || workersBySlot.has(slot)) return null;
+
+    let worker;
+    try {
+      worker = clusterModule.fork(buildWorkerEnvironment(plan, slot));
+    } catch (error) {
+      const failureCount = recordCrash(slot, {
+        pid: null,
+        code: null,
+        signal: null,
+        ready: false,
+        error: String(error?.message || error),
+      });
+      if (failureCount !== null) scheduleRestart(slot, failureCount);
+      return null;
+    }
+
+    const record = { slot, worker, ready: false, readyTimer: null, readyKillTimer: null };
+    workersBySlot.set(slot, record);
+    worker.on("message", (message) => handleWorkerReady(record, message));
+    worker.once("exit", (code, signal) => handleWorkerExit(record, code, signal));
+    record.readyTimer = setTimer(() => {
+      if (workersBySlot.get(slot) !== record || record.ready || shuttingDown) return;
+      emitLog("error", "multicore_worker_ready_timeout", {
+        workerIndex: slot,
+        pid: workerPid(worker),
+        timeoutMs: settings.readyTimeoutMs,
+      });
+      sendWorkerSignal(worker, "SIGTERM");
+      record.readyKillTimer = setTimer(() => {
+        if (workersBySlot.get(slot) !== record || record.ready || shuttingDown) return;
+        emitLog("error", "multicore_worker_ready_force_kill", {
+          workerIndex: slot,
+          pid: workerPid(worker),
+          graceMs: settings.readyKillGraceMs,
+        });
+        sendWorkerSignal(worker, "SIGKILL");
+      }, settings.readyKillGraceMs);
+    }, settings.readyTimeoutMs);
+
+    emitLog("info", "multicore_worker_started", {
+      workerIndex: slot,
+      pid: workerPid(worker),
+      backgroundOwner: slot === 0,
+    });
+    return worker;
+  }
+
+  function start() {
+    if (started) throw new Error("Cluster supervisor has already been started");
+    started = true;
+    if (options.registerSignals !== false) {
+      processRef.once("SIGTERM", () => beginShutdown("SIGTERM"));
+      processRef.once("SIGINT", () => beginShutdown("SIGINT"));
+    }
+    forkSlot(0);
+    return api;
+  }
+
+  function snapshot() {
+    return {
+      started,
+      shuttingDown,
+      secondaryWorkersStarted,
+      workerSlots: Array.from(workersBySlot.keys()).sort((left, right) => left - right),
+      readySlots: Array.from(workersBySlot.values())
+        .filter((record) => record.ready)
+        .map((record) => record.slot)
+        .sort((left, right) => left - right),
+      restartSlots: Array.from(restartTimers.keys()).sort((left, right) => left - right),
+      requestedExitCode,
+      exited,
+    };
+  }
+
+  const api = { beginShutdown, snapshot, start };
+  return api;
+}
+
+module.exports = {
+  DEFAULT_MAX_RESTARTS_PER_WINDOW,
+  DEFAULT_READY_TIMEOUT_MS,
+  DEFAULT_READY_KILL_GRACE_MS,
+  DEFAULT_RESTART_BASE_DELAY_MS,
+  DEFAULT_RESTART_MAX_DELAY_MS,
+  DEFAULT_RESTART_WINDOW_MS,
+  createClusterSupervisor,
+  resolveSupervisorSettings,
+};

--- a/server-lib/multicore.js
+++ b/server-lib/multicore.js
@@ -1,0 +1,534 @@
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+
+const MIB = 1024 * 1024;
+const WORKER_READY_MESSAGE_TYPE = "cch:gateway-ready";
+const DEFAULT_AUTO_MAX_WORKERS = 4;
+const MAX_EXPLICIT_WORKERS = 32;
+const DEFAULT_MEMORY_PER_WORKER_MB = 1024;
+const DEFAULT_PRIMARY_MEMORY_RESERVE_MB = 256;
+
+const CGROUP_FILES = Object.freeze({
+  cpuMaxV2: "/sys/fs/cgroup/cpu.max",
+  cpuQuotaV1: "/sys/fs/cgroup/cpu/cpu.cfs_quota_us",
+  cpuPeriodV1: "/sys/fs/cgroup/cpu/cpu.cfs_period_us",
+  cpuQuotaV1Combined: "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us",
+  cpuPeriodV1Combined: "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us",
+  cpuQuotaV1Root: "/sys/fs/cgroup/cpu.cfs_quota_us",
+  cpuPeriodV1Root: "/sys/fs/cgroup/cpu.cfs_period_us",
+  cpusetV2: "/sys/fs/cgroup/cpuset.cpus.effective",
+  cpusetV1: "/sys/fs/cgroup/cpuset/cpuset.cpus",
+  cpusetV1Root: "/sys/fs/cgroup/cpuset.cpus",
+  memoryMaxV2: "/sys/fs/cgroup/memory.max",
+  memoryLimitV1: "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+  memoryLimitV1Root: "/sys/fs/cgroup/memory.limit_in_bytes",
+});
+
+function readTextFile(readFileSync, filePath) {
+  try {
+    return String(readFileSync(filePath, "utf8")).trim();
+  } catch {
+    return null;
+  }
+}
+
+function parseCpuMax(raw) {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  const [quotaRaw, periodRaw] = raw.trim().split(/\s+/);
+  if (quotaRaw === "max") return Number.POSITIVE_INFINITY;
+  const quota = Number(quotaRaw);
+  const period = Number(periodRaw);
+  if (!Number.isFinite(quota) || quota <= 0 || !Number.isFinite(period) || period <= 0) {
+    return null;
+  }
+  return quota / period;
+}
+
+function parseCpuSet(raw) {
+  if (typeof raw !== "string" || raw.trim().length === 0) return null;
+
+  const ranges = [];
+  for (const item of raw.split(",")) {
+    const token = item.trim();
+    if (!token) return null;
+    const match = /^(\d+)(?:-(\d+))?$/.exec(token);
+    if (!match) return null;
+    const start = Number(match[1]);
+    const end = match[2] === undefined ? start : Number(match[2]);
+    if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || end < start) return null;
+    ranges.push([start, end]);
+  }
+
+  ranges.sort((left, right) => left[0] - right[0]);
+  let count = 0;
+  let currentStart = ranges[0][0];
+  let currentEnd = ranges[0][1];
+  for (let index = 1; index < ranges.length; index += 1) {
+    const [start, end] = ranges[index];
+    if (start <= currentEnd + 1) {
+      currentEnd = Math.max(currentEnd, end);
+      continue;
+    }
+    count += currentEnd - currentStart + 1;
+    currentStart = start;
+    currentEnd = end;
+  }
+  count += currentEnd - currentStart + 1;
+  return count > 0 ? count : null;
+}
+
+function parseMemoryLimit(raw) {
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  if (raw.trim() === "max") return Number.POSITIVE_INFINITY;
+  if (!/^\d+$/.test(raw.trim())) return null;
+  const bytes = Number(raw.trim());
+  return Number.isFinite(bytes) && bytes > 0 ? bytes : null;
+}
+
+function detectRuntimeResources(options = {}) {
+  const osModule = options.osModule || os;
+  const readFileSync = options.readFileSync || fs.readFileSync;
+
+  let availableCpu;
+  try {
+    availableCpu = Number(osModule.availableParallelism?.());
+  } catch {
+    availableCpu = Number.NaN;
+  }
+  if (!Number.isFinite(availableCpu) || availableCpu < 1) {
+    try {
+      availableCpu = osModule.cpus().length;
+    } catch {
+      availableCpu = 1;
+    }
+  }
+  availableCpu = Math.max(1, Math.floor(availableCpu));
+
+  const cpuMaxV2Raw = readTextFile(readFileSync, CGROUP_FILES.cpuMaxV2);
+  let cpuQuota = parseCpuMax(cpuMaxV2Raw);
+  if (cpuQuota === null) {
+    const v1CpuPaths = [
+      [CGROUP_FILES.cpuQuotaV1, CGROUP_FILES.cpuPeriodV1],
+      [CGROUP_FILES.cpuQuotaV1Combined, CGROUP_FILES.cpuPeriodV1Combined],
+      [CGROUP_FILES.cpuQuotaV1Root, CGROUP_FILES.cpuPeriodV1Root],
+    ];
+    for (const [quotaPath, periodPath] of v1CpuPaths) {
+      const quota = Number(readTextFile(readFileSync, quotaPath));
+      const period = Number(readTextFile(readFileSync, periodPath));
+      if (Number.isFinite(quota) && quota > 0 && Number.isFinite(period) && period > 0) {
+        cpuQuota = quota / period;
+        break;
+      }
+    }
+  }
+
+  const cpusetRaw =
+    readTextFile(readFileSync, CGROUP_FILES.cpusetV2) ||
+    readTextFile(readFileSync, CGROUP_FILES.cpusetV1) ||
+    readTextFile(readFileSync, CGROUP_FILES.cpusetV1Root);
+  const cpusetCpu = parseCpuSet(cpusetRaw);
+
+  const cpuCandidates = [availableCpu];
+  if (Number.isFinite(cpuQuota)) cpuCandidates.push(cpuQuota);
+  if (Number.isFinite(cpusetCpu)) cpuCandidates.push(cpusetCpu);
+  const effectiveCpu = Math.max(1, Math.floor(Math.min(...cpuCandidates)));
+
+  let hostMemoryBytes;
+  try {
+    hostMemoryBytes = Number(osModule.totalmem());
+  } catch {
+    hostMemoryBytes = Number.MAX_SAFE_INTEGER;
+  }
+  if (!Number.isFinite(hostMemoryBytes) || hostMemoryBytes <= 0) {
+    hostMemoryBytes = Number.MAX_SAFE_INTEGER;
+  }
+
+  const memoryMaxV2Raw = readTextFile(readFileSync, CGROUP_FILES.memoryMaxV2);
+  let cgroupMemoryBytes = parseMemoryLimit(memoryMaxV2Raw);
+  if (cgroupMemoryBytes === null) {
+    cgroupMemoryBytes = parseMemoryLimit(
+      readTextFile(readFileSync, CGROUP_FILES.memoryLimitV1)
+    );
+  }
+  if (cgroupMemoryBytes === null) {
+    cgroupMemoryBytes = parseMemoryLimit(
+      readTextFile(readFileSync, CGROUP_FILES.memoryLimitV1Root)
+    );
+  }
+  const finiteCgroupMemoryBytes = Number.isFinite(cgroupMemoryBytes)
+    ? cgroupMemoryBytes
+    : null;
+  const effectiveMemoryBytes = Math.floor(
+    Math.min(hostMemoryBytes, finiteCgroupMemoryBytes ?? hostMemoryBytes)
+  );
+
+  return {
+    availableCpu,
+    cpuQuota: Number.isFinite(cpuQuota) ? cpuQuota : null,
+    cpusetCpu,
+    effectiveCpu,
+    hostMemoryBytes: Math.floor(hostMemoryBytes),
+    cgroupMemoryBytes: finiteCgroupMemoryBytes,
+    effectiveMemoryBytes,
+  };
+}
+
+function parseOptionalInteger(env, name, constraints = {}) {
+  const raw = env[name];
+  if (raw === undefined || raw === null || String(raw).trim() === "") return undefined;
+  const normalized = String(raw).trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`${name} must be an integer`);
+  }
+  const value = Number(normalized);
+  if (!Number.isSafeInteger(value)) throw new Error(`${name} is outside the safe integer range`);
+  if (constraints.min !== undefined && value < constraints.min) {
+    throw new Error(`${name} must be at least ${constraints.min}`);
+  }
+  if (constraints.max !== undefined && value > constraints.max) {
+    throw new Error(`${name} must be at most ${constraints.max}`);
+  }
+  return value;
+}
+
+function parseIntegerWithDefault(env, name, defaultValue, constraints = {}) {
+  return parseOptionalInteger(env, name, constraints) ?? defaultValue;
+}
+
+function parseMulticoreMode(raw) {
+  const normalized = String(raw ?? "auto")
+    .trim()
+    .toLowerCase();
+  if (normalized === "auto") return "auto";
+  if (["on", "true", "enabled"].includes(normalized)) return "on";
+  if (["off", "false", "disabled"].includes(normalized)) return "off";
+  throw new Error("CCH_MULTICORE_MODE must be one of auto, on, or off");
+}
+
+function hasCrossProcessInvalidation(env) {
+  const redisUrl = String(env.REDIS_URL ?? "").trim();
+  const rateLimitMode = String(env.ENABLE_RATE_LIMIT ?? "true")
+    .trim()
+    .toLowerCase();
+  return redisUrl.length > 0 && rateLimitMode !== "false" && rateLimitMode !== "0";
+}
+
+function assertCrossProcessInvalidation(env) {
+  if (hasCrossProcessInvalidation(env)) return;
+  throw new Error(
+    "Multicore gateway workers require REDIS_URL and ENABLE_RATE_LIMIT must not be false, " +
+      "so process-local security and routing caches can be invalidated across workers"
+  );
+}
+
+function allocateIntegerBudget(total, workerCount) {
+  if (!Number.isSafeInteger(total) || total < 0) throw new TypeError("total must be an integer");
+  if (!Number.isSafeInteger(workerCount) || workerCount < 1) {
+    throw new TypeError("workerCount must be a positive integer");
+  }
+  const base = Math.floor(total / workerCount);
+  const remainder = total % workerCount;
+  return Array.from({ length: workerCount }, (_, index) => base + (index < remainder ? 1 : 0));
+}
+
+function resolveAggregateBudgets(env) {
+  const production = env.NODE_ENV === "production";
+  const streamGatePerRequestBytes = parseIntegerWithDefault(
+    env,
+    "STREAM_GATE_PREBUFFER_BYTE_CAP",
+    10 * MIB,
+    { min: 1024, max: 64 * MIB }
+  );
+
+  const definitions = [
+    {
+      name: "DB_POOL_MAX",
+      defaultValue: production ? 20 : 10,
+      minPerWorker: 1,
+      max: 200,
+    },
+    {
+      name: "MESSAGE_REQUEST_ASYNC_MAX_PENDING",
+      defaultValue: 5000,
+      minPerWorker: 100,
+      max: 200000,
+    },
+    {
+      name: "DETACHED_STREAM_MAX_CONCURRENCY",
+      defaultValue: 64,
+      minPerWorker: 1,
+      max: 4096,
+    },
+    {
+      name: "DETACHED_STREAM_BUDGET_BYTES",
+      defaultValue: 64 * MIB,
+      minPerWorker: 3 * MIB + 64 * 1024,
+      max: 1024 * MIB,
+    },
+    {
+      name: "DETACHED_STREAM_METERING_RESERVE_BYTES",
+      defaultValue: 16 * MIB,
+      minPerWorker: 64 * 1024,
+      max: 1024 * MIB,
+    },
+    {
+      name: "STREAM_GATE_GLOBAL_PREBUFFER_BYTE_CAP",
+      defaultValue: 256 * MIB,
+      minPerWorker: streamGatePerRequestBytes * 4,
+      max: 2 * 1024 * MIB,
+    },
+    {
+      name: "REPLAY_MAX_CONCURRENT_SPOOLS",
+      defaultValue: 64,
+      minPerWorker: 1,
+      max: 1024,
+    },
+  ];
+
+  const totals = {};
+  for (const definition of definitions) {
+    totals[definition.name] = parseIntegerWithDefault(
+      env,
+      definition.name,
+      definition.defaultValue,
+      { min: definition.minPerWorker, max: definition.max }
+    );
+  }
+
+  if (
+    totals.DETACHED_STREAM_METERING_RESERVE_BYTES > totals.DETACHED_STREAM_BUDGET_BYTES
+  ) {
+    throw new Error(
+      "DETACHED_STREAM_METERING_RESERVE_BYTES cannot exceed DETACHED_STREAM_BUDGET_BYTES"
+    );
+  }
+
+  return { definitions, totals, streamGatePerRequestBytes };
+}
+
+function buildBudgetAllocations(resolvedBudgets, workerCount) {
+  const allocations = {};
+  for (const definition of resolvedBudgets.definitions) {
+    const total = resolvedBudgets.totals[definition.name];
+    const values = allocateIntegerBudget(total, workerCount);
+    if (values.some((value) => value < definition.minPerWorker)) {
+      throw new Error(
+        `${definition.name}=${total} cannot safely support ${workerCount} gateway workers`
+      );
+    }
+    allocations[definition.name] = values;
+  }
+
+  const detachedBudgets = allocations.DETACHED_STREAM_BUDGET_BYTES;
+  const detachedReserves = allocations.DETACHED_STREAM_METERING_RESERVE_BYTES;
+  for (let index = 0; index < workerCount; index += 1) {
+    if (detachedReserves[index] > detachedBudgets[index]) {
+      throw new Error(
+        `Detached stream reserve exceeds its worker budget at worker index ${index}`
+      );
+    }
+  }
+
+  return allocations;
+}
+
+function calculateBudgetCapacity(resolvedBudgets) {
+  return Math.min(
+    ...resolvedBudgets.definitions.map((definition) =>
+      Math.floor(resolvedBudgets.totals[definition.name] / definition.minPerWorker)
+    )
+  );
+}
+
+function createDisabledPlan({ mode, reason, resources, explicitWorkers }) {
+  return {
+    enabled: false,
+    mode,
+    reason,
+    workerCount: 1,
+    explicitWorkers: explicitWorkers ?? null,
+    resources,
+    aggregateBudgets: null,
+    budgetAllocations: null,
+  };
+}
+
+function createMulticorePlan(options = {}) {
+  const env = options.env || process.env;
+  const resources = options.resources || detectRuntimeResources(options.resourceOptions);
+  const mode = parseMulticoreMode(env.CCH_MULTICORE_MODE);
+  if (mode === "off") {
+    // 关闭模式也是紧急回滚入口，应忽略残留的 worker 数配置。
+    return createDisabledPlan({ mode, reason: "mode_off", resources });
+  }
+  const explicitWorkers = parseOptionalInteger(env, "CCH_MULTICORE_WORKERS", {
+    min: 1,
+    max: MAX_EXPLICIT_WORKERS,
+  });
+
+  if (explicitWorkers === 1) {
+    return createDisabledPlan({
+      mode,
+      reason: "explicit_single_worker",
+      resources,
+      explicitWorkers,
+    });
+  }
+  if (env.NODE_ENV !== "production" && (mode === "on" || explicitWorkers !== undefined)) {
+    throw new Error("Multicore gateway workers require NODE_ENV=production");
+  }
+
+  const memoryPerWorkerMb = parseIntegerWithDefault(
+    env,
+    "CCH_MULTICORE_MEMORY_PER_WORKER_MB",
+    DEFAULT_MEMORY_PER_WORKER_MB,
+    { min: 256, max: 65536 }
+  );
+  const primaryMemoryReserveMb = parseIntegerWithDefault(
+    env,
+    "CCH_MULTICORE_PRIMARY_MEMORY_RESERVE_MB",
+    DEFAULT_PRIMARY_MEMORY_RESERVE_MB,
+    { min: 64, max: 16384 }
+  );
+  const memoryPerWorkerBytes = memoryPerWorkerMb * MIB;
+  const primaryMemoryReserveBytes = primaryMemoryReserveMb * MIB;
+  const memoryCapacity = Math.max(
+    0,
+    Math.floor(
+      (resources.effectiveMemoryBytes - primaryMemoryReserveBytes) / memoryPerWorkerBytes
+    )
+  );
+
+  const resolvedBudgets = resolveAggregateBudgets(env);
+  const budgetCapacity = calculateBudgetCapacity(resolvedBudgets);
+  const safeCapacity = Math.min(memoryCapacity, budgetCapacity, MAX_EXPLICIT_WORKERS);
+
+  let workerCount;
+  let reason;
+  if (explicitWorkers !== undefined) {
+    assertCrossProcessInvalidation(env);
+    workerCount = explicitWorkers;
+    reason = "explicit_worker_count";
+    if (workerCount > safeCapacity) {
+      throw new Error(
+        `CCH_MULTICORE_WORKERS=${workerCount} exceeds the safe memory/budget capacity ${safeCapacity}`
+      );
+    }
+  } else if (mode === "on") {
+    assertCrossProcessInvalidation(env);
+    workerCount = Math.min(
+      Math.max(2, Math.floor(resources.effectiveCpu / 2)),
+      DEFAULT_AUTO_MAX_WORKERS,
+      safeCapacity
+    );
+    reason = "mode_on";
+    if (workerCount < 2) {
+      throw new Error(
+        "CCH_MULTICORE_MODE=on requires capacity for at least two gateway workers"
+      );
+    }
+  } else {
+    if (env.NODE_ENV !== "production") {
+      return createDisabledPlan({
+        mode,
+        reason: "non_production",
+        resources,
+        explicitWorkers,
+      });
+    }
+    if (String(env.CI ?? "").toLowerCase() === "true") {
+      return createDisabledPlan({ mode, reason: "ci", resources, explicitWorkers });
+    }
+    if (resources.effectiveCpu < 4) {
+      return createDisabledPlan({
+        mode,
+        reason: "effective_cpu_below_four",
+        resources,
+        explicitWorkers,
+      });
+    }
+    if (!hasCrossProcessInvalidation(env)) {
+      return createDisabledPlan({
+        mode,
+        reason: "cross_process_invalidation_unavailable",
+        resources,
+        explicitWorkers,
+      });
+    }
+
+    workerCount = Math.min(
+      Math.floor(resources.effectiveCpu / 2),
+      DEFAULT_AUTO_MAX_WORKERS,
+      safeCapacity
+    );
+    reason = "auto_resource_eligible";
+    if (workerCount < 2) {
+      return createDisabledPlan({
+        mode,
+        reason: memoryCapacity < 2 ? "insufficient_memory" : "insufficient_shared_budget",
+        resources,
+        explicitWorkers,
+      });
+    }
+  }
+
+  const budgetAllocations = buildBudgetAllocations(resolvedBudgets, workerCount);
+  return {
+    enabled: true,
+    mode,
+    reason,
+    workerCount,
+    explicitWorkers: explicitWorkers ?? null,
+    resources,
+    memoryPerWorkerBytes,
+    primaryMemoryReserveBytes,
+    memoryCapacity,
+    budgetCapacity,
+    aggregateBudgets: resolvedBudgets.totals,
+    budgetAllocations,
+  };
+}
+
+function buildWorkerEnvironment(plan, workerIndex) {
+  if (!plan?.enabled) throw new TypeError("An enabled multicore plan is required");
+  if (!Number.isInteger(workerIndex) || workerIndex < 0 || workerIndex >= plan.workerCount) {
+    throw new RangeError("workerIndex is outside the multicore plan");
+  }
+
+  const workerEnv = {
+    CCH_MULTICORE_ACTIVE: "1",
+    CCH_MULTICORE_WORKER_INDEX: String(workerIndex),
+    CCH_MULTICORE_WORKER_COUNT: String(plan.workerCount),
+    CCH_MULTICORE_BACKGROUND_OWNER: workerIndex === 0 ? "1" : "0",
+    CCH_PROCESS_ROLE: workerIndex === 0 ? "gateway-control" : "gateway",
+    CCH_MULTICORE_EFFECTIVE_VCPUS: String(plan.resources.effectiveCpu),
+    CCH_MULTICORE_EFFECTIVE_MEMORY_BYTES: String(plan.resources.effectiveMemoryBytes),
+  };
+
+  for (const [name, allocations] of Object.entries(plan.budgetAllocations)) {
+    workerEnv[name] = String(allocations[workerIndex]);
+  }
+  return workerEnv;
+}
+
+module.exports = {
+  CGROUP_FILES,
+  DEFAULT_AUTO_MAX_WORKERS,
+  DEFAULT_MEMORY_PER_WORKER_MB,
+  DEFAULT_PRIMARY_MEMORY_RESERVE_MB,
+  MIB,
+  WORKER_READY_MESSAGE_TYPE,
+  allocateIntegerBudget,
+  buildBudgetAllocations,
+  buildWorkerEnvironment,
+  createMulticorePlan,
+  detectRuntimeResources,
+  hasCrossProcessInvalidation,
+  parseCpuMax,
+  parseCpuSet,
+  parseMemoryLimit,
+  parseMulticoreMode,
+  resolveAggregateBudgets,
+};

--- a/server.js
+++ b/server.js
@@ -36,10 +36,8 @@ const dev = isNextDevMode(process.env.NODE_ENV);
 const hostname = process.env.HOSTNAME || "0.0.0.0";
 const port = parseInt(process.env.PORT || (dev ? "13500" : "3000"), 10);
 
-// Loopback target for the in-process WS->HTTP tunnel. When the public bind
-// hostname is a wildcard (0.0.0.0 / ::), tunnel via 127.0.0.1; otherwise use
-// the configured hostname so we still hit the local listener even when bound
-// to a specific interface.
+// 供导出 helper 独立运行时使用的兼容回退目标。实际服务会为每个进程创建私有
+// loopback listener，确保 cluster 中的 WebSocket 连接不会隧道到其他 worker。
 const INTERNAL_TUNNEL_HOST =
   hostname === "0.0.0.0" || hostname === "::" || hostname === "*" ? "127.0.0.1" : hostname;
 
@@ -253,7 +251,7 @@ function sanitizedRequestPath(rawUrl) {
   }
 }
 
-async function handleWebSocketConnection(ws, req) {
+async function handleWebSocketConnection(ws, req, internalHttpTarget) {
   const url = new URL(req.url, `http://${req.headers.host || "localhost"}`);
   const queryModel = url.searchParams.get("model");
   const responsesWsSessionId = randomUUID();
@@ -462,7 +460,8 @@ async function handleWebSocketConnection(ws, req) {
       body,
       responsesWsSessionId,
       registerTurnResource,
-      requestClose
+      requestClose,
+      internalHttpTarget
     );
     raw = "";
     frame = null;
@@ -547,7 +546,8 @@ async function forwardToInternalHttp(
   body,
   responsesWsSessionId,
   registerInternalReq,
-  requestClose
+  requestClose,
+  internalHttpTarget
 ) {
   // requestClose(code, reason) initiates the WebSocket closing handshake AND
   // synchronously marks the client connection closed so the caller's pending
@@ -631,11 +631,17 @@ async function forwardToInternalHttp(
       resolve();
       return true;
     };
+    const tunnelTarget =
+      internalHttpTarget &&
+      typeof internalHttpTarget.hostname === "string" &&
+      Number.isInteger(internalHttpTarget.port)
+        ? internalHttpTarget
+        : { hostname: INTERNAL_TUNNEL_HOST, port };
     const req = http.request(
       {
         method: "POST",
-        hostname: INTERNAL_TUNNEL_HOST,
-        port,
+        hostname: tunnelTarget.hostname,
+        port: tunnelTarget.port,
         path: "/v1/responses",
         headers: internalHeaders,
       },
@@ -1072,6 +1078,53 @@ function isResponsesWsUpgrade(req) {
   return parsed.pathname === WS_PATH;
 }
 
+function listenServer(server, options) {
+  return new Promise((resolve, reject) => {
+    const handleError = (error) => {
+      server.off("listening", handleListening);
+      reject(error);
+    };
+    const handleListening = () => {
+      server.off("error", handleError);
+      resolve(server.address());
+    };
+    server.once("error", handleError);
+    server.once("listening", handleListening);
+    server.listen(options);
+  });
+}
+
+async function listenOnPrivateLoopback(server) {
+  // node:cluster 下必须设置 `exclusive: true`，否则即使监听 port 0，也可能
+  // 由主进程代理并与其他 worker 共享。
+  const address = await listenServer(server, {
+    host: "127.0.0.1",
+    port: 0,
+    exclusive: true,
+  });
+  if (!address || typeof address === "string" || !Number.isInteger(address.port)) {
+    throw new Error("Private loopback listener returned an invalid address");
+  }
+  return { hostname: "127.0.0.1", port: address.port };
+}
+
+function notifyMulticoreReady() {
+  if (process.env.CCH_MULTICORE_ACTIVE !== "1" || typeof process.send !== "function") return;
+  try {
+    // IPC 消息刻意保持极小；请求字节和解析后的对象绝不跨越主进程/worker 通道。
+    const { WORKER_READY_MESSAGE_TYPE } = require("./server-lib/multicore");
+    process.send({
+      type: WORKER_READY_MESSAGE_TYPE,
+      workerIndex: Number(process.env.CCH_MULTICORE_WORKER_INDEX),
+      pid: process.pid,
+    });
+  } catch (error) {
+    log("error", "multicore_ready_notification_failed", {
+      error: String(error && error.message ? error.message : error),
+    });
+  }
+}
+
 async function main() {
   // Surface the build-time Next config via the env var Next's own standalone
   // template uses. See server-lib/standalone-config.js for the full rationale.
@@ -1120,7 +1173,7 @@ async function main() {
   const handler = app.getRequestHandler();
   await app.prepare();
 
-  const server = http.createServer(async (req, res) => {
+  const requestListener = async (req, res) => {
     try {
       const parsedUrl = parse(req.url, true);
       await handler(req, res, parsedUrl);
@@ -1133,7 +1186,13 @@ async function main() {
         res.end("Internal Server Error");
       }
     }
-  });
+  };
+
+  // WebSocket frame 必须重新进入持有客户端连接和持久上游会话的同一个 worker。
+  // 私有独占 listener 无需经 IPC 复制请求正文即可保证这一不变量。
+  const internalServer = http.createServer(requestListener);
+  const internalHttpTarget = await listenOnPrivateLoopback(internalServer);
+  const server = http.createServer(requestListener);
 
   let wss = null;
   if (WebSocketServer) {
@@ -1146,7 +1205,7 @@ async function main() {
       }
       wss.handleUpgrade(req, socket, head, (ws) => {
         log("info", "ws_client_connected", { path: sanitizedRequestPath(req.url) });
-        handleWebSocketConnection(ws, req).catch((err) => {
+        handleWebSocketConnection(ws, req, internalHttpTarget).catch((err) => {
           log("error", "ws_handler_error", {
             error: String(err && err.message ? err.message : err),
           });
@@ -1164,16 +1223,24 @@ async function main() {
     });
   }
 
-  server.listen(port, hostname, () => {
-    log("info", "server_listening", {
-      hostname,
-      port,
-      internalTunnelHost: INTERNAL_TUNNEL_HOST,
-      wsEnabled: !!WebSocketServer,
-    });
-  });
+  try {
+    await listenServer(server, { port, host: hostname });
+  } catch (error) {
+    internalServer.close();
+    throw error;
+  }
 
-  registerOrchestratedShutdown(server, wss);
+  registerOrchestratedShutdown(server, wss, [internalServer]);
+  log("info", "server_listening", {
+    hostname,
+    port,
+    internalTunnelHost: internalHttpTarget.hostname,
+    internalTunnelPort: internalHttpTarget.port,
+    wsEnabled: !!WebSocketServer,
+    workerIndex: process.env.CCH_MULTICORE_WORKER_INDEX ?? null,
+    workerCount: process.env.CCH_MULTICORE_WORKER_COUNT ?? "1",
+  });
+  notifyMulticoreReady();
 }
 
 // Graceful shutdown orchestration. Lives here (not in instrumentation.ts) because
@@ -1181,14 +1248,14 @@ async function main() {
 //
 // Sequence (bounded by SHUTDOWN_HARD_EXIT_MS as the final safety net):
 //   1. Mark shutdown flag    -> /api/health/ready returns 503 -> Service drains
-//   2. server.close()        -> stop accepting; in-flight HTTP finishes
+//   2. server.close()        -> stop accepting public and private HTTP
 //   3. wss.close()           -> reject new WS upgrades
 //   4. Wait for drain        -> bounded by SHUTDOWN_DRAIN_MS
 //   5. runApplicationCleanup -> abort + join tasks, flush writer, close DB pools,
 //      then release non-critical resources. SHUTDOWN_CLEANUP_MS is a soft warning;
 //      the referenced hard watchdog is the final bound for critical barriers.
 //   6. Success logs shutdown_complete and exits 0; cleanup failure exits 1.
-function registerOrchestratedShutdown(server, wss) {
+function registerOrchestratedShutdown(server, wss, auxiliaryServers = []) {
   let shuttingDown = false;
 
   // Positive integer parser: `Number("0") || default` would silently coerce an
@@ -1229,23 +1296,33 @@ function registerOrchestratedShutdown(server, wss) {
     }
 
     // 2 + 3. Stop accepting new connections.
-    const closeServer = new Promise((resolve) => {
-      try {
-        server.close((err) => {
-          if (err) {
-            log("warn", "shutdown_server_close_error", {
-              error: String(err && err.message ? err.message : err),
-            });
-          }
-          resolve();
-        });
-      } catch (err) {
-        log("warn", "shutdown_server_close_threw", {
-          error: String(err && err.message ? err.message : err),
-        });
-        resolve();
-      }
-    });
+    const servers = Array.from(
+      new Set([server, ...(Array.isArray(auxiliaryServers) ? auxiliaryServers : [])].filter(Boolean))
+    );
+    const closeServers = Promise.all(
+      servers.map(
+        (serverHandle, index) =>
+          new Promise((resolve) => {
+            try {
+              serverHandle.close((err) => {
+                if (err) {
+                  log("warn", "shutdown_server_close_error", {
+                    serverKind: index === 0 ? "public" : "auxiliary",
+                    error: String(err && err.message ? err.message : err),
+                  });
+                }
+                resolve();
+              });
+            } catch (err) {
+              log("warn", "shutdown_server_close_threw", {
+                serverKind: index === 0 ? "public" : "auxiliary",
+                error: String(err && err.message ? err.message : err),
+              });
+              resolve();
+            }
+          })
+      )
+    );
 
     const closeWss = new Promise((resolve) => {
       if (!wss || typeof wss.close !== "function") {
@@ -1267,7 +1344,7 @@ function registerOrchestratedShutdown(server, wss) {
         resolve();
       }
     });
-    const closeTransports = Promise.all([closeServer, closeWss]);
+    const closeTransports = Promise.all([closeServers, closeWss]);
 
     // 4. Bounded drain — HTTP and WebSocket close only settle after every in-flight
     //    connection completes; we cap them so a stuck client can't hold us forever.
@@ -1315,10 +1392,14 @@ function registerOrchestratedShutdown(server, wss) {
 
 // Exposed for tests; not part of the long-lived server entrypoint.
 module.exports = {
+  main,
   sanitizedRequestPath,
   isNextDevMode,
   handleWebSocketConnection,
   forwardToInternalHttp,
+  listenServer,
+  listenOnPrivateLoopback,
+  notifyMulticoreReady,
   registerOrchestratedShutdown,
   WS_MAX_PAYLOAD_BYTES,
   MAX_PENDING_BYTES,

--- a/src/actions/provider-groups.ts
+++ b/src/actions/provider-groups.ts
@@ -3,6 +3,7 @@
 import { getTranslations } from "next-intl/server";
 import { emitActionAudit } from "@/lib/audit/emit";
 import { getSession } from "@/lib/auth";
+import { publishGroupMultiplierCacheInvalidation } from "@/lib/cache/provider-group-multiplier-cache";
 import { PROVIDER_GROUP } from "@/lib/constants/provider.constants";
 import { logger } from "@/lib/logger";
 import { bootstrapProviderGroupsFromProviders } from "@/lib/provider-groups/bootstrap";
@@ -128,6 +129,8 @@ export async function createProviderGroup(input: {
       costMultiplier: input.costMultiplier,
       description: input.description ?? null,
     });
+    // 数据库已提交后再广播，避免其他 worker 在事务可见前重新缓存旧倍率。
+    await publishGroupMultiplierCacheInvalidation();
 
     emitActionAudit({
       category: "provider_group",
@@ -209,6 +212,9 @@ export async function updateProviderGroup(
     if (!updated) {
       return { ok: false, error: tError("NOT_FOUND"), errorCode: ERROR_CODES.NOT_FOUND };
     }
+    if (input.costMultiplier !== undefined) {
+      await publishGroupMultiplierCacheInvalidation();
+    }
 
     emitActionAudit({
       category: "provider_group",
@@ -277,6 +283,7 @@ export async function deleteProviderGroup(id: number): Promise<ActionResult<void
     }
 
     await repoDeleteProviderGroup(id);
+    await publishGroupMultiplierCacheInvalidation();
     emitActionAudit({
       category: "provider_group",
       action: "provider_group.delete",

--- a/src/actions/system-config.ts
+++ b/src/actions/system-config.ts
@@ -225,10 +225,6 @@ export async function saveSystemSettings(formData: {
 
     // Invalidate the system settings cache so proxy requests get fresh settings
     invalidateSystemSettingsCache();
-    const { invalidateProviderSelectorSystemSettingsCache } = await import(
-      "@/app/v1/_lib/proxy/provider-selector-settings-cache"
-    );
-    invalidateProviderSelectorSystemSettingsCache();
 
     if (validated.timezone !== undefined) {
       await Promise.all([

--- a/src/app/[locale]/settings/config/_components/system-settings-form.tsx
+++ b/src/app/[locale]/settings/config/_components/system-settings-form.tsx
@@ -23,7 +23,7 @@ import {
   Zap,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -142,6 +142,7 @@ export function SystemSettingsForm({
   replayDefaultEnabled = true,
 }: SystemSettingsFormProps) {
   const router = useRouter();
+  const locale = useLocale();
   const t = useTranslations("settings.config.form");
   const tSettings = useTranslations("settings");
   const tCommon = useTranslations("settings.common");
@@ -648,7 +649,7 @@ export function SystemSettingsForm({
             <SelectItem value="__auto__">{t("timezoneAuto")}</SelectItem>
             {COMMON_TIMEZONES.map((tz) => (
               <SelectItem key={tz} value={tz}>
-                {getTimezoneLabel(tz)}
+                {getTimezoneLabel(tz, locale)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/app/[locale]/settings/config/_components/system-settings-form.tsx
+++ b/src/app/[locale]/settings/config/_components/system-settings-form.tsx
@@ -44,7 +44,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { saveSystemSettings } from "@/lib/api-client/v1/actions/system-config";
 import type { CurrencyCode } from "@/lib/utils";
 import { CURRENCY_CONFIG } from "@/lib/utils";
-import { COMMON_TIMEZONES, getTimezoneLabel } from "@/lib/utils/timezone";
+import { COMMON_TIMEZONES, getTimezoneLabel } from "@/lib/utils/timezone-shared";
 import {
   shouldWarnQuotaDbRefreshIntervalTooHigh,
   shouldWarnQuotaDbRefreshIntervalTooLow,

--- a/src/app/api/admin/system-config/route.ts
+++ b/src/app/api/admin/system-config/route.ts
@@ -126,10 +126,6 @@ export async function POST(req: Request) {
       changes: validated,
     });
     invalidateSystemSettingsCache();
-    const { invalidateProviderSelectorSystemSettingsCache } = await import(
-      "@/app/v1/_lib/proxy/provider-selector-settings-cache"
-    );
-    invalidateProviderSelectorSystemSettingsCache();
     if (validated.timezone !== undefined) {
       await Promise.all([
         invalidateAllOverviewCaches(),

--- a/src/app/v1/_lib/proxy/provider-selector-settings-cache.ts
+++ b/src/app/v1/_lib/proxy/provider-selector-settings-cache.ts
@@ -1,31 +1,13 @@
+import { getCachedSystemSettings } from "@/lib/config/system-settings-cache";
 import { logger } from "@/lib/logger";
-import { getSystemSettings } from "@/repository/system-config";
-
-const SETTINGS_CACHE_TTL_MS = 60_000;
-
-let cachedVerboseProviderError: { value: boolean; expiresAt: number } | null = null;
-
-export function invalidateProviderSelectorSystemSettingsCache(): void {
-  cachedVerboseProviderError = null;
-}
 
 export async function getVerboseProviderErrorCached(): Promise<boolean> {
-  const now = Date.now();
-  if (cachedVerboseProviderError && cachedVerboseProviderError.expiresAt > now) {
-    return cachedVerboseProviderError.value;
-  }
-
   try {
-    const systemSettings = await getSystemSettings();
-    cachedVerboseProviderError = {
-      value: systemSettings.verboseProviderError,
-      expiresAt: now + SETTINGS_CACHE_TTL_MS,
-    };
-    return systemSettings.verboseProviderError;
-  } catch (e) {
+    return (await getCachedSystemSettings()).verboseProviderError;
+  } catch (error) {
     logger.warn(
       "ProviderSelector: Failed to get system settings, using default verboseError=false",
-      { error: e }
+      { error }
     );
     return false;
   }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -402,6 +402,49 @@ async function startApiKeyVacuumFilterSync(): Promise<void> {
   }
 }
 
+/**
+ * 多核心 worker 在 ready 前建立计费倍率缓存订阅，避免首次请求刚写入本地缓存、
+ * 订阅尚未完成时漏过其他进程的更新广播。外部多实例部署仍由热路径懒初始化。
+ */
+async function startGroupMultiplierCacheSync(): Promise<boolean> {
+  const rateLimitRaw = process.env.ENABLE_RATE_LIMIT?.trim();
+  if (rateLimitRaw === "false" || rateLimitRaw === "0" || !process.env.REDIS_URL) {
+    return false;
+  }
+
+  try {
+    const { ensureGroupMultiplierCacheSubscription } = await import(
+      "@/lib/cache/provider-group-multiplier-cache"
+    );
+    return await ensureGroupMultiplierCacheSubscription();
+  } catch (error) {
+    logger.warn("[Instrumentation] Provider group multiplier cache sync init failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+/** 多核心 worker 在 ready 前订阅系统设置更新，避免计费与路由开关跨进程漂移。 */
+async function startSystemSettingsCacheSync(): Promise<boolean> {
+  const rateLimitRaw = process.env.ENABLE_RATE_LIMIT?.trim();
+  if (rateLimitRaw === "false" || rateLimitRaw === "0" || !process.env.REDIS_URL) {
+    return false;
+  }
+
+  try {
+    const { ensureSystemSettingsCacheSubscription } = await import(
+      "@/lib/config/system-settings-cache"
+    );
+    return await ensureSystemSettingsCacheSubscription();
+  } catch (error) {
+    logger.warn("[Instrumentation] System settings cache sync init failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
 function warmupApiKeyVacuumFilter(): void {
   // 预热 API Key Vacuum Filter（减少无效 key 对 DB 的压力）
   try {
@@ -477,6 +520,21 @@ export async function register() {
       // 挂到 globalThis 让 server.js 桥接调用。
       const { bindLifecycleGlobals } = await import("@/lib/lifecycle/shutdown");
       bindLifecycleGlobals();
+    }
+
+    if (process.env.CCH_MULTICORE_ACTIVE === "1") {
+      const [multiplierSyncEnabled, settingsSyncEnabled] = await Promise.all([
+        startGroupMultiplierCacheSync(),
+        startSystemSettingsCacheSync(),
+      ]);
+      if (!multiplierSyncEnabled) {
+        logger.warn(
+          "[Multicore] Provider group multiplier invalidation unavailable; using TTL fallback"
+        );
+      }
+      if (!settingsSyncEnabled) {
+        logger.warn("[Multicore] System settings invalidation unavailable; using TTL fallback");
+      }
     }
 
     // 生产环境: 执行完整初始化(迁移 + 价格表 + 清理任务 + 通知任务)

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -69,7 +69,10 @@ export function registerCrashDiagnostics(): void {
         // Diagnostic reports are durable artifacts. Exclude the entire
         // environment rather than maintaining an incomplete secret allowlist.
         report.excludeEnv = true;
-        return report.writeReport(`report.${trigger}.${Date.now()}.json`, toSafeCrashError(err));
+        return report.writeReport(
+          `report.${trigger}.${process.pid}.${Date.now()}.json`,
+          toSafeCrashError(err)
+        );
       }
     } catch {
       // 写入诊断报告失败不应再抛出
@@ -183,6 +186,12 @@ function logStartupMarker(): void {
  *
  * 注意: 此函数会传播关键错误,调用者应决定是否需要优雅降级
  */
+async function reloadErrorRuleDetectorCache(): Promise<void> {
+  const { errorRuleDetector } = await import("@/lib/error-rule-detector");
+  await errorRuleDetector.reload();
+  logger.info("Error rule detector cache loaded successfully");
+}
+
 async function syncErrorRulesAndInitializeDetector(): Promise<void> {
   // 同步默认错误规则到数据库 - 每次启动都完整同步
   const { syncDefaultErrorRules } = await import("@/repository/error-rules");
@@ -192,9 +201,7 @@ async function syncErrorRulesAndInitializeDetector(): Promise<void> {
   );
 
   // 加载错误规则缓存 - 让关键错误传播
-  const { errorRuleDetector } = await import("@/lib/error-rule-detector");
-  await errorRuleDetector.reload();
-  logger.info("Error rule detector cache loaded successfully");
+  await reloadErrorRuleDetectorCache();
 }
 
 /**
@@ -409,6 +416,26 @@ function warmupApiKeyVacuumFilter(): void {
   void startApiKeyVacuumFilterSync();
 }
 
+async function warmupProxyRuntimeSettings(): Promise<void> {
+  try {
+    const { getProxyRuntimeSettings } = await import("@/lib/system-settings/proxy-runtime");
+    await getProxyRuntimeSettings();
+  } catch (error) {
+    logger.warn("[Instrumentation] Proxy runtime settings warmup failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * 同一进程 cluster 内仅 slot 0 持有单例调度器和队列 consumer。每个网关 worker
+ * 仍需初始化进程本地缓存、生命周期 hook 与可观测性。单进程和外部横向扩容部署
+ * 不携带此标记，因此保持原有行为。
+ */
+export function shouldRunBackgroundTasks(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.CCH_MULTICORE_BACKGROUND_OWNER !== "0";
+}
+
 export async function register() {
   // 仅在服务器端执行
   if (process.env.NEXT_RUNTIME === "nodejs") {
@@ -454,6 +481,35 @@ export async function register() {
 
     // 生产环境: 执行完整初始化(迁移 + 价格表 + 清理任务 + 通知任务)
     if (process.env.NODE_ENV === "production") {
+      if (!shouldRunBackgroundTasks()) {
+        logger.info("[Multicore] Initializing request-only gateway worker", {
+          workerIndex: process.env.CCH_MULTICORE_WORKER_INDEX ?? null,
+          workerCount: process.env.CCH_MULTICORE_WORKER_COUNT ?? null,
+        });
+
+        // 主进程先启动 slot 0，待其报告 ready 后才 fork 仅处理请求的 worker，
+        // 因此迁移和默认规则同步已完成；这里只验证共享存储并初始化进程本地状态。
+        const { checkDatabaseConnection } = await import("@/lib/migrate");
+        const isConnected = await checkDatabaseConnection();
+        if (!isConnected) {
+          logger.error("Cannot start gateway worker without database connection");
+          process.exit(1);
+        }
+
+        warmupApiKeyVacuumFilter();
+        try {
+          await reloadErrorRuleDetectorCache();
+        } catch (error) {
+          logger.error(
+            "[Instrumentation] Non-critical: Error rule detector initialization failed",
+            error
+          );
+        }
+        await warmupProxyRuntimeSettings();
+        logger.info("[Multicore] Request-only gateway worker ready");
+        return;
+      }
+
       const { checkDatabaseConnection, runMigrations, withAdvisoryLock } = await import(
         "@/lib/migrate"
       );
@@ -675,18 +731,7 @@ export async function register() {
       await startReplayCleanupScheduler();
 
       // F1/F3a：预热代理运行时设置快照（stream gate / affinity 的同步读取路径）
-      try {
-        const { getProxyRuntimeSettings } = await import("@/lib/system-settings/proxy-runtime");
-        void getProxyRuntimeSettings().catch((error) => {
-          logger.warn("[Instrumentation] Proxy runtime settings warmup failed", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-      } catch (error) {
-        logger.warn("[Instrumentation] Proxy runtime settings warmup init failed", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
+      await warmupProxyRuntimeSettings();
 
       logger.info("Application ready");
     }
@@ -855,18 +900,7 @@ export async function register() {
         await startReplayCleanupScheduler();
 
         // F1/F3a：预热代理运行时设置快照（stream gate / affinity 的同步读取路径）
-        try {
-          const { getProxyRuntimeSettings } = await import("@/lib/system-settings/proxy-runtime");
-          void getProxyRuntimeSettings().catch((error) => {
-            logger.warn("[Instrumentation] Proxy runtime settings warmup failed", {
-              error: error instanceof Error ? error.message : String(error),
-            });
-          });
-        } catch (error) {
-          logger.warn("[Instrumentation] Proxy runtime settings warmup init failed", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
+        await warmupProxyRuntimeSettings();
       } else {
         logger.warn(
           "[Instrumentation] Database unavailable: skipping endpoint probe scheduler and cleanup"

--- a/src/lib/cache/provider-group-multiplier-cache.ts
+++ b/src/lib/cache/provider-group-multiplier-cache.ts
@@ -1,0 +1,147 @@
+import "server-only";
+
+import { logger } from "@/lib/logger";
+import {
+  CHANNEL_PROVIDER_GROUPS_UPDATED,
+  publishCacheInvalidation,
+  subscribeCacheInvalidation,
+} from "@/lib/redis/pubsub";
+
+const CACHE_TTL_MS = 60_000;
+const MAX_CACHE_ENTRIES = 10_000;
+const SUBSCRIPTION_RETRY_MS = 60_000;
+
+interface CacheEntry {
+  value: number;
+  expiresAt: number;
+}
+
+interface GroupMultiplierCacheState {
+  entries: Map<string, CacheEntry>;
+  version: number;
+  subscriptionInitialized: boolean;
+  subscriptionInitPromise: Promise<boolean> | null;
+  subscriptionCleanup: (() => void) | null;
+  subscriptionNextAttemptAt: number;
+}
+
+const runtimeState = globalThis as typeof globalThis & {
+  __CCH_PROVIDER_GROUP_MULTIPLIER_CACHE__?: GroupMultiplierCacheState;
+};
+
+const state =
+  runtimeState.__CCH_PROVIDER_GROUP_MULTIPLIER_CACHE__ ??
+  (runtimeState.__CCH_PROVIDER_GROUP_MULTIPLIER_CACHE__ = {
+    entries: new Map<string, CacheEntry>(),
+    version: 0,
+    subscriptionInitialized: false,
+    subscriptionInitPromise: null,
+    subscriptionCleanup: null,
+    subscriptionNextAttemptAt: 0,
+  });
+
+export function invalidateGroupMultiplierCache(): void {
+  state.entries.clear();
+  state.version++;
+}
+
+export function readCachedGroupMultiplier(rawGroupString: string): number | undefined {
+  const cached = state.entries.get(rawGroupString);
+  if (!cached) return undefined;
+  if (cached.expiresAt > Date.now()) return cached.value;
+
+  state.entries.delete(rawGroupString);
+  return undefined;
+}
+
+export function getGroupMultiplierCacheVersion(): number {
+  return state.version;
+}
+
+export function writeCachedGroupMultiplier(
+  rawGroupString: string,
+  value: number,
+  expectedVersion: number
+): boolean {
+  if (state.version !== expectedVersion) return false;
+
+  if (!state.entries.has(rawGroupString) && state.entries.size >= MAX_CACHE_ENTRIES) {
+    const oldestKey = state.entries.keys().next().value;
+    if (oldestKey !== undefined) state.entries.delete(oldestKey);
+  }
+
+  state.entries.set(rawGroupString, {
+    value,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+  return true;
+}
+
+/**
+ * 为当前进程建立倍率缓存失效订阅。Redis 暂时不可用时返回 false，热路径会在
+ * 后续请求中重试，并继续以 60 秒 TTL 作为降级上界。
+ */
+export async function ensureGroupMultiplierCacheSubscription(): Promise<boolean> {
+  if (state.subscriptionInitialized) return true;
+  if (state.subscriptionInitPromise) return state.subscriptionInitPromise;
+  if (Date.now() < (state.subscriptionNextAttemptAt ?? 0)) return false;
+
+  state.subscriptionInitPromise = (async () => {
+    try {
+      const cleanup = await subscribeCacheInvalidation(CHANNEL_PROVIDER_GROUPS_UPDATED, () => {
+        invalidateGroupMultiplierCache();
+        logger.debug("[ProviderGroupMultiplierCache] Cache invalidated via pub/sub");
+      });
+      if (!cleanup) {
+        state.subscriptionNextAttemptAt = Date.now() + SUBSCRIPTION_RETRY_MS;
+        return false;
+      }
+
+      state.subscriptionCleanup = cleanup;
+      state.subscriptionInitialized = true;
+      state.subscriptionNextAttemptAt = 0;
+      logger.info("[ProviderGroupMultiplierCache] Cross-process invalidation enabled");
+      return true;
+    } catch (error) {
+      logger.warn("[ProviderGroupMultiplierCache] Failed to subscribe to invalidation", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      state.subscriptionNextAttemptAt = Date.now() + SUBSCRIPTION_RETRY_MS;
+      return false;
+    }
+  })().finally(() => {
+    state.subscriptionInitPromise = null;
+  });
+
+  return state.subscriptionInitPromise;
+}
+
+/** 热路径使用的无 Promise 快速入口；仅首次初始化或退避到期时创建异步任务。 */
+export function startGroupMultiplierCacheSubscription(): void {
+  if (
+    state.subscriptionInitialized ||
+    state.subscriptionInitPromise ||
+    Date.now() < (state.subscriptionNextAttemptAt ?? 0)
+  ) {
+    return;
+  }
+  void ensureGroupMultiplierCacheSubscription();
+}
+
+/** 数据库提交后调用：先同步清空本进程，再广播微小的失效通知。 */
+export async function publishGroupMultiplierCacheInvalidation(): Promise<void> {
+  invalidateGroupMultiplierCache();
+  await publishCacheInvalidation(CHANNEL_PROVIDER_GROUPS_UPDATED);
+}
+
+/** 供进程关闭和隔离测试释放订阅；不会触碰 Redis 中的数据。 */
+export function disposeGroupMultiplierCache(): void {
+  state.subscriptionCleanup?.();
+  state.subscriptionCleanup = null;
+  state.subscriptionInitialized = false;
+  state.subscriptionInitPromise = null;
+  state.subscriptionNextAttemptAt = 0;
+  invalidateGroupMultiplierCache();
+}
+
+export const GROUP_MULTIPLIER_CACHE_MAX_ENTRIES = MAX_CACHE_ENTRIES;

--- a/src/lib/circuit-breaker.ts
+++ b/src/lib/circuit-breaker.ts
@@ -27,7 +27,11 @@ import {
   loadCircuitState,
   saveCircuitState,
 } from "@/lib/redis/circuit-breaker-state";
-import { publishCacheInvalidation, subscribeCacheInvalidation } from "@/lib/redis/pubsub";
+import {
+  CACHE_INVALIDATION_RESYNC_MESSAGE,
+  publishCacheInvalidation,
+  subscribeCacheInvalidation,
+} from "@/lib/redis/pubsub";
 
 // 修复：导出 ProviderHealth 类型，供其他模块使用
 export interface ProviderHealth {
@@ -122,6 +126,22 @@ function parseConfigInvalidationProviderIds(message: string): number[] | null {
   }
 }
 
+/**
+ * Pub/Sub 重连意味着断线窗口内可能漏掉任意 provider 的定向消息。此时必须清空
+ * 当前进程持有的全部配置快照，并推进版本栅栏，避免在途旧查询重新写回。
+ */
+function clearAllConfigCachesAfterResync(): number {
+  let clearedCount = 0;
+  for (const [providerId, health] of healthMap) {
+    bumpConfigCacheVersion(providerId);
+    health.config = null;
+    health.configLoadedAt = null;
+    clearedCount++;
+  }
+  configLoadInFlight.clear();
+  return clearedCount;
+}
+
 async function ensureConfigInvalidationSubscription(): Promise<void> {
   if (configInvalidationSubscriptionInitialized) return;
   if (configInvalidationSubscriptionPromise) return configInvalidationSubscriptionPromise;
@@ -142,6 +162,14 @@ async function ensureConfigInvalidationSubscription(): Promise<void> {
     const cleanup = await subscribeCacheInvalidation(
       CHANNEL_CIRCUIT_BREAKER_CONFIG_UPDATED,
       (message) => {
+        if (message === CACHE_INVALIDATION_RESYNC_MESSAGE) {
+          const count = clearAllConfigCachesAfterResync();
+          logger.info("[CircuitBreaker] Cleared all config caches after pub/sub resync", {
+            count,
+          });
+          return;
+        }
+
         const ids = parseConfigInvalidationProviderIds(message);
         if (!ids) return;
 

--- a/src/lib/config/env.schema.ts
+++ b/src/lib/config/env.schema.ts
@@ -40,7 +40,8 @@ export const EnvSchema = z.object({
   }, z.string().url("数据库URL格式无效")),
   // PostgreSQL 连接池配置（postgres.js）
   // - 多副本部署（k8s）需要结合数据库 max_connections 分摊配置
-  // - DB_POOL_MAX 是每个应用进程内 data/control/writer 三类 pool 的连接总预算
+  // - 单进程时 DB_POOL_MAX 是 data/control/writer 三类 pool 的连接总预算
+  // - 内置 cluster launcher 会在启动 worker 前把容器级总预算分摊为这里读取的进程分片
   DB_POOL_MAX: optionalNumber(
     z.number().int().min(1, "DB_POOL_MAX 不能小于 1").max(200, "DB_POOL_MAX 不能大于 200")
   ),
@@ -200,7 +201,7 @@ export const EnvSchema = z.object({
   // 超时后主动断开该输家连接，仅用已收到的内容尝试计费（通常计不出 -> 跳过）。
   HEDGE_LOSER_DRAIN_TIMEOUT_MS: z.coerce.number().int().min(1000).default(120_000),
 
-  // 客户端断线后的 detached stream 使用进程级带权预算。
+  // 客户端断线后的 detached stream 使用进程级带权预算；内置 cluster 会先分摊容器总预算。
   DETACHED_STREAM_MAX_CONCURRENCY: z.coerce.number().int().min(1).max(4096).default(64),
   DETACHED_STREAM_BUDGET_BYTES: z.coerce
     .number()
@@ -228,6 +229,7 @@ export const EnvSchema = z.object({
     .max(64 * 1024 * 1024)
     .default(10 * 1024 * 1024),
   // 所有正在门禁 precommit 阶段及等待下游消费的前缀共享该进程级预算。
+  // 内置 cluster 会先分摊容器总预算，避免每个 worker 各拿一整份。
   STREAM_GATE_GLOBAL_PREBUFFER_BYTE_CAP: z.coerce
     .number()
     .int()

--- a/src/lib/config/system-settings-cache.ts
+++ b/src/lib/config/system-settings-cache.ts
@@ -13,6 +13,11 @@
  */
 
 import { logger } from "@/lib/logger";
+import {
+  CHANNEL_SYSTEM_SETTINGS_UPDATED,
+  publishCacheInvalidation,
+  subscribeCacheInvalidation,
+} from "@/lib/redis/pubsub";
 import { DEFAULT_SITE_TITLE } from "@/lib/site-title";
 import { REPLAY_CACHE_TTL_MINUTES_DEFAULT } from "@/lib/validation/replay-settings";
 import { getSystemSettings } from "@/repository/system-config";
@@ -21,10 +26,15 @@ import { getEnvConfig } from "./env.schema";
 
 /** Cache TTL in milliseconds (1 minute) */
 const CACHE_TTL_MS = 60 * 1000;
+const SUBSCRIPTION_RETRY_MS = 60 * 1000;
 
 /** Cached settings and timestamp */
 let cachedSettings: SystemSettings | null = null;
 let cachedAt: number = 0;
+let cacheVersion = 0;
+let subscriptionInitialized = false;
+let subscriptionInitPromise: Promise<boolean> | null = null;
+let subscriptionNextAttemptAt = 0;
 
 /** Avoid repeating the same invalid environment-variable warning on every request. */
 let hasWarnedInvalidResponsesWebsocketEnv = false;
@@ -168,6 +178,8 @@ export const DEFAULT_SETTINGS: Pick<
  * @returns System settings (cached or fresh)
  */
 export async function getCachedSystemSettings(): Promise<SystemSettings> {
+  // 多核心启动会在 ready 前等待首次订阅；外部多实例和兼容入口则在首次读取时懒启动。
+  startSystemSettingsCacheSubscription();
   const now = Date.now();
 
   // Return cached if still valid
@@ -176,17 +188,21 @@ export async function getCachedSystemSettings(): Promise<SystemSettings> {
   }
 
   try {
+    const expectedVersion = cacheVersion;
     // Fetch fresh settings from database
     const settings = await getSystemSettings();
 
-    // Update cache
-    cachedSettings = settings;
-    cachedAt = now;
+    // 更新事件可能发生在查询等待期间。版本已变化时仍允许当前请求使用其查询结果，
+    // 但不能让旧快照重新污染后续请求的进程缓存。
+    if (cacheVersion === expectedVersion) {
+      cachedSettings = settings;
+      cachedAt = now;
 
-    logger.debug("[SystemSettingsCache] Settings cached", {
-      enableHttp2: settings.enableHttp2,
-      ttl: CACHE_TTL_MS,
-    });
+      logger.debug("[SystemSettingsCache] Settings cached", {
+        enableHttp2: settings.enableHttp2,
+        ttl: CACHE_TTL_MS,
+      });
+    }
 
     return settings;
   } catch (error) {
@@ -297,8 +313,68 @@ export async function isOpenaiResponsesWebsocketEnabled(): Promise<boolean> {
  * Call this when system settings are saved to ensure
  * the next request gets fresh settings.
  */
-export function invalidateSystemSettingsCache(): void {
+function invalidateSystemSettingsCacheLocal(): void {
   cachedSettings = null;
   cachedAt = 0;
+  cacheVersion++;
   logger.info("[SystemSettingsCache] Cache invalidated");
+}
+
+/**
+ * 为当前进程建立系统设置失效订阅。连接暂时不可用时保留 TTL 降级，并以固定
+ * 退避避免请求热路径反复创建连接任务。
+ */
+export async function ensureSystemSettingsCacheSubscription(): Promise<boolean> {
+  if (subscriptionInitialized) return true;
+  if (subscriptionInitPromise) return subscriptionInitPromise;
+  if (Date.now() < subscriptionNextAttemptAt) return false;
+
+  subscriptionInitPromise = (async () => {
+    try {
+      const cleanup = await subscribeCacheInvalidation(CHANNEL_SYSTEM_SETTINGS_UPDATED, () => {
+        invalidateSystemSettingsCacheLocal();
+        logger.debug("[SystemSettingsCache] Cache invalidated via pub/sub");
+      });
+      if (!cleanup) {
+        subscriptionNextAttemptAt = Date.now() + SUBSCRIPTION_RETRY_MS;
+        return false;
+      }
+
+      subscriptionInitialized = true;
+      subscriptionNextAttemptAt = 0;
+      logger.info("[SystemSettingsCache] Cross-process invalidation enabled");
+      return true;
+    } catch (error) {
+      logger.warn("[SystemSettingsCache] Failed to subscribe to invalidation", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      subscriptionNextAttemptAt = Date.now() + SUBSCRIPTION_RETRY_MS;
+      return false;
+    }
+  })().finally(() => {
+    subscriptionInitPromise = null;
+  });
+
+  return subscriptionInitPromise;
+}
+
+/** 热路径的无等待入口；只有首次初始化或退避到期时会创建异步任务。 */
+export function startSystemSettingsCacheSubscription(): void {
+  if (
+    subscriptionInitialized ||
+    subscriptionInitPromise ||
+    Date.now() < subscriptionNextAttemptAt
+  ) {
+    return;
+  }
+  void ensureSystemSettingsCacheSubscription();
+}
+
+/**
+ * 数据库提交后清空本进程缓存，并广播不含设置内容的微小失效消息。发布失败沿用
+ * 现有 fail-open 语义，由每进程 60 秒 TTL 提供最终收敛上界。
+ */
+export function invalidateSystemSettingsCache(): void {
+  invalidateSystemSettingsCacheLocal();
+  void publishCacheInvalidation(CHANNEL_SYSTEM_SETTINGS_UPDATED);
 }

--- a/src/lib/redis/__tests__/pubsub.test.ts
+++ b/src/lib/redis/__tests__/pubsub.test.ts
@@ -63,7 +63,9 @@ describe("Redis Pub/Sub cache invalidation", () => {
     const { getRedisClient } = await import("@/lib/redis/client");
     (getRedisClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(base);
 
-    const { subscribeCacheInvalidation } = await import("@/lib/redis/pubsub");
+    const { CACHE_INVALIDATION_RESYNC_MESSAGE, subscribeCacheInvalidation } = await import(
+      "@/lib/redis/pubsub"
+    );
     const onInvalidate = vi.fn();
 
     // Start subscription (will wait for ready)
@@ -79,15 +81,17 @@ describe("Redis Pub/Sub cache invalidation", () => {
 
     expect(base.duplicate).toHaveBeenCalledTimes(1);
     expect(subscriber.subscribe).toHaveBeenCalledWith("test-channel");
+    expect(onInvalidate).toHaveBeenCalledTimes(1);
+    expect(onInvalidate).toHaveBeenLastCalledWith(CACHE_INVALIDATION_RESYNC_MESSAGE);
 
     const message = Date.now().toString();
     subscriber.emit("message", "test-channel", message);
-    expect(onInvalidate).toHaveBeenCalledTimes(1);
+    expect(onInvalidate).toHaveBeenCalledTimes(2);
     expect(onInvalidate).toHaveBeenCalledWith(message);
 
     cleanup!();
     subscriber.emit("message", "test-channel", Date.now().toString());
-    expect(onInvalidate).toHaveBeenCalledTimes(1);
+    expect(onInvalidate).toHaveBeenCalledTimes(2);
   });
 
   test("subscribeCacheInvalidation: should resubscribe on reconnect", async () => {
@@ -99,7 +103,9 @@ describe("Redis Pub/Sub cache invalidation", () => {
     const { getRedisClient } = await import("@/lib/redis/client");
     (getRedisClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(base);
 
-    const { subscribeCacheInvalidation } = await import("@/lib/redis/pubsub");
+    const { CACHE_INVALIDATION_RESYNC_MESSAGE, subscribeCacheInvalidation } = await import(
+      "@/lib/redis/pubsub"
+    );
     const onInvalidate = vi.fn();
 
     const subscribePromise = subscribeCacheInvalidation("test-channel", onInvalidate);
@@ -110,20 +116,27 @@ describe("Redis Pub/Sub cache invalidation", () => {
     const cleanup = await subscribePromise;
     expect(cleanup).not.toBeNull();
     expect(subscriber.subscribe).toHaveBeenCalledTimes(1);
+    expect(onInvalidate).toHaveBeenCalledWith(CACHE_INVALIDATION_RESYNC_MESSAGE);
 
     subscriber.subscribe.mockClear();
+    onInvalidate.mockClear();
     subscriber.emit("close");
     subscriber.emit("ready");
     await new Promise((resolve) => setImmediate(resolve));
     expect(subscriber.subscribe).toHaveBeenCalledTimes(1);
     expect(subscriber.subscribe).toHaveBeenCalledWith("test-channel");
+    expect(onInvalidate).toHaveBeenCalledTimes(1);
+    expect(onInvalidate).toHaveBeenCalledWith(CACHE_INVALIDATION_RESYNC_MESSAGE);
 
     subscriber.subscribe.mockClear();
+    onInvalidate.mockClear();
     subscriber.emit("close");
     subscriber.emit("ready");
     await new Promise((resolve) => setImmediate(resolve));
     expect(subscriber.subscribe).toHaveBeenCalledTimes(1);
     expect(subscriber.subscribe).toHaveBeenCalledWith("test-channel");
+    expect(onInvalidate).toHaveBeenCalledTimes(1);
+    expect(onInvalidate).toHaveBeenCalledWith(CACHE_INVALIDATION_RESYNC_MESSAGE);
 
     cleanup!();
   });
@@ -138,7 +151,7 @@ describe("Redis Pub/Sub cache invalidation", () => {
     expect(cleanup).toBeNull();
   });
 
-  test("subscribeCacheInvalidation: should return null on connection error", async () => {
+  test("subscribeCacheInvalidation: should retain registration on connection error", async () => {
     const base = new MockRedis();
     const subscriber = new MockRedis();
     base.duplicate.mockReturnValue(subscriber);
@@ -156,11 +169,12 @@ describe("Redis Pub/Sub cache invalidation", () => {
     subscriber.emit("error", new Error("Connection refused"));
 
     const cleanup = await subscribePromise;
-    expect(cleanup).toBeNull();
+    expect(cleanup).not.toBeNull();
     expect(onInvalidate).not.toHaveBeenCalled();
+    cleanup!();
   });
 
-  test("subscribeCacheInvalidation: should backoff reconnect attempts after connection error", async () => {
+  test("subscribeCacheInvalidation: should persistently recover without a second caller", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
 
@@ -174,16 +188,16 @@ describe("Redis Pub/Sub cache invalidation", () => {
       const { getRedisClient } = await import("@/lib/redis/client");
       (getRedisClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(base);
 
-      const { subscribeCacheInvalidation } = await import("@/lib/redis/pubsub");
+      const { CACHE_INVALIDATION_RESYNC_MESSAGE, subscribeCacheInvalidation } = await import(
+        "@/lib/redis/pubsub"
+      );
+      const onInvalidate = vi.fn();
 
-      const cleanup1Promise = subscribeCacheInvalidation("test-channel", vi.fn());
+      const cleanupPromise = subscribeCacheInvalidation("test-channel", onInvalidate);
       subscriber1.emit("error", new Error("Connection refused"));
 
-      const cleanup1 = await cleanup1Promise;
-      expect(cleanup1).toBeNull();
-      expect(base.duplicate).toHaveBeenCalledTimes(1);
-
-      const cleanup2Promise = subscribeCacheInvalidation("test-channel", vi.fn());
+      const cleanup = await cleanupPromise;
+      expect(cleanup).not.toBeNull();
       expect(base.duplicate).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(999);
@@ -194,49 +208,98 @@ describe("Redis Pub/Sub cache invalidation", () => {
 
       subscriber2.status = "ready";
       subscriber2.emit("ready");
+      await vi.advanceTimersByTimeAsync(0);
 
-      const cleanup2 = await cleanup2Promise;
-      expect(cleanup2).not.toBeNull();
-      cleanup2!();
+      expect(subscriber2.subscribe).toHaveBeenCalledWith("test-channel");
+      expect(onInvalidate).toHaveBeenCalledTimes(1);
+      expect(onInvalidate).toHaveBeenCalledWith(CACHE_INVALIDATION_RESYNC_MESSAGE);
+      cleanup!();
     } finally {
       vi.useRealTimers();
     }
   });
 
-  test("subscribeCacheInvalidation: should rollback callback when subscribe fails and allow retry", async () => {
-    const base = new MockRedis();
-    const subscriber = new MockRedis();
-    base.duplicate.mockReturnValue(subscriber);
-    subscriber.subscribe
-      .mockRejectedValueOnce(new Error("Subscribe failed"))
-      .mockResolvedValueOnce(1);
+  test("subscribeCacheInvalidation: should create a fresh subscriber after retry exhaustion", async () => {
+    vi.useFakeTimers();
+    try {
+      const base = new MockRedis();
+      const subscriber1 = new MockRedis();
+      const subscriber2 = new MockRedis();
+      subscriber1.subscribe.mockResolvedValue(1);
+      subscriber2.subscribe.mockResolvedValue(1);
+      base.duplicate.mockReturnValueOnce(subscriber1).mockReturnValueOnce(subscriber2);
 
-    const { getRedisClient } = await import("@/lib/redis/client");
-    (getRedisClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(base);
+      const { getRedisClient } = await import("@/lib/redis/client");
+      (getRedisClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(base);
 
-    const { subscribeCacheInvalidation } = await import("@/lib/redis/pubsub");
+      const { CACHE_INVALIDATION_RESYNC_MESSAGE, subscribeCacheInvalidation } = await import(
+        "@/lib/redis/pubsub"
+      );
+      const onInvalidate = vi.fn();
 
-    const onInvalidateA = vi.fn();
-    const subscribePromiseA = subscribeCacheInvalidation("test-channel", onInvalidateA);
+      const subscribePromise = subscribeCacheInvalidation("test-channel", onInvalidate);
+      subscriber1.status = "ready";
+      subscriber1.emit("ready");
+      const cleanup = await subscribePromise;
 
-    subscriber.status = "ready";
-    subscriber.emit("ready");
+      onInvalidate.mockClear();
+      subscriber1.status = "end";
+      subscriber1.emit("close");
+      subscriber1.emit("end");
 
-    const cleanupA = await subscribePromiseA;
-    expect(cleanupA).toBeNull();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(base.duplicate).toHaveBeenCalledTimes(2);
 
-    const onInvalidateB = vi.fn();
-    const cleanupB = await subscribeCacheInvalidation("test-channel", onInvalidateB);
-    expect(cleanupB).not.toBeNull();
-    expect(typeof cleanupB).toBe("function");
+      subscriber2.status = "ready";
+      subscriber2.emit("ready");
+      await vi.advanceTimersByTimeAsync(0);
 
-    subscriber.emit("message", "test-channel", Date.now().toString());
+      expect(subscriber2.subscribe).toHaveBeenCalledWith("test-channel");
+      expect(onInvalidate).toHaveBeenCalledTimes(1);
+      expect(onInvalidate).toHaveBeenCalledWith(CACHE_INVALIDATION_RESYNC_MESSAGE);
+      cleanup!();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
-    expect(onInvalidateA).not.toHaveBeenCalled();
-    expect(onInvalidateB).toHaveBeenCalledTimes(1);
-    expect(subscriber.subscribe).toHaveBeenCalledTimes(2);
+  test("subscribeCacheInvalidation: should retain callback when SUBSCRIBE fails and retry", async () => {
+    vi.useFakeTimers();
+    try {
+      const base = new MockRedis();
+      const subscriber = new MockRedis();
+      base.duplicate.mockReturnValue(subscriber);
+      subscriber.subscribe
+        .mockRejectedValueOnce(new Error("Subscribe failed"))
+        .mockResolvedValueOnce(1);
 
-    cleanupB!();
+      const { getRedisClient } = await import("@/lib/redis/client");
+      (getRedisClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(base);
+
+      const { subscribeCacheInvalidation } = await import("@/lib/redis/pubsub");
+
+      const onInvalidateA = vi.fn();
+      const subscribePromiseA = subscribeCacheInvalidation("test-channel", onInvalidateA);
+
+      subscriber.status = "ready";
+      subscriber.emit("ready");
+
+      const cleanupA = await subscribePromiseA;
+      expect(cleanupA).not.toBeNull();
+      expect(onInvalidateA).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(subscriber.subscribe).toHaveBeenCalledTimes(2);
+      expect(onInvalidateA).toHaveBeenCalledTimes(1);
+
+      subscriber.emit("message", "test-channel", Date.now().toString());
+
+      expect(onInvalidateA).toHaveBeenCalledTimes(2);
+
+      cleanupA!();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("subscribeCacheInvalidation: should timeout waiting for ready and disconnect subscriber", async () => {
@@ -255,8 +318,9 @@ describe("Redis Pub/Sub cache invalidation", () => {
       await vi.advanceTimersByTimeAsync(10000);
 
       const cleanup = await subscribePromise;
-      expect(cleanup).toBeNull();
+      expect(cleanup).not.toBeNull();
       expect(subscriber.disconnect).toHaveBeenCalledTimes(1);
+      cleanup!();
     } finally {
       vi.useRealTimers();
     }

--- a/src/lib/redis/pubsub.ts
+++ b/src/lib/redis/pubsub.ts
@@ -7,6 +7,8 @@ import { getRedisClient } from "./client";
 export const CHANNEL_ERROR_RULES_UPDATED = "cch:cache:error_rules:updated";
 export const CHANNEL_REQUEST_FILTERS_UPDATED = "cch:cache:request_filters:updated";
 export const CHANNEL_SENSITIVE_WORDS_UPDATED = "cch:cache:sensitive_words:updated";
+export const CHANNEL_PROVIDER_GROUPS_UPDATED = "cch:cache:provider_groups:updated";
+export const CHANNEL_SYSTEM_SETTINGS_UPDATED = "cch:cache:system_settings:updated";
 // API Key 集合发生变化（典型：创建新 key）时，通知各实例重建 Vacuum Filter，避免误拒绝
 export const CHANNEL_API_KEYS_UPDATED = "cch:cache:api_keys:updated";
 
@@ -203,10 +205,9 @@ function ensureSubscriber(baseClient: Redis): Promise<Redis> {
  * Publish cache invalidation (silent fail, auto-degrade)
  */
 export async function publishCacheInvalidation(channel: string, message?: string): Promise<void> {
-  const redis = getRedisClient();
-  if (!redis) return;
-
   try {
+    const redis = getRedisClient();
+    if (!redis) return;
     await redis.publish(channel, message ?? Date.now().toString());
   } catch (error) {
     logger.warn("[RedisPubSub] Failed to publish cache invalidation", { channel, error });

--- a/src/lib/redis/pubsub.ts
+++ b/src/lib/redis/pubsub.ts
@@ -12,21 +12,33 @@ export const CHANNEL_SYSTEM_SETTINGS_UPDATED = "cch:cache:system_settings:update
 // API Key 集合发生变化（典型：创建新 key）时，通知各实例重建 Vacuum Filter，避免误拒绝
 export const CHANNEL_API_KEYS_UPDATED = "cch:cache:api_keys:updated";
 
+/**
+ * Redis Pub/Sub 不会补发断线期间的消息。每次首次订阅或重连成功后，统一派发此
+ * 合成消息，让订阅方从权威存储重新加载或清空本地缓存。
+ */
+export const CACHE_INVALIDATION_RESYNC_MESSAGE = "cch:cache:resync";
+
 type CacheInvalidationCallback = (message: string) => void;
+
+interface CacheInvalidationRegistration {
+  callback: CacheInvalidationCallback;
+  needsResync: boolean;
+}
 
 let subscriberClient: Redis | null = null;
 let subscriberReady: Promise<Redis> | null = null;
-const subscriptions = new Map<string, Set<CacheInvalidationCallback>>();
+const subscriptions = new Map<string, Set<CacheInvalidationRegistration>>();
 const subscribedChannels = new Set<string>();
+const channelSubscribeInFlight = new Map<string, Promise<boolean>>();
 
-let resubscribeInFlight: Promise<void> | null = null;
-
-const SUBSCRIBER_CONNECT_TIMEOUT_MS = 10000;
-const SUBSCRIBER_CONNECT_BACKOFF_BASE_MS = 1000;
-const SUBSCRIBER_CONNECT_BACKOFF_MAX_MS = 60000;
+const SUBSCRIBER_CONNECT_TIMEOUT_MS = 10_000;
+const SUBSCRIBER_CONNECT_BACKOFF_BASE_MS = 1_000;
+const SUBSCRIBER_CONNECT_BACKOFF_MAX_MS = 60_000;
 
 let subscriberConnectFailures = 0;
 let subscriberNextConnectAt = 0;
+let subscriptionRetryFailures = 0;
+let subscriptionRetryTimer: ReturnType<typeof setTimeout> | null = null;
 
 function computeSubscriberConnectBackoffMs(consecutiveFailures: number): number {
   if (!Number.isFinite(consecutiveFailures) || consecutiveFailures <= 0) return 0;
@@ -36,44 +48,180 @@ function computeSubscriberConnectBackoffMs(consecutiveFailures: number): number 
   return Math.min(SUBSCRIBER_CONNECT_BACKOFF_MAX_MS, backoffMs);
 }
 
-async function resubscribeAll(sub: Redis): Promise<void> {
-  if (resubscribeInFlight) return resubscribeInFlight;
+function hasDesiredSubscriptions(): boolean {
+  for (const registrations of subscriptions.values()) {
+    if (registrations.size > 0) return true;
+  }
+  return false;
+}
 
-  resubscribeInFlight = (async () => {
-    const channelsToSubscribe: string[] = [];
-    for (const [channel, callbacks] of subscriptions) {
-      if (!callbacks || callbacks.size === 0) continue;
-      if (!subscribedChannels.has(channel)) {
-        channelsToSubscribe.push(channel);
-      }
+function allDesiredChannelsSubscribed(): boolean {
+  for (const [channel, registrations] of subscriptions) {
+    if (registrations.size > 0 && !subscribedChannels.has(channel)) return false;
+  }
+  return true;
+}
+
+function markAllSubscriptionsForResync(): void {
+  for (const registrations of subscriptions.values()) {
+    for (const registration of registrations) {
+      registration.needsResync = true;
     }
+  }
+}
 
-    if (channelsToSubscribe.length === 0) return;
+function invokeCallback(
+  channel: string,
+  registration: CacheInvalidationRegistration,
+  message: string
+): void {
+  try {
+    registration.callback(message);
+  } catch (error) {
+    logger.error("[RedisPubSub] Callback error", { channel, error });
+  }
+}
 
-    let successCount = 0;
-    for (const channel of channelsToSubscribe) {
-      try {
-        await sub.subscribe(channel);
-        subscribedChannels.add(channel);
-        successCount++;
-      } catch (error) {
-        logger.warn("[RedisPubSub] Failed to resubscribe channel after reconnect", {
-          channel,
-          error,
-        });
+function dispatchPendingResync(channel: string): void {
+  const registrations = subscriptions.get(channel);
+  if (!registrations || registrations.size === 0) return;
+
+  let count = 0;
+  for (const registration of registrations) {
+    if (!registration.needsResync) continue;
+
+    // 在执行回调前清标记，避免回调同步触发订阅检查时重复派发。
+    registration.needsResync = false;
+    count++;
+    invokeCallback(channel, registration, CACHE_INVALIDATION_RESYNC_MESSAGE);
+  }
+
+  if (count > 0) {
+    logger.info("[RedisPubSub] Forced cache resync after subscription recovery", {
+      channel,
+      callbackCount: count,
+    });
+  }
+}
+
+function clearSubscriptionRetryTimer(): void {
+  if (!subscriptionRetryTimer) return;
+  clearTimeout(subscriptionRetryTimer);
+  subscriptionRetryTimer = null;
+}
+
+function markSubscriptionsHealthy(): void {
+  if (!allDesiredChannelsSubscribed()) return;
+  subscriptionRetryFailures = 0;
+  clearSubscriptionRetryTimer();
+}
+
+function scheduleSubscriptionRetry(): void {
+  if (!hasDesiredSubscriptions() || subscriptionRetryTimer) return;
+
+  subscriptionRetryFailures++;
+  const retryBackoffMs = computeSubscriberConnectBackoffMs(subscriptionRetryFailures);
+  const connectBackoffMs = Math.max(0, subscriberNextConnectAt - Date.now());
+  const delayMs = Math.max(retryBackoffMs, connectBackoffMs);
+
+  subscriptionRetryTimer = setTimeout(() => {
+    subscriptionRetryTimer = null;
+    void reconcileSubscriptions();
+  }, delayMs);
+  subscriptionRetryTimer.unref?.();
+
+  logger.warn("[RedisPubSub] Scheduled persistent subscription retry", {
+    delayMs,
+    consecutiveFailures: subscriptionRetryFailures,
+  });
+}
+
+async function ensureChannelSubscribed(sub: Redis, channel: string): Promise<boolean> {
+  const registrations = subscriptions.get(channel);
+  if (!registrations || registrations.size === 0) return true;
+
+  if (subscribedChannels.has(channel)) {
+    dispatchPendingResync(channel);
+    return true;
+  }
+
+  const existing = channelSubscribeInFlight.get(channel);
+  if (existing) return existing;
+
+  const subscribePromise = (async () => {
+    try {
+      await sub.subscribe(channel);
+
+      // SUBSCRIBE 可能与断线或最后一个 cleanup 竞态；只有当前 ready 连接仍然有效时
+      // 才能发布“已订阅”状态。
+      if (subscriberClient !== sub || sub.status !== "ready") return false;
+
+      const currentRegistrations = subscriptions.get(channel);
+      if (!currentRegistrations || currentRegistrations.size === 0) {
+        await Promise.resolve(sub.unsubscribe(channel)).catch(() => undefined);
+        return true;
       }
-    }
 
-    if (successCount > 0) {
-      logger.info("[RedisPubSub] Resubscribed to channels after reconnect", {
-        count: successCount,
-      });
+      subscribedChannels.add(channel);
+      logger.info("[RedisPubSub] Subscribed to channel", { channel });
+      dispatchPendingResync(channel);
+      return true;
+    } catch (error) {
+      logger.warn("[RedisPubSub] Failed to subscribe channel", { channel, error });
+      return false;
     }
   })().finally(() => {
-    resubscribeInFlight = null;
+    if (channelSubscribeInFlight.get(channel) === subscribePromise) {
+      channelSubscribeInFlight.delete(channel);
+    }
   });
 
-  return resubscribeInFlight;
+  channelSubscribeInFlight.set(channel, subscribePromise);
+  return subscribePromise;
+}
+
+async function subscribeAllDesiredChannels(sub: Redis): Promise<boolean> {
+  const channels = Array.from(subscriptions.entries())
+    .filter(([, registrations]) => registrations.size > 0)
+    .map(([channel]) => channel);
+
+  const results = await Promise.all(
+    channels.map((channel) => ensureChannelSubscribed(sub, channel))
+  );
+  const healthy = results.every(Boolean) && allDesiredChannelsSubscribed();
+
+  if (healthy) {
+    markSubscriptionsHealthy();
+  } else {
+    scheduleSubscriptionRetry();
+  }
+
+  return healthy;
+}
+
+async function reconcileSubscriptions(preferredSubscriber?: Redis): Promise<void> {
+  if (!hasDesiredSubscriptions()) {
+    subscriptionRetryFailures = 0;
+    clearSubscriptionRetryTimer();
+    return;
+  }
+
+  try {
+    const baseClient = getRedisClient();
+    if (!baseClient) {
+      scheduleSubscriptionRetry();
+      return;
+    }
+
+    const sub =
+      preferredSubscriber && preferredSubscriber === subscriberClient
+        ? preferredSubscriber
+        : await ensureSubscriber(baseClient);
+    await subscribeAllDesiredChannels(sub);
+  } catch {
+    // ensureSubscriber 已记录连接失败详情；这里只维持持久重试，避免按 channel 刷屏。
+    scheduleSubscriptionRetry();
+  }
 }
 
 function ensureSubscriber(baseClient: Redis): Promise<Redis> {
@@ -149,22 +297,34 @@ function ensureSubscriber(baseClient: Redis): Promise<Redis> {
       subscriberConnectFailures = 0;
       subscriberNextConnectAt = 0;
 
-      readySub.on("error", (error) =>
-        logger.warn("[RedisPubSub] Subscriber connection error", { error })
-      );
-      readySub.on("close", () => subscribedChannels.clear());
-      readySub.on("end", () => subscribedChannels.clear());
-      readySub.on("ready", () => void resubscribeAll(readySub));
+      readySub.on("error", (error) => {
+        if (subscriberClient !== readySub) return;
+        logger.warn("[RedisPubSub] Subscriber connection error", { error });
+      });
+      readySub.on("close", () => {
+        if (subscriberClient !== readySub) return;
+        subscribedChannels.clear();
+        markAllSubscriptionsForResync();
+        scheduleSubscriptionRetry();
+      });
+      readySub.on("end", () => {
+        if (subscriberClient !== readySub) return;
+        subscribedChannels.clear();
+        markAllSubscriptionsForResync();
+        subscriberClient = null;
+        subscriberReady = null;
+        scheduleSubscriptionRetry();
+      });
+      readySub.on("ready", () => {
+        if (subscriberClient !== readySub) return;
+        void reconcileSubscriptions(readySub);
+      });
 
       readySub.on("message", (channel: string, message: string) => {
-        const callbacks = subscriptions.get(channel);
-        if (!callbacks || callbacks.size === 0) return;
-        for (const cb of callbacks) {
-          try {
-            cb(message);
-          } catch (error) {
-            logger.error("[RedisPubSub] Callback error", { channel, error });
-          }
+        const registrations = subscriptions.get(channel);
+        if (!registrations || registrations.size === 0) return;
+        for (const registration of registrations) {
+          invokeCallback(channel, registration, message);
         }
       });
 
@@ -179,11 +339,15 @@ function ensureSubscriber(baseClient: Redis): Promise<Redis> {
     function startConnection(): void {
       if (settled) return;
 
-      sub = baseClient.duplicate();
-      sub.once("ready", onReady);
-      sub.once("error", onError);
+      try {
+        sub = baseClient.duplicate();
+        sub.once("ready", onReady);
+        sub.once("error", onError);
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
 
-      // Timeout 10 seconds
       timeoutId = setTimeout(() => {
         if (sub?.status !== "ready") {
           fail(new Error("Redis subscriber connection timeout"));
@@ -215,8 +379,11 @@ export async function publishCacheInvalidation(channel: string, message?: string
 }
 
 /**
- * Subscribe to cache invalidation
- * Returns cleanup function on success, null on failure
+ * Subscribe to cache invalidation.
+ *
+ * Redis 已配置时，回调会先持久登记；即使首次连接失败也返回 cleanup，并由本模块
+ * 在后台有界退避重试。首次订阅和每次断线恢复后会派发一条 RESYNC 合成消息，
+ * 用于覆盖 Pub/Sub 天生无法补发的断线窗口。仅 Redis 未配置/被禁用时返回 null。
  */
 export async function subscribeCacheInvalidation(
   channel: string,
@@ -225,45 +392,50 @@ export async function subscribeCacheInvalidation(
   const baseClient = getRedisClient();
   if (!baseClient) return null;
 
-  let sub: Redis;
-  try {
-    sub = await ensureSubscriber(baseClient);
-  } catch {
-    // ensureSubscriber 内部已记录连接失败与 backoff 信息，避免这里按 channel 重复刷屏
-    return null;
-  }
+  const registration: CacheInvalidationRegistration = {
+    callback,
+    // 订阅建立前缓存可能已经加载；首次 SUBSCRIBE 成功也必须从权威存储对齐一次。
+    needsResync: true,
+  };
+  const registrations = subscriptions.get(channel) ?? new Set<CacheInvalidationRegistration>();
+  registrations.add(registration);
+  subscriptions.set(channel, registrations);
 
-  const callbacks = subscriptions.get(channel) ?? new Set<CacheInvalidationCallback>();
-  callbacks.add(callback);
-  subscriptions.set(channel, callbacks);
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
 
-  if (!subscribedChannels.has(channel)) {
-    try {
-      await sub.subscribe(channel);
-      subscribedChannels.add(channel);
-      logger.info("[RedisPubSub] Subscribed to channel", { channel });
-    } catch (error) {
-      callbacks.delete(callback);
-      if (callbacks.size === 0) {
-        subscriptions.delete(channel);
-      }
-      logger.warn("[RedisPubSub] Failed to subscribe channel", { channel, error });
-      return null;
+    const current = subscriptions.get(channel);
+    if (!current) return;
+
+    current.delete(registration);
+    if (current.size > 0) return;
+
+    subscriptions.delete(channel);
+    subscribedChannels.delete(channel);
+    if (subscriberClient) {
+      void Promise.resolve(subscriberClient.unsubscribe(channel)).catch(() => undefined);
     }
-  }
 
-  return () => {
-    const cbs = subscriptions.get(channel);
-    if (!cbs) return;
-
-    cbs.delete(callback);
-
-    if (cbs.size === 0) {
-      subscriptions.delete(channel);
-      subscribedChannels.delete(channel);
-      if (subscriberClient) {
-        void subscriberClient.unsubscribe(channel);
-      }
+    if (!hasDesiredSubscriptions()) {
+      subscriptionRetryFailures = 0;
+      clearSubscriptionRetryTimer();
     }
   };
+
+  try {
+    const sub = await ensureSubscriber(baseClient);
+    const subscribed = await ensureChannelSubscribed(sub, channel);
+    if (subscribed) {
+      markSubscriptionsHealthy();
+    } else {
+      scheduleSubscriptionRetry();
+    }
+  } catch {
+    // 回调仍保留在 desired subscriptions 中，后台恢复后会自动订阅并强制 resync。
+    scheduleSubscriptionRetry();
+  }
+
+  return cleanup;
 }

--- a/src/lib/sensitive-word-detector.ts
+++ b/src/lib/sensitive-word-detector.ts
@@ -29,6 +29,8 @@ class SensitiveWordCache {
   private regex: RegexPattern[] = [];
   private lastReloadTime: number = 0;
   private isLoading: boolean = false;
+  private activeReloadPromise: Promise<void> | null = null;
+  private reloadRequestedWhileLoading = false;
 
   private eventEmitterCleanup: (() => void) | null = null;
   private redisPubSubCleanup: (() => void) | null = null;
@@ -85,62 +87,79 @@ class SensitiveWordCache {
    * 从数据库重新加载敏感词列表
    */
   async reload(): Promise<void> {
-    if (this.isLoading) {
-      logger.warn("[SensitiveWordCache] Reload already in progress, skipping");
-      return;
+    if (this.activeReloadPromise) {
+      // 管理端写入或 pub/sub resync 可能与已有加载重叠。排队补跑而不是丢弃，
+      // 否则断线窗口内的新敏感词可能永久缺失于本地快照。
+      this.reloadRequestedWhileLoading = true;
+      return this.activeReloadPromise;
     }
 
-    this.isLoading = true;
+    const reloadLoop = (async () => {
+      do {
+        this.reloadRequestedWhileLoading = false;
+        this.isLoading = true;
 
-    try {
-      logger.info("[SensitiveWordCache] Reloading sensitive words from database...");
+        try {
+          logger.info("[SensitiveWordCache] Reloading sensitive words from database...");
 
-      const words = await getActiveSensitiveWords();
+          const words = await getActiveSensitiveWords();
+          const nextContains: string[] = [];
+          const nextExact = new Set<string>();
+          const nextRegex: RegexPattern[] = [];
 
-      // 清空旧缓存
-      this.contains = [];
-      this.exact.clear();
-      this.regex = [];
+          // 先构建完整的新快照，再同步替换，避免加载期间暴露部分规则。
+          for (const word of words) {
+            const lowerWord = word.word.toLowerCase();
 
-      // 按类型分组
-      for (const word of words) {
-        const lowerWord = word.word.toLowerCase();
+            switch (word.matchType) {
+              case "contains":
+                nextContains.push(lowerWord);
+                break;
 
-        switch (word.matchType) {
-          case "contains":
-            this.contains.push(lowerWord);
-            break;
+              case "exact":
+                nextExact.add(lowerWord);
+                break;
 
-          case "exact":
-            this.exact.add(lowerWord);
-            break;
+              case "regex":
+                try {
+                  const pattern = new RegExp(word.word, "i");
+                  nextRegex.push({ pattern, word: word.word });
+                } catch (error) {
+                  logger.error(`[SensitiveWordCache] Invalid regex pattern: ${word.word}`, error);
+                }
+                break;
 
-          case "regex":
-            try {
-              const pattern = new RegExp(word.word, "i");
-              this.regex.push({ pattern, word: word.word });
-            } catch (error) {
-              logger.error(`[SensitiveWordCache] Invalid regex pattern: ${word.word}`, error);
+              default:
+                logger.warn(`[SensitiveWordCache] Unknown match type: ${word.matchType}`);
             }
-            break;
+          }
 
-          default:
-            logger.warn(`[SensitiveWordCache] Unknown match type: ${word.matchType}`);
+          this.contains = nextContains;
+          this.exact = nextExact;
+          this.regex = nextRegex;
+          this.lastReloadTime = Date.now();
+
+          logger.info(
+            `[SensitiveWordCache] Loaded ${words.length} sensitive words: ` +
+              `contains=${this.contains.length}, exact=${this.exact.size}, regex=${this.regex.length}`
+          );
+        } catch (error) {
+          logger.error("[SensitiveWordCache] Failed to reload sensitive words:", error);
+          // 失败时不清空现有缓存，保持降级可用
+        } finally {
+          this.isLoading = false;
         }
-      }
+      } while (this.reloadRequestedWhileLoading);
+    })();
 
-      this.lastReloadTime = Date.now();
+    this.activeReloadPromise = reloadLoop.finally(() => {
+      // 覆盖循环条件检查与 Promise settle 之间到达的极窄竞态窗口。
+      const shouldRestart = this.reloadRequestedWhileLoading;
+      this.activeReloadPromise = null;
+      if (shouldRestart) return this.reload();
+    });
 
-      logger.info(
-        `[SensitiveWordCache] Loaded ${words.length} sensitive words: ` +
-          `contains=${this.contains.length}, exact=${this.exact.size}, regex=${this.regex.length}`
-      );
-    } catch (error) {
-      logger.error("[SensitiveWordCache] Failed to reload sensitive words:", error);
-      // 失败时不清空现有缓存，保持降级可用
-    } finally {
-      this.isLoading = false;
-    }
+    return this.activeReloadPromise;
   }
 
   /**

--- a/src/lib/utils/timezone-shared.ts
+++ b/src/lib/utils/timezone-shared.ts
@@ -47,7 +47,7 @@ export function isValidIANATimezone(timezone: string): boolean {
 }
 
 /** 生成包含当前 UTC offset 的下拉框标签。 */
-export function getTimezoneLabel(timezone: string, locale = "en"): string {
+export function getTimezoneLabel(timezone: string, locale: string): string {
   if (!isValidIANATimezone(timezone)) return timezone;
 
   try {

--- a/src/lib/utils/timezone-shared.ts
+++ b/src/lib/utils/timezone-shared.ts
@@ -1,0 +1,75 @@
+/** 浏览器与服务端均可安全使用的纯时区工具；不得引入数据库或 Node-only 依赖。 */
+
+export const COMMON_TIMEZONES = [
+  "UTC",
+  "Asia/Shanghai",
+  "Asia/Tokyo",
+  "Asia/Seoul",
+  "Asia/Singapore",
+  "Asia/Hong_Kong",
+  "Asia/Taipei",
+  "Asia/Bangkok",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "Europe/Moscow",
+  "Europe/Amsterdam",
+  "Europe/Rome",
+  "Europe/Madrid",
+  "America/New_York",
+  "America/Los_Angeles",
+  "America/Chicago",
+  "America/Denver",
+  "America/Toronto",
+  "America/Vancouver",
+  "America/Sao_Paulo",
+  "America/Mexico_City",
+  "Pacific/Auckland",
+  "Pacific/Sydney",
+  "Australia/Melbourne",
+  "Australia/Perth",
+] as const;
+
+export type CommonTimezone = (typeof COMMON_TIMEZONES)[number];
+
+/** 使用运行时 IANA 数据库校验时区标识。 */
+export function isValidIANATimezone(timezone: string): boolean {
+  if (!timezone || typeof timezone !== "string") return false;
+
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** 生成包含当前 UTC offset 的下拉框标签。 */
+export function getTimezoneLabel(timezone: string, locale = "en"): string {
+  if (!isValidIANATimezone(timezone)) return timezone;
+
+  try {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      timeZone: timezone,
+      timeZoneName: "longOffset",
+    });
+    const offset = formatter
+      .formatToParts(new Date())
+      .find((part) => part.type === "timeZoneName")?.value;
+    return `(${offset ?? ""}) ${timezone}`;
+  } catch {
+    return timezone;
+  }
+}
+
+/** 返回指定时区当前相对 UTC 的分钟偏移。 */
+export function getTimezoneOffsetMinutes(timezone: string): number {
+  if (!isValidIANATimezone(timezone)) return 0;
+
+  const now = new Date();
+  const utcDate = new Date(now.toLocaleString("en-US", { timeZone: "UTC" }));
+  const timezoneDate = new Date(now.toLocaleString("en-US", { timeZone: timezone }));
+  return (timezoneDate.getTime() - utcDate.getTime()) / (1000 * 60);
+}

--- a/src/lib/utils/timezone.ts
+++ b/src/lib/utils/timezone.ts
@@ -11,128 +11,15 @@
 import { getEnvConfig } from "@/lib/config/env.schema";
 import { getCachedSystemSettings } from "@/lib/config/system-settings-cache";
 import { logger } from "@/lib/logger";
+import { isValidIANATimezone } from "./timezone-shared";
 
-/**
- * Common IANA timezone identifiers for dropdown UI.
- * Organized by region for better UX.
- */
-export const COMMON_TIMEZONES = [
-  // UTC
-  "UTC",
-  // Asia
-  "Asia/Shanghai",
-  "Asia/Tokyo",
-  "Asia/Seoul",
-  "Asia/Singapore",
-  "Asia/Hong_Kong",
-  "Asia/Taipei",
-  "Asia/Bangkok",
-  "Asia/Dubai",
-  "Asia/Kolkata",
-  // Europe
-  "Europe/London",
-  "Europe/Paris",
-  "Europe/Berlin",
-  "Europe/Moscow",
-  "Europe/Amsterdam",
-  "Europe/Rome",
-  "Europe/Madrid",
-  // Americas
-  "America/New_York",
-  "America/Los_Angeles",
-  "America/Chicago",
-  "America/Denver",
-  "America/Toronto",
-  "America/Vancouver",
-  "America/Sao_Paulo",
-  "America/Mexico_City",
-  // Pacific
-  "Pacific/Auckland",
-  "Pacific/Sydney",
-  "Australia/Melbourne",
-  "Australia/Perth",
-] as const;
-
-export type CommonTimezone = (typeof COMMON_TIMEZONES)[number];
-
-/**
- * Validates if a string is a valid IANA timezone identifier.
- *
- * Uses the Intl.DateTimeFormat API which is based on the IANA timezone database.
- * This approach is more reliable than maintaining a static list.
- *
- * @param timezone - The timezone string to validate
- * @returns true if the timezone is valid, false otherwise
- *
- * @example
- * isValidIANATimezone("Asia/Shanghai") // true
- * isValidIANATimezone("America/New_York") // true
- * isValidIANATimezone("UTC") // true
- * isValidIANATimezone("Invalid/Zone") // false
- * isValidIANATimezone("CST") // false (abbreviations not valid)
- */
-export function isValidIANATimezone(timezone: string): boolean {
-  if (!timezone || typeof timezone !== "string") {
-    return false;
-  }
-
-  try {
-    // Intl.DateTimeFormat will throw if the timezone is invalid
-    Intl.DateTimeFormat(undefined, { timeZone: timezone });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Gets the display label for a timezone.
- * Returns the offset and common name for UI display.
- *
- * @param timezone - IANA timezone identifier
- * @param locale - Locale for formatting (default: "en")
- * @returns Display label like "(UTC+08:00) Asia/Shanghai"
- */
-export function getTimezoneLabel(timezone: string, locale = "en"): string {
-  if (!isValidIANATimezone(timezone)) {
-    return timezone;
-  }
-
-  try {
-    const now = new Date();
-    const formatter = new Intl.DateTimeFormat(locale, {
-      timeZone: timezone,
-      timeZoneName: "longOffset",
-    });
-
-    const parts = formatter.formatToParts(now);
-    const offsetPart = parts.find((p) => p.type === "timeZoneName");
-    const offset = offsetPart?.value || "";
-
-    // Format: "(UTC+08:00) Asia/Shanghai" or "(GMT+08:00) Asia/Shanghai"
-    return `(${offset}) ${timezone}`;
-  } catch {
-    return timezone;
-  }
-}
-
-/**
- * Gets the current UTC offset in minutes for a timezone.
- *
- * @param timezone - IANA timezone identifier
- * @returns Offset in minutes (positive = ahead of UTC, negative = behind)
- */
-export function getTimezoneOffsetMinutes(timezone: string): number {
-  if (!isValidIANATimezone(timezone)) {
-    return 0;
-  }
-
-  const now = new Date();
-  const utcDate = new Date(now.toLocaleString("en-US", { timeZone: "UTC" }));
-  const tzDate = new Date(now.toLocaleString("en-US", { timeZone: timezone }));
-
-  return (tzDate.getTime() - utcDate.getTime()) / (1000 * 60);
-}
+export {
+  COMMON_TIMEZONES,
+  type CommonTimezone,
+  getTimezoneLabel,
+  getTimezoneOffsetMinutes,
+  isValidIANATimezone,
+} from "./timezone-shared";
 
 /**
  * Resolves the system timezone using the fallback chain:

--- a/src/lib/utils/timezone.ts
+++ b/src/lib/utils/timezone.ts
@@ -11,7 +11,7 @@
 import { getEnvConfig } from "@/lib/config/env.schema";
 import { getCachedSystemSettings } from "@/lib/config/system-settings-cache";
 import { logger } from "@/lib/logger";
-import { isValidIANATimezone } from "./timezone-shared";
+import { isValidIANATimezone } from "@/lib/utils/timezone-shared";
 
 export {
   COMMON_TIMEZONES,

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -15,7 +15,7 @@ import {
   PUBLIC_STATUS_INTERVAL_OPTIONS,
 } from "@/lib/public-status/constants";
 import { CURRENCY_CONFIG } from "@/lib/utils/currency";
-import { isValidIANATimezone } from "@/lib/utils/timezone";
+import { isValidIANATimezone } from "@/lib/utils/timezone-shared";
 import {
   DISCOVERY_FIELD_LIMITS,
   DISCOVERY_SETTINGS_INVALID_ERROR_CODE,

--- a/src/repository/provider-groups.ts
+++ b/src/repository/provider-groups.ts
@@ -3,6 +3,14 @@ import "server-only";
 import { asc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { db } from "@/drizzle/db";
 import { providerGroups, providers } from "@/drizzle/schema";
+import {
+  getGroupMultiplierCacheVersion,
+  invalidateGroupMultiplierCache,
+  publishGroupMultiplierCacheInvalidation,
+  readCachedGroupMultiplier,
+  startGroupMultiplierCacheSubscription,
+  writeCachedGroupMultiplier,
+} from "@/lib/cache/provider-group-multiplier-cache";
 import { PROVIDER_GROUP } from "@/lib/constants/provider.constants";
 import { parseProviderGroups } from "@/lib/utils/provider-group";
 import type {
@@ -31,26 +39,7 @@ function toProviderGroup(row: ProviderGroupRow): ProviderGroup {
   };
 }
 
-// ---------------------------------------------------------------------------
-// In-memory cache for getGroupCostMultiplier (hot-path, called per request)
-// ---------------------------------------------------------------------------
-
-const CACHE_TTL_MS = 60_000; // 60 seconds
-
-interface CacheEntry {
-  value: number;
-  expiresAt: number;
-}
-
-const multiplierCache = new Map<string, CacheEntry>();
-
-/**
- * Invalidate the in-memory cost multiplier cache.
- * Call this after any mutation (create / update / delete) to provider groups.
- */
-export function invalidateGroupMultiplierCache(): void {
-  multiplierCache.clear();
-}
+export { invalidateGroupMultiplierCache };
 
 // ---------------------------------------------------------------------------
 // Query functions
@@ -117,7 +106,6 @@ export async function createProviderGroup(input: CreateProviderGroupInput): Prom
     })
     .returning();
 
-  invalidateGroupMultiplierCache();
   return toProviderGroup(row);
 }
 
@@ -149,7 +137,6 @@ export async function updateProviderGroup(
 
   if (!row) return null;
 
-  invalidateGroupMultiplierCache();
   return toProviderGroup(row);
 }
 
@@ -195,7 +182,7 @@ export async function ensureProviderGroupsExist(names: string[]): Promise<void> 
     .values(unique.map((name) => ({ name })))
     .onConflictDoNothing({ target: providerGroups.name });
 
-  invalidateGroupMultiplierCache();
+  await publishGroupMultiplierCacheInvalidation();
 }
 
 /**
@@ -215,7 +202,6 @@ export async function deleteProviderGroup(id: number): Promise<void> {
   }
 
   await db.delete(providerGroups).where(eq(providerGroups.id, id));
-  invalidateGroupMultiplierCache();
 }
 
 // ---------------------------------------------------------------------------
@@ -234,33 +220,31 @@ export async function deleteProviderGroup(id: number): Promise<void> {
  *
  * Falls back to 1.0 when none of the groups exist.
  *
- * Results are cached in-memory with a 60-second TTL so that the proxy
- * pipeline can call this on every request without extra DB round-trips.
+ * Results are cached in-memory with a 60-second TTL and a 10,000-entry bound
+ * so that the proxy pipeline can call this on every request without unbounded
+ * memory growth or extra DB round-trips.
  * Cache misses (value === 1.0 because no matching row was found) are NOT
  * cached, so newly-created groups propagate on the next request.
  *
- * Note: this cache is per-process. In multi-instance deployments, a mutation
- * on one node will not invalidate other nodes' caches; worst-case staleness
- * is bounded by CACHE_TTL_MS.
+ * 每个进程通过 Redis Pub/Sub 接收失效通知。订阅暂时不可用时自动退化到 TTL；
+ * 版本号可防止失效事件之后才返回的旧查询结果重新污染缓存。
  */
 export async function getGroupCostMultiplier(rawGroupString: string): Promise<number> {
-  const now = Date.now();
+  // 已有缓存的进程必须同时拥有失效订阅。初始化不阻塞热路径；多核心启动器会在
+  // worker ready 前主动等待首次订阅，外部多实例部署则在首次请求时懒启动。
+  startGroupMultiplierCacheSubscription();
 
   // Cache hit fast-path: we key the cache on the raw input string so that
   // repeated lookups for the same user bypass parsing + DB entirely.
-  const cached = multiplierCache.get(rawGroupString);
-  if (cached && cached.expiresAt > now) {
-    return cached.value;
-  }
-  if (cached) {
-    multiplierCache.delete(rawGroupString);
-  }
+  const cached = readCachedGroupMultiplier(rawGroupString);
+  if (cached !== undefined) return cached;
 
   const parsedGroups = parseProviderGroups(rawGroupString);
   if (parsedGroups.length === 0) {
     return 1.0;
   }
 
+  const cacheVersion = getGroupMultiplierCacheVersion();
   const rows = await db
     .select({
       name: providerGroups.name,
@@ -283,10 +267,7 @@ export async function getGroupCostMultiplier(rawGroupString: string): Promise<nu
   // Only cache real hits. Caching misses would defer new-group visibility by
   // up to CACHE_TTL_MS on this process and is rarely worth the win.
   if (resolved !== null) {
-    multiplierCache.set(rawGroupString, {
-      value: resolved,
-      expiresAt: now + CACHE_TTL_MS,
-    });
+    writeCachedGroupMultiplier(rawGroupString, resolved, cacheVersion);
     return resolved;
   }
 

--- a/tests/unit/actions/provider-groups-description-merge.test.ts
+++ b/tests/unit/actions/provider-groups-description-merge.test.ts
@@ -5,6 +5,9 @@ const mockFindProviderGroupById = vi.hoisted(() => vi.fn());
 const mockFindProviderGroupByName = vi.hoisted(() => vi.fn());
 const mockRepoCreateProviderGroup = vi.hoisted(() => vi.fn());
 const mockRepoUpdateProviderGroup = vi.hoisted(() => vi.fn());
+const mockRepoDeleteProviderGroup = vi.hoisted(() => vi.fn());
+const mockCountProvidersUsingGroup = vi.hoisted(() => vi.fn());
+const mockPublishGroupMultiplierCacheInvalidation = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/auth", () => ({
   getSession: mockGetSession,
@@ -13,6 +16,16 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("next-intl/server", () => ({
   getTranslations: async () => (key: string) => key,
 }));
+
+vi.mock("@/lib/cache/provider-group-multiplier-cache", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/cache/provider-group-multiplier-cache")
+  >("@/lib/cache/provider-group-multiplier-cache");
+  return {
+    ...actual,
+    publishGroupMultiplierCacheInvalidation: mockPublishGroupMultiplierCacheInvalidation,
+  };
+});
 
 vi.mock("@/repository/provider-groups", async () => {
   const actual = await vi.importActual<typeof import("@/repository/provider-groups")>(
@@ -24,6 +37,8 @@ vi.mock("@/repository/provider-groups", async () => {
     findProviderGroupByName: mockFindProviderGroupByName,
     createProviderGroup: mockRepoCreateProviderGroup,
     updateProviderGroup: mockRepoUpdateProviderGroup,
+    deleteProviderGroup: mockRepoDeleteProviderGroup,
+    countProvidersUsingGroup: mockCountProvidersUsingGroup,
   };
 });
 
@@ -61,6 +76,9 @@ describe("provider-groups action description merge", () => {
       }),
     });
     mockFindProviderGroupByName.mockResolvedValue(null);
+    mockCountProvidersUsingGroup.mockResolvedValue(0);
+    mockRepoDeleteProviderGroup.mockResolvedValue(undefined);
+    mockPublishGroupMultiplierCacheInvalidation.mockResolvedValue(undefined);
     mockRepoCreateProviderGroup.mockResolvedValue({
       id: 12,
       name: "new-group",
@@ -103,6 +121,37 @@ describe("provider-groups action description merge", () => {
         },
       }),
     });
+    expect(mockPublishGroupMultiplierCacheInvalidation).not.toHaveBeenCalled();
+  });
+
+  it("publishes multiplier invalidation only after a committed multiplier update", async () => {
+    const { updateProviderGroup } = await import("@/actions/provider-groups");
+
+    const result = await updateProviderGroup(11, { costMultiplier: 2 });
+
+    expect(result.ok).toBe(true);
+    expect(mockPublishGroupMultiplierCacheInvalidation).toHaveBeenCalledTimes(1);
+    expect(mockRepoUpdateProviderGroup.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPublishGroupMultiplierCacheInvalidation.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("publishes invalidation after create and delete commits", async () => {
+    const { createProviderGroup, deleteProviderGroup } = await import("@/actions/provider-groups");
+
+    expect(
+      await createProviderGroup({ name: "new-group", costMultiplier: 1, description: "" })
+    ).toMatchObject({ ok: true });
+    expect(mockRepoCreateProviderGroup.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPublishGroupMultiplierCacheInvalidation.mock.invocationCallOrder[0]
+    );
+
+    mockPublishGroupMultiplierCacheInvalidation.mockClear();
+    expect(await deleteProviderGroup(11)).toMatchObject({ ok: true });
+    expect(mockPublishGroupMultiplierCacheInvalidation).toHaveBeenCalledTimes(1);
+    expect(mockRepoDeleteProviderGroup.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPublishGroupMultiplierCacheInvalidation.mock.invocationCallOrder[0]
+    );
   });
 
   it("rejects descriptionNote when merged payload would exceed the UTF-8 byte limit", async () => {

--- a/tests/unit/deploy-dockerfile-contract.test.ts
+++ b/tests/unit/deploy-dockerfile-contract.test.ts
@@ -23,7 +23,7 @@ describe("deploy/Dockerfile runtime contract", () => {
     const reportsDirectory = "RUN mkdir -p /app/reports && chown node:node /app/reports";
     const user = "USER node";
     const command =
-      'CMD ["node", "--report-on-fatalerror", "--report-uncaught-exception", "--report-exclude-env", "--report-directory=/app/reports", "server.js"]';
+      'CMD ["node", "--report-on-fatalerror", "--report-uncaught-exception", "--report-exclude-env", "--report-directory=/app/reports", "cluster.js"]';
 
     expect(dockerfile).toContain(reportsDirectory);
     expect(dockerfile).toContain(user);

--- a/tests/unit/instrumentation-multicore-role.test.ts
+++ b/tests/unit/instrumentation-multicore-role.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { shouldRunBackgroundTasks } from "@/instrumentation";
+
+describe("instrumentation multicore role gating", () => {
+  it("preserves standalone and external-replica startup behavior by default", () => {
+    expect(shouldRunBackgroundTasks({})).toBe(true);
+    expect(shouldRunBackgroundTasks({ CCH_MULTICORE_BACKGROUND_OWNER: "1" })).toBe(true);
+  });
+
+  it("disables singleton schedulers only for an explicitly marked request worker", () => {
+    expect(shouldRunBackgroundTasks({ CCH_MULTICORE_BACKGROUND_OWNER: "0" })).toBe(false);
+    expect(shouldRunBackgroundTasks({ CCH_MULTICORE_BACKGROUND_OWNER: "false" })).toBe(true);
+  });
+});

--- a/tests/unit/instrumentation-multicore-startup.test.ts
+++ b/tests/unit/instrumentation-multicore-startup.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ENV_KEYS = [
+  "NEXT_RUNTIME",
+  "NODE_ENV",
+  "CI",
+  "CCH_MULTICORE_BACKGROUND_OWNER",
+  "CCH_MULTICORE_WORKER_INDEX",
+  "CCH_MULTICORE_WORKER_COUNT",
+  "ENABLE_RATE_LIMIT",
+  "REDIS_URL",
+] as const;
+
+const savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe.sequential("request-only multicore instrumentation startup", () => {
+  it("initializes local caches without migrations, schedulers or queue consumers", async () => {
+    vi.resetModules();
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.NODE_ENV = "production";
+    process.env.CCH_MULTICORE_BACKGROUND_OWNER = "0";
+    process.env.CCH_MULTICORE_WORKER_INDEX = "1";
+    process.env.CCH_MULTICORE_WORKER_COUNT = "2";
+    process.env.ENABLE_RATE_LIMIT = "false";
+    delete process.env.CI;
+    delete process.env.REDIS_URL;
+
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    };
+    const startCacheCleanup = vi.fn();
+    const startBackgroundReload = vi.fn();
+    const initLangfuse = vi.fn(async () => {});
+    const bindLifecycleGlobals = vi.fn();
+    const checkDatabaseConnection = vi.fn(async () => true);
+    const runMigrations = vi.fn(async () => {});
+    const reloadErrorRules = vi.fn(async () => {});
+    const getProxyRuntimeSettings = vi.fn(async () => ({}));
+    const backgroundQueueModuleFactory = vi.fn(() => ({ scheduleAutoCleanup: vi.fn() }));
+
+    vi.doMock("@/drizzle/admitted-client", () => ({ findSafeDatabaseError: () => null }));
+    vi.doMock("@/lib/cache/session-cache", () => ({ startCacheCleanup }));
+    vi.doMock("@/lib/lifecycle/benign-errors", () => ({
+      getBenignBrokenPipeCode: () => null,
+    }));
+    vi.doMock("@/lib/logger", () => ({ logger }));
+    vi.doMock("@/lib/redis/pubsub", () => ({
+      CHANNEL_API_KEYS_UPDATED: "api-keys",
+      subscribeCacheInvalidation: vi.fn(async () => null),
+    }));
+    vi.doMock("@/lib/security/api-key-vacuum-filter", () => ({
+      apiKeyVacuumFilter: { startBackgroundReload, invalidateAndReload: vi.fn() },
+    }));
+    vi.doMock("@/lib/langfuse", () => ({ initLangfuse }));
+    vi.doMock("@/lib/lifecycle/shutdown", () => ({ bindLifecycleGlobals }));
+    vi.doMock("@/lib/migrate", () => ({
+      checkDatabaseConnection,
+      runMigrations,
+      withAdvisoryLock: vi.fn(),
+    }));
+    vi.doMock("@/lib/error-rule-detector", () => ({
+      errorRuleDetector: { reload: reloadErrorRules },
+    }));
+    vi.doMock("@/lib/system-settings/proxy-runtime", () => ({ getProxyRuntimeSettings }));
+    vi.doMock("@/lib/log-cleanup/cleanup-queue", backgroundQueueModuleFactory);
+
+    const processOn = vi
+      .spyOn(process, "on")
+      .mockImplementation((() => process) as typeof process.on);
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    const { register } = await import("@/instrumentation");
+    await register();
+
+    expect(processOn).toHaveBeenCalledWith("uncaughtException", expect.any(Function));
+    expect(processOn).toHaveBeenCalledWith("unhandledRejection", expect.any(Function));
+    expect(initLangfuse).toHaveBeenCalledTimes(1);
+    expect(startCacheCleanup).toHaveBeenCalledWith(60);
+    expect(bindLifecycleGlobals).toHaveBeenCalledTimes(1);
+    expect(checkDatabaseConnection).toHaveBeenCalledTimes(1);
+    expect(startBackgroundReload).toHaveBeenCalledWith({ reason: "startup" });
+    expect(reloadErrorRules).toHaveBeenCalledTimes(1);
+    expect(getProxyRuntimeSettings).toHaveBeenCalledTimes(1);
+    expect(runMigrations).not.toHaveBeenCalled();
+    expect(backgroundQueueModuleFactory).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith("[Multicore] Request-only gateway worker ready");
+  });
+});

--- a/tests/unit/instrumentation-multicore-startup.test.ts
+++ b/tests/unit/instrumentation-multicore-startup.test.ts
@@ -4,6 +4,7 @@ const ENV_KEYS = [
   "NEXT_RUNTIME",
   "NODE_ENV",
   "CI",
+  "CCH_MULTICORE_ACTIVE",
   "CCH_MULTICORE_BACKGROUND_OWNER",
   "CCH_MULTICORE_WORKER_INDEX",
   "CCH_MULTICORE_WORKER_COUNT",
@@ -28,12 +29,13 @@ describe.sequential("request-only multicore instrumentation startup", () => {
     vi.resetModules();
     process.env.NEXT_RUNTIME = "nodejs";
     process.env.NODE_ENV = "production";
+    process.env.CCH_MULTICORE_ACTIVE = "1";
     process.env.CCH_MULTICORE_BACKGROUND_OWNER = "0";
     process.env.CCH_MULTICORE_WORKER_INDEX = "1";
     process.env.CCH_MULTICORE_WORKER_COUNT = "2";
-    process.env.ENABLE_RATE_LIMIT = "false";
+    process.env.ENABLE_RATE_LIMIT = "true";
     delete process.env.CI;
-    delete process.env.REDIS_URL;
+    process.env.REDIS_URL = "redis://redis:6379";
 
     const logger = {
       info: vi.fn(),
@@ -47,6 +49,8 @@ describe.sequential("request-only multicore instrumentation startup", () => {
     const bindLifecycleGlobals = vi.fn();
     const checkDatabaseConnection = vi.fn(async () => true);
     const runMigrations = vi.fn(async () => {});
+    const ensureGroupMultiplierCacheSubscription = vi.fn(async () => true);
+    const ensureSystemSettingsCacheSubscription = vi.fn(async () => true);
     const reloadErrorRules = vi.fn(async () => {});
     const getProxyRuntimeSettings = vi.fn(async () => ({}));
     const backgroundQueueModuleFactory = vi.fn(() => ({ scheduleAutoCleanup: vi.fn() }));
@@ -66,6 +70,12 @@ describe.sequential("request-only multicore instrumentation startup", () => {
     }));
     vi.doMock("@/lib/langfuse", () => ({ initLangfuse }));
     vi.doMock("@/lib/lifecycle/shutdown", () => ({ bindLifecycleGlobals }));
+    vi.doMock("@/lib/cache/provider-group-multiplier-cache", () => ({
+      ensureGroupMultiplierCacheSubscription,
+    }));
+    vi.doMock("@/lib/config/system-settings-cache", () => ({
+      ensureSystemSettingsCacheSubscription,
+    }));
     vi.doMock("@/lib/migrate", () => ({
       checkDatabaseConnection,
       runMigrations,
@@ -90,6 +100,8 @@ describe.sequential("request-only multicore instrumentation startup", () => {
     expect(initLangfuse).toHaveBeenCalledTimes(1);
     expect(startCacheCleanup).toHaveBeenCalledWith(60);
     expect(bindLifecycleGlobals).toHaveBeenCalledTimes(1);
+    expect(ensureGroupMultiplierCacheSubscription).toHaveBeenCalledTimes(1);
+    expect(ensureSystemSettingsCacheSubscription).toHaveBeenCalledTimes(1);
     expect(checkDatabaseConnection).toHaveBeenCalledTimes(1);
     expect(startBackgroundReload).toHaveBeenCalledWith({ reason: "startup" });
     expect(reloadErrorRules).toHaveBeenCalledTimes(1);

--- a/tests/unit/lib/circuit-breaker.test.ts
+++ b/tests/unit/lib/circuit-breaker.test.ts
@@ -66,6 +66,7 @@ function setupCircuitBreakerMocks(options?: {
       options?.config?.loadProviderCircuitConfig ?? vi.fn(async () => defaultConfig),
   }));
   vi.doMock("@/lib/redis/pubsub", () => ({
+    CACHE_INVALIDATION_RESYNC_MESSAGE: "cch:cache:resync",
     publishCacheInvalidation: options?.pubsub?.publishCacheInvalidation ?? vi.fn(async () => {}),
     subscribeCacheInvalidation:
       options?.pubsub?.subscribeCacheInvalidation ?? vi.fn(async () => null),
@@ -398,6 +399,50 @@ describe("circuit-breaker", () => {
 
       await recordFailure(1, new Error("boom"));
       expect(loadProviderCircuitConfigMock).toHaveBeenCalledTimes(2);
+    } finally {
+      if (originalCi === undefined) {
+        delete process.env.CI;
+      } else {
+        process.env.CI = originalCi;
+      }
+    }
+  });
+
+  test("pub/sub 重连 resync 应清除全部已加载的配置缓存", async () => {
+    setupFakeTime();
+
+    const originalCi = process.env.CI;
+    process.env.CI = "false";
+
+    try {
+      vi.resetModules();
+      let onInvalidation: ((message: string) => void) | null = null;
+      const loadProviderCircuitConfigMock = vi.fn(async () => ({
+        failureThreshold: 10,
+        openDuration: 1800000,
+        halfOpenSuccessThreshold: 2,
+      }));
+
+      setupCircuitBreakerMocks({
+        config: { loadProviderCircuitConfig: loadProviderCircuitConfigMock },
+        pubsub: {
+          subscribeCacheInvalidation: vi.fn(async (_channel, callback) => {
+            onInvalidation = callback;
+            return () => {};
+          }),
+        },
+      });
+
+      const { recordFailure } = await import("@/lib/circuit-breaker");
+      await recordFailure(1, new Error("boom"));
+      await recordFailure(2, new Error("boom"));
+      expect(loadProviderCircuitConfigMock).toHaveBeenCalledTimes(2);
+
+      onInvalidation!("cch:cache:resync");
+
+      await recordFailure(1, new Error("boom"));
+      await recordFailure(2, new Error("boom"));
+      expect(loadProviderCircuitConfigMock).toHaveBeenCalledTimes(4);
     } finally {
       if (originalCi === undefined) {
         delete process.env.CI;

--- a/tests/unit/lib/config/system-settings-cache.test.ts
+++ b/tests/unit/lib/config/system-settings-cache.test.ts
@@ -6,6 +6,12 @@ const getSystemSettingsMock = vi.fn();
 const loggerDebugMock = vi.fn();
 const loggerWarnMock = vi.fn();
 const loggerInfoMock = vi.fn();
+const pubsubHarness = vi.hoisted(() => ({
+  callback: null as ((message: string) => void) | null,
+  cleanup: vi.fn(),
+  publish: vi.fn(),
+  subscribe: vi.fn(),
+}));
 
 const originalResponsesWebsocketEnv = process.env.ENABLE_OPENAI_RESPONSES_WEBSOCKET;
 const originalStreamGateMode = process.env.STREAM_GATE_MODE;
@@ -25,6 +31,12 @@ vi.mock("@/lib/logger", () => ({
     trace: vi.fn(),
     error: vi.fn(),
   },
+}));
+
+vi.mock("@/lib/redis/pubsub", () => ({
+  CHANNEL_SYSTEM_SETTINGS_UPDATED: "cch:cache:system_settings:updated",
+  publishCacheInvalidation: pubsubHarness.publish,
+  subscribeCacheInvalidation: pubsubHarness.subscribe,
 }));
 
 function createSettings(overrides: Partial<SystemSettings> = {}): SystemSettings {
@@ -79,6 +91,7 @@ async function loadCache() {
     isHttp2Enabled: mod.isHttp2Enabled,
     isOpenaiResponsesWebsocketEnabled: mod.isOpenaiResponsesWebsocketEnabled,
     invalidateSystemSettingsCache: mod.invalidateSystemSettingsCache,
+    ensureSystemSettingsCacheSubscription: mod.ensureSystemSettingsCacheSubscription,
   };
 }
 
@@ -88,6 +101,14 @@ beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-01-03T00:00:00.000Z"));
   delete process.env.ENABLE_OPENAI_RESPONSES_WEBSOCKET;
+  pubsubHarness.callback = null;
+  pubsubHarness.publish.mockResolvedValue(undefined);
+  pubsubHarness.subscribe.mockImplementation(
+    async (_channel: string, callback: (message: string) => void) => {
+      pubsubHarness.callback = callback;
+      return pubsubHarness.cleanup;
+    }
+  );
 });
 
 afterEach(() => {
@@ -225,9 +246,54 @@ describe("SystemSettingsCache", () => {
     expect(await getCachedSystemSettings()).toBe(settingsA);
 
     invalidateSystemSettingsCache();
-    expect(loggerInfoMock).toHaveBeenCalledTimes(1);
+    expect(loggerInfoMock).toHaveBeenCalledWith("[SystemSettingsCache] Cache invalidated");
+    await vi.waitFor(() =>
+      expect(pubsubHarness.publish).toHaveBeenCalledWith("cch:cache:system_settings:updated")
+    );
 
     expect(await getCachedSystemSettings()).toBe(settingsB);
+    expect(getSystemSettingsMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("其他进程广播更新后应清空本地系统设置缓存", async () => {
+    const settingsA = createSettings({ id: 411, billingModelSource: "original" });
+    const settingsB = createSettings({ id: 412, billingModelSource: "redirected" });
+    getSystemSettingsMock.mockResolvedValueOnce(settingsA).mockResolvedValueOnce(settingsB);
+
+    const { getCachedSystemSettings, ensureSystemSettingsCacheSubscription } = await loadCache();
+    await ensureSystemSettingsCacheSubscription();
+
+    expect(await getCachedSystemSettings()).toBe(settingsA);
+    expect(await getCachedSystemSettings()).toBe(settingsA);
+    pubsubHarness.callback?.("updated");
+
+    expect(await getCachedSystemSettings()).toBe(settingsB);
+    expect(getSystemSettingsMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("失效事件后不得让较早发出的查询重新缓存旧设置", async () => {
+    const oldSettings = createSettings({ id: 421, billHedgeLosers: true });
+    const newSettings = createSettings({ id: 422, billHedgeLosers: false });
+    let resolveOldQuery: ((settings: SystemSettings) => void) | undefined;
+    getSystemSettingsMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<SystemSettings>((resolve) => {
+            resolveOldQuery = resolve;
+          })
+      )
+      .mockResolvedValueOnce(newSettings);
+
+    const { getCachedSystemSettings, ensureSystemSettingsCacheSubscription } = await loadCache();
+    await ensureSystemSettingsCacheSubscription();
+
+    const oldResult = getCachedSystemSettings();
+    expect(getSystemSettingsMock).toHaveBeenCalledTimes(1);
+    pubsubHarness.callback?.("updated");
+    resolveOldQuery?.(oldSettings);
+    expect(await oldResult).toBe(oldSettings);
+
+    expect(await getCachedSystemSettings()).toBe(newSettings);
     expect(getSystemSettingsMock).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/unit/lib/sensitive-word-detector-reload-queue.test.ts
+++ b/tests/unit/lib/sensitive-word-detector-reload-queue.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { SensitiveWord } from "@/repository/sensitive-words";
+
+const mocks = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  return {
+    getActiveSensitiveWords: vi.fn(),
+    onRedisInvalidation: null as ((message: string) => void) | null,
+    eventEmitter: {
+      on(event: string, handler: (...args: unknown[]) => void) {
+        const current = listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
+        current.add(handler);
+        listeners.set(event, current);
+      },
+      off(event: string, handler: (...args: unknown[]) => void) {
+        listeners.get(event)?.delete(handler);
+      },
+      removeAllListeners() {
+        listeners.clear();
+      },
+    },
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      trace: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/repository/sensitive-words", () => ({
+  getActiveSensitiveWords: mocks.getActiveSensitiveWords,
+}));
+
+vi.mock("@/lib/event-emitter", () => ({
+  eventEmitter: mocks.eventEmitter,
+}));
+
+vi.mock("@/lib/redis/pubsub", () => ({
+  CHANNEL_SENSITIVE_WORDS_UPDATED: "sensitiveWordsUpdated",
+  subscribeCacheInvalidation: vi.fn(
+    async (_channel: string, callback: (message: string) => void) => {
+      mocks.onRedisInvalidation = callback;
+      return () => {};
+    }
+  ),
+}));
+
+vi.mock("@/lib/logger", () => ({ logger: mocks.logger }));
+
+function buildWord(id: number, word: string): SensitiveWord {
+  return {
+    id,
+    word,
+    matchType: "contains",
+    description: null,
+    isEnabled: true,
+    createdAt: new Date("2026-08-29T00:00:00.000Z"),
+    updatedAt: new Date("2026-08-29T00:00:00.000Z"),
+  };
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mocks.eventEmitter.removeAllListeners();
+  mocks.onRedisInvalidation = null;
+  delete (globalThis as Record<string, unknown>).__CCH_SENSITIVE_WORD_DETECTOR__;
+});
+
+describe("SensitiveWordCache reload queue", () => {
+  test("pub/sub resync 到达加载期间时应补跑并保留最新规则", async () => {
+    let resolveFirstLoad: ((value: SensitiveWord[]) => void) | undefined;
+    mocks.getActiveSensitiveWords
+      .mockImplementationOnce(
+        () =>
+          new Promise<SensitiveWord[]>((resolve) => {
+            resolveFirstLoad = resolve;
+          })
+      )
+      .mockResolvedValueOnce([buildWord(2, "new-rule")]);
+
+    const { sensitiveWordDetector } = await import("@/lib/sensitive-word-detector");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const firstReload = sensitiveWordDetector.reload();
+    await Promise.resolve();
+    expect(mocks.onRedisInvalidation).not.toBeNull();
+    mocks.onRedisInvalidation!("cch:cache:resync");
+
+    resolveFirstLoad?.([buildWord(1, "old-rule")]);
+    await firstReload;
+
+    expect(mocks.getActiveSensitiveWords).toHaveBeenCalledTimes(2);
+    expect(sensitiveWordDetector.detect("contains new-rule here").matched).toBe(true);
+    expect(sensitiveWordDetector.detect("contains old-rule here").matched).toBe(false);
+    sensitiveWordDetector.destroy();
+  });
+});

--- a/tests/unit/proxy/provider-selector-system-settings-cache.test.ts
+++ b/tests/unit/proxy/provider-selector-system-settings-cache.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const getSystemSettingsMock = vi.hoisted(() => vi.fn());
+const getCachedSystemSettingsMock = vi.hoisted(() => vi.fn());
 
-vi.mock("@/repository/system-config", () => ({
-  getSystemSettings: getSystemSettingsMock,
+vi.mock("@/lib/config/system-settings-cache", () => ({
+  getCachedSystemSettings: getCachedSystemSettingsMock,
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -23,19 +23,14 @@ describe("provider-selector system settings cache", () => {
     vi.resetModules();
   });
 
-  test("invalidateProviderSelectorSystemSettingsCache clears cached verboseProviderError", async () => {
-    getSystemSettingsMock
+  test("复用统一系统设置缓存并读取最新 verboseProviderError", async () => {
+    getCachedSystemSettingsMock
       .mockResolvedValueOnce({ verboseProviderError: false })
       .mockResolvedValueOnce({ verboseProviderError: true });
 
     const mod = await import("@/app/v1/_lib/proxy/provider-selector-settings-cache");
-    const first = await mod.getVerboseProviderErrorCached();
-    expect(first).toBe(false);
-
-    mod.invalidateProviderSelectorSystemSettingsCache();
-
-    const second = await mod.getVerboseProviderErrorCached();
-    expect(second).toBe(true);
-    expect(getSystemSettingsMock).toHaveBeenCalledTimes(2);
+    expect(await mod.getVerboseProviderErrorCached()).toBe(false);
+    expect(await mod.getVerboseProviderErrorCached()).toBe(true);
+    expect(getCachedSystemSettingsMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/repository/provider-groups.test.ts
+++ b/tests/unit/repository/provider-groups.test.ts
@@ -43,6 +43,12 @@ const returningMock = vi.fn();
 const onConflictDoNothingMock = vi.fn();
 const setMock = vi.fn();
 const deleteWhereMock = vi.fn();
+const pubsubHarness = vi.hoisted(() => ({
+  callback: null as ((message: string) => void) | null,
+  cleanup: vi.fn(),
+  publish: vi.fn(),
+  subscribe: vi.fn(),
+}));
 
 function createQuery<T>(result: T, whereArgs?: unknown[]) {
   const query: any = Promise.resolve(result);
@@ -100,6 +106,20 @@ vi.mock("@/drizzle/schema", () => ({
   },
 }));
 
+vi.mock("@/lib/redis/pubsub", () => ({
+  CHANNEL_PROVIDER_GROUPS_UPDATED: "cch:cache:provider_groups:updated",
+  publishCacheInvalidation: pubsubHarness.publish,
+  subscribeCacheInvalidation: pubsubHarness.subscribe,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
 function fakeRow(
   overrides: Partial<{
     id: number;
@@ -121,10 +141,22 @@ function fakeRow(
 }
 
 describe("provider-groups repository", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    const { disposeGroupMultiplierCache } = await import(
+      "@/lib/cache/provider-group-multiplier-cache"
+    );
+    disposeGroupMultiplierCache();
     vi.resetModules();
     vi.clearAllMocks();
     resetChainMocks();
+    pubsubHarness.callback = null;
+    pubsubHarness.publish.mockResolvedValue(undefined);
+    pubsubHarness.subscribe.mockImplementation(
+      async (_channel: string, callback: (message: string) => void) => {
+        pubsubHarness.callback = callback;
+        return pubsubHarness.cleanup;
+      }
+    );
   });
 
   describe("getGroupCostMultiplier", () => {
@@ -197,6 +229,130 @@ describe("provider-groups repository", () => {
       const second = await getGroupCostMultiplier("flip");
       expect(second).toBe(4.0);
       expect(selectMock.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    });
+
+    it("invalidates a cached multiplier when another process publishes an update", async () => {
+      selectMock
+        .mockImplementationOnce(() =>
+          createQuery([fakeRow({ name: "remote", costMultiplier: "1.5000" })])
+        )
+        .mockImplementationOnce(() =>
+          createQuery([fakeRow({ name: "remote", costMultiplier: "4.0000" })])
+        );
+
+      const { getGroupCostMultiplier, invalidateGroupMultiplierCache } = await import(
+        "@/repository/provider-groups"
+      );
+      const { ensureGroupMultiplierCacheSubscription } = await import(
+        "@/lib/cache/provider-group-multiplier-cache"
+      );
+      invalidateGroupMultiplierCache();
+      await ensureGroupMultiplierCacheSubscription();
+
+      expect(await getGroupCostMultiplier("remote")).toBe(1.5);
+      expect(await getGroupCostMultiplier("remote")).toBe(1.5);
+      expect(selectMock).toHaveBeenCalledTimes(1);
+
+      pubsubHarness.callback?.("updated");
+      expect(await getGroupCostMultiplier("remote")).toBe(4);
+      expect(selectMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not re-cache an old in-flight query after an invalidation event", async () => {
+      let resolveOldQuery: ((rows: ReturnType<typeof fakeRow>[]) => void) | undefined;
+      const oldQuery: any = new Promise<ReturnType<typeof fakeRow>[]>((resolve) => {
+        resolveOldQuery = resolve;
+      });
+      oldQuery.from = vi.fn(() => oldQuery);
+      oldQuery.where = vi.fn(() => oldQuery);
+
+      selectMock
+        .mockImplementationOnce(() => oldQuery)
+        .mockImplementationOnce(() =>
+          createQuery([fakeRow({ name: "racing", costMultiplier: "4.0000" })])
+        );
+
+      const { getGroupCostMultiplier, invalidateGroupMultiplierCache } = await import(
+        "@/repository/provider-groups"
+      );
+      const { ensureGroupMultiplierCacheSubscription } = await import(
+        "@/lib/cache/provider-group-multiplier-cache"
+      );
+      invalidateGroupMultiplierCache();
+      await ensureGroupMultiplierCacheSubscription();
+
+      const oldResult = getGroupCostMultiplier("racing");
+      expect(selectMock).toHaveBeenCalledTimes(1);
+      pubsubHarness.callback?.("updated");
+      resolveOldQuery?.([fakeRow({ name: "racing", costMultiplier: "1.5000" })]);
+      expect(await oldResult).toBe(1.5);
+
+      expect(await getGroupCostMultiplier("racing")).toBe(4);
+      expect(selectMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("bounds the per-process multiplier cache entry count", async () => {
+      const {
+        GROUP_MULTIPLIER_CACHE_MAX_ENTRIES,
+        getGroupMultiplierCacheVersion,
+        invalidateGroupMultiplierCache,
+        readCachedGroupMultiplier,
+        writeCachedGroupMultiplier,
+      } = await import("@/lib/cache/provider-group-multiplier-cache");
+      invalidateGroupMultiplierCache();
+      const version = getGroupMultiplierCacheVersion();
+
+      for (let index = 0; index <= GROUP_MULTIPLIER_CACHE_MAX_ENTRIES; index++) {
+        writeCachedGroupMultiplier(`group-${index}`, index, version);
+      }
+
+      expect(readCachedGroupMultiplier("group-0")).toBeUndefined();
+      expect(readCachedGroupMultiplier(`group-${GROUP_MULTIPLIER_CACHE_MAX_ENTRIES}`)).toBe(
+        GROUP_MULTIPLIER_CACHE_MAX_ENTRIES
+      );
+    });
+
+    it("expires entries and rejects writes from an invalidated query version", async () => {
+      const {
+        getGroupMultiplierCacheVersion,
+        invalidateGroupMultiplierCache,
+        readCachedGroupMultiplier,
+        writeCachedGroupMultiplier,
+      } = await import("@/lib/cache/provider-group-multiplier-cache");
+      const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+      invalidateGroupMultiplierCache();
+      const oldVersion = getGroupMultiplierCacheVersion();
+
+      expect(writeCachedGroupMultiplier("expiring", 2, oldVersion)).toBe(true);
+      now.mockReturnValue(61_001);
+      expect(readCachedGroupMultiplier("expiring")).toBeUndefined();
+
+      invalidateGroupMultiplierCache();
+      expect(writeCachedGroupMultiplier("stale", 3, oldVersion)).toBe(false);
+      expect(readCachedGroupMultiplier("stale")).toBeUndefined();
+      now.mockRestore();
+    });
+
+    it("backs off subscription retries after a connection failure", async () => {
+      pubsubHarness.subscribe.mockRejectedValueOnce(new Error("subscriber unavailable"));
+      const { ensureGroupMultiplierCacheSubscription } = await import(
+        "@/lib/cache/provider-group-multiplier-cache"
+      );
+
+      expect(await ensureGroupMultiplierCacheSubscription()).toBe(false);
+      expect(await ensureGroupMultiplierCacheSubscription()).toBe(false);
+      expect(pubsubHarness.subscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("backs off when Redis subscription is unavailable without throwing", async () => {
+      pubsubHarness.subscribe.mockResolvedValueOnce(null);
+      const { ensureGroupMultiplierCacheSubscription } = await import(
+        "@/lib/cache/provider-group-multiplier-cache"
+      );
+
+      expect(await ensureGroupMultiplierCacheSubscription()).toBe(false);
+      expect(await ensureGroupMultiplierCacheSubscription()).toBe(false);
+      expect(pubsubHarness.subscribe).toHaveBeenCalledTimes(1);
     });
 
     it("resolves comma-separated groups by taking the first matching parsed group from a single query", async () => {
@@ -277,6 +433,26 @@ describe("provider-groups repository", () => {
       expect(count).toBe(1);
       expect(whereArgs).toHaveLength(1);
       expect(sqlToString(whereArgs[0]).toLowerCase()).toContain("deleted");
+    });
+  });
+
+  describe("ensureProviderGroupsExist", () => {
+    it("publishes group creation invalidation after the insert completes", async () => {
+      let finishInsert: (() => void) | undefined;
+      onConflictDoNothingMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishInsert = resolve;
+          })
+      );
+
+      const { ensureProviderGroupsExist } = await import("@/repository/provider-groups");
+      const operation = ensureProviderGroupsExist(["new-group"]);
+      expect(pubsubHarness.publish).not.toHaveBeenCalled();
+
+      finishInsert?.();
+      await operation;
+      expect(pubsubHarness.publish).toHaveBeenCalledWith("cch:cache:provider_groups:updated");
     });
   });
 

--- a/tests/unit/server-cluster-supervisor.test.ts
+++ b/tests/unit/server-cluster-supervisor.test.ts
@@ -173,6 +173,26 @@ describe("cluster supervisor", () => {
     expect(logs).toContain("multicore_worker_restart_scheduled");
   });
 
+  it("absorbs asynchronous worker errors and lets exit drive one restart", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    const { supervisor, logs } = makeSupervisor(clusterModule);
+    supervisor.start();
+    const failedWorker = clusterModule.workers[0];
+
+    expect(() => failedWorker.emit("error", new Error("spawn EAGAIN"))).not.toThrow();
+    expect(logs).toContain("multicore_worker_error");
+    expect(supervisor.snapshot().restartSlots).toEqual([]);
+
+    failedWorker.emit("exit", 1, null);
+    expect(supervisor.snapshot().restartSlots).toEqual([0]);
+    vi.advanceTimersByTime(10);
+
+    expect(clusterModule.workers).toHaveLength(2);
+    expect(clusterModule.workers[1].env.CCH_MULTICORE_WORKER_INDEX).toBe("0");
+    expect(logs.filter((event) => event === "multicore_worker_exited")).toHaveLength(1);
+  });
+
   it("restarts an unexpectedly exited worker in the same resource slot", () => {
     vi.useFakeTimers();
     const clusterModule = new FakeCluster();
@@ -207,7 +227,7 @@ describe("cluster supervisor", () => {
     expect(clusterModule.workers[1].env.CCH_MULTICORE_WORKER_INDEX).toBe("0");
   });
 
-  it("force-kills a startup worker that ignores the readiness SIGTERM", () => {
+  it("rejects late readiness and force-kills a startup worker after timeout", () => {
     vi.useFakeTimers();
     const clusterModule = new FakeCluster();
     const { supervisor, logs } = makeSupervisor(clusterModule, {
@@ -223,10 +243,17 @@ describe("cluster supervisor", () => {
       },
     });
     supervisor.start();
+    const stalledOwner = clusterModule.workers[0];
 
-    vi.advanceTimersByTime(120);
-    expect(clusterModule.workers[0].process.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
-    expect(clusterModule.workers[0].process.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+    vi.advanceTimersByTime(100);
+    ready(stalledOwner);
+    expect(supervisor.snapshot().readySlots).toEqual([]);
+    expect(clusterModule.workers).toHaveLength(1);
+    expect(logs).toContain("multicore_worker_ready_after_timeout");
+
+    vi.advanceTimersByTime(20);
+    expect(stalledOwner.process.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(stalledOwner.process.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
     expect(logs).toContain("multicore_worker_ready_force_kill");
   });
 

--- a/tests/unit/server-cluster-supervisor.test.ts
+++ b/tests/unit/server-cluster-supervisor.test.ts
@@ -1,0 +1,321 @@
+import { EventEmitter } from "node:events";
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const requireFromHere = createRequire(import.meta.url);
+const { createMulticorePlan, WORKER_READY_MESSAGE_TYPE } = requireFromHere(
+  "../../server-lib/multicore.js"
+) as {
+  WORKER_READY_MESSAGE_TYPE: string;
+  createMulticorePlan: (options: unknown) => MulticorePlan;
+};
+const { createClusterSupervisor, resolveSupervisorSettings } = requireFromHere(
+  "../../server-lib/cluster-supervisor.js"
+) as {
+  createClusterSupervisor: (options: Record<string, unknown>) => Supervisor;
+  resolveSupervisorSettings: (env: Record<string, string>) => { shutdownTimeoutMs: number };
+};
+
+type MulticorePlan = { enabled: boolean; workerCount: number };
+type Supervisor = {
+  beginShutdown: (signal: string, exitCode?: number, reason?: string) => void;
+  snapshot: () => {
+    workerSlots: number[];
+    readySlots: number[];
+    restartSlots: number[];
+    shuttingDown: boolean;
+  };
+  start: () => Supervisor;
+};
+
+class FakeWorker extends EventEmitter {
+  readonly env: Record<string, string>;
+  readonly process: { pid: number; kill: ReturnType<typeof vi.fn> };
+
+  constructor(env: Record<string, string>, pid: number) {
+    super();
+    this.env = env;
+    this.process = { pid, kill: vi.fn() };
+  }
+}
+
+class FakeCluster {
+  readonly workers: FakeWorker[] = [];
+  readonly fork = vi.fn((env: Record<string, string>) => {
+    const worker = new FakeWorker(env, 10_000 + this.workers.length);
+    this.workers.push(worker);
+    return worker;
+  });
+}
+
+function plan(workerCount = 3): MulticorePlan {
+  return createMulticorePlan({
+    env: {
+      NODE_ENV: "production",
+      ENABLE_RATE_LIMIT: "true",
+      REDIS_URL: "redis://redis:6379",
+      CCH_MULTICORE_WORKERS: String(workerCount),
+    },
+    resources: {
+      availableCpu: 8,
+      cpuQuota: null,
+      cpusetCpu: null,
+      effectiveCpu: 8,
+      hostMemoryBytes: 16 * 1024 * 1024 * 1024,
+      cgroupMemoryBytes: 16 * 1024 * 1024 * 1024,
+      effectiveMemoryBytes: 16 * 1024 * 1024 * 1024,
+    },
+  });
+}
+
+function ready(worker: FakeWorker) {
+  worker.emit("message", { type: WORKER_READY_MESSAGE_TYPE });
+}
+
+function makeSupervisor(
+  clusterModule: FakeCluster,
+  override: Record<string, unknown> = {}
+): { supervisor: Supervisor; exit: ReturnType<typeof vi.fn>; logs: string[] } {
+  const exit = vi.fn();
+  const logs: string[] = [];
+  const supervisor = createClusterSupervisor({
+    clusterModule,
+    plan: plan(),
+    processRef: Object.assign(new EventEmitter(), { env: {}, exit }),
+    registerSignals: false,
+    exit,
+    log: (_level: string, event: string) => logs.push(event),
+    settings: {
+      readyTimeoutMs: 100,
+      shutdownTimeoutMs: 500,
+      restartWindowMs: 1000,
+      maxRestartsPerWindow: 5,
+      restartBaseDelayMs: 10,
+      restartMaxDelayMs: 100,
+      forceExitGraceMs: 10,
+    },
+    ...override,
+  });
+  return { supervisor, exit, logs };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("cluster supervisor", () => {
+  it("rejects invalid supervisor inputs and timing values", () => {
+    expect(() => createClusterSupervisor({})).toThrow(/clusterModule/);
+    expect(() =>
+      createClusterSupervisor({ clusterModule: new FakeCluster(), plan: { enabled: false } })
+    ).toThrow(/enabled multicore plan/);
+    expect(() => resolveSupervisorSettings({ CCH_MULTICORE_READY_TIMEOUT_MS: "zero" })).toThrow(
+      /positive integer/
+    );
+  });
+
+  it("keeps the primary shutdown deadline beyond every worker hard deadline", () => {
+    expect(resolveSupervisorSettings({ SHUTDOWN_HARD_EXIT_MS: "40000" }).shutdownTimeoutMs).toBe(
+      45000
+    );
+    expect(() =>
+      resolveSupervisorSettings({
+        SHUTDOWN_HARD_EXIT_MS: "40000",
+        CCH_MULTICORE_SHUTDOWN_TIMEOUT_MS: "30000",
+      })
+    ).toThrow(/must exceed/);
+  });
+
+  it("starts only the background owner, then forks request workers after it is ready", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    const { supervisor, logs } = makeSupervisor(clusterModule);
+
+    supervisor.start();
+    expect(clusterModule.workers).toHaveLength(1);
+    expect(clusterModule.workers[0].env).toMatchObject({
+      CCH_MULTICORE_WORKER_INDEX: "0",
+      CCH_MULTICORE_BACKGROUND_OWNER: "1",
+      CCH_PROCESS_ROLE: "gateway-control",
+    });
+    expect(supervisor.snapshot()).toMatchObject({ workerSlots: [0], readySlots: [] });
+
+    clusterModule.workers[0].emit("message", { type: "unrelated" });
+    expect(clusterModule.workers).toHaveLength(1);
+    ready(clusterModule.workers[0]);
+    expect(clusterModule.workers).toHaveLength(3);
+    expect(clusterModule.workers[1].env.CCH_MULTICORE_BACKGROUND_OWNER).toBe("0");
+    expect(clusterModule.workers[2].env.CCH_MULTICORE_BACKGROUND_OWNER).toBe("0");
+
+    ready(clusterModule.workers[1]);
+    ready(clusterModule.workers[2]);
+    expect(supervisor.snapshot()).toMatchObject({
+      workerSlots: [0, 1, 2],
+      readySlots: [0, 1, 2],
+    });
+    expect(logs).toContain("multicore_cluster_ready");
+    expect(() => supervisor.start()).toThrow(/already been started/);
+  });
+
+  it("retries a synchronous cluster fork failure", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    clusterModule.fork.mockImplementationOnce(() => {
+      throw new Error("fork failed");
+    });
+    const { supervisor, logs } = makeSupervisor(clusterModule);
+
+    supervisor.start();
+    expect(supervisor.snapshot().restartSlots).toEqual([0]);
+    vi.advanceTimersByTime(10);
+    expect(clusterModule.workers).toHaveLength(1);
+    expect(logs).toContain("multicore_worker_restart_scheduled");
+  });
+
+  it("restarts an unexpectedly exited worker in the same resource slot", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    const { supervisor } = makeSupervisor(clusterModule);
+    supervisor.start();
+    ready(clusterModule.workers[0]);
+    const failedWorker = clusterModule.workers[1];
+
+    failedWorker.emit("exit", 1, null);
+    expect(supervisor.snapshot().restartSlots).toEqual([1]);
+    vi.advanceTimersByTime(10);
+
+    expect(clusterModule.workers).toHaveLength(4);
+    expect(clusterModule.workers[3].env.CCH_MULTICORE_WORKER_INDEX).toBe("1");
+    expect(clusterModule.workers[3].env.DB_POOL_MAX).toBe(failedWorker.env.DB_POOL_MAX);
+  });
+
+  it("terminates an unready worker and restarts it after exit", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    const { supervisor, logs } = makeSupervisor(clusterModule);
+    supervisor.start();
+    const stalledOwner = clusterModule.workers[0];
+
+    vi.advanceTimersByTime(100);
+    expect(stalledOwner.process.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(logs).toContain("multicore_worker_ready_timeout");
+
+    stalledOwner.emit("exit", null, "SIGTERM");
+    vi.advanceTimersByTime(10);
+    expect(clusterModule.workers).toHaveLength(2);
+    expect(clusterModule.workers[1].env.CCH_MULTICORE_WORKER_INDEX).toBe("0");
+  });
+
+  it("force-kills a startup worker that ignores the readiness SIGTERM", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    const { supervisor, logs } = makeSupervisor(clusterModule, {
+      settings: {
+        readyTimeoutMs: 100,
+        readyKillGraceMs: 20,
+        shutdownTimeoutMs: 500,
+        restartWindowMs: 1000,
+        maxRestartsPerWindow: 5,
+        restartBaseDelayMs: 10,
+        restartMaxDelayMs: 100,
+        forceExitGraceMs: 10,
+      },
+    });
+    supervisor.start();
+
+    vi.advanceTimersByTime(120);
+    expect(clusterModule.workers[0].process.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(clusterModule.workers[0].process.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+    expect(logs).toContain("multicore_worker_ready_force_kill");
+  });
+
+  it("forwards shutdown, waits for workers, and never restarts them", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    const { supervisor, exit } = makeSupervisor(clusterModule);
+    supervisor.start();
+    ready(clusterModule.workers[0]);
+
+    supervisor.beginShutdown("SIGTERM");
+    expect(supervisor.snapshot().shuttingDown).toBe(true);
+    for (const worker of clusterModule.workers) {
+      expect(worker.process.kill).toHaveBeenCalledWith("SIGTERM");
+      worker.emit("exit", 0, null);
+    }
+
+    expect(exit).toHaveBeenCalledWith(0);
+    vi.runAllTimers();
+    expect(clusterModule.workers).toHaveLength(3);
+  });
+
+  it("fails the primary after a bounded worker crash loop", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    const { supervisor, exit, logs } = makeSupervisor(clusterModule, {
+      settings: {
+        readyTimeoutMs: 100,
+        shutdownTimeoutMs: 500,
+        restartWindowMs: 1000,
+        maxRestartsPerWindow: 2,
+        restartBaseDelayMs: 10,
+        restartMaxDelayMs: 100,
+        forceExitGraceMs: 10,
+      },
+    });
+    supervisor.start();
+    ready(clusterModule.workers[0]);
+
+    clusterModule.workers[1].emit("exit", 1, null);
+    vi.advanceTimersByTime(10);
+    clusterModule.workers[3].emit("exit", 1, null);
+
+    expect(logs).toContain("multicore_worker_crash_loop");
+    expect(clusterModule.workers[0].process.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(clusterModule.workers[2].process.kill).toHaveBeenCalledWith("SIGTERM");
+    clusterModule.workers[0].emit("exit", 0, null);
+    clusterModule.workers[2].emit("exit", 0, null);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("uses a hard bound and SIGKILL when graceful shutdown does not finish", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    const { supervisor, exit, logs } = makeSupervisor(clusterModule);
+    supervisor.start();
+    supervisor.beginShutdown("SIGTERM");
+
+    vi.advanceTimersByTime(500);
+    expect(clusterModule.workers[0].process.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(logs).toContain("multicore_shutdown_timeout");
+    vi.advanceTimersByTime(10);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("propagates a worker cleanup failure and a repeated shutdown escalation", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    const { supervisor, exit } = makeSupervisor(clusterModule);
+    supervisor.start();
+    supervisor.beginShutdown("SIGTERM");
+    supervisor.beginShutdown("SIGTERM", 1, "escalated");
+    clusterModule.workers[0].emit("exit", 1, null);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("can bind primary SIGINT/SIGTERM handlers", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    const processRef = Object.assign(new EventEmitter(), { env: {}, exit: vi.fn() });
+    const supervisor = createClusterSupervisor({
+      clusterModule,
+      plan: plan(2),
+      processRef,
+      exit: processRef.exit,
+      settings: { shutdownTimeoutMs: 500 },
+    });
+    supervisor.start();
+    processRef.emit("SIGINT");
+    expect(clusterModule.workers[0].process.kill).toHaveBeenCalledWith("SIGINT");
+  });
+});

--- a/tests/unit/server-cluster-supervisor.test.ts
+++ b/tests/unit/server-cluster-supervisor.test.ts
@@ -93,6 +93,7 @@ function makeSupervisor(
       restartBaseDelayMs: 10,
       restartMaxDelayMs: 100,
       forceExitGraceMs: 10,
+      workerErrorExitGraceMs: 10,
     },
     ...override,
   });
@@ -173,7 +174,7 @@ describe("cluster supervisor", () => {
     expect(logs).toContain("multicore_worker_restart_scheduled");
   });
 
-  it("absorbs asynchronous worker errors and lets exit drive one restart", () => {
+  it("lets a natural exit finish an asynchronous worker error exactly once", () => {
     vi.useFakeTimers();
     const clusterModule = new FakeCluster();
     const { supervisor, logs } = makeSupervisor(clusterModule);
@@ -183,6 +184,8 @@ describe("cluster supervisor", () => {
     expect(() => failedWorker.emit("error", new Error("spawn EAGAIN"))).not.toThrow();
     expect(logs).toContain("multicore_worker_error");
     expect(supervisor.snapshot().restartSlots).toEqual([]);
+    vi.advanceTimersByTime(9);
+    expect(failedWorker.process.kill).not.toHaveBeenCalled();
 
     failedWorker.emit("exit", 1, null);
     expect(supervisor.snapshot().restartSlots).toEqual([0]);
@@ -191,6 +194,33 @@ describe("cluster supervisor", () => {
     expect(clusterModule.workers).toHaveLength(2);
     expect(clusterModule.workers[1].env.CCH_MULTICORE_WORKER_INDEX).toBe("0");
     expect(logs.filter((event) => event === "multicore_worker_exited")).toHaveLength(1);
+  });
+
+  it("force-kills and synthesizes one exit when error is not followed by exit", () => {
+    vi.useFakeTimers();
+    const clusterModule = new FakeCluster();
+    const { supervisor, logs } = makeSupervisor(clusterModule);
+    supervisor.start();
+    const failedWorker = clusterModule.workers[0];
+
+    failedWorker.emit("error", new Error("spawn EAGAIN"));
+    failedWorker.emit("error", new Error("duplicate error"));
+    vi.advanceTimersByTime(10);
+    expect(failedWorker.process.kill).toHaveBeenCalledTimes(1);
+    expect(failedWorker.process.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(logs).toContain("multicore_worker_error_force_kill");
+
+    vi.advanceTimersByTime(10);
+    expect(logs).toContain("multicore_worker_exit_missing");
+    expect(supervisor.snapshot().restartSlots).toEqual([0]);
+    expect(logs.filter((event) => event === "multicore_worker_exited")).toHaveLength(1);
+
+    // 合成终态之后迟到的真实 exit 不得重复计数或重复拉起。
+    failedWorker.emit("exit", 1, null);
+    expect(logs.filter((event) => event === "multicore_worker_exited")).toHaveLength(1);
+    vi.advanceTimersByTime(10);
+    expect(clusterModule.workers).toHaveLength(2);
+    expect(clusterModule.workers[1].env.CCH_MULTICORE_WORKER_INDEX).toBe("0");
   });
 
   it("restarts an unexpectedly exited worker in the same resource slot", () => {
@@ -255,6 +285,12 @@ describe("cluster supervisor", () => {
     expect(stalledOwner.process.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
     expect(stalledOwner.process.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
     expect(logs).toContain("multicore_worker_ready_force_kill");
+
+    vi.advanceTimersByTime(10);
+    expect(logs).toContain("multicore_worker_exit_missing");
+    expect(supervisor.snapshot().restartSlots).toEqual([0]);
+    stalledOwner.emit("exit", null, "SIGKILL");
+    expect(logs.filter((event) => event === "multicore_worker_exited")).toHaveLength(1);
   });
 
   it("forwards shutdown, waits for workers, and never restarts them", () => {

--- a/tests/unit/server-multicore-config.test.ts
+++ b/tests/unit/server-multicore-config.test.ts
@@ -1,0 +1,313 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const requireFromHere = createRequire(import.meta.url);
+const multicore = requireFromHere("../../server-lib/multicore.js") as {
+  CGROUP_FILES: Record<string, string>;
+  MIB: number;
+  allocateIntegerBudget: (total: number, workers: number) => number[];
+  buildWorkerEnvironment: (plan: MulticorePlan, workerIndex: number) => Record<string, string>;
+  createMulticorePlan: (options: {
+    env: Record<string, string | undefined>;
+    resources: RuntimeResources;
+  }) => MulticorePlan;
+  detectRuntimeResources: (options: {
+    osModule: {
+      availableParallelism?: () => number;
+      cpus: () => unknown[];
+      totalmem: () => number;
+    };
+    readFileSync: (path: string) => string;
+  }) => RuntimeResources;
+  parseCpuMax: (raw: string) => number | null;
+  parseCpuSet: (raw: string) => number | null;
+  parseMemoryLimit: (raw: string) => number | null;
+  hasCrossProcessInvalidation: (env: Record<string, string | undefined>) => boolean;
+};
+
+type RuntimeResources = {
+  availableCpu: number;
+  cpuQuota: number | null;
+  cpusetCpu: number | null;
+  effectiveCpu: number;
+  hostMemoryBytes: number;
+  cgroupMemoryBytes: number | null;
+  effectiveMemoryBytes: number;
+};
+
+type MulticorePlan = {
+  enabled: boolean;
+  mode: string;
+  reason: string;
+  workerCount: number;
+  resources: RuntimeResources;
+  aggregateBudgets: Record<string, number> | null;
+  budgetAllocations: Record<string, number[]> | null;
+};
+
+const MIB = 1024 * 1024;
+
+function resources(cpu: number, memoryMiB = 8192): RuntimeResources {
+  return {
+    availableCpu: cpu,
+    cpuQuota: null,
+    cpusetCpu: null,
+    effectiveCpu: cpu,
+    hostMemoryBytes: memoryMiB * MIB,
+    cgroupMemoryBytes: memoryMiB * MIB,
+    effectiveMemoryBytes: memoryMiB * MIB,
+  };
+}
+
+function productionEnv(override: Record<string, string | undefined> = {}) {
+  return {
+    NODE_ENV: "production",
+    ENABLE_RATE_LIMIT: "true",
+    REDIS_URL: "redis://redis:6379",
+    ...override,
+  };
+}
+
+describe("multicore resource detection", () => {
+  it("uses the strictest availableParallelism, cgroup quota, cpuset and memory limits", () => {
+    const files = new Map<string, string>([
+      [multicore.CGROUP_FILES.cpuMaxV2, "350000 100000"],
+      [multicore.CGROUP_FILES.cpusetV2, "0-2,4-6"],
+      [multicore.CGROUP_FILES.memoryMaxV2, String(4096 * MIB)],
+    ]);
+
+    const detected = multicore.detectRuntimeResources({
+      osModule: {
+        availableParallelism: () => 8,
+        cpus: () => Array.from({ length: 16 }),
+        totalmem: () => 16 * 1024 * MIB,
+      },
+      readFileSync: (path) => {
+        const value = files.get(path);
+        if (value === undefined) throw new Error("missing");
+        return value;
+      },
+    });
+
+    expect(detected).toMatchObject({
+      availableCpu: 8,
+      cpuQuota: 3.5,
+      cpusetCpu: 6,
+      effectiveCpu: 3,
+      cgroupMemoryBytes: 4096 * MIB,
+      effectiveMemoryBytes: 4096 * MIB,
+    });
+  });
+
+  it("falls back to cgroup v1 and os.cpus when newer probes are unavailable", () => {
+    const files = new Map<string, string>([
+      [multicore.CGROUP_FILES.cpuQuotaV1, "400000"],
+      [multicore.CGROUP_FILES.cpuPeriodV1, "100000"],
+      [multicore.CGROUP_FILES.cpusetV1, "2-5"],
+      [multicore.CGROUP_FILES.memoryLimitV1, String(2048 * MIB)],
+    ]);
+
+    const detected = multicore.detectRuntimeResources({
+      osModule: {
+        availableParallelism: () => Number.NaN,
+        cpus: () => Array.from({ length: 12 }),
+        totalmem: () => 32 * 1024 * MIB,
+      },
+      readFileSync: (path) => {
+        const value = files.get(path);
+        if (value === undefined) throw new Error("missing");
+        return value;
+      },
+    });
+
+    expect(detected.effectiveCpu).toBe(4);
+    expect(detected.effectiveMemoryBytes).toBe(2048 * MIB);
+  });
+
+  it("parses quota, cpuset and unlimited memory formats defensively", () => {
+    expect(multicore.parseCpuMax("max 100000")).toBe(Number.POSITIVE_INFINITY);
+    expect(multicore.parseCpuMax("200000 100000")).toBe(2);
+    expect(multicore.parseCpuMax("broken")).toBeNull();
+    expect(multicore.parseCpuSet("0-3,2-5,8")).toBe(7);
+    expect(multicore.parseCpuSet("3-1")).toBeNull();
+    expect(multicore.parseMemoryLimit("max")).toBe(Number.POSITIVE_INFINITY);
+    expect(multicore.parseMemoryLimit("0")).toBeNull();
+  });
+});
+
+describe("multicore plan", () => {
+  it("automatically enables two workers at 4 vCPU and preserves aggregate budgets", () => {
+    const plan = multicore.createMulticorePlan({
+      env: productionEnv(),
+      resources: resources(4, 4096),
+    });
+
+    expect(plan).toMatchObject({
+      enabled: true,
+      reason: "auto_resource_eligible",
+      workerCount: 2,
+    });
+    expect(plan.budgetAllocations).not.toBeNull();
+    for (const [name, allocations] of Object.entries(plan.budgetAllocations ?? {})) {
+      expect(allocations.reduce((sum, value) => sum + value, 0)).toBe(
+        plan.aggregateBudgets?.[name]
+      );
+    }
+
+    const owner = multicore.buildWorkerEnvironment(plan, 0);
+    const requestOnly = multicore.buildWorkerEnvironment(plan, 1);
+    expect(owner).toMatchObject({
+      CCH_MULTICORE_WORKER_INDEX: "0",
+      CCH_MULTICORE_WORKER_COUNT: "2",
+      CCH_MULTICORE_BACKGROUND_OWNER: "1",
+      CCH_PROCESS_ROLE: "gateway-control",
+      DB_POOL_MAX: "10",
+    });
+    expect(requestOnly).toMatchObject({
+      CCH_MULTICORE_BACKGROUND_OWNER: "0",
+      CCH_PROCESS_ROLE: "gateway",
+      DB_POOL_MAX: "10",
+    });
+  });
+
+  it("scales to four request processes on 8 vCPU when memory is sufficient", () => {
+    const plan = multicore.createMulticorePlan({
+      env: productionEnv(),
+      resources: resources(8, 8192),
+    });
+
+    expect(plan.enabled).toBe(true);
+    expect(plan.workerCount).toBe(4);
+    expect(plan.budgetAllocations?.STREAM_GATE_GLOBAL_PREBUFFER_BYTE_CAP).toEqual([
+      64 * MIB,
+      64 * MIB,
+      64 * MIB,
+      64 * MIB,
+    ]);
+  });
+
+  it.each([
+    [productionEnv(), resources(3, 8192), "effective_cpu_below_four"],
+    [{ NODE_ENV: "development" }, resources(8, 8192), "non_production"],
+    [productionEnv({ CI: "true" }), resources(8, 8192), "ci"],
+    [productionEnv(), resources(4, 1024), "insufficient_memory"],
+  ])("keeps a single process when automatic eligibility is not met", (env, limits, reason) => {
+    const plan = multicore.createMulticorePlan({ env, resources: limits });
+    expect(plan).toMatchObject({ enabled: false, workerCount: 1, reason });
+  });
+
+  it("allows an explicit, memory-safe override below four vCPU", () => {
+    const plan = multicore.createMulticorePlan({
+      env: productionEnv({ CCH_MULTICORE_WORKERS: "3" }),
+      resources: resources(2, 4096),
+    });
+    expect(plan).toMatchObject({ enabled: true, workerCount: 3, reason: "explicit_worker_count" });
+    expect(plan.budgetAllocations?.DB_POOL_MAX).toEqual([7, 7, 6]);
+  });
+
+  it("rejects multiple Next development workers that would race on build state", () => {
+    expect(() =>
+      multicore.createMulticorePlan({
+        env: { NODE_ENV: "development", CCH_MULTICORE_WORKERS: "2" },
+        resources: resources(8),
+      })
+    ).toThrow(/NODE_ENV=production/);
+  });
+
+  it("lets off and an explicit single-worker setting disable clustering", () => {
+    const off = multicore.createMulticorePlan({
+      env: productionEnv({ CCH_MULTICORE_MODE: "off", CCH_MULTICORE_WORKERS: "invalid" }),
+      resources: resources(8),
+    });
+    const single = multicore.createMulticorePlan({
+      env: productionEnv({ CCH_MULTICORE_WORKERS: "1" }),
+      resources: resources(8),
+    });
+    expect(off.reason).toBe("mode_off");
+    expect(single.reason).toBe("explicit_single_worker");
+  });
+
+  it("supports an intentional on override while retaining memory guards", () => {
+    const forced = multicore.createMulticorePlan({
+      env: productionEnv({ CCH_MULTICORE_MODE: "on" }),
+      resources: resources(2, 3072),
+    });
+    expect(forced).toMatchObject({ enabled: true, workerCount: 2, reason: "mode_on" });
+
+    expect(() =>
+      multicore.createMulticorePlan({
+        env: productionEnv({ CCH_MULTICORE_MODE: "on" }),
+        resources: resources(2, 1024),
+      })
+    ).toThrow(/at least two gateway workers/);
+  });
+
+  it("requires a configured cross-process invalidation channel before clustering", () => {
+    expect(multicore.hasCrossProcessInvalidation(productionEnv())).toBe(true);
+    expect(multicore.hasCrossProcessInvalidation(productionEnv({ REDIS_URL: undefined }))).toBe(
+      false
+    );
+    expect(
+      multicore.hasCrossProcessInvalidation(productionEnv({ ENABLE_RATE_LIMIT: "false" }))
+    ).toBe(false);
+
+    const automatic = multicore.createMulticorePlan({
+      env: productionEnv({ REDIS_URL: undefined }),
+      resources: resources(8),
+    });
+    expect(automatic).toMatchObject({
+      enabled: false,
+      reason: "cross_process_invalidation_unavailable",
+    });
+
+    expect(() =>
+      multicore.createMulticorePlan({
+        env: productionEnv({
+          CCH_MULTICORE_WORKERS: "2",
+          ENABLE_RATE_LIMIT: "false",
+        }),
+        resources: resources(8),
+      })
+    ).toThrow(/process-local security and routing caches/);
+  });
+
+  it("fails fast instead of multiplying memory or invalid per-worker budgets", () => {
+    expect(() =>
+      multicore.createMulticorePlan({
+        env: productionEnv({ CCH_MULTICORE_WORKERS: "4" }),
+        resources: resources(8, 3072),
+      })
+    ).toThrow(/safe memory\/budget capacity/);
+
+    expect(() =>
+      multicore.createMulticorePlan({
+        env: productionEnv({
+          CCH_MULTICORE_WORKERS: "4",
+          STREAM_GATE_PREBUFFER_BYTE_CAP: String(64 * MIB),
+        }),
+        resources: resources(8, 8192),
+      })
+    ).toThrow(/safe memory\/budget capacity/);
+
+    expect(() =>
+      multicore.createMulticorePlan({
+        env: productionEnv({ CCH_MULTICORE_MODE: "sometimes" }),
+        resources: resources(8),
+      })
+    ).toThrow(/auto, on, or off/);
+  });
+
+  it("splits integer budgets deterministically with the remainder on low slots", () => {
+    expect(multicore.allocateIntegerBudget(20, 3)).toEqual([7, 7, 6]);
+    expect(multicore.allocateIntegerBudget(3, 5)).toEqual([1, 1, 1, 0, 0]);
+    expect(() => multicore.allocateIntegerBudget(1, 0)).toThrow(/positive integer/);
+  });
+
+  it("rejects an out-of-range worker index", () => {
+    const plan = multicore.createMulticorePlan({
+      env: productionEnv(),
+      resources: resources(4, 4096),
+    });
+    expect(() => multicore.buildWorkerEnvironment(plan, 2)).toThrow(/outside/);
+  });
+});

--- a/tests/unit/server-multicore-config.test.ts
+++ b/tests/unit/server-multicore-config.test.ts
@@ -24,6 +24,11 @@ const multicore = requireFromHere("../../server-lib/multicore.js") as {
   parseMemoryLimit: (raw: string) => number | null;
   hasCrossProcessInvalidation: (env: Record<string, string | undefined>) => boolean;
 };
+const launcher = requireFromHere("../../cluster.js") as {
+  normalizeStandaloneEnvironment: (
+    env: Record<string, string | undefined>
+  ) => Record<string, string | undefined>;
+};
 
 type RuntimeResources = {
   availableCpu: number;
@@ -136,6 +141,28 @@ describe("multicore resource detection", () => {
 });
 
 describe("multicore plan", () => {
+  it("restores the full owner role when multicore mode falls back to one process", () => {
+    const env = {
+      CCH_MULTICORE_ACTIVE: "1",
+      CCH_MULTICORE_WORKER_INDEX: "7",
+      CCH_MULTICORE_WORKER_COUNT: "8",
+      CCH_MULTICORE_BACKGROUND_OWNER: "0",
+      CCH_PROCESS_ROLE: "gateway",
+      CCH_MULTICORE_EFFECTIVE_VCPUS: "8",
+      CCH_MULTICORE_EFFECTIVE_MEMORY_BYTES: String(8192 * MIB),
+    };
+
+    expect(launcher.normalizeStandaloneEnvironment(env)).toMatchObject({
+      CCH_MULTICORE_ACTIVE: "0",
+      CCH_MULTICORE_WORKER_INDEX: "0",
+      CCH_MULTICORE_WORKER_COUNT: "1",
+      CCH_MULTICORE_BACKGROUND_OWNER: "1",
+      CCH_PROCESS_ROLE: "gateway-control",
+    });
+    expect(env.CCH_MULTICORE_EFFECTIVE_VCPUS).toBeUndefined();
+    expect(env.CCH_MULTICORE_EFFECTIVE_MEMORY_BYTES).toBeUndefined();
+  });
+
   it("automatically enables two workers at 4 vCPU and preserves aggregate budgets", () => {
     const plan = multicore.createMulticorePlan({
       env: productionEnv(),

--- a/tests/unit/server-multicore-ready.test.ts
+++ b/tests/unit/server-multicore-ready.test.ts
@@ -1,0 +1,47 @@
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const requireFromHere = createRequire(import.meta.url);
+const { notifyMulticoreReady } = requireFromHere("../../server.js") as {
+  notifyMulticoreReady: () => void;
+};
+const { WORKER_READY_MESSAGE_TYPE } = requireFromHere("../../server-lib/multicore.js") as {
+  WORKER_READY_MESSAGE_TYPE: string;
+};
+
+const originalSend = process.send;
+
+afterEach(() => {
+  if (originalSend) {
+    process.send = originalSend;
+  } else {
+    delete process.send;
+  }
+  delete process.env.CCH_MULTICORE_ACTIVE;
+  delete process.env.CCH_MULTICORE_WORKER_INDEX;
+  vi.restoreAllMocks();
+});
+
+describe("multicore worker readiness message", () => {
+  it("sends only tiny identity metadata after a clustered worker is listening", () => {
+    const send = vi.fn();
+    process.send = send as typeof process.send;
+    process.env.CCH_MULTICORE_ACTIVE = "1";
+    process.env.CCH_MULTICORE_WORKER_INDEX = "2";
+
+    notifyMulticoreReady();
+
+    expect(send).toHaveBeenCalledWith({
+      type: WORKER_READY_MESSAGE_TYPE,
+      workerIndex: 2,
+      pid: process.pid,
+    });
+  });
+
+  it("does not use IPC in standalone mode", () => {
+    const send = vi.fn();
+    process.send = send as typeof process.send;
+    notifyMulticoreReady();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/server-private-loopback.test.ts
+++ b/tests/unit/server-private-loopback.test.ts
@@ -1,0 +1,52 @@
+import http from "node:http";
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it } from "vitest";
+
+const requireFromHere = createRequire(import.meta.url);
+const { listenOnPrivateLoopback } = requireFromHere("../../server.js") as {
+  listenOnPrivateLoopback: (server: http.Server) => Promise<{ hostname: string; port: number }>;
+};
+
+const openServers = new Set<http.Server>();
+
+afterEach(async () => {
+  await Promise.all(
+    Array.from(
+      openServers,
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        })
+    )
+  );
+  openServers.clear();
+});
+
+describe("private WebSocket loopback listener", () => {
+  it("binds an ephemeral IPv4 loopback port and serves the local Next handler", async () => {
+    const server = http.createServer((request, response) => {
+      expect(request.url).toBe("/v1/responses");
+      response.end("same-worker");
+    });
+    openServers.add(server);
+
+    const target = await listenOnPrivateLoopback(server);
+    expect(target.hostname).toBe("127.0.0.1");
+    expect(target.port).toBeGreaterThan(0);
+    expect(server.address()).toMatchObject({ address: "127.0.0.1", port: target.port });
+
+    const body = await new Promise<string>((resolve, reject) => {
+      http
+        .get(
+          { hostname: target.hostname, port: target.port, path: "/v1/responses" },
+          (response) => {
+            const chunks: Buffer[] = [];
+            response.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+            response.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+          }
+        )
+        .on("error", reject);
+    });
+    expect(body).toBe("same-worker");
+  });
+});

--- a/tests/unit/server-response-write-backpressure.test.ts
+++ b/tests/unit/server-response-write-backpressure.test.ts
@@ -27,7 +27,8 @@ type ServerModule = {
       response?: http.IncomingMessage | null,
       settleTurn?: () => boolean
     ) => boolean | undefined,
-    close?: (code: number, reason: string) => void
+    close?: (code: number, reason: string) => void,
+    internalHttpTarget?: { hostname: string; port: number }
   ) => Promise<void>;
 };
 
@@ -125,6 +126,30 @@ afterEach(() => {
 });
 
 describe("server response write backpressure", () => {
+  it("uses the explicit per-worker loopback target instead of the shared public port", async () => {
+    const events: string[] = [];
+    const request = createClientRequest(true, events);
+    let capturedOptions: http.RequestOptions | undefined;
+    vi.spyOn(http, "request").mockImplementation((options) => {
+      capturedOptions = options as http.RequestOptions;
+      setImmediate(() => request.emit("error", new Error("test settlement")));
+      return request;
+    });
+    const input = requestInput();
+
+    await serverModule.forwardToInternalHttp(
+      input.ws,
+      input.request,
+      input.body,
+      "test-session",
+      undefined,
+      undefined,
+      { hostname: "127.0.0.1", port: 43123 }
+    );
+
+    expect(capturedOptions).toMatchObject({ hostname: "127.0.0.1", port: 43123 });
+  });
+
   it("waits for request drain before ending a backpressured payload", async () => {
     const events: string[] = [];
     const request = createClientRequest(false, events);

--- a/tests/unit/server-shutdown.test.ts
+++ b/tests/unit/server-shutdown.test.ts
@@ -18,7 +18,8 @@ const requireFromHere = createRequire(import.meta.url);
 type ServerJsModule = {
   registerOrchestratedShutdown: (
     server: { close: (cb: (err?: Error) => void) => void; on?: unknown },
-    wss: { close: (cb?: (err?: Error) => void) => void } | null
+    wss: { close: (cb?: (err?: Error) => void) => void } | null,
+    auxiliaryServers?: Array<{ close: (cb: (err?: Error) => void) => void }>
   ) => void;
 };
 
@@ -60,6 +61,9 @@ describe.sequential("registerOrchestratedShutdown", () => {
     const closeServer = vi.fn((cb: (err?: Error) => void) => {
       setTimeout(() => cb(), 5);
     });
+    const closePrivateServer = vi.fn((cb: (err?: Error) => void) => {
+      setTimeout(() => cb(), 5);
+    });
     const closeWss = vi.fn();
     const server = { close: closeServer };
     const wss = { close: closeWss };
@@ -77,7 +81,7 @@ describe.sequential("registerOrchestratedShutdown", () => {
     process.exit = exitSpy;
 
     const { registerOrchestratedShutdown } = loadServerModule();
-    registerOrchestratedShutdown(server, wss);
+    registerOrchestratedShutdown(server, wss, [{ close: closePrivateServer }]);
 
     // Trigger SIGTERM
     process.emit("SIGTERM");
@@ -87,6 +91,7 @@ describe.sequential("registerOrchestratedShutdown", () => {
 
     expect(markShuttingDown).toHaveBeenCalledTimes(1);
     expect(closeServer).toHaveBeenCalledTimes(1);
+    expect(closePrivateServer).toHaveBeenCalledTimes(1);
     expect(closeWss).toHaveBeenCalledTimes(1);
     expect(runApplicationCleanup).toHaveBeenCalledWith(
       "SIGTERM",


### PR DESCRIPTION
## 背景

当前网关的 JSON 解析、请求过滤、协议转换、响应分析和 usage/计费写回集中在单个 Node.js event loop，4+ vCPU 容器无法充分利用可用核心。

## 方案

- 新增资源感知型 cluster launcher；primary 只分发 socket handle，每个 worker 独占完整请求生命周期，请求正文、JSON AST 和响应体均不经过业务 IPC。
- 默认 auto 仅在 production、非 CI、有效 vCPU >= 4、内存和共享预算均足够且 Redis 跨进程缓存失效可用时启用；4/6/8+ vCPU 默认分别启动 2/3/4 个 worker。
- 同时识别 os.availableParallelism、cgroup v1/v2 CPU quota、cpuset 和 memory limit；默认按每 worker 1024 MiB、primary 256 MiB 做安全容量判断。
- 将 DB pool、message writer pending、detached stream、stream gate 和 replay 并发等容器级总预算确定性分摊到 worker，避免多进程直接放大连接数和缓冲内存。
- slot 0 先完成迁移、规则同步和 singleton 后台任务，再启动 request-only worker；其余 worker 只初始化进程本地缓存、生命周期和可观测性。
- 每个 worker 使用独占的 127.0.0.1:0 私有 listener，保证 Responses WebSocket 内部 HTTP 回到持有连接与上游 session 的同一进程。
- supervisor 提供 ready timeout、SIGTERM 后强杀、指数退避、crash-loop 退出和有界优雅关闭。
- 新增完整设计与运维文档 docs/multicore-gateway.md，并同步 Docker、Kubernetes 和环境变量说明。

## 正确性与内存

- 不把大正文或解析对象投递到 worker_threads/child process，避免 structured clone、字符串/AST 双份驻留和大请求排队造成的 RSS 放大。
- usage、计费、replay complete、亲和绑定和 durable message 写回仍在请求所属 worker 内按原顺序完成，不引入裸 fire-and-forget 或跨进程事务重排。
- 多进程要求 REDIS_URL 且 ENABLE_RATE_LIMIT 未关闭，以同步错误规则、请求过滤器、敏感词、Provider cache 和 API Key Vacuum Filter 等进程本地快照的失效；auto 缺失时回退单进程，显式多进程则 fail fast。
- keep-alive、HTTP/2 多路复用和单条 WebSocket 仍具有连接级亲和性；大规模部署仍建议优先按 Pod 横向扩展。

## 验证

- bun run lint
- bun run lint:fix（无修改）
- bun run typecheck
- bun run build
- bun run test：878 个文件通过、2 个跳过；8732 项通过、25 项跳过
- 所有新增 CJS 均通过 node --check
- standalone 双 worker 冒烟：slot 0/1 分别建立独立私有回环端口，发出 multicore_cluster_ready，公共端口连续 12 次健康检查均返回 200，SIGINT 后 worker 与端口均清理











<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR introduces a resource-aware Node.js cluster launcher that distributes complete gateway request lifecycles across workers while reserving singleton initialization and background work for slot 0.

- Detects effective CPU and memory limits and selects a bounded worker count.
- Deterministically partitions container-wide database, stream, replay, and writer budgets among workers.
- Adds worker readiness, restart, crash-loop, and bounded shutdown supervision.
- Adds cross-process cache invalidation and worker-local WebSocket loopback listeners.
- Updates standalone packaging, container entry points, configuration, documentation, and tests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains in the eligible follow-up review scope.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| cluster.js | Adds the production primary entry point, resource-plan selection, single-process fallback, and cluster supervisor startup. |
| server-lib/multicore.js | Implements resource detection, multicore eligibility, worker-count selection, and deterministic shared-budget allocation. |
| server-lib/cluster-supervisor.js | Implements staged worker startup, readiness deadlines, identity-guarded restarts, crash-loop handling, and bounded shutdown. |
| server.js | Integrates worker readiness, private loopback listeners, worker-role metadata, and orchestrated shutdown with the existing gateway. |
| src/instrumentation.ts | Splits full control-worker initialization from request-only worker initialization while preserving process-local runtime setup. |
| src/lib/redis/pubsub.ts | Extends Redis invalidation subscription and reconnection behavior needed by independent gateway processes. |
| scripts/copy-custom-server-to-standalone.cjs | Copies the cluster launcher and its server-lib dependencies into the standalone runtime output. |
| deploy/Dockerfile | Switches the canonical production image to the packaged cluster launcher. |
| docs/multicore-gateway.md | Documents worker selection, topology, shared budgets, cache synchronization, failure handling, and operational constraints. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Client[Gateway clients] --> Primary[Cluster primary<br/>public listener]
  Primary --> W0[Worker 0<br/>gateway-control]
  Primary --> W1[Worker 1<br/>request-only]
  Primary --> WN[Worker N<br/>request-only]
  W0 --> Local0[Private loopback listener]
  W1 --> Local1[Private loopback listener]
  WN --> LocalN[Private loopback listener]
  W0 --> Jobs[Singleton migrations and background work]
  W0 --> Redis[(Redis invalidation)]
  W1 --> Redis
  WN --> Redis
  W0 --> DB[(PostgreSQL)]
  W1 --> DB
  WN --> DB
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(gateway): 保证跨进程失效订阅自动恢复"](https://github.com/ding113/claude-code-hub/commit/7e807c5a3f82a92af216cc95c3276f2807e14ab6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58078432)</sub>

<!-- /greptile_comment -->