### PR TITLE
fix(proxy): use undici fetch with ProxyAgent on Node 24

### DIFF
--- a/src/actions/providers.ts
+++ b/src/actions/providers.ts
@@ -48,6 +48,7 @@ import {
 import { getPresetsForProvider } from "@/lib/provider-testing/presets";
 import {
   createProxyAgentForProvider,
+  fetchWithDispatcher,
   isValidProxyUrl,
   type ProviderProxyConfig,
 } from "@/lib/proxy-agent";
@@ -3428,7 +3429,7 @@ export async function testProviderProxy(data: {
       }
 
       // 发起测试请求
-      const response = await fetch(data.providerUrl, init);
+      const response = await fetchWithDispatcher(data.providerUrl, init);
       const responseTime = Date.now() - startTime;
 
       return {
@@ -4321,7 +4322,7 @@ async function executeProviderApiTest(
         init.dispatcher = proxyConfig.agent;
       }
 
-      let response = await fetch(url, init);
+      let response = await fetchWithDispatcher(url, init);
       let responseTime = Date.now() - startTime;
 
       const shouldAttemptDirectRetry =
@@ -4343,7 +4344,7 @@ async function executeProviderApiTest(
 
         const fallbackStartTime = Date.now();
         try {
-          response = await fetch(url, fallbackInit);
+          response = await fetchWithDispatcher(url, fallbackInit);
           responseTime = Date.now() - fallbackStartTime;
 
           logger.info("Provider API test: Direct connection succeeded after proxy failure", {
@@ -5341,7 +5342,7 @@ async function executeProxiedFetch(
     init.dispatcher = proxy.agent;
   }
 
-  return fetch(url, init);
+  return fetchWithDispatcher(url, init);
 }
 
 /**

--- a/src/app/v1/_lib/proxy/forwarder.ts
+++ b/src/app/v1/_lib/proxy/forwarder.ts
@@ -32,7 +32,11 @@ import {
   getEndpointFilterStats,
   getPreferredProviderEndpoints,
 } from "@/lib/provider-endpoints/endpoint-selector";
-import { getGlobalAgentPool, getProxyAgentForProvider } from "@/lib/proxy-agent";
+import {
+  fetchWithDispatcher,
+  getGlobalAgentPool,
+  getProxyAgentForProvider,
+} from "@/lib/proxy-agent";
 import {
   isHttp2TransportQuarantined,
   quarantineHttp2Transport,
@@ -3823,7 +3827,7 @@ export class ProxyForwarder {
     }
     const fetchWithDispatch = async (url: string, requestInit: UndiciFetchOptions) => {
       onUpstreamDispatch?.();
-      return await fetch(url, requestInit);
+      return await fetchWithDispatcher(url, requestInit);
     };
 
     // ⭐ 双路超时控制（first-byte / total）

--- a/src/lib/provider-testing/test-service.test.ts
+++ b/src/lib/provider-testing/test-service.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+const { fetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn<typeof fetch>(),
+}));
+
 vi.mock("@/lib/proxy-agent", () => ({
   createProxyAgentForProvider: vi.fn(() => null),
+  fetchWithDispatcher: (...args: Parameters<typeof fetch>) => fetchMock(...args),
 }));
 
 import { executeProviderTest } from "./test-service";
-
-const fetchMock = vi.fn<typeof fetch>();
 
 function createMockResponse(
   responseBody: string,

--- a/src/lib/provider-testing/test-service.ts
+++ b/src/lib/provider-testing/test-service.ts
@@ -5,7 +5,11 @@
  */
 
 import { applyOpencodeSessionHeader } from "@/app/v1/_lib/headers";
-import { createProxyAgentForProvider, type ProviderProxyConfig } from "@/lib/proxy-agent";
+import {
+  createProxyAgentForProvider,
+  fetchWithDispatcher,
+  type ProviderProxyConfig,
+} from "@/lib/proxy-agent";
 import { parseResponse } from "./parsers";
 import {
   getExecutionPresetCandidates,
@@ -245,7 +249,7 @@ async function runSingleAttempt(
       while (true) {
         attemptStartTime = Date.now();
         firstByteMs = undefined;
-        const response = await fetch(requestUrl, fetchOptions);
+        const response = await fetchWithDispatcher(requestUrl, fetchOptions);
         firstByteMs = Date.now() - attemptStartTime;
 
         const responseBody = await response.text();

--- a/src/lib/proxy-agent.ts
+++ b/src/lib/proxy-agent.ts
@@ -1,5 +1,11 @@
 import { socksDispatcher } from "fetch-socks";
-import { Agent, type Dispatcher, ProxyAgent, setGlobalDispatcher } from "undici";
+import {
+  Agent,
+  type Dispatcher,
+  ProxyAgent,
+  setGlobalDispatcher,
+  fetch as undiciFetch,
+} from "undici";
 import { getGlobalAgentPool as getPool } from "@/lib/proxy-agent/agent-pool";
 import type { Provider } from "@/types/provider";
 import { getEnvConfig } from "./config/env.schema";
@@ -59,6 +65,18 @@ export interface ProviderProxyConfig {
   name?: string;
   proxyUrl: string | null;
   proxyFallbackToDirect: boolean;
+}
+
+/**
+ * Dispatch fetch through the same undici build that created ProxyAgent / socksDispatcher.
+ * Node 24 global fetch rejects those dispatchers with
+ * `UND_ERR_INVALID_ARG: invalid onRequestStart method` in ~12ms and never opens the proxy socket.
+ */
+export function fetchWithDispatcher(
+  url: string,
+  init?: RequestInit & { dispatcher?: unknown }
+): Promise<Response> {
+  return undiciFetch(url, init as never) as unknown as Promise<Response>;
 }
 
 /**

--- a/src/lib/webhook/notifier.ts
+++ b/src/lib/webhook/notifier.ts
@@ -1,7 +1,11 @@
 import { createHmac } from "node:crypto";
 import type { Dispatcher } from "undici";
 import { logger } from "@/lib/logger";
-import { createProxyAgentForProvider, type ProxyConfig } from "@/lib/proxy-agent";
+import {
+  createProxyAgentForProvider,
+  fetchWithDispatcher,
+  type ProxyConfig,
+} from "@/lib/proxy-agent";
 import { createRenderer, type Renderer } from "./renderers";
 import type {
   ProviderType,
@@ -177,7 +181,7 @@ export class WebhookNotifier {
     url: string,
     init: RequestInit & { dispatcher?: Dispatcher }
   ): Promise<WebhookResult> {
-    const response = await fetch(url, init);
+    const response = await fetchWithDispatcher(url, init);
 
     if (!response.ok) {
       const errorBody = await response.text().catch(() => "");

--- a/tests/unit/actions/providers-api-test.test.ts
+++ b/tests/unit/actions/providers-api-test.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+const { fetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn<typeof fetch>(),
+}));
+
 const getSessionMock = vi.fn();
 const executeProviderTestMock = vi.fn();
 const getPresetsForProviderMock = vi.fn();
@@ -77,6 +81,7 @@ vi.mock("@/lib/validation/provider-url", () => ({
 
 vi.mock("@/lib/proxy-agent", () => ({
   createProxyAgentForProvider: createProxyAgentForProviderMock,
+  fetchWithDispatcher: (...args: Parameters<typeof fetch>) => fetchMock(...args),
   isValidProxyUrl: vi.fn(() => true),
 }));
 
@@ -86,8 +91,6 @@ vi.mock("@/app/v1/_lib/gemini/auth", () => ({
     isJson: isJsonMock,
   },
 }));
-
-const fetchMock = vi.fn<typeof fetch>();
 
 describe("providers api test actions", () => {
   beforeEach(() => {

--- a/tests/unit/lib/proxy-agent/fetch-with-dispatcher.test.ts
+++ b/tests/unit/lib/proxy-agent/fetch-with-dispatcher.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { undiciFetchMock } = vi.hoisted(() => ({
+  undiciFetchMock: vi.fn(),
+}));
+
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    fetch: undiciFetchMock,
+  };
+});
+
+import { fetchWithDispatcher } from "@/lib/proxy-agent";
+
+describe("fetchWithDispatcher", () => {
+  afterEach(() => {
+    undiciFetchMock.mockReset();
+  });
+
+  it("forwards url and dispatcher to npm undici fetch", async () => {
+    const response = new Response("ok");
+    undiciFetchMock.mockResolvedValue(response);
+    const dispatcher = { onRequestStart() {} };
+
+    await expect(
+      fetchWithDispatcher("https://example.com/v1", {
+        method: "POST",
+        dispatcher,
+      })
+    ).resolves.toBe(response);
+
+    expect(undiciFetchMock).toHaveBeenCalledTimes(1);
+    expect(undiciFetchMock).toHaveBeenCalledWith("https://example.com/v1", {
+      method: "POST",
+      dispatcher,
+    });
+  });
+});

--- a/tests/unit/webhook/notifier.test.ts
+++ b/tests/unit/webhook/notifier.test.ts
@@ -1,16 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/proxy-agent", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    fetchWithDispatcher: (...args: Parameters<typeof fetch>) => mockFetch(...args),
+  };
+});
+
 import { WebhookNotifier } from "@/lib/webhook/notifier";
 import type { StructuredMessage } from "@/lib/webhook/types";
 
 describe("WebhookNotifier", () => {
-  const mockFetch = vi.fn();
-
   beforeEach(() => {
-    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## Summary

Node 24 的 global `fetch` 和 npm `undici` 不是同一份实现。把 `ProxyAgent` / `socksDispatcher` 传给 global `fetch` 时，会立刻抛出 `UND_ERR_INVALID_ARG: invalid onRequestStart method`，大约 12ms 就失败，代理 socket 根本不会打开。

`available-models` 已经走 `undici.request()`，不受影响。真正走 `fetch(..., { dispatcher })` 的路径（runtime 转发、供应商测试、webhook）在 Node 24 上会静默打不穿代理。

背景补充（已核实）：

- 生产运行时为 Node 24+：`deploy/Dockerfile` 的 runner 阶段使用 `node:trixie-slim`
- 仓库依赖 npm `undici@^8.9.0`（见 `package.json`），与 Node 24 内置的 undici 是两份代码，dispatcher 接口不互通
- `src/app/v1/_lib/gemini/auth.ts` 已有 `import { fetch } from "undici"` 的先例，本 PR 将该模式推广到所有携带 dispatcher 的 fetch 调用

**Related Issues / PRs:**

- Related to #1378 - undici 依赖版本管理背景：当时为兼容 Bun 构建回退至 ^7，后重新升级至 ^8.9.0。本 PR 处理的正是"npm undici 与 Node 内置 undici 是两份实现"这一分歧在运行时的表现
- See also #118 - 同样在 ProxyForwarder 观察到 `UND_ERR_INVALID_ARG`，但根因不同（供应商 URL 缺少路径），已由 #120 通过 URL 校验修复；与本 PR 的 dispatcher 兼容性问题无关，列出仅为方便按错误码检索时区分

## Fix

新增 `fetchWithDispatcher()`，内部调用创建 dispatcher 的同一份 npm `undici.fetch`：

- `ProxyForwarder` 上游转发
- 供应商连通性 / API 测试 / 拉模型
- webhook 发送

## Changes

### Core Changes

- `src/lib/proxy-agent.ts`：新增导出 `fetchWithDispatcher(url, init)`，桥接 npm undici 的 fetch 返回类型与全局 `Response` 类型
- `src/app/v1/_lib/proxy/forwarder.ts`：`fetchWithDispatch` 闭包改走 `fetchWithDispatcher`（覆盖正常转发、HTTP/1.1 回退与重试共 3 处调用点）
- `src/actions/providers.ts`：`testProviderProxy`、`executeProviderApiTest`（含代理失败后的直连重试）、`executeProxiedFetch` 共 4 处调用点切换
- `src/lib/provider-testing/test-service.ts`：`runSingleAttempt` 切换
- `src/lib/webhook/notifier.ts`：webhook 发送切换

### Supporting Changes

- 测试 mock 调整：`test-service.test.ts`、`providers-api-test.test.ts`、`notifier.test.ts` 不再 stub 全局 `fetch`，改为 mock `fetchWithDispatcher`（通过 `vi.hoisted` 保证 mock 引用可用）

### 行为说明

上述路径切换后，无论是否配置了代理，这些请求都会统一走 npm undici 8 的 fetch 实现（而非 Node 内置 global fetch），避免两份 undici 在同一请求路径上混用。

## Breaking Changes

无。`fetchWithDispatcher` 为新增导出，其余均为内部调用点替换，无公开接口、函数签名或数据库 schema 变更。

## Tests

- 新增 `tests/unit/lib/proxy-agent/fetch-with-dispatcher.test.ts` 单测：确认 url 和 dispatcher 原样转发给 npm undici fetch
- 更新 provider testing / providers API test / webhook 的 mock，不再依赖 global `fetch`

## How to verify

在 Node 24 上给供应商配置 HTTP/SOCKS 代理后发一条 `/v1/messages`。修复前会在约 12ms 内出现 `UND_ERR_INVALID_ARG`；修复后请求会真正经过代理。

## Checklist

- [ ] 代码遵循项目规范
- [ ] 已完成自查
- [ ] 本地测试通过
- [ ] 文档已按需更新

---
*Description enhanced by Claude AI*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
