### PR TITLE
fix(proxy): record routing trace events during legacy hedge racing

### DIFF
--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -1733,7 +1733,8 @@ export class ProxyForwarder {
       const hedgePromise = ProxyForwarder.sendStreamingWithHedge(
         session,
         discoverySettings,
-        legacyHedgeMaxInFlight
+        legacyHedgeMaxInFlight,
+        requestStartedAt
       );
       void hedgePromise.catch(() => undefined);
       return await hedgePromise;
@@ -4846,7 +4847,8 @@ export class ProxyForwarder {
   private static async sendStreamingWithHedge(
     session: ProxySession,
     settings: SystemSettings,
-    maxInFlight: number
+    maxInFlight: number,
+    requestStartedAt: number
   ): Promise<Response> {
     const initialProvider = session.provider;
     if (!initialProvider) {
@@ -4867,6 +4869,17 @@ export class ProxyForwarder {
     let lastErrorCategory: ErrorCategory | null = null;
     const attempts = new Set<StreamingHedgeAttempt>();
     const failedProviderIds: number[] = [];
+    // Legacy hedge is a single parallel wave. Round 1 (not 0) keeps the routing
+    // trace view from labelling every attempt as sticky.
+    const HEDGE_TRACE_ROUND = 1;
+    const hedgeMetrics = new DiscoveryRequestMetrics(
+      {
+        requestId: session.messageContext?.id ?? null,
+        sessionId: session.sessionId ?? "",
+        keyId: session.authState?.key?.id ?? 0,
+      },
+      requestStartedAt
+    );
 
     let resolveResult: ((result: { response?: Response; error?: Error }) => void) | null = null;
     const resultPromise = new Promise<{ response?: Response; error?: Error }>((resolve) => {
@@ -4992,6 +5005,57 @@ export class ProxyForwarder {
         });
     };
 
+    const traceProvider = (attempt: StreamingHedgeAttempt) => ({
+      id: attempt.provider.id,
+      name: attempt.provider.name,
+      priority: attempt.provider.priority || 0,
+    });
+
+    const traceAttemptStarted = (attempt: StreamingHedgeAttempt) => {
+      hedgeMetrics.attemptStarted({
+        attemptId: attempt.attemptId,
+        providerId: attempt.provider.id,
+        round: HEDGE_TRACE_ROUND,
+        kind: "normal",
+      });
+      session.appendRoutingTraceEvent({
+        type: "attempt_started",
+        attemptId: attempt.attemptId,
+        attemptKind: "normal",
+        round: HEDGE_TRACE_ROUND,
+        provider: traceProvider(attempt),
+        activeAttemptCount: attempts.size,
+        configuredCap: maxInFlight,
+      });
+    };
+
+    const traceAttemptFinished = (
+      attempt: StreamingHedgeAttempt,
+      context: {
+        outcome: "winner" | "failed" | "cancelled" | "client_abort";
+        cancellationKind?: string;
+        statusCode?: number;
+        reason?: string;
+      }
+    ) => {
+      hedgeMetrics.attemptFinished(attempt.attemptId, {
+        providerId: attempt.provider.id,
+        outcome: context.outcome,
+        cancellationKind: context.cancellationKind ?? null,
+      });
+      session.appendRoutingTraceEvent({
+        type: "attempt_finished",
+        attemptId: attempt.attemptId,
+        attemptKind: "normal",
+        round: HEDGE_TRACE_ROUND,
+        provider: traceProvider(attempt),
+        outcome: context.outcome,
+        ...(context.cancellationKind ? { cancellationKind: context.cancellationKind } : {}),
+        ...(context.statusCode != null ? { statusCode: context.statusCode } : {}),
+        ...(context.reason ? { reason: context.reason } : {}),
+      });
+    };
+
     const abortAttempt = (attempt: StreamingHedgeAttempt, reason: string) => {
       if (attempt.settled) return;
       attempt.settled = true;
@@ -5001,6 +5065,10 @@ export class ProxyForwarder {
       }
       attempts.delete(attempt);
       session.removeLiveActiveProvider(attempt.provider.id);
+      traceAttemptFinished(attempt, {
+        outcome: reason === "client_abort" ? "client_abort" : "cancelled",
+        cancellationKind: reason,
+      });
 
       // 竞速输家计费开启：仅标记 + 记录决策链，不取消连接、不释放 agent。
       // 实际的后台 drain 由 runAttempt 的 .then 流程发起（它独占 reader，避免并发读）。
@@ -5504,6 +5572,10 @@ export class ProxyForwarder {
           attempt.thresholdTimer = null;
         }
         attempts.delete(attempt);
+        traceAttemptFinished(attempt, {
+          outcome: "client_abort",
+          cancellationKind: "client_abort",
+        });
 
         session.addProviderToChain(attempt.provider, {
           ...attempt.endpointAudit,
@@ -5619,6 +5691,11 @@ export class ProxyForwarder {
             clearTimeout(attempt.thresholdTimer);
             attempt.thresholdTimer = null;
           }
+          traceAttemptFinished(attempt, {
+            outcome: "failed",
+            ...(statusCode != null ? { statusCode } : {}),
+            reason: "reactive_rectifier_retry",
+          });
           attempt.requestAttemptCount += 1;
           attempt.dispatched = false;
           attempt.startedAtMonotonic = 0;
@@ -5627,6 +5704,7 @@ export class ProxyForwarder {
           attempt.healthSettlementClaimed = false;
           attempt.healthOutcome = null;
           attempt.hedgeSaturationRecorded = false;
+          traceAttemptStarted(attempt);
           runAttempt(attempt);
           return;
         }
@@ -5655,6 +5733,11 @@ export class ProxyForwarder {
         attempt.thresholdTimer = null;
       }
       attempts.delete(attempt);
+      traceAttemptFinished(attempt, {
+        outcome: "failed",
+        ...(statusCode != null ? { statusCode } : {}),
+        reason: ErrorCategory[errorCategory]?.toLowerCase(),
+      });
       ProxyForwarder.markProviderFailed(session, failedProviderIds, attempt.provider.id);
 
       if (
@@ -5731,6 +5814,27 @@ export class ProxyForwarder {
 
       attempt.settled = true;
       attempts.delete(attempt);
+      traceAttemptFinished(attempt, {
+        outcome: "winner",
+        statusCode: attempt.response.status,
+      });
+      session.appendRoutingTraceEvent({
+        type: "winner_committed",
+        attemptId: attempt.attemptId,
+        attemptKind: "normal",
+        round: HEDGE_TRACE_ROUND,
+        provider: traceProvider(attempt),
+        statusCode: attempt.response.status,
+      });
+      session.setRoutingTraceSummary(
+        hedgeMetrics.snapshot({
+          outcome: "success",
+          statusCode: attempt.response.status,
+          winnerOrigin: "normal",
+          winnerProviderId: attempt.provider.id,
+          winnerRound: HEDGE_TRACE_ROUND,
+        })
+      );
 
       for (const activeAttempt of attempts) {
         getAttemptModelRedirect(activeAttempt);
@@ -5985,6 +6089,7 @@ export class ProxyForwarder {
 
       attempts.add(attempt);
       session.addLiveActiveProvider(provider);
+      traceAttemptStarted(attempt);
 
       // Record hedge participant launch in decision chain
       // (first provider is already recorded via initial_selection or session_reuse)
@@ -6106,6 +6211,12 @@ export class ProxyForwarder {
       await finishIfExhausted();
       const result = await resultPromise;
       if (result.error) {
+        session.setRoutingTraceSummary(
+          hedgeMetrics.snapshot({
+            outcome: lastErrorCategory === ErrorCategory.CLIENT_ABORT ? "client_abort" : "failed",
+            statusCode: result.error instanceof ProxyError ? result.error.statusCode : 500,
+          })
+        );
         throw result.error;
       }
       return result.response as Response;

--- a/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
+++ b/tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts
@@ -6440,4 +6440,181 @@ describe("ProxyForwarder - first-byte hedge scheduling", () => {
     expect(doForward).not.toHaveBeenCalled();
     expect(addSpy.mock.calls.filter(([type]) => type === "abort")).toHaveLength(0);
   });
+
+  test("legacy hedge records the full attempt lifecycle in the routing trace", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const slow = createProvider({ id: 11, name: "slow", firstByteTimeoutStreamingMs: 100 });
+      const fast = createProvider({ id: 22, name: "fast", firstByteTimeoutStreamingMs: 100 });
+      const session = createSession();
+      setProviderWithSessionRef(session, slow);
+
+      mocks.pickRandomProviderWithExclusion.mockResolvedValueOnce(fast);
+
+      const doForward = vi.spyOn(
+        ProxyForwarder as unknown as {
+          doForward: (...args: unknown[]) => Promise<Response>;
+        },
+        "doForward"
+      );
+
+      const controller1 = new AbortController();
+      const controller2 = new AbortController();
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = controller1;
+        runtime.clearResponseTimeout = vi.fn();
+        runtime.releaseAgent = vi.fn();
+        return createStreamingResponse({
+          label: "slow",
+          firstChunkDelayMs: 220,
+          controller: controller1,
+        });
+      });
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = controller2;
+        runtime.clearResponseTimeout = vi.fn();
+        runtime.releaseAgent = vi.fn();
+        return createStreamingResponse({
+          label: "fast",
+          firstChunkDelayMs: 40,
+          controller: controller2,
+        });
+      });
+
+      const responsePromise = ProxyForwarder.send(session);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(doForward).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(50);
+      const response = await responsePromise;
+      expect(await response.text()).toContain('"provider":"fast"');
+
+      const trace = session.finalizeRoutingTrace(200);
+      expect(trace?.mode).toBe("legacy_hedge");
+
+      const started = trace?.events.filter((event) => event.type === "attempt_started") ?? [];
+      expect(started.map((event) => event.attemptId)).toEqual([
+        "legacy-hedge-1-1",
+        "legacy-hedge-2-1",
+      ]);
+      expect(started.map((event) => event.provider?.id)).toEqual([slow.id, fast.id]);
+      for (const event of started) {
+        // round 1 (not 0) keeps the trace view from rendering every attempt as sticky
+        expect(event.round).toBe(1);
+        expect(event.attemptKind).toBe("normal");
+      }
+
+      const finished = trace?.events.filter((event) => event.type === "attempt_finished") ?? [];
+      expect(finished.find((event) => event.attemptId === "legacy-hedge-2-1")).toMatchObject({
+        outcome: "winner",
+        statusCode: 200,
+      });
+      expect(finished.find((event) => event.attemptId === "legacy-hedge-1-1")).toMatchObject({
+        outcome: "cancelled",
+        cancellationKind: "hedge_loser",
+      });
+
+      expect(trace?.events.find((event) => event.type === "winner_committed")).toMatchObject({
+        attemptId: "legacy-hedge-2-1",
+        statusCode: 200,
+      });
+
+      expect(trace?.summary).toMatchObject({
+        outcome: "success",
+        attemptsPerRequest: 2,
+        maxActiveAttempts: 2,
+        rounds: 1,
+        winnerOrigin: "normal",
+        winnerProviderId: fast.id,
+        winnerRound: 1,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("legacy hedge records every failed attempt and a failure summary", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const provider1 = createProvider({ id: 1, name: "p1", firstByteTimeoutStreamingMs: 100 });
+      const provider2 = createProvider({ id: 2, name: "p2", firstByteTimeoutStreamingMs: 100 });
+      const session = createSession();
+      session.setProvider(provider1);
+
+      mocks.pickRandomProviderWithExclusion
+        .mockResolvedValueOnce(provider2)
+        .mockResolvedValueOnce(null);
+
+      const doForward = vi.spyOn(
+        ProxyForwarder as unknown as {
+          doForward: (...args: unknown[]) => Promise<Response>;
+        },
+        "doForward"
+      );
+
+      const controller1 = new AbortController();
+      const controller2 = new AbortController();
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = controller1;
+        runtime.clearResponseTimeout = vi.fn();
+        return createDelayedFailure({
+          delayMs: 150,
+          error: new UpstreamProxyError("upstream down", 502),
+          controller: controller1,
+        });
+      });
+
+      doForward.mockImplementationOnce(async (attemptSession) => {
+        const runtime = attemptSession as ProxySession & AttemptRuntime;
+        runtime.responseController = controller2;
+        runtime.clearResponseTimeout = vi.fn();
+        return createDelayedFailure({
+          delayMs: 160,
+          error: new UpstreamProxyError("upstream down", 502),
+          controller: controller2,
+        });
+      });
+
+      const responsePromise = ProxyForwarder.send(session);
+      const errorPromise = responsePromise.catch((rejection) => rejection as UpstreamProxyError);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(doForward).toHaveBeenCalledTimes(2);
+
+      await vi.runAllTimersAsync();
+      await errorPromise;
+
+      const trace = session.finalizeRoutingTrace(503);
+      const started = trace?.events.filter((event) => event.type === "attempt_started") ?? [];
+      const finished = trace?.events.filter((event) => event.type === "attempt_finished") ?? [];
+      expect(started).toHaveLength(2);
+      expect(finished).toHaveLength(2);
+      for (const event of finished) {
+        expect(event).toMatchObject({
+          outcome: "failed",
+          statusCode: 502,
+          reason: "provider_error",
+        });
+      }
+
+      expect(trace?.summary).toMatchObject({
+        outcome: "failed",
+        attemptsPerRequest: 2,
+        rounds: 1,
+        winnerOrigin: "none",
+        winnerProviderId: null,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## 问题

关闭 Discovery、开启旧版供应商竞速（legacy hedge）时，日志详情的「决策链」标签页只渲染出路由模式横幅、配置快照和请求结果，供应商尝试区显示「没有记录到供应商尝试」，统计行恒为 `0 轮 · 0 次尝试 · 最大并发 0` —— 尽管这条请求确实有多个供应商在竞速。

## 根因

不是 UI 问题，`DiscoveryTraceView` 完全是事件驱动的。

`LogicTraceTab.tsx:226-229` 把 `discovery` **和** `legacy_hedge` 两种 trace 都路由进 `DiscoveryTraceView`，该视图的尝试卡片由 `buildAttempts()` 折叠 `trace.events` 得到，轮次/尝试数/最大并发由 `deriveRuntimeStats()` 数 `attempt_started` / `attempt_finished` 事件得到。

`sendInternal`（`forwarder.ts:1710`）无条件初始化 trace（mode = `legacy_hedge`），所以 mode、config、`request_started`、`request_finished` 都在。但 `sendStreamingWithHedge` 只发 `hedge_slot_saturated` 和 `client_abort_no_first_byte` 两个事件，从不发 `attempt_started` / `attempt_finished` / `winner_committed`，也从不调用 `setRoutingTraceSummary` —— 全部 11 处 attempt 级事件和 2 处 summary 快照都只长在 `sendStreamingWithDiscovery` 里。

trace 落库了，只是里面没有任何 attempt 事件。

## 改动

只改 `sendStreamingWithHedge`，复用已有的 `DiscoveryRequestMetrics`（除名字外无 discovery 专属逻辑，`snapshot()` 产出的正是 `RoutingTraceSummaryV1`），零 UI / i18n 改动：

- `startAttempt` 发 `attempt_started`
- `abortAttempt`（竞速输家 / 客户端中断）、`handleAttemptFailure` 的 client-abort 与终态失败分支、主动纠偏重试分支各发 `attempt_finished`
- 重试分支在 `attemptId` 被重写前先关旧 id、重写后再开新 id，保证计数配平
- `commitWinner` 发 `attempt_finished(winner)` + `winner_committed` + 成功 summary 快照；失败出口发失败 summary

attempt 统一用 `round: 1`、`attemptKind: "normal"`：`DiscoveryTraceView` 的 `normalizeRole(value, 0)` 会把 round 0 的 attempt 一律标成 sticky，而旧版 hedge 本质是单轮并行竞速。

## 范围

- 不动 `legacy_serial` / `single_upstream` —— `LogicTraceTab` 只把 `discovery` 和 `legacy_hedge` 分流到新面板，其余模式走经典链路卡片视图，本来就正常。
- 不补 `binding_finalized`（「绑定结果」行）—— 需要解开 `response-handler.ts:1820` 的 `discoveryLease` 门槛和 post-terminal 补丁写入路径，风险和改动面明显更大。
- `provider-chain-popover.tsx:335` 与 `SummaryTab.tsx:699` 都硬门在 `mode === "discovery"`，本次改动不影响它们。

## 验证

- 新增 2 个单测（竞速胜出 / 全部失败），已确认**去掉修复即失败**（`expected [] to deeply equal [ 'legacy-hedge-1-1', … ]`，正是复现的现象）
- `bunx vitest run tests/unit/proxy/proxy-forwarder-hedge-first-byte.test.ts` → 79 passed
- `bun run test`（独占机器）→ 8780 passed / 0 failed
- `bun run typecheck` → 0；`bun run lint` → clean；`bun run build` → 0

以下为 dev 上的存量失败，已用 stash 对比确认与本次改动无关：`test:coverage:include-session-id-in-errors` 覆盖率阈值（该 config 的 sourceFiles 只含 `error-session-id.ts` / `proxy-handler.ts`），`test:v1` 的 6 个文件（依赖本地 DB/Redis，clean tree 上失败更多：13 vs 9）。

## 关联

- Follow-up to #1351 - 引入请求级路由追踪（routing trace）与决策链面板的 PR；本 PR 把 attempt 级事件与 summary 快照补齐到 `legacy_hedge` 路径，使该面板对旧版竞速也可读
- Follow-up to #1462 - 该 PR 为旧版 hedge 路径补充了 `hedge_slot_saturated` / `client_abort_no_first_byte` 两个事件；本 PR 在同一路径补全完整的 attempt 生命周期事件

*Related links added by Claude AI*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

