### PR TITLE
fix(proxy): strip stale content encoding after reserialization

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -3778,6 +3778,21 @@ export class ProxyForwarder {
       }
     }
 
+    if (
+      requestBody !== undefined &&
+      !ProxyForwarder.getEndpointPolicy(session).bypassForwarderPreprocessing &&
+      processedHeaders.has("content-encoding")
+    ) {
+      const previousContentEncoding = processedHeaders.get("content-encoding");
+      processedHeaders.delete("content-encoding");
+      logger.debug("ProxyForwarder: Removed stale content-encoding from serialized request body", {
+        providerId: provider.id,
+        providerName: provider.name,
+        contentEncoding: previousContentEncoding,
+        path: session.requestUrl.pathname,
+      });
+    }
+
     if (session.shouldPersistSessionDebugArtifacts()) {
       const detailSnapshotSession = session as ProxySessionWithDetailSnapshotRuntime;
       detailSnapshotSession.detailSnapshotRequestAfter = {

--- a/tests/unit/proxy/proxy-forwarder-raw-passthrough-regression.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-raw-passthrough-regression.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
     eligible: false,
   })),
   tryResponsesWebsocketUpstream: vi.fn(),
+  applyFinalRequestFilters: vi.fn(async () => undefined),
 }));
 
 vi.mock("@/lib/config", async (importOriginal) => {
@@ -49,6 +50,12 @@ vi.mock("@/app/v1/_lib/responses-ws/upstream-adapter", async (importOriginal) =>
     tryResponsesWebsocketUpstream: mocks.tryResponsesWebsocketUpstream,
   };
 });
+
+vi.mock("@/lib/request-filter-engine", () => ({
+  requestFilterEngine: {
+    applyFinal: mocks.applyFinalRequestFilters,
+  },
+}));
 
 import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
 import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
@@ -176,6 +183,71 @@ describe("ProxyForwarder raw passthrough regression", () => {
     await doForward(session, provider, provider.url);
 
     expect(readBodyText(capturedInit?.body)).toBe(originalBody);
+  });
+
+  it("非 raw 请求重新序列化后移除失真的 content-encoding 与 content-length", async () => {
+    const originalBody = '{\n  "model": "gpt-5.5",\n  "input": [1, 2, 3]\n}\n';
+    const session = createRawPassthroughSession(originalBody, {
+      "content-encoding": "snappy",
+    });
+    const endpointPolicy = resolveEndpointPolicy("/v1/responses");
+    Object.assign(session, {
+      requestUrl: new URL("https://proxy.example.com/v1/responses"),
+      endpointPolicy,
+      getEndpointPolicy: vi.fn(() => endpointPolicy),
+    });
+    const provider = createProvider();
+
+    let capturedBody: BodyInit | undefined;
+    let capturedHeaders: Headers | null = null;
+    const fetchWithoutAutoDecode = vi.spyOn(ProxyForwarder as any, "fetchWithoutAutoDecode");
+    fetchWithoutAutoDecode.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body ?? undefined;
+      capturedHeaders = new Headers(init.headers);
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json", "content-length": "2" },
+      });
+    });
+
+    const { doForward } = ProxyForwarder as unknown as {
+      doForward: (session: ProxySession, provider: Provider, baseUrl: string) => Promise<Response>;
+    };
+
+    await doForward(session, provider, provider.url);
+
+    expect(readBodyText(capturedBody)).toBe(JSON.stringify(JSON.parse(originalBody)));
+    expect(capturedHeaders?.get("content-encoding")).toBeNull();
+    expect(capturedHeaders?.get("content-length")).toBeNull();
+  });
+
+  it("raw passthrough 保留无法解码的 content-encoding 与原始请求体字节", async () => {
+    const originalBody = '{\n  "model": "gpt-5.5",\n  "input": [1, 2, 3]\n}\n';
+    const session = createRawPassthroughSession(originalBody, {
+      "content-encoding": "snappy",
+    });
+    const provider = createProvider();
+
+    let capturedBody: BodyInit | undefined;
+    let capturedHeaders: Headers | null = null;
+    const fetchWithoutAutoDecode = vi.spyOn(ProxyForwarder as any, "fetchWithoutAutoDecode");
+    fetchWithoutAutoDecode.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body ?? undefined;
+      capturedHeaders = new Headers(init.headers);
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json", "content-length": "2" },
+      });
+    });
+
+    const { doForward } = ProxyForwarder as unknown as {
+      doForward: (session: ProxySession, provider: Provider, baseUrl: string) => Promise<Response>;
+    };
+
+    await doForward(session, provider, provider.url);
+
+    expect(readBodyText(capturedBody)).toBe(originalBody);
+    expect(capturedHeaders?.get("content-encoding")).toBe("snappy");
   });
 
   it("remote compaction v2 保留 /v1/responses wire path 与原始请求体", async () => {


### PR DESCRIPTION
## Summary

- strip stale `content-encoding` after non-raw request bodies are reserialized
- preserve `content-encoding` and exact request bytes for raw passthrough endpoints
- keep `content-length` handling on the existing outbound transport blacklist

This is a narrow follow-up to [#1238](https://github.com/ding113/claude-code-hub/pull/1238).

## Why

#1238 strips `content-encoding` after successful decompression, but an encoding retained or reintroduced later can still reach the final forwarded headers. Non-raw paths serialize a new JSON or multipart body, so that encoding no longer describes the transmitted bytes and can make the upstream decode plaintext. Raw passthrough paths still need the original encoding header.

## Tests

- [x] non-raw reserialization strips stale `content-encoding` and `content-length`
- [x] raw passthrough preserves `content-encoding` and exact request bytes
- [x] targeted proxy tests (14 tests)
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun run lint:fix`
- [x] `bun run typecheck`
- [x] `bun run test` (879 test files passed; 8795 tests passed)
- [x] `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR removes stale `content-encoding` metadata from reserialized outbound request bodies while preserving the header and exact bytes for raw-passthrough endpoints.
- Adds conditional cleanup of `content-encoding` after non-raw body serialization.
- Adds regression coverage for both reserialized and raw-passthrough requests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed header handling aligned to the distinction between reserialized and raw-passthrough request bodies.

Non-raw outbound bodies are newly serialized before the encoding header is removed, while raw-passthrough bodies retain both their original bytes and encoding metadata; no actionable failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/app/v1/_lib/proxy/forwarder.ts | Removes `content-encoding` only when a defined request body has passed through the normal preprocessing and serialization path. |
| tests/unit/proxy/proxy-forwarder-raw-passthrough-regression.test.ts | Covers stale framing-header removal for reserialized requests and preservation of encoding metadata and exact bytes for raw passthrough. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(proxy): strip stale content encoding..."](https://github.com/ding113/claude-code-hub/commit/0e713f6cc2a289e341003d3b067d1a92607e98ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59027340)</sub>

<!-- /greptile_comment -->