### PR TITLE
feat(langfuse): reconstruct streamed outputs and enrich traces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -220,6 +220,8 @@ LANGFUSE_SECRET_KEY=                        # Langfuse project secret key (sk-lf
 LANGFUSE_BASE_URL=https://cloud.langfuse.com  # Langfuse server URL (self-hosted or cloud)
 LANGFUSE_SAMPLE_RATE=1.0                    # Trace sampling rate (0.0-1.0, default: 1.0 = 100%)
 LANGFUSE_DEBUG=false                        # Enable Langfuse debug logging
+LANGFUSE_TRACING_ENVIRONMENT=               # Optional environment tag (production/staging). Do not start with langfuse
+LANGFUSE_RELEASE=                           # Optional release identifier (git sha or VERSION)
 
 # 智能探测配置
 # 功能说明：当熔断器处于 OPEN 状态时，定期探测供应商以实现更快恢复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 ## Unreleased
 
+### 新增
+
+- Langfuse 流式请求还原完整最终输出（Claude / OpenAI Chat Completions / Responses / Gemini），避免把原始 SSE 文本当作 generation output
+- Langfuse 将客户端原始请求头写入 generation `client_metadata`（凭据中间打码）
+- 支持 `LANGFUSE_TRACING_ENVIRONMENT` / `LANGFUSE_RELEASE` 传入 LangfuseSpanProcessor
+
+### 优化
+
+- Langfuse trace 名称改为 `user:shortModel`，去掉供应商前缀
+- 按 Langfuse JS SDK v5 在 `propagateAttributes` 内创建 observation
+- 大请求/响应体 1 MiB 截断，并在异步发送前快照，避免观测路径拖住完整 body
+
 ### 修复
 
 - 修复上游响应流发生 error 后 Node/Undici body 未完成销毁的问题：Node-to-Web adapter 和 demand-driven pump

--- a/src/app/v1/_lib/proxy/session.ts
+++ b/src/app/v1/_lib/proxy/session.ts
@@ -428,6 +428,13 @@ export class ProxySession {
     return original !== current;
   }
 
+  /**
+   * 客户端原始请求头（会话创建时的副本，不含请求过滤器后续修改）。
+   */
+  getOriginalHeaders(): Headers {
+    return this.originalHeaders;
+  }
+
   setAuthState(state: AuthState): void {
     this.authState = state;
     if (state.user) {

--- a/src/lib/config/env.schema.ts
+++ b/src/lib/config/env.schema.ts
@@ -270,6 +270,9 @@ export const EnvSchema = z.object({
   LANGFUSE_BASE_URL: z.string().default("https://cloud.langfuse.com"),
   LANGFUSE_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(1.0),
   LANGFUSE_DEBUG: z.string().default("false").transform(booleanTransform),
+  // v5 first-class attributes; consumed by LangfuseSpanProcessor
+  LANGFUSE_TRACING_ENVIRONMENT: z.string().optional(),
+  LANGFUSE_RELEASE: z.string().optional(),
 
   // IP 归属地查询服务
   // 默认使用官方托管服务；可通过 IP_GEO_API_URL 自托管

--- a/src/lib/langfuse/emit-proxy-trace.ts
+++ b/src/lib/langfuse/emit-proxy-trace.ts
@@ -1,5 +1,11 @@
 import type { UsageMetrics } from "@/app/v1/_lib/proxy/response-handler";
 import type { ProxySession } from "@/app/v1/_lib/proxy/session";
+import { finalizeStreamOutputForClient } from "@/lib/langfuse/stream-final-output";
+import {
+  createFinalOutputUnavailable,
+  type StreamFinalOutput,
+} from "@/lib/langfuse/stream-final-output-core";
+import type { TraceContext } from "@/lib/langfuse/trace-proxy-request";
 import { logger } from "@/lib/logger";
 import type { CostBreakdown } from "@/lib/utils/cost-calculation";
 
@@ -62,6 +68,11 @@ function buildLangfuseSessionSnapshot(session: ProxySession): ProxySession {
       ? truncateResponseTextForLangfuse(session.forwardedRequestBody)
       : null;
   const requestMessage = buildRequestMessagePreview(session.request.message);
+  const clientIp = session.clientIp;
+  const originalHeaders =
+    typeof session.getOriginalHeaders === "function"
+      ? new Headers(session.getOriginalHeaders())
+      : new Headers(session.headers);
 
   return {
     startTime: session.startTime,
@@ -82,7 +93,9 @@ function buildLangfuseSessionSnapshot(session: ProxySession): ProxySession {
     forwardStartTime: session.forwardStartTime,
     forwardedRequestBody,
     sessionId: session.sessionId,
+    clientIp,
     originalFormat: session.originalFormat,
+    getOriginalHeaders: () => new Headers(originalHeaders),
     getMessagesLength: () => messagesLength,
     getEndpoint: () => endpoint,
     getCurrentModel: () => currentModel,
@@ -94,6 +107,18 @@ function buildLangfuseSessionSnapshot(session: ProxySession): ProxySession {
     getCacheTtlResolved: () => cacheTtlResolved,
     getContext1mApplied: () => context1mApplied,
   } as unknown as ProxySession;
+}
+
+function enqueueLangfuseTrace(traceContext: TraceContext): void {
+  void import("@/lib/langfuse/trace-proxy-request")
+    .then(({ traceProxyRequest }) => {
+      void traceProxyRequest(traceContext);
+    })
+    .catch((err) => {
+      logger.warn("[Langfuse] Proxy trace failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
 }
 
 /**
@@ -119,9 +144,9 @@ export function emitProxyLangfuseTrace(
     });
     return;
   }
-
   const {
     responseHeaders,
+    responseText: rawResponseText,
     durationMs,
     statusCode,
     isStreaming,
@@ -131,26 +156,37 @@ export function emitProxyLangfuseTrace(
     sseEventCount,
     errorMessage,
   } = data;
+  let finalResponseOutput: StreamFinalOutput | undefined;
 
-  void import("@/lib/langfuse/trace-proxy-request")
-    .then(({ traceProxyRequest }) => {
-      void traceProxyRequest({
-        session: sessionSnapshot,
-        responseHeaders,
-        durationMs,
-        statusCode,
-        isStreaming,
-        responseText,
-        usageMetrics,
-        costUsd,
-        costBreakdown,
-        sseEventCount,
-        errorMessage,
+  if (isStreaming && rawResponseText.length > 0) {
+    try {
+      finalResponseOutput = finalizeStreamOutputForClient(
+        rawResponseText,
+        session.originalFormat,
+        true
+      );
+    } catch (error) {
+      finalResponseOutput = createFinalOutputUnavailable("stream_error");
+      logger.warn("[Langfuse] Stream finalization failed", {
+        error: error instanceof Error ? error.message : String(error),
       });
-    })
-    .catch((err) => {
-      logger.warn("[Langfuse] Proxy trace failed", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
+    }
+  }
+
+  const traceResponseText = isStreaming ? undefined : responseText;
+
+  enqueueLangfuseTrace({
+    session: sessionSnapshot,
+    responseHeaders,
+    durationMs,
+    statusCode,
+    isStreaming,
+    ...(traceResponseText !== undefined ? { responseText: traceResponseText } : {}),
+    ...(finalResponseOutput !== undefined ? { finalResponseOutput } : {}),
+    usageMetrics,
+    costUsd,
+    costBreakdown,
+    sseEventCount,
+    errorMessage,
+  });
 }

--- a/src/lib/langfuse/index.ts
+++ b/src/lib/langfuse/index.ts
@@ -25,12 +25,21 @@ export async function initLangfuse(): Promise<void> {
     const { NodeSDK: OtelNodeSDK } = await import("@opentelemetry/sdk-node");
     const { LangfuseSpanProcessor: LfSpanProcessor } = await import("@langfuse/otel");
 
+    if (process.env.LANGFUSE_DEBUG === "true") {
+      const { configureGlobalLogger, LogLevel } = await import("@langfuse/core");
+      configureGlobalLogger({ level: LogLevel.DEBUG });
+    }
+
     const sampleRate = Number.parseFloat(process.env.LANGFUSE_SAMPLE_RATE || "1.0");
+    const environment = process.env.LANGFUSE_TRACING_ENVIRONMENT || undefined;
+    const release = process.env.LANGFUSE_RELEASE || undefined;
 
     spanProcessor = new LfSpanProcessor({
       publicKey: process.env.LANGFUSE_PUBLIC_KEY,
       secretKey: process.env.LANGFUSE_SECRET_KEY,
       baseUrl: process.env.LANGFUSE_BASE_URL || "https://cloud.langfuse.com",
+      environment,
+      release,
       // Only export spans from langfuse-sdk scope (avoid noise from other OTel instrumentations)
       shouldExportSpan: ({ otelSpan }) => otelSpan.instrumentationScope.name === "langfuse-sdk",
     });
@@ -54,13 +63,10 @@ export async function initLangfuse(): Promise<void> {
     logger.info("[Langfuse] Observability initialized", {
       baseUrl: process.env.LANGFUSE_BASE_URL || "https://cloud.langfuse.com",
       sampleRate,
+      environment: environment ?? null,
+      release: release ?? null,
       debug: process.env.LANGFUSE_DEBUG === "true",
     });
-
-    if (process.env.LANGFUSE_DEBUG === "true") {
-      const { configureGlobalLogger, LogLevel } = await import("@langfuse/core");
-      configureGlobalLogger({ level: LogLevel.DEBUG });
-    }
   } catch (error) {
     logger.error("[Langfuse] Failed to initialize", {
       error: error instanceof Error ? error.message : String(error),

--- a/src/lib/langfuse/stream-final-output-anthropic.ts
+++ b/src/lib/langfuse/stream-final-output-anthropic.ts
@@ -1,0 +1,227 @@
+import {
+  createFinalOutputUnavailable,
+  finalizeStreamOutput,
+  type ParsedStreamFrames,
+  type StreamFinalOutput,
+  type StreamFrame,
+} from "@/lib/langfuse/stream-final-output-core";
+
+type JsonObject = Record<string, unknown>;
+
+type ContentBlockState = {
+  readonly block: JsonObject;
+  readonly inputJsonFragments: string[];
+  readonly isToolUse: boolean;
+  stopped: boolean;
+};
+
+export function finalizeAnthropicStreamOutput(parsedFrames: ParsedStreamFrames): StreamFinalOutput {
+  const metadata = {
+    eventCount: parsedFrames.frames.length,
+    framing: parsedFrames.framing,
+  } as const;
+  const blocks = new Map<number, ContentBlockState>();
+  let messageSkeleton: JsonObject | undefined;
+  let messageStopped = false;
+
+  for (const frame of parsedFrames.frames) {
+    const eventName = getEventName(frame);
+    if (eventName === null) {
+      continue;
+    }
+
+    switch (eventName) {
+      case "message_start": {
+        const data = getEventData(frame);
+        const message = data === null ? null : data.message;
+        if (messageSkeleton !== undefined || !isJsonObject(message)) {
+          return createFinalOutputUnavailable("malformed_frame", metadata);
+        }
+        if (hasOwn(message, "content") && !Array.isArray(message.content)) {
+          return createFinalOutputUnavailable("malformed_frame", metadata);
+        }
+        messageSkeleton = { ...message };
+        break;
+      }
+      case "content_block_start": {
+        const data = getEventData(frame);
+        const index = getIndex(data);
+        const contentBlock = data === null ? null : data.content_block;
+        if (index === null || !isJsonObject(contentBlock) || blocks.has(index)) {
+          return createFinalOutputUnavailable("malformed_frame", metadata);
+        }
+        if (messageSkeleton === undefined) {
+          return createFinalOutputUnavailable("malformed_frame", metadata);
+        }
+        blocks.set(index, {
+          block: { ...contentBlock },
+          inputJsonFragments: [],
+          isToolUse: contentBlock.type === "tool_use",
+          stopped: false,
+        });
+        break;
+      }
+      case "content_block_delta": {
+        const data = getEventData(frame);
+        const index = getIndex(data);
+        const delta = data === null ? null : data.delta;
+        const blockState = index === null ? undefined : blocks.get(index);
+        if (
+          index === null ||
+          !isJsonObject(delta) ||
+          blockState === undefined ||
+          blockState.stopped
+        ) {
+          return createFinalOutputUnavailable("malformed_frame", metadata);
+        }
+
+        const deltaType = delta.type;
+        if (deltaType === "text_delta") {
+          const text = delta.text;
+          if (blockState.block.type !== "text" || typeof text !== "string") {
+            return createFinalOutputUnavailable("malformed_frame", metadata);
+          }
+          blockState.block.text = appendText(blockState.block.text, text);
+        } else if (deltaType === "thinking_delta") {
+          const thinking = delta.thinking;
+          if (blockState.block.type !== "thinking" || typeof thinking !== "string") {
+            return createFinalOutputUnavailable("malformed_frame", metadata);
+          }
+          blockState.block.thinking = appendText(blockState.block.thinking, thinking);
+        } else if (deltaType === "signature_delta") {
+          const signature = delta.signature;
+          if (blockState.block.type !== "thinking" || typeof signature !== "string") {
+            return createFinalOutputUnavailable("malformed_frame", metadata);
+          }
+          blockState.block.signature = appendText(blockState.block.signature, signature);
+        } else if (deltaType === "input_json_delta") {
+          const partialJson = delta.partial_json;
+          if (!blockState.isToolUse || typeof partialJson !== "string") {
+            return createFinalOutputUnavailable("malformed_frame", metadata);
+          }
+          blockState.inputJsonFragments.push(partialJson);
+        } else {
+          return createFinalOutputUnavailable("malformed_frame", metadata);
+        }
+        break;
+      }
+      case "content_block_stop": {
+        const data = getEventData(frame);
+        const index = getIndex(data);
+        const blockState = index === null ? undefined : blocks.get(index);
+        if (index === null || blockState === undefined || blockState.stopped) {
+          return createFinalOutputUnavailable("malformed_frame", metadata);
+        }
+        if (blockState.isToolUse) {
+          const inputJson = blockState.inputJsonFragments.join("");
+          try {
+            const parsedInput: unknown = JSON.parse(inputJson);
+            blockState.block.input = parsedInput;
+          } catch (error) {
+            if (error instanceof SyntaxError) {
+              return createFinalOutputUnavailable("malformed_frame", metadata);
+            }
+            throw error;
+          }
+        }
+        blockState.stopped = true;
+        break;
+      }
+      case "message_delta": {
+        const data = getEventData(frame);
+        const delta = data === null ? null : data.delta;
+        if (data === null || messageSkeleton === undefined || !isJsonObject(delta)) {
+          return createFinalOutputUnavailable("malformed_frame", metadata);
+        }
+        if (hasOwn(delta, "stop_reason")) {
+          const stopReason = delta.stop_reason;
+          if (stopReason !== null && typeof stopReason !== "string") {
+            return createFinalOutputUnavailable("malformed_frame", metadata);
+          }
+          messageSkeleton.stop_reason = stopReason;
+        }
+        if (hasOwn(delta, "stop_sequence")) {
+          const stopSequence = delta.stop_sequence;
+          if (stopSequence !== null && typeof stopSequence !== "string") {
+            return createFinalOutputUnavailable("malformed_frame", metadata);
+          }
+          messageSkeleton.stop_sequence = stopSequence;
+        }
+        if (hasOwn(data, "usage")) {
+          const usage = data.usage;
+          if (!isJsonObject(usage)) {
+            return createFinalOutputUnavailable("malformed_frame", metadata);
+          }
+          const previousUsage = messageSkeleton.usage;
+          messageSkeleton.usage = isJsonObject(previousUsage)
+            ? { ...previousUsage, ...usage }
+            : usage;
+        }
+        break;
+      }
+      case "message_stop": {
+        if (getEventData(frame) === null) {
+          return createFinalOutputUnavailable("malformed_frame", metadata);
+        }
+        messageStopped = true;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  if (messageSkeleton === undefined) {
+    return createFinalOutputUnavailable("malformed_frame", metadata);
+  }
+  if (!messageStopped) {
+    return createFinalOutputUnavailable("no_terminal_event", metadata);
+  }
+  if ([...blocks.values()].some((blockState) => !blockState.stopped)) {
+    return createFinalOutputUnavailable("malformed_frame", metadata);
+  }
+
+  const content = [...blocks.entries()]
+    .sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
+    .map(([, blockState]) => blockState.block);
+  const message =
+    blocks.size > 0 || hasOwn(messageSkeleton, "content")
+      ? { ...messageSkeleton, content }
+      : { ...messageSkeleton };
+
+  return finalizeStreamOutput(message, metadata);
+}
+
+function getEventName(frame: StreamFrame): string | null {
+  if (frame.event !== null) {
+    return frame.event;
+  }
+  if (!isJsonObject(frame.data) || typeof frame.data.type !== "string") {
+    return null;
+  }
+  return frame.data.type;
+}
+
+function getEventData(frame: StreamFrame): JsonObject | null {
+  if (!isJsonObject(frame.data)) {
+    return null;
+  }
+  return frame.data;
+}
+
+function getIndex(data: JsonObject | null): number | null {
+  const index = data?.index;
+  return typeof index === "number" && Number.isInteger(index) && index >= 0 ? index : null;
+}
+
+function appendText(previous: unknown, next: string): string {
+  return typeof previous === "string" ? previous + next : next;
+}
+
+function hasOwn(object: JsonObject, key: string): boolean {
+  return Object.hasOwn(object, key);
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/langfuse/stream-final-output-core.ts
+++ b/src/lib/langfuse/stream-final-output-core.ts
@@ -1,0 +1,234 @@
+import { isSSEText, parseSSEData } from "@/lib/utils/sse";
+
+export const LANGFUSE_FINAL_OUTPUT_MAX_SERIALIZED_CHARS = 1024 * 1024;
+export const STREAM_ACCUMULATOR_TRUNCATED_MARKER = "\n\n: [cch_truncated]\n\n";
+
+const STREAM_FINAL_OUTPUT_REASONS = [
+  "accumulator_truncated",
+  "malformed_frame",
+  "empty_stream",
+  "stream_error",
+  "over_budget",
+  "unsupported_framing",
+  "no_terminal_event",
+] as const;
+
+export type StreamFinalOutputUnavailableReason = (typeof STREAM_FINAL_OUTPUT_REASONS)[number];
+
+export type StreamFraming = "sse" | "ndjson" | "json-array";
+
+export type StreamFrame = {
+  readonly framing: StreamFraming;
+  readonly event: string | null;
+  readonly data: unknown;
+};
+
+export type ParsedStreamFrames = {
+  readonly kind: "frames";
+  readonly framing: StreamFraming;
+  readonly frames: readonly StreamFrame[];
+};
+
+export type StreamFinalOutputDiagnosticMetadata = {
+  readonly eventCount?: number;
+  readonly status?: number | null;
+  readonly framing?: StreamFraming;
+  readonly serializedBytes?: number;
+  readonly maxSerializedBytes?: number;
+};
+
+export type StreamFinalOutputDiagnostic = {
+  readonly kind: "final_output_unavailable";
+  readonly reason: StreamFinalOutputUnavailableReason;
+  readonly eventCount: number;
+  readonly status?: number | null;
+  readonly framing?: StreamFraming;
+  readonly serializedBytes?: number;
+  readonly maxSerializedBytes?: number;
+};
+
+export type StreamFinalOutput =
+  | { readonly kind: "final"; readonly value: unknown }
+  | StreamFinalOutputDiagnostic;
+
+export type ParseStreamFramesResult = ParsedStreamFrames | StreamFinalOutputDiagnostic;
+
+export function createFinalOutputUnavailable(
+  reason: StreamFinalOutputUnavailableReason,
+  metadata: StreamFinalOutputDiagnosticMetadata = {}
+): StreamFinalOutputDiagnostic {
+  const diagnostic: StreamFinalOutputDiagnostic = {
+    kind: "final_output_unavailable",
+    reason,
+    eventCount: metadata.eventCount ?? 0,
+  };
+
+  return {
+    ...diagnostic,
+    ...(metadata.status !== undefined ? { status: metadata.status } : {}),
+    ...(metadata.framing !== undefined ? { framing: metadata.framing } : {}),
+    ...(metadata.serializedBytes !== undefined
+      ? { serializedBytes: metadata.serializedBytes }
+      : {}),
+    ...(metadata.maxSerializedBytes !== undefined
+      ? { maxSerializedBytes: metadata.maxSerializedBytes }
+      : {}),
+  };
+}
+
+export function parseStreamFrames(streamText: string): ParseStreamFramesResult {
+  if (streamText.includes(STREAM_ACCUMULATOR_TRUNCATED_MARKER)) {
+    return createFinalOutputUnavailable("accumulator_truncated");
+  }
+
+  const trimmedText = streamText.trim();
+  if (trimmedText.length === 0) {
+    return createFinalOutputUnavailable("empty_stream");
+  }
+
+  if (isSSEText(streamText)) {
+    return parseSSEFrames(streamText);
+  }
+
+  if (trimmedText.startsWith("[")) {
+    return parseJsonArrayFrames(trimmedText);
+  }
+
+  if (trimmedText.startsWith("{")) {
+    return parseNdjsonFrames(streamText);
+  }
+
+  return createFinalOutputUnavailable("unsupported_framing");
+}
+
+export function finalizeStreamOutput(
+  value: unknown,
+  metadata: StreamFinalOutputDiagnosticMetadata = {}
+): StreamFinalOutput {
+  let serializedValue: string;
+
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) {
+      return createFinalOutputUnavailable("stream_error", metadata);
+    }
+    serializedValue = serialized;
+  } catch (error) {
+    if (error instanceof TypeError) {
+      return createFinalOutputUnavailable("stream_error", metadata);
+    }
+    throw error;
+  }
+
+  if (serializedValue.length > LANGFUSE_FINAL_OUTPUT_MAX_SERIALIZED_CHARS) {
+    return createFinalOutputUnavailable("over_budget", {
+      ...metadata,
+      serializedBytes: serializedValue.length,
+      maxSerializedBytes: LANGFUSE_FINAL_OUTPUT_MAX_SERIALIZED_CHARS,
+    });
+  }
+
+  return { kind: "final", value };
+}
+
+function parseSSEFrames(streamText: string): ParseStreamFramesResult {
+  const events = parseSSEData(streamText);
+  if (
+    events.length === 0 ||
+    events.some((event) => typeof event.data === "string" && event.data !== "[DONE]")
+  ) {
+    return createFinalOutputUnavailable("malformed_frame", {
+      eventCount: events.length,
+      framing: "sse",
+    });
+  }
+
+  return {
+    kind: "frames",
+    framing: "sse",
+    frames: events.map((event) => ({
+      framing: "sse",
+      event: event.event,
+      data: event.data,
+    })),
+  };
+}
+
+function parseNdjsonFrames(streamText: string): ParseStreamFramesResult {
+  const lines = streamText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const frames: StreamFrame[] = [];
+
+  for (const line of lines) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return createFinalOutputUnavailable("malformed_frame", {
+          eventCount: frames.length,
+          framing: "ndjson",
+        });
+      }
+      throw error;
+    }
+
+    if (!isJsonObject(parsed)) {
+      return createFinalOutputUnavailable("malformed_frame", {
+        eventCount: frames.length,
+        framing: "ndjson",
+      });
+    }
+
+    frames.push({ framing: "ndjson", event: null, data: parsed });
+  }
+
+  if (frames.length === 0) {
+    return createFinalOutputUnavailable("empty_stream");
+  }
+
+  return { kind: "frames", framing: "ndjson", frames };
+}
+
+function parseJsonArrayFrames(streamText: string): ParseStreamFramesResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(streamText);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return createFinalOutputUnavailable("malformed_frame", {
+        framing: "json-array",
+      });
+    }
+    throw error;
+  }
+
+  if (!Array.isArray(parsed)) {
+    return createFinalOutputUnavailable("malformed_frame", {
+      framing: "json-array",
+    });
+  }
+
+  const frames: StreamFrame[] = [];
+  for (const record of parsed) {
+    if (!isJsonObject(record)) {
+      return createFinalOutputUnavailable("malformed_frame", {
+        eventCount: frames.length,
+        framing: "json-array",
+      });
+    }
+    frames.push({ framing: "json-array", event: null, data: record });
+  }
+
+  if (frames.length === 0) {
+    return createFinalOutputUnavailable("empty_stream");
+  }
+
+  return { kind: "frames", framing: "json-array", frames };
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/langfuse/stream-final-output-gemini.ts
+++ b/src/lib/langfuse/stream-final-output-gemini.ts
@@ -1,0 +1,222 @@
+import {
+  createFinalOutputUnavailable,
+  finalizeStreamOutput,
+  type ParsedStreamFrames,
+  type StreamFinalOutput,
+} from "@/lib/langfuse/stream-final-output-core";
+
+type JsonRecord = Record<string, unknown>;
+
+type CandidateState = {
+  candidate: JsonRecord;
+  explicitIndex: number | null;
+  position: number;
+};
+
+export function finalizeGeminiStreamOutput(parsed: ParsedStreamFrames): StreamFinalOutput {
+  const metadata = {
+    eventCount: parsed.frames.length,
+    framing: parsed.framing,
+  };
+
+  if (parsed.frames.length === 0) {
+    return createFinalOutputUnavailable("empty_stream", metadata);
+  }
+
+  const firstRecord = asJsonRecord(parsed.frames[0]?.data);
+  const isEnvelope = firstRecord !== null && isJsonRecord(firstRecord.response);
+  const responseMetadata: JsonRecord = {};
+  const envelopeMetadata: JsonRecord = {};
+  const candidates: CandidateState[] = [];
+
+  for (const frame of parsed.frames) {
+    const frameRecord = asJsonRecord(frame.data);
+    if (frameRecord === null) {
+      continue;
+    }
+
+    if (isEnvelope) {
+      mergeLatestNonNullFields(envelopeMetadata, frameRecord, ["response"]);
+    }
+
+    const response = isEnvelope ? asJsonRecord(frameRecord.response) : frameRecord;
+    if (response === null) {
+      continue;
+    }
+
+    mergeLatestNonNullFields(responseMetadata, response, ["candidates"]);
+
+    const frameCandidates = response.candidates;
+    if (!Array.isArray(frameCandidates)) {
+      continue;
+    }
+
+    frameCandidates.forEach((candidateValue, position) => {
+      const candidate = asJsonRecord(candidateValue);
+      if (candidate === null) {
+        return;
+      }
+
+      const explicitIndex = readCandidateIndex(candidate.index);
+      const existing = findCandidateState(candidates, position, explicitIndex);
+      if (existing === null) {
+        candidates.push({
+          candidate: cloneCandidate(candidate),
+          explicitIndex,
+          position,
+        });
+        return;
+      }
+
+      if (existing.explicitIndex === null && explicitIndex !== null) {
+        existing.explicitIndex = explicitIndex;
+        existing.candidate.index = explicitIndex;
+      }
+      mergeCandidate(existing.candidate, candidate);
+    });
+  }
+
+  if (candidates.length === 0) {
+    return createFinalOutputUnavailable("no_terminal_event", metadata);
+  }
+
+  const hasTerminalCandidate = candidates.some(
+    ({ candidate }) => candidate.finishReason !== null && candidate.finishReason !== undefined
+  );
+  if (!hasTerminalCandidate) {
+    return createFinalOutputUnavailable("no_terminal_event", metadata);
+  }
+
+  responseMetadata.candidates = candidates.map(({ candidate }) => candidate);
+  const value = isEnvelope
+    ? {
+        ...envelopeMetadata,
+        response: responseMetadata,
+      }
+    : responseMetadata;
+
+  return finalizeStreamOutput(value, metadata);
+}
+
+function findCandidateState(
+  candidates: readonly CandidateState[],
+  position: number,
+  explicitIndex: number | null
+): CandidateState | null {
+  if (explicitIndex !== null) {
+    return (
+      candidates.find((state) => state.explicitIndex === explicitIndex) ??
+      candidates.find((state) => state.explicitIndex === null && state.position === position) ??
+      null
+    );
+  }
+
+  return (
+    candidates.find((state) => state.explicitIndex === null && state.position === position) ??
+    candidates.find((state) => state.explicitIndex === position) ??
+    null
+  );
+}
+
+function cloneCandidate(candidate: JsonRecord): JsonRecord {
+  const cloned: JsonRecord = { ...candidate };
+  const content = asJsonRecord(candidate.content);
+  if (content !== null) {
+    cloned.content = cloneContent(content);
+  }
+  return cloned;
+}
+
+function cloneContent(content: JsonRecord): JsonRecord {
+  const cloned: JsonRecord = { ...content };
+  const parts = content.parts;
+  if (Array.isArray(parts)) {
+    cloned.parts = parts.map(clonePart);
+  }
+  return cloned;
+}
+
+function clonePart(part: unknown): unknown {
+  const record = asJsonRecord(part);
+  return record === null ? part : { ...record };
+}
+
+function mergeCandidate(target: JsonRecord, incoming: JsonRecord): void {
+  mergeLatestNonNullFields(target, incoming, ["content", "index"]);
+
+  const incomingContent = asJsonRecord(incoming.content);
+  if (incomingContent === null) {
+    return;
+  }
+
+  const targetContent = asJsonRecord(target.content);
+  if (targetContent === null) {
+    target.content = cloneContent(incomingContent);
+    return;
+  }
+
+  mergeLatestNonNullFields(targetContent, incomingContent, ["parts", "role"]);
+  if (targetContent.role === undefined && incomingContent.role !== undefined) {
+    targetContent.role = incomingContent.role;
+  }
+
+  const incomingParts = incomingContent.parts;
+  if (!Array.isArray(incomingParts)) {
+    return;
+  }
+
+  const targetParts = Array.isArray(targetContent.parts) ? [...targetContent.parts] : [];
+  for (const part of incomingParts) {
+    appendContentPart(targetParts, part);
+  }
+  targetContent.parts = targetParts;
+}
+
+function appendContentPart(parts: unknown[], part: unknown): void {
+  const partRecord = asJsonRecord(part);
+  if (partRecord === null || !isTextOnlyPart(partRecord)) {
+    parts.push(clonePart(part));
+    return;
+  }
+
+  const lastPart = parts[parts.length - 1];
+  const lastPartRecord = asJsonRecord(lastPart);
+  if (lastPartRecord !== null && isTextOnlyPart(lastPartRecord)) {
+    parts[parts.length - 1] = {
+      ...lastPartRecord,
+      text: `${lastPartRecord.text}${partRecord.text}`,
+    };
+    return;
+  }
+
+  parts.push({ ...partRecord });
+}
+
+function isTextOnlyPart(part: JsonRecord): part is JsonRecord & { text: string } {
+  return typeof part.text === "string" && Object.keys(part).every((key) => key === "text");
+}
+
+function mergeLatestNonNullFields(
+  target: JsonRecord,
+  incoming: JsonRecord,
+  excludedKeys: readonly string[]
+): void {
+  for (const [key, value] of Object.entries(incoming)) {
+    if (excludedKeys.includes(key) || value === null || value === undefined) {
+      continue;
+    }
+    target[key] = value;
+  }
+}
+
+function readCandidateIndex(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+function asJsonRecord(value: unknown): JsonRecord | null {
+  return isJsonRecord(value) ? value : null;
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/langfuse/stream-final-output-openai.ts
+++ b/src/lib/langfuse/stream-final-output-openai.ts
@@ -1,0 +1,256 @@
+import {
+  createFinalOutputUnavailable,
+  finalizeStreamOutput,
+  type ParsedStreamFrames,
+  type StreamFinalOutput,
+} from "@/lib/langfuse/stream-final-output-core";
+
+type JsonRecord = Record<string, unknown>;
+
+type FunctionAccumulator = {
+  name?: string;
+  arguments: string;
+};
+
+type ToolCallAccumulator = {
+  readonly index: number;
+  id?: string;
+  type?: string;
+  function: FunctionAccumulator;
+};
+
+type ChoiceAccumulator = {
+  readonly index: number;
+  readonly message: JsonRecord;
+  readonly toolCalls: Map<number, ToolCallAccumulator>;
+  functionCall?: FunctionAccumulator;
+  finishReason?: string;
+  logprobs?: unknown;
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function appendString(target: JsonRecord, key: string, value: unknown): void {
+  if (typeof value !== "string") return;
+  const previous = target[key];
+  target[key] = typeof previous === "string" ? previous + value : value;
+}
+
+function retainFirstString(target: JsonRecord, key: string, value: unknown): void {
+  if (typeof value !== "string" || typeof target[key] === "string") return;
+  target[key] = value;
+}
+
+function appendFunctionDelta(target: FunctionAccumulator, delta: unknown): void {
+  if (!isRecord(delta)) return;
+  retainFirstString(target, "name", delta.name);
+  appendString(target, "arguments", delta.arguments);
+}
+
+function createFunctionAccumulator(): FunctionAccumulator {
+  return { arguments: "" };
+}
+
+function readChoiceAccumulator(
+  choices: Map<number, ChoiceAccumulator>,
+  index: number
+): ChoiceAccumulator {
+  const existing = choices.get(index);
+  if (existing) return existing;
+
+  const created: ChoiceAccumulator = {
+    index,
+    message: {},
+    toolCalls: new Map(),
+  };
+  choices.set(index, created);
+  return created;
+}
+
+function foldToolCalls(choice: ChoiceAccumulator, value: unknown): void {
+  if (!Array.isArray(value)) return;
+
+  value.forEach((rawToolCall, position) => {
+    if (!isRecord(rawToolCall)) return;
+    const index = typeof rawToolCall.index === "number" ? rawToolCall.index : position;
+    const existing = choice.toolCalls.get(index);
+    const toolCall = existing ?? {
+      index,
+      function: createFunctionAccumulator(),
+    };
+
+    if (typeof rawToolCall.id === "string" && toolCall.id === undefined) {
+      toolCall.id = rawToolCall.id;
+    }
+    if (typeof rawToolCall.type === "string" && toolCall.type === undefined) {
+      toolCall.type = rawToolCall.type;
+    }
+    appendFunctionDelta(toolCall.function, rawToolCall.function);
+    choice.toolCalls.set(index, toolCall);
+  });
+}
+
+function foldChoice(choice: ChoiceAccumulator, rawChoice: unknown): void {
+  if (!isRecord(rawChoice)) return;
+  const delta = isRecord(rawChoice.delta) ? rawChoice.delta : {};
+
+  retainFirstString(choice.message, "role", delta.role);
+  retainFirstString(choice.message, "id", delta.id);
+  retainFirstString(choice.message, "name", delta.name);
+  appendString(choice.message, "content", delta.content);
+  appendString(choice.message, "reasoning_content", delta.reasoning_content);
+
+  if (isRecord(delta.function_call)) {
+    choice.functionCall ??= createFunctionAccumulator();
+    appendFunctionDelta(choice.functionCall, delta.function_call);
+  }
+  foldToolCalls(choice, delta.tool_calls);
+
+  if (typeof rawChoice.finish_reason === "string") {
+    choice.finishReason = rawChoice.finish_reason;
+  }
+  if (rawChoice.logprobs !== null && rawChoice.logprobs !== undefined) {
+    choice.logprobs = rawChoice.logprobs;
+  }
+}
+
+function buildFunctionValue(value: FunctionAccumulator): JsonRecord {
+  return {
+    ...(value.name !== undefined ? { name: value.name } : {}),
+    ...(value.arguments.length > 0 ? { arguments: value.arguments } : {}),
+  };
+}
+
+function buildToolCallValue(value: ToolCallAccumulator): JsonRecord {
+  return {
+    index: value.index,
+    ...(value.id !== undefined ? { id: value.id } : {}),
+    ...(value.type !== undefined ? { type: value.type } : {}),
+    function: buildFunctionValue(value.function),
+  };
+}
+
+function buildChoiceValue(value: ChoiceAccumulator): JsonRecord {
+  const toolCalls = [...value.toolCalls.values()]
+    .sort((left, right) => left.index - right.index)
+    .map(buildToolCallValue);
+  const message = {
+    ...value.message,
+    ...(value.functionCall ? { function_call: buildFunctionValue(value.functionCall) } : {}),
+    ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+  };
+
+  return {
+    index: value.index,
+    message,
+    finish_reason: value.finishReason ?? null,
+    logprobs: value.logprobs ?? null,
+  };
+}
+
+export function finalizeOpenAIChatStream(frames: ParsedStreamFrames): StreamFinalOutput {
+  const choices = new Map<number, ChoiceAccumulator>();
+  let id: string | undefined;
+  let created: number | undefined;
+  let model: string | undefined;
+  let systemFingerprint: string | undefined;
+  let usage: JsonRecord | undefined;
+
+  for (const frame of frames.frames) {
+    if (typeof frame.data === "string") continue;
+    if (!isRecord(frame.data)) continue;
+
+    if (typeof frame.data.id === "string") id = frame.data.id;
+    if (typeof frame.data.created === "number") created = frame.data.created;
+    if (typeof frame.data.model === "string") model = frame.data.model;
+    if (typeof frame.data.system_fingerprint === "string") {
+      systemFingerprint = frame.data.system_fingerprint;
+    }
+    if (isRecord(frame.data.usage)) usage = frame.data.usage;
+
+    if (!Array.isArray(frame.data.choices)) continue;
+    frame.data.choices.forEach((rawChoice, position) => {
+      const index =
+        isRecord(rawChoice) && typeof rawChoice.index === "number" ? rawChoice.index : position;
+      foldChoice(readChoiceAccumulator(choices, index), rawChoice);
+    });
+  }
+
+  if (
+    choices.size === 0 ||
+    [...choices.values()].some((choice) => choice.finishReason === undefined)
+  ) {
+    return createFinalOutputUnavailable("no_terminal_event", {
+      eventCount: frames.frames.length,
+      framing: frames.framing,
+    });
+  }
+
+  const value = {
+    id: id ?? "",
+    object: "chat.completion",
+    created: created ?? 0,
+    model: model ?? "",
+    ...(systemFingerprint !== undefined ? { system_fingerprint: systemFingerprint } : {}),
+    choices: [...choices.values()]
+      .sort((left, right) => left.index - right.index)
+      .map(buildChoiceValue),
+    ...(usage !== undefined ? { usage } : {}),
+  };
+
+  return finalizeStreamOutput(value, {
+    eventCount: frames.frames.length,
+    framing: frames.framing,
+  });
+}
+
+function eventType(frame: ParsedStreamFrames["frames"][number]): string | null {
+  if (isRecord(frame.data) && typeof frame.data.type === "string") return frame.data.type;
+  return frame.event;
+}
+
+function responseDiagnostic(
+  frames: ParsedStreamFrames,
+  reason: "stream_error" | "no_terminal_event"
+) {
+  return createFinalOutputUnavailable(reason, {
+    eventCount: frames.frames.length,
+    framing: frames.framing,
+  });
+}
+
+export function finalizeOpenAIResponsesStream(frames: ParsedStreamFrames): StreamFinalOutput {
+  for (const frame of frames.frames) {
+    if (typeof frame.data === "string" || !isRecord(frame.data)) continue;
+    const type = eventType(frame);
+
+    if (type === "response.failed" || type === "response.error" || type === "error") {
+      return responseDiagnostic(frames, "stream_error");
+    }
+    if (type === "response.completed") {
+      if (isRecord(frame.data.response)) {
+        return finalizeStreamOutput(frame.data.response, {
+          eventCount: frames.frames.length,
+          framing: frames.framing,
+        });
+      }
+      return responseDiagnostic(frames, "stream_error");
+    }
+    if (type === "response.incomplete") {
+      if (!isRecord(frame.data.response)) return responseDiagnostic(frames, "stream_error");
+      const incompleteDetails = frame.data.incomplete_details;
+      const value =
+        incompleteDetails !== undefined && incompleteDetails !== null
+          ? { ...frame.data.response, incomplete_details: incompleteDetails }
+          : frame.data.response;
+      return finalizeStreamOutput(value, {
+        eventCount: frames.frames.length,
+        framing: frames.framing,
+      });
+    }
+  }
+
+  return responseDiagnostic(frames, "no_terminal_event");
+}

--- a/src/lib/langfuse/stream-final-output.ts
+++ b/src/lib/langfuse/stream-final-output.ts
@@ -1,0 +1,56 @@
+import { finalizeAnthropicStreamOutput } from "@/lib/langfuse/stream-final-output-anthropic";
+import {
+  createFinalOutputUnavailable,
+  type ParsedStreamFrames,
+  parseStreamFrames,
+  type StreamFinalOutput,
+} from "@/lib/langfuse/stream-final-output-core";
+import { finalizeGeminiStreamOutput } from "@/lib/langfuse/stream-final-output-gemini";
+import {
+  finalizeOpenAIChatStream,
+  finalizeOpenAIResponsesStream,
+} from "@/lib/langfuse/stream-final-output-openai";
+
+export type StreamClientFormat = "claude" | "openai" | "response" | "gemini" | "gemini-cli";
+
+type StreamFinalizer = (frames: ParsedStreamFrames) => StreamFinalOutput;
+
+const STREAM_FINALIZERS: Readonly<Record<StreamClientFormat, StreamFinalizer>> = {
+  claude: finalizeAnthropicStreamOutput,
+  openai: finalizeOpenAIChatStream,
+  response: finalizeOpenAIResponsesStream,
+  gemini: finalizeGeminiStreamOutput,
+  "gemini-cli": finalizeGeminiStreamOutput,
+};
+
+export function finalizeStreamOutputForClient(
+  streamText: string,
+  clientFormat: StreamClientFormat,
+  isStreaming: boolean
+): StreamFinalOutput | undefined {
+  if (!isStreaming) {
+    return undefined;
+  }
+
+  try {
+    const parsed = parseStreamFrames(streamText);
+    if (parsed.kind !== "frames") {
+      return parsed;
+    }
+
+    const finalizer = STREAM_FINALIZERS[clientFormat];
+    if (finalizer === undefined) {
+      return createFinalOutputUnavailable("unsupported_framing", {
+        eventCount: parsed.frames.length,
+        framing: parsed.framing,
+      });
+    }
+
+    return finalizer(parsed);
+  } catch (error) {
+    if (error instanceof Error) {
+      return createFinalOutputUnavailable("stream_error");
+    }
+    return createFinalOutputUnavailable("stream_error");
+  }
+}

--- a/src/lib/langfuse/trace-proxy-request.ts
+++ b/src/lib/langfuse/trace-proxy-request.ts
@@ -3,11 +3,56 @@ import type { UsageMetrics } from "@/app/v1/_lib/proxy/response-handler";
 import type { ProxySession } from "@/app/v1/_lib/proxy/session";
 import { redactHeaders } from "@/lib/api/v1/_shared/redaction";
 import { isLangfuseEnabled } from "@/lib/langfuse/index";
+import {
+  createFinalOutputUnavailable,
+  type StreamFinalOutput,
+} from "@/lib/langfuse/stream-final-output-core";
 import { logger } from "@/lib/logger";
 import type { CostBreakdown } from "@/lib/utils/cost-calculation";
 
 const LANGFUSE_JSON_PARSE_MAX_CHARS = 1024 * 1024;
 const LANGFUSE_TEXT_PREVIEW_EDGE_CHARS = 128 * 1024;
+const LANGFUSE_PROPAGATED_STRING_MAX_CHARS = 200;
+
+function clampLangfusePropagatedString(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return value.length <= LANGFUSE_PROPAGATED_STRING_MAX_CHARS
+    ? value
+    : value.slice(0, LANGFUSE_PROPAGATED_STRING_MAX_CHARS);
+}
+
+function clampLangfusePropagatedMetadata(metadata: Record<string, string>): Record<string, string> {
+  const clamped: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    const next = clampLangfusePropagatedString(value);
+    if (next !== undefined) {
+      clamped[key] = next;
+    }
+  }
+  return clamped;
+}
+
+function clampLangfuseTags(tags: string[]): string[] {
+  return tags
+    .map((tag) => clampLangfusePropagatedString(tag))
+    .filter((tag): tag is string => tag !== undefined);
+}
+
+/** Keep the segment after the last `/` so provider prefixes stay out of the name. */
+function langfuseModelShortName(model: string | undefined): string {
+  if (!model) return "unknown";
+  const separator = model.lastIndexOf("/");
+  const shortName = separator >= 0 ? model.slice(separator + 1) : model;
+  return shortName || "unknown";
+}
+
+function buildLangfuseDisplayName(
+  username: string | undefined,
+  model: string | undefined
+): string | undefined {
+  const shortModel = langfuseModelShortName(model);
+  return clampLangfusePropagatedString(username ? `${username}:${shortModel}` : shortModel);
+}
 
 function buildRequestBodySummary(session: ProxySession): Record<string, unknown> {
   const msg = session.request.message as Record<string, unknown>;
@@ -68,6 +113,24 @@ function redactLangfuseHeaders(headers: Headers): Record<string, string> {
   return redactHeaders(externalHeaders);
 }
 
+function headersToSanitizedRecord(headers: Headers): Record<string, string> {
+  const sanitizedText = sanitizeHeaders(headers);
+  if (!sanitizedText || sanitizedText === "(empty)") {
+    return {};
+  }
+
+  const record: Record<string, string> = {};
+  for (const line of sanitizedText.split(/\r?\n/).filter(Boolean)) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+    const name = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim();
+    if (!name) continue;
+    record[name] = record[name] ? `${record[name]}\n${value}` : value;
+  }
+  return record;
+}
+
 const SUCCESS_REASONS = new Set([
   "request_success",
   "retry_success",
@@ -100,6 +163,7 @@ export interface TraceContext {
   durationMs: number;
   statusCode: number;
   responseText?: string;
+  finalResponseOutput?: StreamFinalOutput;
   isStreaming: boolean;
   sseEventCount?: number;
   errorMessage?: string;
@@ -128,9 +192,132 @@ function isResponseMissing(ctx: TraceContext): boolean {
   return true;
 }
 
-function buildResponseOutput(ctx: TraceContext): unknown {
+type ResponseOutputMetadata = {
+  id?: unknown;
+  status?: unknown;
+  model?: unknown;
+};
+
+type ResponseCapture = {
+  output: unknown;
+  metadata?: ResponseOutputMetadata;
+  usageDetails?: {
+    input_tokens?: number;
+    input_tokens_details?: { cached_tokens?: number };
+    output_tokens?: number;
+    output_tokens_details?: { reasoning_tokens?: number };
+    total_tokens?: number;
+  };
+};
+
+const RESPONSE_TOOL_CALL_EXCLUDED_FIELDS: Record<string, true> = {
+  id: true,
+  status: true,
+  internal_chat_message_metadata_passthrough: true,
+  metadata: true,
+};
+
+function sanitizeResponseOutputItem(value: unknown, isInsideToolCall = false): unknown {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return value;
+
+  const item = value as Record<string, unknown>;
+  const isToolCall =
+    isInsideToolCall ||
+    (typeof item.type === "string" && (item.type.endsWith("_call") || item.type === "tool_calls"));
+
+  return Object.fromEntries(
+    Object.entries(item)
+      .filter(([key]) => !isToolCall || RESPONSE_TOOL_CALL_EXCLUDED_FIELDS[key] === undefined)
+      .map(([key, child]) => [
+        key,
+        Array.isArray(child)
+          ? child.map((entry) => sanitizeResponseOutputItem(entry, isToolCall))
+          : sanitizeResponseOutputItem(child, isToolCall),
+      ])
+  );
+}
+
+function buildResponseCapture(ctx: TraceContext): ResponseCapture {
+  const responseValue =
+    ctx.finalResponseOutput?.kind === "final"
+      ? ctx.finalResponseOutput.value
+      : ctx.isStreaming || !ctx.responseText
+        ? undefined
+        : tryParseJsonSafe(ctx.responseText);
+
+  if (
+    ctx.session.originalFormat === "response" &&
+    typeof responseValue === "object" &&
+    responseValue !== null &&
+    !Array.isArray(responseValue)
+  ) {
+    const response = responseValue as Record<string, unknown>;
+    const usage =
+      typeof response.usage === "object" &&
+      response.usage !== null &&
+      !Array.isArray(response.usage)
+        ? (response.usage as Record<string, unknown>)
+        : undefined;
+    const inputTokenDetails =
+      typeof usage?.input_tokens_details === "object" &&
+      usage.input_tokens_details !== null &&
+      !Array.isArray(usage.input_tokens_details)
+        ? (usage.input_tokens_details as Record<string, unknown>)
+        : undefined;
+    const outputTokenDetails =
+      typeof usage?.output_tokens_details === "object" &&
+      usage.output_tokens_details !== null &&
+      !Array.isArray(usage.output_tokens_details)
+        ? (usage.output_tokens_details as Record<string, unknown>)
+        : undefined;
+    const usageDetails: ResponseCapture["usageDetails"] = usage
+      ? {
+          ...(typeof usage.input_tokens === "number" ? { input_tokens: usage.input_tokens } : {}),
+          ...(typeof inputTokenDetails?.cached_tokens === "number"
+            ? { input_tokens_details: { cached_tokens: inputTokenDetails.cached_tokens } }
+            : {}),
+          ...(typeof usage.output_tokens === "number"
+            ? { output_tokens: usage.output_tokens }
+            : {}),
+          ...(typeof outputTokenDetails?.reasoning_tokens === "number"
+            ? { output_tokens_details: { reasoning_tokens: outputTokenDetails.reasoning_tokens } }
+            : {}),
+          ...(typeof usage.total_tokens === "number" ? { total_tokens: usage.total_tokens } : {}),
+        }
+      : undefined;
+    const metadata: ResponseOutputMetadata = {
+      ...(response.id !== undefined ? { id: response.id } : {}),
+      ...(response.status !== undefined ? { status: response.status } : {}),
+      ...(response.model !== undefined ? { model: response.model } : {}),
+    };
+
+    return {
+      output: Array.isArray(response.output)
+        ? response.output.map((item) => sanitizeResponseOutputItem(item))
+        : undefined,
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+      ...(usageDetails && Object.keys(usageDetails).length > 0 ? { usageDetails } : {}),
+    };
+  }
+
+  if (ctx.finalResponseOutput?.kind === "final") {
+    return { output: ctx.finalResponseOutput.value };
+  }
+  if (ctx.finalResponseOutput !== undefined) {
+    return { output: ctx.finalResponseOutput };
+  }
+
+  if (ctx.isStreaming) {
+    return {
+      output: createFinalOutputUnavailable("no_terminal_event", {
+        eventCount: ctx.sseEventCount ?? 0,
+        status: ctx.statusCode,
+      }),
+    };
+  }
+
   if (ctx.responseText) {
-    return tryParseJsonSafe(ctx.responseText);
+    return { output: tryParseJsonSafe(ctx.responseText) };
   }
 
   const responseMissing = isResponseMissing(ctx);
@@ -149,7 +336,7 @@ function buildResponseOutput(ctx: TraceContext): unknown {
     output.errorMessage = ctx.errorMessage;
   }
 
-  return output;
+  return { output };
 }
 
 function buildLargeTextPreview(text: string): Record<string, unknown> {
@@ -212,12 +399,14 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
     }
 
     // Actual request body (forwarded to upstream after all preprocessing) - no truncation
+    // Actual request and response bodies are not truncated.
     const actualRequestBody = session.forwardedRequestBody
       ? tryParseJsonSafe(session.forwardedRequestBody)
       : session.request.message;
-
-    // Actual response body - no truncation
-    const actualResponseBody = buildResponseOutput(ctx);
+    const actualResponse = buildResponseCapture(ctx);
+    const actualResponseBody = actualResponse.output;
+    const responseOutputMetadata = actualResponse.metadata;
+    const responseUsageDetails = actualResponse.usageDetails;
     const responseMissing = isResponseMissing(ctx);
 
     // Root span metadata (former input/output summaries moved here)
@@ -227,6 +416,9 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
       model: session.getCurrentModel(),
       clientFormat: session.originalFormat,
       providerName: provider?.name,
+      userName: messageContext?.user?.name ?? session.userName ?? null,
+      keyName: messageContext?.key?.name ?? null,
+      clientIp: session.clientIp ?? null,
       statusCode,
       durationMs,
       errorMessage: ctx.errorMessage,
@@ -237,22 +429,25 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
     };
 
     // Build tags - include provider name and model
-    const tags: string[] = [];
-    if (provider?.providerType) tags.push(provider.providerType);
-    if (provider?.name) tags.push(provider.name);
-    if (session.originalFormat) tags.push(session.originalFormat);
-    if (session.getCurrentModel()) tags.push(session.getCurrentModel()!);
-    tags.push(getStatusCategory(statusCode));
+    const tags = clampLangfuseTags([
+      ...(provider?.providerType ? [provider.providerType] : []),
+      ...(provider?.name ? [provider.name] : []),
+      ...(session.originalFormat ? [session.originalFormat] : []),
+      ...(session.getCurrentModel() ? [session.getCurrentModel()!] : []),
+      getStatusCategory(statusCode),
+    ]);
 
-    // Build trace-level metadata (propagateAttributes requires all values to be strings)
-    const traceMetadata: Record<string, string> = {
+    // Build trace-level metadata (propagateAttributes requires all values to be strings ≤200)
+    const traceMetadata = clampLangfusePropagatedMetadata({
+      userName: messageContext?.user?.name ?? session.userName ?? "",
       keyName: messageContext?.key?.name ?? "",
+      clientIp: session.clientIp ?? "",
       endpoint: session.getEndpoint() ?? "",
       method: session.method,
       clientFormat: session.originalFormat,
       userAgent: session.userAgent ?? "",
       requestSequence: String(session.getRequestSequence()),
-    };
+    });
 
     const requestHeaders = redactLangfuseHeaders(session.headers);
     const responseHeaders = redactLangfuseHeaders(ctx.responseHeaders);
@@ -276,7 +471,9 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
       userAgent: session.userAgent,
       requestSequence: session.getRequestSequence(),
       sessionId: session.sessionId,
-      keyName: messageContext?.key?.name,
+      userName: messageContext?.user?.name ?? session.userName ?? null,
+      keyName: messageContext?.key?.name ?? null,
+      clientIp: session.clientIp ?? null,
       // Timing
       durationMs,
       ttftMs: session.ttftMs,
@@ -294,25 +491,34 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
       sseEventCount: ctx.sseEventCount,
       requestHeaders,
       responseHeaders,
+      client_metadata: headersToSanitizedRecord(
+        typeof session.getOriginalHeaders === "function"
+          ? session.getOriginalHeaders()
+          : session.headers
+      ),
+      ...(responseOutputMetadata !== undefined ? { response: responseOutputMetadata } : {}),
     };
 
-    // Build usage details for Langfuse generation
-    const usageDetails: Record<string, number> | undefined = ctx.usageMetrics
-      ? {
-          ...(ctx.usageMetrics.input_tokens != null
-            ? { input: ctx.usageMetrics.input_tokens }
-            : {}),
-          ...(ctx.usageMetrics.output_tokens != null
-            ? { output: ctx.usageMetrics.output_tokens }
-            : {}),
-          ...(ctx.usageMetrics.cache_read_input_tokens != null
-            ? { cache_read_input_tokens: ctx.usageMetrics.cache_read_input_tokens }
-            : {}),
-          ...(ctx.usageMetrics.cache_creation_input_tokens != null
-            ? { cache_creation_input_tokens: ctx.usageMetrics.cache_creation_input_tokens }
-            : {}),
-        }
-      : undefined;
+    // Responses API reports native Langfuse token dimensions from its own output.
+    const usageDetails: Record<string, number> | undefined =
+      responseUsageDetails !== undefined
+        ? (responseUsageDetails as unknown as Record<string, number>)
+        : ctx.usageMetrics
+          ? {
+              ...(ctx.usageMetrics.input_tokens != null
+                ? { input: ctx.usageMetrics.input_tokens }
+                : {}),
+              ...(ctx.usageMetrics.output_tokens != null
+                ? { output: ctx.usageMetrics.output_tokens }
+                : {}),
+              ...(ctx.usageMetrics.cache_read_input_tokens != null
+                ? { cache_read_input_tokens: ctx.usageMetrics.cache_read_input_tokens }
+                : {}),
+              ...(ctx.usageMetrics.cache_creation_input_tokens != null
+                ? { cache_creation_input_tokens: ctx.usageMetrics.cache_creation_input_tokens }
+                : {}),
+            }
+          : undefined;
 
     // Build cost details (prefer breakdown, fallback to total-only)
     const costDetails: Record<string, number> | undefined = ctx.costBreakdown
@@ -321,48 +527,52 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
         ? { total: Number.parseFloat(ctx.costUsd) }
         : undefined;
 
-    // Create the root trace span with actual bodies, level, and metadata
-    const rootSpan = startObservation(
-      "proxy-request",
-      {
-        input: actualRequestBody,
-        output: actualResponseBody,
-        level: rootSpanLevel,
-        metadata: rootSpanMetadata,
-      },
-      {
-        startTime: requestStartTime,
-      }
-    );
+    const username = messageContext?.user?.name ?? session.userName ?? undefined;
+    const displayName =
+      buildLangfuseDisplayName(username, session.getCurrentModel() ?? undefined) ?? "unknown";
 
-    // Propagate trace attributes
+    // Official v5: wrap ALL observations in propagateAttributes so userId/sessionId/tags
+    // land on the root span too. Child startObservation on the wrapper drops startTime;
+    // use the module-level API with parentSpanContext instead.
     await propagateAttributes(
       {
-        userId: messageContext?.user?.name ?? undefined,
-        sessionId: session.sessionId ?? undefined,
+        userId: clampLangfusePropagatedString(username),
+        sessionId: clampLangfusePropagatedString(session.sessionId ?? undefined),
         tags,
         metadata: traceMetadata,
-        traceName: `${session.method} ${session.getEndpoint() ?? "/"}`,
+        traceName: displayName,
       },
       async () => {
-        // 1. Guard pipeline span (if forwardStartTime was recorded)
+        const rootSpan = startObservation(
+          displayName,
+          {
+            input: actualRequestBody,
+            output: actualResponseBody,
+            level: rootSpanLevel,
+            metadata: rootSpanMetadata,
+          },
+          {
+            startTime: requestStartTime,
+          }
+        );
+
+        const parentSpanContext = rootSpan.otelSpan.spanContext();
+
         if (forwardStartDate) {
-          const guardSpan = rootSpan.startObservation(
+          const guardSpan = startObservation(
             "guard-pipeline",
             {
               output: { durationMs: guardPipelineMs, passed: true },
             },
-            { startTime: requestStartTime } as Record<string, unknown>
+            { startTime: requestStartTime, parentSpanContext }
           );
           guardSpan.end(forwardStartDate);
         }
 
-        // 2. Provider attempt events (one per failed/hedge chain item)
         for (const rawItem of session.getProviderChain()) {
           const item = sanitizeProviderChainValue(rawItem) as typeof rawItem;
-          // Hedge trigger: informational event (not a success or failure)
           if (item.reason === "hedge_triggered") {
-            const hedgeObs = rootSpan.startObservation(
+            const hedgeObs = startObservation(
               "hedge-trigger",
               {
                 level: "WARNING" as ObservationLevel,
@@ -380,14 +590,15 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
               {
                 asType: "event",
                 startTime: new Date(item.timestamp ?? session.startTime),
-              } as { asType: "event" }
+                parentSpanContext,
+              }
             );
             hedgeObs.end();
             continue;
           }
 
           if (!isSuccessReason(item.reason)) {
-            const eventObs = rootSpan.startObservation(
+            const eventObs = startObservation(
               "provider-attempt",
               {
                 level: isErrorReason(item.reason) ? "ERROR" : "WARNING",
@@ -406,35 +617,31 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
               {
                 asType: "event",
                 startTime: new Date(item.timestamp ?? session.startTime),
-              } as { asType: "event" }
+                parentSpanContext,
+              }
             );
             eventObs.end();
           }
         }
 
-        // 3. LLM generation (startTime = forwardStartTime when available)
         const generationStartTime = forwardStartDate ?? requestStartTime;
-
-        // Generation input/output = raw payload, no truncation
-        const generationInput = actualRequestBody;
-        const generationOutput = buildResponseOutput(ctx);
-
-        // Create the LLM generation observation
-        const generation = rootSpan.startObservation(
+        const generation = startObservation(
           "llm-call",
           {
             model: session.getCurrentModel() ?? undefined,
-            input: generationInput,
-            output: generationOutput,
+            input: actualRequestBody,
+            output: actualResponseBody,
             ...(usageDetails && Object.keys(usageDetails).length > 0 ? { usageDetails } : {}),
             ...(costDetails ? { costDetails } : {}),
             metadata: generationMetadata,
           },
-          // SDK runtime supports startTime on child observations but types don't expose it
-          { asType: "generation", startTime: generationStartTime } as { asType: "generation" }
+          {
+            asType: "generation",
+            startTime: generationStartTime,
+            parentSpanContext,
+          }
         );
 
-        // Set TTFT as completionStartTime
         if (session.ttftMs != null) {
           generation.update({
             completionStartTime: new Date(session.startTime + session.ttftMs),
@@ -442,16 +649,9 @@ export async function traceProxyRequest(ctx: TraceContext): Promise<void> {
         }
 
         generation.end(requestEndTime);
+        rootSpan.end(requestEndTime);
       }
     );
-
-    // Explicitly set trace-level input/output (propagateAttributes does not support these)
-    rootSpan.setTraceIO({
-      input: actualRequestBody,
-      output: actualResponseBody,
-    });
-
-    rootSpan.end(requestEndTime);
   } catch (error) {
     logger.warn("[Langfuse] Failed to trace proxy request", {
       error: error instanceof Error ? error.message : String(error),

--- a/tests/unit/langfuse/emit-proxy-trace.test.ts
+++ b/tests/unit/langfuse/emit-proxy-trace.test.ts
@@ -1,24 +1,232 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { ProxySession } from "@/app/v1/_lib/proxy/session";
+import { emitProxyLangfuseTrace } from "@/lib/langfuse/emit-proxy-trace";
+import * as streamFinalOutput from "@/lib/langfuse/stream-final-output";
 
-vi.mock("@/lib/logger", () => ({
-  logger: {
-    warn: vi.fn(),
-  },
+const { mockTraceProxyRequest, mockTraceModuleLoaded, mockLoggerWarn } = vi.hoisted(() => ({
+  mockTraceProxyRequest: vi.fn().mockResolvedValue(undefined),
+  mockTraceModuleLoaded: vi.fn(),
+  mockLoggerWarn: vi.fn(),
 }));
 
-import { emitProxyLangfuseTrace } from "@/lib/langfuse/emit-proxy-trace";
-import { logger } from "@/lib/logger";
+vi.mock("@/lib/langfuse/trace-proxy-request", () => {
+  mockTraceModuleLoaded();
+  return { traceProxyRequest: mockTraceProxyRequest };
+});
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: mockLoggerWarn },
+}));
+
+function createMockSession(originalFormat: "openai" | "claude" = "openai"): ProxySession {
+  const startTime = 1_700_000_000_000;
+  const session = {
+    startTime,
+    method: "POST",
+    headers: new Headers({ "content-type": "application/json" }),
+    request: {
+      message: { model: "gpt-test", messages: [{ role: "user", content: "hello" }] },
+      model: "gpt-test",
+      log: "",
+      note: undefined,
+    },
+    originalFormat,
+    userAgent: "test-client",
+    sessionId: "session-test",
+    clientIp: "127.0.0.1",
+    provider: null,
+    messageContext: null,
+    ttfbMs: null,
+    forwardStartTime: startTime + 1,
+    forwardedRequestBody: null,
+    getEndpoint: () => "/v1/chat/completions",
+    getRequestSequence: () => 1,
+    getMessagesLength: () => 1,
+    getCurrentModel: () => "gpt-test",
+    getOriginalModel: () => "gpt-test",
+    isModelRedirected: () => false,
+    getProviderChain: () => [],
+    getSpecialSettings: () => null,
+    getCacheTtlResolved: () => null,
+    getContext1mApplied: () => false,
+  } as ProxySession;
+
+  return session;
+}
+
+function chatFrame(content: string, extra: Record<string, unknown> = {}): string {
+  return `data: ${JSON.stringify({
+    id: "chat-test",
+    object: "chat.completion.chunk",
+    created: 1_700_000_000,
+    model: "gpt-test",
+    choices: [{ index: 0, delta: { content }, ...extra }],
+  })}\n\n`;
+}
+
+function waitForTrace(): Promise<void> {
+  return vi.waitFor(() => expect(mockTraceProxyRequest).toHaveBeenCalled());
+}
 
 describe("emitProxyLangfuseTrace", () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.clearAllMocks();
+  const originalPublicKey = process.env.LANGFUSE_PUBLIC_KEY;
+  const originalSecretKey = process.env.LANGFUSE_SECRET_KEY;
+
+  beforeEach(() => {
+    process.env.LANGFUSE_PUBLIC_KEY = "pk-test";
+    process.env.LANGFUSE_SECRET_KEY = "sk-test";
+    mockTraceProxyRequest.mockClear();
+    mockTraceModuleLoaded.mockClear();
+    mockLoggerWarn.mockClear();
   });
 
-  it("never lets a synchronous session snapshot failure escape", () => {
-    vi.stubEnv("LANGFUSE_PUBLIC_KEY", "test-public");
-    vi.stubEnv("LANGFUSE_SECRET_KEY", "test-secret");
+  afterEach(() => {
+    if (originalPublicKey === undefined) delete process.env.LANGFUSE_PUBLIC_KEY;
+    else process.env.LANGFUSE_PUBLIC_KEY = originalPublicKey;
+    if (originalSecretKey === undefined) delete process.env.LANGFUSE_SECRET_KEY;
+    else process.env.LANGFUSE_SECRET_KEY = originalSecretKey;
+    vi.restoreAllMocks();
+  });
+
+  test("finalizes a complete Chat response before the raw response cap", async () => {
+    const leadingFrames = Array.from({ length: 7_000 }, () => chatFrame(""));
+    const trailingFrames = Array.from({ length: 7_000 }, () => chatFrame(""));
+    const responseText = [
+      ...leadingFrames,
+      chatFrame("meaningful delta beyond the old raw head/tail window", {
+        delta: { content: "meaningful delta beyond the old raw head/tail window" },
+      }),
+      ...trailingFrames,
+      chatFrame("", { finish_reason: "stop" }),
+      "data: [DONE]\n\n",
+    ].join("");
+
+    emitProxyLangfuseTrace(createMockSession("openai"), {
+      responseHeaders: new Headers(),
+      responseText,
+      usageMetrics: null,
+      costUsd: "0.25",
+      costBreakdown: { total: 0.25 },
+      statusCode: 200,
+      durationMs: 25,
+      isStreaming: true,
+      sseEventCount: 14_002,
+      errorMessage: "completed with trace metadata",
+    });
+
+    await waitForTrace();
+
+    const traceContext = mockTraceProxyRequest.mock.calls[0]?.[0];
+    expect(traceContext.finalResponseOutput).toEqual({
+      kind: "final",
+      value: {
+        id: "chat-test",
+        object: "chat.completion",
+        created: 1_700_000_000,
+        model: "gpt-test",
+        choices: [
+          {
+            index: 0,
+            message: {
+              content: "meaningful delta beyond the old raw head/tail window",
+            },
+            finish_reason: "stop",
+            logprobs: null,
+          },
+        ],
+      },
+    });
+    expect(traceContext).not.toHaveProperty("responseText");
+    expect(traceContext).toEqual(
+      expect.objectContaining({
+        responseHeaders: expect.any(Headers),
+        durationMs: 25,
+        statusCode: 200,
+        isStreaming: true,
+        usageMetrics: null,
+        costUsd: "0.25",
+        costBreakdown: { total: 0.25 },
+        sseEventCount: 14_002,
+        errorMessage: "completed with trace metadata",
+      })
+    );
+  });
+
+  test("does no finalization or dynamic tracing work when credentials are missing", () => {
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    const finalizeSpy = vi.spyOn(streamFinalOutput, "finalizeStreamOutputForClient");
+
+    emitProxyLangfuseTrace(createMockSession(), {
+      responseHeaders: new Headers(),
+      responseText: 'data: {"choices":[]}\n\n',
+      usageMetrics: null,
+      costUsd: undefined,
+      statusCode: 200,
+      durationMs: 25,
+      isStreaming: true,
+    });
+
+    expect(finalizeSpy).not.toHaveBeenCalled();
+    expect(mockTraceModuleLoaded).not.toHaveBeenCalled();
+    expect(mockTraceProxyRequest).not.toHaveBeenCalled();
+  });
+
+  test("uses a bounded diagnostic when finalization throws without blocking tracing", async () => {
+    const finalizeSpy = vi
+      .spyOn(streamFinalOutput, "finalizeStreamOutputForClient")
+      .mockImplementation(() => {
+        throw new Error("unexpected finalizer failure");
+      });
+
+    expect(() =>
+      emitProxyLangfuseTrace(createMockSession(), {
+        responseHeaders: new Headers(),
+        responseText: 'data: {"choices":[]}\n\n',
+        usageMetrics: null,
+        costUsd: undefined,
+        statusCode: 200,
+        durationMs: 25,
+        isStreaming: true,
+      })
+    ).not.toThrow();
+
+    await waitForTrace();
+
+    const traceContext = mockTraceProxyRequest.mock.calls[0]?.[0];
+    expect(finalizeSpy).toHaveBeenCalledWith('data: {"choices":[]}\n\n', "openai", true);
+    expect(traceContext.finalResponseOutput).toEqual({
+      kind: "final_output_unavailable",
+      reason: "stream_error",
+      eventCount: 0,
+    });
+    expect(traceContext).not.toHaveProperty("responseText");
+  });
+
+  test("keeps the existing bounded text path for non-stream responses", async () => {
+    const finalizeSpy = vi.spyOn(streamFinalOutput, "finalizeStreamOutputForClient");
+    const responseText = "x".repeat(1024 * 1024 + 1);
+
+    emitProxyLangfuseTrace(createMockSession("claude"), {
+      responseHeaders: new Headers(),
+      responseText,
+      usageMetrics: null,
+      costUsd: undefined,
+      statusCode: 200,
+      durationMs: 25,
+      isStreaming: false,
+    });
+
+    await waitForTrace();
+
+    const traceContext = mockTraceProxyRequest.mock.calls[0]?.[0];
+    const expectedResponseText = `${"x".repeat(128 * 1024)}\n\n[langfuse_response_truncated]\n\n${"x".repeat(128 * 1024)}`;
+    expect(finalizeSpy).not.toHaveBeenCalled();
+    expect(traceContext.responseText).toBe(expectedResponseText);
+    expect(traceContext).not.toHaveProperty("finalResponseOutput");
+  });
+
+  test("never lets a synchronous session snapshot failure escape", () => {
     const session = {
       getProviderChain() {
         throw new Error("snapshot exploded");
@@ -36,7 +244,7 @@ describe("emitProxyLangfuseTrace", () => {
         isStreaming: false,
       })
     ).not.toThrow();
-    expect(logger.warn).toHaveBeenCalledWith("[Langfuse] Proxy trace snapshot failed", {
+    expect(mockLoggerWarn).toHaveBeenCalledWith("[Langfuse] Proxy trace snapshot failed", {
       error: "snapshot exploded",
     });
   });

--- a/tests/unit/langfuse/langfuse-trace.test.ts
+++ b/tests/unit/langfuse/langfuse-trace.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
+import type { StreamFinalOutput } from "@/lib/langfuse/stream-final-output-core";
 
 // Mock the langfuse modules at the top level
 const mockStartObservation = vi.fn();
@@ -26,30 +27,51 @@ const mockEventObs: any = {
 };
 
 const mockSetTraceIO = vi.fn();
+const MOCK_PARENT_SPAN_CONTEXT = { traceId: "lf-trace", spanId: "lf-root" };
+const propagateState = { active: false };
+const createdInsidePropagate: boolean[] = [];
 
 const mockRootSpan = {
   startObservation: vi.fn(),
   setTraceIO: mockSetTraceIO,
   end: mockSpanEnd,
+  otelSpan: { spanContext: () => MOCK_PARENT_SPAN_CONTEXT },
 };
 
-// Default: route by observation name
+function getObservationCall(name: string) {
+  return mockStartObservation.mock.calls.find((c: unknown[]) => c[0] === name);
+}
+
+function getObservationCalls(name: string) {
+  return mockStartObservation.mock.calls.filter((c: unknown[]) => c[0] === name);
+}
+
 function setupDefaultStartObservation() {
   mockRootSpan.startObservation.mockImplementation((name: string) => {
     if (name === "guard-pipeline") return mockGuardSpan;
-    if (name === "provider-attempt") return mockEventObs;
-    return mockGeneration; // "llm-call"
+    if (name === "provider-attempt" || name === "hedge-trigger") return mockEventObs;
+    return mockGeneration;
   });
 }
 
 vi.mock("@langfuse/tracing", () => ({
   startObservation: (...args: unknown[]) => {
     mockStartObservation(...args);
+    createdInsidePropagate.push(propagateState.active);
+    const name = args[0] as string;
+    if (name === "guard-pipeline") return mockGuardSpan;
+    if (name === "provider-attempt" || name === "hedge-trigger") return mockEventObs;
+    if (name === "llm-call") return mockGeneration;
     return mockRootSpan;
   },
   propagateAttributes: async (attrs: unknown, fn: () => Promise<void>) => {
     mockPropagateAttributes(attrs);
-    await fn();
+    propagateState.active = true;
+    try {
+      await fn();
+    } finally {
+      propagateState.active = false;
+    }
   },
 }));
 
@@ -69,14 +91,21 @@ vi.mock("@/lib/langfuse/index", () => ({
 
 function createMockSession(overrides: Record<string, unknown> = {}) {
   const startTime = (overrides.startTime as number) ?? Date.now() - 500;
-  return {
-    startTime,
-    method: "POST",
-    headers: new Headers({
+  const headers =
+    (overrides.headers as Headers | undefined) ??
+    new Headers({
       "content-type": "application/json",
       "x-api-key": "test-mock-key-not-real",
       "user-agent": "claude-code/1.0",
-    }),
+    });
+  const getOriginalHeaders =
+    typeof overrides.getOriginalHeaders === "function"
+      ? (overrides.getOriginalHeaders as () => Headers)
+      : () => new Headers(headers);
+
+  return {
+    startTime,
+    method: "POST",
     request: {
       message: {
         model: "claude-sonnet-4-20250514",
@@ -90,6 +119,7 @@ function createMockSession(overrides: Record<string, unknown> = {}) {
     originalFormat: "claude",
     userAgent: "claude-code/1.0",
     sessionId: "sess_abc12345_def67890",
+    clientIp: "192.168.1.42",
     provider: {
       id: 1,
       name: "anthropic-main",
@@ -124,6 +154,8 @@ function createMockSession(overrides: Record<string, unknown> = {}) {
     getContext1mApplied: () => false,
     getGroupCostMultiplier: () => 1,
     ...overrides,
+    headers,
+    getOriginalHeaders,
   } as any;
 }
 
@@ -131,6 +163,7 @@ describe("traceProxyRequest", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     langfuseEnabled = true;
+    createdInsidePropagate.length = 0;
     setupDefaultStartObservation();
   });
 
@@ -164,7 +197,8 @@ describe("traceProxyRequest", () => {
 
     // Root span should have actual request body as input (not summary)
     const rootCall = mockStartObservation.mock.calls[0];
-    expect(rootCall[0]).toBe("proxy-request");
+    expect(rootCall[0]).toBe("testuser:claude-sonnet-4-20250514");
+
     // Input should be the actual request message (since forwardedRequestBody is null)
     expect(rootCall[1].input).toEqual(
       expect.objectContaining({
@@ -187,7 +221,7 @@ describe("traceProxyRequest", () => {
     );
 
     // Should have child observations
-    const callNames = mockRootSpan.startObservation.mock.calls.map((c: unknown[]) => c[0]);
+    const callNames = mockStartObservation.mock.calls.map((c: unknown[]) => c[0]);
     expect(callNames).toContain("guard-pipeline");
     expect(callNames).toContain("llm-call");
 
@@ -209,9 +243,7 @@ describe("traceProxyRequest", () => {
     });
 
     // Find the llm-call invocation
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall).toBeDefined();
     expect(llmCall[1].input).toEqual(session.request.message);
   });
@@ -229,9 +261,7 @@ describe("traceProxyRequest", () => {
       responseText: JSON.stringify(responseBody),
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[1].output).toEqual(responseBody);
   });
 
@@ -264,9 +294,7 @@ describe("traceProxyRequest", () => {
       isStreaming: false,
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     const metadata = llmCall[1].metadata;
     expect(metadata.requestHeaders).toEqual({
       authorization: "[REDACTED]",
@@ -280,11 +308,18 @@ describe("traceProxyRequest", () => {
       "set-cookie": "[REDACTED]",
       "x-response-id": "response-456",
     });
+    expect(metadata.client_metadata).toEqual({
+      authorization: "Bearer requ******cret",
+      cookie: "requ******cret",
+      "content-type": "application/json",
+      "x-api-key": "requ******cret",
+      "x-request-id": "request-123",
+    });
 
     const serializedSdkArguments = JSON.stringify({
       rootObservation: mockStartObservation.mock.calls,
       propagatedAttributes: mockPropagateAttributes.mock.calls,
-      childObservations: mockRootSpan.startObservation.mock.calls,
+      childObservations: mockStartObservation.mock.calls,
       generationUpdates: mockGenerationUpdate.mock.calls,
       generationEnds: mockGenerationEnd.mock.calls,
       guardEnds: mockGuardSpanEnd.mock.calls,
@@ -298,6 +333,58 @@ describe("traceProxyRequest", () => {
     expect(serializedSdkArguments).not.toContain("x-cch-");
     expect(serializedSdkArguments).not.toContain("future-internal-canary");
     expect(serializedSdkArguments).not.toContain("ws-session-canary");
+  });
+
+  test("records mashed client-sent headers in client_metadata", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+    const authorizationSecret = "Bearer request-authorization-secret";
+    const apiKeySecret = "request-api-key-secret";
+    const cookieSecret = "session=request-cookie-secret";
+    const basicSecret = "Basic dXNlcjpwYXNz";
+
+    await traceProxyRequest({
+      session: createMockSession({
+        headers: new Headers({
+          authorization: "Bearer filter-injected-authorization-secret",
+          "x-filter-added": "from-request-filter",
+        }),
+        getOriginalHeaders: () =>
+          new Headers({
+            authorization: authorizationSecret,
+            "x-api-key": apiKeySecret,
+            cookie: cookieSecret,
+            "x-auth-token": "short",
+            "proxy-authorization": basicSecret,
+            "content-type": "application/json",
+            "user-agent": "claude-code/1.0",
+            "x-request-id": "request-123",
+          }),
+      }),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: false,
+    });
+
+    const llmCall = getObservationCall("llm-call");
+    const clientMetadata = llmCall[1].metadata.client_metadata;
+
+    expect(clientMetadata).toEqual({
+      authorization: "Bearer requ******cret",
+      "x-api-key": "requ******cret",
+      cookie: "sess******cret",
+      "x-auth-token": "[REDACTED]",
+      "proxy-authorization": "Basi******YXNz",
+      "content-type": "application/json",
+      "user-agent": "claude-code/1.0",
+      "x-request-id": "request-123",
+    });
+    expect(clientMetadata).not.toHaveProperty("x-filter-added");
+
+    const serializedClientMetadata = JSON.stringify(clientMetadata);
+    for (const secret of [authorizationSecret, apiKeySecret, cookieSecret, basicSecret]) {
+      expect(serializedClientMetadata).not.toContain(secret);
+    }
   });
 
   test("should include provider name and model in tags", async () => {
@@ -325,6 +412,73 @@ describe("traceProxyRequest", () => {
     );
   });
 
+  test("should prefix trace name with username and include user/key/ip metadata", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+
+    await traceProxyRequest({
+      session: createMockSession(),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: false,
+    });
+
+    expect(mockPropagateAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceName: "testuser:claude-sonnet-4-20250514",
+        metadata: expect.objectContaining({
+          userName: "testuser",
+          keyName: "default-key",
+          clientIp: "192.168.1.42",
+        }),
+      })
+    );
+    expect(getObservationCall("testuser:claude-sonnet-4-20250514")).toBeDefined();
+  });
+
+  test("should use the bare model as trace name when username is absent", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+
+    await traceProxyRequest({
+      session: createMockSession({ messageContext: null, userName: undefined }),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: false,
+    });
+
+    expect(mockPropagateAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceName: "claude-sonnet-4-20250514",
+      })
+    );
+    expect(getObservationCall("claude-sonnet-4-20250514")).toBeDefined();
+  });
+
+  test("strips provider prefixes from observation and trace names at the last slash", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+
+    await traceProxyRequest({
+      session: createMockSession({
+        getCurrentModel: () => "openrouter/anthropic/claude-sonnet-4-20250514",
+      }),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: false,
+    });
+
+    expect(mockPropagateAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceName: "testuser:claude-sonnet-4-20250514",
+      })
+    );
+    expect(getObservationCall("testuser:claude-sonnet-4-20250514")).toBeDefined();
+    expect(
+      getObservationCall("testuser:openrouter/anthropic/claude-sonnet-4-20250514")
+    ).toBeUndefined();
+  });
+
   test("should include usage details when provided", async () => {
     const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
 
@@ -342,9 +496,7 @@ describe("traceProxyRequest", () => {
       costUsd: "0.0015",
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[1].usageDetails).toEqual({
       input: 100,
       output: 50,
@@ -379,9 +531,7 @@ describe("traceProxyRequest", () => {
       isStreaming: false,
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     const metadata = llmCall[1].metadata;
     expect(metadata.providerChain).toEqual(providerChain);
     expect(metadata.specialSettings).toEqual({ maxThinking: 8192 });
@@ -422,9 +572,7 @@ describe("traceProxyRequest", () => {
       isStreaming: true,
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[1].metadata.requestSummary).toEqual(
       expect.objectContaining({
         model: "claude-sonnet-4-20250514",
@@ -457,9 +605,7 @@ describe("traceProxyRequest", () => {
       isStreaming: false,
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[1].metadata.modelRedirected).toBe(true);
     expect(llmCall[1].metadata.originalModel).toBe("claude-sonnet-4-20250514");
   });
@@ -500,17 +646,20 @@ describe("traceProxyRequest", () => {
     const expectedForwardStart = new Date(startTime + 5);
 
     // Root span gets startTime in options (3rd arg)
-    expect(mockStartObservation).toHaveBeenCalledWith("proxy-request", expect.any(Object), {
-      startTime: expectedStart,
-    });
+    expect(mockStartObservation).toHaveBeenCalledWith(
+      "testuser:claude-sonnet-4-20250514",
+      expect.any(Object),
+      {
+        startTime: expectedStart,
+      }
+    );
 
     // Generation gets forwardStartTime in options (3rd arg)
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[2]).toEqual({
       asType: "generation",
       startTime: expectedForwardStart,
+      parentSpanContext: MOCK_PARENT_SPAN_CONTEXT,
     });
 
     // Both end() calls receive the computed endTime
@@ -571,16 +720,14 @@ describe("traceProxyRequest", () => {
       responseText: largeContent,
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     const output = llmCall[1].output as string;
     // Should be the full content, no truncation
     expect(output).toBe(largeContent);
     expect(output).not.toContain("...[truncated]");
   });
 
-  test("should show streaming output with sseEventCount when no responseText", async () => {
+  test("should use a bounded diagnostic when streaming output has no finalizer result and no responseText", async () => {
     const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
 
     await traceProxyRequest({
@@ -592,12 +739,12 @@ describe("traceProxyRequest", () => {
       sseEventCount: 42,
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[1].output).toEqual({
-      streaming: true,
-      sseEventCount: 42,
+      kind: "final_output_unavailable",
+      reason: "no_terminal_event",
+      eventCount: 42,
+      status: 200,
     });
   });
 
@@ -621,15 +768,9 @@ describe("traceProxyRequest", () => {
     const rootCall = mockStartObservation.mock.calls[0];
     expect(rootCall[1].output).toEqual(expectedOutput);
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[1].output).toEqual(expectedOutput);
-    expect(mockRootSpan.setTraceIO).toHaveBeenCalledWith(
-      expect.objectContaining({
-        output: expectedOutput,
-      })
-    );
+    expect(mockSetTraceIO).not.toHaveBeenCalled();
   });
 
   test("should mark missing non-stream output when request input exists", async () => {
@@ -659,15 +800,9 @@ describe("traceProxyRequest", () => {
     const rootCall = mockStartObservation.mock.calls[0];
     expect(rootCall[1].output).toEqual(expectedOutput);
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[1].output).toEqual(expectedOutput);
-    expect(mockRootSpan.setTraceIO).toHaveBeenCalledWith(
-      expect.objectContaining({
-        output: expectedOutput,
-      })
-    );
+    expect(mockSetTraceIO).not.toHaveBeenCalled();
   });
 
   test("should include costUsd in root span metadata", async () => {
@@ -690,7 +825,7 @@ describe("traceProxyRequest", () => {
     );
   });
 
-  test("should set trace-level input/output via setTraceIO with actual bodies", async () => {
+  test("should set input/output on the root observation instead of deprecated setTraceIO", async () => {
     const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
     const responseBody = { result: "ok" };
 
@@ -704,13 +839,238 @@ describe("traceProxyRequest", () => {
       costUsd: "0.05",
     });
 
-    expect(mockSetTraceIO).toHaveBeenCalledWith({
-      input: expect.objectContaining({
+    const rootCall = getObservationCall("testuser:claude-sonnet-4-20250514");
+
+    expect(rootCall?.[1].input).toEqual(
+      expect.objectContaining({
         model: "claude-sonnet-4-20250514",
         messages: expect.any(Array),
-      }),
-      output: responseBody,
+      })
+    );
+    expect(rootCall?.[1].output).toEqual(responseBody);
+    expect(mockSetTraceIO).not.toHaveBeenCalled();
+  });
+
+  test("should emit only sanitized Responses output and native Responses usage", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+    const responseBody = {
+      id: "resp_123",
+      object: "response",
+      created_at: 1,
+      completed_at: 2,
+      background: true,
+      error: null,
+      incomplete_details: null,
+      frequency_penalty: 0,
+      presence_penalty: 0,
+      temperature: 1,
+      top_p: 1,
+      top_logprobs: 0,
+      max_output_tokens: 100,
+      max_tool_calls: 2,
+      parallel_tool_calls: true,
+      tool_choice: "auto",
+      truncation: "disabled",
+      store: false,
+      previous_response_id: "resp_previous",
+      prompt_cache_key: "cache-key",
+      prompt_cache_retention: "24h",
+      reasoning: { effort: "high" },
+      safety_identifier: "user-hash",
+      service_tier: "default",
+      text: { format: { type: "text" } },
+      tools: [{ type: "function", name: "lookup" }],
+      tool_usage: { count: 1 },
+      user: "user_123",
+      metadata: { request: "metadata" },
+      status: "completed",
+      model: "gpt-5.6",
+      output: [
+        {
+          id: "msg_123",
+          type: "message",
+          status: "completed",
+          content: [{ type: "output_text", text: "Hello" }],
+        },
+        {
+          id: "fc_123",
+          type: "function_call",
+          status: "completed",
+          internal_chat_message_metadata_passthrough: { internal: true },
+          metadata: { internal: true },
+          call_id: "call_123",
+          name: "lookup",
+          arguments: '{"city":"Taipei"}',
+        },
+      ],
+      usage: {
+        input_tokens: 100,
+        input_tokens_details: { cached_tokens: 25 },
+        output_tokens: 50,
+        output_tokens_details: { reasoning_tokens: 10 },
+        total_tokens: 150,
+      },
+    };
+
+    await traceProxyRequest({
+      session: createMockSession({ originalFormat: "response" }),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: false,
+      responseText: JSON.stringify(responseBody),
     });
+
+    const expectedOutput = [
+      {
+        id: "msg_123",
+        type: "message",
+        status: "completed",
+        content: [{ type: "output_text", text: "Hello" }],
+      },
+      {
+        type: "function_call",
+        call_id: "call_123",
+        name: "lookup",
+        arguments: '{"city":"Taipei"}',
+      },
+    ];
+    const rootCall = mockStartObservation.mock.calls[0];
+    const llmCall = getObservationCall("llm-call");
+
+    expect(rootCall[1].output).toEqual(expectedOutput);
+    expect(llmCall?.[1]).toMatchObject({
+      output: expectedOutput,
+      usageDetails: responseBody.usage,
+      metadata: { response: { id: "resp_123", status: "completed", model: "gpt-5.6" } },
+    });
+    expect(mockSetTraceIO).not.toHaveBeenCalled();
+  });
+
+  test("should sanitize finalized streaming Responses output", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+    const finalResponseOutput: StreamFinalOutput = {
+      kind: "final",
+      value: {
+        id: "resp_stream",
+        object: "response",
+        status: "completed",
+        model: "gpt-5.6",
+        output: [
+          {
+            id: "tool_123",
+            type: "function_call",
+            status: "completed",
+            metadata: { hidden: true },
+            call_id: "call_123",
+          },
+        ],
+        usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+      },
+    };
+
+    await traceProxyRequest({
+      session: createMockSession({ originalFormat: "response" }),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: true,
+      finalResponseOutput,
+    });
+
+    const llmCall = getObservationCall("llm-call");
+
+    expect(llmCall?.[1]).toMatchObject({
+      output: [{ type: "function_call", call_id: "call_123" }],
+      usageDetails: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+      metadata: { response: { id: "resp_stream", status: "completed", model: "gpt-5.6" } },
+    });
+  });
+
+  test("should reuse structured streaming output across all Langfuse output sinks", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+    const finalValue = {
+      id: "chat-1",
+      object: "chat.completion",
+      choices: [{ index: 0, message: { role: "assistant", content: "hello" } }],
+    };
+    const finalResponseOutput: StreamFinalOutput = { kind: "final", value: finalValue };
+
+    await traceProxyRequest({
+      session: createMockSession({ originalFormat: "openai" }),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: true,
+      responseText: 'data: {"choices":[{"delta":{"content":"hello"}}]}\n\ndata: [DONE]\n\n',
+      finalResponseOutput,
+    });
+
+    const rootCall = mockStartObservation.mock.calls[0];
+    const llmCall = getObservationCall("llm-call");
+
+    expect(rootCall[1].output).toBe(finalValue);
+    expect(llmCall?.[1].output).toBe(finalValue);
+    expect(mockSetTraceIO).not.toHaveBeenCalled();
+    expect(JSON.stringify(rootCall[1].output)).not.toContain("data: ");
+    expect(JSON.stringify(llmCall?.[1].output)).not.toContain("data: ");
+  });
+
+  test("should use a structured diagnostic as the shared streaming output", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+    const diagnostic: StreamFinalOutput = {
+      kind: "final_output_unavailable",
+      reason: "no_terminal_event",
+      eventCount: 2,
+      framing: "sse",
+    };
+
+    await traceProxyRequest({
+      session: createMockSession(),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: true,
+      responseText: "data: partial\n\n",
+      finalResponseOutput: diagnostic,
+    });
+
+    const rootCall = mockStartObservation.mock.calls[0];
+    const llmCall = getObservationCall("llm-call");
+
+    expect(rootCall[1].output).toBe(diagnostic);
+    expect(llmCall?.[1].output).toBe(diagnostic);
+    expect(mockSetTraceIO).not.toHaveBeenCalled();
+  });
+
+  test("should use a bounded diagnostic when streaming output has no finalizer result", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+    const rawSse = 'data: {"choices":[{"delta":{"content":"partial"}}]}\n\ndata: [DONE]';
+    const diagnostic: StreamFinalOutput = {
+      kind: "final_output_unavailable",
+      reason: "no_terminal_event",
+      eventCount: 2,
+      status: 200,
+    };
+
+    await traceProxyRequest({
+      session: createMockSession({ originalFormat: "openai" }),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: true,
+      sseEventCount: 2,
+      responseText: rawSse,
+    });
+
+    const rootCall = mockStartObservation.mock.calls[0];
+    const llmCall = getObservationCall("llm-call");
+
+    expect(rootCall[1].output).toEqual(diagnostic);
+    expect(llmCall?.[1].output).toEqual(diagnostic);
+    expect(mockSetTraceIO).not.toHaveBeenCalled();
+    expect(JSON.stringify(rootCall[1].output)).not.toContain("data:");
+    expect(JSON.stringify(llmCall?.[1].output)).not.toContain("data:");
   });
 
   // --- New tests for multi-span hierarchy ---
@@ -729,14 +1089,15 @@ describe("traceProxyRequest", () => {
       isStreaming: false,
     });
 
-    const guardCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "guard-pipeline"
-    );
+    const guardCall = getObservationCall("guard-pipeline");
     expect(guardCall).toBeDefined();
     expect(guardCall[1]).toEqual({
       output: { durationMs: 8, passed: true },
     });
-    expect(guardCall[2]).toEqual({ startTime: new Date(startTime) });
+    expect(guardCall[2]).toEqual({
+      startTime: new Date(startTime),
+      parentSpanContext: MOCK_PARENT_SPAN_CONTEXT,
+    });
 
     // Guard span should end at forwardStartTime
     expect(mockGuardSpanEnd).toHaveBeenCalledWith(new Date(forwardStartTime));
@@ -753,9 +1114,7 @@ describe("traceProxyRequest", () => {
       isStreaming: false,
     });
 
-    const guardCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "guard-pipeline"
-    );
+    const guardCall = getObservationCall("guard-pipeline");
     expect(guardCall).toBeUndefined();
     expect(mockGuardSpanEnd).not.toHaveBeenCalled();
   });
@@ -803,9 +1162,7 @@ describe("traceProxyRequest", () => {
       isStreaming: false,
     });
 
-    const eventCalls = mockRootSpan.startObservation.mock.calls.filter(
-      (c: unknown[]) => c[0] === "provider-attempt"
-    );
+    const eventCalls = getObservationCalls("provider-attempt");
     // 2 failed items (retry_failed + system_error), success is skipped
     expect(eventCalls).toHaveLength(2);
 
@@ -828,6 +1185,7 @@ describe("traceProxyRequest", () => {
     expect(eventCalls[0][2]).toEqual({
       asType: "event",
       startTime: new Date(failTimestamp),
+      parentSpanContext: MOCK_PARENT_SPAN_CONTEXT,
     });
 
     // Second event: system_error -> ERROR level
@@ -849,12 +1207,11 @@ describe("traceProxyRequest", () => {
       isStreaming: false,
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[2]).toEqual({
       asType: "generation",
       startTime: new Date(forwardStartTime),
+      parentSpanContext: MOCK_PARENT_SPAN_CONTEXT,
     });
   });
 
@@ -871,12 +1228,11 @@ describe("traceProxyRequest", () => {
       isStreaming: false,
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[2]).toEqual({
       asType: "generation",
       startTime: new Date(startTime),
+      parentSpanContext: MOCK_PARENT_SPAN_CONTEXT,
     });
   });
 
@@ -917,9 +1273,7 @@ describe("traceProxyRequest", () => {
     expect(rootCall[1].metadata.timingBreakdown).toEqual(expectedTimingBreakdown);
 
     // Generation metadata should also have timingBreakdown
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[1].metadata.timingBreakdown).toEqual(expectedTimingBreakdown);
   });
 
@@ -939,9 +1293,7 @@ describe("traceProxyRequest", () => {
       isStreaming: false,
     });
 
-    const eventCalls = mockRootSpan.startObservation.mock.calls.filter(
-      (c: unknown[]) => c[0] === "provider-attempt"
-    );
+    const eventCalls = getObservationCalls("provider-attempt");
     expect(eventCalls).toHaveLength(0);
   });
 
@@ -971,11 +1323,7 @@ describe("traceProxyRequest", () => {
     const rootCall = mockStartObservation.mock.calls[0];
     expect(rootCall[1].input).toEqual(JSON.parse(forwardedBody));
 
-    // setTraceIO should also use forwarded body
-    expect(mockSetTraceIO).toHaveBeenCalledWith({
-      input: JSON.parse(forwardedBody),
-      output: { ok: true },
-    });
+    expect(mockSetTraceIO).not.toHaveBeenCalled();
   });
 
   test("should set root span level to DEFAULT for successful request", async () => {
@@ -1066,9 +1414,7 @@ describe("traceProxyRequest", () => {
       costBreakdown,
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[1].costDetails).toEqual(costBreakdown);
   });
 
@@ -1084,9 +1430,7 @@ describe("traceProxyRequest", () => {
       costUsd: "0.05",
     });
 
-    const llmCall = mockRootSpan.startObservation.mock.calls.find(
-      (c: unknown[]) => c[0] === "llm-call"
-    );
+    const llmCall = getObservationCall("llm-call");
     expect(llmCall[1].costDetails).toEqual({ total: 0.05 });
   });
 
@@ -1115,6 +1459,67 @@ describe("traceProxyRequest", () => {
     expect(metadata.durationMs).toBe(500);
     expect(metadata.costUsd).toBe("0.05");
     expect(metadata.timingBreakdown).toBeDefined();
+  });
+
+  test("creates every observation inside propagateAttributes", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+
+    await traceProxyRequest({
+      session: createMockSession(),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: false,
+    });
+
+    expect(createdInsidePropagate.length).toBeGreaterThan(0);
+    expect(createdInsidePropagate.every(Boolean)).toBe(true);
+    expect(getObservationCall("testuser:claude-sonnet-4-20250514")).toBeDefined();
+
+    expect(getObservationCall("llm-call")?.[2]).toEqual(
+      expect.objectContaining({
+        asType: "generation",
+        parentSpanContext: MOCK_PARENT_SPAN_CONTEXT,
+      })
+    );
+  });
+
+  test("clamps propagated metadata values to 200 characters", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+    const longUserAgent = `claude-code/${"x".repeat(400)}`;
+
+    await traceProxyRequest({
+      session: createMockSession({ userAgent: longUserAgent }),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: false,
+    });
+
+    expect(mockPropagateAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          userAgent: longUserAgent.slice(0, 200),
+        }),
+      })
+    );
+  });
+
+  test("omits empty propagated metadata fields", async () => {
+    const { traceProxyRequest } = await import("@/lib/langfuse/trace-proxy-request");
+
+    await traceProxyRequest({
+      session: createMockSession({ messageContext: null, userName: undefined, clientIp: null }),
+      responseHeaders: new Headers(),
+      durationMs: 500,
+      statusCode: 200,
+      isStreaming: false,
+    });
+
+    const metadata = mockPropagateAttributes.mock.calls[0][0].metadata as Record<string, string>;
+    expect(metadata).not.toHaveProperty("userName");
+    expect(metadata).not.toHaveProperty("keyName");
+    expect(metadata).not.toHaveProperty("clientIp");
   });
 });
 

--- a/tests/unit/langfuse/shutdown-timeout.test.ts
+++ b/tests/unit/langfuse/shutdown-timeout.test.ts
@@ -131,4 +131,43 @@ describe.sequential("shutdownLangfuse", () => {
     expect(elapsed).toBeGreaterThanOrEqual(40);
     expect(elapsed).toBeLessThan(500);
   });
+
+  it("passes LANGFUSE_TRACING_ENVIRONMENT and LANGFUSE_RELEASE to the span processor", async () => {
+    let received: Record<string, unknown> | undefined;
+
+    vi.doMock("@langfuse/otel", () => ({
+      LangfuseSpanProcessor: class {
+        constructor(params: Record<string, unknown>) {
+          received = params;
+          Object.assign(this, {
+            forceFlush: () => Promise.resolve(),
+          });
+        }
+      },
+    }));
+    vi.doMock("@opentelemetry/sdk-node", () => ({
+      NodeSDK: class {
+        start() {}
+        shutdown() {
+          return Promise.resolve();
+        }
+      },
+    }));
+
+    vi.stubEnv("LANGFUSE_PUBLIC_KEY", "pk-test");
+    vi.stubEnv("LANGFUSE_SECRET_KEY", "sk-test");
+    vi.stubEnv("LANGFUSE_TRACING_ENVIRONMENT", "production");
+    vi.stubEnv("LANGFUSE_RELEASE", "0.9.3");
+
+    const { initLangfuse, shutdownLangfuse } = await import("@/lib/langfuse");
+    await initLangfuse();
+
+    expect(received).toEqual(
+      expect.objectContaining({
+        environment: "production",
+        release: "0.9.3",
+      })
+    );
+    await shutdownLangfuse();
+  });
 });

--- a/tests/unit/langfuse/stream-final-output-anthropic.test.ts
+++ b/tests/unit/langfuse/stream-final-output-anthropic.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test } from "vitest";
+import type {
+  ParsedStreamFrames,
+  StreamFrame,
+  StreamFinalOutput,
+} from "@/lib/langfuse/stream-final-output-core";
+import { finalizeAnthropicStreamOutput } from "@/lib/langfuse/stream-final-output-anthropic";
+
+function frame(event: string, data: unknown): StreamFrame {
+  return { framing: "sse", event, data };
+}
+
+function frames(...items: StreamFrame[]): ParsedStreamFrames {
+  return { kind: "frames", framing: "sse", frames: items };
+}
+
+function contentBlockStart(index: number, contentBlock: unknown): StreamFrame {
+  return frame("content_block_start", {
+    type: "content_block_start",
+    index,
+    content_block: contentBlock,
+  });
+}
+
+function contentBlockDelta(index: unknown, delta: unknown): StreamFrame {
+  return frame("content_block_delta", { type: "content_block_delta", index, delta });
+}
+
+function contentBlockStop(index: number): StreamFrame {
+  return frame("content_block_stop", { type: "content_block_stop", index });
+}
+
+function expectFinal(result: StreamFinalOutput): {
+  readonly kind: "final";
+  readonly value: unknown;
+} {
+  expect(result.kind).toBe("final");
+  if (result.kind !== "final") {
+    throw new Error("Expected final output");
+  }
+  return result;
+}
+
+describe("finalizeAnthropicStreamOutput", () => {
+  test("reconstructs text, thinking, signature, tool input, and final usage", () => {
+    const result = expectFinal(
+      finalizeAnthropicStreamOutput(
+        frames(
+          frame("message_start", {
+            type: "message_start",
+            message: {
+              id: "msg_123",
+              type: "message",
+              role: "assistant",
+              model: "claude-test",
+              content: [],
+              stop_reason: null,
+              stop_sequence: null,
+              usage: { input_tokens: 4 },
+              vendor_message_field: "preserve-me",
+            },
+          }),
+          contentBlockStart(0, { type: "text", text: "", vendor_block_field: "keep-me" }),
+          contentBlockDelta(0, { type: "text_delta", text: "Hello" }),
+          contentBlockDelta(0, { type: "text_delta", text: " world" }),
+          contentBlockStart(1, { type: "thinking", thinking: "" }),
+          contentBlockDelta(1, { type: "thinking_delta", thinking: "reason" }),
+          contentBlockDelta(1, { type: "thinking_delta", thinking: "ing" }),
+          contentBlockDelta(1, { type: "signature_delta", signature: "sig-part" }),
+          contentBlockStart(2, {
+            type: "tool_use",
+            id: "tool_123",
+            name: "search",
+            input: {},
+            vendor_tool_field: 7,
+          }),
+          contentBlockDelta(2, { type: "input_json_delta", partial_json: '{"query":"ca' }),
+          contentBlockDelta(2, { type: "input_json_delta", partial_json: 'ts","limit":' }),
+          contentBlockDelta(2, { type: "input_json_delta", partial_json: "2}" }),
+          contentBlockStop(0),
+          contentBlockStop(1),
+          contentBlockStop(2),
+          frame("message_delta", {
+            type: "message_delta",
+            delta: { stop_reason: "tool_use", stop_sequence: null },
+            usage: { output_tokens: 12 },
+          }),
+          frame("message_stop", { type: "message_stop" })
+        )
+      )
+    );
+
+    expect(result.value).toEqual({
+      id: "msg_123",
+      type: "message",
+      role: "assistant",
+      model: "claude-test",
+      content: [
+        { type: "text", text: "Hello world", vendor_block_field: "keep-me" },
+        { type: "thinking", thinking: "reasoning", signature: "sig-part" },
+        {
+          type: "tool_use",
+          id: "tool_123",
+          name: "search",
+          input: { query: "cats", limit: 2 },
+          vendor_tool_field: 7,
+        },
+      ],
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      usage: { input_tokens: 4, output_tokens: 12 },
+      vendor_message_field: "preserve-me",
+    });
+  });
+
+  test("orders completed blocks by event index rather than arrival order", () => {
+    const result = expectFinal(
+      finalizeAnthropicStreamOutput(
+        frames(
+          frame("message_start", {
+            type: "message_start",
+            message: { id: "msg_order", type: "message", content: [] },
+          }),
+          contentBlockStart(2, { type: "text", text: "" }),
+          contentBlockDelta(2, { type: "text_delta", text: "third" }),
+          contentBlockStart(0, { type: "text", text: "" }),
+          contentBlockDelta(0, { type: "text_delta", text: "first" }),
+          contentBlockStart(1, { type: "text", text: "" }),
+          contentBlockDelta(1, { type: "text_delta", text: "second" }),
+          contentBlockStop(2),
+          contentBlockStop(0),
+          contentBlockStop(1),
+          frame("message_stop", { type: "message_stop" })
+        )
+      )
+    );
+
+    expect(result.value).toMatchObject({
+      content: [
+        { type: "text", text: "first" },
+        { type: "text", text: "second" },
+        { type: "text", text: "third" },
+      ],
+    });
+  });
+
+  test("returns malformed_frame when tool JSON is incomplete at block stop", () => {
+    const result = finalizeAnthropicStreamOutput(
+      frames(
+        frame("message_start", {
+          type: "message_start",
+          message: { id: "msg_bad_tool", type: "message", content: [] },
+        }),
+        contentBlockStart(0, { type: "tool_use", id: "tool_bad", name: "search", input: {} }),
+        contentBlockDelta(0, { type: "input_json_delta", partial_json: '{"secret":"partial' }),
+        contentBlockStop(0),
+        frame("message_stop", { type: "message_stop" })
+      )
+    );
+
+    expect(result).toMatchObject({
+      kind: "final_output_unavailable",
+      reason: "malformed_frame",
+    });
+    expect(JSON.stringify(result)).not.toContain("partial");
+    expect(JSON.stringify(result)).not.toContain("data:");
+  });
+
+  test("returns no_terminal_event when message_stop is absent", () => {
+    const result = finalizeAnthropicStreamOutput(
+      frames(
+        frame("message_start", {
+          type: "message_start",
+          message: { id: "msg_incomplete", type: "message", content: [] },
+        }),
+        contentBlockStart(0, { type: "text", text: "" }),
+        contentBlockDelta(0, { type: "text_delta", text: "unfinished" })
+      )
+    );
+
+    expect(result).toEqual({
+      kind: "final_output_unavailable",
+      reason: "no_terminal_event",
+      eventCount: 3,
+      framing: "sse",
+    });
+  });
+
+  test("returns a bounded malformed diagnostic for malformed event data", () => {
+    const result = finalizeAnthropicStreamOutput(
+      frames(
+        frame("message_start", {
+          type: "message_start",
+          message: { secret: "model-output" },
+        }),
+        contentBlockDelta("not-an-index", { type: "text_delta", text: "hidden" })
+      )
+    );
+
+    expect(result).toMatchObject({
+      kind: "final_output_unavailable",
+      reason: "malformed_frame",
+      eventCount: 2,
+      framing: "sse",
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("model-output");
+    expect(serialized).not.toContain("hidden");
+    expect(serialized).not.toContain("data:");
+  });
+
+  test("returns malformed_frame for an unknown content block delta type", () => {
+    const result = finalizeAnthropicStreamOutput(
+      frames(
+        frame("message_start", {
+          type: "message_start",
+          message: { id: "msg_unknown_delta", type: "message", content: [] },
+        }),
+        contentBlockStart(0, { type: "text", text: "" }),
+        contentBlockDelta(0, { type: "unknown_delta", text: "hidden" })
+      )
+    );
+
+    expect(result).toEqual({
+      kind: "final_output_unavailable",
+      reason: "malformed_frame",
+      eventCount: 3,
+      framing: "sse",
+    });
+    expect(JSON.stringify(result)).not.toContain("hidden");
+  });
+
+  test("ignores ping events while reconstructing a message", () => {
+    const result = expectFinal(
+      finalizeAnthropicStreamOutput(
+        frames(
+          frame("message_start", {
+            type: "message_start",
+            message: { id: "msg_ping", type: "message", content: [] },
+          }),
+          frame("ping", { type: "ping" }),
+          contentBlockStart(0, { type: "text", text: "" }),
+          contentBlockDelta(0, { type: "text_delta", text: "still complete" }),
+          contentBlockStop(0),
+          frame("message_stop", { type: "message_stop" })
+        )
+      )
+    );
+
+    expect(result.value).toMatchObject({
+      id: "msg_ping",
+      content: [{ type: "text", text: "still complete" }],
+    });
+  });
+});

--- a/tests/unit/langfuse/stream-final-output-core.test.ts
+++ b/tests/unit/langfuse/stream-final-output-core.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "vitest";
+import {
+  finalizeStreamOutput,
+  parseStreamFrames,
+  type ParseStreamFramesResult,
+  type ParsedStreamFrames,
+} from "@/lib/langfuse/stream-final-output-core";
+
+function expectFrames(result: ParseStreamFramesResult): ParsedStreamFrames {
+  expect(result.kind).toBe("frames");
+  if (result.kind !== "frames") {
+    throw new Error("Expected parsed stream frames");
+  }
+  return result;
+}
+
+describe("parseStreamFrames", () => {
+  test("parses ordered SSE events with parsed JSON data", () => {
+    const streamText = [
+      "event: message_start",
+      'data: {"type":"message_start"}',
+      "",
+      "event: content_block_delta",
+      'data: {"type":"content_block_delta","text":"Hello"}',
+      "",
+      "event: message_stop",
+      'data: {"type":"message_stop"}',
+      "",
+    ].join("\n");
+
+    const result = expectFrames(parseStreamFrames(streamText));
+
+    expect(result).toEqual({
+      kind: "frames",
+      framing: "sse",
+      frames: [
+        {
+          framing: "sse",
+          event: "message_start",
+          data: { type: "message_start" },
+        },
+        {
+          framing: "sse",
+          event: "content_block_delta",
+          data: { type: "content_block_delta", text: "Hello" },
+        },
+        {
+          framing: "sse",
+          event: "message_stop",
+          data: { type: "message_stop" },
+        },
+      ],
+    });
+  });
+
+  test("preserves the SSE completion sentinel for protocol parsers", () => {
+    const result = expectFrames(parseStreamFrames('data: {"type":"done"}\n\ndata: [DONE]\n\n'));
+
+    expect(result.frames).toEqual([
+      {
+        framing: "sse",
+        event: "message",
+        data: { type: "done" },
+      },
+      {
+        framing: "sse",
+        event: "message",
+        data: "[DONE]",
+      },
+    ]);
+  });
+
+  test("parses ordered NDJSON object records", () => {
+    const streamText = [
+      '{"type":"response.output_text.delta","text":"Hello"}',
+      '{"type":"response.completed","status":"completed"}',
+    ].join("\n");
+
+    const result = expectFrames(parseStreamFrames(streamText));
+
+    expect(result.framing).toBe("ndjson");
+    expect(result.frames).toEqual([
+      {
+        framing: "ndjson",
+        event: null,
+        data: { type: "response.output_text.delta", text: "Hello" },
+      },
+      {
+        framing: "ndjson",
+        event: null,
+        data: { type: "response.completed", status: "completed" },
+      },
+    ]);
+  });
+
+  test("parses a JSON array as ordered records", () => {
+    const result = expectFrames(
+      parseStreamFrames('[{"type":"candidate","text":"Hello"},{"type":"done"}]')
+    );
+
+    expect(result.framing).toBe("json-array");
+    expect(result.frames).toEqual([
+      {
+        framing: "json-array",
+        event: null,
+        data: { type: "candidate", text: "Hello" },
+      },
+      {
+        framing: "json-array",
+        event: null,
+        data: { type: "done" },
+      },
+    ]);
+  });
+
+  test("returns accumulator_truncated before parsing an otherwise valid stream", () => {
+    const streamText =
+      'data: {"type":"message_start"}\n\n\n: [cch_truncated]\n\ndata: {"type":"message_stop"}\n\n';
+
+    const result = parseStreamFrames(streamText);
+
+    expect(result).toEqual({
+      kind: "final_output_unavailable",
+      reason: "accumulator_truncated",
+      eventCount: 0,
+    });
+    expect(JSON.stringify(result)).not.toContain("message_start");
+  });
+
+  test("returns malformed_frame for malformed JSON in an SSE data line", () => {
+    const streamText = 'event: message\ndata: {"secret":"model-output"\n\n';
+
+    const result = parseStreamFrames(streamText);
+
+    expect(result).toMatchObject({
+      kind: "final_output_unavailable",
+      reason: "malformed_frame",
+      eventCount: 1,
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("data:");
+    expect(serialized).not.toContain("model-output");
+  });
+
+  test("returns malformed_frame for malformed JSON in NDJSON", () => {
+    const streamText = '{"type":"valid"}\n{"secret":"model-output"';
+
+    const result = parseStreamFrames(streamText);
+
+    expect(result).toMatchObject({
+      kind: "final_output_unavailable",
+      reason: "malformed_frame",
+      eventCount: 1,
+    });
+    expect(JSON.stringify(result)).not.toContain("model-output");
+  });
+
+  test("returns empty_stream for empty input", () => {
+    expect(parseStreamFrames("\n  \n")).toEqual({
+      kind: "final_output_unavailable",
+      reason: "empty_stream",
+      eventCount: 0,
+    });
+  });
+
+  test("returns unsupported_framing for non-framed text", () => {
+    expect(parseStreamFrames("plain model output")).toEqual({
+      kind: "final_output_unavailable",
+      reason: "unsupported_framing",
+      eventCount: 0,
+    });
+  });
+});
+
+describe("finalizeStreamOutput", () => {
+  test("returns a native final output when its JSON representation is within budget", () => {
+    const value = { type: "message", content: [{ type: "text", text: "Hello" }] };
+
+    expect(finalizeStreamOutput(value, { eventCount: 2, status: 200 })).toEqual({
+      kind: "final",
+      value,
+    });
+  });
+
+  test("returns over_budget without partial output or raw body text", () => {
+    const rawModelOutput = "model-output-".repeat(100_000);
+    const value = { content: rawModelOutput };
+
+    const result = finalizeStreamOutput(value, { eventCount: 42, status: 200 });
+
+    expect(result).toMatchObject({
+      kind: "final_output_unavailable",
+      reason: "over_budget",
+      status: 200,
+      eventCount: 42,
+    });
+    if (result.kind !== "final_output_unavailable") {
+      throw new Error("Expected over-budget diagnostic");
+    }
+    expect(result.serializedBytes).toBeGreaterThan(result.maxSerializedBytes);
+    expect(JSON.stringify(result)).not.toContain(rawModelOutput);
+    expect(JSON.stringify(result)).not.toContain("model-output-");
+  });
+});

--- a/tests/unit/langfuse/stream-final-output-gemini.test.ts
+++ b/tests/unit/langfuse/stream-final-output-gemini.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from "vitest";
+import {
+  parseStreamFrames,
+  type ParseStreamFramesResult,
+  type ParsedStreamFrames,
+} from "@/lib/langfuse/stream-final-output-core";
+import { finalizeGeminiStreamOutput } from "@/lib/langfuse/stream-final-output-gemini";
+
+function expectFrames(result: ParseStreamFramesResult): ParsedStreamFrames {
+  expect(result.kind).toBe("frames");
+  if (result.kind !== "frames") {
+    throw new Error("Expected parsed stream frames");
+  }
+  return result;
+}
+
+function expectFinalValue(result: ReturnType<typeof finalizeGeminiStreamOutput>): unknown {
+  expect(result.kind).toBe("final");
+  if (result.kind !== "final") {
+    throw new Error("Expected a final Gemini response");
+  }
+  return result.value;
+}
+
+describe("finalizeGeminiStreamOutput", () => {
+  test("folds direct Gemini SSE candidates, text, function parts, and final metadata", () => {
+    const streamText = [
+      'data: {"candidates":[{"index":0,"content":{"role":"model","parts":[{"text":"Hel"}]}},{"index":1,"content":{"role":"model","parts":[{"functionCall":{"name":"lookup","args":{"query":"weather"}}}]}}],"modelVersion":"gemini-2.5-flash","promptFeedback":{"blockReason":"BLOCKED"}}',
+      "",
+      'data: {"candidates":[{"index":1,"content":{"parts":[{"functionResponse":{"name":"lookup","response":{"temperature":21}}}]},"finishReason":"STOP","safetyRatings":[{"category":"HARM_CATEGORY_HARASSMENT","probability":"NEGLIGIBLE"}]},{"index":0,"content":{"parts":[{"text":"lo"}]},"finishReason":"STOP","citationMetadata":{"citationSources":[{"startIndex":0,"endIndex":5,"uri":"https://example.test/source","license":"CC"}]}}],"usageMetadata":{"promptTokenCount":4,"candidatesTokenCount":6,"totalTokenCount":10},"responseId":"response-2"}',
+      "",
+    ].join("\n");
+
+    const result = finalizeGeminiStreamOutput(expectFrames(parseStreamFrames(streamText)));
+
+    expect(result).toEqual({
+      kind: "final",
+      value: {
+        candidates: [
+          {
+            index: 0,
+            content: {
+              role: "model",
+              parts: [{ text: "Hello" }],
+            },
+            finishReason: "STOP",
+            citationMetadata: {
+              citationSources: [
+                {
+                  startIndex: 0,
+                  endIndex: 5,
+                  uri: "https://example.test/source",
+                  license: "CC",
+                },
+              ],
+            },
+          },
+          {
+            index: 1,
+            content: {
+              role: "model",
+              parts: [
+                { functionCall: { name: "lookup", args: { query: "weather" } } },
+                {
+                  functionResponse: {
+                    name: "lookup",
+                    response: { temperature: 21 },
+                  },
+                },
+              ],
+            },
+            finishReason: "STOP",
+            safetyRatings: [
+              {
+                category: "HARM_CATEGORY_HARASSMENT",
+                probability: "NEGLIGIBLE",
+              },
+            ],
+          },
+        ],
+        modelVersion: "gemini-2.5-flash",
+        promptFeedback: { blockReason: "BLOCKED" },
+        usageMetadata: {
+          promptTokenCount: 4,
+          candidatesTokenCount: 6,
+          totalTokenCount: 10,
+        },
+        responseId: "response-2",
+      },
+    });
+  });
+
+  test("folds direct Gemini NDJSON by candidate position and keeps latest metadata", () => {
+    const streamText = [
+      JSON.stringify({
+        candidates: [{ content: { role: "model", parts: [{ text: "A" }] } }],
+        modelVersion: "gemini-old",
+      }),
+      JSON.stringify({
+        candidates: [{ content: { parts: [{ text: "B" }] }, finishReason: "STOP" }],
+        usageMetadata: {
+          promptTokenCount: 1,
+          candidatesTokenCount: 2,
+          totalTokenCount: 3,
+        },
+      }),
+      JSON.stringify({ modelVersion: "gemini-latest", responseId: "response-3" }),
+    ].join("\n");
+
+    const result = finalizeGeminiStreamOutput(expectFrames(parseStreamFrames(streamText)));
+
+    expect(expectFinalValue(result)).toEqual({
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [{ text: "AB" }],
+          },
+          finishReason: "STOP",
+        },
+      ],
+      modelVersion: "gemini-latest",
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 2,
+        totalTokenCount: 3,
+      },
+      responseId: "response-3",
+    });
+  });
+
+  test("folds JSON-array frames into a native Gemini response", () => {
+    const streamText = JSON.stringify([
+      {
+        candidates: [
+          {
+            index: 0,
+            content: { role: "model", parts: [{ text: "array" }] },
+          },
+        ],
+      },
+      {
+        candidates: [{ index: 0, finishReason: "STOP" }],
+        usageMetadata: {
+          promptTokenCount: 2,
+          candidatesTokenCount: 5,
+          totalTokenCount: 7,
+        },
+      },
+    ]);
+
+    const result = finalizeGeminiStreamOutput(expectFrames(parseStreamFrames(streamText)));
+
+    expect(expectFinalValue(result)).toEqual({
+      candidates: [
+        {
+          index: 0,
+          content: {
+            role: "model",
+            parts: [{ text: "array" }],
+          },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 2,
+        candidatesTokenCount: 5,
+        totalTokenCount: 7,
+      },
+    });
+  });
+
+  test("preserves the Gemini CLI response envelope while folding its inner response", () => {
+    const streamText = [
+      JSON.stringify({
+        response: {
+          candidates: [
+            {
+              content: { role: "model", parts: [{ text: "cli " }] },
+            },
+          ],
+          modelVersion: "gemini-cli-model",
+        },
+        sessionId: "session-1",
+      }),
+      JSON.stringify({
+        response: {
+          candidates: [{ content: { parts: [{ text: "answer" }] }, finishReason: "STOP" }],
+          usageMetadata: {
+            promptTokenCount: 3,
+            candidatesTokenCount: 4,
+            totalTokenCount: 7,
+          },
+        },
+        traceId: "trace-2",
+      }),
+    ].join("\n");
+
+    const result = finalizeGeminiStreamOutput(expectFrames(parseStreamFrames(streamText)));
+
+    expect(expectFinalValue(result)).toEqual({
+      response: {
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [{ text: "cli answer" }],
+            },
+            finishReason: "STOP",
+          },
+        ],
+        modelVersion: "gemini-cli-model",
+        usageMetadata: {
+          promptTokenCount: 3,
+          candidatesTokenCount: 4,
+          totalTokenCount: 7,
+        },
+      },
+      sessionId: "session-1",
+      traceId: "trace-2",
+    });
+  });
+
+  test("returns empty_stream for an empty parsed frame list", () => {
+    const result = finalizeGeminiStreamOutput({
+      kind: "frames",
+      framing: "ndjson",
+      frames: [],
+    });
+
+    expect(result).toEqual({
+      kind: "final_output_unavailable",
+      reason: "empty_stream",
+      eventCount: 0,
+      framing: "ndjson",
+    });
+  });
+
+  test("returns no_terminal_event without retaining incomplete text", () => {
+    const streamText = JSON.stringify({
+      candidates: [{ content: { role: "model", parts: [{ text: "partial-secret" }] } }],
+    });
+    const result = finalizeGeminiStreamOutput(expectFrames(parseStreamFrames(streamText)));
+
+    expect(result).toEqual({
+      kind: "final_output_unavailable",
+      reason: "no_terminal_event",
+      eventCount: 1,
+      framing: "ndjson",
+    });
+    expect(JSON.stringify(result)).not.toContain("partial-secret");
+  });
+
+  test("core malformed NDJSON diagnostics contain no raw NDJSON payload", () => {
+    const result = parseStreamFrames(
+      `${JSON.stringify({ candidates: [{ content: { parts: [{ text: "safe-secret" }] } }] })}\n{"secret":"partial`
+    );
+
+    expect(result).toMatchObject({
+      kind: "final_output_unavailable",
+      reason: "malformed_frame",
+      framing: "ndjson",
+    });
+    expect(JSON.stringify(result)).not.toContain("safe-secret");
+    expect(JSON.stringify(result)).not.toContain("partial");
+  });
+});

--- a/tests/unit/langfuse/stream-final-output-openai.test.ts
+++ b/tests/unit/langfuse/stream-final-output-openai.test.ts
@@ -1,0 +1,519 @@
+import { describe, expect, test } from "vitest";
+import type {
+  ParsedStreamFrames,
+  StreamFinalOutput,
+} from "@/lib/langfuse/stream-final-output-core";
+import {
+  finalizeOpenAIChatStream,
+  finalizeOpenAIResponsesStream,
+} from "@/lib/langfuse/stream-final-output-openai";
+
+type FrameRecord = {
+  readonly event?: string;
+  readonly data: unknown;
+};
+
+function frames(records: readonly FrameRecord[]): ParsedStreamFrames {
+  return {
+    kind: "frames",
+    framing: "sse",
+    frames: records.map((record) => ({
+      framing: "sse",
+      event: record.event ?? "message",
+      data: record.data,
+    })),
+  };
+}
+
+function finalValue(result: StreamFinalOutput): Record<string, unknown> {
+  expect(result.kind).toBe("final");
+  if (result.kind !== "final") {
+    throw new Error("Expected a final output");
+  }
+  if (!isRecord(result.value)) {
+    throw new Error("Expected an object final output");
+  }
+  return result.value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+describe("finalizeOpenAIChatStream", () => {
+  test("returns no_terminal_event for a DONE-only stream", () => {
+    const result = finalizeOpenAIChatStream(frames([{ data: "[DONE]" }]));
+
+    expect(result).toEqual({
+      kind: "final_output_unavailable",
+      reason: "no_terminal_event",
+      eventCount: 1,
+      framing: "sse",
+    });
+  });
+
+  test("returns no_terminal_event for a partial stream without DONE or finish reasons", () => {
+    const result = finalizeOpenAIChatStream(
+      frames([
+        {
+          data: {
+            id: "chatcmpl-partial",
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant", content: "unfinished" },
+                finish_reason: null,
+              },
+            ],
+          },
+        },
+      ])
+    );
+
+    expect(result).toEqual({
+      kind: "final_output_unavailable",
+      reason: "no_terminal_event",
+      eventCount: 1,
+      framing: "sse",
+    });
+  });
+
+  test("returns no_terminal_event when DONE follows a choice with a null finish reason", () => {
+    const result = finalizeOpenAIChatStream(
+      frames([
+        {
+          data: {
+            id: "chatcmpl-truncated",
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant", content: "truncated" },
+                finish_reason: null,
+              },
+            ],
+          },
+        },
+        { data: "[DONE]" },
+      ])
+    );
+
+    expect(result).toEqual({
+      kind: "final_output_unavailable",
+      reason: "no_terminal_event",
+      eventCount: 2,
+      framing: "sse",
+    });
+  });
+
+  test("finalizes all choices with non-null finish reasons without DONE", () => {
+    const result = finalizeOpenAIChatStream(
+      frames([
+        {
+          data: {
+            id: "chatcmpl-finished",
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant", content: "first" },
+                finish_reason: "stop",
+              },
+              {
+                index: 1,
+                delta: { role: "assistant", content: "second" },
+                finish_reason: "length",
+              },
+            ],
+          },
+        },
+      ])
+    );
+
+    expect(finalValue(result)).toMatchObject({
+      id: "chatcmpl-finished",
+      choices: [
+        { index: 0, message: { content: "first" }, finish_reason: "stop" },
+        { index: 1, message: { content: "second" }, finish_reason: "length" },
+      ],
+    });
+  });
+
+  test("concatenates reasoning-only deltas into one native chat completion", () => {
+    const result = finalizeOpenAIChatStream(
+      frames([
+        {
+          data: {
+            id: "chatcmpl-reasoning",
+            object: "chat.completion.chunk",
+            created: 100,
+            model: "gpt-test",
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant", reasoning_content: "First " },
+                finish_reason: null,
+              },
+            ],
+          },
+        },
+        {
+          data: {
+            id: "chatcmpl-reasoning",
+            object: "chat.completion.chunk",
+            created: 100,
+            model: "gpt-test",
+            choices: [
+              {
+                index: 0,
+                delta: { reasoning_content: "second" },
+                finish_reason: null,
+              },
+            ],
+          },
+        },
+        {
+          data: {
+            id: "chatcmpl-reasoning",
+            object: "chat.completion.chunk",
+            created: 100,
+            model: "gpt-test",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          },
+        },
+        { data: "[DONE]" },
+      ])
+    );
+
+    expect(finalValue(result)).toEqual({
+      id: "chatcmpl-reasoning",
+      object: "chat.completion",
+      created: 100,
+      model: "gpt-test",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", reasoning_content: "First second" },
+          finish_reason: "stop",
+          logprobs: null,
+        },
+      ],
+    });
+  });
+
+  test("folds choices by index and retains first role, id, and names", () => {
+    const result = finalizeOpenAIChatStream(
+      frames([
+        {
+          data: {
+            id: "chatcmpl-multi",
+            object: "chat.completion.chunk",
+            created: 101,
+            model: "gpt-test",
+            choices: [
+              {
+                index: 1,
+                delta: { role: "assistant", id: "message-1", name: "first-name", content: "B" },
+                finish_reason: null,
+              },
+              {
+                index: 0,
+                delta: { role: "assistant", id: "message-0", name: "zero-name", content: "A" },
+                finish_reason: null,
+              },
+            ],
+          },
+        },
+        {
+          data: {
+            id: "chatcmpl-multi",
+            object: "chat.completion.chunk",
+            created: 101,
+            model: "gpt-test",
+            choices: [
+              {
+                index: 0,
+                delta: { id: "later-0", name: "later-name", content: "0" },
+                finish_reason: "stop",
+              },
+              {
+                index: 1,
+                delta: { id: "later-1", content: "1" },
+                finish_reason: "length",
+              },
+            ],
+          },
+        },
+      ])
+    );
+
+    expect(finalValue(result)).toMatchObject({
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            id: "message-0",
+            name: "zero-name",
+            content: "A0",
+          },
+          finish_reason: "stop",
+        },
+        {
+          index: 1,
+          message: {
+            role: "assistant",
+            id: "message-1",
+            name: "first-name",
+            content: "B1",
+          },
+          finish_reason: "length",
+        },
+      ],
+    });
+  });
+
+  test("concatenates indexed tool-call and legacy function arguments", () => {
+    const result = finalizeOpenAIChatStream(
+      frames([
+        {
+          data: {
+            id: "chatcmpl-tools",
+            object: "chat.completion.chunk",
+            created: 102,
+            model: "gpt-tools",
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  role: "assistant",
+                  function_call: { name: "legacy", arguments: '{"a":' },
+                  tool_calls: [
+                    {
+                      index: 1,
+                      id: "call-1",
+                      type: "function",
+                      function: { name: "second", arguments: '{"b":' },
+                    },
+                    {
+                      index: 0,
+                      id: "call-0",
+                      type: "function",
+                      function: { name: "first", arguments: '{"c":' },
+                    },
+                  ],
+                },
+                finish_reason: null,
+              },
+            ],
+          },
+        },
+        {
+          data: {
+            id: "chatcmpl-tools",
+            object: "chat.completion.chunk",
+            created: 102,
+            model: "gpt-tools",
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  function_call: { name: "later", arguments: "1}" },
+                  tool_calls: [
+                    {
+                      index: 1,
+                      id: null,
+                      type: null,
+                      function: { name: null, arguments: "2}" },
+                    },
+                    {
+                      index: 0,
+                      function: { arguments: "3}" },
+                    },
+                  ],
+                },
+                finish_reason: "tool_calls",
+              },
+            ],
+          },
+        },
+      ])
+    );
+
+    expect(finalValue(result)).toMatchObject({
+      choices: [
+        {
+          message: {
+            function_call: { name: "legacy", arguments: '{"a":1}' },
+            tool_calls: [
+              {
+                index: 0,
+                id: "call-0",
+                type: "function",
+                function: { name: "first", arguments: '{"c":3}' },
+              },
+              {
+                index: 1,
+                id: "call-1",
+                type: "function",
+                function: { name: "second", arguments: '{"b":2}' },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    });
+  });
+
+  test("does not let null deltas overwrite accumulated values and applies final metadata", () => {
+    const usage = { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 };
+    const logprobs = { content: [{ token: "hello" }] };
+    const result = finalizeOpenAIChatStream(
+      frames([
+        {
+          data: {
+            id: "chatcmpl-meta",
+            object: "chat.completion.chunk",
+            created: 103,
+            model: "gpt-meta",
+            system_fingerprint: "fp-1",
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant", content: "hello", reasoning_content: "think" },
+                finish_reason: null,
+                logprobs: null,
+              },
+            ],
+          },
+        },
+        {
+          data: {
+            id: null,
+            object: "chat.completion.chunk",
+            created: null,
+            model: null,
+            system_fingerprint: null,
+            choices: [
+              {
+                index: 0,
+                delta: { role: null, content: null, reasoning_content: null },
+                finish_reason: "stop",
+                logprobs,
+              },
+            ],
+            usage,
+          },
+        },
+      ])
+    );
+
+    expect(finalValue(result)).toEqual({
+      id: "chatcmpl-meta",
+      object: "chat.completion",
+      created: 103,
+      model: "gpt-meta",
+      system_fingerprint: "fp-1",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "hello", reasoning_content: "think" },
+          finish_reason: "stop",
+          logprobs,
+        },
+      ],
+      usage,
+    });
+  });
+});
+
+describe("finalizeOpenAIResponsesStream", () => {
+  test("returns the native response from response.completed", () => {
+    const response = {
+      id: "resp-complete",
+      object: "response",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+    };
+
+    const result = finalizeOpenAIResponsesStream(
+      frames([
+        { event: "response.created", data: { type: "response.created" } },
+        { event: "response.completed", data: { type: "response.completed", response } },
+      ])
+    );
+
+    expect(finalValue(result)).toEqual(response);
+  });
+
+  test("retains an incomplete response and its incomplete details", () => {
+    const response = {
+      id: "resp-incomplete",
+      object: "response",
+      status: "incomplete",
+      output: [],
+    };
+    const incompleteDetails = { reason: "max_output_tokens" };
+
+    const result = finalizeOpenAIResponsesStream(
+      frames([
+        {
+          event: "response.incomplete",
+          data: {
+            type: "response.incomplete",
+            response,
+            incomplete_details: incompleteDetails,
+          },
+        },
+      ])
+    );
+
+    expect(finalValue(result)).toEqual({ ...response, incomplete_details: incompleteDetails });
+  });
+
+  test("returns a stream_error diagnostic for response.failed", () => {
+    const result = finalizeOpenAIResponsesStream(
+      frames([
+        {
+          event: "response.failed",
+          data: { type: "response.failed", response: { status: "failed" } },
+        },
+      ])
+    );
+
+    expect(result).toEqual({
+      kind: "final_output_unavailable",
+      reason: "stream_error",
+      eventCount: 1,
+      framing: "sse",
+    });
+  });
+
+  test("returns a stream_error diagnostic for an error event", () => {
+    const result = finalizeOpenAIResponsesStream(
+      frames([{ event: "error", data: { type: "error", message: "upstream failed" } }])
+    );
+
+    expect(result).toMatchObject({
+      kind: "final_output_unavailable",
+      reason: "stream_error",
+      eventCount: 1,
+    });
+    expect(JSON.stringify(result)).not.toContain("upstream failed");
+  });
+
+  test("returns no_terminal_event when no terminal response event exists", () => {
+    const result = finalizeOpenAIResponsesStream(
+      frames([
+        { event: "response.output_text.delta", data: { type: "response.output_text.delta" } },
+      ])
+    );
+
+    expect(result).toEqual({
+      kind: "final_output_unavailable",
+      reason: "no_terminal_event",
+      eventCount: 1,
+      framing: "sse",
+    });
+  });
+});

--- a/tests/unit/langfuse/stream-final-output.test.ts
+++ b/tests/unit/langfuse/stream-final-output.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test, vi } from "vitest";
+import { finalizeStreamOutputForClient } from "@/lib/langfuse/stream-final-output";
+
+const anthropicStream = [
+  "event: message_start",
+  'data: {"type":"message_start","message":{"id":"msg-1","type":"message","role":"assistant","content":[]}}',
+  "",
+  "event: content_block_start",
+  'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+  "",
+  "event: content_block_delta",
+  'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}',
+  "",
+  "event: content_block_stop",
+  'data: {"type":"content_block_stop","index":0}',
+  "",
+  "event: message_stop",
+  'data: {"type":"message_stop"}',
+  "",
+].join("\n");
+
+const openAiChatStream = [
+  'data: {"id":"chat-1","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
+
+const openAiResponsesStream = [
+  "event: response.completed",
+  'data: {"type":"response.completed","response":{"id":"response-1","object":"response","status":"completed","output":[]}}',
+  "",
+].join("\n");
+
+const geminiStream = [
+  'data: {"candidates":[{"content":{"parts":[{"text":"hello"}]},"finishReason":"STOP"}]}',
+  "",
+].join("\n");
+
+const geminiCliStream = [
+  JSON.stringify({
+    response: {
+      candidates: [{ content: { parts: [{ text: "hello" }] }, finishReason: "STOP" }],
+    },
+    sessionId: "session-1",
+  }),
+].join("\n");
+
+describe("finalizeStreamOutputForClient", () => {
+  test.each([
+    ["claude", anthropicStream, "message"],
+    ["openai", openAiChatStream, "chat.completion"],
+    ["response", openAiResponsesStream, "response"],
+    ["gemini", geminiStream, "candidates"],
+    ["gemini-cli", geminiCliStream, "response"],
+  ] as const)("routes %s streaming input to its native finalizer", (format, streamText, key) => {
+    const result = finalizeStreamOutputForClient(streamText, format, true);
+
+    expect(result?.kind).toBe("final");
+    if (result?.kind !== "final") {
+      throw new Error(`Expected a final output for ${format}`);
+    }
+
+    if (format === "claude") {
+      expect(result.value).toEqual(expect.objectContaining({ type: key }));
+    } else if (format === "openai") {
+      expect(result.value).toEqual(expect.objectContaining({ object: key }));
+    } else if (format === "response") {
+      expect(result.value).toEqual(expect.objectContaining({ object: key }));
+    } else if (format === "gemini") {
+      expect(result.value).toEqual(expect.objectContaining({ [key]: expect.any(Array) }));
+    } else {
+      expect(result.value).toEqual(expect.objectContaining({ [key]: expect.any(Object) }));
+    }
+  });
+
+  test("returns absent for non-streaming input without parsing the body", () => {
+    expect(finalizeStreamOutputForClient("not a stream", "claude", false)).toBeUndefined();
+  });
+
+  test.each([
+    ["empty_stream", ""],
+    ["malformed_frame", 'event: message\ndata: {"secret":"partial"\n\n'],
+    ["accumulator_truncated", 'data: {"type":"message_start"}\n\n\n: [cch_truncated]\n\n'],
+  ] as const)("returns a bounded diagnostic for %s stream input", (reason, streamText) => {
+    const result = finalizeStreamOutputForClient(streamText, "claude", true);
+
+    expect(result).toMatchObject({
+      kind: "final_output_unavailable",
+      reason,
+    });
+    expect(JSON.stringify(result)).not.toContain("data:");
+    expect(JSON.stringify(result)).not.toContain("partial");
+  });
+
+  test("passes an upstream stream error through as a bounded diagnostic", () => {
+    const result = finalizeStreamOutputForClient(
+      'event: error\ndata: {"type":"error","message":"upstream secret"}\n\n',
+      "response",
+      true
+    );
+
+    expect(result).toMatchObject({
+      kind: "final_output_unavailable",
+      reason: "stream_error",
+    });
+    expect(JSON.stringify(result)).not.toContain("upstream secret");
+    expect(JSON.stringify(result)).not.toContain("data:");
+  });
+
+  test("converts an unexpected parser exception into a stream_error diagnostic", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/langfuse/stream-final-output-core", async () => {
+      const actual = await vi.importActual<
+        typeof import("@/lib/langfuse/stream-final-output-core")
+      >("@/lib/langfuse/stream-final-output-core");
+      return {
+        ...actual,
+        parseStreamFrames: () => {
+          throw new Error("unexpected parser failure");
+        },
+      };
+    });
+
+    const { finalizeStreamOutputForClient: mockedDispatcher } = await import(
+      "@/lib/langfuse/stream-final-output"
+    );
+    const result = mockedDispatcher("data: {}\n\n", "claude", true);
+
+    expect(result).toEqual({
+      kind: "final_output_unavailable",
+      reason: "stream_error",
+      eventCount: 0,
+    });
+
+    vi.doUnmock("@/lib/langfuse/stream-final-output-core");
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
## Summary

Improve Langfuse traces without changing proxy routing or billing.

Streaming requests currently dump raw SSE/NDJSON into the generation output. This PR reconstructs a complete JSON final output for Claude, OpenAI Chat Completions, Responses, and Gemini, then records that as the observation output.

## Related

- Follow-up to #791 — builds on the original Langfuse observability integration (`src/lib/langfuse/*`)
- Related to #1120 — reworks the fire-and-forget trace emitter (`emit-proxy-trace.ts`) introduced for error-path tracing

## Problem

For streaming requests, the Langfuse generation `output` was the raw accumulated SSE/NDJSON text, which is unreadable in the Langfuse UI and loses the semantic structure (content blocks, tool calls, usage). Additionally, the trace name (`METHOD /endpoint`) was not useful for scanning, client headers observed by tracing were the post-filter ones, and Langfuse v5 attributes (`environment`, `release`) were not propagated.

## Solution

- Parse accumulated stream text into frames (SSE / NDJSON / JSON-array) and run a per-client-format finalizer that replays the frame sequence into the equivalent non-streaming JSON response:
  - `stream-final-output-anthropic.ts`: rebuilds the message from `message_start` / `content_block_start` / deltas (incl. tool-use `input_json_delta` assembly) / `message_delta` / `message_stop`
  - `stream-final-output-openai.ts`: Chat Completions choice/tool-call accumulation and Responses API event replay
  - `stream-final-output-gemini.ts`: candidates/parts reconstruction (shared by `gemini` and `gemini-cli` client formats)
  - `stream-final-output-core.ts`: framing detection, 1 MiB serialized-output budget, and typed diagnostics (`final_output_unavailable` with reason: `accumulator_truncated`, `malformed_frame`, `empty_stream`, `over_budget`, `unsupported_framing`, `no_terminal_event`, `stream_error`) instead of failing the trace
- Finalization runs in `emitProxyLangfuseTrace` **before** the async trace export, so streaming traces carry `finalResponseOutput` (raw `responseText` is no longer passed for streaming)
- Trace observation hierarchy now created inside `propagateAttributes` per Langfuse JS SDK v5; child observations use module-level `startObservation` with `parentSpanContext` to preserve `startTime` (replaces the previous `rootSpan.setTraceIO` call)
- Trace name is now `user:shortModel` (segment after the last `/`), propagated strings/tags clamped to 200 chars
- Sanitized original client headers recorded as generation `metadata.client_metadata` (credentials masked, via `sanitizeHeaders`); root metadata enriched with `userName`, `keyName`, `clientIp`
- Responses API output sanitized (tool-call internals stripped) and its native usage reported as Langfuse `usageDetails` dimensions (`input_tokens`, cached/reasoning details, `total_tokens`) plus response `id`/`status`/`model` metadata
- `ProxySession.getOriginalHeaders()` exposes the pre-filter header copy so tracing does not observe request-filter mutations
- New env vars `LANGFUSE_TRACING_ENVIRONMENT` / `LANGFUSE_RELEASE` passed into `LangfuseSpanProcessor`; `LANGFUSE_DEBUG` logger config moved ahead of SDK init

Out of scope: Prometheus / `emitProxyMetrics`.

## Files

- New: `src/lib/langfuse/stream-final-output*.ts` (5 files) and matching unit tests (5 test files)
- `emit-proxy-trace.ts` / `trace-proxy-request.ts` / `index.ts`
- `src/app/v1/_lib/proxy/session.ts` — `getOriginalHeaders()` for unfiltered client headers
- `src/lib/config/env.schema.ts` + `.env.example`: `LANGFUSE_TRACING_ENVIRONMENT`, `LANGFUSE_RELEASE`
- `CHANGELOG.md` (Unreleased section)

## Breaking Changes

None. All new env vars are optional, no exports were removed, no schema/migration changes, and the `emitProxyLangfuseTrace` signature is unchanged. Proxy routing and billing paths are untouched.

## Test plan

- [x] `bunx vitest run tests/unit/langfuse src/lib/langfuse` — 9 files, 122 tests passed
- [x] `bun run lint`
- [x] `bun run typecheck`
- [ ] Docker Build Test (CI)

Checklist:

- [x] Base branch is `dev`
- [x] No Prometheus / metrics changes
- [x] CHANGELOG Unreleased updated

---
*Description enhanced by Claude AI*
