### PR TITLE
fix(proxy): quarantine failing HTTP/2 routes and retry over HTTP/1.1

### DIFF
--- a/src/app/v1/_lib/proxy/errors.ts
+++ b/src/app/v1/_lib/proxy/errors.ts
@@ -1087,6 +1087,8 @@ const HTTP2_ERROR_PATTERNS = [
   "REFUSED_STREAM",
 ];
 
+const HTTP2_ERROR_CAUSE_MAX_DEPTH = 4;
+
 /**
  * 检测是否为 HTTP/2 协议错误
  *
@@ -1114,12 +1116,39 @@ const HTTP2_ERROR_PATTERNS = [
  * isHttp2Error(new Error('Connection refused')) // false
  */
 export function isHttp2Error(error: Error): boolean {
-  // 组合错误信息进行检测
-  const errorString = [error.name, error.message, (error as NodeJS.ErrnoException).code ?? ""]
-    .join(" ")
-    .toUpperCase();
+  const seen = new Set<object>();
+  let current: unknown = error;
 
-  return HTTP2_ERROR_PATTERNS.some((pattern) => errorString.includes(pattern.toUpperCase()));
+  for (let depth = 0; depth <= HTTP2_ERROR_CAUSE_MAX_DEPTH; depth += 1) {
+    if (current === null || (typeof current !== "object" && typeof current !== "function")) {
+      return false;
+    }
+
+    const currentObject = current as object;
+    if (seen.has(currentObject)) return false;
+    seen.add(currentObject);
+
+    const candidate = current as {
+      name?: unknown;
+      message?: unknown;
+      code?: unknown;
+      cause?: unknown;
+    };
+    const errorString = [candidate.name, candidate.message, candidate.code]
+      .filter(
+        (value): value is string | number => typeof value === "string" || typeof value === "number"
+      )
+      .join(" ")
+      .toUpperCase();
+
+    if (HTTP2_ERROR_PATTERNS.some((pattern) => errorString.includes(pattern.toUpperCase()))) {
+      return true;
+    }
+
+    current = candidate.cause;
+  }
+
+  return false;
 }
 
 /**

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -33,6 +33,10 @@ import {
   getPreferredProviderEndpoints,
 } from "@/lib/provider-endpoints/endpoint-selector";
 import { getGlobalAgentPool, getProxyAgentForProvider } from "@/lib/proxy-agent";
+import {
+  isHttp2TransportQuarantined,
+  quarantineHttp2Transport,
+} from "@/lib/proxy-agent/http2-quarantine";
 import { RateLimitService } from "@/lib/rate-limit/service";
 import type { SessionBindingSnapshot } from "@/lib/redis/session-binding";
 import { SessionManager } from "@/lib/session-manager";
@@ -3946,7 +3950,9 @@ export class ProxyForwarder {
     };
 
     // ⭐ 获取 HTTP/2 全局开关设置
-    const enableHttp2 = await isHttp2Enabled();
+    const http2EnabledBySetting = await isHttp2Enabled();
+    let enableHttp2 = http2EnabledBySetting;
+    let http2Attempted = false;
 
     // ⭐ 应用代理配置（如果配置了）- 使用 Agent Pool 缓存连接
     // 注意：proxyConfig 与 directConnectionCacheKey 的声明保持在 try 外部，
@@ -3968,7 +3974,14 @@ export class ProxyForwarder {
     try {
       // ⭐ 把 agent 获取 & 配置日志放进 try 块，确保获取后到 fetch 之前任何异常
       // （例如 URL 解析失败）都会走 catch 的统一释放逻辑，避免泄漏 activeRequests。
+      enableHttp2 =
+        http2EnabledBySetting &&
+        !isHttp2TransportQuarantined({
+          targetUrl: proxyUrl,
+          proxyUrl: provider.proxyUrl,
+        });
       proxyConfig = await getProxyAgentForProvider(provider, proxyUrl, enableHttp2);
+      http2Attempted = enableHttp2 && (proxyConfig?.http2Enabled ?? true);
 
       if (proxyConfig) {
         init.dispatcher = proxyConfig.agent;
@@ -4284,9 +4297,13 @@ export class ProxyForwarder {
       // ⭐ HTTP/2 协议错误检测与透明回退
       // 场景：HTTP/2 连接失败（GOAWAY、RST_STREAM、PROTOCOL_ERROR 等）
       // 策略：透明回退到 HTTP/1.1，不触发供应商切换或熔断器
-      if (enableHttp2 && isHttp2Error(err)) {
+      if (http2Attempted && isHttp2Error(err)) {
         const http2CacheKey = proxyConfig?.cacheKey ?? directConnectionCacheKey;
         const http2DispatcherId = proxyConfig?.dispatcherId ?? directConnectionDispatcherId;
+        quarantineHttp2Transport({
+          targetUrl: proxyUrl,
+          proxyUrl: provider.proxyUrl,
+        });
         logger.warn("ProxyForwarder: HTTP/2 protocol error detected, falling back to HTTP/1.1", {
           providerId: provider.id,
           providerName: provider.name,
@@ -4295,6 +4312,7 @@ export class ProxyForwarder {
           errorName: err.name,
           errorMessage: err.message || "(empty message)",
           errorCode: err.code || "N/A",
+          h1OnlyQuarantine: true,
         });
 
         // 记录到决策链（标记为 HTTP/2 回退）

--- a/src/lib/proxy-agent/http2-quarantine.ts
+++ b/src/lib/proxy-agent/http2-quarantine.ts
@@ -1,0 +1,53 @@
+type Http2TransportRoute = {
+  targetUrl: string;
+  proxyUrl?: string | null;
+};
+
+const HTTP2_QUARANTINE_TTL_MS = 5 * 60 * 1000;
+const HTTP2_QUARANTINE_MAX_ROUTES = 1024;
+
+const quarantinedRoutes = new Map<string, number>();
+
+function normalizeOrigin(value: string): string {
+  return new URL(value).origin;
+}
+
+function pruneExpired(now: number): void {
+  for (const [key, expiresAt] of quarantinedRoutes) {
+    if (expiresAt <= now) quarantinedRoutes.delete(key);
+  }
+}
+
+export function getHttp2TransportKey(route: Http2TransportRoute): string {
+  const targetOrigin = normalizeOrigin(route.targetUrl);
+  const proxyOrigin = route.proxyUrl ? normalizeOrigin(route.proxyUrl) : "direct";
+  return `${targetOrigin}|${proxyOrigin}`;
+}
+
+export function isHttp2TransportQuarantined(route: Http2TransportRoute): boolean {
+  const now = Date.now();
+  pruneExpired(now);
+  const expiresAt = quarantinedRoutes.get(getHttp2TransportKey(route));
+  return expiresAt !== undefined && expiresAt > now;
+}
+
+export function quarantineHttp2Transport(route: Http2TransportRoute): void {
+  const now = Date.now();
+  pruneExpired(now);
+  const key = getHttp2TransportKey(route);
+
+  // Refresh the route's TTL and insertion order so repeatedly failing routes stay
+  // visible while the map remains bounded by the oldest known route.
+  quarantinedRoutes.delete(key);
+  quarantinedRoutes.set(key, now + HTTP2_QUARANTINE_TTL_MS);
+
+  while (quarantinedRoutes.size > HTTP2_QUARANTINE_MAX_ROUTES) {
+    const oldestKey = quarantinedRoutes.keys().next().value;
+    if (oldestKey === undefined) break;
+    quarantinedRoutes.delete(oldestKey);
+  }
+}
+
+export function clearHttp2TransportQuarantine(): void {
+  quarantinedRoutes.clear();
+}

--- a/tests/unit/lib/proxy-agent/http2-quarantine.test.ts
+++ b/tests/unit/lib/proxy-agent/http2-quarantine.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearHttp2TransportQuarantine,
+  getHttp2TransportKey,
+  isHttp2TransportQuarantined,
+  quarantineHttp2Transport,
+} from "@/lib/proxy-agent/http2-quarantine";
+
+describe("HTTP/2 transport quarantine", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    clearHttp2TransportQuarantine();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps target and proxy origins isolated without retaining credentials", () => {
+    const key = getHttp2TransportKey({
+      targetUrl: "https://co.yes.vg/team/v1/responses?token=secret",
+      proxyUrl: "https://user:password@proxy.example.com:8443/path",
+    });
+
+    expect(key).toBe("https://co.yes.vg|https://proxy.example.com:8443");
+    expect(key).not.toContain("secret");
+    expect(key).not.toContain("password");
+  });
+
+  it("quarantines an origin and expires it after the bounded TTL", () => {
+    const route = { targetUrl: "https://co.yes.vg/team/v1/responses", proxyUrl: null };
+
+    expect(isHttp2TransportQuarantined(route)).toBe(false);
+    quarantineHttp2Transport(route);
+    expect(isHttp2TransportQuarantined(route)).toBe(true);
+
+    vi.advanceTimersByTime(5 * 60 * 1000 - 1);
+    expect(isHttp2TransportQuarantined(route)).toBe(true);
+    vi.advanceTimersByTime(1);
+    expect(isHttp2TransportQuarantined(route)).toBe(false);
+  });
+
+  it("does not quarantine a different target or proxy origin", () => {
+    const route = { targetUrl: "https://co.yes.vg/team/v1/responses", proxyUrl: null };
+    quarantineHttp2Transport(route);
+
+    expect(
+      isHttp2TransportQuarantined({ targetUrl: "https://other.example.com/v1/responses" })
+    ).toBe(false);
+    expect(
+      isHttp2TransportQuarantined({
+        targetUrl: route.targetUrl,
+        proxyUrl: "https://proxy.example.com",
+      })
+    ).toBe(false);
+  });
+
+  it("bounds retained route state when many origins fail", () => {
+    for (let index = 0; index < 1_100; index += 1) {
+      quarantineHttp2Transport({ targetUrl: `https://provider-${index}.example.com/v1` });
+    }
+
+    expect(isHttp2TransportQuarantined({ targetUrl: "https://provider-1099.example.com/v1" })).toBe(
+      true
+    );
+    expect(isHttp2TransportQuarantined({ targetUrl: "https://provider-0.example.com/v1" })).toBe(
+      false
+    );
+  });
+});

--- a/tests/unit/proxy/proxy-forwarder-http2-fallback.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-http2-fallback.test.ts
@@ -1,0 +1,317 @@
+import { createHash } from "node:crypto";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveEndpointPolicy } from "@/app/v1/_lib/proxy/endpoint-policy";
+import { ProxyForwarder } from "@/app/v1/_lib/proxy/forwarder";
+import { ProxySession } from "@/app/v1/_lib/proxy/session";
+import {
+  clearHttp2TransportQuarantine,
+  isHttp2TransportQuarantined,
+} from "@/lib/proxy-agent/http2-quarantine";
+import { resetGlobalAgentPool } from "@/lib/proxy-agent";
+import type { Provider } from "@/types/provider";
+
+const mocks = vi.hoisted(() => ({
+  isHttp2Enabled: vi.fn(async () => true),
+  request: vi.fn(),
+}));
+
+vi.mock("@/lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/config")>();
+  return { ...actual, isHttp2Enabled: mocks.isHttp2Enabled };
+});
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    trace: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+  },
+}));
+
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return { ...actual, request: mocks.request };
+});
+
+vi.mock("@/app/v1/_lib/proxy/provider-selector", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/v1/_lib/proxy/provider-selector")>();
+  return {
+    ...actual,
+    ProxyProviderResolver: {
+      ...actual.ProxyProviderResolver,
+      pickRandomProviderWithExclusion: vi.fn(async () => null),
+    },
+  };
+});
+
+function createProvider(): Provider {
+  return {
+    id: 1,
+    name: "yescode-codex",
+    url: "https://co.yes.vg/team/v1/responses",
+    key: "upstream-key",
+    providerVendorId: null,
+    isEnabled: true,
+    weight: 1,
+    priority: 0,
+    groupPriorities: null,
+    costMultiplier: 1,
+    groupTag: null,
+    providerType: "openai-compatible",
+    preserveClientIp: false,
+    modelRedirects: null,
+    allowedModels: null,
+    mcpPassthroughType: "none",
+    mcpPassthroughUrl: null,
+    limit5hUsd: null,
+    limitDailyUsd: null,
+    dailyResetMode: "fixed",
+    dailyResetTime: "00:00",
+    limitWeeklyUsd: null,
+    limitMonthlyUsd: null,
+    limitTotalUsd: null,
+    totalCostResetAt: null,
+    limitConcurrentSessions: 0,
+    maxRetryAttempts: null,
+    circuitBreakerFailureThreshold: 5,
+    circuitBreakerOpenDuration: 1_800_000,
+    circuitBreakerHalfOpenSuccessThreshold: 2,
+    proxyUrl: null,
+    proxyFallbackToDirect: false,
+    firstByteTimeoutStreamingMs: 30_000,
+    streamingIdleTimeoutMs: 10_000,
+    requestTimeoutNonStreamingMs: 1_000,
+    websiteUrl: null,
+    faviconUrl: null,
+    cacheTtlPreference: null,
+    context1mPreference: null,
+    codexReasoningEffortPreference: null,
+    codexReasoningSummaryPreference: null,
+    codexTextVerbosityPreference: null,
+    codexParallelToolCallsPreference: null,
+    codexImageGenerationPreference: null,
+    anthropicMaxTokensPreference: null,
+    anthropicThinkingBudgetPreference: null,
+    geminiGoogleSearchPreference: null,
+    tpm: 0,
+    rpm: 0,
+    rpd: 0,
+    cc: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+}
+
+function createSession(provider: Provider, content = "hello"): ProxySession {
+  const session = Object.create(ProxySession.prototype) as ProxySession;
+  const headers = new Headers({ "content-type": "application/json" });
+  Object.assign(session, {
+    startTime: Date.now(),
+    method: "POST",
+    requestUrl: new URL("https://co.yes.vg/team/v1/responses"),
+    headers,
+    originalHeaders: new Headers(headers),
+    headerLog: "{}",
+    request: {
+      message: {
+        model: "gpt-5.5",
+        input: [{ role: "user", content }],
+      },
+      log: "{}",
+    },
+    userAgent: "test-agent",
+    context: null,
+    clientAbortSignal: null,
+    userName: "test-user",
+    authState: { success: true, user: null, key: null, apiKey: null },
+    provider,
+    messageContext: null,
+    sessionId: null,
+    requestSequence: 1,
+    originalFormat: "response",
+    providerType: provider.providerType,
+    originalModelName: null,
+    originalUrlPathname: null,
+    providerChain: [],
+    cacheTtlResolved: null,
+    context1mApplied: false,
+    specialSettings: [],
+    cachedPriceData: undefined,
+    cachedBillingModelSource: undefined,
+    endpointPolicy: resolveEndpointPolicy("/team/v1/responses"),
+    isHeaderModified: () => false,
+  });
+  return session;
+}
+
+function responseFixture(): {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: Readable;
+} {
+  return {
+    statusCode: 200,
+    headers: {
+      "content-type": "text/plain",
+      "content-length": "11",
+    },
+    body: Readable.from(['{"ok":true}']),
+  };
+}
+
+function releaseAgent(session: ProxySession): void {
+  (session as ProxySession & { releaseAgent?: () => void }).releaseAgent?.();
+}
+
+function bodyDigest(body: unknown): string {
+  return createHash("sha256")
+    .update(String(body ?? ""))
+    .digest("hex");
+}
+
+describe("ProxyForwarder HTTP/2 fallback", () => {
+  beforeEach(() => {
+    clearHttp2TransportQuarantine();
+    mocks.isHttp2Enabled.mockResolvedValue(true);
+    mocks.request.mockReset();
+  });
+
+  afterEach(async () => {
+    clearHttp2TransportQuarantine();
+    await resetGlobalAgentPool();
+  });
+
+  it("retries the same body over H1 and keeps later attempts on H1", async () => {
+    const h2Error = new Error("Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM");
+    Object.assign(h2Error, { code: "ERR_HTTP2_STREAM_ERROR" });
+    mocks.request.mockRejectedValueOnce(h2Error);
+    mocks.request.mockResolvedValueOnce(responseFixture());
+    mocks.request.mockResolvedValueOnce(responseFixture());
+
+    const provider = createProvider();
+    const firstSession = createSession(provider, "x".repeat(5_700_000));
+    const firstResponse = await (
+      ProxyForwarder as unknown as {
+        doForward: (...args: unknown[]) => Promise<Response>;
+      }
+    ).doForward(firstSession, provider, provider.url);
+
+    expect(firstResponse.status).toBe(200);
+    expect(mocks.request).toHaveBeenCalledTimes(2);
+    const firstInit = mocks.request.mock.calls[0]?.[1] as RequestInit & { dispatcher?: unknown };
+    const fallbackInit = mocks.request.mock.calls[1]?.[1] as RequestInit & {
+      dispatcher?: unknown;
+    };
+    expect(firstInit.dispatcher).toBeDefined();
+    expect(fallbackInit.dispatcher).toBeUndefined();
+    expect(bodyDigest(fallbackInit.body)).toBe(bodyDigest(firstInit.body));
+    expect(
+      isHttp2TransportQuarantined({ targetUrl: provider.url, proxyUrl: provider.proxyUrl })
+    ).toBe(true);
+    releaseAgent(firstSession);
+
+    const secondSession = createSession(provider, "x".repeat(5_700_000));
+    const secondResponse = await (
+      ProxyForwarder as unknown as {
+        doForward: (...args: unknown[]) => Promise<Response>;
+      }
+    ).doForward(secondSession, provider, provider.url);
+
+    expect(secondResponse.status).toBe(200);
+    expect(mocks.request).toHaveBeenCalledTimes(3);
+    const quarantinedInit = mocks.request.mock.calls[2]?.[1] as RequestInit & {
+      dispatcher?: unknown;
+    };
+    expect(quarantinedInit.dispatcher).toBeUndefined();
+    expect(quarantinedInit.body).toBe(firstInit.body);
+    releaseAgent(secondSession);
+  });
+
+  it("downgrades when Undici wraps the H2 reset in nested causes", async () => {
+    const rootCause = new Error("Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM");
+    Object.assign(rootCause, { code: "ERR_HTTP2_STREAM_ERROR" });
+    const wrapped = new Error("fetch failed", { cause: rootCause });
+    const outer = new Error("request failed", { cause: wrapped });
+    mocks.request.mockRejectedValueOnce(outer);
+    mocks.request.mockResolvedValueOnce(responseFixture());
+
+    const provider = createProvider();
+    const session = createSession(provider);
+    const response = await (
+      ProxyForwarder as unknown as {
+        doForward: (...args: unknown[]) => Promise<Response>;
+      }
+    ).doForward(session, provider, provider.url);
+
+    expect(response.status).toBe(200);
+    expect(mocks.request).toHaveBeenCalledTimes(2);
+    const fallbackInit = mocks.request.mock.calls[1]?.[1] as RequestInit & {
+      dispatcher?: unknown;
+    };
+    expect(fallbackInit.dispatcher).toBeUndefined();
+    releaseAgent(session);
+  });
+
+  it("does not replay a response-body reset after headers are returned", async () => {
+    const bodyError = new Error("Stream closed with error code NGHTTP2_INTERNAL_ERROR");
+    Object.assign(bodyError, { code: "ERR_HTTP2_STREAM_ERROR" });
+    const body = new Readable({
+      read() {
+        this.push("prefix");
+        queueMicrotask(() => this.destroy(bodyError));
+      },
+    });
+    mocks.request.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: { "content-type": "text/plain" },
+      body,
+    });
+
+    const provider = createProvider();
+    const session = createSession(provider);
+    const response = await (
+      ProxyForwarder as unknown as {
+        doForward: (...args: unknown[]) => Promise<Response>;
+      }
+    ).doForward(session, provider, provider.url);
+
+    await expect(response.text()).rejects.toThrow("NGHTTP2_INTERNAL_ERROR");
+    expect(mocks.request).toHaveBeenCalledTimes(1);
+    releaseAgent(session);
+  });
+
+  it("lets the normal vendor retry path reuse H1 after a failed downgrade", async () => {
+    const provider = createProvider();
+    provider.maxRetryAttempts = 2;
+    const h2Error = new Error("Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM");
+    Object.assign(h2Error, { code: "ERR_HTTP2_STREAM_ERROR" });
+    const h1Error = new Error("upstream remained unavailable");
+    Object.assign(h1Error, { code: "ECONNRESET" });
+    mocks.request.mockRejectedValueOnce(h2Error).mockRejectedValueOnce(h1Error);
+    mocks.request.mockResolvedValueOnce(responseFixture());
+
+    const session = createSession(provider);
+    const response = await ProxyForwarder.send(session);
+
+    expect(response.status).toBe(200);
+    expect(mocks.request).toHaveBeenCalledTimes(3);
+    const firstInit = mocks.request.mock.calls[0]?.[1] as RequestInit & { dispatcher?: unknown };
+    const fallbackInit = mocks.request.mock.calls[1]?.[1] as RequestInit & {
+      dispatcher?: unknown;
+    };
+    const retryInit = mocks.request.mock.calls[2]?.[1] as RequestInit & {
+      dispatcher?: unknown;
+    };
+    expect(firstInit.dispatcher).toBeDefined();
+    expect(fallbackInit.dispatcher).toBeUndefined();
+    expect(retryInit.dispatcher).toBeUndefined();
+    expect(bodyDigest(retryInit.body)).toBe(bodyDigest(firstInit.body));
+    expect(session.getProviderChain().some((item) => item.reason === "http2_fallback")).toBe(true);
+    releaseAgent(session);
+  });
+});

--- a/tests/unit/transport-error-detection.test.ts
+++ b/tests/unit/transport-error-detection.test.ts
@@ -83,6 +83,11 @@ describe("isTransportError", () => {
       expect(isTransportError(err)).toBe(true);
     });
 
+    it("should detect NGHTTP2_ENHANCE_YOUR_CALM in message", () => {
+      const err = new Error("Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM");
+      expect(isHttp2Error(err)).toBe(true);
+    });
+
     it("should detect GOAWAY errors", () => {
       const err = new Error("GOAWAY session");
       expect(isTransportError(err)).toBe(true);
@@ -113,6 +118,25 @@ describe("isTransportError", () => {
       const err = new Error("request failed");
       (err as Error & { cause: Error }).cause = cause;
       expect(isTransportError(err)).toBe(true);
+    });
+
+    it("should detect HTTP/2 protocol errors through a bounded cause chain", () => {
+      const root = new Error("Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM");
+      (root as NodeJS.ErrnoException).code = "ERR_HTTP2_STREAM_ERROR";
+      const middle = new Error("fetch failed", { cause: root });
+      const outer = new Error("request failed", { cause: middle });
+
+      expect(isHttp2Error(outer)).toBe(true);
+      expect(isTransportError(outer)).toBe(true);
+    });
+
+    it("should stop traversing cyclic cause chains", () => {
+      const first = new Error("request failed");
+      const second = new Error("retry wrapper");
+      (first as Error & { cause?: unknown }).cause = second;
+      (second as Error & { cause?: unknown }).cause = first;
+
+      expect(isHttp2Error(first)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- quarantine target/proxy origins for five minutes after a real HTTP/2 reset, so later requests use HTTP/1.1 instead of reopening the same H2 failure
- recognize wrapped Undici HTTP/2 errors through a bounded, cycle-safe cause chain
- preserve the existing one-attempt H2-to-H1 fallback and vendor retry budgets
- add ablation/regression coverage for exact NGHTTP2_ENHANCE_YOUR_CALM errors, nested causes, 5.7 MB body replay, vendor retry no-oscillation, TTL/isolation/bounds, and post-header stream resets

## Problem

When an upstream keeps resetting HTTP/2 streams (production shape: `ERR_HTTP2_STREAM_ERROR` / `NGHTTP2_ENHANCE_YOUR_CALM`), the existing one-attempt H2-to-H1 fallback saved the current request, but the next request to the same route negotiated H2 again and hit the same reset - every request paid a failed H2 attempt (including re-uploading multi-MB bodies) before falling back.

Additionally, Undici can wrap the underlying H2 reset inside nested `cause` chains (`"fetch failed"` -> root reset), which the previous top-level-only string match in `isHttp2Error()` did not recognize, so those failures never entered the fallback path at all.

**Related:**
- Follow-up to #1009 - builds on the HTTP/2 transport-error classification added there (same `errors.ts` / `transport-error-detection` tests): extends detection to wrapped cause chains and adds route-level H1 quarantine on top
- Related to #1190 - complementary scope: #1190 evicts unhealthy dispatchers per generation, this PR downgrades the (target origin, proxy origin) route to H1 for a bounded window

## Solution

1. New process-local quarantine (`src/lib/proxy-agent/http2-quarantine.ts`): map keyed by `targetOrigin|proxyOrigin` (credentials stripped via `URL.origin`, `direct` when no proxy), 5-minute TTL, capped at 1024 routes with oldest-first eviction; re-quarantining a route refreshes its TTL and recency. After the TTL expires, H2 is probed again automatically.
2. Before agent acquisition, `ProxyForwarder` disables H2 for quarantined routes: proxied routes get `allowH2: false`, direct routes skip the pooled H2 dispatcher entirely and use plain HTTP/1.1 fetch.
3. On a detected H2 error the route is quarantined (`h1OnlyQuarantine: true` log field), then the existing single H1 retry runs with the same request body.
4. The fallback trigger now requires that H2 was actually attempted for this request (`http2Attempted`, also false for SOCKS proxies) instead of merely enabled by settings, so H1-only failures are no longer misclassified as H2 fallbacks.
5. `isHttp2Error()` traverses `error.cause` up to depth 4 with a seen-set guard for cyclic chains, matching only string/number `name`/`message`/`code` values.

## Changes

No breaking changes - purely additive; no schema, migration, or API surface changes.

### Core Changes
- `src/lib/proxy-agent/http2-quarantine.ts` (new): bounded, TTL-based per-route H2 quarantine store
- `src/app/v1/_lib/proxy/forwarder.ts`: consult the quarantine before enabling H2, track `http2Attempted`, quarantine the route on a real H2 error
- `src/app/v1/_lib/proxy/errors.ts`: bounded, cycle-safe cause-chain traversal in `isHttp2Error()`

### Tests
- `tests/unit/lib/proxy-agent/http2-quarantine.test.ts` (new): key isolation without credential retention, TTL expiry, cross-route isolation, 1024-route bound
- `tests/unit/proxy/proxy-forwarder-http2-fallback.test.ts` (new): H1 retry reuses the same 5.7 MB body and later attempts stay on H1; nested-cause downgrade; no replay of response-body resets after headers; vendor retry path stays on H1 without oscillation
- `tests/unit/transport-error-detection.test.ts`: exact `NGHTTP2_ENHANCE_YOUR_CALM` message match, bounded cause-chain detection, cyclic cause chains terminate

## Validation

- bunx vitest run tests/unit/proxy/proxy-forwarder-http2-fallback.test.ts tests/unit/lib/proxy-agent/http2-quarantine.test.ts tests/unit/transport-error-detection.test.ts --configLoader bundle (31 passed)
- bun run test (8,804 passed, 13 skipped)
- bun run typecheck
- bun run lint (existing Biome schema-version info only)
- bun run build
- git diff --check

## Ablation result

A local HTTP/2 reset experiment produced the same Node error shape as production (ERR_HTTP2_STREAM_ERROR / NGHTTP2_ENHANCE_YOUR_CALM). The same request body succeeded over HTTP/1.1. The implementation now keeps subsequent vendor retries on H1 for the quarantined route.

## Notes

The quarantine is process-local and bounded; it is intentionally not an endpoint-wide circuit breaker and does not replay response-body resets after bytes have been returned.

---
*Description enhanced by Claude AI*
