### PR TITLE
fix(test): isolate motion animations in happy-dom

### DIFF
--- a/messages/ja/dashboard.json
+++ b/messages/ja/dashboard.json
@@ -522,7 +522,7 @@
         "configTotalTimeout": "全体タイムアウト",
         "configStickyCooldown": "Sticky タイムアウトのクールダウン",
         "configStickyBindingTtl": "Sticky バインドの有効期間 (SESSION_TTL)",
-        "slotSaturation": "Hedge スロット飽和（{count} 件）",
+        "slotSaturation": "Hedge スロット飽和 ({count} 件)",
         "slotSaturationEvent": "{provider} · {active}/{cap} 件がアクティブ · 経過 {elapsed}ms",
         "attemptDetails": {
           "providerId": "Provider ID",

--- a/tests/framer-motion.mock.tsx
+++ b/tests/framer-motion.mock.tsx
@@ -1,0 +1,49 @@
+import { createElement, type ComponentType, type ReactNode } from "react";
+import { vi } from "vitest";
+
+type MotionProps = {
+  children?: ReactNode;
+  [key: string]: unknown;
+};
+
+const motionOnlyProps = new Set([
+  "animate",
+  "custom",
+  "exit",
+  "initial",
+  "layout",
+  "layoutId",
+  "onAnimationComplete",
+  "onAnimationStart",
+  "transition",
+  "variants",
+  "whileFocus",
+  "whileHover",
+  "whileInView",
+  "whileTap",
+]);
+
+function createMotionComponent(tag: string): ComponentType<MotionProps> {
+  return ({ children, ...props }) => {
+    const domProps = Object.fromEntries(
+      Object.entries(props).filter(([name]) => !motionOnlyProps.has(name))
+    );
+    return createElement(tag, domProps, children);
+  };
+}
+
+const motionComponents = new Map<string, ComponentType<MotionProps>>();
+const motion = new Proxy({} as Record<string, ComponentType<MotionProps>>, {
+  get: (_target, property: string | symbol) => {
+    if (typeof property !== "string") return undefined;
+
+    const existing = motionComponents.get(property);
+    if (existing) return existing;
+
+    const component = createMotionComponent(property);
+    motionComponents.set(property, component);
+    return component;
+  },
+});
+
+vi.mock("framer-motion", () => ({ motion }));

--- a/tests/unit/auth/login-page-site-title.test.tsx
+++ b/tests/unit/auth/login-page-site-title.test.tsx
@@ -5,6 +5,7 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../../framer-motion.mock";
 import LoginPage from "../../../src/app/[locale]/login/page";
 
 const mockPush = vi.hoisted(() => vi.fn());

--- a/tests/unit/login/login-footer-system-name.test.tsx
+++ b/tests/unit/login/login-footer-system-name.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../../framer-motion.mock";
 import LoginPage from "@/app/[locale]/login/page";
 import { DEFAULT_SITE_TITLE } from "@/lib/site-title";
 

--- a/tests/unit/login/login-footer-version.test.tsx
+++ b/tests/unit/login/login-footer-version.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../../framer-motion.mock";
 import LoginPage from "@/app/[locale]/login/page";
 
 const mockPush = vi.hoisted(() => vi.fn());

--- a/tests/unit/login/login-loading-state.test.tsx
+++ b/tests/unit/login/login-loading-state.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { createRoot } from "react-dom/client";
 import { act } from "react";
+import "../../framer-motion.mock";
 import LoginPage from "@/app/[locale]/login/page";
 
 const mockPush = vi.hoisted(() => vi.fn());

--- a/tests/unit/login/login-overlay-a11y.test.tsx
+++ b/tests/unit/login/login-overlay-a11y.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { createRoot } from "react-dom/client";
 import { act } from "react";
+import "../../framer-motion.mock";
 import LoginPage from "@/app/[locale]/login/page";
 
 const mockPush = vi.hoisted(() => vi.fn());

--- a/tests/unit/login/login-ui-redesign.test.tsx
+++ b/tests/unit/login/login-ui-redesign.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { createRoot } from "react-dom/client";
 import { act } from "react";
+import "../../framer-motion.mock";
 import LoginPage from "@/app/[locale]/login/page";
 
 const mockPush = vi.hoisted(() => vi.fn());

--- a/tests/unit/login/login-visual-regression.test.tsx
+++ b/tests/unit/login/login-visual-regression.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { createRoot } from "react-dom/client";
 import { act } from "react";
+import "../../framer-motion.mock";
 import LoginPage from "@/app/[locale]/login/page";
 
 // Mocks

--- a/tests/unit/settings/providers/provider-form-endpoint-pool.test.tsx
+++ b/tests/unit/settings/providers/provider-form-endpoint-pool.test.tsx
@@ -8,6 +8,7 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { NextIntlClientProvider } from "next-intl";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import "../../../framer-motion.mock";
 import { ProviderForm } from "../../../../src/app/[locale]/settings/providers/_components/forms/provider-form";
 import { Dialog } from "../../../../src/components/ui/dialog";
 import enMessages from "../../../../messages/en";

--- a/tests/unit/settings/providers/provider-form-total-limit-ui.test.tsx
+++ b/tests/unit/settings/providers/provider-form-total-limit-ui.test.tsx
@@ -8,6 +8,7 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { NextIntlClientProvider } from "next-intl";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import "../../../framer-motion.mock";
 import { ProviderForm } from "../../../../src/app/[locale]/settings/providers/_components/forms/provider-form";
 import { Dialog } from "../../../../src/components/ui/dialog";
 import enMessages from "../../../../messages/en";


### PR DESCRIPTION
## Summary
Fix CI failures on `dev` caused by two independent regressions: unhandled animation-cancellation rejections from Framer Motion in happy-dom component tests, and a Japanese punctuation contract violation introduced by the hedge routing feature.

## Problem

**1. happy-dom animation rejections**

Seven login-page tests and two provider-form tests mount real component trees built with `motion.*` elements (`src/app/[locale]/login/page.tsx`, provider-form sections/cards). When these DOM-only tests unmount the animated trees, Framer Motion's cancelled animations surface as unhandled rejections under happy-dom and fail the suite.

**2. Japanese punctuation contract regression**

`messages/ja/dashboard.json` must contain only half-width parentheses, a contract enforced by `tests/unit/i18n/ja-dashboard-parentheses.test.ts` (`expect(text).not.toMatch(/[（）]/)`). The newly added `slotSaturation` key used full-width parentheses, breaking that test.

**Related Issues / PRs:**
- Follow-up to #1462 - fixes the `slotSaturation` full-width-parentheses regression introduced by the hedge concurrency feature

## Solution
- Add a shared `tests/framer-motion.mock.tsx` that replaces every `motion.*` component with a plain DOM element of the same tag, stripping motion-only props (`animate`, `exit`, `variants`, `transition`, `while*`, ...) so they never reach the DOM as invalid attributes. Rendering output is otherwise unchanged, keeping DOM assertions meaningful.
- Opt the 9 affected tests into the mock via side-effect import.
- Change `slotSaturation` from `（{count} 件）` to `({count} 件)`, consistent with adjacent keys such as `configStickyBindingTtl`.

## Changes

### Core Changes
- `tests/framer-motion.mock.tsx` (new): Proxy-based `motion` mock with per-tag component caching
- 9 test files: import the mock (login page tests x7, provider form tests x2)
- `messages/ja/dashboard.json`: normalize `slotSaturation` to half-width parentheses

## Testing
- No production code paths changed; this PR is test infrastructure plus a single locale string fix
- The i18n fix restores `tests/unit/i18n/ja-dashboard-parentheses.test.ts` to green
- Full unit suite passes locally: 879 files, 8793 tests

## Checklist
- [ ] Code follows project conventions
- [ ] Self-review completed
- [x] Tests pass locally
- [ ] Documentation updated (not needed - no behavior change)

---
*Description enhanced by Claude AI*

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes happy-dom component tests by replacing Framer Motion elements with plain DOM wrappers and updates Japanese slot-saturation punctuation.

- Adds a reusable, test-only Framer Motion mock that strips animation-specific props.
- Applies the mock to login and provider-form tests that render animated trees.
- Normalizes the Japanese slot-saturation message to half-width parentheses.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness, security, or test-contract issues identified.

The new mock covers the Framer Motion usage reached by the changed tests, preserves their relevant DOM attributes and children, and the localization edit retains its interpolation contract.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tests/framer-motion.mock.tsx | Adds a scoped DOM-compatible motion mock whose supported exports and props cover the newly affected test paths. |
| messages/ja/dashboard.json | Changes only the slot-saturation punctuation while preserving the interpolation placeholder and message meaning. |
| tests/unit/auth/login-page-site-title.test.tsx | Imports the shared animation mock before loading the login page under test. |
| tests/unit/login/login-ui-redesign.test.tsx | Isolates login UI assertions from Framer Motion animation lifecycle behavior. |
| tests/unit/settings/providers/provider-form-endpoint-pool.test.tsx | Uses the shared mock for provider-form rendering without changing the tested form behavior. |
| tests/unit/settings/providers/provider-form-total-limit-ui.test.tsx | Uses the shared mock to prevent animation cleanup from interfering with total-limit UI assertions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): isolate motion animations in ..."](https://github.com/ding113/claude-code-hub/commit/04e4c5055d950b283d438ef36da8de3d1c8f6e16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58966706)</sub>

<!-- /greptile_comment -->